### PR TITLE
search: remove UserID logic for dotcom repo resolution

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -612,10 +612,16 @@ type ReposListOptions struct {
 	// IDs of repos to list. When zero-valued, this is omitted from the predicate set.
 	IDs []api.RepoID
 
+	// NOTE: UserID is a deprecated field from cloud v1. There is still code
+	// using it, but you can treat it as a noop.
+	//
 	// UserID, if non zero, will limit the set of results to repositories added by the user
 	// through external services. Mutually exclusive with the ExternalServiceIDs and SearchContextID options.
 	UserID int32
 
+	// NOTE: OrgID is a deprecated field from cloud v1. There is still code
+	// using it, but you can treat it as a noop.
+	//
 	// OrgID, if non zero, will limit the set of results to repositories owned by the organization
 	// through external services. Mutually exclusive with the ExternalServiceIDs and SearchContextID options.
 	OrgID int32

--- a/internal/search/zoekt/BUILD.bazel
+++ b/internal/search/zoekt/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/search/zoekt",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//cmd/frontend/envvar",
         "//internal/actor",
         "//internal/api",
         "//internal/conf",

--- a/internal/search/zoekt/indexed_search.go
+++ b/internal/search/zoekt/indexed_search.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/atomic"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -751,29 +750,16 @@ func (t *GlobalTextSearchJob) Attributes(v job.Verbosity) (res []attribute.KeyVa
 func (t *GlobalTextSearchJob) Children() []job.Describer       { return nil }
 func (t *GlobalTextSearchJob) MapChildren(job.MapFunc) job.Job { return t }
 
-// Get all private repos for the the current actor. On sourcegraph.com, those are
-// only the repos directly added by the user. Otherwise it's all repos the user has
-// access to on all connected code hosts / external services.
+// Get all private repos for the the current actor.
 func privateReposForActor(ctx context.Context, logger log.Logger, db database.DB, repoOptions search.RepoOptions) []types.MinimalRepo {
 	tr, ctx := trace.New(ctx, "privateReposForActor")
 	defer tr.End()
 
-	userID := int32(0)
-	if envvar.SourcegraphDotComMode() {
-		if a := actor.FromContext(ctx); a.IsAuthenticated() {
-			userID = a.UID
-		} else {
-			tr.AddEvent("skipping private repo resolution for unauthed user")
-			return nil
-		}
-	}
-	tr.SetAttributes(attribute.Int64("userID", int64(userID)))
-
-	// TODO: We should use repos.Resolve here. However, the logic for
-	// UserID is different to repos.Resolve, so we need to work out how
-	// best to address that first.
+	// TODO: We should use repos.Resolve here. However, this logic was added
+	// when we used UserID on sourcegraph.com and it was handled differently
+	// in repos.Resolve. We need to confirm and test the change to
+	// repos.Resolve.
 	userPrivateRepos, err := db.Repos().ListMinimalRepos(ctx, database.ReposListOptions{
-		UserID:         userID, // Zero valued when not in sourcegraph.com mode
 		OnlyPrivate:    true,
 		LimitOffset:    &database.LimitOffset{Limit: limits.SearchLimits(conf.Get()).MaxRepos + 1},
 		OnlyForks:      repoOptions.OnlyForks,
@@ -784,6 +770,10 @@ func privateReposForActor(ctx context.Context, logger log.Logger, db database.DB
 	})
 
 	if err != nil {
+		var userID int32
+		if a := actor.FromContext(ctx); a != nil {
+			userID = a.UID
+		}
 		logger.Error("doResults: failed to list user private repos", log.Error(err), log.Int32("user-id", userID))
 		tr.AddEvent("error resolving user private repos", trace.Error(err))
 	}


### PR DESCRIPTION
In cloud v1 we would automically include all user added private repos. However, we no longer have user added external services so this code is a noop. In fact on cloud we have no private repos, so effectively this should always return an empty list on dotcom.

This commits doesn't yet do the TODO around using repos.Resolve, since I'm worried about changing too much at once. Feels like a good follow-up.

Additionally there are a few more uses of UserID and OrgID on the repo listing API. It wasn't obvious to me how to update those call sites, so I just added a comment noting the deprecation and would rather follow-up with other PRs.

Test Plan: just relying on unit tests. The only possible functional change is on dotcom, but in that case it was always empty since we have no private repos on dotcom.