### PR TITLE
search: Cleanup CodeMirror query input (part 1)

### DIFF
--- a/client/branded/BUILD.bazel
+++ b/client/branded/BUILD.bazel
@@ -105,6 +105,7 @@ ts_project(
         "src/search-ui/documentation/ModalVideo.tsx",
         "src/search-ui/experimental.ts",
         "src/search-ui/index.ts",
+        "src/search-ui/input/BaseCodeMirrorQueryInput.tsx",
         "src/search-ui/input/CodeMirrorQueryInput.tsx",
         "src/search-ui/input/LazyQueryInput.tsx",
         "src/search-ui/input/QueryInput.ts",

--- a/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.story.tsx
+++ b/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.story.tsx
@@ -1,0 +1,42 @@
+import type { Meta, Story } from '@storybook/react'
+
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
+
+import { BaseCodeMirrorQueryInput, type BaseCodeMirrorQueryInputProps } from './BaseCodeMirrorQueryInput'
+
+const config: Meta = {
+    title: 'branded/search-ui/input/BaseCodeMirrorQueryInput',
+    parameters: {
+        chromatic: { viewports: [500] },
+    },
+}
+
+export default config
+
+const defaultProps: BaseCodeMirrorQueryInputProps = {
+    value: 'r:sourcegraph/.* test [a-z]* /is this a regex?/ author:me',
+    interpretComments: false,
+    patternType: SearchPatternType.standard,
+}
+
+export const Default: Story = () => (
+    <BrandedStory>
+        {() => (
+            <>
+                <div className="m-3">
+                    'literal' search pattern:
+                    <BaseCodeMirrorQueryInput {...defaultProps} patternType={SearchPatternType.literal} />
+                </div>
+                <div className="m-3">
+                    'regexp' search pattern:
+                    <BaseCodeMirrorQueryInput {...defaultProps} patternType={SearchPatternType.regexp} />
+                </div>
+                <div className="m-3">
+                    'standard' search pattern:
+                    <BaseCodeMirrorQueryInput {...defaultProps} patternType={SearchPatternType.standard} />
+                </div>
+            </>
+        )}
+    </BrandedStory>
+)

--- a/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.tsx
@@ -1,0 +1,158 @@
+import { type RefObject, forwardRef, memo, useEffect, useImperativeHandle, useMemo, useRef } from 'react'
+
+import { defaultKeymap, historyKeymap, history } from '@codemirror/commands'
+import type { Extension } from '@codemirror/state'
+import { EditorView, drawSelection, keymap } from '@codemirror/view'
+import classNames from 'classnames'
+
+import { TraceSpanProvider } from '@sourcegraph/observability-client'
+import { type Editor, useCodeMirror, useCompartment } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
+import type { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+
+import { parseInputAsQuery, setQueryParseOptions } from './codemirror/parsedQuery'
+import { querySyntaxHighlighting } from './codemirror/syntax-highlighting'
+
+const EMPTY: Extension = []
+
+// These extensions do not depend on any component props
+const staticExtensions: Extension = [
+    // Default keybindings to ensure the editor behaves correctly
+    keymap.of(defaultKeymap),
+    // Additional keybindings history support
+    keymap.of(historyKeymap),
+    // History support. It allows the user, together with the history keybindings
+    // to redo/undo input changes.
+    history(),
+    // Let CodeMirror style selected text to make it work better with decorations
+    // that change the background color.
+    drawSelection(),
+    // Apply syntax highlighting to query elements
+    querySyntaxHighlighting,
+    // The input is styled deliberately without a border so that it
+    // can be integrated with various other UI elements.
+    EditorView.theme({
+        '.cm-content': {
+            caretColor: 'var(--search-query-text-color)',
+            color: 'var(--search-query-text-color)',
+            fontFamily: 'var(--code-font-family)',
+            fontSize: 'var(--code-font-size)',
+            // Reset default padding
+            padding: 0,
+            // We need 1px padding to make the cursor visible at position 0
+            paddingLeft: '1px',
+        },
+        '.cm-line': {
+            // Reset default padding
+            padding: 0,
+        },
+        '&.cm-focused .cm-selectionLayer .cm-selectionBackground': {
+            backgroundColor: 'var(--code-selection-bg-2)',
+        },
+        '.cm-selectionLayer .cm-selectionBackground': {
+            backgroundColor: 'var(--code-selection-bg)',
+        },
+    }),
+]
+
+export interface BaseCodeMirrorQueryInputProps {
+    className?: string
+
+    /**
+     * The current value of the input
+     */
+    value: string
+
+    /**
+     * Additional CodeMirror extensions.
+     */
+    extension?: Extension
+
+    /**
+     * Called when the editor was instantiated.
+     */
+    onEditorCreated?: (editor: EditorView) => void
+
+    // Query specific props
+    /**
+     * Pattern type used to parse the query. This influences
+     * syntax highlighting.
+     */
+    patternType: SearchPatternType
+
+    /**
+     * Whether or not to recognize comments in the query input.
+     */
+    interpretComments: boolean
+}
+
+/**
+ * BaseCodeMirrorQueryInput is a minimal query input. It provides syntax highlighting
+ * and base theming.
+ * Any additional functionality (autocompletion, diagnostics, token info, etc) has to be provided via extensions.
+ */
+export const BaseCodeMirrorQueryInput = memo(
+    forwardRef<Editor, BaseCodeMirrorQueryInputProps>(
+        ({ onEditorCreated, patternType, interpretComments, value, className, extension = EMPTY }, ref) => {
+            const containerRef = useRef<HTMLDivElement | null>(null)
+            const editorRef = useRef<EditorView | null>(null)
+
+            const parsedQueryExtension = useQueryParser(editorRef, patternType, interpretComments)
+            const externalExtension = useCompartment(editorRef, extension)
+            const allExtensions = useMemo(
+                () => [staticExtensions, parsedQueryExtension, externalExtension],
+                [parsedQueryExtension, externalExtension]
+            )
+
+            useCodeMirror(editorRef, containerRef, value, allExtensions)
+
+            useImperativeHandle(
+                ref,
+                () => ({
+                    focus() {
+                        editorRef.current?.focus()
+                    },
+                    blur() {
+                        editorRef.current?.contentDOM.blur()
+                    },
+                }),
+                []
+            )
+
+            // Notify parent component about editor instance. Among other things,
+            // having a reference to the editor allows other components to initiate
+            // transactions.
+            useEffect(() => {
+                if (editorRef.current) {
+                    onEditorCreated?.(editorRef.current)
+                }
+            }, [onEditorCreated])
+
+            return (
+                <TraceSpanProvider name="CodeMirrorQueryInput">
+                    <div
+                        ref={containerRef}
+                        className={classNames(className, 'test-query-input', 'test-editor')}
+                        data-editor="codemirror6"
+                    />
+                </TraceSpanProvider>
+            )
+        }
+    )
+)
+BaseCodeMirrorQueryInput.displayName = 'BaseCodeMirrorQueryInput'
+
+function useQueryParser(
+    editorRef: RefObject<EditorView>,
+    patternType: SearchPatternType,
+    interpretComments: boolean
+): Extension {
+    // Update pattern type and/or interpretComments when changed and update parsed representation of query input
+    useEffect(() => {
+        editorRef.current?.dispatch({ effects: setQueryParseOptions.of({ patternType, interpretComments }) })
+    }, [editorRef, patternType, interpretComments])
+
+    // We only need to compute this extension on first render. In subsequent renders
+    // the above effect updates the parser parameters.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return useMemo(() => parseInputAsQuery({ patternType, interpretComments }), [])
+}

--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.module.scss
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.module.scss
@@ -40,13 +40,6 @@
         }
 
         :global(.cm-content) {
-            caret-color: var(--search-query-text-color);
-            font-family: var(--code-font-family);
-            font-size: var(--code-font-size);
-            color: var(--search-query-text-color);
-            // Disable default padding
-            padding: 0;
-
             &:global(.focus-visible),
             &:focus-visible {
                 box-shadow: none;
@@ -62,11 +55,6 @@
                 overflow-wrap: anywhere;
                 flex-shrink: 1;
             }
-        }
-
-        :global(.cm-line) {
-            // Disable default padding
-            padding: 0;
         }
 
         :global(.cm-placeholder) {

--- a/client/branded/src/search-ui/input/codemirror/active-filter.ts
+++ b/client/branded/src/search-ui/input/codemirror/active-filter.ts
@@ -8,6 +8,11 @@ import { queryTokens } from './parsedQuery'
 
 const activeFilterFacet = Facet.define<Filter>()
 const activeFilterExtension = activeFilterFacet.computeN([queryTokens, 'selection'], state => {
+    // Do not mark a token as active if the user is selecting text. This avoids
+    // conflicts with the selection color.
+    if (!state.selection.main.empty) {
+        return []
+    }
     const query = state.facet(queryTokens)
     const position = state.selection.main.head
     return query.tokens.filter(

--- a/client/branded/src/search-ui/input/codemirror/parsedQuery.ts
+++ b/client/branded/src/search-ui/input/codemirror/parsedQuery.ts
@@ -11,25 +11,6 @@ export interface QueryTokens {
     tokens: Token[]
 }
 
-/**
- * Use this effect to update parse options.
- */
-export const setQueryParseOptions = StateEffect.define<{
-    patternType: SearchPatternType
-    interpretComments?: boolean
-}>()
-
-/**
- * Facet representing the parsed query. Other extensions can use this to access
- * the parsed query.
- */
-export const queryTokens = Facet.define<QueryTokens, QueryTokens>({
-    combine(input) {
-        // There will always only be one extension which parses this query
-        return input[0] ?? { patternType: SearchPatternType.standard, tokens: [] }
-    },
-})
-
 export const parsedQuery = Facet.define<ParseResult, Node | null>({
     combine(input) {
         return input[0]?.type === 'success' ? input[0].node : null
@@ -47,26 +28,21 @@ export const decoratedTokens = Facet.define<DecoratedToken[], DecoratedToken[]>(
 })
 
 /**
- * Returns the token at the current position (if any)
+ * Facet representing the parsed query. Other extensions can use this to access
+ * the parsed query. Populates the {@link parsedQuery} and {@link decoratedTokens} facets.
  */
-export function tokenAt(tokens: Token[], position: number): Token | undefined {
-    // We do a exclusive end check for whitespace tokens so that the token that
-    // possibly follows the whitespace token is picked instead.
-    return tokens.find(({ range, type }) =>
-        range.start <= position && type === 'whitespace' ? range.end > position : range.end >= position
-    )
-}
-
-/**
- * Returns the current query tokens
- */
-export function tokens(state: EditorState): Token[] {
-    return state.facet(queryTokens).tokens
-}
-
-export function getParsedQuery(state: EditorState): Node | null {
-    return state.facet(parsedQuery)
-}
+export const queryTokens: Facet<QueryTokens, QueryTokens> = Facet.define<QueryTokens, QueryTokens>({
+    combine(input) {
+        // There will always only be one extension which parses this query
+        return input[0] ?? { patternType: SearchPatternType.standard, tokens: [] }
+    },
+    enables(self) {
+        return [
+            parsedQuery.compute([self], state => parseSearchQuery({ type: 'success', term: state.facet(self).tokens })),
+            decoratedTokens.compute([self], state => state.facet(self).tokens.flatMap(decorate)),
+        ]
+    },
+})
 
 interface ParseOptions {
     patternType: SearchPatternType
@@ -96,27 +72,51 @@ export function parseInputAsQuery(initialParseOptions: ParseOptions): Extension 
             // Parse the query using our existing parser. It depends on the
             // current input (obviously) and the current parse options. It gets
             // recomputed whenever one of those values changes.
-            return [
-                queryTokens.compute(['doc', parseOptions], state => {
-                    const textDocument = state.sliceDoc()
-                    const { patternType, interpretComments } = state.field(parseOptions)
-                    if (!textDocument) {
-                        return { patternType, tokens: [] }
-                    }
+            return queryTokens.compute(['doc', parseOptions], state => {
+                const textDocument = state.sliceDoc()
+                const { patternType, interpretComments } = state.field(parseOptions)
+                if (!textDocument) {
+                    return { patternType, tokens: [] }
+                }
 
-                    const result = scanSearchQuery(textDocument, interpretComments, patternType)
-                    return {
-                        patternType,
-                        tokens: result.type === 'success' ? result.term : [],
-                    }
-                }),
-                parsedQuery.compute([queryTokens], state =>
-                    parseSearchQuery({ type: 'success', term: state.facet(queryTokens).tokens })
-                ),
-                decoratedTokens.compute([queryTokens], state => state.facet(queryTokens).tokens.flatMap(decorate)),
-            ]
+                const result = scanSearchQuery(textDocument, interpretComments, patternType)
+                return {
+                    patternType,
+                    tokens: result.type === 'success' ? result.term : [],
+                }
+            })
         },
     })
+}
+
+/**
+ * Use this effect to update parse options.
+ */
+export const setQueryParseOptions = StateEffect.define<{
+    patternType: SearchPatternType
+    interpretComments?: boolean
+}>()
+
+/**
+ * Returns the token at the current position (if any)
+ */
+export function tokenAt(tokens: Token[], position: number): Token | undefined {
+    // We do a exclusive end check for whitespace tokens so that the token that
+    // possibly follows the whitespace token is picked instead.
+    return tokens.find(({ range, type }) =>
+        range.start <= position && type === 'whitespace' ? range.end > position : range.end >= position
+    )
+}
+
+/**
+ * Returns the current query tokens
+ */
+export function tokens(state: EditorState): Token[] {
+    return state.facet(queryTokens).tokens
+}
+
+export function getParsedQuery(state: EditorState): Node | null {
+    return state.facet(parsedQuery)
 }
 
 /**

--- a/client/branded/src/search-ui/input/codemirror/token-info.ts
+++ b/client/branded/src/search-ui/input/codemirror/token-info.ts
@@ -54,7 +54,7 @@ const hoverStyle = [
         '.sg-decorated-token-hover': {
             backgroundColor: 'var(--gray-02)',
         },
-        '&dark .sg-decorated-token-hover': {
+        '.theme-dark & .sg-decorated-token-hover': {
             backgroundColor: 'var(--gray-08)',
         },
     }),

--- a/client/branded/src/search-ui/input/experimental/codemirror/history.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/history.ts
@@ -23,12 +23,12 @@ const formatTimeOptions = {
 
 function createHistorySuggestionSource(
     source: () => RecentSearch[],
-    submitQuery: (query: string) => void
+    submitQuery: (query: string, view: EditorView) => void
 ): Source['query'] {
     const applySuggestion = (option: Option, view: EditorView): void => {
         setMode(view, null)
         view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: option.label } })
-        submitQuery(option.label)
+        submitQuery(option.label, view)
     }
 
     return state => {
@@ -64,7 +64,7 @@ function createHistorySuggestionSource(
 export function searchHistoryExtension(config: {
     mode: ModeDefinition
     source: () => RecentSearch[]
-    submitQuery: (query: string) => void
+    submitQuery: (query: string, view: EditorView) => void
 }): Extension {
     return [
         modesFacet.of([config.mode]),

--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -15,7 +15,7 @@ export const filterDecoration = [
             padding: '1px 0',
             backgroundColor: '#eff2f5a0', // --gray-02 with transparency to make selection visible
         },
-        '&dark .sg-query-token-filter-context': {
+        '.theme-dark & .sg-query-token-filter-context': {
             backgroundColor: '#343a4da0', // --gray-08 with transparency to make selection visible
         },
     }),

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -367,7 +367,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                 <div className={styles.searchNavBar}>
                     <SearchNavbarItem
                         {...props}
-                        isLightTheme={isLightTheme}
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         searchContextsEnabled={searchContextsEnabled}
                         isRepositoryRelatedPage={isRepositoryRelatedPage}

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -16,7 +16,7 @@ import { editorHeight } from '@sourcegraph/shared/src/components/CodeMirrorEdito
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
-import { type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner, useObservable, Icon } from '@sourcegraph/wildcard'
@@ -171,7 +171,7 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
                                 patternType={SearchPatternType.standard}
                                 interpretComments={true}
                                 onEditorCreated={setEditor}
-                                extensions={useMemo(
+                                extension={useMemo(
                                     () => [
                                         EditorView.lineWrapping,
                                         queryCompletion,

--- a/client/web/src/notebooks/blocks/suggestions/SearchTypeSuggestionsInput.tsx
+++ b/client/web/src/notebooks/blocks/suggestions/SearchTypeSuggestionsInput.tsx
@@ -118,7 +118,7 @@ export const SearchTypeSuggestionsInput = <S extends SymbolMatch | PathMatch>({
                     onEditorCreated={onEditorCreatedLocal}
                     patternType={SearchPatternType.standard}
                     interpretComments={true}
-                    extensions={useMemo(
+                    extension={useMemo(
                         () => [blockKeymap({ runBlock }), changeListener(setQueryInput), singleLine, extension ?? []],
                         [setQueryInput, runBlock, extension]
                     )}

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -107,7 +107,7 @@ export const SearchConsolePage: React.FunctionComponent<React.PropsWithChildren<
                             patternType={patternType}
                             interpretComments={true}
                             value={searchQuery.value}
-                            extensions={extensions}
+                            extension={extensions}
                         />
                     </div>
                     <Button className="mt-2" onClick={triggerSearch} variant="primary">

--- a/client/web/src/search/input/ExperimentalSearchInput.tsx
+++ b/client/web/src/search/input/ExperimentalSearchInput.tsx
@@ -3,7 +3,7 @@ import { type FC, type PropsWithChildren, useCallback, useEffect, useMemo, useRe
 import { Prec } from '@codemirror/state'
 
 // This component makes the experimental search input accessible in the web app
-// eslint-disable-next-line no-restricted-imports
+
 import {
     type Action,
     CodeMirrorQueryInputWrapper,
@@ -14,7 +14,6 @@ import {
     searchHistoryExtension,
     selectionListener,
 } from '@sourcegraph/branded/src/search-ui/experimental'
-import type { Editor } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import type { SearchContextProps, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { FILTERS, FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { resolveFilterMemoized } from '@sourcegraph/shared/src/search/query/utils'
@@ -132,8 +131,6 @@ export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInp
         getSearchContextRef.current = () => selectedSearchContextSpec
     }, [selectedSearchContextSpec])
 
-    const editorRef = useRef<Editor | null>(null)
-
     const suggestionSource = useMemo(
         () =>
             createSuggestionsSource({
@@ -157,10 +154,10 @@ export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInp
                     placeholder: 'Filter history',
                 },
                 source: () => recentSearchesRef.current ?? [],
-                submitQuery: query => {
+                submitQuery: (query, view) => {
                     if (submitSearchRef?.current) {
                         submitSearchRef.current?.({ query })
-                        editorRef.current?.blur()
+                        view.contentDOM.blur()
                     }
                 },
             }),
@@ -183,13 +180,11 @@ export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInp
 
     return (
         <CodeMirrorQueryInputWrapper
-            ref={editorRef}
             patternType={inputProps.patternType}
             interpretComments={false}
             queryState={inputProps.queryState}
             onChange={inputProps.onChange}
             onSubmit={inputProps.onSubmit}
-            isLightTheme={inputProps.isLightTheme}
             placeholder="Search for code or files..."
             suggestionSource={suggestionSource}
             extensions={extensions}

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -27,7 +27,6 @@ interface Props
     isSourcegraphDotCom: boolean
     isSearchAutoFocusRequired?: boolean
     isRepositoryRelatedPage?: boolean
-    isLightTheme: boolean
 }
 
 const selectQueryState = ({
@@ -93,7 +92,6 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                     queryState={queryState}
                     onChange={setQueryState}
                     onSubmit={onSubmit}
-                    isLightTheme={props.isLightTheme}
                     platformContext={props.platformContext}
                     authenticatedUser={props.authenticatedUser}
                     fetchSearchContexts={props.fetchSearchContexts}

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -15,7 +15,6 @@ import {
     type SearchModeProps,
     getUserSearchContextNamespaces,
 } from '@sourcegraph/shared/src/search'
-import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Form } from '@sourcegraph/wildcard'
 
 import { Notices } from '../../../global/Notices'
@@ -72,7 +71,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
     const location = useLocation()
     const navigate = useNavigate()
 
-    const isLightTheme = useIsLightTheme()
     const { caseSensitive, patternType, searchMode } = useNavbarQueryState(queryStateSelector, shallow)
     const [experimentalQueryInput] = useExperimentalQueryInput()
 
@@ -138,7 +136,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
             queryState={queryState}
             onChange={setQueryState}
             onSubmit={onSubmit}
-            isLightTheme={isLightTheme}
             platformContext={platformContext}
             authenticatedUser={authenticatedUser}
             fetchSearchContexts={fetchSearchContexts}


### PR DESCRIPTION
First part of `N` to clean up the CodeMirror query input implementation.

## Context/plan

We currently have to "main" query input implementations, the "old" one in `client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx` and the experimental/new one in `client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx`. They share quite a bit of code but not as much as they could.

There are also two "configurations" of the old query input, `CodeMirrorMonacoFacade` and `CodeMirrorQueryInput`.

All these differ from each other in two ways: 
1. which (CodeMirror) extensions configured
2. how they integrate with other UI elements "around" them

My plan is to simplify at least the first one by rearranging the logic inside these components into reusable/configurable extensions that can be passed into a single "base" query input components. A lot of the functionality is already in extensions but more can be done here.
I think this will make things more manageable and easier to understand.

The purpose of the base query input is to provide the absolute minimal functionality for a query input, which is primarily syntax highlighting, default keybindings and other default styles.
More advanced features are then added as extension as needed, including but not limited to: 
- active token decoration
- token hover information
- autocompletion
- query validation
- ...

By making these configurable we'll be able to provide a better UX in the context where the input is used (for example the query input for search contexts should only allow certain filters).

## Changes in this PR

- Addition of the new `BaseCodeMirrorQueryInput` which provides syntax highlighting, styling and keyboard bindings.
- This new component is used by 
  - the existing `CodeMirrorQueryInput` component, which adds search query validation, token hover information and other styles on top
  - the experimental/new query input
- Removed styles from other components that are not provided in the base component
- Changed the `activeFilterExtension` to not highlight the active filter when the user is selecting text. This avoids conflicts between decoration and selection background colors.
- Removed `&dark` from all base themes and use the global `.theme-dark` selector instead. This lets us avoid the `isLightTheme` hook and theme changes are fully handled by CSS.
- Changed the implementation of the `useCompartment` hook (which was unused) to make it easier to use. It now returns the initial extension to use when initializing the editor and will handle updates by itself.


## Test plan

- Inspected new stories for base query input
- Compared styles, text selection, token hover and autjocompletion behavior side by side for
  - main query input (old and new)
  - search context query input
  - notebooks query input
