### PR TITLE
proto: Add editorconfig to ident using two spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ indent_size = 4
 [*.go]
 indent_style = tab
 
-[{*.kt,*.java,*.kts,*.lua,*.js,*.jsx,*.json,*.yml,*.yaml,*.md,.babelrc,.stylelintrc}]
+[{*.kt,*.java,*.kts,*.lua,*.js,*.jsx,*.json,*.yml,*.yaml,*.md,.babelrc,.stylelintrc,*.proto}]
 indent_size = 2
 
 [*.md]


### PR DESCRIPTION
The default my editor uses is 4 spaces, which always throws formatting errors in CI. This makes my life easier :)

## Test plan

VSCode no longer uses 4 spaces which makes the linter angry. 