### PR TITLE
Display all external accounts for each auth provider

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1995,6 +1995,7 @@ ts_project(
         "src/tracking/util.test.ts",
         "src/user/index.test.ts",
         "src/user/settings/auth/ExternalAccount.test.tsx",
+        "src/user/settings/auth/ExternalAccountsSignIn.test.tsx",
         "src/user/settings/profile/UserSettingsProfilePage.test.tsx",
         "src/user/settings/research/ProductResearch.test.tsx",
         "src/util/checkRequestAccessAllowed.test.ts",

--- a/client/web/src/user/settings/auth/ExternalAccount.test.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.test.tsx
@@ -9,6 +9,14 @@ import type { NormalizedExternalAccount } from './ExternalAccountsSignIn'
 const mockAccount: NormalizedExternalAccount = {
     name: 'Github',
     icon: ({ className }) => <GithubIcon className={className} />,
+    authProvider: {
+        serviceType: 'github',
+        displayName: 'github',
+        isBuiltin: false,
+        authenticationURL: 'https://example.com',
+        serviceID: '123',
+        clientID: '123',
+    },
 }
 
 describe('ExternalAccountConnectionDetails', () => {

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -60,7 +60,7 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
                     isOpen={isRemoveAccountModalOpen}
                 />
             )}
-            <AddGerritAccountModal
+            {isAddGerritAccountModalOpen && (<AddGerritAccountModal
                 serviceID={authProvider.serviceID}
                 onDidAdd={() => {
                     onDidAdd()
@@ -68,7 +68,7 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
                 }}
                 onDismiss={() => setIsGerritAccountModalOpen(false)}
                 isOpen={isAddGerritAccountModalOpen}
-            />
+            />)}
             <div className="align-self-center">
                 <AccountIcon className="mb-0 mr-2" />
             </div>

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -60,15 +60,17 @@ export const ExternalAccount: React.FunctionComponent<React.PropsWithChildren<Pr
                     isOpen={isRemoveAccountModalOpen}
                 />
             )}
-            {isAddGerritAccountModalOpen && (<AddGerritAccountModal
-                serviceID={authProvider.serviceID}
-                onDidAdd={() => {
-                    onDidAdd()
-                    setIsGerritAccountModalOpen(false)
-                }}
-                onDismiss={() => setIsGerritAccountModalOpen(false)}
-                isOpen={isAddGerritAccountModalOpen}
-            />)}
+            {isAddGerritAccountModalOpen && (
+                <AddGerritAccountModal
+                    serviceID={authProvider.serviceID}
+                    onDidAdd={() => {
+                        onDidAdd()
+                        setIsGerritAccountModalOpen(false)
+                    }}
+                    onDismiss={() => setIsGerritAccountModalOpen(false)}
+                    isOpen={isAddGerritAccountModalOpen}
+                />
+            )}
             <div className="align-self-center">
                 <AccountIcon className="mb-0 mr-2" />
             </div>

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react'
+
+import type { AuthProvider } from '../../../jscontext'
+
+import { ExternalAccountsSignIn } from './ExternalAccountsSignIn'
+import { UserExternalAccount } from './UserSettingsSecurityPage'
+
+const mockAccountsByServiceID: Partial<Record<string, UserExternalAccount[]>> = {
+    '123': [{
+        id: '1',
+        serviceID: '123',
+        serviceType: 'github',
+        publicAccountData: {
+            displayName: 'account1',
+            login: 'account1',
+            url: 'https://example.com/account1',
+        },
+        clientID: '123',
+    },
+    {
+        id: '2',
+        serviceID: '123',
+        serviceType: 'github',
+        publicAccountData: {
+            displayName: 'account2',
+            login: 'account2',
+            url: 'https://example.com/account2',
+        },
+        clientID: '123',
+    }]
+}
+
+const mockAuthProviders: AuthProvider[] = [
+    {
+        serviceType: 'github',
+        displayName: 'GitHub',
+        serviceID: '123',
+        clientID: '123',
+        isBuiltin: false,
+        authenticationURL: 'https://example.com',
+    },
+]
+
+describe('ExternalAccountsSignIn', () => {
+    test('renders multiple accounts correctly', () => {
+        const cmp = render(
+            <ExternalAccountsSignIn
+                accounts={mockAccountsByServiceID}
+                authProviders={mockAuthProviders}
+                onDidRemove={() => { }}
+                onDidAdd={() => { }}
+                onDidError={() => { }}
+            />
+        )
+        expect(cmp.asFragment()).toMatchSnapshot()
+    })
+})

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
@@ -3,10 +3,10 @@ import { render } from '@testing-library/react'
 import type { AuthProvider } from '../../../jscontext'
 
 import { ExternalAccountsSignIn } from './ExternalAccountsSignIn'
