### PR TITLE
rename env var WEBPACK_DEV_SERVER to WEB_BUILDER_DEV_SERVER

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -91,7 +91,7 @@ type Common struct {
 
 	Manifest *assets.WebpackManifest
 
-	WebpackDevServer bool // whether the Webpack dev server is running (WEBPACK_DEV_SERVER env var)
+	WebpackDevServer bool // whether the Webpack dev server is running (WEB_BUILDER_DEV_SERVER env var)
 
 	// The fields below have zero values when not on a repo page.
 	Repo         *types.Repo
@@ -99,7 +99,7 @@ type Common struct {
 	api.CommitID        // resolved SHA1 revision
 }
 
-var webpackDevServer, _ = strconv.ParseBool(os.Getenv("WEBPACK_DEV_SERVER"))
+var webpackDevServer, _ = strconv.ParseBool(os.Getenv("WEB_BUILDER_DEV_SERVER"))
 
 // repoShortName trims the first path element of the given repo name if it has
 // at least two path components.

--- a/cmd/frontend/internal/app/ui/tmpl.go
+++ b/cmd/frontend/internal/app/ui/tmpl.go
@@ -31,7 +31,7 @@ var (
 	versionCacheMu sync.RWMutex
 	versionCache   = make(map[string]string)
 
-	_, noAssetVersionString = os.LookupEnv("WEBPACK_DEV_SERVER")
+	_, noAssetVersionString = os.LookupEnv("WEB_BUILDER_DEV_SERVER")
 )
 
 // Functions that are exposed to templates.

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -16,7 +16,7 @@ import (
 
 func main() {
 	sanitycheck.Pass()
-	if os.Getenv("WEBPACK_DEV_SERVER") == "1" {
+	if os.Getenv("WEB_BUILDER_DEV_SERVER") == "1" {
 		assets.UseDevAssetsProvider()
 	}
 	svcmain.SingleServiceMainWithoutConf(shared.Service, svcmain.Config{}, svcmain.OutOfBandConfiguration{

--- a/cmd/sourcegraph/main.go
+++ b/cmd/sourcegraph/main.go
@@ -42,7 +42,7 @@ var services = []service.Service{
 
 func main() {
 	sanitycheck.Pass()
-	if os.Getenv("WEBPACK_DEV_SERVER") == "1" {
+	if os.Getenv("WEB_BUILDER_DEV_SERVER") == "1" {
 		assets.UseDevAssetsProvider()
 	}
 	osscmd.MainOSS(services, os.Args)

--- a/dev/sg/sg.config.example.yaml
+++ b/dev/sg/sg.config.example.yaml
@@ -25,7 +25,7 @@ commands:
       CONFIGURATION_MODE: server
       USE_ENHANCED_LANGUAGE_DETECTION: false
       # This needs to be set on `frontend` too so that `app.html` is rendered correctly
-      WEBPACK_DEV_SERVER: 1
+      WEB_BUILDER_DEV_SERVER: 1
     watch:
       - internal
       - cmd/frontend
@@ -76,7 +76,7 @@ commands:
     cmd: ./node_modules/.bin/gulp --silent --color dev
     install: pnpm install
     env:
-      WEBPACK_DEV_SERVER: 1
+      WEB_BUILDER_DEV_SERVER: 1
       NODE_ENV: development
       NODE_OPTIONS: '--max_old_space_size=8192'
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -165,7 +165,7 @@ commands:
       SITE_CONFIG_FILE: "../dev-private/enterprise/dev/site-config.json"
       SITE_CONFIG_ESCAPE_HATCH_PATH: "$HOME/.sourcegraph/site-config.json"
       # frontend processes need this to be so that the paths to the assets are rendered correctly
-      WEBPACK_DEV_SERVER: 1
+      WEB_BUILDER_DEV_SERVER: 1
     watch:
       - lib
       - internal
@@ -935,7 +935,7 @@ commands:
     env:
       SITE_CONFIG_FILE: "../dev-private/enterprise/dev/site-config.json"
       SITE_CONFIG_ESCAPE_HATCH_PATH: "$HOME/.sourcegraph/site-config.json"
-      WEBPACK_DEV_SERVER: 1
+      WEB_BUILDER_DEV_SERVER: 1
     watch:
       - cmd
       - enterprise
@@ -987,7 +987,7 @@ bazelCommands:
       SITE_CONFIG_FILE: "../dev-private/enterprise/dev/site-config.json"
       SITE_CONFIG_ESCAPE_HATCH_PATH: "$HOME/.sourcegraph/site-config.json"
       # frontend processes need this to be so that the paths to the assets are rendered correctly
-      WEBPACK_DEV_SERVER: 1
+      WEB_BUILDER_DEV_SERVER: 1
   worker:
     target: //cmd/worker
     precmd: |

--- a/ui/assets/doc.go
+++ b/ui/assets/doc.go
@@ -11,7 +11,7 @@
 // And to support working with dev assets, with the webpack process handling them for you, you can use:
 //
 //	 func main() {
-//		if os.Getenv("WEBPACK_DEV_SERVER") == "1" {
+//		if os.Getenv("WEB_BUILDER_DEV_SERVER") == "1" {
 //			assets.UseDevAssetsProvider()
 //		}
 //		// ...


### PR DESCRIPTION
This env var was already used when running either Webpack or esbuild. In the future Webpack will no longer be used, so a more general name not tied to the specific bundler is best.

(Command: `fastmod -e yaml,go,md WEBPACK_DEV_SERVER WEB_BUILDER_DEV_SERVER`)




## Test plan

This was only used for local dev. Run a local dev server with `sg start` and confirm that frontend assets are built.