### PR TITLE
Fixup script path after move

### DIFF
--- a/dev/ci/integration/executors/test.sh
+++ b/dev/ci/integration/executors/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
 set -e
 


### PR DESCRIPTION
Was moved out of enterprise/, so this is no longer correct.

## Test plan

CI