### PR TITLE
bext: skip github e2e tests

### DIFF
--- a/client/browser/src/end-to-end/github.test.ts
+++ b/client/browser/src/end-to-end/github.test.ts
@@ -13,7 +13,9 @@ import { retry } from '@sourcegraph/shared/src/testing/utils'
 
 import { closeInstallPageTab, testSingleFilePage } from './shared'
 
-describe('Sourcegraph browser extension on github.com', function () {
+// Skip github.com tests because the redesign broke the extension for the file pages,
+// and the pull request tests were already skipped.
+describe.skip('Sourcegraph browser extension on github.com', function () {
     this.slow(8000)
 
     const { browser, sourcegraphBaseUrl, ...restConfig } = getConfig('browser', 'sourcegraphBaseUrl')

--- a/client/browser/src/end-to-end/gitlab.test.ts
+++ b/client/browser/src/end-to-end/gitlab.test.ts
@@ -47,6 +47,8 @@ describe('Sourcegraph browser extension on Gitlab Server', () => {
     // Take a screenshot when a test fails.
     afterEachSaveScreenshotIfFailed(() => driver.page)
 
+    // gitlab.com/sourcegraph now redirects to gitlab.com/SourcegraphCody, so that's
+    // the URL that will be generated on hover.
     const url = new URL(
         '/SourcegraphCody/jsonrpc2/blob/dbf20885e7ff39b0d5b64878148113e8433571f1/call_opt.go',
         GITLAB_BASE_URL

--- a/client/browser/src/end-to-end/gitlab.test.ts
+++ b/client/browser/src/end-to-end/gitlab.test.ts
@@ -17,7 +17,7 @@ const { sourcegraphBaseUrl, ...restConfig } = getConfig('sourcegraphBaseUrl')
 describe('Sourcegraph browser extension on Gitlab Server', () => {
     let driver: Driver
 
-    before(async function () {
+    before(async function() {
         this.timeout(4 * 60 * 1000)
         driver = await createDriverForTest({ loadExtension: true, sourcegraphBaseUrl })
 
@@ -48,7 +48,7 @@ describe('Sourcegraph browser extension on Gitlab Server', () => {
     afterEachSaveScreenshotIfFailed(() => driver.page)
 
     const url = new URL(
-        '/sourcegraph/jsonrpc2/blob/dbf20885e7ff39b0d5b64878148113e8433571f1/call_opt.go',
+        '/SourcegraphCody/jsonrpc2/blob/dbf20885e7ff39b0d5b64878148113e8433571f1/call_opt.go',
         GITLAB_BASE_URL
     )
     testSingleFilePage({

--- a/client/browser/src/end-to-end/gitlab.test.ts
+++ b/client/browser/src/end-to-end/gitlab.test.ts
@@ -17,7 +17,7 @@ const { sourcegraphBaseUrl, ...restConfig } = getConfig('sourcegraphBaseUrl')
 describe('Sourcegraph browser extension on Gitlab Server', () => {
     let driver: Driver
 
-    before(async function() {
+    before(async function () {
         this.timeout(4 * 60 * 1000)
         driver = await createDriverForTest({ loadExtension: true, sourcegraphBaseUrl })
 


### PR DESCRIPTION
Skipping GitHub e2e tests for the extension because the extension no longer works in the file view after the GitHub redesign. 

## Test plan

E2E tests pass.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
