### PR TITLE
bzl: fix ownership of generated monitoring config

### DIFF
--- a/monitoring/BUILD.bazel
+++ b/monitoring/BUILD.bazel
@@ -45,7 +45,7 @@ genrule(
         mkdir -p sg_config_grafana/provisioning/dashboards/sourcegraph/ && \
         mv monitoring/grafana/* sg_config_grafana/provisioning/dashboards/sourcegraph/ &&\
 
-        tar -cf $@ usr/share/grafana/public/dashboards/ sg_config_grafana/provisioning/dashboards/sourcegraph/
+        tar -cf $@ --uid=0 --gid=0 --numeric-owner usr/share/grafana/public/dashboards/ sg_config_grafana/provisioning/dashboards/sourcegraph/
         """,
     tools = ["//monitoring"],
     visibility = ["//visibility:public"],

--- a/monitoring/BUILD.bazel
+++ b/monitoring/BUILD.bazel
@@ -45,7 +45,11 @@ genrule(
         mkdir -p sg_config_grafana/provisioning/dashboards/sourcegraph/ && \
         mv monitoring/grafana/* sg_config_grafana/provisioning/dashboards/sourcegraph/ &&\
 
-        tar -cf $@ --uid=0 --gid=0 --numeric-owner usr/share/grafana/public/dashboards/ sg_config_grafana/provisioning/dashboards/sourcegraph/
+        if tar --version | grep -q bsdtar; then
+          tar -cf $@ --uid=0 --gid=0 --numeric-owner usr/share/grafana/public/dashboards/ sg_config_grafana/provisioning/dashboards/sourcegraph/
+        else
+          tar -cf $@ --owner=:0 --group=:0 --numeric-owner usr/share/grafana/public/dashboards/ sg_config_grafana/provisioning/dashboards/sourcegraph/
+        fi
         """,
     tools = ["//monitoring"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
While debugging builds running against Aspect Workflows, we stumbled across this issue: 

```
=== RUN: File Existence Test: Dashboard config
--- FAIL
duration: 0s
Error: /sg_config_grafana/provisioning/dashboards/sourcegraph/gitserver.json has incorrect user ownership. Expected: 0, Actual: 501
```

This is happening because we're creating the monitoring config tarball manually with a `genrule` instead of using `pkg_tar` (for convenience). Because the commands for that rule are not explicitly set the ownership on these files, it just end up being whatever user the agent is running the build with.

This works against normal Bazel CI agent, because they're running everything as root (yes bad, that's why we're happy to switch for AW). But when running it on the upcoming agents, it will instead end up with the wrong user, and will fail as shown above. 

This PR fixes this. 

## Test plan

Tests are now passing locally, as this is a similar setup, i.e bazel is not running as root. 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
