### PR TITLE
Chore: simplify enterprise init in `worker`

### DIFF
--- a/cmd/worker/shared/BUILD.bazel
+++ b/cmd/worker/shared/BUILD.bazel
@@ -57,6 +57,5 @@ go_library(
         "//internal/symbols",
         "//lib/errors",
         "@com_github_prometheus_client_golang//prometheus",
-        "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -154,14 +154,12 @@ func Start(ctx context.Context, observationCtx *observation.Context, ready servi
 		return errors.Wrap(err, "initializing keyring")
 	}
 
-	if enterpriseInit != nil {
-		db, err := workerdb.InitDB(observationCtx)
-		if err != nil {
-			return errors.Wrap(err, "Failed to create database connection")
-		}
-
-		enterpriseInit(db)
+	db, err := workerdb.InitDB(observationCtx)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create database connection")
 	}
+
+	enterpriseInit(db)
 
 	// Emit metrics to help site admins detect instances that accidentally
 	// omit a job from from the instance's deployment configuration.

--- a/cmd/worker/shared/service.go
+++ b/cmd/worker/shared/service.go
@@ -26,7 +26,7 @@ func (svc) Start(ctx context.Context, observationCtx *observation.Context, ready
 	// so we init the built-in auth provider just in case.
 	userpasswd.Init()
 
-	return Start(ctx, observationCtx, ready, config.(*Config), getEnterpriseInit(observationCtx.Logger))
+	return Start(ctx, observationCtx, ready, config.(*Config))
 }
 
 var Service service.Service = svc{}


### PR DESCRIPTION
Now that everything is enterprise, we can simplify the initialization a bit. This PR mostly just inlines the `enterpriseInit` logic so that it always runs.

## Test plan

Ran `sg start` and saw worker do its thing.
