### PR TITLE
Log frontend events and then strip ?signup and ?signin query paramete…

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -476,12 +476,15 @@ export function setDebugEventLoggingEnabled(enabled: boolean): void {
  */
 function handleQueryEvents(url: string): void {
     const parsedUrl = new URL(url)
-    const isBadgeRedirect = !!parsedUrl.searchParams.get('badge')
-    if (isBadgeRedirect) {
-        eventLogger.log('RepoBadgeRedirected')
+    if (parsedUrl.searchParams.has('signup')) {
+        eventLogger.log('web:auth:signUpCompleted')
     }
 
-    stripURLParameters(url, ['utm_campaign', 'utm_source', 'utm_medium', 'badge'])
+    if (parsedUrl.searchParams.has('signin')) {
+        eventLogger.log('web:auth:signInCompleted')
+    }
+
+    stripURLParameters(url, ['utm_campaign', 'utm_source', 'utm_medium', 'signup', 'signin'])
 }
 
 /**


### PR DESCRIPTION
…rs when seen

Also removed the no longer used ?badge URM param.

This is a follow-on to https://github.com/sourcegraph/sourcegraph/pull/53880

@akalia25 let me know if the event names here look correct

## Test plan

Tested locally