### PR TITLE
Add redirect to post-signup survey on token routes

### DIFF
--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
@@ -20,6 +20,11 @@ interface Props extends Pick<UserSettingsAreaRouteContext, 'user' | 'authenticat
 
 export const UserSettingsTokensArea: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
     const [newToken, setNewToken] = useState<CreateAccessTokenResult['createAccessToken'] | undefined>()
+
+    const onDidPresentNewToken = useCallback(() => {
+        setNewToken(undefined)
+    }, [])
+
     if (props.isSourcegraphDotCom && props.authenticatedUser && !props.authenticatedUser.completedPostSignup) {
         const returnTo = window.location.href
         const params = new URLSearchParams()
@@ -27,11 +32,6 @@ export const UserSettingsTokensArea: React.FunctionComponent<React.PropsWithChil
         const navigateTo = PageRoutes.PostSignUp + '?' + params.toString()
         return <Navigate to={navigateTo.toString()} replace={true} />
     }
-
-    const onDidPresentNewToken = useCallback(() => {
-        setNewToken(undefined)
-    }, [])
-
     return (
         <Routes>
             <Route

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useState } from 'react'
 
-import { Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes } from 'react-router-dom'
 
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { NotFoundPage } from '../../../components/HeroPage'
 import type { CreateAccessTokenResult } from '../../../graphql-operations'
+import { PageRoutes } from '../../../routes.constants'
 import type { UserSettingsAreaRouteContext } from '../UserSettingsArea'
 
 import { UserSettingsCreateAccessTokenCallbackPage } from './UserSettingsCreateAccessTokenCallbackPage'
@@ -19,6 +20,13 @@ interface Props extends Pick<UserSettingsAreaRouteContext, 'user' | 'authenticat
 
 export const UserSettingsTokensArea: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
     const [newToken, setNewToken] = useState<CreateAccessTokenResult['createAccessToken'] | undefined>()
