### PR TITLE
fix background page bundle name

### DIFF
--- a/client/browser/src/browser-extension/pages/background.html
+++ b/client/browser/src/browser-extension/pages/background.html
@@ -2,6 +2,6 @@
 <html>
     <head>
         <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-        <script type="text/javascript" src="/js/background.bundle.js"></script>
+        <script type="text/javascript" src="/js/backgroundPage.main.bundle.js"></script>
     </head>
 </html>


### PR DESCRIPTION
Followup (fix) to #57229.

## Test plan

Run Chrome extension from unpacked local build and confirm that the background page loads successfully.