### PR TITLE
sg: fix sg ops issue with dogfood-k8s

### DIFF
--- a/dev/sg/internal/images/dockerhub.go
+++ b/dev/sg/internal/images/dockerhub.go
@@ -50,6 +50,12 @@ func (r *DockerHub) Org() string {
 	return r.org
 }
 
+// Public returns if the registry is used for public purposes or not.
+// Right now, we only use DockerHub for public releases, so it's always true.
+func (r *DockerHub) Public() bool {
+	return true
+}
+
 func (r *DockerHub) tryLoadingCredsFromStore() error {
 	dockerCredentials := &credentials.Credentials{
 		ServerURL: "https://registry.hub.docker.com/v2",

--- a/dev/sg/internal/images/gcr.go
+++ b/dev/sg/internal/images/gcr.go
@@ -37,6 +37,12 @@ func (r *GCR) Org() string {
 	return r.org
 }
 
+// Public returns if the registry is used for public purposes or not.
+// Right now, we never use GCR for public releases, so it's always false.
+func (r *GCR) Public() bool {
+	return false
+}
+
 // LoadToken gets the access-token to reach GCR through the environment.
 func (r *GCR) LoadToken() error {
 	b, err := exec.Command("gcloud", "auth", "print-access-token").Output()

--- a/dev/sg/internal/images/helm.go
+++ b/dev/sg/internal/images/helm.go
@@ -39,7 +39,21 @@ func UpdateHelmManifest(ctx context.Context, registry Registry, path string, op 
 	// sourcegraph.image.repository.
 	existingReg, err := readRegistry(values)
 	if err != nil {
-		return err
+		// github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s doesn't have the
+		// sourcegraph.image.repository object being defined, so we can't swap registries
+		// if we want to use an internal release.
+		//
+		// This is fine as long as we go for using the public registry, so we can safely
+		// ignore the error. But we don't we try to build a private release, in which
+		// case we *need* to define explictly the registry.
+		//
+		// This is a case of deviations between the two helm repos, and best be addressed
+		// by the release team.
+		if !registry.Public() {
+			return err
+		} else {
+			std.Out.WriteLine(output.Styled(output.StyleWarning, fmt.Sprintf("skipping updating registry as it's public which we assume is the default, %q", err.Error())))
+		}
 	}
 	valuesFileString = strings.ReplaceAll(
 		valuesFileString,

--- a/dev/sg/internal/images/registry.go
+++ b/dev/sg/internal/images/registry.go
@@ -21,6 +21,7 @@ type Registry interface {
 	GetLatest(repo string, latest func(tags []string) (string, error)) (*Repository, error)
 	Host() string
 	Org() string
+	Public() bool
 }
 
 type Repository struct {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/285

## Test plan

Ran the updating command against the repo, with a `sg` built with the code from this PR. It went fine as expected. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
