### PR TITLE
ctags: update darwin ctags sha256

### DIFF
--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -67,7 +67,7 @@ def tool_deps():
 
     http_file(
         name = "universal-ctags-darwin-arm64",
-        sha256 = "269d9ae1d1dd39b8b266b31c4ad653b87ba004888bba8a8b9db23bfcc7ac503a",
+        sha256 = "b771e522c1d5a4f40ffdfa03400637f5e0dfba8caa0bc9038574b13b8f232a84",
         url = "https://storage.googleapis.com/universal_ctags/aarch64-darwin/bin/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )


### PR DESCRIPTION
The following action updated the arm64 darwin ctags binary, which means it has a new hash

https://github.com/sourcegraph/sourcegraph/actions/runs/6384355462/job/17326849491

Related to: https://github.com/sourcegraph/devx-support/issues/274

## Test plan
Executed locally and CI 

