### PR TITLE
extsvc: Ensure created_at is set

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -12,7 +12,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/tidwall/gjson"
 	"github.com/xeipuuv/gojsonschema"
 	"golang.org/x/time/rate"
@@ -21,6 +20,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -693,6 +693,11 @@ func (e *externalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 			return err
 		}
 		s.CodeHostID = &chID
+
+		// Ensure CreatedAt is set.
+		if s.CreatedAt.IsZero() {
+			s.CreatedAt = timeutil.Now()
+		}
 	}
 
 	// Get the list services that are marked as deleted. We don't know at this point


### PR DESCRIPTION
In case we ever don't set the created_at field, this makes sure that it's set to a time other than `time.Time{}`.

Closes https://github.com/sourcegraph/sourcegraph/issues/36224

## Test plan

CI and checked references of this function.