### PR TITLE
[backport 5.2] gitserver: disk-info: make test hit two separate gitserver addresses

### DIFF
--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//semaphore",
@@ -106,6 +107,7 @@ go_test(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_x_time//rate",
     ],
 )

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/sourcegraph/conc/pool"
 	"github.com/sourcegraph/go-diff/diff"
@@ -531,10 +532,17 @@ func (c *clientImplementor) getDiskInfo(ctx context.Context, addr AddressWithCli
 	if rs.StatusCode != http.StatusOK {
 		return nil, errors.Newf("http status %d: %s", rs.StatusCode, readResponseBody(io.LimitReader(rs.Body, 200)))
 	}
-	var resp proto.DiskInfoResponse
-	if err := json.NewDecoder(rs.Body).Decode(&resp); err != nil {
-		return nil, err
+
+	body, err := io.ReadAll(rs.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading read disk info response body")
 	}
+
+	var resp proto.DiskInfoResponse
+	if err := protojson.Unmarshal(body, &resp); err != nil {
+		return nil, errors.Wrap(err, "parsing disk info response body")
+	}
+
 	return &resp, nil
 }
 

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -29,6 +30,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -1511,20 +1513,42 @@ func TestClient_IsRepoCloneableGRPC(t *testing.T) {
 }
 
 func TestClient_SystemsInfo(t *testing.T) {
-	const gitserverAddr = "172.16.8.1:8080"
-	var mockResponse = &proto.DiskInfoResponse{
-		FreeSpace:  102400,
-		TotalSpace: 409600,
+	const (
+		gitserverAddr1 = "172.16.8.1:8080"
+		gitserverAddr2 = "172.16.8.2:8080"
+	)
+
+	expectedResponses := []gitserver.SystemInfo{
+		{
+			Address:    gitserverAddr1,
+			FreeSpace:  102400,
+			TotalSpace: 409600,
+		},
+		{
+			Address:    gitserverAddr2,
+			FreeSpace:  51200,
+			TotalSpace: 204800,
+		},
 	}
+	sort.Slice(expectedResponses, func(i, j int) bool {
+		return expectedResponses[i].Address < expectedResponses[j].Address
+	})
 
 	runTest := func(t *testing.T, client gitserver.Client) {
 		ctx := context.Background()
 		info, err := client.SystemsInfo(ctx)
 		require.NoError(t, err, "unexpected error")
-		require.Len(t, info, 1, "expected 1 disk info")
-		require.Equal(t, gitserverAddr, info[0].Address)
-		require.Equal(t, mockResponse.FreeSpace, info[0].FreeSpace)
-		require.Equal(t, mockResponse.TotalSpace, info[0].TotalSpace)
+
+		sort.Slice(info, func(i, j int) bool {
+			return info[i].Address < info[j].Address
+		})
+
+		require.Len(t, info, len(expectedResponses), "expected %d disk info(s)", len(expectedResponses))
+		for i := range expectedResponses {
+			require.Equal(t, info[i].Address, expectedResponses[i].Address)
+			require.Equal(t, info[i].FreeSpace, expectedResponses[i].FreeSpace)
+			require.Equal(t, info[i].TotalSpace, expectedResponses[i].TotalSpace)
+		}
 	}
 
 	t.Run("GRPC", func(t *testing.T) {
@@ -1540,11 +1564,26 @@ func TestClient_SystemsInfo(t *testing.T) {
 		})
 
 		called := false
-		source := gitserver.NewTestClientSource(t, []string{gitserverAddr}, func(o *gitserver.TestClientSourceOptions) {
+		source := gitserver.NewTestClientSource(t, []string{gitserverAddr1, gitserverAddr2}, func(o *gitserver.TestClientSourceOptions) {
+			responseByAddress := make(map[string]*proto.DiskInfoResponse, len(expectedResponses))
+			for _, response := range expectedResponses {
+				responseByAddress[response.Address] = &proto.DiskInfoResponse{
+					FreeSpace:   response.FreeSpace,
+					TotalSpace:  response.TotalSpace,
+					PercentUsed: response.PercentUsed,
+				}
+			}
+
 			o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
 				mockDiskInfo := func(ctx context.Context, in *proto.DiskInfoRequest, opts ...grpc.CallOption) (*proto.DiskInfoResponse, error) {
+					address := cc.Target()
+					response, ok := responseByAddress[address]
+					if !ok {
+						t.Fatalf("received unexpected address %q", address)
+					}
+
 					called = true
-					return mockResponse, nil
+					return response, nil
 				}
 				return &mockClient{mockDiskInfo: mockDiskInfo}
 			}
@@ -1569,14 +1608,13 @@ func TestClient_SystemsInfo(t *testing.T) {
 		t.Cleanup(func() {
 			conf.Mock(nil)
 		})
-		expected := fmt.Sprintf("http://%s", gitserverAddr)
 
 		called := false
-		source := gitserver.NewTestClientSource(t, []string{gitserverAddr}, func(o *gitserver.TestClientSourceOptions) {
+		source := gitserver.NewTestClientSource(t, []string{gitserverAddr1, gitserverAddr2}, func(o *gitserver.TestClientSourceOptions) {
 			o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
 				mockDiskInfo := func(ctx context.Context, in *proto.DiskInfoRequest, opts ...grpc.CallOption) (*proto.DiskInfoResponse, error) {
 					called = true
-					return mockResponse, nil
+					return nil, nil
 				}
 				return &mockClient{mockDiskInfo: mockDiskInfo}
 			}
@@ -1584,17 +1622,27 @@ func TestClient_SystemsInfo(t *testing.T) {
 
 		client := gitserver.NewTestClient(
 			httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
-				switch r.URL.String() {
-				case expected + "/disk-info":
-					encoded, _ := json.Marshal(mockResponse)
-					body := io.NopCloser(strings.NewReader(strings.TrimSpace(string(encoded))))
-					return &http.Response{
-						StatusCode: 200,
-						Body:       body,
-					}, nil
-				default:
-					return nil, errors.Newf("unexpected URL: %q", r.URL.String())
+				responseByAddress := make(map[string]*proto.DiskInfoResponse, len(expectedResponses))
+				for _, response := range expectedResponses {
+					responseByAddress[fmt.Sprintf("http://%s/disk-info", response.Address)] = &proto.DiskInfoResponse{
+						FreeSpace:   response.FreeSpace,
+						TotalSpace:  response.TotalSpace,
+						PercentUsed: response.PercentUsed,
+					}
 				}
+
+				address := r.URL.String()
+				response, ok := responseByAddress[address]
+				if !ok {
+					return nil, errors.Newf("unexpected URL: %q", address)
+				}
+
+				encoded, _ := protojson.Marshal(response)
+				body := io.NopCloser(strings.NewReader(string(encoded)))
+				return &http.Response{
+					StatusCode: 200,
+					Body:       body,
+				}, nil
 			}),
 			source,
 		)


### PR DESCRIPTION
Manual backport of #57318 since there were merge conflicts. 


## Test plan

CI