### PR TITLE
Add docs for the new custom commands mode property

### DIFF
--- a/doc/cody/custom-commands.md
+++ b/doc/cody/custom-commands.md
@@ -158,6 +158,20 @@ Type: `string`
 
 Example: `"Summarize the given git changes in 3-5 sentences"`
 
+#### `commands.<id>.mode`
+
+The interaction mode to use. Allows you to choose if the command add to the current Cody chat, starts a new inline chat, or inserts/replaces code directly in the editor.
+
+Type: `string`
+
+Default: `"ask"`
+
+Values:
+- `"ask"` — Focus the chat view and add to the current chat
+- `"inline"` — Start a new inline chat
+- `"insert"` — Insert the response above the code
+- `"replace"` — Replace the code with the response
+
 #### `commands.<id>.context`
 
 Optional context data to generate and pass to Cody.

--- a/doc/cody/custom-commands.md
+++ b/doc/cody/custom-commands.md
@@ -160,7 +160,7 @@ Example: `"Summarize the given git changes in 3-5 sentences"`
 
 #### `commands.<id>.mode`
 
-The interaction mode to use. Allows you to choose if the command add to the current Cody chat, starts a new inline chat, or inserts/replaces code directly in the editor.
+The interaction mode to use.
 
 Type: `string`
 


### PR DESCRIPTION
This adds docs for the new `mode` custom commands property, which was introduced in sourcegraph/cody#1116.

## Test plan

- Updated doc
- Verified preview link

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@add-custom-command-mode-property)