### PR TITLE
uploadstore: Don't read AWS config for blobstore backend

### DIFF
--- a/internal/uploadstore/config.go
+++ b/internal/uploadstore/config.go
@@ -22,6 +22,8 @@ func normalizeConfig(t Config) Config {
 	o.Backend = strings.ToLower(o.Backend)
 
 	if o.Backend == "blobstore" {
+		o.S3.IsBlobstore = true
+
 		// No manual provisioning on blobstore.
 		o.ManageBucket = true
 

--- a/internal/uploadstore/config_test.go
+++ b/internal/uploadstore/config_test.go
@@ -38,8 +38,8 @@ func TestS3ClientOptions(t *testing.T) {
 }
 
 func TestS3ClientConfig(t *testing.T) {
-	config := Config{
-		Backend:      "s3",
+	config := normalizeConfig(Config{
+		Backend:      "blobstore",
 		Bucket:       "lsif-uploads",
 		ManageBucket: true,
 		TTL:          8 * time.Hour,
@@ -49,7 +49,7 @@ func TestS3ClientConfig(t *testing.T) {
 			SecretAccessKey: "secret-access-key",
 			SessionToken:    "session-token",
 		},
-	}
+	})
 
 	cfg, err := s3ClientConfig(context.Background(), config.S3)
 	if err != nil {


### PR DESCRIPTION
Before this change, we would try to read AWS config files on disk and talk to the metadata server to get a role assumption. That was super unnecessary and meant that Sourcegraph wouldn't start up properly when AWS was misconfigured locally, although we never actually needed to talk to AWS.

Closes https://github.com/sourcegraph/sourcegraph/issues/56599

## Test plan

Verified that embedding jobs which talk to blobstore still work and upload an index properly. Also adjusted tests. Is there something else I could try?