### PR TITLE
search jobs: add state aggregation to GetSearchJob

### DIFF
--- a/cmd/frontend/internal/search/httpapi/export.go
+++ b/cmd/frontend/internal/search/httpapi/export.go
@@ -1,7 +1,6 @@
 package httpapi
 
 import (
-	"database/sql"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/service"
 	"github.com/sourcegraph/sourcegraph/internal/search/exhaustive/store"
@@ -80,7 +80,7 @@ func httpError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, auth.ErrMustBeSiteAdminOrSameUser):
 		http.Error(w, err.Error(), http.StatusForbidden)
-	case errors.Is(err, store.ErrNoResults), errors.Is(err, sql.ErrNoRows):
+	case errors.Is(err, store.ErrNoResults):
 		http.Error(w, err.Error(), http.StatusNotFound)
 	default:
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -47,11 +47,7 @@ func (r *searchJobResolver) Query() string {
 }
 
 func (r *searchJobResolver) State(ctx context.Context) string {
-	// We don't set the AggState during job creation
-	if r.Job.AggState != "" {
-		return r.Job.AggState.ToGraphQL()
-	}
-	return r.Job.State.ToGraphQL()
+	return r.Job.AggState.ToGraphQL()
 }
 
 func (r *searchJobResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {

--- a/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/cmd/worker/internal/search/exhaustive_search_test.go
@@ -64,7 +64,7 @@ func TestExhaustiveSearch(t *testing.T) {
 	job, err := svc.CreateSearchJob(userCtx, query)
 	require.NoError(err)
 
-	// Do some assertations on the job before it runs
+	// Do some assertions on the job before it runs
 	{
 		require.Equal(userID, job.InitiatorID)
 		require.Equal(query, job.Query)
@@ -81,14 +81,6 @@ func TestExhaustiveSearch(t *testing.T) {
 	{
 		jobs, err := svc.ListSearchJobs(userCtx, store.ListArgs{})
 		require.NoError(err)
-
-		// HACK: Don't test agg state. Here we compare a result from GetSearchJob and
-		// ListSearchJobs. However, AggState is only set in ListSearchJobs.
-		//
-		// We don't want to set AggState in GetSearchJob because it is fairly expensive,
-		// and we call GetSearchJob a lot as part of the security checks, so we want to
-		// keep it as lean as possible.
-		jobs[0].AggState = job.AggState
 
 		require.Equal([]*types.ExhaustiveSearchJob{job}, jobs)
 	}
@@ -140,6 +132,8 @@ func TestExhaustiveSearch(t *testing.T) {
 		// only assert on State since the rest are non-deterministic.
 		require.Equal(types.JobStateCompleted, job2.State)
 		job2.WorkerJob = job.WorkerJob
+		// ignore AggState. We fetched the job at different stages of its lifecycle so
+		// the states differ.
 		job2.AggState = job.AggState
 		require.Equal(job, job2)
 	}

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -211,7 +211,7 @@ func (s *Service) GetSearchJobLogsWriterTo(parentCtx context.Context, id int64) 
 	defer endObservation(1, observation.Args{})
 
 	// 🚨 SECURITY: only someone with access to the job may copy the blobs
-	if _, err := s.GetSearchJob(ctx, id); err != nil {
+	if err := s.store.UserHasAccess(ctx, id); err != nil {
 		return nil, err
 	}
 
@@ -283,8 +283,7 @@ func (s *Service) DeleteSearchJob(ctx context.Context, id int64) (err error) {
 	}()
 
 	// 🚨 SECURITY: only someone with access to the job may delete data and the db entries
-	_, err = s.GetSearchJob(ctx, id)
-	if err != nil {
+	if err := s.store.UserHasAccess(ctx, id); err != nil {
 		return err
 	}
 
@@ -325,8 +324,7 @@ func (s *Service) GetSearchJobCSVWriterTo(parentCtx context.Context, id int64) (
 	defer endObservation(1, observation.Args{})
 
 	// 🚨 SECURITY: only someone with access to the job may copy the blobs
-	_, err = s.GetSearchJob(ctx, id)
-	if err != nil {
+	if err := s.store.UserHasAccess(ctx, id); err != nil {
 		return nil, err
 	}
 

--- a/internal/search/exhaustive/store/exhaustive_search_jobs.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs.go
@@ -217,12 +217,7 @@ func (s *Store) UserHasAccess(ctx context.Context, id int64) (err error) {
 	))
 	defer endObservation(1, observation.Args{})
 
-	where := sqlf.Sprintf("id = %d", id)
-	q := sqlf.Sprintf(
-		getExhaustiveSearchJobQueryFmtStr,
-		sqlf.Sprintf("initiator_id"),
-		where,
-	)
+	q := sqlf.Sprintf("SELECT initiator_id FROM exhaustive_search_jobs WHERE id = %s", id)
 
 	var initiatorID int32
 	err = s.Store.QueryRow(ctx, q).Scan(&initiatorID)
@@ -286,12 +281,6 @@ const aggStateSubQuery = `
 			FROM (
 				-- getAggregateStateTable
 				%s) AS state_histogram) AS transposed_state_histogram
-`
-
-const getExhaustiveSearchJobQueryFmtStr = `
-SELECT %s FROM exhaustive_search_jobs
-WHERE (%s)
-LIMIT 1
 `
 
 type ListArgs struct {

--- a/internal/search/exhaustive/store/store.go
+++ b/internal/search/exhaustive/store/store.go
@@ -62,6 +62,7 @@ type operations struct {
 	createExhaustiveSearchJob *observation.Operation
 	cancelSearchJob           *observation.Operation
 	getExhaustiveSearchJob    *observation.Operation
+	userHasAccess             *observation.Operation
 	listExhaustiveSearchJobs  *observation.Operation
 	deleteExhaustiveSearchJob *observation.Operation
 
@@ -94,6 +95,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		createExhaustiveSearchJob: op("CreateExhaustiveSearchJob"),
 		cancelSearchJob:           op("CancelSearchJob"),
 		getExhaustiveSearchJob:    op("GetExhaustiveSearchJob"),
+		userHasAccess:             op("UserHasAccess"),
 		listExhaustiveSearchJobs:  op("ListExhaustiveSearchJobs"),
 		deleteExhaustiveSearchJob: op("DeleteExhaustiveSearchJob"),
 


### PR DESCRIPTION
This removes the awkwardness introduced [here](#56957) between `Get` and `List` for exhaustive search. The problem was that we used `Get` to retrieve the job AND for security checks. This PR decouples these two concerns.

- We add a dedicated method to the store for security checks and update all call sites
- The remaining calls to Get are legit calls to retrieve the job
- We update `Get` to include the aggregated state, just like `List`.

Note:

This doesn't mean we shouldn't investigate a more elegant solution for state aggregation long term, but at least the complexity is now confined to the store and doesn't leak to the API anymore.

## Test plan
This is a refactor, so relying on CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
