### PR TITLE
[bug] Display user permissions even if the GQL resolver has errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fixed a user's Permissions page being inaccessible if the user has had no permission syncs with an external account connected. [#57372](https://github.com/sourcegraph/sourcegraph/pull/57372)
+- Fixed a bug where site admins could not view a user's permissions if they didn't have access to all of the repositories the user has. Admins still won't be able to see repositories they don't have access to, but they will now be able to view the rest of the user's repository permissions. [#57375](https://github.com/sourcegraph/sourcegraph/pull/57375)
 
 ### Removed
 

--- a/client/web/src/components/FilteredConnection/hooks/usePageSwitcherPagination.ts
+++ b/client/web/src/components/FilteredConnection/hooks/usePageSwitcherPagination.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import type { ApolloError, WatchQueryFetchPolicy } from '@apollo/client'
+import type { ApolloClientOptions, ApolloError, WatchQueryFetchPolicy } from '@apollo/client'
 import { useNavigate, useLocation } from 'react-router-dom'
 
 import { type GraphQLResult, useQuery } from '@sourcegraph/http-client'
@@ -62,6 +62,7 @@ interface UsePaginatedConnectionConfig<TResult> {
 interface UsePaginatedConnectionParameters<TResult, TVariables extends PaginatedConnectionQueryArguments, TNode> {
     query: string
     variables: Omit<TVariables, 'first' | 'last' | 'before' | 'after'>
+    errorPolicy: 'none' | 'ignore' | 'all'
     getConnection: (result: GraphQLResult<TResult>) => PaginatedConnection<TNode> | undefined
     options?: UsePaginatedConnectionConfig<TResult>
 }
@@ -80,6 +81,7 @@ const DEFAULT_PAGE_SIZE = 20
 export const usePageSwitcherPagination = <TResult, TVariables extends PaginatedConnectionQueryArguments, TNode>({
     query,
     variables,
+    errorPolicy,
     getConnection,
     options,
 }: UsePaginatedConnectionParameters<TResult, TVariables, TNode>): UsePaginatedConnectionResult<
@@ -111,6 +113,7 @@ export const usePageSwitcherPagination = <TResult, TVariables extends PaginatedC
         fetchPolicy: options?.fetchPolicy,
         onCompleted: options?.onCompleted,
         pollInterval: options?.pollInterval,
+        errorPolicy: errorPolicy || 'none',
     })
 
     const data = currentData ?? previousData

--- a/client/web/src/components/FilteredConnection/hooks/usePageSwitcherPagination.ts
+++ b/client/web/src/components/FilteredConnection/hooks/usePageSwitcherPagination.ts
@@ -62,7 +62,7 @@ interface UsePaginatedConnectionConfig<TResult> {
 interface UsePaginatedConnectionParameters<TResult, TVariables extends PaginatedConnectionQueryArguments, TNode> {
     query: string
     variables: Omit<TVariables, 'first' | 'last' | 'before' | 'after'>
-    errorPolicy: 'none' | 'ignore' | 'all'
+    errorPolicy?: 'none' | 'ignore' | 'all'
     getConnection: (result: GraphQLResult<TResult>) => PaginatedConnection<TNode> | undefined
     options?: UsePaginatedConnectionConfig<TResult>
 }
@@ -113,7 +113,7 @@ export const usePageSwitcherPagination = <TResult, TVariables extends PaginatedC
         fetchPolicy: options?.fetchPolicy,
         onCompleted: options?.onCompleted,
         pollInterval: options?.pollInterval,
-        errorPolicy: errorPolicy || 'none',
+        errorPolicy,
     })
 
     const data = currentData ?? previousData

--- a/client/web/src/components/FilteredConnection/hooks/usePageSwitcherPagination.ts
+++ b/client/web/src/components/FilteredConnection/hooks/usePageSwitcherPagination.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import type { ApolloClientOptions, ApolloError, WatchQueryFetchPolicy } from '@apollo/client'
+import type { ApolloError, WatchQueryFetchPolicy } from '@apollo/client'
 import { useNavigate, useLocation } from 'react-router-dom'
 
 import { type GraphQLResult, useQuery } from '@sourcegraph/http-client'
