### PR TITLE
Fixup script path after move

### DIFF
--- a/dev/ci/integration/executors/run.sh
+++ b/dev/ci/integration/executors/run.sh
@@ -2,7 +2,7 @@
 
 # This script runs the executors-e2e test suite against a candidate server image.
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 root_dir=$(pwd)
 set -ex
 


### PR DESCRIPTION
Was moved out of enterprise/, so this is no longer correct.

## Test plan

CI