### PR TITLE
Handle a case where "symbols" field returned from squirrel is null

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -253,15 +253,16 @@ export class API {
         if (!payload) {
             return
         }
-
-        for (const symbol of payload.symbols) {
-            if (isInRange(position, symbol.def)) {
-                return symbol
-            }
-
-            for (const reference of symbol.refs ?? []) {
-                if (isInRange(position, reference)) {
+        if (payload.symbols) {
+            for (const symbol of payload.symbols) {
+                if (isInRange(position, symbol.def)) {
                     return symbol
+                }
+
+                for (const reference of symbol.refs ?? []) {
+                    if (isInRange(position, reference)) {
+                        return symbol
+                    }
                 }
             }
         }
@@ -472,7 +473,7 @@ export interface RepoCommitPath {
 }
 
 type LocalCodeIntelPayload = {
-    symbols: LocalSymbol[]
+    symbols: LocalSymbol[] | null
 } | null
 
 interface LocalSymbol {


### PR DESCRIPTION
On Dotcom a hover on a symbol was crashing because of null response from Squirrel: https://sourcegraph.com/github.com/github/stack-graphs/-/blob/tree-sitter-stack-graphs/examples/nested-scope/tests/shadowing.py?L7 (stand on `foo()` at the bottom)

Fix is just to handle the null.

Before: 
![CleanShot 2023-10-06 at 12 27 30](https://github.com/sourcegraph/sourcegraph/assets/1052965/bd4469d6-80cb-44f6-892c-dc3b630ee73e)

After: 
![CleanShot 2023-10-06 at 12 38 15](https://github.com/sourcegraph/sourcegraph/assets/1052965/bcfe3a0a-63fb-44b8-b2e4-57771ce5f5d0)

--- 

What I'm confused about is how this happens? We seems to explicitly initialise the symbols array in the only place that matters: https://github.com/sourcegraph/sourcegraph/blob/main/cmd/symbols/squirrel/local_code_intel.go#L112

SO answer suggests that we're doing it right: https://stackoverflow.com/questions/56200925/return-an-empty-array-instead-of-null-with-golang-for-json-return-with-gin

And adding an empty test case also produces an empty array in json, not null.


## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
