### PR TITLE
gitserver: Consistently set HOME to .p4home for perforce

### DIFF
--- a/cmd/gitserver/internal/gitserverfs/fs.go
+++ b/cmd/gitserver/internal/gitserverfs/fs.go
@@ -25,13 +25,13 @@ const TempDirName = ".tmp"
 // and where it will store cache data.
 const P4HomeName = ".p4home"
 
-func MakeP4HomeDir(reposDir string) (p4home string, _ error) {
+func MakeP4HomeDir(reposDir string) (string, error) {
 	p4Home := filepath.Join(reposDir, P4HomeName)
 	// Ensure the directory exists
 	if err := os.MkdirAll(p4Home, os.ModePerm); err != nil {
 		return "", errors.Wrapf(err, "ensuring p4Home exists: %q", p4Home)
 	}
-	return p4home, nil
+	return p4Home, nil
 }
 
 func RepoDirFromName(reposDir string, name api.RepoName) common.GitDir {

--- a/cmd/gitserver/internal/patch.go
+++ b/cmd/gitserver/internal/patch.go
@@ -409,7 +409,12 @@ func (s *Server) shelveChangelist(ctx context.Context, req protocol.CreateCommit
 	repo := string(req.Repo)
 	baseCommit := string(req.BaseCommit)
 
-	p4user, p4passwd, p4host, p4depot, _ := perforce.DecomposePerforceRemoteURL(remoteURL)
+	p4home, err := gitserverfs.MakeP4HomeDir(s.ReposDir)
+	if err != nil {
+		return "", err
+	}
+
+	p4user, p4passwd, p4port, p4depot, _ := perforce.DecomposePerforceRemoteURL(remoteURL)
 
 	if p4depot == "" {
 		// the remoteURL was constructed without a path to indicate the depot
@@ -445,9 +450,10 @@ func (s *Server) shelveChangelist(ctx context.Context, req protocol.CreateCommit
 	commonEnv := append(os.Environ(), []string{
 		tmpGitPathEnv,
 		altObjectsEnv,
-		fmt.Sprintf("P4PORT=%s", p4host),
+		fmt.Sprintf("P4PORT=%s", p4port),
 		fmt.Sprintf("P4USER=%s", p4user),
 		fmt.Sprintf("P4PASSWD=%s", p4passwd),
+		fmt.Sprintf("HOME=%s", p4home),
 		fmt.Sprintf("P4CLIENT=%s", p4client),
 	}...)
 

--- a/cmd/gitserver/internal/perforce/cloneable.go
+++ b/cmd/gitserver/internal/perforce/cloneable.go
@@ -7,10 +7,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func IsDepotPathCloneable(ctx context.Context, p4port, p4user, p4passwd, depotPath string) error {
+func IsDepotPathCloneable(ctx context.Context, p4home, p4port, p4user, p4passwd, depotPath string) error {
 	// start with a test and set up trust if necessary
-	if err := P4TestWithTrust(ctx, p4port, p4user, p4passwd); err != nil {
-		return err
+	if err := P4TestWithTrust(ctx, p4home, p4port, p4user, p4passwd); err != nil {
+		return errors.Wrap(err, "checking perforce credentials")
 	}
 
 	// the path could be a path into a depot, or it could be just a depot
@@ -22,7 +22,7 @@ func IsDepotPathCloneable(ctx context.Context, p4port, p4user, p4passwd, depotPa
 	depot := strings.Split(strings.TrimLeft(depotPath, "/"), "/")[0]
 
 	// get a list of depots that match the supplied depot (if it's defined)
-	depots, err := P4Depots(ctx, p4port, p4user, p4passwd, depot)
+	depots, err := P4Depots(ctx, p4home, p4port, p4user, p4passwd, depot)
 	if err != nil {
 		return err
 	}

--- a/cmd/gitserver/internal/perforce/depots.go
+++ b/cmd/gitserver/internal/perforce/depots.go
@@ -44,7 +44,7 @@ type PerforceDepot struct {
 // P4Depots returns all of the depots to which the user has access on the host
 // and whose names match the given nameFilter, which can contain asterisks (*) for wildcards
 // if nameFilter is blank, return all depots
-func P4Depots(ctx context.Context, host, username, password, nameFilter string) ([]PerforceDepot, error) {
+func P4Depots(ctx context.Context, p4home, p4port, p4user, p4passwd, nameFilter string) ([]PerforceDepot, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -55,9 +55,10 @@ func P4Depots(ctx context.Context, host, username, password, nameFilter string) 
 		cmd = exec.CommandContext(ctx, "p4", "-Mj", "-ztag", "depots", "-e", nameFilter)
 	}
 	cmd.Env = append(os.Environ(),
-		"P4PORT="+host,
-		"P4USER="+username,
-		"P4PASSWD="+password,
+		"P4PORT="+p4port,
+		"P4USER="+p4user,
+		"P4PASSWD="+p4passwd,
+		"HOME="+p4home,
 	)
 
 	out, err := executil.RunCommandCombinedOutput(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd))

--- a/cmd/gitserver/internal/perforce/login.go
+++ b/cmd/gitserver/internal/perforce/login.go
@@ -15,21 +15,25 @@ import (
 )
 
 // P4TestWithTrust attempts to test the Perforce server and performs a trust operation when needed.
-func P4TestWithTrust(ctx context.Context, port, username, password string) error {
+func P4TestWithTrust(ctx context.Context, p4home, p4port, p4user, p4passwd string) error {
 	// Attempt to check connectivity, may be prompted to trust.
-	err := P4Test(ctx, port, username, password)
+	err := P4Test(ctx, p4home, p4port, p4user, p4passwd)
 	if err == nil {
 		return nil // The test worked, session still valid for the user
 	}
 
 	// If the output indicates that we have to run p4trust first, do that.
 	if strings.Contains(err.Error(), "To allow connection use the 'p4 trust' command.") {
-		err := P4Trust(ctx, port)
+		err := P4Trust(ctx, p4home, p4port)
 		if err != nil {
 			return errors.Wrap(err, "trust")
 		}
 		// Now attempt to run p4test again.
-		return P4Test(ctx, port, username, password)
+		err = P4Test(ctx, p4home, p4port, p4user, p4passwd)
+		if err != nil {
+			return errors.Wrap(err, "testing connection after trust")
+		}
+		return nil
 	}
 
 	// Something unexpected happened, bubble up the error
@@ -37,13 +41,14 @@ func P4TestWithTrust(ctx context.Context, port, username, password string) error
 }
 
 // P4Trust blindly accepts fingerprint of the Perforce server.
-func P4Trust(ctx context.Context, host string) error {
+func P4Trust(ctx context.Context, p4home, host string) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "p4", "trust", "-y", "-f")
 	cmd.Env = append(os.Environ(),
 		"P4PORT="+host,
+		"HOME="+p4home,
 	)
 
 	out, err := executil.RunCommandCombinedOutput(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd))
@@ -59,8 +64,8 @@ func P4Trust(ctx context.Context, host string) error {
 	return nil
 }
 
-// P4Test uses `p4 login -s` to test the Perforce connection: host, port, user, password.
-func P4Test(ctx context.Context, host, username, password string) error {
+// P4Test uses `p4 login -s` to test the Perforce connection: port, user, passwd.
+func P4Test(ctx context.Context, p4home, p4port, p4user, p4passwd string) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -70,9 +75,10 @@ func P4Test(ctx context.Context, host, username, password string) error {
 	// so it seems like the perfect alternative to `p4 ping`.
 	cmd := exec.CommandContext(ctx, "p4", "login", "-s")
 	cmd.Env = append(os.Environ(),
-		"P4PORT="+host,
-		"P4USER="+username,
-		"P4PASSWD="+password,
+		"P4PORT="+p4port,
+		"P4USER="+p4user,
+		"P4PASSWD="+p4passwd,
+		"HOME="+p4home,
 	)
 
 	out, err := executil.RunCommandCombinedOutput(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd))

--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/accesslog"
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/gitserverfs"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -280,6 +281,11 @@ func (gs *GRPCServer) P4Exec(req *proto.P4ExecRequest, ss proto.GitserverService
 		return status.Error(codes.InvalidArgument, fmt.Sprintf("subcommand %q is not allowed", subCommand))
 	}
 
+	p4home, err := gitserverfs.MakeP4HomeDir(gs.Server.ReposDir)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+
 	// Log which actor is accessing p4-exec.
 	//
 	// p4-exec is currently only used for fetching user based permissions information
@@ -291,7 +297,7 @@ func (gs *GRPCServer) P4Exec(req *proto.P4ExecRequest, ss proto.GitserverService
 	)
 
 	// Make sure credentials are valid before heavier operation
-	err := perforce.P4TestWithTrust(ss.Context(), req.GetP4Port(), req.GetP4User(), req.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ss.Context(), p4home, req.GetP4Port(), req.GetP4User(), req.GetP4Passwd())
 	if err != nil {
 		if ctxErr := ss.Context().Err(); ctxErr != nil {
 			return status.FromContextError(ctxErr).Err()
@@ -456,7 +462,12 @@ func (gs *GRPCServer) IsPerforcePathCloneable(ctx context.Context, req *proto.Is
 		return nil, status.Error(codes.InvalidArgument, "no DepotPath given")
 	}
 
-	err := perforce.IsDepotPathCloneable(ctx, req.GetP4Port(), req.GetP4User(), req.GetP4Passwd(), req.GetDepotPath())
+	p4home, err := gitserverfs.MakeP4HomeDir(gs.Server.ReposDir)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	err = perforce.IsDepotPathCloneable(ctx, p4home, req.GetP4Port(), req.GetP4User(), req.GetP4Passwd(), req.GetDepotPath())
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
@@ -465,7 +476,12 @@ func (gs *GRPCServer) IsPerforcePathCloneable(ctx context.Context, req *proto.Is
 }
 
 func (gs *GRPCServer) CheckPerforceCredentials(ctx context.Context, req *proto.CheckPerforceCredentialsRequest) (*proto.CheckPerforceCredentialsResponse, error) {
-	err := perforce.P4TestWithTrust(ctx, req.GetP4Port(), req.GetP4User(), req.GetP4Passwd())
+	p4home, err := gitserverfs.MakeP4HomeDir(gs.Server.ReposDir)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	err = perforce.P4TestWithTrust(ctx, p4home, req.GetP4Port(), req.GetP4User(), req.GetP4Passwd())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -177,7 +177,7 @@ func TestExecRequest(t *testing.T) {
 	db := dbmocks.NewMockDB()
 	gr := dbmocks.NewMockGitserverRepoStore()
 	db.GitserverReposFunc.SetDefaultReturn(gr)
-	reposDir := "/testroot"
+	reposDir := t.TempDir()
 	s := &Server{
 		Logger:            logtest.Scoped(t),
 		ObservationCtx:    observation.TestContextTB(t),
@@ -289,7 +289,7 @@ func TestServer_handleP4Exec(t *testing.T) {
 
 		s := &Server{
 			Logger:                  logger,
-			ReposDir:                "/testroot",
+			ReposDir:                t.TempDir(),
 			ObservationCtx:          observation.TestContextTB(t),
 			skipCloneForTests:       true,
 			DB:                      dbmocks.NewMockDB(),

--- a/cmd/gitserver/internal/vcssyncer/vcs_syncer_perforce.go
+++ b/cmd/gitserver/internal/vcssyncer/vcs_syncer_perforce.go
@@ -56,7 +56,7 @@ func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, _ api.RepoName, r
 		return errors.Wrap(err, "decompose")
 	}
 
-	return perforce.IsDepotPathCloneable(ctx, host, username, password, path)
+	return perforce.IsDepotPathCloneable(ctx, s.P4Home, host, username, password, path)
 }
 
 // CloneCommand returns the command to be executed for cloning a Perforce depot as a Git repository.
@@ -66,7 +66,7 @@ func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, remoteURL *vcs.U
 		return nil, errors.Wrap(err, "decompose")
 	}
 
-	err = perforce.P4TestWithTrust(ctx, p4port, username, password)
+	err = perforce.P4TestWithTrust(ctx, s.P4Home, p4port, username, password)
 	if err != nil {
 		return nil, errors.Wrap(err, "test with trust")
 	}
@@ -112,7 +112,7 @@ func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, _ a
 		return nil, errors.Wrap(err, "decompose")
 	}
 
-	err = perforce.P4TestWithTrust(ctx, host, username, password)
+	err = perforce.P4TestWithTrust(ctx, s.P4Home, host, username, password)
 	if err != nil {
 		return nil, errors.Wrap(err, "test with trust")
 	}
@@ -145,6 +145,7 @@ func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, _ a
 			"P4PORT="+host,
 			"P4USER="+username,
 			"P4PASSWD="+password,
+			"HOME="+s.P4Home,
 		)
 		dir.Set(cmd.Cmd)
 		if output, err := executil.RunCommandCombinedOutput(ctx, cmd); err != nil {


### PR DESCRIPTION
When running perforce commands, we should set HOME to the .p4home dir in our data directory. All other directories aren't writable in our default helm deployment, and writing a p4trust file to the actual users $HOME will break.

Closes https://github.com/sourcegraph/sourcegraph/issues/53268

Closes https://github.com/sourcegraph/sourcegraph/issues/56261

## Test plan

To test, I spun up a helm-based k8s deployment in the docker for mac k8s environment. First with the latest insiders images off main, and the issue from #53268 showed up for connecting to my locally hosted SSL enabled perforce server.
Then, built a new image with these fixes in, and the connection to the Perforce server no longer fails.
Also verified that the trust file is written at the expected path. 