### PR TITLE
release: update 5.2.1 release to 10am SAST

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -26,7 +26,7 @@
     "5.2.1": {
       "codeFreezeDate": "2023-10-11T10:00:00.000-07:00",
       "securityApprovalDate": "2023-10-11T10:00:00.000-07:00",
-      "releaseDate": "2023-10-18T10:00:00.000-07:00",
+      "releaseDate": "2023-10-18T10:00:00.000+02:00",
       "current": "5.2.1",
       "captainGitHubUsername": "keegancsmith",
       "captainSlackUsername": "keegan"


### PR DESCRIPTION
This updates the release date to being 10am in my working hours, rather than 7pm.

Test Plan: Ran "pnpm run release tracking:timeline" in dryRun mode. Once in main will run for real. Given the cal event already exists, might require Bolaji to update the event time.