### PR TITLE
users: Remove searchable attribute

### DIFF
--- a/client/shared/src/auth.ts
+++ b/client/shared/src/auth.ts
@@ -41,7 +41,6 @@ export const currentAuthStateQuery = gql`
             }
             viewerCanAdminister
             tosAccepted
-            searchable
             hasVerifiedEmail
             completedPostSignup
             emails {

--- a/client/shared/src/testing/integration/graphQlResults.ts
+++ b/client/shared/src/testing/integration/graphQlResults.ts
@@ -18,7 +18,6 @@ export const currentUserMock = {
     organizations: { nodes: [] },
     session: { canSignOut: true },
     viewerCanAdminister: true,
-    searchable: true,
     emails: [{ email: 'felix@sourcegraph.com', isPrimary: true, verified: true }],
     latestSettings: null,
     hasVerifiedEmail: true,

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -64,7 +64,6 @@ const authUser: AuthenticatedUser = {
     completedPostSignup: true,
     databaseID: 0,
     tosAccepted: true,
-    searchable: true,
     emails: [{ email: 'alice@sourcegraph.com', isPrimary: true, verified: true }],
     latestSettings: null,
     permissions: { nodes: [] },

--- a/client/web/src/enterprise/code-monitoring/testing/util.ts
+++ b/client/web/src/enterprise/code-monitoring/testing/util.ts
@@ -25,7 +25,6 @@ export const mockUser: AuthenticatedUser = {
     completedPostSignup: true,
     session: { __typename: 'Session', canSignOut: true },
     tosAccepted: true,
-    searchable: true,
     emails: [{ email: 'user@me.com', isPrimary: true, verified: true }],
     latestSettings: null,
     permissions: { nodes: [] },

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -86,7 +86,6 @@ const authUser: AuthenticatedUser = {
     completedPostSignup: true,
     databaseID: 0,
     tosAccepted: true,
-    searchable: true,
     emails: [{ email: 'alice@sourcegraph.com', isPrimary: true, verified: true }],
     latestSettings: null,
     permissions: { nodes: [] },

--- a/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
+++ b/client/web/src/integration/insights/utils/override-insights-graphql-api.ts
@@ -96,7 +96,6 @@ export function overrideInsightsGraphQLApi(props: OverrideGraphQLExtensionsProps
                 },
                 session: { canSignOut: true },
                 viewerCanAdminister: true,
-                searchable: true,
                 emails: [],
                 latestSettings: null,
                 permissions: { nodes: [] },

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -51,7 +51,6 @@ export type SourcegraphContextCurrentUser = Pick<
     | 'settingsURL'
     | 'viewerCanAdminister'
     | 'tosAccepted'
-    | 'searchable'
     | 'organizations'
     | 'session'
     | 'emails'

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -278,10 +278,6 @@ type Mutation {
     """
     setTosAccepted(userID: ID): EmptyResponse!
     """
-    Current user opt in/out from being searchable in the users picker.
-    """
-    setSearchable(searchable: Boolean!): EmptyResponse!
-    """
     Sets the user to have completed the post-signup flow.
     If the ID is omitted, the current user is assumed.
 
@@ -6450,10 +6446,6 @@ type User implements Node & SettingsSubject & Namespace {
     Whether the user has already accepted the terms of service or not.
     """
     tosAccepted: Boolean!
-    """
-    Whether the user accepted to be searched in the users picker or not.
-    """
-    searchable: Boolean!
     """
     The user's usage statistics on Sourcegraph.
     """

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -231,10 +231,6 @@ func (r *UserResolver) CompletedPostSignup(ctx context.Context) (bool, error) {
 	return r.user.CompletedPostSignup, nil
 }
 
-func (r *UserResolver) Searchable(_ context.Context) bool {
-	return r.user.Searchable
-}
-
 type updateUserArgs struct {
 	User        graphql.ID
 	Username    *string
@@ -496,27 +492,6 @@ func (r *schemaResolver) updateAffectedUser(ctx context.Context, affectedUserID 
 	}
 
 	if err := r.db.Users().Update(ctx, affectedUserID, update); err != nil {
-		return nil, err
-	}
-
-	return &EmptyResponse{}, nil
-}
-
-func (r *schemaResolver) SetSearchable(ctx context.Context, args *struct{ Searchable bool }) (*EmptyResponse, error) {
-	user, err := r.db.Users().GetByCurrentAuthUser(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if user == nil {
-		return nil, errors.New("no authenticated user")
-	}
-
-	searchable := args.Searchable
-	update := database.UserUpdate{
-		Searchable: &searchable,
-	}
-
-	if err := r.db.Users().Update(ctx, user.ID, update); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -106,7 +106,6 @@ type CurrentUser struct {
 	SettingsURL         string     `json:"settingsURL"`
 	ViewerCanAdminister bool       `json:"viewerCanAdminister"`
 	TosAccepted         bool       `json:"tosAccepted"`
-	Searchable          bool       `json:"searchable"`
 	HasVerifiedEmail    bool       `json:"hasVerifiedEmail"`
 	CompletedPostSignUp bool       `json:"completedPostSignup"`
 
@@ -458,7 +457,6 @@ func createCurrentUser(ctx context.Context, user *types.User, db database.DB) *C
 		ID:                  userResolver.ID(),
 		LatestSettings:      resolveLatestSettings(ctx, userResolver),
 		Organizations:       resolveUserOrganizations(ctx, userResolver),
-		Searchable:          userResolver.Searchable(ctx),
 		SettingsURL:         derefString(userResolver.SettingsURL()),
 		SiteAdmin:           siteAdmin,
 		TosAccepted:         userResolver.TosAccepted(ctx),

--- a/internal/database/org_members.go
+++ b/internal/database/org_members.go
@@ -102,7 +102,7 @@ func (m *orgMemberStore) GetByOrgID(ctx context.Context, orgID int32) ([]*types.
 func (u *orgMemberStore) AutocompleteMembersSearch(ctx context.Context, orgID int32, query string) ([]*types.OrgMemberAutocompleteSearchItem, error) {
 	pattern := query + "%"
 	q := sqlf.Sprintf(`SELECT u.id, u.username, u.display_name, u.avatar_url, (SELECT COUNT(o.org_id) from org_members o WHERE o.org_id = %d AND o.user_id = u.id) as inorg
