### PR TITLE
search jobs: mention bucket config in the docs

### DIFF
--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -40,7 +40,7 @@ Set the following environment variables to target an S3 bucket you've already pr
 
 ### Using GCS
 
-To target a GCS bucket you've already provisioned, set the following environment variables. Authentication is done through a service account key, supplied as either a path to a volume-mounted file, or the contents read in as an environment variable payload.
+Set the following environment variables to target a GCS bucket you've already provisioned. Authentication is done through a service account key, either as a path to a volume-mounted file or the contents read in as an environment variable payload.
 
 - `SEARCH_JOBS_UPLOAD_BACKEND=GCS`
 - `SEARCH_JOBS_UPLOAD_BUCKET=<my bucket name>`

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -31,7 +31,7 @@ Set the following environment variables to target an S3 bucket you've already pr
 - `SEARCH_JOBS_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS=true` (optional; set to use EC2 metadata API over static credentials)
 - `SEARCH_JOBS_UPLOAD_AWS_REGION=us-east-1` (default)
 
-**_Note:_** If a non-default region is supplied, ensure that the subdomain of the endpoint URL (_the `AWS_ENDPOINT` value_) matches the target region.
+> NOTE: If a non-default region is supplied, ensure that the subdomain of the endpoint URL (_the `AWS_ENDPOINT` value_) matches the target region.
 
 > NOTE: You don't need to set the `SEARCH_JOBS_UPLOAD_AWS_ACCESS_KEY_ID` environment variable when using `SEARCH_JOBS_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS=true` because role credentials will be automatically resolved.
 

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -16,7 +16,7 @@ To enable Search Jobs, you need to configure a managed object storage service to
 
 To target a managed object storage service, you will need to set a handful of environment variables for configuration and authentication to the target service. **If you are running a sourcegraph/server deployment, set the environment variables on the server container. Otherwise, if running via Docker-compose or Kubernetes, set the environment variables on the `frontend` and `worker` containers.**
 
-#### Using S3
+### Using S3
 
 Set the following environment variables to target an S3 bucket you've already provisioned. Authentication can be done through [an access and secret key pair](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) (and optionally through session token) or via the EC2 metadata API.
 

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -18,7 +18,7 @@ To target a managed object storage service, you will need to set a handful of en
 
 #### Using S3
 
-To target an S3 bucket you've already provisioned, set the following environment variables. Authentication can be done through [an access and secret key pair](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) (and optional session token), or via the EC2 metadata API.
+Set the following environment variables to target an S3 bucket you've already provisioned. Authentication can be done through [an access and secret key pair](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) (and optionally through session token) or via the EC2 metadata API.
 
 **_Warning:_** Remember never to commit aws access keys in git. Consider using a secret handling service offered by your cloud provider.
 

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -10,8 +10,48 @@ With Search Jobs, you can start a search, let it run in the background, and then
 
 ## Enable Search Jobs
 
-To enable Search Jobs:
+To enable Search Jobs you need to configure a managed object storage service to store the results of your search jobs and then enable the feature in the site administration.
 
+### Storing search results
+
+To target a managed object storage service, you will need to set a handful of environment variables for configuration and authentication to the target service. **If you are running a sourcegraph/server deployment, set the environment variables on the server container. Otherwise, if running via Docker-compose or Kubernetes, set the environment variables on the `frontend` and `worker` containers.**
+
+#### Using S3
+
+To target an S3 bucket you've already provisioned, set the following environment variables. Authentication can be done through [an access and secret key pair](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) (and optional session token), or via the EC2 metadata API.
+
+**_Warning:_** Remember never to commit aws access keys in git. Consider using a secret handling service offered by your cloud provider.
+
+- `SEARCH_JOBS_UPLOAD_BACKEND=S3`
+- `SEARCH_JOBS_UPLOAD_BUCKET=<my bucket name>`
+- `SEARCH_JOBS_UPLOAD_AWS_ENDPOINT=https://s3.us-east-1.amazonaws.com`
+- `SEARCH_JOBS_UPLOAD_AWS_ACCESS_KEY_ID=<your access key>`
+- `SEARCH_JOBS_UPLOAD_AWS_SECRET_ACCESS_KEY=<your secret key>`
+- `SEARCH_JOBS_UPLOAD_AWS_SESSION_TOKEN=<your session token>` (optional)
+- `SEARCH_JOBS_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS=true` (optional; set to use EC2 metadata API over static credentials)
+- `SEARCH_JOBS_UPLOAD_AWS_REGION=us-east-1` (default)
+
+**_Note:_** If a non-default region is supplied, ensure that the subdomain of the endpoint URL (_the `AWS_ENDPOINT` value_) matches the target region.
+
+> NOTE: You don't need to set the `SEARCH_JOBS_UPLOAD_AWS_ACCESS_KEY_ID` environment variable when using `SEARCH_JOBS_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS=true` because role credentials will be automatically resolved.
+
+#### Using GCS
+
+To target a GCS bucket you've already provisioned, set the following environment variables. Authentication is done through a service account key, supplied as either a path to a volume-mounted file, or the contents read in as an environment variable payload.
+
+- `SEARCH_JOBS_UPLOAD_BACKEND=GCS`
+- `SEARCH_JOBS_UPLOAD_BUCKET=<my bucket name>`
+- `SEARCH_JOBS_UPLOAD_GCP_PROJECT_ID=<my project id>`
+- `SEARCH_JOBS_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE=</path/to/file>`
+- `SEARCH_JOBS_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT=<{"my": "content"}>`
+
+#### Provisioning buckets
+
+If you would like to allow your Sourcegraph instance to control the creation and lifecycle configuration management of the target buckets, set the following environment variables:
+
+- `SEARCH_JOBS_UPLOAD_MANAGE_BUCKET=true`
+
+### Site adminstration
 - Login to your Sourcegraph instance and go to the site admin
 - Next, click the site configuration
 - From here, you'll see `experimentalFeatures`

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -12,7 +12,7 @@ With Search Jobs, you can start a search, let it run in the background, and then
 
 To enable Search Jobs, you need to configure a managed object storage service to store the results of your search jobs and then enable the feature in the site administration.
 
