### PR TITLE
gitserver: remove lazy constructor for atomicGitServerConns

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -60,22 +59,8 @@ var ClientMocks, emptyClientMocks struct {
 	LocalGitCommandReposDir string
 }
 
-// initConnsOnce is used internally in getAtomicGitServerConns. Only use it there.
-var initConnsOnce sync.Once
-
 // conns is the global variable holding a reference to the gitserver connections.
-//
-// WARNING: Do not use it directly. Instead use getAtomicGitServerConns to ensure conns is
-// initialised correctly.
-var conns *atomicGitServerConns
-
-func getAtomicGitserverConns() *atomicGitServerConns {
-	initConnsOnce.Do(func() {
-		conns = &atomicGitServerConns{}
-	})
-
-	return conns
-}
+var conns = &atomicGitServerConns{}
 
 // ResetClientMocks clears the mock functions set on Mocks (so that subsequent
 // tests don't inadvertently use them).
@@ -111,7 +96,7 @@ func NewClient() Client {
 		// frontend internal API)
 		userAgent:    filepath.Base(os.Args[0]),
 		operations:   getOperations(),
-		clientSource: getAtomicGitserverConns(),
+		clientSource: conns,
 	}
 }
 

--- a/internal/gitserver/gitolite.go
+++ b/internal/gitserver/gitolite.go
@@ -22,14 +22,12 @@ type GitoliteLister struct {
 }
 
 func NewGitoliteLister(cli httpcli.Doer) *GitoliteLister {
-	atomicConns := getAtomicGitserverConns()
-
 	return &GitoliteLister{
 		httpClient: cli,
 		addrs: func() []string {
-			return atomicConns.get().Addresses
+			return conns.get().Addresses
 		},
-		grpcClient: atomicConns,
+		grpcClient: conns,
 		userAgent:  filepath.Base(os.Args[0]),
 	}
 }

--- a/internal/gitserver/grpc_test.go
+++ b/internal/gitserver/grpc_test.go
@@ -104,9 +104,7 @@ func TestClient_AddrForRepo_UsesConfToRead_PinnedRepos(t *testing.T) {
 		map[string]string{"repo1": "gitserver2"},
 	)
 
-	atomicConns := getAtomicGitserverConns()
-
-	atomicConns.update(cfg)
+	conns.update(cfg)
 
 	ctx := context.Background()
 	addr := client.AddrForRepo(ctx, "repo1")
@@ -117,7 +115,7 @@ func TestClient_AddrForRepo_UsesConfToRead_PinnedRepos(t *testing.T) {
 		[]string{"gitserver1", "gitserver2"},
 		map[string]string{"repo1": "gitserver1"},
 	)
-	atomicConns.update(cfg)
+	conns.update(cfg)
 
 	require.Equal(t, "gitserver1", client.AddrForRepo(ctx, "repo1"))
 }


### PR DESCRIPTION
We don't actually do anything in the constructor, so we can remove the sync.Once and the helper.

Test Plan: go test