### PR TITLE
sg: Install p4 cli for local dev

### DIFF
--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -119,6 +119,11 @@ var Mac = []category{
 					).Wait()
 				},
 			},
+			{
+				Name:  "p4 CLI",
+				Check: checkAction(check.InPath("p4")),
+				Fix:   cmdFix(`brew install --cask p4`),
+			},
 		},
 	},
 	{

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -120,7 +120,7 @@ var Mac = []category{
 				},
 			},
 			{
-				Name:  "p4 CLI",
+				Name:  "p4 CLI (Perforce)",
 				Check: checkAction(check.InPath("p4")),
 				Fix:   cmdFix(`brew install --cask p4`),
 			},

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -14,11 +14,8 @@ import (
 )
 
 func aptGetInstall(pkg string, preinstall ...string) check.FixAction[CheckArgs] {
-	commands := []string{
-		`sudo apt-get update`,
-	}
-	commands = append(commands, preinstall...)
-	commands = append(commands, fmt.Sprintf("sudo apt-get install -y %s", pkg))
+	commands := preinstall
+	commands = append(commands, "sudo apt-get update", fmt.Sprintf("sudo apt-get install -y %s", pkg))
 	return cmdFixes(commands...)
 }
 
@@ -99,7 +96,7 @@ var Ubuntu = []category{
 				Name: "asdf",
 				// TODO add the if Keegan check
 				Check: checkAction(check.CommandOutputContains("asdf", "version")),
-				Fix: func(ctx context.Context, cio check.IO, args CheckArgs) error {
+				Fix: func(ctx context.Context, cio check.IO, _ CheckArgs) error {
 					if err := usershell.Run(ctx, "git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.9.0").StreamLines(cio.Verbose); err != nil {
 						return err
 					}
@@ -107,6 +104,17 @@ var Ubuntu = []category{
 						`echo ". $HOME/.asdf/asdf.sh" >>`, usershell.ShellConfigPath(ctx),
 					).Wait()
 				},
+			},
+			{
+				Name:  "p4 CLI (Perforce)",
+				Check: checkAction(check.InPath("p4")),
+				// https://www.perforce.com/perforce-packages
+				// https://superuser.com/a/1512272/186941
+				Fix: aptGetInstall("helix-cli",
+					"wget -qO - https://package.perforce.com/perforce.pubkey | sudo apt-key add -",
+					"printf \"deb http://package.perforce.com/apt/ubuntu $(lsb_release -sc) release\" | sudo tee /etc/apt/sources.list.d/perforce.list",
+					"sudo cat /etc/apt/sources.list.d/perforce.list",
+				),
 			},
 		},
 	},

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -113,7 +113,6 @@ var Ubuntu = []category{
 				Fix: aptGetInstall("helix-cli",
 					"wget -qO - https://package.perforce.com/perforce.pubkey | sudo apt-key add -",
 					"printf \"deb http://package.perforce.com/apt/ubuntu $(lsb_release -sc) release\" | sudo tee /etc/apt/sources.list.d/perforce.list",
-					"sudo cat /etc/apt/sources.list.d/perforce.list",
 				),
 			},
 		},


### PR DESCRIPTION
Since we are working with perforce a bunch and have test suites that need the CLI that are currently skipped locally, I think it makes sense to add the p4 CLI here. 

The installation for ubuntu seems more involved and requires adding package sources and so forth, which I'm not sure we want to do. If you have a good idea on how to best implement this for linux as well, let me know.

## Test plan

Ran `go run ./dev/sg setup` locally and verified things work. 