### PR TITLE
Allow to edit code host config temporarily in local dev by default

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -134,6 +134,9 @@ env:
 
   TELEMETRY_GATEWAY_EXPORTER_EXPORT_ADDR: "http://127.0.0.1:10080"
 
+  # By default, allow temporary edits to external services.
+  EXTSVC_CONFIG_ALLOW_EDITS: true
+
 commands:
   server:
     description: Run an all-in-one sourcegraph/server image


### PR DESCRIPTION
I often want to quickly test a config change to a code host config, but then realize I forgot to set this env var manually again and then need to restart the entire stack. I don't think disallowing edits is a great default, so instead of adding it to my override file I'm proposing to add it to the general configuration.

What do people think?

## Test plan

Tested in local dev that it is respected properly. 