### PR TITLE
Telemetry: fix nil panic 

### DIFF
--- a/internal/telemetry/BUILD.bazel
+++ b/internal/telemetry/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//internal/version",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_google_protobuf//types/known/structpb",
-        "@org_uber_go_zap//zapcore",
     ],
 )
 

--- a/internal/telemetry/BUILD.bazel
+++ b/internal/telemetry/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//internal/version",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_google_protobuf//types/known/structpb",
+        "@org_uber_go_zap//zapcore",
     ],
 )
 

--- a/internal/telemetry/besteffort.go
+++ b/internal/telemetry/besteffort.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/sourcegraph/log"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -26,10 +27,14 @@ func NewBestEffortEventRecorder(logger log.Logger, recorder *EventRecorder) *Bes
 // actor, logging any recording errors it encounters. Parameters are optional.
 func (r *BestEffortEventRecorder) Record(ctx context.Context, feature eventFeature, action eventAction, parameters *EventParameters) {
 	if err := r.recorder.Record(ctx, feature, action, parameters); err != nil {
-		trace.Logger(ctx, r.logger).Error("failed to record telemetry event",
+		fields := []zapcore.Field{
 			log.String("feature", string(feature)),
 			log.String("action", string(action)),
-			log.Int("parameters.version", parameters.Version),
-			log.Error(err))
+			log.Error(err),
+		}
+		if parameters != nil {
+			fields = append(fields, log.Int("parameters.version", parameters.Version))
+		}
+		trace.Logger(ctx, r.logger).Error("failed to record telemetry event", fields...)
 	}
 }

--- a/internal/telemetry/besteffort.go
+++ b/internal/telemetry/besteffort.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/sourcegraph/log"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -27,7 +26,7 @@ func NewBestEffortEventRecorder(logger log.Logger, recorder *EventRecorder) *Bes
 // actor, logging any recording errors it encounters. Parameters are optional.
 func (r *BestEffortEventRecorder) Record(ctx context.Context, feature eventFeature, action eventAction, parameters *EventParameters) {
 	if err := r.recorder.Record(ctx, feature, action, parameters); err != nil {
-		fields := []zapcore.Field{
+		fields := []log.Field{
 			log.String("feature", string(feature)),
 			log.String("action", string(action)),
 			log.Error(err),

--- a/internal/telemetry/telemetrytest/BUILD.bazel
+++ b/internal/telemetry/telemetrytest/BUILD.bazel
@@ -21,8 +21,10 @@ go_test(
     srcs = ["telemetrytest_test.go"],
     embed = [":telemetrytest"],
     deps = [
+        "//internal/telemetry",
         "//internal/telemetrygateway/v1:telemetrygateway",
         "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/telemetry/telemetrytest/telemetrytest_test.go
+++ b/internal/telemetry/telemetrytest/telemetrytest_test.go
@@ -2,11 +2,14 @@ package telemetrytest
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1"
 )
 
@@ -25,4 +28,18 @@ func TestFakeTelemetryEventsExportQueueStore(t *testing.T) {
 	require.Len(t, s.events, 1)
 	require.Equal(t, "asdfasdf", s.events[0].Id)
 	autogold.Expect([]string{"Feature - Action"}).Equal(t, s.GetMockQueuedEvents().Summary())
+}
+
+func TestBestEffort(t *testing.T) {
+	t.Run("no panic on nil parameters", func(t *testing.T) {
+		erroringStore := NewMockEventsStore()
+		erroringStore.StoreEventsFunc.SetDefaultReturn(errors.New("BOOM"))
+
+		r := telemetry.NewBestEffortEventRecorder(
+			logtest.Scoped(t),
+			telemetry.NewEventRecorder(erroringStore),
+		)
+
+		r.Record(context.Background(), telemetry.FeatureExample, telemetry.ActionAttempted, nil)
+	})
 }


### PR DESCRIPTION
This fixes a [nil panic](https://files.slack.com/files-pri/T02FSM7DL-F0601EYB25S/new_error_in_sourcegraph-dev_sourcegraph-frontend_sourcegraph-frontend-5c688b9445-frtdq) that was showing up when recording with nil parameters, which is documented as an okay thing to do. 

## Test plan

Added a test that this no longer panics when recording fails.
