### PR TITLE
search: do not specify user or org id from search contexts

### DIFF
--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -283,8 +283,6 @@ func (r *Resolver) doQueryDB(ctx context.Context, tr trace.Trace, op search.Repo
 	// a query, which replaces the context:foo term at query parsing time.
 	if searchContext.Query == "" {
 		options.SearchContextID = searchContext.ID
-		options.UserID = searchContext.NamespaceUserID
-		options.OrgID = searchContext.NamespaceOrgID
 	}
 
 	tr.AddEvent("Repos.ListMinimalRepos - start")
@@ -912,8 +910,6 @@ func computeExcludedRepos(ctx context.Context, db database.DB, op search.RepoOpt
 		NoPrivate:       op.Visibility == query.Public,
 		OnlyPrivate:     op.Visibility == query.Private,
 		SearchContextID: searchContext.ID,
-		UserID:          searchContext.NamespaceUserID,
-		OrgID:           searchContext.NamespaceOrgID,
 	}
 
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
We don't have repos associated with user or org anymore. I was thinking stuff would go wrong since we were setting these values, but if you read the database code if SearchContextID is set we ignore the UserID and OrgID.

This change is part of removing UserID and OrgID from the repos API.

Test Plan: go test. Additionally manually inspected some tables on dotcom to understand what data we had for these fields.