### PR TITLE
switching ctags to tagged versions

### DIFF
--- a/wolfi-packages/ctags.yaml
+++ b/wolfi-packages/ctags.yaml
@@ -1,4 +1,5 @@
-# Melange-based replacement for https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/symbols/ctags-install-alpine.sh
+# universal-ctags package
+# Version from the universal-ctags project tags page: https://github.com/universal-ctags/ctags/tags
 
 package:
   name: ctags

--- a/wolfi-packages/ctags.yaml
+++ b/wolfi-packages/ctags.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: ctags
-  version: f95bb3497f53748c2b6afc7f298cff218103ab90
+  version: 5.9.20220403.0
   epoch: 2
   description: "A maintained ctags implementation"
   target-architecture:
@@ -33,8 +33,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://codeload.github.com/universal-ctags/ctags/tar.gz/${{package.version}}
-      expected-sha256: 1cb9b090f5cefa7704032df4c6ea2aca09d0adf8b2739be0aa3d4aaa720d0079
+      uri: https://github.com/universal-ctags/ctags/archive/refs/tags/p${{package.version}}.tar.gz
+      expected-sha256: df966f73ae6082acb9f4f7fe4e27f53a593782380f28ccf65f0ac38aaf697888
   - name: Autogen
     runs: |
       ./autogen.sh


### PR DESCRIPTION
This PR is switching Ctags packages from hash versions to tagged versions

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
CI Build Checks