### PR TITLE
ctags: update universal-ctags sha

### DIFF
--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -67,7 +67,7 @@ def tool_deps():
 
     http_file(
         name = "universal-ctags-darwin-arm64",
-        sha256 = "b771e522c1d5a4f40ffdfa03400637f5e0dfba8caa0bc9038574b13b8f232a84",
+        sha256 = "6631f0bbd65cdedc155fcd9e17c8c31102aeffc78e2438799d4fb43297c5d473",
         url = "https://storage.googleapis.com/universal_ctags/aarch64-darwin/bin/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )


### PR DESCRIPTION
The universal-ctags for arm darwin isn't stable, and a new binary has been uploaded replacing the old one which caused the sha to be updated. This is being fixed in #57296.

Part of https://github.com/sourcegraph/devx-support/issues/274
## Test plan
```
curl -L -o universal_ctags https://storage.googleapis.com/universal_ctags/aarch64-darwin/bin/universal-ctags-5.9.20220403.0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 2612k    0 2612k    0     0  1090k      0 --:--:--  0:00:02 --:--:-- 1093k

sourcegraph on  wb/update-ctags-sha [$?] via 🐹 v1.20.8 took 2s
❯ sha256sum universal_ctags
6631f0bbd65cdedc155fcd9e17c8c31102aeffc78e2438799d4fb43297c5d473  universal_ctags
```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