+    if (props.isSourcegraphDotCom && props.authenticatedUser && !props.authenticatedUser.completedPostSignup) {
+        const returnTo = window.location.href
+        const params = new URLSearchParams()
+        params.set('returnTo', returnTo)
+        const navigateTo = PageRoutes.PostSignUp + '?' + params.toString()
+        return <Navigate to={navigateTo.toString()} replace={true} />
+    }
 
     const onDidPresentNewToken = useCallback(() => {
         setNewToken(undefined)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   browserify-zlib: 0.2.0
   '@types/webpack': '5'
@@ -8,7 +12,7 @@ overrides:
   webpack: '5'
   tslib: 2.1.0
 
-packageExtensionsChecksum: 234f976e1d4970c786ebd2aca0fd682a
+packageExtensionsChecksum: 769402dc957b3bd672d434d157a19e86
 
 importers:
 
@@ -7891,11 +7895,11 @@ packages:
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
-      '@types/webpack': 4.x || 5.x
+      '@types/webpack': '5'
       react-refresh: '>=0.10.0 <1.0.0'
       sockjs-client: ^1.4.0
       type-fest: '>=0.17.0 <4.0.0'
-      webpack: '>=4.43.0 <6.0.0'
+      webpack: '5'
       webpack-dev-server: 3.x || 4.x
       webpack-hot-middleware: 2.x
       webpack-plugin-serve: 0.x || 1.x
@@ -7931,11 +7935,11 @@ packages:
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
-      '@types/webpack': 4.x || 5.x
+      '@types/webpack': '5'
       react-refresh: '>=0.10.0 <1.0.0'
       sockjs-client: ^1.4.0
       type-fest: '>=0.17.0 <4.0.0'
-      webpack: '>=4.43.0 <6.0.0'
+      webpack: '5'
       webpack-dev-server: 3.x || 4.x
       webpack-hot-middleware: 2.x
       webpack-plugin-serve: 0.x || 1.x
@@ -9635,7 +9639,7 @@ packages:
   /@statoscope/webpack-plugin@5.24.0(webpack@5.75.0):
     resolution: {integrity: sha512-8GX0ULmvwZRAqQClLMdzV1L/Y9PBJZTwBTXiiKzU4+vypRiI7VA+fz9aZ2XGWErVonXbrIvclj2IAQMbz/z2YQ==}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@statoscope/report-writer': 5.22.0
@@ -9654,7 +9658,7 @@ packages:
   /@statoscope/webpack-stats-extension-compressed@5.24.0(webpack@5.75.0):
     resolution: {integrity: sha512-yJyYo/TC393MZcA/txnd/37WubSdGNpVAncFlifVtJoGgsD9GrqltN8aUiaVPBDy/r4N4qP9+8T6OQ/Ha4J4DA==}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       '@statoscope/stats': 5.14.1
       '@statoscope/stats-extension-compressed': 5.24.0
@@ -9665,7 +9669,7 @@ packages:
   /@statoscope/webpack-stats-extension-package-info@5.24.0(webpack@5.75.0):
     resolution: {integrity: sha512-AXtYSbvyyFdgn1H/bnE2gu0oEhKBiHbeZA/gCJM+hEWOwGWnz61+qiPxYj2QnOnXN8XmjHho3jf0Gd4eW3dJfw==}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       '@statoscope/stats': 5.14.1
       '@statoscope/stats-extension-package-info': 5.24.0
@@ -10931,7 +10935,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       typescript: '*'
-      webpack: '*'
+      webpack: '5'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -11225,7 +11229,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       typescript: '*'
-      webpack: '*'
+      webpack: '5'
     peerDependenciesMeta:
       '@storybook/builder-webpack5':
         optional: true
@@ -11682,7 +11686,7 @@ packages:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
-      webpack: '>= 4'
+      webpack: '5'
     dependencies:
       debug: 4.3.4
       endent: 2.0.1
@@ -14100,7 +14104,7 @@ packages:
     resolution: {integrity: sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack: 5.x.x
+      webpack: '5'
       webpack-cli: 5.x.x
     dependencies:
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -14110,7 +14114,7 @@ packages:
     resolution: {integrity: sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack: 5.x.x
+      webpack: '5'
       webpack-cli: 5.x.x
     dependencies:
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -14120,7 +14124,7 @@ packages:
     resolution: {integrity: sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack: 5.x.x
+      webpack: '5'
       webpack-cli: 5.x.x
       webpack-dev-server: '*'
     peerDependenciesMeta:
@@ -15089,7 +15093,7 @@ packages:
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
-      webpack: '>=2'
+      webpack: '5'
     dependencies:
       '@babel/core': 7.21.0
       find-cache-dir: 3.3.2
@@ -15104,7 +15108,7 @@ packages:
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
-      webpack: '>=2'
+      webpack: '5'
     dependencies:
       '@babel/core': 7.22.9
       find-cache-dir: 3.3.2
@@ -15118,7 +15122,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
-      webpack: '>=5'
+      webpack: '5'
     dependencies:
       '@babel/core': 7.21.0
       find-cache-dir: 3.3.2
@@ -15714,6 +15718,7 @@ packages:
 
   /bplist-parser@0.1.1:
     resolution: {integrity: sha512-2AEM0FXy8ZxVLBuqX0hqt1gDwcnz2zygEkQ6zaD5Wko/sB9paUNwlpawrFtKeHUAQUOzjVy9AO4oeonqIHKA9Q==}
+    requiresBuild: true
     dependencies:
       big-integer: 1.6.51
     dev: true
@@ -16831,7 +16836,7 @@ packages:
     resolution: {integrity: sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      webpack: ^5.1.0
+      webpack: '5'
     dependencies:
       schema-utils: 4.0.0
       serialize-javascript: 6.0.0
@@ -17248,7 +17253,7 @@ packages:
     resolution: {integrity: sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==}
     engines: {node: '>= 8.9.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       camelcase: 5.3.1
       cssesc: 3.0.0
@@ -17270,7 +17275,7 @@ packages:
     resolution: {integrity: sha512-0wyN5vXMQZu6BvjbrPdUJvkCzGEO24HC7IS7nW4llc6BBFC+zwR9CKtYGv63Puzsg10L/o12inMY5/2ByzfD6w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.27.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.27)
       loader-utils: 2.0.4
@@ -17289,7 +17294,7 @@ packages:
     resolution: {integrity: sha512-oqGbbVcBJkm8QwmnNzrFrWTnudnRZC+1eXikLJl0n4ljcfotgRifpg2a1lKy8jTrc4/d9A/ap1GFq1jDKG7J+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^5.0.0
+      webpack: '5'
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.27)
       postcss: 8.4.27
@@ -17311,7 +17316,7 @@ packages:
       csso: '*'
       esbuild: '*'
       lightningcss: '*'
-      webpack: ^5.0.0
+      webpack: '5'
     peerDependenciesMeta:
       '@parcel/css':
         optional: true
@@ -20221,7 +20226,7 @@ packages:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
@@ -20488,7 +20493,7 @@ packages:
       eslint: '>= 6'
       typescript: '>= 2.7'
       vue-template-compiler: '*'
-      webpack: '>= 4'
+      webpack: '5'
     peerDependenciesMeta:
       eslint:
         optional: true
@@ -20516,7 +20521,7 @@ packages:
       eslint: '>= 6'
       typescript: '>= 2.7'
       vue-template-compiler: '*'
-      webpack: '>= 4'
+      webpack: '5'
     peerDependenciesMeta:
       eslint:
         optional: true
@@ -21902,7 +21907,7 @@ packages:
     resolution: {integrity: sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==}
     engines: {node: '>=6.9'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       '@types/html-minifier-terser': 5.1.1
       '@types/tapable': 1.0.7
@@ -21925,7 +21930,7 @@ packages:
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
-      webpack: ^5.20.0
+      webpack: '5'
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -26012,7 +26017,7 @@ packages:
     resolution: {integrity: sha512-EdlUizq13o0Pd+uCp+WO/JpkLvHRVGt97RqfeGhXqAcorYo1ypJSpkV+WDT0vY/kmh/p7wRdJNJtuyK540PXDw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^5.0.0
+      webpack: '5'
     dependencies:
       schema-utils: 4.0.0
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -26200,7 +26205,7 @@ packages:
     resolution: {integrity: sha512-TP5NkCAV0OeFTry5k/d60KR7CkhTXL4kgJKtE3BzjgbDb5TGEPEhoKmHBrSa6r7Oc0sNbPLZhKD/TP2ig7A+/A==}
     peerDependencies:
       monaco-editor: 0.22.x || 0.23.x || 0.24.x
-      webpack: ^4.5.0 || 5.x
+      webpack: '5'
     dependencies:
       loader-utils: 2.0.4
       monaco-editor: 0.24.0
@@ -27856,7 +27861,7 @@ packages:
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       postcss: ^7.0.0 || ^8.0.1
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       cosmiconfig: 7.0.1
       klona: 2.0.5
@@ -27872,7 +27877,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       postcss: ^7.0.0 || ^8.0.1
-      webpack: ^5.0.0
+      webpack: '5'
     dependencies:
       cosmiconfig: 7.0.1
       klona: 2.0.5
@@ -27886,7 +27891,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       postcss: ^7.0.0 || ^8.0.1
-      webpack: ^5.0.0
+      webpack: '5'
     dependencies:
       cosmiconfig: 7.0.1
       klona: 2.0.5
@@ -28842,7 +28847,7 @@ packages:
     resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
@@ -30333,7 +30338,7 @@ packages:
       node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       sass: ^1.3.0
       sass-embedded: '*'
-      webpack: ^5.0.0
+      webpack: '5'
     peerDependenciesMeta:
       fibers:
         optional: true
@@ -31118,7 +31123,7 @@ packages:
     resolution: {integrity: sha512-Re0wX5CtM6gW7bZA64ONOfEPEhwbiSF/vz6e2GvadjuaPrQcHTQdRGsD8+BE7iUOysXH8tIenkPCQBEcspXsNg==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
-      webpack: ^1 || ^2 || ^3 || ^4 || ^5
+      webpack: '5'
     dependencies:
       chalk: 4.1.2
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -31577,7 +31582,7 @@ packages:
     resolution: {integrity: sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==}
     engines: {node: '>= 8.9.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.0
@@ -31588,7 +31593,7 @@ packages:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
@@ -31599,7 +31604,7 @@ packages:
     resolution: {integrity: sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^5.0.0
+      webpack: '5'
     dependencies:
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
 
@@ -32153,7 +32158,7 @@ packages:
     resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       cacache: 15.0.5
       find-cache-dir: 3.3.2
@@ -32176,7 +32181,7 @@ packages:
       '@swc/core': '*'
       esbuild: '*'
       uglify-js: '*'
-      webpack: ^5.1.0
+      webpack: '5'
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -32526,7 +32531,7 @@ packages:
     engines: {node: '>=12.0.0'}
     peerDependencies:
       typescript: '*'
-      webpack: ^5.0.0
+      webpack: '5'
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.10.0
@@ -33130,6 +33135,7 @@ packages:
   /untildify@2.1.0:
     resolution: {integrity: sha512-sJjbDp2GodvkB0FZZcn7k6afVisqX5BZD7Yq3xp4nN2O15BBK0cLm3Vwn2vQaF7UDS0UUsrQMkkplmDI5fskig==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       os-homedir: 1.0.2
     dev: true
@@ -33238,7 +33244,7 @@ packages:
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       file-loader: '*'
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     peerDependenciesMeta:
       file-loader:
         optional: true
@@ -33986,7 +33992,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@webpack-cli/generators': '*'
-      webpack: 5.x.x
+      webpack: '5'
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
@@ -34018,7 +34024,7 @@ packages:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
     engines: {node: '>= 6'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       memory-fs: 0.4.1
       mime: 2.6.0
@@ -34032,7 +34038,7 @@ packages:
     resolution: {integrity: sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==}
     engines: {node: '>= v10.23.3'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       colorette: 1.4.0
       mem: 8.1.1
@@ -34047,7 +34053,7 @@ packages:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       colorette: 2.0.19
       memfs: 3.4.12
@@ -34061,7 +34067,7 @@ packages:
     engines: {node: '>= 12.13.0'}
     hasBin: true
     peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0
+      webpack: '5'
       webpack-cli: '*'
     peerDependenciesMeta:
       webpack-cli:
@@ -34108,7 +34114,7 @@ packages:
     resolution: {integrity: sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==}
     engines: {node: '>= 4.3 < 5.0.0 || >= 5.10'}
     peerDependencies:
-      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
+      webpack: '5'
     dependencies:
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
     dev: true
@@ -34134,7 +34140,7 @@ packages:
     resolution: {integrity: sha512-8RQfMAdc5Uw3QbCQ/CBV/AXqOR8mt03B6GJmRbhWopE8GzRfEpn+k0ZuWywxW+5QZsffhmFDY1J6ohqJo+eMuw==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      webpack: ^5.47.0
+      webpack: '5'
     dependencies:
       tapable: 2.2.1
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -34411,7 +34417,7 @@ packages:
     resolution: {integrity: sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
+      webpack: '5'
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   browserify-zlib: 0.2.0
   '@types/webpack': '5'
@@ -12,7 +8,7 @@ overrides:
   webpack: '5'
   tslib: 2.1.0
 
-packageExtensionsChecksum: 769402dc957b3bd672d434d157a19e86
+packageExtensionsChecksum: 234f976e1d4970c786ebd2aca0fd682a
 
 importers:
 
@@ -7895,11 +7891,11 @@ packages:
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
-      '@types/webpack': '5'
+      '@types/webpack': 4.x || 5.x
       react-refresh: '>=0.10.0 <1.0.0'
       sockjs-client: ^1.4.0
       type-fest: '>=0.17.0 <4.0.0'
-      webpack: '5'
+      webpack: '>=4.43.0 <6.0.0'
       webpack-dev-server: 3.x || 4.x
       webpack-hot-middleware: 2.x
       webpack-plugin-serve: 0.x || 1.x
@@ -7935,11 +7931,11 @@ packages:
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
-      '@types/webpack': '5'
+      '@types/webpack': 4.x || 5.x
       react-refresh: '>=0.10.0 <1.0.0'
       sockjs-client: ^1.4.0
       type-fest: '>=0.17.0 <4.0.0'
-      webpack: '5'
+      webpack: '>=4.43.0 <6.0.0'
       webpack-dev-server: 3.x || 4.x
       webpack-hot-middleware: 2.x
       webpack-plugin-serve: 0.x || 1.x
@@ -9639,7 +9635,7 @@ packages:
   /@statoscope/webpack-plugin@5.24.0(webpack@5.75.0):
     resolution: {integrity: sha512-8GX0ULmvwZRAqQClLMdzV1L/Y9PBJZTwBTXiiKzU4+vypRiI7VA+fz9aZ2XGWErVonXbrIvclj2IAQMbz/z2YQ==}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@statoscope/report-writer': 5.22.0
@@ -9658,7 +9654,7 @@ packages:
   /@statoscope/webpack-stats-extension-compressed@5.24.0(webpack@5.75.0):
     resolution: {integrity: sha512-yJyYo/TC393MZcA/txnd/37WubSdGNpVAncFlifVtJoGgsD9GrqltN8aUiaVPBDy/r4N4qP9+8T6OQ/Ha4J4DA==}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       '@statoscope/stats': 5.14.1
       '@statoscope/stats-extension-compressed': 5.24.0
@@ -9669,7 +9665,7 @@ packages:
   /@statoscope/webpack-stats-extension-package-info@5.24.0(webpack@5.75.0):
     resolution: {integrity: sha512-AXtYSbvyyFdgn1H/bnE2gu0oEhKBiHbeZA/gCJM+hEWOwGWnz61+qiPxYj2QnOnXN8XmjHho3jf0Gd4eW3dJfw==}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       '@statoscope/stats': 5.14.1
       '@statoscope/stats-extension-package-info': 5.24.0
@@ -10935,7 +10931,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       typescript: '*'
-      webpack: '5'
+      webpack: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -11229,7 +11225,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       typescript: '*'
-      webpack: '5'
+      webpack: '*'
     peerDependenciesMeta:
       '@storybook/builder-webpack5':
         optional: true
@@ -11686,7 +11682,7 @@ packages:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
-      webpack: '5'
+      webpack: '>= 4'
     dependencies:
       debug: 4.3.4
       endent: 2.0.1
@@ -14104,7 +14100,7 @@ packages:
     resolution: {integrity: sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -14114,7 +14110,7 @@ packages:
     resolution: {integrity: sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -14124,7 +14120,7 @@ packages:
     resolution: {integrity: sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: 5.x.x
       webpack-cli: 5.x.x
       webpack-dev-server: '*'
     peerDependenciesMeta:
@@ -15093,7 +15089,7 @@ packages:
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
-      webpack: '5'
+      webpack: '>=2'
     dependencies:
       '@babel/core': 7.21.0
       find-cache-dir: 3.3.2
@@ -15108,7 +15104,7 @@ packages:
     engines: {node: '>= 8.9'}
     peerDependencies:
       '@babel/core': ^7.0.0
-      webpack: '5'
+      webpack: '>=2'
     dependencies:
       '@babel/core': 7.22.9
       find-cache-dir: 3.3.2
@@ -15122,7 +15118,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
-      webpack: '5'
+      webpack: '>=5'
     dependencies:
       '@babel/core': 7.21.0
       find-cache-dir: 3.3.2
@@ -15718,7 +15714,6 @@ packages:
 
   /bplist-parser@0.1.1:
     resolution: {integrity: sha512-2AEM0FXy8ZxVLBuqX0hqt1gDwcnz2zygEkQ6zaD5Wko/sB9paUNwlpawrFtKeHUAQUOzjVy9AO4oeonqIHKA9Q==}
-    requiresBuild: true
     dependencies:
       big-integer: 1.6.51
     dev: true
@@ -16836,7 +16831,7 @@ packages:
     resolution: {integrity: sha512-wLXLIBwpul/ALcm7Aj+69X0pYT3BYt6DdPn3qrgBIh9YejV9Bju9ShhlAsjujLyWMo6SAweFIWaUoFmXZNuNrg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^5.1.0
     dependencies:
       schema-utils: 4.0.0
       serialize-javascript: 6.0.0
@@ -17253,7 +17248,7 @@ packages:
     resolution: {integrity: sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==}
     engines: {node: '>= 8.9.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       camelcase: 5.3.1
       cssesc: 3.0.0
@@ -17275,7 +17270,7 @@ packages:
     resolution: {integrity: sha512-0wyN5vXMQZu6BvjbrPdUJvkCzGEO24HC7IS7nW4llc6BBFC+zwR9CKtYGv63Puzsg10L/o12inMY5/2ByzfD6w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.27.0 || ^5.0.0
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.27)
       loader-utils: 2.0.4
@@ -17294,7 +17289,7 @@ packages:
     resolution: {integrity: sha512-oqGbbVcBJkm8QwmnNzrFrWTnudnRZC+1eXikLJl0n4ljcfotgRifpg2a1lKy8jTrc4/d9A/ap1GFq1jDKG7J+Q==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^5.0.0
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.27)
       postcss: 8.4.27
@@ -17316,7 +17311,7 @@ packages:
       csso: '*'
       esbuild: '*'
       lightningcss: '*'
-      webpack: '5'
+      webpack: ^5.0.0
     peerDependenciesMeta:
       '@parcel/css':
         optional: true
@@ -20226,7 +20221,7 @@ packages:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
@@ -20493,7 +20488,7 @@ packages:
       eslint: '>= 6'
       typescript: '>= 2.7'
       vue-template-compiler: '*'
-      webpack: '5'
+      webpack: '>= 4'
     peerDependenciesMeta:
       eslint:
         optional: true
@@ -20521,7 +20516,7 @@ packages:
       eslint: '>= 6'
       typescript: '>= 2.7'
       vue-template-compiler: '*'
-      webpack: '5'
+      webpack: '>= 4'
     peerDependenciesMeta:
       eslint:
         optional: true
@@ -21907,7 +21902,7 @@ packages:
     resolution: {integrity: sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==}
     engines: {node: '>=6.9'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       '@types/html-minifier-terser': 5.1.1
       '@types/tapable': 1.0.7
@@ -21930,7 +21925,7 @@ packages:
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^5.20.0
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -26017,7 +26012,7 @@ packages:
     resolution: {integrity: sha512-EdlUizq13o0Pd+uCp+WO/JpkLvHRVGt97RqfeGhXqAcorYo1ypJSpkV+WDT0vY/kmh/p7wRdJNJtuyK540PXDw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^5.0.0
     dependencies:
       schema-utils: 4.0.0
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -26205,7 +26200,7 @@ packages:
     resolution: {integrity: sha512-TP5NkCAV0OeFTry5k/d60KR7CkhTXL4kgJKtE3BzjgbDb5TGEPEhoKmHBrSa6r7Oc0sNbPLZhKD/TP2ig7A+/A==}
     peerDependencies:
       monaco-editor: 0.22.x || 0.23.x || 0.24.x
-      webpack: '5'
+      webpack: ^4.5.0 || 5.x
     dependencies:
       loader-utils: 2.0.4
       monaco-editor: 0.24.0
@@ -27861,7 +27856,7 @@ packages:
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       postcss: ^7.0.0 || ^8.0.1
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       cosmiconfig: 7.0.1
       klona: 2.0.5
@@ -27877,7 +27872,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       postcss: ^7.0.0 || ^8.0.1
-      webpack: '5'
+      webpack: ^5.0.0
     dependencies:
       cosmiconfig: 7.0.1
       klona: 2.0.5
@@ -27891,7 +27886,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       postcss: ^7.0.0 || ^8.0.1
-      webpack: '5'
+      webpack: ^5.0.0
     dependencies:
       cosmiconfig: 7.0.1
       klona: 2.0.5
@@ -28847,7 +28842,7 @@ packages:
     resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
@@ -30338,7 +30333,7 @@ packages:
       node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       sass: ^1.3.0
       sass-embedded: '*'
-      webpack: '5'
+      webpack: ^5.0.0
     peerDependenciesMeta:
       fibers:
         optional: true
@@ -31123,7 +31118,7 @@ packages:
     resolution: {integrity: sha512-Re0wX5CtM6gW7bZA64ONOfEPEhwbiSF/vz6e2GvadjuaPrQcHTQdRGsD8+BE7iUOysXH8tIenkPCQBEcspXsNg==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^1 || ^2 || ^3 || ^4 || ^5
     dependencies:
       chalk: 4.1.2
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -31582,7 +31577,7 @@ packages:
     resolution: {integrity: sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==}
     engines: {node: '>= 8.9.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.0
@@ -31593,7 +31588,7 @@ packages:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
@@ -31604,7 +31599,7 @@ packages:
     resolution: {integrity: sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^5.0.0
     dependencies:
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
 
@@ -32158,7 +32153,7 @@ packages:
     resolution: {integrity: sha512-jTgXh40RnvOrLQNgIkwEKnQ8rmHjHK4u+6UBEi+W+FPmvb+uo+chJXntKe7/3lW5mNysgSWD60KyesnhW8D6MQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       cacache: 15.0.5
       find-cache-dir: 3.3.2
@@ -32181,7 +32176,7 @@ packages:
       '@swc/core': '*'
       esbuild: '*'
       uglify-js: '*'
-      webpack: '5'
+      webpack: ^5.1.0
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -32531,7 +32526,7 @@ packages:
     engines: {node: '>=12.0.0'}
     peerDependencies:
       typescript: '*'
-      webpack: '5'
+      webpack: ^5.0.0
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.10.0
@@ -33135,7 +33130,6 @@ packages:
   /untildify@2.1.0:
     resolution: {integrity: sha512-sJjbDp2GodvkB0FZZcn7k6afVisqX5BZD7Yq3xp4nN2O15BBK0cLm3Vwn2vQaF7UDS0UUsrQMkkplmDI5fskig==}
     engines: {node: '>=0.10.0'}
-    requiresBuild: true
     dependencies:
       os-homedir: 1.0.2
     dev: true
@@ -33244,7 +33238,7 @@ packages:
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       file-loader: '*'
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       file-loader:
         optional: true
@@ -33992,7 +33986,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@webpack-cli/generators': '*'
-      webpack: '5'
+      webpack: 5.x.x
       webpack-bundle-analyzer: '*'
       webpack-dev-server: '*'
     peerDependenciesMeta:
@@ -34024,7 +34018,7 @@ packages:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
     engines: {node: '>= 6'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       memory-fs: 0.4.1
       mime: 2.6.0
@@ -34038,7 +34032,7 @@ packages:
     resolution: {integrity: sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==}
     engines: {node: '>= v10.23.3'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       colorette: 1.4.0
       mem: 8.1.1
@@ -34053,7 +34047,7 @@ packages:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       colorette: 2.0.19
       memfs: 3.4.12
@@ -34067,7 +34061,7 @@ packages:
     engines: {node: '>= 12.13.0'}
     hasBin: true
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.37.0 || ^5.0.0
       webpack-cli: '*'
     peerDependenciesMeta:
       webpack-cli:
@@ -34114,7 +34108,7 @@ packages:
     resolution: {integrity: sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==}
     engines: {node: '>= 4.3 < 5.0.0 || >= 5.10'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
     dev: true
@@ -34140,7 +34134,7 @@ packages:
     resolution: {integrity: sha512-8RQfMAdc5Uw3QbCQ/CBV/AXqOR8mt03B6GJmRbhWopE8GzRfEpn+k0ZuWywxW+5QZsffhmFDY1J6ohqJo+eMuw==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
       webpack: 5.75.0(esbuild@0.17.14)(webpack-cli@5.0.1)
@@ -34417,7 +34411,7 @@ packages:
     resolution: {integrity: sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
-      webpack: '5'
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1


### PR DESCRIPTION
Closes [#1267](https://github.com/sourcegraph/cody/issues/1267)

Fixes an issue where the Token creation routes don't have the logic to check if the user has completed the post-signup survey, leading to scenarios where, when signing into Sourcegraph for the first time to create a token, the user wouldn't be asked to complete the quick survey.

## Test plan

Local verification by redirecting to the token creation page on sign-in

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
