### PR TITLE
gitserver: disk-info: make test hit two separate gitserver addresses

### DIFF
--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//semaphore",
@@ -98,5 +99,6 @@ go_test(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )


### PR DESCRIPTION
Depends on #57316 

When I run go test -race on this, I get the following (expected) race condition that @eseliger 's #57316 PR will fix. 

```
=== RUN   TestClient_SystemsInfo/GRPC
==================
WARNING: DATA RACE
Write at 0x00c000e40e9f by goroutine 112:
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func3.2.1.1()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1585 +0xe4
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.(*mockClient).DiskInfo()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1776 +0x74
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).getDiskInfo()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:519 +0xe0
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).SystemsInfo.func1()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:480 +0x74
  github.com/sourcegraph/conc/panics.(*Catcher).Try()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/panics/panics.go:23 +0x60
  github.com/sourcegraph/conc.(*WaitGroup).Go.func1()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/waitgroup.go:32 +0x74

Previous write at 0x00c000e40e9f by goroutine 111:
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func3.2.1.1()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1585 +0xe4
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.(*mockClient).DiskInfo()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1776 +0x74
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).getDiskInfo()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:519 +0xe0
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).SystemsInfo.func1()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:480 +0x74
  github.com/sourcegraph/conc/panics.(*Catcher).Try()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/panics/panics.go:23 +0x60
  github.com/sourcegraph/conc.(*WaitGroup).Go.func1()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/waitgroup.go:32 +0x74

Goroutine 112 (running) created at:
  github.com/sourcegraph/conc.(*WaitGroup).Go()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/waitgroup.go:30 +0xd4
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).SystemsInfo()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:479 +0x174
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func2()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1539 +0x78
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func3()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1594 +0x30c
  testing.tRunner()
      /Users/ggilmore/go/go1.20.5/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /Users/ggilmore/go/go1.20.5/src/testing/testing.go:1629 +0x40

Goroutine 111 (finished) created at:
  github.com/sourcegraph/conc.(*WaitGroup).Go()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/waitgroup.go:30 +0xd4
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).SystemsInfo()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:479 +0x174
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func2()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1539 +0x78
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func3()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1594 +0x30c
  testing.tRunner()
      /Users/ggilmore/go/go1.20.5/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /Users/ggilmore/go/go1.20.5/src/testing/testing.go:1629 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00044a420 by goroutine 112:
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).SystemsInfo.func1()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:485 +0x1fc
  github.com/sourcegraph/conc/panics.(*Catcher).Try()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/panics/panics.go:23 +0x60
  github.com/sourcegraph/conc.(*WaitGroup).Go.func1()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/waitgroup.go:32 +0x74

Previous write at 0x00c00044a420 by goroutine 111:
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).SystemsInfo.func1()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:485 +0x2b0
  github.com/sourcegraph/conc/panics.(*Catcher).Try()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/panics/panics.go:23 +0x60
  github.com/sourcegraph/conc.(*WaitGroup).Go.func1()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/waitgroup.go:32 +0x74

Goroutine 112 (running) created at:
  github.com/sourcegraph/conc.(*WaitGroup).Go()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/waitgroup.go:30 +0xd4
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).SystemsInfo()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:479 +0x174
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func2()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1539 +0x78
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func3()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1594 +0x30c
  testing.tRunner()
      /Users/ggilmore/go/go1.20.5/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /Users/ggilmore/go/go1.20.5/src/testing/testing.go:1629 +0x40

Goroutine 111 (finished) created at:
  github.com/sourcegraph/conc.(*WaitGroup).Go()
      /Users/ggilmore/go/pkg/mod/github.com/sourcegraph/conc@v0.2.0/waitgroup.go:30 +0xd4
  github.com/sourcegraph/sourcegraph/internal/gitserver.(*clientImplementor).SystemsInfo()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client.go:479 +0x174
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func2()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1539 +0x78
  github.com/sourcegraph/sourcegraph/internal/gitserver_test.TestClient_SystemsInfo.func3()
      /Users/ggilmore/dev/sourcegraph/internal/gitserver/client_test.go:1594 +0x30c
  testing.tRunner()
      /Users/ggilmore/go/go1.20.5/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /Users/ggilmore/go/go1.20.5/src/testing/testing.go:1629 +0x40
==================
    testing.go:1446: race detected during execution of test
    --- FAIL: TestClient_SystemsInfo/GRPC (0.00s)


```



## Test plan

This is adding unit tests