@@ -62,7 +62,6 @@ interface UsePaginatedConnectionConfig<TResult> {
 interface UsePaginatedConnectionParameters<TResult, TVariables extends PaginatedConnectionQueryArguments, TNode> {
     query: string
     variables: Omit<TVariables, 'first' | 'last' | 'before' | 'after'>
-    errorPolicy?: 'none' | 'ignore' | 'all'
     getConnection: (result: GraphQLResult<TResult>) => PaginatedConnection<TNode> | undefined
     options?: UsePaginatedConnectionConfig<TResult>
 }
@@ -81,7 +80,6 @@ const DEFAULT_PAGE_SIZE = 20
 export const usePageSwitcherPagination = <TResult, TVariables extends PaginatedConnectionQueryArguments, TNode>({
     query,
     variables,
-    errorPolicy,
     getConnection,
     options,
 }: UsePaginatedConnectionParameters<TResult, TVariables, TNode>): UsePaginatedConnectionResult<
@@ -113,7 +111,6 @@ export const usePageSwitcherPagination = <TResult, TVariables extends PaginatedC
         fetchPolicy: options?.fetchPolicy,
         onCompleted: options?.onCompleted,
         pollInterval: options?.pollInterval,
-        errorPolicy,
     })
 
     const data = currentData ?? previousData

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -197,7 +197,7 @@ const TableColumns: IColumn<INode>[] = [
             ) : (
                 <div className="py-2">
                     <ExternalRepositoryIcon externalRepo={{ serviceType: 'unknown' }} />
-                    You do not have access to this repository
+                    Private repository
                 </div>
             ),
     },

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -65,7 +65,6 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<React.PropsWit
             userID: user.id,
             query: debouncedQuery,
         },
