### PR TITLE
gomod: update zoekt to allow CTAGS_COMMAND=ctags

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5976,8 +5976,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:5zlXkgLiskj4oBm+WlyGXbDK7JrHKfBDti2gaHPPVzo=",
-        version = "v0.0.0-20230929125214-1065c6646489",
+        sum = "h1:I0ziTkFvoZ+DPjsCerxwM/ElemkYvk6Jrd0mB1a3ZNg=",
+        version = "v0.0.0-20231005061020-cc1b5cda7073",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -551,7 +551,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230929125214-1065c6646489
+	github.com/sourcegraph/zoekt v0.0.0-20231005061020-cc1b5cda7073
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1598,8 +1598,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230929125214-1065c6646489 h1:5zlXkgLiskj4oBm+WlyGXbDK7JrHKfBDti2gaHPPVzo=
-github.com/sourcegraph/zoekt v0.0.0-20230929125214-1065c6646489/go.mod h1:gHfSe997J5w8zX5MGHFei/darZmml75Xvpoykwtknlo=
+github.com/sourcegraph/zoekt v0.0.0-20231005061020-cc1b5cda7073 h1:I0ziTkFvoZ+DPjsCerxwM/ElemkYvk6Jrd0mB1a3ZNg=
+github.com/sourcegraph/zoekt v0.0.0-20231005061020-cc1b5cda7073/go.mod h1:gHfSe997J5w8zX5MGHFei/darZmml75Xvpoykwtknlo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This just includes one commit which is a convenience for our dev environments.

- https://github.com/sourcegraph/zoekt/commit/cc1b5cda70 ctags: allow binary to be anything with validation

Test Plan: see test plan in that commit. Otherwise go test

Fixes https://github.com/sourcegraph/sourcegraph/issues/57336
