### PR TITLE
JetBrains: show icon when agent doesnt start/crashes

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -4,6 +4,7 @@ import com.google.gson.GsonBuilder
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.ex.EditorEventMulticasterEx
@@ -14,6 +15,7 @@ import com.intellij.openapi.util.SystemInfoRt
 import com.intellij.util.system.CpuArch
 import com.sourcegraph.cody.CodyAgentFocusListener
 import com.sourcegraph.cody.agent.protocol.ClientInfo
+import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
 import com.sourcegraph.config.ConfigUtil
 import java.io.File
 import java.io.IOException
@@ -22,6 +24,7 @@ import java.net.URI
 import java.nio.file.*
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.atomic.AtomicBoolean
@@ -128,6 +131,11 @@ class CodyAgent(private val project: Project) : Disposable {
             .redirectErrorStream(false)
             .redirectError(ProcessBuilder.Redirect.PIPE)
             .start()
+    process.onExit().thenApplyAsync {
+      if (it.exitValue() != 0) {
+        CodyAutocompleteStatusService.resetApplication(project)
+      }
+    }
 
     // Redirect agent stderr into idea.log by buffering line by line into `logger.warn()`
     // statements. Without this logic, the stderr output of the agent process is lost if the process
@@ -165,27 +173,25 @@ class CodyAgent(private val project: Project) : Disposable {
   companion object {
     var logger = Logger.getInstance(CodyAgent::class.java)
     private val PLUGIN_ID = PluginId.getId("com.sourcegraph.jetbrains")
-    @JvmField val executorService = Executors.newCachedThreadPool()
+    @JvmField val executorService: ExecutorService = Executors.newCachedThreadPool()
 
     @JvmStatic
     fun getClient(project: Project): CodyAgentClient {
-      return project.getService(CodyAgent::class.java).client
+      return project.service<CodyAgent>().client
     }
 
     @JvmStatic
     fun getInitializedServer(project: Project): CompletableFuture<CodyAgentServer?> {
-      return project.getService(CodyAgent::class.java).initialized
+      return project.service<CodyAgent>().initialized
     }
 
     @JvmStatic
     fun isConnected(project: Project): Boolean {
-      val agent = project.getService(CodyAgent::class.java)
+      val agent = project.service<CodyAgent>()
       // NOTE(olafurpg): there are probably too many conditions below. We test multiple conditions
       // because we don't know 100% yet what exactly constitutes a "connected" state. Out of
-      // abundance
-      // of caution, we check everything we can think of.
-      return (agent?.agentProcess != null &&
-          agent.agentProcess!!.isAlive &&
+      // abundance of caution, we check everything we can think of.
+      return (agent.agentProcess?.isAlive == true &&
           !agent.listeningToJsonRpc.isDone &&
           !agent.listeningToJsonRpc.isCancelled &&
           agent.client.server != null)
@@ -218,7 +224,7 @@ class CodyAgent(private val project: Project) : Disposable {
 
     private fun agentDirectory(): Path? {
       val fromProperty = System.getProperty("cody-agent.directory", "")
-      if (!fromProperty.isEmpty()) {
+      if (fromProperty.isNotEmpty()) {
         return Paths.get(fromProperty)
       }
       val plugin = PluginManagerCore.getPlugin(PLUGIN_ID) ?: return null
@@ -253,7 +259,7 @@ class CodyAgent(private val project: Project) : Disposable {
 
     private fun traceWriter(): PrintWriter? {
       val tracePath = System.getProperty("cody-agent.trace-path", "")
-      if (!tracePath.isEmpty()) {
+      if (tracePath.isNotEmpty()) {
         val trace = Paths.get(tracePath)
         try {
           Files.createDirectories(trace.parent)

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -87,6 +87,7 @@ class CodyAgent(private val project: Project) : Disposable {
     } catch (e: Exception) {
       agentNotRunningExplanation = "unable to start Cody agent"
       logger.warn(agentNotRunningExplanation, e)
+      CodyAutocompleteStatusService.resetApplication(project)
     }
   }
 

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentManager.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentManager.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.agent
 
 import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
 import java.util.concurrent.TimeUnit
 
 object CodyAgentManager {
@@ -18,14 +19,18 @@ object CodyAgentManager {
 
   @JvmStatic
   fun startAgent(project: Project) {
-    if (project.isDisposed) {
-      return
+    try {
+      if (project.isDisposed) {
+        return
+      }
+      val service = project.getService(CodyAgent::class.java) ?: return
+      if (CodyAgent.isConnected(project)) {
+        return
+      }
+      service.initialize()
+    } finally {
+      CodyAutocompleteStatusService.resetApplication(project)
     }
-    val service = project.getService(CodyAgent::class.java) ?: return
-    if (CodyAgent.isConnected(project)) {
-      return
-    }
-    service.initialize()
   }
 
   @JvmStatic

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.startup.StartupActivity
 import com.sourcegraph.cody.agent.CodyAgentManager
 import com.sourcegraph.cody.auth.SelectOneOfTheAccountsAsActive
 import com.sourcegraph.cody.config.SettingsMigration
+import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
 import com.sourcegraph.config.CodyAuthNotificationActivity
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.telemetry.TelemetryInitializerActivity
@@ -22,5 +23,6 @@ class PostStartupActivity : StartupActivity.DumbAware {
     SelectOneOfTheAccountsAsActive().runActivity(project)
     CodyAuthNotificationActivity().runActivity(project)
     if (ConfigUtil.isCodyEnabled()) CodyAgentManager.startAgent(project)
+    CodyAutocompleteStatusService.resetApplication(project)
   }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatus.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatus.kt
@@ -30,7 +30,7 @@ enum class CodyAutocompleteStatus : PresentableEnum, WithIcon {
     override val icon: Icon = Icons.StatusBar.CodyAutocompleteUnavailable
   },
   CodyAgentNotRunning {
-    override fun getPresentableText(): String = "Cody Agent not running"
+    override fun getPresentableText(): String = "Cody encountered an unexpected error"
 
     override val icon: Icon = Icons.StatusBar.CodyAutocompleteUnavailable
   },

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatus.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatus.kt
@@ -29,6 +29,11 @@ enum class CodyAutocompleteStatus : PresentableEnum, WithIcon {
 
     override val icon: Icon = Icons.StatusBar.CodyAutocompleteUnavailable
   },
+  CodyAgentNotRunning {
+    override fun getPresentableText(): String = "Cody Agent not running"
+
+    override val icon: Icon = Icons.StatusBar.CodyAutocompleteUnavailable
+  },
   Ready {
     override fun getPresentableText(): String = "Cody autocomplete is enabled"
 

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.config.CodySignedOutNotification
 import com.sourcegraph.config.ConfigUtil
@@ -44,6 +45,8 @@ class CodyAutocompleteStatusService : CodyAutocompleteStatusListener, Disposable
                 CodyAutocompleteStatus.CodyDisabled
               } else if (!ConfigUtil.isCodyAutocompleteEnabled()) {
                 CodyAutocompleteStatus.AutocompleteDisabled
+              } else if (!CodyAgent.isConnected(project)) {
+                CodyAutocompleteStatus.CodyAgentNotRunning
               } else if (CodyAuthenticationManager.instance.getActiveAccount(project) == null) {
                 CodySignedOutNotification.show(project)
                 CodyAutocompleteStatus.CodyNotSignedIn

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
@@ -79,7 +79,7 @@ class CodyAutocompleteStatusService : CodyAutocompleteStatusListener, Disposable
     }
   }
 
-  override fun dispose() {}
+  override fun dispose() = Unit
 
   companion object {
 

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
@@ -6,7 +6,7 @@ import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.config.ConfigUtil
 
-class CodyDisableAutocompleteAction : DumbAwareAction() {
+class CodyDisableAutocompleteAction : DumbAwareAction("Disable Cody Autocomplete") {
   override fun actionPerformed(e: AnActionEvent) {
     CodyApplicationSettings.instance.isCodyAutocompleteEnabled = false
     CodyAutocompleteManager.instance.clearAutocompleteSuggestionsForAllProjects()

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableAutocompleteAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyEnableAutocompleteAction.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.config.ConfigUtil
 
-class CodyEnableAutocompleteAction : DumbAwareAction() {
+class CodyEnableAutocompleteAction : DumbAwareAction("Enable Cody Autocomplete") {
   override fun actionPerformed(e: AnActionEvent) {
     CodyApplicationSettings.instance.isCodyAutocompleteEnabled = true
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyManageAccountsAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyManageAccountsAction.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.DumbAwareAction
 import com.sourcegraph.cody.config.ui.AccountConfigurable
 
-class CodyManageAccountsAction : DumbAwareAction() {
+class CodyManageAccountsAction : DumbAwareAction("Manage Accounts") {
   override fun actionPerformed(e: AnActionEvent) {
     ShowSettingsUtil.getInstance().showSettingsDialog(e.project, AccountConfigurable::class.java)
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyOpenSettingsAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyOpenSettingsAction.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.DumbAwareAction
 import com.sourcegraph.cody.config.ui.CodyConfigurable
 
-class CodyOpenSettingsAction : DumbAwareAction() {
+class CodyOpenSettingsAction : DumbAwareAction("Open Settings") {
   override fun actionPerformed(e: AnActionEvent) {
     ShowSettingsUtil.getInstance().showSettingsDialog(e.project, CodyConfigurable::class.java)
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -1,5 +1,7 @@
 package com.sourcegraph.cody.statusbar
 
+import com.intellij.ide.actions.ShowLogAction
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.sourcegraph.config.ConfigUtil
@@ -8,5 +10,20 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
   override fun update(e: AnActionEvent) {
     super.update(e)
     e.presentation.isVisible = ConfigUtil.isCodyEnabled()
+  }
+
+  override fun getChildren(e: AnActionEvent?): Array<AnAction> {
+    return listOfNotNull(
+            CodyEnableAutocompleteAction(),
+            CodyDisableAutocompleteAction(),
+            CodyEnableLanguageForAutocompleteAction(),
+            CodyDisableLanguageForAutocompleteAction(),
+            CodyManageAccountsAction(),
+            CodyOpenSettingsAction(),
+            if (CodyAutocompleteStatusService.getCurrentStatus() ==
+                CodyAutocompleteStatus.CodyAgentNotRunning)
+                ShowLogAction()
+            else null)
+        .toTypedArray()
   }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -1,7 +1,6 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.ide.actions.AboutAction
-import com.intellij.internal.OpenLogAction
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
@@ -17,9 +16,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
     if (CodyAutocompleteStatusService.getCurrentStatus() ==
         CodyAutocompleteStatus.CodyAgentNotRunning)
         return listOf(
-                OpenLogAction().apply {
-                  templatePresentation.text = "Open Log To Troubleshoot Issue"
-                },
+                OpenLogAction(),
                 AboutAction().apply {
                   templatePresentation.text = "Open About To Troubleshoot Issue"
                 },

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.statusbar
 
-import com.intellij.idea.ActionsBundle
+import com.intellij.ide.actions.AboutAction
 import com.intellij.internal.OpenLogAction
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -14,6 +14,18 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
   }
 
   override fun getChildren(e: AnActionEvent?): Array<AnAction> {
+    if (CodyAutocompleteStatusService.getCurrentStatus() ==
+        CodyAutocompleteStatus.CodyAgentNotRunning)
+        return listOf(
+                OpenLogAction().apply {
+                  templatePresentation.text = "Open Log To Troubleshoot Issue"
+                },
+                AboutAction().apply {
+                  templatePresentation.text = "Open About To Troubleshoot Issue"
+                },
+                ReportCodyBugAction())
+            .toTypedArray()
+
     return listOfNotNull(
             CodyEnableAutocompleteAction(),
             CodyDisableAutocompleteAction(),
@@ -21,12 +33,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
             CodyDisableLanguageForAutocompleteAction(),
             CodyManageAccountsAction(),
             CodyOpenSettingsAction(),
-            if (CodyAutocompleteStatusService.getCurrentStatus() ==
-                CodyAutocompleteStatus.CodyAgentNotRunning)
-                OpenLogAction().apply {
-                  templatePresentation.text = ActionsBundle.message("action.OpenLog.text")
-                }
-            else null)
+        )
         .toTypedArray()
   }
 }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -1,6 +1,8 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.ide.actions.ShowLogAction
+import com.intellij.idea.ActionsBundle
+import com.intellij.internal.OpenLogAction
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
@@ -22,7 +24,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
             CodyOpenSettingsAction(),
             if (CodyAutocompleteStatusService.getCurrentStatus() ==
                 CodyAutocompleteStatus.CodyAgentNotRunning)
-                ShowLogAction()
+                OpenLogAction().apply { templatePresentation.text = ActionsBundle.message("action.OpenLog.text") }
             else null)
         .toTypedArray()
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.statusbar
 
-import com.intellij.ide.actions.ShowLogAction
 import com.intellij.idea.ActionsBundle
 import com.intellij.internal.OpenLogAction
 import com.intellij.openapi.actionSystem.AnAction
@@ -24,7 +23,9 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
             CodyOpenSettingsAction(),
             if (CodyAutocompleteStatusService.getCurrentStatus() ==
                 CodyAutocompleteStatus.CodyAgentNotRunning)
-                OpenLogAction().apply { templatePresentation.text = ActionsBundle.message("action.OpenLog.text") }
+                OpenLogAction().apply {
+                  templatePresentation.text = ActionsBundle.message("action.OpenLog.text")
+                }
             else null)
         .toTypedArray()
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/OpenLogAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/OpenLogAction.kt
@@ -1,0 +1,29 @@
+package com.sourcegraph.cody.statusbar
+
+import com.intellij.idea.LoggerFactory
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications.Bus
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
+
+class OpenLogAction() : DumbAwareAction("Open Log To Troubleshoot Issue") {
+
+  override fun actionPerformed(e: AnActionEvent) {
+    val project = e.project
+    if (project != null) {
+      val file =
+          LocalFileSystem.getInstance().refreshAndFindFileByNioFile(LoggerFactory.getLogFilePath())
+      if (file != null) {
+        VfsUtil.markDirtyAndRefresh(true, false, false, *arrayOf(file))
+        FileEditorManager.getInstance(project).openFile(file, true)
+      } else {
+        val title = "Cannot find '" + LoggerFactory.getLogFilePath() + "'"
+        Bus.notify(Notification("System Messages", title, "", NotificationType.INFORMATION))
+      }
+    }
+  }
+}

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/ReportCodyBugAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/statusbar/ReportCodyBugAction.kt
@@ -1,0 +1,11 @@
+package com.sourcegraph.cody.statusbar
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+
+class ReportCodyBugAction : DumbAwareAction("Open GitHub To Report Cody Issue") {
+  override fun actionPerformed(p0: AnActionEvent) {
+    BrowserUtil.open("https://github.com/sourcegraph/sourcegraph/issues/new?template=jetbrains.md")
+  }
+}

--- a/client/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/client/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -174,35 +174,6 @@
             text="Run Cody App"
             icon="/icons/codyLogoSm.svg"/>
 
-
-        <action
-            id="cody.enableCodyAutocomplete"
-            class="com.sourcegraph.cody.statusbar.CodyEnableAutocompleteAction"
-            text="Enable Cody Autocomplete"/>
-
-        <action
-            id="cody.disableCodyAutocomplete"
-            class="com.sourcegraph.cody.statusbar.CodyDisableAutocompleteAction"
-            text="Disable Cody Autocomplete"/>
-
-        <action
-            id="cody.enableLanguageForCodyAutocomplete"
-            class="com.sourcegraph.cody.statusbar.CodyEnableLanguageForAutocompleteAction"/>
-
-        <action
-            id="cody.disableLanguageForCodyAutocomplete"
-            class="com.sourcegraph.cody.statusbar.CodyDisableLanguageForAutocompleteAction"/>
-
-        <action
-            id="cody.statusBar.manageAccounts"
-            class="com.sourcegraph.cody.statusbar.CodyManageAccountsAction"
-            text="Manage Accounts"/>
-
-        <action
-            id="cody.statusBar.openSettings"
-            class="com.sourcegraph.cody.statusbar.CodyOpenSettingsAction"
-            text="Open Settings"/>
-
         <group id="CodyChatActionsGroup">
             <reference ref="cody.resetCurrentConversation"/>
         </group>
@@ -226,12 +197,6 @@
 
         <group id="CodyStatusBarActions" popup="true" text="Cody" searchable="false"
                class="com.sourcegraph.cody.statusbar.CodyStatusBarActionGroup">
-            <reference ref="cody.enableCodyAutocomplete"/>
-            <reference ref="cody.disableCodyAutocomplete"/>
-            <reference ref="cody.enableLanguageForCodyAutocomplete"/>
-            <reference ref="cody.disableLanguageForCodyAutocomplete"/>
-            <reference ref="cody.statusBar.manageAccounts"/>
-            <reference ref="cody.statusBar.openSettings"/>
         </group>
 
         <group id="Cody.Accounts.AddAccount">


### PR DESCRIPTION
Adds status bar state for when the agent binary cant be run or crashes while running, as well as a menu option to open idea.log (like in the Help dropdown) in the editor

![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/2510f415-eb6a-4d83-b241-8e3fb40439c6)


## Test plan

Tested cases:
- Binary cant be executed (arm64 bin on amd64 machine)
- Process gets terminated externally (SIGTERM)