### PR TITLE
Disable code monitors on sourcegraph.com

### DIFF
--- a/client/web/src/enterprise/EnterpriseWebApp.tsx
+++ b/client/web/src/enterprise/EnterpriseWebApp.tsx
@@ -68,7 +68,7 @@ const hardcodedConfig = {
     codeInsightsEnabled: true,
     searchContextsEnabled: true,
     notebooksEnabled: true,
-    codeMonitoringEnabled: true,
+    codeMonitoringEnabled: !window.context?.sourcegraphDotComMode,
     searchAggregationEnabled: true,
     ownEnabled: true,
 } satisfies StaticHardcodedAppConfig

--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -62,7 +62,12 @@ export const enterpriseRoutes: RouteObject[] = [
     },
     {
         path: EnterprisePageRoutes.CodeMonitoring,
-        element: <LegacyRoute render={props => <GlobalCodeMonitoringArea {...props} />} />,
+        element: (
+            <LegacyRoute
+                condition={props => props.codeMonitoringEnabled}
+                render={props => <GlobalCodeMonitoringArea {...props} />}
+            />
+        ),
     },
     {
         path: EnterprisePageRoutes.Insights,

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -146,7 +146,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
     // but should not show in the navbar. Users can still
     // access this feature via the context dropdown.
     const showSearchContext = searchContextsEnabled && !isSourcegraphDotCom
-    const showCodeMonitoring = codeMonitoringEnabled && !isCodyApp && !isSourcegraphDotCom
+    const showCodeMonitoring = codeMonitoringEnabled && !isCodyApp
     const showSearchNotebook = notebooksEnabled && !isCodyApp && !isSourcegraphDotCom
     const isLicensed = !!window.context?.licenseInfo || isCodyApp // Assume licensed when running as a native app
     const showBatchChanges = props.batchChangesEnabled && isLicensed && !isCodyApp && !isSourcegraphDotCom

--- a/cmd/frontend/internal/codemonitors/init.go
+++ b/cmd/frontend/internal/codemonitors/init.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/codemonitors/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -21,6 +22,11 @@ func Init(
 	_ conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
+	// No code monitors on sourcegraph.com.
+	if envvar.SourcegraphDotComMode() {
+		return nil
+	}
+
 	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(log.Scoped("codeMonitorResolver", ""), db)
 	return nil
 }

--- a/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
+++ b/enterprise/cmd/worker/internal/codemonitors/codemonitor_job.go
@@ -3,6 +3,7 @@ package codemonitors
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/internal/codemonitors/background"
@@ -26,6 +27,11 @@ func (j *codeMonitorJob) Config() []env.Config {
 }
 
 func (j *codeMonitorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	// No code monitors on sourcegraph.com.
+	if envvar.SourcegraphDotComMode() {
+		return nil, nil
+	}
+
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See https://sourcegraph.slack.com/archives/CHEKCRWKV/p1696253622091899, code monitors have been hidden in the UI for a while but old ones still create a good amount of load on our systems and we currently don't want to invest in supporting the scale of sourcegraph.com better.

## Test plan

Verified using `sg start dotcom`.