### PR TITLE
nix: do not manage bazel on MacOS

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -107,13 +107,14 @@ mkShell {
     rustfmt
     libiconv
     clippy
-
+  ] ++ lib.optional hostPlatform.isLinux (with pkgs; [
+    # bazel via nix is broken on MacOS for us. Lets just rely on bazelisk from brew.
     # special sauce bazel stuff.
     bazelisk # needed to please sg, but not used directly by us
-    (if hostPlatform.isLinux then bazel-fhs else bazel-wrapper)
+    bazel-fhs
     bazel-watcher
     bazel-buildtools
-  ];
+  ]);
 
   # Startup postgres, redis & set nixos specific stuff
   shellHook = ''


### PR DESCRIPTION
It has been broken for me since the nix changes a few weeks ago. I've mostly been devving on linux so I've been ignoring it.

Test Plan: nix develop on my mbp