### PR TITLE
Use focus-visible instead of focus pseudo selector

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -70,7 +70,6 @@ js_library(
     deps = [
         "//:node_modules/autoprefixer",
         "//:node_modules/postcss-custom-media",
-        "//:node_modules/postcss-focus-visible",
         "//:node_modules/postcss-inset",
     ],
 )

--- a/client/branded/src/search-ui/components/QueryExamples.module.scss
+++ b/client/branded/src/search-ui/components/QueryExamples.module.scss
@@ -20,13 +20,13 @@
         box-shadow: none;
     }
 
-    &:focus {
+    &:focus-visible {
         border: 1px solid transparent;
         box-shadow: 0 0 0 0.125rem var(--primary-2);
         outline: none;
     }
 
-    &:active:focus {
+    &:active:focus-visible {
         border: 1px solid var(--border-color);
         box-shadow: none;
     }

--- a/client/branded/src/search-ui/components/RepoMetadata.module.scss
+++ b/client/branded/src/search-ui/components/RepoMetadata.module.scss
@@ -7,7 +7,7 @@
 }
 
 .badge-button {
-    &:focus,
+    &:focus-visible,
     &:hover {
         background-color: var(--badge-dark);
     }

--- a/client/branded/src/search-ui/input/SearchContextDropdown.module.scss
+++ b/client/branded/src/search-ui/input/SearchContextDropdown.module.scss
@@ -18,18 +18,18 @@
 
     &:hover,
     &:active,
-    &:focus {
+    &:focus-visible {
         text-decoration: none;
         color: var(--search-query-text-color);
     }
 
     &:hover,
-    &:focus {
+    &:focus-visible {
         background-color: var(--color-bg-2);
         border-color: var(--color-bg-2);
     }
 
-    &:focus {
+    &:focus-visible {
         border-color: var(--border-active-color);
         box-shadow: none;
     }

--- a/client/jetbrains/webview/src/search/input/JetBrainsToggles.module.scss
+++ b/client/jetbrains/webview/src/search/input/JetBrainsToggles.module.scss
@@ -43,7 +43,7 @@
         background-color: var(--jb-hover-button-bg);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: none;
     }
 

--- a/client/web/src/enterprise/insights/components/views/card/InsightCard.module.scss
+++ b/client/web/src/enterprise/insights/components/views/card/InsightCard.module.scss
@@ -5,7 +5,7 @@
     cursor: default;
     outline: none;
 
-    &:focus,
+    &:focus-visible,
     &:focus-within {
         box-shadow: var(--focus-box-shadow);
     }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/navigation/CodeHostsNavigation.module.scss
@@ -35,14 +35,14 @@
     border-bottom-left-radius: 0;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
         color: var(--danger);
         background-color: var(--danger-4);
     }
 
     :global(.theme-dark) & {
         &:hover,
-        &:focus {
+        &:focus-visible {
             color: var(--light-text);
             background-color: var(--danger-2);
         }
@@ -86,7 +86,7 @@
             color: var(--light-text);
 
             &:hover,
-            &:focus {
+            &:focus-visible {
                 color: var(--light-text) !important;
                 background-color: var(--primary-3) !important;
             }
@@ -128,14 +128,14 @@
     border-radius: var(--border-radius);
 
     &:hover,
-    &:focus {
+    &:focus-visible {
         color: var(--danger);
         background-color: var(--danger-4);
     }
 
     :global(.theme-dark) & {
         &:hover,
-        &:focus {
+        &:focus-visible {
             color: var(--light-text);
             background-color: var(--danger-2);
         }

--- a/client/wildcard/src/components/Button/Button.module.scss
+++ b/client/wildcard/src/components/Button/Button.module.scss
@@ -79,7 +79,7 @@ input.btn {
     }
 
     &:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
-        &:hover:not(:global(.focus-visible)):not(:focus-visible),
+        &:hover:not(:global(.focus)):not(:focus-visible),
         &:active,
         &:global(.active) {
             text-decoration: underline;
@@ -87,7 +87,7 @@ input.btn {
         }
 
         &:focus-visible,
-        &:global(.focus-visible) {
+        &:global(.focus) {
             text-decoration: underline;
 
             :global(.theme-light) & {
@@ -137,7 +137,7 @@ input.btn {
     border: none;
     cursor: pointer;
 
-    &.focus-visible:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
+    &.focus:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
         box-shadow: 0 0 0 2px var(--primary-2);
     }
 
@@ -192,7 +192,7 @@ input.btn {
     }
 
     &:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
-        &:hover:not(:global(.focus-visible)):not(:focus-visible),
+        &:hover:not(:global(.focus)):not(:focus-visible),
         &:active,
         &:global(.active) {
             color: var(--btn-text-color);
@@ -200,7 +200,7 @@ input.btn {
         }
 
         &:focus-visible,
-        &:global(.focus-visible) {
+        &:global(.focus) {
             color: var(--btn-text-color);
             background-color: var(--btn-base-color);
             border-color: var(--body-bg);
@@ -247,7 +247,7 @@ input.btn {
             fill: var(--btn-base-color);
         }
 
-        &:hover:not(:global(.focus-visible)):not(:focus-visible),
+        &:hover:not(:global(.focus)):not(:focus-visible),
         &:active,
         &:global(.active) {
             background-color: var(--color-bg-1);
@@ -268,7 +268,7 @@ input.btn {
         }
 
         &:focus-visible,
-        &:global(.focus-visible) {
+        &:global(.focus) {
             color: var(--body-color);
             background-color: var(--body-bg);
             border-color: var(--body-bg);
@@ -358,7 +358,7 @@ input.btn {
         }
 
         &:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
-            &:hover:not(:global(.focus-visible)):not(:focus-visible),
+            &:hover:not(:global(.focus)):not(:focus-visible),
             &:active,
             &:global(.active) {
                 text-decoration: none;
@@ -371,7 +371,7 @@ input.btn {
             }
 
             &:focus-visible,
-            &:global(.focus-visible) {
+            &:global(.focus) {
                 box-shadow: 0 0 0 2px var(--primary-2);
             }
 

--- a/client/wildcard/src/components/Button/Button.module.scss
+++ b/client/wildcard/src/components/Button/Button.module.scss
@@ -44,7 +44,7 @@
 // since button doesn't use disabled attribute we enforce/mimic the native
 // disabled control styles.
 input.btn {
-    &:focus {
+    &:focus-visible {
         outline: 2px solid var(--primary-2);
         outline-offset: 2px;
     }
@@ -79,15 +79,15 @@ input.btn {
     }
 
     &:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
-        &:hover:not(:global(.focus)):not(:focus),
+        &:hover:not(:global(.focus-visible)):not(:focus-visible),
         &:active,
         &:global(.active) {
             text-decoration: underline;
             color: var(--link-hover-color);
         }
 
-        &:focus,
-        &:global(.focus) {
+        &:focus-visible,
+        &:global(.focus-visible) {
             text-decoration: underline;
 
             :global(.theme-light) & {
@@ -137,7 +137,7 @@ input.btn {
     border: none;
     cursor: pointer;
 
-    &:focus-visible:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
+    &.focus-visible:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
         box-shadow: 0 0 0 2px var(--primary-2);
     }
 
@@ -192,15 +192,15 @@ input.btn {
     }
 
     &:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
-        &:hover:not(:global(.focus)):not(:focus),
+        &:hover:not(:global(.focus-visible)):not(:focus-visible),
         &:active,
         &:global(.active) {
             color: var(--btn-text-color);
             background-color: var(--btn-dark-color-variant);
         }
 
-        &:focus,
-        &:global(.focus) {
+        &:focus-visible,
+        &:global(.focus-visible) {
             color: var(--btn-text-color);
             background-color: var(--btn-base-color);
             border-color: var(--body-bg);
@@ -247,7 +247,7 @@ input.btn {
             fill: var(--btn-base-color);
         }
 
-        &:hover:not(:global(.focus)):not(:focus),
+        &:hover:not(:global(.focus-visible)):not(:focus-visible),
         &:active,
         &:global(.active) {
             background-color: var(--color-bg-1);
@@ -267,8 +267,8 @@ input.btn {
             }
         }
 
-        &:focus,
-        &:global(.focus) {
+        &:focus-visible,
+        &:global(.focus-visible) {
             color: var(--body-color);
             background-color: var(--body-bg);
             border-color: var(--body-bg);
@@ -358,7 +358,7 @@ input.btn {
         }
 
         &:not(:disabled):not(:global(.disabled)):not([aria-disabled='true']) {
-            &:hover:not(:global(.focus)):not(:focus),
+            &:hover:not(:global(.focus-visible)):not(:focus-visible),
             &:active,
             &:global(.active) {
                 text-decoration: none;
@@ -370,8 +370,8 @@ input.btn {
                 }
             }
 
-            &:focus,
-            &:global(.focus) {
+            &:focus-visible,
+            &:global(.focus-visible) {
                 box-shadow: 0 0 0 2px var(--primary-2);
             }
 

--- a/client/wildcard/src/global-styles/base.scss
+++ b/client/wildcard/src/global-styles/base.scss
@@ -28,6 +28,7 @@
 :focus:not(:focus-visible) {
     outline: none;
 }
+
 :focus-visible {
     outline: 0;
     box-shadow: var(--focus-box-shadow);

--- a/client/wildcard/src/global-styles/base.scss
+++ b/client/wildcard/src/global-styles/base.scss
@@ -25,11 +25,11 @@
 
 // Show a focus ring when performing keyboard navigation. Uses the polyfill at
 // https://github.com/WICG/focus-visible because few browsers support :focus-visible.
-:focus:not(:focus-visible) {
+:focus:not(.focus-visible) {
     outline: none;
 }
 
-:focus-visible {
+.focus-visible {
     outline: 0;
     box-shadow: var(--focus-box-shadow);
 }

--- a/client/wildcard/src/global-styles/custom-forms.scss
+++ b/client/wildcard/src/global-styles/custom-forms.scss
@@ -40,10 +40,10 @@
     appearance: none;
     transition: var(--custom-forms-transition);
 
-    &:focus {
-        border-color: var(--input-focus-border-color);
+    &.focus-visible {
         outline: 0;
         box-shadow: var(--input-focus-box-shadow);
+        border-color: var(--input-focus-border-color);
 
         &::-ms-value {
             // For visual consistency with other platforms/browsers,

--- a/client/wildcard/src/global-styles/forms.scss
+++ b/client/wildcard/src/global-styles/forms.scss
@@ -204,7 +204,7 @@ progress {
         opacity: 1;
     }
 
-    &:focus-visible {
+    &.focus-visible {
         border-color: var(--input-focus-border-color);
         box-shadow: var(--input-focus-box-shadow);
     }

--- a/client/wildcard/src/global-styles/forms.scss
+++ b/client/wildcard/src/global-styles/forms.scss
@@ -62,15 +62,6 @@ button {
     border-radius: 0;
 }
 
-// Work around a Firefox/IE bug where the transparent `button` background
-// results in a loss of the default `button` focus styles.
-//
-// Credit: https://github.com/suitcss/base/
-button:focus {
-    outline: 1px dotted;
-    outline: 5px auto -webkit-focus-ring-color;
-}
-
 input,
 button,
 select,
@@ -213,7 +204,7 @@ progress {
         opacity: 1;
     }
 
-    &:focus {
+    &:focus-visible {
         border-color: var(--input-focus-border-color);
         box-shadow: var(--input-focus-box-shadow);
     }


### PR DESCRIPTION
Resolves part of https://github.com/sourcegraph/sourcegraph/issues/44878

## Context

- `:focus` is unconditional selector, every time when element is focused (regardless of what caused this focus) this selector will match
- `:focus-visible` is conditional, and browser decides when this selector will match, for example clicks on button shouldn't trigger focus-ring style, so focus-visible won't be triggered/matched.

In our styles we're heavily using `:focus` selector, and therefore we have a lot of controls which always have focus-ring styles, sometimes this also causes having double focus-ring UI (our custom ring from `base.scss` and browser standard ring)

So this PR replaces `:focus` to `:focus-visible` in some places where it makes sense, we still need to use :focus somewhere where it should be use (like search boxes, input, ..etc)

### Difference between `:focus-visible` and `.focus-visible`
Different browsers have different heuristics about showing focus ring, for example select UI does have focus ring if you click it in Chrome, but it doesn't have focus ring in Safari. So to unify this behaviour and support browsers in which :focus-visible is still unavailable (very small percentage but still) we use focus-visible polyfill and focus-visible postcss plugin.

In general this works in a way that we track all clicks and keyboards strokes and add `.focus-visible` class to focusable elements (only if we navigate to them through keyboard)

## Test plan
- Check that clicking on buttons doesn't trigger focus ring appearance 
- Check that clicking on select doesn't trigger focus ring appearance 
- Check that both buttons and select controls still have focus ring if you're navigation though keyboard 
