### PR TITLE
gitserver: Pass HTTPS remote URL password as env var

### DIFF
--- a/cmd/gitserver/internal/executil/BUILD.bazel
+++ b/cmd/gitserver/internal/executil/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//cmd/gitserver/internal/cacert",
         "//internal/conf",
+        "//internal/vcs",
         "//internal/wrexec",
         "//lib/errors",
         "//lib/process",
@@ -23,8 +24,10 @@ go_test(
     embed = [":executil"],
     deps = [
         "//internal/conf",
+        "//internal/vcs",
         "//schema",
         "@com_github_google_go_cmp//cmp",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/cmd/gitserver/internal/patch.go
+++ b/cmd/gitserver/internal/patch.go
@@ -127,16 +127,18 @@ func (s *Server) CreateCommitFromPatch(ctx context.Context, req protocol.CreateC
 
 	// Temporary logging command wrapper
 	prefix := fmt.Sprintf("%d %s ", atomic.AddUint64(&patchID, 1), repo)
-	run := func(cmd *exec.Cmd, reason string) ([]byte, error) {
+	run := func(cmd *exec.Cmd, reason string, isRemote bool) ([]byte, error) {
 		if !gitcli.IsAllowedGitCmd(logger, cmd.Args[1:], common.GitDir(tmpRepoDir)) {
 			return nil, errors.New("command not on allow list")
 		}
 
 		t := time.Now()
 
-		// Configure the command to be able to talk to a remote since one of our
-		// commands could be git push
-		executil.ConfigureRemoteGitCommand(cmd)
+		if isRemote {
+			// Configure the command to be able to talk to a remote since one of our
+			// commands could be git push
+			executil.ConfigureRemoteGitCommand(cmd, remoteURL)
+		}
 
 		out, err := s.recordingCommandFactory.Wrap(ctx, s.logger, cmd).CombinedOutput()
 		logger := logger.With(
@@ -166,7 +168,7 @@ func (s *Server) CreateCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Dir = tmpRepoDir
 	cmd.Env = append(os.Environ(), tmpGitPathEnv)
 
-	if _, err := run(cmd, "init tmp repo"); err != nil {
+	if _, err := run(cmd, "init tmp repo", false); err != nil {
 		return resp
 	}
 
@@ -174,7 +176,7 @@ func (s *Server) CreateCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Dir = tmpRepoDir
 	cmd.Env = append(os.Environ(), tmpGitPathEnv, altObjectsEnv)
 
-	if out, err := run(cmd, "basing staging on base rev"); err != nil {
+	if out, err := run(cmd, "basing staging on base rev", false); err != nil {
 		logger.Error("Failed to base the temporary repo on the base revision",
 			log.String("output", string(out)),
 		)
@@ -188,7 +190,7 @@ func (s *Server) CreateCommitFromPatch(ctx context.Context, req protocol.CreateC
 	cmd.Env = append(os.Environ(), tmpGitPathEnv, altObjectsEnv)
 	cmd.Stdin = patchReader
 
-	if out, err := run(cmd, "applying patch"); err != nil {
+	if out, err := run(cmd, "applying patch", false); err != nil {
 		logger.Error("Failed to apply patch", log.String("output", string(out)))
 		return resp
 	}
@@ -235,7 +237,7 @@ func (s *Server) CreateCommitFromPatch(ctx context.Context, req protocol.CreateC
 		fmt.Sprintf("GIT_AUTHOR_DATE=%v", req.CommitInfo.Date),
 	}...)
 
-	if out, err := run(cmd, "committing patch"); err != nil {
+	if out, err := run(cmd, "committing patch", false); err != nil {
 		logger.Error("Failed to commit patch.", log.String("output", string(out)))
 		return resp
 	}
@@ -320,7 +322,7 @@ func (s *Server) CreateCommitFromPatch(ctx context.Context, req protocol.CreateC
 				)
 			}
 
-			if out, err = run(cmd, "pushing ref"); err != nil {
+			if out, err = run(cmd, "pushing ref", true); err != nil {
 				logger.Error("Failed to push", log.String("commit", cmtHash), log.String("output", string(out)))
 				return resp
 			}
@@ -332,7 +334,7 @@ func (s *Server) CreateCommitFromPatch(ctx context.Context, req protocol.CreateC
 		cmd = exec.CommandContext(ctx, "git", "update-ref", "--", ref, cmtHash)
 		cmd.Dir = repoGitDir
 
-		if out, err = run(cmd, "creating ref"); err != nil {
+		if out, err = run(cmd, "creating ref", false); err != nil {
 			logger.Error("Failed to create ref for commit.", log.String("commit", cmtHash), log.String("output", string(out)))
 			return resp
 		}

--- a/cmd/gitserver/internal/server.go
+++ b/cmd/gitserver/internal/server.go
@@ -1282,7 +1282,7 @@ func setHEAD(ctx context.Context, logger log.Logger, rcf *wrexec.RecordingComman
 	r := urlredactor.New(remoteURL)
 
 	// Configure the command to be able to talk to a remote.
-	executil.ConfigureRemoteGitCommand(cmd)
+	executil.ConfigureRemoteGitCommand(cmd, remoteURL)
 
 	output, err := rcf.WrapWithRepoName(ctx, logger, repoName, cmd).WithRedactorFunc(r.Redact).CombinedOutput()
 	if err != nil {

--- a/cmd/gitserver/internal/vcssyncer/git.go
+++ b/cmd/gitserver/internal/vcssyncer/git.go
@@ -56,7 +56,7 @@ func (s *gitRepoSyncer) IsCloneable(ctx context.Context, repoName api.RepoName, 
 	cmd := exec.CommandContext(ctx, "git", args...)
 
 	// Configure the command to be able to talk to a remote.
-	executil.ConfigureRemoteGitCommand(cmd)
+	executil.ConfigureRemoteGitCommand(cmd, remoteURL)
 
 	out, err := s.recordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repoName, cmd).WithRedactorFunc(r.Redact).CombinedOutput()
 	if err != nil {
@@ -97,7 +97,7 @@ func (s *gitRepoSyncer) Clone(ctx context.Context, repo api.RepoName, remoteURL 
 	}
 	// see issue #7322: skip LFS content in repositories with Git LFS configured.
 	cmd.Env = append(cmd.Env, "GIT_LFS_SKIP_SMUDGE=1")
-	executil.ConfigureRemoteGitCommand(cmd)
+	executil.ConfigureRemoteGitCommand(cmd, remoteURL)
 
 	tryWrite(s.logger, progressWriter, "Fetching remote contents\n")
 	redactor := urlredactor.New(remoteURL)
@@ -121,7 +121,7 @@ func (s *gitRepoSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, repoName 
 
 	if configRemoteOpts {
 		// Configure the command to be able to talk to a remote.
-		executil.ConfigureRemoteGitCommand(cmd)
+		executil.ConfigureRemoteGitCommand(cmd, remoteURL)
 	}
 
 	output, err := s.recordingCommandFactory.WrapWithRepoName(ctx, log.NoOp(), repoName, cmd).WithRedactorFunc(r.Redact).CombinedOutput()


### PR DESCRIPTION
This change feeds git the HTTPS URL user:password part via env vars through an inline shell script. Before, the password would be part of the command args, which is viewable in ps, top and so forth. Now, the secret can no longer be copied from the output of top.

Thanks to Keegan for the suggestion to use an inline script and an env var!

Closes https://github.com/sourcegraph/security-issues/issues/244

Closes https://github.com/sourcegraph/sourcegraph/issues/56810

## Test plan

CI integration tests, manually verified that clones, conn checks and so forth still work locally. Also verified that in `top` the credentials no longer show up, and no local credential helper is invoked. We believe now is the best time to merge such a change, so we have the longest possible period of us dogfooding this before a release goes out. 