-        errorPolicy: 'all',
         getConnection: ({ data }) => {
             if (data?.node?.__typename === 'User') {
                 const node = data.node as IUser

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -55,7 +55,7 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<React.PropsWit
     const [{ query }, setSearchQuery] = useURLSyncedState({ query: '' })
     const debouncedQuery = useDebounce(query, 300)
 
-    const { connection, data, loading, error, refetch, variables, ...paginationProps } = usePageSwitcherPagination<
+    const { connection, data, loading, refetch, variables, ...paginationProps } = usePageSwitcherPagination<
         UserPermissionsInfoResult,
         UserPermissionsInfoVariables,
         INode
@@ -65,6 +65,7 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<React.PropsWit
             userID: user.id,
             query: debouncedQuery,
         },
+        errorPolicy: 'all',
         getConnection: ({ data }) => {
             if (data?.node?.__typename === 'User') {
                 const node = data.node as IUser
@@ -188,10 +189,15 @@ const TableColumns: IColumn<INode>[] = [
         key: 'repository',
         header: 'Repository',
         render: ({ repository }: INode) =>
-            repository && (
+            repository ? (
                 <div key={repository.id} className="py-2">
                     <ExternalRepositoryIcon externalRepo={repository.externalRepository} />
                     <RepoLink repoName={repository.name} to={repository.url} />
+                </div>
+            ) : (
+                <div className="py-2">
+                    <ExternalRepositoryIcon externalRepo={{ serviceType: 'unknown' }} />
+                    You do not have access to this repository
                 </div>
             ),
     },

--- a/cmd/frontend/graphqlbackend/authz.go
+++ b/cmd/frontend/graphqlbackend/authz.go
@@ -133,7 +133,7 @@ type PermissionsInfoResolver interface {
 
 type PermissionsInfoRepositoryResolver interface {
 	ID() graphql.ID
-	Repository() *RepositoryResolver
+	Repository(ctx context.Context) (*RepositoryResolver, error)
 	Reason() string
 	UpdatedAt() *gqlutil.DateTime
 }

--- a/cmd/frontend/internal/authz/resolvers/permissions_info.go
+++ b/cmd/frontend/internal/authz/resolvers/permissions_info.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -61,7 +62,7 @@ func (r *permissionsInfoResolver) Unrestricted(_ context.Context) bool {
 var permissionsInfoRepositoryConnectionMaxPageSize = 100
 
 var permissionsInfoRepositoryConnectionOptions = &graphqlutil.ConnectionResolverOptions{
-	OrderBy:     database.OrderBy{{Field: "repo.name"}},
+	OrderBy:     database.OrderBy{{Field: "repo.id"}},
 	Ascending:   true,
 	MaxPageSize: &permissionsInfoRepositoryConnectionMaxPageSize,
 }
@@ -98,7 +99,12 @@ func (s *permissionsInfoRepositoriesStore) MarshalCursor(node graphqlbackend.Per
 }
 
 func (s *permissionsInfoRepositoriesStore) UnmarshalCursor(cursor string, _ database.OrderBy) (*string, error) {
-	cursorSQL := fmt.Sprintf("'%s'", cursor)
+	repoID, err := graphqlbackend.UnmarshalRepositoryID(graphql.ID(cursor))
+	if err != nil {
+		return nil, err
+	}
+
+	cursorSQL := strconv.Itoa(int(repoID))
 
 	return &cursorSQL, nil
 }

--- a/cmd/frontend/internal/authz/resolvers/permissions_info.go
+++ b/cmd/frontend/internal/authz/resolvers/permissions_info.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -91,7 +92,7 @@ type permissionsInfoRepositoriesStore struct {
 }
 
 func (s *permissionsInfoRepositoriesStore) MarshalCursor(node graphqlbackend.PermissionsInfoRepositoryResolver, _ database.OrderBy) (*string, error) {
-	cursor := node.Repository().Name()
+	cursor := string(node.ID())
 
 	return &cursor, nil
 }
@@ -135,8 +136,14 @@ func (r permissionsInfoRepositoryResolver) ID() graphql.ID {
 	return graphqlbackend.MarshalRepositoryID(r.perm.Repo.ID)
 }
 
-func (r permissionsInfoRepositoryResolver) Repository() *graphqlbackend.RepositoryResolver {
-	return graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(), r.perm.Repo)
+func (r permissionsInfoRepositoryResolver) Repository(ctx context.Context) (*graphqlbackend.RepositoryResolver, error) {
+	repo, err := r.db.Repos().Get(ctx, r.perm.Repo.ID)
+	// If the errcode is NotFound, we return nil, nil, as we know that the repo should exist at this point.
+	// So this should mean that this user simply cannot see the repository.
+	if err != nil && errcode.IsNotFound(err) {
+		return nil, nil
+	}
+	return graphqlbackend.NewRepositoryResolver(r.db, gitserver.NewClient(), repo), err
 }
 
 func (r permissionsInfoRepositoryResolver) Reason() string {

--- a/internal/database/perms_store.go
+++ b/internal/database/perms_store.go
@@ -1884,7 +1884,7 @@ func (s *permsStore) ListUserPermissions(ctx context.Context, userID int32, args
 	}
 
 	conds := []*sqlf.Query{authzParams.ToAuthzQuery()}
-	order := sqlf.Sprintf("es.id, repo.name ASC")
+	order := sqlf.Sprintf("repo.name ASC")
 	limit := sqlf.Sprintf("")
 
 	if args != nil {

--- a/internal/database/perms_store.go
+++ b/internal/database/perms_store.go
@@ -204,7 +204,6 @@ func perms(logger log.Logger, db DB, clock func() time.Time) *permsStore {
 	store := basestore.NewWithHandle(db.Handle())
 
 	return &permsStore{logger: logger, Store: store, clock: clock, db: NewDBWith(logger, store)}
-
 }
 
 func PermsWith(logger log.Logger, other basestore.ShareableStore, clock func() time.Time) PermsStore {
@@ -1301,7 +1300,6 @@ var ScanPermissions = basestore.NewSliceScanner(func(s dbutil.Scanner) (authz.Pe
 })
 
 func (s *permsStore) loadUserRepoPermissions(ctx context.Context, userID, userExternalAccountID, repoID int32) ([]authz.Permission, error) {
-
 	clauses := []*sqlf.Query{sqlf.Sprintf("TRUE")}
 
 	if userID != 0 {
@@ -1928,7 +1926,7 @@ WITH accessible_repos AS (
 		repo.id,
 		repo.name,
 		repo.private,
-		es.unrestricted,
+		BOOL_OR(es.unrestricted) as unrestricted,
 		-- We need row_id to preserve the order, because ORDER BY is done in this subquery
 		row_number() OVER() as row_id
 	FROM repo
@@ -1937,6 +1935,7 @@ WITH accessible_repos AS (
 	WHERE
 		repo.deleted_at IS NULL
 		AND %s -- Authz Conds, Pagination Conds, Search
+	GROUP BY repo.id
 	ORDER BY %s
 	%s -- Limit
 )

--- a/internal/database/perms_store_test.go
+++ b/internal/database/perms_store_test.go
@@ -1189,28 +1189,32 @@ func TestPermsStore_SetRepoPerms(t *testing.T) {
 		},
 		{
 			name: "add",
-			updates: []testUpdate{{
-				repoID: 1,
-				users: []authz.UserIDWithExternalAccountID{{
-					UserID:            1,
-					ExternalAccountID: 1,
-				}}}, {
-				repoID: 2,
-				users: []authz.UserIDWithExternalAccountID{{
-					UserID:            1,
-					ExternalAccountID: 1,
+			updates: []testUpdate{
+				{
+					repoID: 1,
+					users: []authz.UserIDWithExternalAccountID{{
+						UserID:            1,
+						ExternalAccountID: 1,
+					}},
 				}, {
-					UserID:            2,
-					ExternalAccountID: 2,
-				}}}, {
-				repoID: 3,
-				users: []authz.UserIDWithExternalAccountID{{
-					UserID:            3,
-					ExternalAccountID: 3,
+					repoID: 2,
+					users: []authz.UserIDWithExternalAccountID{{
+						UserID:            1,
+						ExternalAccountID: 1,
+					}, {
+						UserID:            2,
+						ExternalAccountID: 2,
+					}},
 				}, {
-					UserID:            4,
-					ExternalAccountID: 4,
-				}}},
+					repoID: 3,
+					users: []authz.UserIDWithExternalAccountID{{
+						UserID:            3,
+						ExternalAccountID: 3,
+					}, {
+						UserID:            4,
+						ExternalAccountID: 4,
+					}},
+				},
 			},
 			expectedPerms: []authz.Permission{
 				{RepoID: 1, UserID: 1, ExternalAccountID: 1, Source: authz.SourceRepoSync},
@@ -1239,36 +1243,41 @@ func TestPermsStore_SetRepoPerms(t *testing.T) {
 		},
 		{
 			name: "add and update",
-			updates: []testUpdate{{
-				repoID: 1,
-				users: []authz.UserIDWithExternalAccountID{{
-					UserID:            1,
-					ExternalAccountID: 1,
-				}}}, {
-				repoID: 1,
-				users: []authz.UserIDWithExternalAccountID{{
-					UserID:            2,
-					ExternalAccountID: 2,
+			updates: []testUpdate{
+				{
+					repoID: 1,
+					users: []authz.UserIDWithExternalAccountID{{
+						UserID:            1,
+						ExternalAccountID: 1,
+					}},
 				}, {
-					UserID:            3,
-					ExternalAccountID: 3,
-				}}}, {
-				repoID: 2,
-				users: []authz.UserIDWithExternalAccountID{{
-					UserID:            1,
-					ExternalAccountID: 1,
+					repoID: 1,
+					users: []authz.UserIDWithExternalAccountID{{
+						UserID:            2,
+						ExternalAccountID: 2,
+					}, {
+						UserID:            3,
+						ExternalAccountID: 3,
+					}},
 				}, {
-					UserID:            2,
-					ExternalAccountID: 2,
-				}}}, {
-				repoID: 2,
-				users: []authz.UserIDWithExternalAccountID{{
-					UserID:            3,
-					ExternalAccountID: 3,
+					repoID: 2,
+					users: []authz.UserIDWithExternalAccountID{{
+						UserID:            1,
+						ExternalAccountID: 1,
+					}, {
+						UserID:            2,
+						ExternalAccountID: 2,
+					}},
 				}, {
-					UserID:            4,
-					ExternalAccountID: 4,
-				}}},
+					repoID: 2,
+					users: []authz.UserIDWithExternalAccountID{{
+						UserID:            3,
+						ExternalAccountID: 3,
+					}, {
+						UserID:            4,
+						ExternalAccountID: 4,
+					}},
+				},
 			},
 			expectedPerms: []authz.Permission{
 				{RepoID: 1, UserID: 2, ExternalAccountID: 2, Source: authz.SourceRepoSync},
@@ -1312,7 +1321,8 @@ func TestPermsStore_SetRepoPerms(t *testing.T) {
 				}, {
 					UserID:            3,
 					ExternalAccountID: 3,
-				}}}, {
+				}},
+			}, {
 				repoID: 1,
 				users:  []authz.UserIDWithExternalAccountID{},
 			}},
@@ -2378,7 +2388,8 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 								RepoID: 2,
 								Perm:   authz.Read,
 							},
-						}, {
+						},
+						{
 							accounts: &extsvc.Accounts{
 								ServiceType: authz.SourcegraphServiceType,
 								ServiceID:   authz.SourcegraphServiceID,
@@ -3945,7 +3956,7 @@ func TestPermsStore_ListUserPermissions(t *testing.T) {
                                  VALUES(1, 1, ''), (2, 1, ''), (3, 1, ''), (4, 1, '')`),
 		sqlf.Sprintf(`INSERT INTO external_services(id, display_name, kind, config, unrestricted) VALUES(2, 'GitHub #2 Unrestricted', 'GITHUB', '{}', TRUE)`),
 		sqlf.Sprintf(`INSERT INTO external_service_repos(repo_id, external_service_id, clone_url)
-                                 VALUES(5, 2, '')`),
+                                 VALUES(5, 2, ''), (4, 2, '')`),
 	}
 	for _, q := range qs {
 		if err := s.execute(ctx, q); err != nil {


### PR DESCRIPTION
Fixes an issue where admins can't view a user's permissions if they don't have access to all of the repos a user has access to.

Previously the page would just load forever, now admins are told they can't see the repo:

![image](https://github.com/sourcegraph/sourcegraph/assets/6427795/44ad2d6c-97fe-4c89-bcfb-8c32e36a2d59)

## Test plan

Manual tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