-		FROM users u WHERE (u.username ILIKE %s OR u.display_name ILIKE %s) AND u.searchable IS TRUE AND u.deleted_at IS NULL ORDER BY id ASC LIMIT 10`, orgID, pattern, pattern)
+		FROM users u WHERE (u.username ILIKE %s OR u.display_name ILIKE %s) AND u.deleted_at IS NULL ORDER BY id ASC LIMIT 10`, orgID, pattern, pattern)
 
 	rows, err := u.Query(ctx, q)
 	if err != nil {

--- a/internal/database/org_members_db_test.go
+++ b/internal/database/org_members_db_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
@@ -262,16 +261,6 @@ func TestOrgMembers_AutocompleteMembersSearch(t *testing.T) {
 			username: "testuser11",
 			email:    "em119@test.com",
 		},
-		{
-			name:     "searchabletrue",
-			username: "testuser12",
-			email:    "em19@test.com",
-		},
-		{
-			name:     "test user12",
-			username: "searchablefalse",
-			email:    "em19@test.com",
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -295,22 +284,5 @@ func TestOrgMembers_AutocompleteMembersSearch(t *testing.T) {
 
 	if want := 10; len(users) != want {
 		t.Errorf("got %d, want %d", len(users), want)
-	}
-
-	user, err := db.Users().GetByUsername(ctx, "searchablefalse")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := db.Users().Update(ctx, user.ID, UserUpdate{Searchable: pointers.Ptr(false)}); err != nil {
-		t.Fatal(err)
-	}
-
-	users2, err := db.OrgMembers().AutocompleteMembersSearch(ctx, 1, "searchable")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if want := 1; len(users2) != want {
-		t.Errorf("got %d, want %d", len(users2), want)
 	}
 }

--- a/internal/database/perms_store.go
+++ b/internal/database/perms_store.go
@@ -2112,7 +2112,6 @@ func (s *permsStore) scanUsersPermissionsInfo(rows dbutil.Scanner) (*types.User,
 		&u.BuiltinAuth,
 		&u.InvalidatedSessionsAt,
 		&u.TosAccepted,
-		&u.Searchable,
 		&dbutil.NullTime{Time: &updatedAt},
 	)
 	if err != nil {
@@ -2137,7 +2136,6 @@ SELECT
 	users.passwd IS NOT NULL,
 	users.invalidated_sessions_at,
 	users.tos_accepted,
-	users.searchable,
 	urp.updated_at AS permissions_updated_at
 FROM
 	users

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -856,7 +856,6 @@ type User struct {
 	InvalidatedSessionsAt time.Time
 	TosAccepted           bool
 	CompletedPostSignup   bool
-	Searchable            bool
 	SCIMControlled        bool
 }
 


### PR DESCRIPTION
We no longer expose any controls for this field that used to exist for multi-tenant sourcegraph.com. Thus, I'm proposing that we remove it. When you join Sourcegraph.com, your profile will be visible anyways, so this is not leaking data.

## Test plan

CI and verified the field is not used anywhere.