-import { UserExternalAccount } from './UserSettingsSecurityPage'
+import type { UserExternalAccount } from './UserSettingsSecurityPage'
 
-const mockAccountsByServiceID: Partial<Record<string, UserExternalAccount[]>> = {
-    '123': [
+const mockAccounts: UserExternalAccount[] =
+    [
         {
             id: '1',
             serviceID: '123',
@@ -29,8 +29,7 @@ const mockAccountsByServiceID: Partial<Record<string, UserExternalAccount[]>> = 
             },
             clientID: '123',
         },
-    ],
-}
+    ]
 
 const mockAuthProviders: AuthProvider[] = [
     {
@@ -47,7 +46,7 @@ describe('ExternalAccountsSignIn', () => {
     test('renders multiple accounts correctly', () => {
         const cmp = render(
             <ExternalAccountsSignIn
-                accounts={mockAccountsByServiceID}
+                accounts={mockAccounts}
                 authProviders={mockAuthProviders}
                 onDidRemove={() => {}}
                 onDidAdd={() => {}}

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
@@ -5,31 +5,30 @@ import type { AuthProvider } from '../../../jscontext'
 import { ExternalAccountsSignIn } from './ExternalAccountsSignIn'
 import type { UserExternalAccount } from './UserSettingsSecurityPage'
 
-const mockAccounts: UserExternalAccount[] =
-    [
-        {
-            id: '1',
-            serviceID: '123',
-            serviceType: 'github',
-            publicAccountData: {
-                displayName: 'account1',
-                login: 'account1',
-                url: 'https://example.com/account1',
-            },
-            clientID: '123',
+const mockAccounts: UserExternalAccount[] = [
+    {
+        id: '1',
+        serviceID: '123',
+        serviceType: 'github',
+        publicAccountData: {
+            displayName: 'account1',
+            login: 'account1',
+            url: 'https://example.com/account1',
         },
-        {
-            id: '2',
-            serviceID: '123',
-            serviceType: 'github',
-            publicAccountData: {
-                displayName: 'account2',
-                login: 'account2',
-                url: 'https://example.com/account2',
-            },
-            clientID: '123',
+        clientID: '123',
+    },
+    {
+        id: '2',
+        serviceID: '123',
+        serviceType: 'github',
+        publicAccountData: {
+            displayName: 'account2',
+            login: 'account2',
+            url: 'https://example.com/account2',
         },
-    ]
+        clientID: '123',
+    },
+]
 
 const mockAuthProviders: AuthProvider[] = [
     {

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.test.tsx
@@ -6,28 +6,30 @@ import { ExternalAccountsSignIn } from './ExternalAccountsSignIn'
 import { UserExternalAccount } from './UserSettingsSecurityPage'
 
 const mockAccountsByServiceID: Partial<Record<string, UserExternalAccount[]>> = {
-    '123': [{
-        id: '1',
-        serviceID: '123',
-        serviceType: 'github',
-        publicAccountData: {
-            displayName: 'account1',
-            login: 'account1',
-            url: 'https://example.com/account1',
+    '123': [
+        {
+            id: '1',
+            serviceID: '123',
+            serviceType: 'github',
+            publicAccountData: {
+                displayName: 'account1',
+                login: 'account1',
+                url: 'https://example.com/account1',
+            },
+            clientID: '123',
         },
-        clientID: '123',
-    },
-    {
-        id: '2',
-        serviceID: '123',
-        serviceType: 'github',
-        publicAccountData: {
-            displayName: 'account2',
-            login: 'account2',
-            url: 'https://example.com/account2',
+        {
+            id: '2',
+            serviceID: '123',
+            serviceType: 'github',
+            publicAccountData: {
+                displayName: 'account2',
+                login: 'account2',
+                url: 'https://example.com/account2',
+            },
+            clientID: '123',
         },
-        clientID: '123',
-    }]
+    ],
 }
 
 const mockAuthProviders: AuthProvider[] = [
@@ -47,9 +49,9 @@ describe('ExternalAccountsSignIn', () => {
             <ExternalAccountsSignIn
                 accounts={mockAccountsByServiceID}
                 authProviders={mockAuthProviders}
-                onDidRemove={() => { }}
-                onDidAdd={() => { }}
-                onDidError={() => { }}
+                onDidRemove={() => {}}
+                onDidAdd={() => {}}
+                onDidError={() => {}}
             />
         )
         expect(cmp.asFragment()).toMatchSnapshot()

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
@@ -44,12 +44,12 @@ const getNormalizedAccounts = (
 
     const { icon, title: name } = defaultExternalAccounts[authProvider.serviceType]
 
-    let normalizedAccounts: NormalizedExternalAccount[] = []
+    const normalizedAccounts: NormalizedExternalAccount[] = []
     const providerAccounts = accounts.filter(
         acc => acc.clientID === authProvider.clientID && acc.serviceID === authProvider.serviceID
     )
     for (const providerAccount of providerAccounts || []) {
-        let normalizedAccount: NormalizedExternalAccount = {
+        const normalizedAccount: NormalizedExternalAccount = {
             icon,
             name,
             authProvider,
@@ -85,12 +85,10 @@ export const ExternalAccountsSignIn: React.FunctionComponent<React.PropsWithChil
     onDidError,
     onDidAdd,
 }) => {
-    const accountGroups = authProviders.map(authProvider => {
-        return {
-            authProvider,
-            accounts: getNormalizedAccounts(accounts, authProvider),
-        }
-    })
+    const accountGroups = authProviders.map(authProvider => ({
+        authProvider,
+        accounts: getNormalizedAccounts(accounts, authProvider),
+    }))
     const accountsList = accountGroups
         .flatMap(group => group.accounts)
         .map(account => (

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
@@ -15,6 +15,7 @@ import styles from './ExternalAccountsSignIn.module.scss'
 export interface NormalizedExternalAccount {
     name: string
     icon: React.ComponentType<React.PropsWithChildren<{ className?: string }>>
+    authProvider: AuthProvider
     // some data may be missing if account is not setup
     external?: UserExternalAccount['publicAccountData'] & {
         id: string
@@ -29,36 +30,50 @@ interface Props {
     onDidAdd: () => void
 }
 
-const getNormalizedAccount = (
+const getNormalizedAccounts = (
     accounts: Partial<Record<string, UserExternalAccount[]>>,
     authProvider: AuthProvider
-): NormalizedExternalAccount | null => {
+): NormalizedExternalAccount[] => {
     if (
         authProvider.serviceType === 'builtin' ||
         authProvider.serviceType === 'http-header' ||
         authProvider.serviceType === 'sourcegraph-operator'
     ) {
-        return null
+        return []
     }
 
     const { icon, title: name } = defaultExternalAccounts[authProvider.serviceType]
 
-    const normalizedAccount: NormalizedExternalAccount = {
-        icon,
-        name,
-    }
-
-    const providerAccounts = accounts[authProvider.serviceID]
-
-    const providerAccount = providerAccounts?.find(acc => acc.clientID === authProvider.clientID)
-    if (providerAccount?.publicAccountData) {
-        normalizedAccount.external = {
-            id: providerAccount.id,
-            ...providerAccount.publicAccountData,
+    let normalizedAccounts: NormalizedExternalAccount[] = []
+    const providerAccounts = accounts[authProvider.serviceID]?.filter(acc => acc.clientID === authProvider.clientID)
+    for (const providerAccount of providerAccounts || []) {
+        let normalizedAccount: NormalizedExternalAccount = {
+            icon,
+            name,
+            authProvider,
         }
+
+        if (providerAccount?.publicAccountData) {
+            normalizedAccount.external = {
+                id: providerAccount.id,
+                ...providerAccount.publicAccountData,
+            }
+        }
+
+        normalizedAccounts.push(normalizedAccount)
     }
 
-    return normalizedAccount
+    if (normalizedAccounts.length === 0) {
+        return [
+            {
+                icon,
+                name,
+                authProvider,
+            },
+        ]
+    }
+
+    return normalizedAccounts
 }
 
 export const ExternalAccountsSignIn: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
@@ -67,34 +82,28 @@ export const ExternalAccountsSignIn: React.FunctionComponent<React.PropsWithChil
     onDidRemove,
     onDidError,
     onDidAdd,
-}) => (
-    <>
-        {authProviders && (
-            <ul className="list-group">
-                {authProviders.map(authProvider => {
-                    // if auth provider for this account doesn't exist -
-                    // don't display the account as an option
-                    const normAccount = getNormalizedAccount(accounts, authProvider)
-                    if (normAccount) {
-                        return (
-                            <li
-                                key={normAccount.external ? normAccount.external.id : authProvider.serviceID}
-                                className={classNames('list-group-item', styles.externalAccount)}
-                            >
-                                <ExternalAccount
-                                    account={normAccount}
-                                    authProvider={authProvider}
-                                    onDidRemove={onDidRemove}
-                                    onDidError={onDidError}
-                                    onDidAdd={onDidAdd}
-                                />
-                            </li>
-                        )
-                    }
-
-                    return null
-                })}
-            </ul>
-        )}
-    </>
-)
+}) => {
+    const accountGroups = authProviders.map(authProvider => {
+        return {
+            authProvider,
+            accounts: getNormalizedAccounts(accounts, authProvider),
+        }
+    })
+    const accountsList = accountGroups
+        .flatMap(group => group.accounts)
+        .map(account => (
+            <li
+                key={account.external ? account.external.id : account.authProvider.serviceID}
+                className={classNames('list-group-item', styles.externalAccount)}
+            >
+                <ExternalAccount
+                    account={account}
+                    authProvider={account.authProvider}
+                    onDidRemove={onDidRemove}
+                    onDidError={onDidError}
+                    onDidAdd={onDidAdd}
+                />
+            </li>
+        ))
+    return <>{authProviders && <ul className="list-group">{accountsList}</ul>}</>
+}

--- a/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccountsSignIn.tsx
@@ -8,7 +8,7 @@ import type { ErrorLike } from '@sourcegraph/common'
 import { defaultExternalAccounts } from '../../../components/externalAccounts/externalAccounts'
 
 import { ExternalAccount } from './ExternalAccount'
-import type { AccountsByServiceID, UserExternalAccount } from './UserSettingsSecurityPage'
+import type { UserExternalAccount } from './UserSettingsSecurityPage'
 
 import styles from './ExternalAccountsSignIn.module.scss'
 
@@ -23,7 +23,7 @@ export interface NormalizedExternalAccount {
 }
 
 interface Props {
-    accounts: AccountsByServiceID
+    accounts: UserExternalAccount[]
     authProviders: AuthProvider[]
     onDidRemove: (id: string, name: string) => void
     onDidError: (error: ErrorLike) => void
@@ -31,7 +31,7 @@ interface Props {
 }
 
 const getNormalizedAccounts = (
-    accounts: Partial<Record<string, UserExternalAccount[]>>,
+    accounts: UserExternalAccount[],
     authProvider: AuthProvider
 ): NormalizedExternalAccount[] => {
     if (
@@ -45,7 +45,9 @@ const getNormalizedAccounts = (
     const { icon, title: name } = defaultExternalAccounts[authProvider.serviceType]
 
     let normalizedAccounts: NormalizedExternalAccount[] = []
-    const providerAccounts = accounts[authProvider.serviceID]?.filter(acc => acc.clientID === authProvider.clientID)
+    const providerAccounts = accounts.filter(
+        acc => acc.clientID === authProvider.clientID && acc.serviceID === authProvider.serviceID
+    )
     for (const providerAccount of providerAccounts || []) {
         let normalizedAccount: NormalizedExternalAccount = {
             icon,

--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -45,7 +45,6 @@ type ServiceType = AuthProvider['serviceType']
 
 export type ExternalAccountsByType = Partial<Record<ServiceType, UserExternalAccount>>
 export type AuthProvidersByBaseURL = Partial<Record<string, AuthProvider>>
-export type AccountsByServiceID = Partial<Record<string, UserExternalAccount[]>>
 
 interface UserExternalAccountsResult {
     user: {
@@ -90,15 +89,6 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
     const setNewPasswordConfirmationField = (element: HTMLInputElement | null): void => {
         newPasswordConfirmationField = element
     }
-
-    // auth providers by service ID
-    const accountsByServiceID = accounts.fetched?.reduce((accumulator: AccountsByServiceID, account) => {
-        const accountArray = accumulator[account.serviceID] ?? []
-        accountArray.push(account)
-        accumulator[account.serviceID] = accountArray
-
-        return accumulator
-    }, {})
 
     useEffect(() => {
         eventLogger.logPageView('UserSettingsPassword')
@@ -209,10 +199,10 @@ export const UserSettingsSecurityPage: React.FunctionComponent<React.PropsWithCh
             )}
 
             {/* fetched external accounts */}
-            {accountsByServiceID && (
+            {accounts.fetched && (
                 <Container>
                     <ExternalAccountsSignIn
-                        accounts={accountsByServiceID}
+                        accounts={accounts.fetched}
                         authProviders={props.context.authProviders}
                         onDidError={handleError}
                         onDidRemove={onAccountRemoval}

--- a/client/web/src/user/settings/auth/__snapshots__/ExternalAccountsSignIn.test.tsx.snap
+++ b/client/web/src/user/settings/auth/__snapshots__/ExternalAccountsSignIn.test.tsx.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExternalAccountsSignIn renders multiple accounts correctly 1`] = `
+<DocumentFragment>
+  <ul
+    class="list-group"
+  >
+    <li
+      class="list-group-item externalAccount"
+    >
+      <div
+        class="d-flex align-items-start"
+      >
+        <div
+          class="align-self-center"
+        >
+          <svg
+            class="mdi-icon mb-0 mr-2"
+            fill="currentColor"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+            />
+          </svg>
+        </div>
+        <div
+          class="flex-1 flex-column"
+        >
+          <h3
+            class="h3 m-0"
+          >
+            GitHub
+          </h3>
+          <div
+            class="text-muted"
+          >
+            account1 (
+            <a
+              class=""
+              href="https://example.com/account1"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              @account1
+            </a>
+            )
+          </div>
+        </div>
+        <div
+          class="align-self-center"
+        >
+          <button
+            class="text-danger px-0"
+            type="button"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </li>
+    <li
+      class="list-group-item externalAccount"
+    >
+      <div
+        class="d-flex align-items-start"
+      >
+        <div
+          class="align-self-center"
+        >
+          <svg
+            class="mdi-icon mb-0 mr-2"
+            fill="currentColor"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M12,2A10,10 0 0,0 2,12C2,16.42 4.87,20.17 8.84,21.5C9.34,21.58 9.5,21.27 9.5,21C9.5,20.77 9.5,20.14 9.5,19.31C6.73,19.91 6.14,17.97 6.14,17.97C5.68,16.81 5.03,16.5 5.03,16.5C4.12,15.88 5.1,15.9 5.1,15.9C6.1,15.97 6.63,16.93 6.63,16.93C7.5,18.45 8.97,18 9.54,17.76C9.63,17.11 9.89,16.67 10.17,16.42C7.95,16.17 5.62,15.31 5.62,11.5C5.62,10.39 6,9.5 6.65,8.79C6.55,8.54 6.2,7.5 6.75,6.15C6.75,6.15 7.59,5.88 9.5,7.17C10.29,6.95 11.15,6.84 12,6.84C12.85,6.84 13.71,6.95 14.5,7.17C16.41,5.88 17.25,6.15 17.25,6.15C17.8,7.5 17.45,8.54 17.35,8.79C18,9.5 18.38,10.39 18.38,11.5C18.38,15.32 16.04,16.16 13.81,16.41C14.17,16.72 14.5,17.33 14.5,18.26C14.5,19.6 14.5,20.68 14.5,21C14.5,21.27 14.66,21.59 15.17,21.5C19.14,20.16 22,16.42 22,12A10,10 0 0,0 12,2Z"
+            />
+          </svg>
+        </div>
+        <div
+          class="flex-1 flex-column"
+        >
+          <h3
+            class="h3 m-0"
+          >
+            GitHub
+          </h3>
+          <div
+            class="text-muted"
+          >
+            account2 (
+            <a
+              class=""
+              href="https://example.com/account2"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              @account2
+            </a>
+            )
+          </div>
+        </div>
+        <div
+          class="align-self-center"
+        >
+          <button
+            class="text-danger px-0"
+            type="button"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </li>
+  </ul>
+</DocumentFragment>
+`;


### PR DESCRIPTION
As a follow-up to https://github.com/sourcegraph/cody/issues/1267 , this PR displays all connected external accounts for each auth provider.

Under normal circumstances, a user shouldn't have more than one external account per auth provider. But there are ways in which it could happen, such as linking directly to an Auth Provider sign-in page like VS Code does, or possibly when auth providers get removed and added and edited etc.

Regardless, I think it's a good change that changes nothing about the regular behaviour, and alleviates confusion in the unlikely scenario that something wonky happened (and allows users to disconnect those extra external accounts).

Before:

![Screenshot 2023-10-04 at 11 12 08](https://github.com/sourcegraph/sourcegraph/assets/6427795/fc31e8c0-c535-48c6-82ad-719b05f9e798)


After:

![Screenshot 2023-10-04 at 11 13 49](https://github.com/sourcegraph/sourcegraph/assets/6427795/66d56300-00bd-448c-8258-3839d5f97a38)


## Test plan

Added snapshot test that confirms that both accounts are shown for a single auth provider.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
