### PR TITLE
graphqlbackend: remove unused repositoryConnectionResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/log"
@@ -128,7 +126,7 @@ func (r *schemaResolver) Repositories(ctx context.Context, args *repositoryArgs)
 
 	connectionOptions := graphqlutil.ConnectionResolverOptions{
 		MaxPageSize: &maxPageSize,
-		OrderBy:     database.OrderBy{{Field: string(ToDBRepoListColumn(orderBy))}, {Field: "id"}},
+		OrderBy:     database.OrderBy{{Field: string(toDBRepoListColumn(orderBy))}, {Field: "id"}},
 		Ascending:   !args.Descending,
 	}
 
@@ -256,152 +254,7 @@ type RepositoryConnectionResolver interface {
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
 }
 
-var _ RepositoryConnectionResolver = &repositoryConnectionResolver{}
-
-type repositoryConnectionResolver struct {
-	logger log.Logger
-	db     database.DB
-	opt    database.ReposListOptions
-
-	// cache results because they are used by multiple fields
-	once  sync.Once
-	repos []*types.Repo
-	err   error
-}
-
-func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Repo, error) {
-	r.once.Do(func() {
-		opt2 := r.opt
-
-		if envvar.SourcegraphDotComMode() {
-			// 🚨 SECURITY: Don't allow non-admins to perform huge queries on Sourcegraph.com.
-			if isSiteAdmin := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db) == nil; !isSiteAdmin {
-				if opt2.LimitOffset == nil {
-					opt2.LimitOffset = &database.LimitOffset{Limit: 1000}
-				}
-			}
-		}
-
-		reposClient := backend.NewRepos(r.logger, r.db, gitserver.NewClient())
-		for {
-			// Cursor-based pagination requires that we fetch limit+1 records, so
-			// that we know whether or not there's an additional page (or more)
-			// beyond the current one. We reset the limit immediately afterward for
-			// any subsequent calculations.
-			if opt2.LimitOffset != nil {
-				opt2.LimitOffset.Limit++
-			}
-			repos, err := reposClient.List(ctx, opt2)
-			if err != nil {
-				r.err = err
-				return
-			}
-			if opt2.LimitOffset != nil {
-				opt2.LimitOffset.Limit--
-			}
-			reposFromDB := len(repos)
-
-			r.repos = append(r.repos, repos...)
-
-			if opt2.LimitOffset == nil {
-				break
-			} else {
-				// check if we filtered some repos and if we need to get more from the DB
-				if len(repos) >= opt2.Limit || reposFromDB < opt2.Limit {
-					break
-				}
-				opt2.Offset += opt2.Limit
-			}
-		}
-	})
-
-	return r.repos, r.err
-}
-
-func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*RepositoryResolver, error) {
-	repos, err := r.compute(ctx)
-	if err != nil {
-		return nil, err
-	}
-	resolvers := make([]*RepositoryResolver, 0, len(repos))
-	client := gitserver.NewClient()
-	for i, repo := range repos {
-		if r.opt.LimitOffset != nil && i == r.opt.Limit {
-			break
-		}
-
-		resolvers = append(resolvers, NewRepositoryResolver(r.db, client, repo))
-	}
-	return resolvers, nil
-}
-
-func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *TotalCountArgs) (countptr *int32, err error) {
-	if r.opt.UserID != 0 {
-		// 🚨 SECURITY: If filtering by user, restrict to that user
-		if err := auth.CheckSameUser(ctx, r.opt.UserID); err != nil {
-			return nil, err
-		}
-	} else if r.opt.OrgID != 0 {
-		if err := auth.CheckOrgAccess(ctx, r.db, r.opt.OrgID); err != nil {
-			return nil, err
-		}
-	} else {
-		// 🚨 SECURITY: Only site admins can list all repos, because a total repository
-		// count does not respect repository permissions.
-		if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
-			return nil, err
-		}
-	}
-
-	// Counting repositories is slow on Sourcegraph.com. Don't wait very long for an exact count.
-	if !args.Precise && envvar.SourcegraphDotComMode() {
-		if len(r.opt.Query) < 4 {
-			return nil, nil
-		}
-
-		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, 300*time.Millisecond)
-		defer cancel()
-		defer func() {
-			if ctx.Err() == context.DeadlineExceeded {
-				countptr = nil
-				err = nil
-			}
-		}()
-	}
-
-	count, err := r.db.Repos().Count(ctx, r.opt)
-	return pointers.Ptr(int32(count)), err
-}
-
-func (r *repositoryConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	repos, err := r.compute(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if len(repos) == 0 || r.opt.LimitOffset == nil || len(repos) <= r.opt.Limit || len(r.opt.Cursors) == 0 {
-		return graphqlutil.HasNextPage(false), nil
-	}
-
-	cursor := r.opt.Cursors[0]
-
-	var value string
-	switch cursor.Column {
-	case string(database.RepoListName):
-		value = string(repos[len(repos)-1].Name)
-	case string(database.RepoListCreatedAt):
-		value = repos[len(repos)-1].CreatedAt.Format("2006-01-02 15:04:05.999999")
-	}
-	return graphqlutil.NextPageCursor(MarshalRepositoryCursor(
-		&types.Cursor{
-			Column:    cursor.Column,
-			Value:     value,
-			Direction: cursor.Direction,
-		},
-	)), nil
-}
-
-func ToDBRepoListColumn(ob string) database.RepoListColumn {
+func toDBRepoListColumn(ob string) database.RepoListColumn {
 	switch ob {
 	case "REPO_URI", "REPOSITORY_NAME":
 		return database.RepoListName

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -238,12 +238,6 @@ func (s *repositoriesConnectionStore) ComputeNodes(ctx context.Context, args *da
 	return resolvers, nil
 }
 
-// NOTE(naman): The old resolver `RepositoryConnectionResolver` defined below is
-// deprecated and replaced by `graphqlutil.ConnectionResolver` above which implements
-// proper cursor-based pagination and do not support `precise` argument for totalCount.
-// The old resolver is still being used by `AuthorizedUserRepositories` API, therefore
-// the code is not removed yet.
-
 type TotalCountArgs struct {
 	Precise bool
 }


### PR DESCRIPTION
This resolver is not actually used. I think it could of been removed a while ago as per Naman's comment about it being unused. The interface for it needs to remain, but the actual implementation here can be removed.

Test Plan: go test. If that is happy we know the code is unused.