-### Storing search results
+## Storing search results
 
 To target a managed object storage service, you will need to set a handful of environment variables for configuration and authentication to the target service. **If you are running a sourcegraph/server deployment, set the environment variables on the server container. Otherwise, if running via Docker-compose or Kubernetes, set the environment variables on the `frontend` and `worker` containers.**
 

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -20,7 +20,7 @@ To target a managed object storage service, you will need to set a handful of en
 
 Set the following environment variables to target an S3 bucket you've already provisioned. Authentication can be done through [an access and secret key pair](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) (and optionally through session token) or via the EC2 metadata API.
 
-**_Warning:_** Remember never to commit aws access keys in git. Consider using a secret handling service offered by your cloud provider.
+>NOTE: Never commit AWS access keys in Git. You should consider using a secret handling service offered by your cloud provider.
 
 - `SEARCH_JOBS_UPLOAD_BACKEND=S3`
 - `SEARCH_JOBS_UPLOAD_BUCKET=<my bucket name>`

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -45,7 +45,7 @@ To target a GCS bucket you've already provisioned, set the following environment
 - `SEARCH_JOBS_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE=</path/to/file>`
 - `SEARCH_JOBS_UPLOAD_GOOGLE_APPLICATION_CREDENTIALS_FILE_CONTENT=<{"my": "content"}>`
 
-#### Provisioning buckets
+### Provisioning buckets
 
 If you would like to allow your Sourcegraph instance to control the creation and lifecycle configuration management of the target buckets, set the following environment variables:
 

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -35,7 +35,7 @@ Set the following environment variables to target an S3 bucket you've already pr
 
 > NOTE: You don't need to set the `SEARCH_JOBS_UPLOAD_AWS_ACCESS_KEY_ID` environment variable when using `SEARCH_JOBS_UPLOAD_AWS_USE_EC2_ROLE_CREDENTIALS=true` because role credentials will be automatically resolved.
 
-#### Using GCS
+### Using GCS
 
 To target a GCS bucket you've already provisioned, set the following environment variables. Authentication is done through a service account key, supplied as either a path to a volume-mounted file, or the contents read in as an environment variable payload.
 

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -14,7 +14,10 @@ To enable Search Jobs, you need to configure a managed object storage service to
 
 ## Storing search results
 
-To target a managed object storage service, you will need to set a handful of environment variables for configuration and authentication to the target service. **If you are running a sourcegraph/server deployment, set the environment variables on the server container. Otherwise, if running via Docker-compose or Kubernetes, set the environment variables on the `frontend` and `worker` containers.**
+To target a managed object storage service, you must set a handful of environment variables for configuration and authentication to the target service. 
+
+- If you are running a `sourcegraph/server` deployment, set the environment variables on the server container
+- If you are running via Docker-compose or Kubernetes, set the environment variables on the `frontend` and `worker` containers
 
 ### Using S3
 

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -10,7 +10,7 @@ With Search Jobs, you can start a search, let it run in the background, and then
 
 ## Enable Search Jobs
 
-To enable Search Jobs you need to configure a managed object storage service to store the results of your search jobs and then enable the feature in the site administration.
+To enable Search Jobs, you need to configure a managed object storage service to store the results of your search jobs and then enable the feature in the site administration.
 
 ### Storing search results
 


### PR DESCRIPTION
To enable search jobs, the user needs to configure a storage bucket first.

Test plan:
CI


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@sh/search-jobs-update-docs)