### PR TITLE
gitserver: Prevent concurrent writes to errs

### DIFF
--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -45,7 +45,6 @@ go_library(
         "@com_github_golang_groupcache//lru",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
-        "@com_github_sourcegraph_conc//:conc",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_go_diff//diff",
         "@com_github_sourcegraph_log//:log",

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/sourcegraph/conc"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/sourcegraph/go-diff/diff"
 	sglog "github.com/sourcegraph/log"
@@ -470,27 +469,26 @@ type SystemInfo struct {
 
 func (c *clientImplementor) SystemsInfo(ctx context.Context) ([]SystemInfo, error) {
 	addresses := c.clientSource.Addresses()
-	infos := make([]SystemInfo, 0, len(addresses))
-	wg := conc.NewWaitGroup()
-	var errs errors.MultiError
+
+	wg := pool.NewWithResults[SystemInfo]().WithErrors().WithContext(ctx)
+
 	for _, addr := range addresses {
 		addr := addr // capture addr
-		wg.Go(func() {
+		wg.Go(func(ctx context.Context) (SystemInfo, error) {
 			response, err := c.getDiskInfo(ctx, addr)
 			if err != nil {
-				errs = errors.Append(errs, err)
-				return
+				return SystemInfo{}, err
 			}
-			infos = append(infos, SystemInfo{
+			return SystemInfo{
 				Address:     addr.Address(),
 				FreeSpace:   response.GetFreeSpace(),
 				TotalSpace:  response.GetTotalSpace(),
 				PercentUsed: response.GetPercentUsed(),
-			})
+			}, nil
 		})
 	}
-	wg.Wait()
-	return infos, errs
+
+	return wg.Wait()
 }
 
 func (c *clientImplementor) SystemInfo(ctx context.Context, addr string) (SystemInfo, error) {
@@ -498,10 +496,12 @@ func (c *clientImplementor) SystemInfo(ctx context.Context, addr string) (System
 	if ac == nil {
 		return SystemInfo{}, errors.Newf("no client for address: %s", addr)
 	}
+
 	response, err := c.getDiskInfo(ctx, ac)
 	if err != nil {
 		return SystemInfo{}, nil
 	}
+
 	return SystemInfo{
 		Address:    ac.Address(),
 		FreeSpace:  response.FreeSpace,


### PR DESCRIPTION
This change switches to conc for the pooling, to prevent multiple go routines potentially writing to the same errs slice.

## Test plan

Manually checked the endpoint still works. 