### PR TITLE
[bug] Fix syncUserPerms creating user repo permissions with NULL external account IDs

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -231,7 +231,7 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (n
 
 	// Create/update the external account and ensure it's associated with the user ID
 	if !extAcctSaved {
-		err := externalAccountsStore.AssociateUserAndSave(ctx, userID, op.ExternalAccount, op.ExternalAccountData)
+		_, err := externalAccountsStore.AssociateUserAndSave(ctx, userID, op.ExternalAccount, op.ExternalAccountData)
 		if err != nil {
 			return newUserSaved, 0, "Unexpected error associating the external account with your Sourcegraph user. The most likely cause for this problem is that another Sourcegraph user is already linked with this external account. A site admin or the other user can unlink the account to fix this problem.", err
 		}

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -739,22 +739,22 @@ func (m *mocks) CreateUserAndSave(_ context.Context, newUser database.NewUser, s
 }
 
 // AssociateUserAndSave mocks database.ExternalAccounts.AssociateUserAndSave
-func (m *mocks) AssociateUserAndSave(_ context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) (err error) {
+func (m *mocks) AssociateUserAndSave(_ context.Context, userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) (_ *extsvc.Account, err error) {
 	if m.associateUserAndSaveErr != nil {
-		return m.associateUserAndSaveErr
+		return nil, m.associateUserAndSaveErr
 	}
 
 	// Check if ext acct is associated with different user
 	for _, u := range m.userInfos {
 		for _, a := range u.extAccts {
 			if a == spec && u.user.ID != userID {
-				return errors.Errorf("unable to change association of external account from user %d to user %d (delete the external account and then try again)", u.user.ID, userID)
+				return nil, errors.Errorf("unable to change association of external account from user %d to user %d (delete the external account and then try again)", u.user.ID, userID)
 			}
 		}
 	}
 
 	m.savedExtAccts[userID] = append(m.savedExtAccts[userID], spec)
-	return nil
+	return nil, nil
 }
 
 // GetByVerifiedEmail mocks database.Users.GetByVerifiedEmail

--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -567,7 +567,8 @@ func TestRemoveStalePerforceAccount(t *testing.T) {
 		data := extsvc.AccountData{
 			Data: extsvc.NewUnencryptedData(serializedData),
 		}
-		require.NoError(t, db.UserExternalAccounts().Insert(ctx, createdUser.ID, spec, data))
+		_, err = db.UserExternalAccounts().Insert(ctx, createdUser.ID, spec, data)
+		require.NoError(t, err)
 
 		// Confirm that the external account was added
 		accounts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{

--- a/cmd/frontend/graphqlbackend/external_accounts_test.go
+++ b/cmd/frontend/graphqlbackend/external_accounts_test.go
@@ -141,7 +141,7 @@ func TestExternalAccounts_AddExternalAccount(t *testing.T) {
 				},
 			}, nil)
 
-			userextaccts.InsertFunc.SetDefaultHook(func(ctx context.Context, uID int32, acctSpec extsvc.AccountSpec, acctData extsvc.AccountData) error {
+			userextaccts.InsertFunc.SetDefaultHook(func(ctx context.Context, uID int32, acctSpec extsvc.AccountSpec, acctData extsvc.AccountData) (*extsvc.Account, error) {
 				if uID != tc.user.ID {
 					t.Errorf("got userID %d, want %d", uID, tc.user.ID)
 				}
@@ -154,7 +154,7 @@ func TestExternalAccounts_AddExternalAccount(t *testing.T) {
 				if acctSpec.AccountID != "1234" {
 					t.Errorf("got account ID %q, want %q", acctSpec.AccountID, "alice")
 				}
-				return nil
+				return nil, nil
 			})
 			confGet := func() *conf.Unified {
 				return &conf.Unified{}

--- a/cmd/frontend/internal/auth/sourcegraphoperator/associate.go
+++ b/cmd/frontend/internal/auth/sourcegraphoperator/associate.go
@@ -80,7 +80,7 @@ func addSourcegraphOperatorExternalAccount(ctx context.Context, db database.DB, 
 		if err != nil {
 			return errors.Wrap(err, "failed to marshal account data")
 		}
-		if err := db.UserExternalAccounts().AssociateUserAndSave(ctx, userID, extsvc.AccountSpec{
+		if _, err := db.UserExternalAccounts().AssociateUserAndSave(ctx, userID, extsvc.AccountSpec{
 			ServiceType: auth.SourcegraphOperatorProviderType,
 			ServiceID:   serviceID,
 			ClientID:    details.ClientID,

--- a/cmd/frontend/internal/auth/sourcegraphoperator/associate_test.go
+++ b/cmd/frontend/internal/auth/sourcegraphoperator/associate_test.go
@@ -198,7 +198,7 @@ func TestAddSourcegraphOperatorExternalAccount(t *testing.T) {
 				require.NoError(t, err)
 				err = db.Users().SetIsSiteAdmin(ctx, u.ID, true)
 				require.NoError(t, err)
-				err = db.UserExternalAccounts().AssociateUserAndSave(ctx, u.ID, extsvc.AccountSpec{
+				_, err = db.UserExternalAccounts().AssociateUserAndSave(ctx, u.ID, extsvc.AccountSpec{
 					ServiceType: auth.SourcegraphOperatorProviderType,
 					ServiceID:   serviceID,
 					ClientID:    "soap_client",

--- a/cmd/frontend/internal/authz/webhooks/github_test.go
+++ b/cmd/frontend/internal/authz/webhooks/github_test.go
@@ -68,7 +68,7 @@ func TestGitHubWebhooks(t *testing.T) {
 	require.NoError(t, err)
 
 	accountID := int64(123)
-	err = db.UserExternalAccounts().Insert(ctx, u.ID, extsvc.AccountSpec{
+	_, err = db.UserExternalAccounts().Insert(ctx, u.ID, extsvc.AccountSpec{
 		ServiceType: extsvc.TypeGitHub,
 		ServiceID:   "https://github.com/",
 		AccountID:   strconv.Itoa(int(accountID)),

--- a/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -458,7 +458,7 @@ func (s *PermsSyncer) fetchUserPermsViaExternalAccounts(ctx context.Context, use
 		}
 		providerLogger.Debug("account found for provider", log.String("provider_urn", provider.URN()), log.Int32("user_id", user.ID), log.Int32("account_id", acct.ID))
 
-		err = accounts.AssociateUserAndSave(ctx, user.ID, acct.AccountSpec, acct.AccountData)
+		acct, err = accounts.AssociateUserAndSave(ctx, user.ID, acct.AccountSpec, acct.AccountData)
 		if err != nil {
 			providerLogger.Error("could not associate external account to user", log.Error(err))
 			continue

--- a/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -814,8 +814,8 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
 
 	perms := dbmocks.NewMockPermsStore()
-	perms.SetUserExternalAccountPermsFunc.PushHook(func(ctx context.Context, uieai authz.UserIDWithExternalAccountID, i []int32, ps authz.PermsSource) (*database.SetPermissionsResult, error) {
-		if uieai.ExternalAccountID == 0 {
+	perms.SetUserExternalAccountPermsFunc.PushHook(func(ctx context.Context, ids authz.UserIDWithExternalAccountID, i []int32, ps authz.PermsSource) (*database.SetPermissionsResult, error) {
+		if ids.ExternalAccountID == 0 {
 			t.Fatal("ExternalAccountID should not be 0")
 		}
 		return &database.SetPermissionsResult{}, nil

--- a/cmd/repo-updater/internal/authz/perms_syncer_test.go
+++ b/cmd/repo-updater/internal/authz/perms_syncer_test.go
@@ -762,13 +762,6 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 		authz.SetProviders(true, nil)
 	})
 
-	extAccount := extsvc.Account{
-		AccountSpec: extsvc.AccountSpec{
-			ServiceType: p.ServiceType(),
-			ServiceID:   p.ServiceID(),
-		},
-	}
-
 	users := dbmocks.NewMockUserStore()
 	users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
 		return &types.User{ID: id}, nil
@@ -790,7 +783,14 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 	userEmails := dbmocks.NewMockUserEmailsStore()
 
 	externalAccounts := dbmocks.NewMockUserExternalAccountsStore()
-	externalAccounts.ListFunc.SetDefaultReturn([]*extsvc.Account{&extAccount}, nil)
+	externalAccounts.ListFunc.SetDefaultReturn([]*extsvc.Account{}, nil)
+	externalAccounts.AssociateUserAndSaveFunc.SetDefaultReturn(&extsvc.Account{
+		ID: 1,
+		AccountSpec: extsvc.AccountSpec{
+			ServiceType: p.ServiceType(),
+			ServiceID:   p.ServiceID(),
+		},
+	}, nil)
 
 	subRepoPerms := dbmocks.NewMockSubRepoPermsStore()
 
@@ -814,7 +814,12 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 	reposStore.ExternalServiceStoreFunc.SetDefaultReturn(externalServices)
 
 	perms := dbmocks.NewMockPermsStore()
-	perms.SetUserExternalAccountPermsFunc.SetDefaultReturn(&database.SetPermissionsResult{}, nil)
+	perms.SetUserExternalAccountPermsFunc.PushHook(func(ctx context.Context, uieai authz.UserIDWithExternalAccountID, i []int32, ps authz.PermsSource) (*database.SetPermissionsResult, error) {
+		if uieai.ExternalAccountID == 0 {
+			t.Fatal("ExternalAccountID should not be 0")
+		}
+		return &database.SetPermissionsResult{}, nil
+	})
 
 	s := NewPermsSyncer(logtest.Scoped(t), db, reposStore, perms, timeutil.Now)
 
@@ -830,6 +835,14 @@ func TestPermsSyncer_syncUserPerms_subRepoPermissions(t *testing.T) {
 				"def": {
 					Paths: []string{"/include1", "/include2", "-/exclude1", "-/exclude2"},
 				},
+			},
+		}, nil
+	}
+	p.fetchAccount = func(ctx context.Context, user *types.User, accounts []*extsvc.Account, emails []string) (*extsvc.Account, error) {
+		return &extsvc.Account{
+			AccountSpec: extsvc.AccountSpec{
+				ServiceType: p.ServiceType(),
+				ServiceID:   p.ServiceID(),
 			},
 		}, nil
 	}

--- a/cmd/worker/internal/auth/sourcegraph_operator_cleaner_test.go
+++ b/cmd/worker/internal/auth/sourcegraph_operator_cleaner_test.go
@@ -91,7 +91,7 @@ func TestSourcegraphOperatorCleanHandler(t *testing.T) {
 	_, err = db.Handle().ExecContext(ctx, `UPDATE user_external_accounts SET created_at = $1 WHERE user_id = $2`,
 		time.Now().Add(-61*time.Minute), morgan.ID)
 	require.NoError(t, err)
-	err = db.UserExternalAccounts().AssociateUserAndSave(
+	_, err = db.UserExternalAccounts().AssociateUserAndSave(
 		ctx,
 		morgan.ID,
 		extsvc.AccountSpec{
@@ -208,14 +208,15 @@ func TestSourcegraphOperatorCleanHandler(t *testing.T) {
 		UserID: alex.ID,
 	}))
 	// make another SOAP account, this one isn't expired
-	require.NoError(t, db.UserExternalAccounts().AssociateUserAndSave(ctx, alex.ID,
+	_, err = db.UserExternalAccounts().AssociateUserAndSave(ctx, alex.ID,
 		extsvc.AccountSpec{
 			ServiceType: auth.SourcegraphOperatorProviderType,
 			ServiceID:   "https://sourcegraph.com",
 			ClientID:    "soap",
 			AccountID:   "alex2",
 		},
-		extsvc.AccountData{}))
+		extsvc.AccountData{})
+	require.NoError(t, err)
 	// make alex and admin, alex shouldn't be changed
 	require.NoError(t, db.Users().SetIsSiteAdmin(ctx, alex.ID, true))
 

--- a/cmd/worker/internal/permissions/perms_syncer_scheduler_test.go
+++ b/cmd/worker/internal/permissions/perms_syncer_scheduler_test.go
@@ -79,7 +79,7 @@ func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
 		require.NoError(t, err)
 
 		// Creating an external account
-		err = externalAccountStore.Insert(ctx, user1.ID, extsvc.AccountSpec{ServiceType: "test", ServiceID: "test", AccountID: user1.Username}, extsvc.AccountData{})
+		_, err = externalAccountStore.Insert(ctx, user1.ID, extsvc.AccountSpec{ServiceType: "test", ServiceID: "test", AccountID: user1.Username}, extsvc.AccountData{})
 		require.NoError(t, err)
 
 		// Creating a repo.
@@ -124,7 +124,7 @@ func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
 		require.NoError(t, err)
 
 		// Creating an external account
-		err = externalAccountStore.Insert(ctx, user2.ID, extsvc.AccountSpec{ServiceType: "test", ServiceID: "test", AccountID: user2.Username}, extsvc.AccountData{})
+		_, err = externalAccountStore.Insert(ctx, user2.ID, extsvc.AccountSpec{ServiceType: "test", ServiceID: "test", AccountID: user2.Username}, extsvc.AccountData{})
 		require.NoError(t, err)
 
 		// Creating a repo.

--- a/dev/sg/sg_db.go
+++ b/dev/sg/sg_db.go
@@ -364,7 +364,7 @@ func dbUpdateUserExternalAccount(cmd *cli.Context) error {
 
 	logger.Info("Writing external account to the DB")
 
-	err = db.UserExternalAccounts().AssociateUserAndSave(
+	_, err = db.UserExternalAccounts().AssociateUserAndSave(
 		ctx,
 		user.ID,
 		extsvc.AccountSpec{

--- a/internal/database/authz_test.go
+++ b/internal/database/authz_test.go
@@ -71,7 +71,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 	}
 
 	// Add two external accounts
-	err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID,
+	_, err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID,
 		extsvc.AccountSpec{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.com/",
@@ -82,7 +82,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID,
+	_, err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID,
 		extsvc.AccountSpec{
 			ServiceType: "github",
 			ServiceID:   "https://github.com/",

--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -78893,7 +78893,7 @@ type MockUserExternalAccountsStore struct {
 func NewMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 	return &MockUserExternalAccountsStore{
 		AssociateUserAndSaveFunc: &UserExternalAccountsStoreAssociateUserAndSaveFunc{
-			defaultHook: func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (r0 error) {
+			defaultHook: func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (r0 *extsvc.Account, r1 error) {
 				return
 			},
 		},
@@ -78933,7 +78933,7 @@ func NewMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 			},
 		},
 		InsertFunc: &UserExternalAccountsStoreInsertFunc{
-			defaultHook: func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (r0 error) {
+			defaultHook: func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (r0 *extsvc.Account, r1 error) {
 				return
 			},
 		},
@@ -78996,7 +78996,7 @@ func NewMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 func NewStrictMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 	return &MockUserExternalAccountsStore{
 		AssociateUserAndSaveFunc: &UserExternalAccountsStoreAssociateUserAndSaveFunc{
-			defaultHook: func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error {
+			defaultHook: func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error) {
 				panic("unexpected invocation of MockUserExternalAccountsStore.AssociateUserAndSave")
 			},
 		},
@@ -79036,7 +79036,7 @@ func NewStrictMockUserExternalAccountsStore() *MockUserExternalAccountsStore {
 			},
 		},
 		InsertFunc: &UserExternalAccountsStoreInsertFunc{
-			defaultHook: func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error {
+			defaultHook: func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error) {
 				panic("unexpected invocation of MockUserExternalAccountsStore.Insert")
 			},
 		},
@@ -79162,24 +79162,24 @@ func NewMockUserExternalAccountsStoreFrom(i database.UserExternalAccountsStore) 
 // when the AssociateUserAndSave method of the parent
 // MockUserExternalAccountsStore instance is invoked.
 type UserExternalAccountsStoreAssociateUserAndSaveFunc struct {
-	defaultHook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error
-	hooks       []func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error
+	defaultHook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error)
+	hooks       []func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error)
 	history     []UserExternalAccountsStoreAssociateUserAndSaveFuncCall
 	mutex       sync.Mutex
 }
 
 // AssociateUserAndSave delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockUserExternalAccountsStore) AssociateUserAndSave(v0 context.Context, v1 int32, v2 extsvc.AccountSpec, v3 extsvc.AccountData) error {
-	r0 := m.AssociateUserAndSaveFunc.nextHook()(v0, v1, v2, v3)
-	m.AssociateUserAndSaveFunc.appendCall(UserExternalAccountsStoreAssociateUserAndSaveFuncCall{v0, v1, v2, v3, r0})
-	return r0
+func (m *MockUserExternalAccountsStore) AssociateUserAndSave(v0 context.Context, v1 int32, v2 extsvc.AccountSpec, v3 extsvc.AccountData) (*extsvc.Account, error) {
+	r0, r1 := m.AssociateUserAndSaveFunc.nextHook()(v0, v1, v2, v3)
+	m.AssociateUserAndSaveFunc.appendCall(UserExternalAccountsStoreAssociateUserAndSaveFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the AssociateUserAndSave
 // method of the parent MockUserExternalAccountsStore instance is invoked
 // and the hook queue is empty.
-func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) SetDefaultHook(hook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error) {
+func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) SetDefaultHook(hook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error)) {
 	f.defaultHook = hook
 }
 
@@ -79188,7 +79188,7 @@ func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) SetDefaultHook(hook 
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) PushHook(hook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error) {
+func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) PushHook(hook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -79196,20 +79196,20 @@ func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) PushHook(hook func(c
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error {
-		return r0
+func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) SetDefaultReturn(r0 *extsvc.Account, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error {
-		return r0
+func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) PushReturn(r0 *extsvc.Account, r1 error) {
+	f.PushHook(func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error) {
+		return r0, r1
 	})
 }
 
-func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) nextHook() func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error {
+func (f *UserExternalAccountsStoreAssociateUserAndSaveFunc) nextHook() func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -79258,7 +79258,10 @@ type UserExternalAccountsStoreAssociateUserAndSaveFuncCall struct {
 	Arg3 extsvc.AccountData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 *extsvc.Account
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -79270,7 +79273,7 @@ func (c UserExternalAccountsStoreAssociateUserAndSaveFuncCall) Args() []interfac
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserExternalAccountsStoreAssociateUserAndSaveFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // UserExternalAccountsStoreCountFunc describes the behavior when the Count
@@ -80036,24 +80039,24 @@ func (c UserExternalAccountsStoreHandleFuncCall) Results() []interface{} {
 // Insert method of the parent MockUserExternalAccountsStore instance is
 // invoked.
 type UserExternalAccountsStoreInsertFunc struct {
-	defaultHook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error
-	hooks       []func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error
+	defaultHook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error)
+	hooks       []func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error)
 	history     []UserExternalAccountsStoreInsertFuncCall
 	mutex       sync.Mutex
 }
 
 // Insert delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockUserExternalAccountsStore) Insert(v0 context.Context, v1 int32, v2 extsvc.AccountSpec, v3 extsvc.AccountData) error {
-	r0 := m.InsertFunc.nextHook()(v0, v1, v2, v3)
-	m.InsertFunc.appendCall(UserExternalAccountsStoreInsertFuncCall{v0, v1, v2, v3, r0})
-	return r0
+func (m *MockUserExternalAccountsStore) Insert(v0 context.Context, v1 int32, v2 extsvc.AccountSpec, v3 extsvc.AccountData) (*extsvc.Account, error) {
+	r0, r1 := m.InsertFunc.nextHook()(v0, v1, v2, v3)
+	m.InsertFunc.appendCall(UserExternalAccountsStoreInsertFuncCall{v0, v1, v2, v3, r0, r1})
+	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the Insert method of the
 // parent MockUserExternalAccountsStore instance is invoked and the hook
 // queue is empty.
-func (f *UserExternalAccountsStoreInsertFunc) SetDefaultHook(hook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error) {
+func (f *UserExternalAccountsStoreInsertFunc) SetDefaultHook(hook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error)) {
 	f.defaultHook = hook
 }
 
@@ -80062,7 +80065,7 @@ func (f *UserExternalAccountsStoreInsertFunc) SetDefaultHook(hook func(context.C
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *UserExternalAccountsStoreInsertFunc) PushHook(hook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error) {
+func (f *UserExternalAccountsStoreInsertFunc) PushHook(hook func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -80070,20 +80073,20 @@ func (f *UserExternalAccountsStoreInsertFunc) PushHook(hook func(context.Context
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UserExternalAccountsStoreInsertFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error {
-		return r0
+func (f *UserExternalAccountsStoreInsertFunc) SetDefaultReturn(r0 *extsvc.Account, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error) {
+		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UserExternalAccountsStoreInsertFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error {
-		return r0
+func (f *UserExternalAccountsStoreInsertFunc) PushReturn(r0 *extsvc.Account, r1 error) {
+	f.PushHook(func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error) {
+		return r0, r1
 	})
 }
 
-func (f *UserExternalAccountsStoreInsertFunc) nextHook() func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) error {
+func (f *UserExternalAccountsStoreInsertFunc) nextHook() func(context.Context, int32, extsvc.AccountSpec, extsvc.AccountData) (*extsvc.Account, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -80131,7 +80134,10 @@ type UserExternalAccountsStoreInsertFuncCall struct {
 	Arg3 extsvc.AccountData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 error
+	Result0 *extsvc.Account
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -80143,7 +80149,7 @@ func (c UserExternalAccountsStoreInsertFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c UserExternalAccountsStoreInsertFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // UserExternalAccountsStoreListFunc describes the behavior when the List

--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -75,7 +75,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		AuthData: extsvc.NewUnencryptedData(authData),
 		Data:     extsvc.NewUnencryptedData(data),
 	}
-	if err := db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID, spec, accountData); err != nil {
+	if _, err := db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID, spec, accountData); err != nil {
 		t.Fatal(err)
 	}
 
@@ -362,7 +362,7 @@ func TestExternalAccounts_ListForUsers(t *testing.T) {
 			userIDs = append(userIDs, user.ID)
 		} else {
 			// Last user gets all the accounts.
-			err := db.UserExternalAccounts().AssociateUserAndSave(ctx, userIDs[2], spec, extsvc.AccountData{})
+			_, err := db.UserExternalAccounts().AssociateUserAndSave(ctx, userIDs[2], spec, extsvc.AccountData{})
 			require.NoError(t, err)
 		}
 	}
@@ -488,7 +488,7 @@ func TestExternalAccounts_Encryption(t *testing.T) {
 	}
 
 	// AssociateUserAndSave should encrypt the accountData correctly
-	err = store.AssociateUserAndSave(ctx, userID, spec, accountData)
+	_, err = store.AssociateUserAndSave(ctx, userID, spec, accountData)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -599,7 +599,7 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID, spec, extsvc.AccountData{})
+		_, err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID, spec, extsvc.AccountData{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -660,10 +660,10 @@ func TestExternalAccounts_DeleteList(t *testing.T) {
 	user, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 	spec.ServiceID = "xb2"
 	require.NoError(t, err)
-	err = db.UserExternalAccounts().Insert(ctx, user.ID, spec, extsvc.AccountData{})
+	_, err = db.UserExternalAccounts().Insert(ctx, user.ID, spec, extsvc.AccountData{})
 	require.NoError(t, err)
 	spec.ServiceID = "xb3"
-	err = db.UserExternalAccounts().Insert(ctx, user.ID, spec, extsvc.AccountData{})
+	_, err = db.UserExternalAccounts().Insert(ctx, user.ID, spec, extsvc.AccountData{})
 	require.NoError(t, err)
 
 	accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1})
@@ -703,10 +703,10 @@ func TestExternalAccounts_TouchExpiredList(t *testing.T) {
 		user, err := db.UserExternalAccounts().CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 		spec.ServiceID = "xb2"
 		require.NoError(t, err)
-		err = db.UserExternalAccounts().Insert(ctx, user.ID, spec, extsvc.AccountData{})
+		_, err = db.UserExternalAccounts().Insert(ctx, user.ID, spec, extsvc.AccountData{})
 		require.NoError(t, err)
 		spec.ServiceID = "xb3"
-		err = db.UserExternalAccounts().Insert(ctx, user.ID, spec, extsvc.AccountData{})
+		_, err = db.UserExternalAccounts().Insert(ctx, user.ID, spec, extsvc.AccountData{})
 		require.NoError(t, err)
 
 		accts, err := db.UserExternalAccounts().List(ctx, ExternalAccountsListOptions{UserID: 1})

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -476,7 +476,7 @@ VALUES (%s, %s, '')
 
 	// Set up external accounts for alice and bob
 	for _, user := range []*types.User{alice, bob} {
-		err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID, extsvc.AccountSpec{ServiceType: extsvc.TypeGitHub, ServiceID: "https://github.com/", AccountID: user.Username}, extsvc.AccountData{})
+		_, err = db.UserExternalAccounts().AssociateUserAndSave(ctx, user.ID, extsvc.AccountSpec{ServiceType: extsvc.TypeGitHub, ServiceID: "https://github.com/", AccountID: user.Username}, extsvc.AccountData{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -705,7 +705,6 @@ func TestUsers_GetByUsername(t *testing.T) {
 			t.Errorf("got %s, but want %s", have.Username, want)
 		}
 	}
-
 }
 
 func TestUsers_GetByUsernames(t *testing.T) {
@@ -936,7 +935,7 @@ func TestUsers_RecoverUsers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = db.UserExternalAccounts().AssociateUserAndSave(ctx, otherUser.ID,
+	_, err = db.UserExternalAccounts().AssociateUserAndSave(ctx, otherUser.ID,
 		extsvc.AccountSpec{
 			ServiceType: "github",
 			ServiceID:   "https://github.com/",
@@ -948,7 +947,7 @@ func TestUsers_RecoverUsers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	//Test reviving a user that does not exist
+	// Test reviving a user that does not exist
 	t.Run("fails on nonexistent user", func(t *testing.T) {
 		ru, err := db.Users().RecoverUsersList(ctx, []int32{65})
 		if err != nil {
@@ -958,7 +957,7 @@ func TestUsers_RecoverUsers(t *testing.T) {
 			t.Errorf("got %d recovered users, want 0", len(ru))
 		}
 	})
-	//Test reviving a user that does exist and hasn't not been deleted
+	// Test reviving a user that does exist and hasn't not been deleted
 	t.Run("fails on non-deleted user", func(t *testing.T) {
 		ru, err := db.Users().RecoverUsersList(ctx, []int32{user.ID})
 		if err == nil {
@@ -969,7 +968,7 @@ func TestUsers_RecoverUsers(t *testing.T) {
 		}
 	})
 
-	//Test reviving a user that does exist and does not have additional resources deleted in the same timeframe
+	// Test reviving a user that does exist and does not have additional resources deleted in the same timeframe
 	t.Run("revives user with no additional resources", func(t *testing.T) {
 		err := db.Users().Delete(ctx, user.ID)
 		if err != nil {
@@ -995,7 +994,7 @@ func TestUsers_RecoverUsers(t *testing.T) {
 			t.Errorf("got %d users, want 1", len(users))
 		}
 	})
-	//Test reviving a user that does exist and does have additional resources deleted in the same timeframe
+	// Test reviving a user that does exist and does have additional resources deleted in the same timeframe
 	t.Run("revives user and additional resources", func(t *testing.T) {
 		err := db.Users().Delete(ctx, otherUser.ID)
 		if err != nil {

--- a/internal/extsvc/gerrit/externalaccount/externalaccount.go
+++ b/internal/extsvc/gerrit/externalaccount/externalaccount.go
@@ -40,7 +40,7 @@ func AddGerritExternalAccount(ctx context.Context, db database.DB, userID int32,
 		return err
 	}
 
-	if err = db.UserExternalAccounts().AssociateUserAndSave(ctx, userID, accountSpec, accountData); err != nil {
+	if _, err = db.UserExternalAccounts().AssociateUserAndSave(ctx, userID, accountSpec, accountData); err != nil {
 		return err
 	}
 

--- a/internal/own/ownref_test.go
+++ b/internal/own/ownref_test.go
@@ -364,7 +364,8 @@ func initUser(ctx context.Context, t *testing.T, db database.DB) (*types.User, e
 		AccountID:   "5C1M",
 	}
 	scimAccountData := extsvc.AccountData{Data: extsvc.NewUnencryptedData(json.RawMessage("{}"))}
-	require.NoError(t, db.UserExternalAccounts().Insert(ctx, user.ID, scimSpec, scimAccountData))
+	_, err = db.UserExternalAccounts().Insert(ctx, user.ID, scimSpec, scimAccountData)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		providers.MockProviders = nil
 	})
@@ -387,7 +388,8 @@ func addMockExternalAccount(ctx context.Context, t *testing.T, db database.DB, u
 	accountData := extsvc.AccountData{
 		Data: extsvc.NewUnencryptedData(data),
 	}
-	require.NoError(t, db.UserExternalAccounts().Insert(ctx, userID, spec, accountData))
+	_, err := db.UserExternalAccounts().Insert(ctx, userID, spec, accountData)
+	require.NoError(t, err)
 	mockProvider := providers.MockAuthProvider{
 		MockConfigID:          providers.ConfigID{Type: serviceType},
 		MockPublicAccountData: &extsvc.PublicAccountData{Login: handle},

--- a/internal/sourcegraphoperator/associate.go
+++ b/internal/sourcegraphoperator/associate.go
@@ -79,7 +79,7 @@ func addSourcegraphOperatorExternalAccount(ctx context.Context, db database.DB, 
 		if err != nil {
 			return errors.Wrap(err, "failed to marshal account data")
 		}
-		if err := db.UserExternalAccounts().AssociateUserAndSave(ctx, userID, extsvc.AccountSpec{
+		if _, err := db.UserExternalAccounts().AssociateUserAndSave(ctx, userID, extsvc.AccountSpec{
 			ServiceType: auth.SourcegraphOperatorProviderType,
 			ServiceID:   serviceID,
 			ClientID:    details.ClientID,


### PR DESCRIPTION
Closes #57418 

UserExternalAccountsStore operations that add a user external account now returns the created external account.
This fixes an issue in the permissions syncer where, for providers that implement `FetchAccount`, the created external account is used without an external account ID in the first sync, which leads to entries in the `user_repo_permissions` table where the external account ID is `NULL`.

## Test plan

Unit test adjusted to assert that the user repo permissions inserted does not have an external account ID of 0.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
