### PR TITLE
ctags actions: only upload when a change to ctags nix is pushed to main

### DIFF
--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -36,8 +36,8 @@ jobs:
         name: Rename an prepare for upload
         run: |
           mkdir -p dist
-          cp -R -L ./result/bin/* dist/
-          ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+          cp -R -L ./result/bin/universal-ctags-* dist/
+          ls dist/ | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
@@ -72,9 +72,8 @@ jobs:
         name: Rename an prepare for upload
         run: |
           mkdir -p dist
-          cp -R -L ./result/bin/* dist/
-          ls -la dist/
-          ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+          cp -R -L ./result/bin/universal-ctags-* dist/
+          ls dist/ | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
@@ -108,9 +107,8 @@ jobs:
         name: Rename an prepare for upload
         run: |
           mkdir -p dist
-          cp -R -L ./result/bin/* dist/
-          ls -la dist/
-          ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+          cp -R -L ./result/bin/universal-ctags-* dist/
+          ls dist/ | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -31,19 +31,25 @@ jobs:
         name: Run `nix build`
         run: |
           nix build .#ctags
-          ls ./result/bin/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
           sudo codesign --force -s - ./result/bin/universal-ctags-*
+      - id: 'rename-and-upload'
+        name: Rename an prepare for upload
+        run: |
+          mkdir -p dist
+          cp -r ./result/bin/ dist/
+          ls dist/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+          shasum -a 256 ./result/bin/universal-ctags-*
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
-          shasum -a 256 ./result/bin/universal-ctags-*
+          shasum -a 256 ./dist/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         # github.head_ref is only available for pull requests
         # if the event type is not pull_requet we have to use github.ref_name
         if: ${{ github.ref_name == 'main' }}
         with:
-          path: './result/bin/'
+          path: './dist/'
           destination: 'universal_ctags/x86_64-darwin/'
           glob: 'universal-ctags-*'
   aarch64-darwin:
@@ -62,19 +68,25 @@ jobs:
         name: Run `nix build`
         run: |
           nix build .#ctags-aarch64-darwin
-          ls ./result/bin/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
           sudo codesign --force -s - ./result/bin/universal-ctags-*
+      - id: 'rename-and-upload'
+        name: Rename an prepare for upload
+        run: |
+          mkdir -p dist
+          cp -r ./result/bin/ dist/
+          ls dist/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+          shasum -a 256 ./result/bin/universal-ctags-*
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
-          shasum -a 256 ./result/bin/universal-ctags-*
+          shasum -a 256 ./dist/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         # github.head_ref is only available for pull requests
         # if the event type is not pull_requet we have to use github.ref_name
         if: ${{ github.ref_name == 'main' }}
         with:
-          path: './result/bin/'
+          path: './dist/'
           destination: 'universal_ctags/aarch64-darwin'
           glob: 'universal-ctags-*'
   x86_64-linux:
@@ -93,17 +105,23 @@ jobs:
         name: Run `nix build`
         run: |
           nix build .#ctags
-          ls ./result/bin/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+      - id: 'rename-and-upload'
+        name: Rename an prepare for upload
+        run: |
+          mkdir -p dist
+          cp -r ./result/bin/ dist/
+          ls dist/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+          shasum -a 256 ./result/bin/universal-ctags-*
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
-          sha256sum ./result/bin/universal-ctags-*
+          shasum -a 256 ./dist/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         # github.head_ref is only available for pull requests
         # if the event type is not pull_requet we have to use github.ref_name
         if: ${{ github.ref_name == 'main' }}
         with:
-          path: './result/bin/'
+          path: './dist/'
           destination: 'universal_ctags/x86_64-linux'
           glob: 'universal-ctags-*'

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -37,8 +37,7 @@ jobs:
         run: |
           mkdir -p dist
           cp -r ./result/bin/ dist/
-          ls dist/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
-          shasum -a 256 ./result/bin/universal-ctags-*
+          ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
@@ -74,8 +73,8 @@ jobs:
         run: |
           mkdir -p dist
           cp -r ./result/bin/ dist/
-          ls dist/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
-          shasum -a 256 ./result/bin/universal-ctags-*
+          ls -la dist/
+          ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
@@ -110,8 +109,8 @@ jobs:
         run: |
           mkdir -p dist
           cp -r ./result/bin/ dist/
-          ls dist/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
-          shasum -a 256 ./result/bin/universal-ctags-*
+          ls -la dist/
+          ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           mkdir -p dist
           cp -R -L ./result/bin/universal-ctags-* dist/
-          ls dist/ | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+          cd dist/ && ls | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
@@ -73,7 +73,7 @@ jobs:
         run: |
           mkdir -p dist
           cp -R -L ./result/bin/universal-ctags-* dist/
-          ls dist/ | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+          cd dist/ && ls | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
@@ -108,7 +108,7 @@ jobs:
         run: |
           mkdir -p dist
           cp -R -L ./result/bin/universal-ctags-* dist/
-          ls dist/ | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
+          cd dist/ && ls | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -36,6 +36,9 @@ jobs:
         name: Show hash of ctags
         run: |
           shasum -a 256 ./result/bin/universal-ctags-*
+          echo "${GITHUB_REF_NAME}"
+          echo "${GITHUB_REF_NAME}"
+          env
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
@@ -64,6 +67,8 @@ jobs:
         name: Show hash of ctags
         run: |
           shasum -a 256 ./result/bin/universal-ctags-*
+          echo "${GITHUB_REF_NAME}"
+          env
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
@@ -91,6 +96,8 @@ jobs:
         name: Show hash of ctags
         run: |
           sha256sum ./result/bin/universal-ctags-*
+          echo "${GITHUB_REF_NAME}"
+          env
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -36,7 +36,7 @@ jobs:
         name: Rename an prepare for upload
         run: |
           mkdir -p dist
-          cp -r ./result/bin/ dist/
+          cp -r ./result/bin/* dist/
           ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
@@ -72,7 +72,7 @@ jobs:
         name: Rename an prepare for upload
         run: |
           mkdir -p dist
-          cp -r ./result/bin/ dist/
+          cp -r ./result/bin/* dist/
           ls -la dist/
           ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
@@ -108,7 +108,7 @@ jobs:
         name: Rename an prepare for upload
         run: |
           mkdir -p dist
-          cp -r ./result/bin/ dist/
+          cp -r ./result/bin/* dist/
           ls -la dist/
           ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -36,7 +36,7 @@ jobs:
         name: Rename an prepare for upload
         run: |
           mkdir -p dist
-          cp -r ./result/bin/* dist/
+          cp -R -L ./result/bin/* dist/
           ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
@@ -72,7 +72,7 @@ jobs:
         name: Rename an prepare for upload
         run: |
           mkdir -p dist
-          cp -r ./result/bin/* dist/
+          cp -R -L ./result/bin/* dist/
           ls -la dist/
           ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
@@ -108,7 +108,7 @@ jobs:
         name: Rename an prepare for upload
         run: |
           mkdir -p dist
-          cp -r ./result/bin/* dist/
+          cp -R -L ./result/bin/* dist/
           ls -la dist/
           ls 'dist/universal-ctags-*' | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -36,9 +36,9 @@ jobs:
         name: Show hash of ctags
         run: |
           shasum -a 256 ./result/bin/universal-ctags-*
-          echo "${GITHUB_REF_NAME}"
-          echo "${GITHUB_REF_NAME}"
-          env
+          echo "1. ${{ github.ref_name }}"
+          echo "2. ${{ github.head_ref }}"
+          echo "3. ${{ github.ref_name || github.head_ref }}"
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
@@ -67,8 +67,9 @@ jobs:
         name: Show hash of ctags
         run: |
           shasum -a 256 ./result/bin/universal-ctags-*
-          echo "${GITHUB_REF_NAME}"
-          env
+          echo "1. ${{ github.ref_name }}"
+          echo "2. ${{ github.head_ref }}"
+          echo "3. ${{ github.ref_name || github.head_ref }}"
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
@@ -96,8 +97,9 @@ jobs:
         name: Show hash of ctags
         run: |
           sha256sum ./result/bin/universal-ctags-*
-          echo "${GITHUB_REF_NAME}"
-          env
+          echo "1. ${{ github.ref_name }}"
+          echo "2. ${{ github.head_ref }}"
+          echo "3. ${{ github.ref_name || github.head_ref }}"
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - 'dev/nix/ctags.nix'
     branches:
-        - 'main'
+        - 'wb/ctags-workflow'
   pull_request:
     paths:
       - 'dev/nix/ctags.nix'
@@ -38,7 +38,7 @@ jobs:
           shasum -a 256 ./result/bin/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
-        if: ${{ env.GITHUB_REF_NAME == 'main' }}
+        if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/x86_64-darwin/'
@@ -66,7 +66,7 @@ jobs:
           shasum -a 256 ./result/bin/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
-        if: ${{ env.GITHUB_REF_NAME == 'main' }}
+        if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/aarch64-darwin'
@@ -93,7 +93,7 @@ jobs:
           sha256sum ./result/bin/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
-        if: ${{ env.GITHUB_REF_NAME == 'main' }}
+        if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/x86_64-linux'

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -1,6 +1,11 @@
 name: universal-ctags
 
 on:
+  push:
+    paths:
+      - 'dev/nix/ctags.nix'
+    branches:
+        - 'main'
   pull_request:
     paths:
       - 'dev/nix/ctags.nix'
@@ -11,7 +16,7 @@ permissions:
 
 jobs:
   x86_64-darwin:
-    name: Build ctags
+    name: Build ctags x86_64-darwin
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,14 +32,19 @@ jobs:
         run: |
           nix build .#ctags
           sudo codesign --force -s - ./result/bin/universal-ctags-*
+      - id: 'show-hash'
+        name: Show hash of ctags
+        run: |
+          sha256sum ./result/bin/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
+        if: ${{ env.GITHUB_REF_NAME == 'main' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/x86_64-darwin/'
           glob: 'universal-ctags-*'
   aarch64-darwin:
-    name: Build ctags
+    name: Build ctags aarch64-darwin
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -50,14 +60,19 @@ jobs:
         run: |
           nix build .#ctags-aarch64-darwin
           sudo codesign --force -s - ./result/bin/universal-ctags-*
+      - id: 'show-hash'
+        name: Show hash of ctags
+        run: |
+          sha256sum ./result/bin/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
+        if: ${{ env.GITHUB_REF_NAME == 'main' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/aarch64-darwin'
           glob: 'universal-ctags-*'
   x86_64-linux:
-    name: Build ctags
+    name: Build ctags x86_64-linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -72,8 +87,13 @@ jobs:
         name: Run `nix build`
         run: |
           nix build .#ctags
+      - id: 'show-hash'
+        name: Show hash of ctags
+        run: |
+          sha256sum ./result/bin/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
+        if: ${{ env.GITHUB_REF_NAME == 'main' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/x86_64-linux'

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -31,6 +31,7 @@ jobs:
         name: Run `nix build`
         run: |
           nix build .#ctags
+          ls ./result/bin/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
           sudo codesign --force -s - ./result/bin/universal-ctags-*
       - id: 'show-hash'
         name: Show hash of ctags
@@ -61,6 +62,7 @@ jobs:
         name: Run `nix build`
         run: |
           nix build .#ctags-aarch64-darwin
+          ls ./result/bin/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
           sudo codesign --force -s - ./result/bin/universal-ctags-*
       - id: 'show-hash'
         name: Show hash of ctags
@@ -91,6 +93,7 @@ jobs:
         name: Run `nix build`
         run: |
           nix build .#ctags
+          ls ./result/bin/universal-ctags-* | xargs -I{} mv {} "{}.$(git rev-parse --short HEAD)"
       - id: 'show-hash'
         name: Show hash of ctags
         run: |

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -35,7 +35,7 @@ jobs:
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
-          sha256sum ./result/bin/universal-ctags-*
+          shasum -a 256 ./result/bin/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         if: ${{ env.GITHUB_REF_NAME == 'main' }}
@@ -63,7 +63,7 @@ jobs:
       - id: 'show-hash'
         name: Show hash of ctags
         run: |
-          sha256sum ./result/bin/universal-ctags-*
+          shasum -a 256 ./result/bin/universal-ctags-*
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         if: ${{ env.GITHUB_REF_NAME == 'main' }}

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -40,7 +40,7 @@ jobs:
         uses: 'google-github-actions/upload-cloud-storage@v1'
         # github.head_ref is only available for pull requests
         # if the event type is not pull_requet we have to use github.ref_name
-        if: ${{ github.head_ref == 'wb/ctags-workflow' }}
+        if: ${{ github.ref_name == 'main' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/x86_64-darwin/'
@@ -70,7 +70,7 @@ jobs:
         uses: 'google-github-actions/upload-cloud-storage@v1'
         # github.head_ref is only available for pull requests
         # if the event type is not pull_requet we have to use github.ref_name
-        if: ${{ github.head_ref == 'wb/ctags-workflow' }}
+        if: ${{ github.ref_name == 'main' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/aarch64-darwin'
@@ -99,7 +99,7 @@ jobs:
         uses: 'google-github-actions/upload-cloud-storage@v1'
         # github.head_ref is only available for pull requests
         # if the event type is not pull_requet we have to use github.ref_name
-        if: ${{ github.head_ref == 'wb/ctags-workflow' }}
+        if: ${{ github.ref_name == 'main' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/x86_64-linux'

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -36,12 +36,11 @@ jobs:
         name: Show hash of ctags
         run: |
           shasum -a 256 ./result/bin/universal-ctags-*
-          echo "1. ${{ github.ref_name }}"
-          echo "2. ${{ github.head_ref }}"
-          echo "3. ${{ github.ref_name || github.head_ref }}"
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
-        if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
+        # github.head_ref is only available for pull requests
+        # if the event type is not pull_requet we have to use github.ref_name
+        if: ${{ github.head_ref == 'wb/ctags-workflow' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/x86_64-darwin/'
@@ -67,12 +66,11 @@ jobs:
         name: Show hash of ctags
         run: |
           shasum -a 256 ./result/bin/universal-ctags-*
-          echo "1. ${{ github.ref_name }}"
-          echo "2. ${{ github.head_ref }}"
-          echo "3. ${{ github.ref_name || github.head_ref }}"
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
-        if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
+        # github.head_ref is only available for pull requests
+        # if the event type is not pull_requet we have to use github.ref_name
+        if: ${{ github.head_ref == 'wb/ctags-workflow' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/aarch64-darwin'
@@ -97,12 +95,11 @@ jobs:
         name: Show hash of ctags
         run: |
           sha256sum ./result/bin/universal-ctags-*
-          echo "1. ${{ github.ref_name }}"
-          echo "2. ${{ github.head_ref }}"
-          echo "3. ${{ github.ref_name || github.head_ref }}"
       - id: 'upload-file'
         uses: 'google-github-actions/upload-cloud-storage@v1'
-        if: ${{ env.GITHUB_REF_NAME == 'wb/ctags-workflow' }}
+        # github.head_ref is only available for pull requests
+        # if the event type is not pull_requet we have to use github.ref_name
+        if: ${{ github.head_ref == 'wb/ctags-workflow' }}
         with:
           path: './result/bin/'
           destination: 'universal_ctags/x86_64-linux'

--- a/dev/nix/ctags.nix
+++ b/dev/nix/ctags.nix
@@ -18,6 +18,7 @@ let
   stdenv = pkgsStatic.stdenv;
 in
 # yoinked from github.com/nixos/nixpkgs
+# small change to trigger workflow
 unNixifyDylibs { inherit pkgs; } (stdenv.mkDerivation rec {
   pname = "universal-ctags";
   version = "5.9.20220403.0";


### PR DESCRIPTION
Small improvements:
* have the platform in the job name
* print out the hashes of the binaries
* only upload a new binary if a commit it pushed to main


## Test plan
A bit hard to test but:
* make a small change to `dev/nix/ctags.nix` and see:
** it shouldn't upload anything
** print out the hashes
![Screenshot 2023-10-03 at 11 25 46](https://github.com/sourcegraph/sourcegraph/assets/1001709/a4bf3539-4712-4ac5-ad97-352872df3b2c)

