### PR TITLE
search: exhaustive panic on uploadstore error

### DIFF
--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -400,7 +400,6 @@ func writeSearchJobCSV(ctx context.Context, iter *iterator.Iterator[string], upl
 	writeKey := func(key string, skipHeader bool) (int64, error) {
 		rc, err := uploadStore.Get(ctx, key)
 		if err != nil {
-			_ = rc.Close()
 			return 0, err
 		}
 		defer rc.Close()


### PR DESCRIPTION
If we fail to get from the upload store it would result in a panic due to trying to close the reader. However, the only practical way to trigger this path is to cancel the download request, which means the user luckily wouldn't see this panic.

Test Plan: go test to ensure nothing regresses further. Otherwise I am relying on just code review.
