### PR TITLE
show "Reload" for esbuild dynamic import errors

### DIFF
--- a/client/web/src/components/ErrorBoundary.test.tsx
+++ b/client/web/src/components/ErrorBoundary.test.tsx
@@ -11,6 +11,11 @@ const ThrowError: React.FunctionComponent<React.PropsWithChildren<unknown>> = ()
     throw new Error('x')
 }
 
+/** Throws an error that resembles the  error when a dynamic import(...) fails.  */
+const ThrowDynamicImportError: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => {
+    throw new TypeError('Failed to fetch dynamically imported module: https://example.com/x.js')
+}
+
 /** Throws an error that resembles the Webpack error when chunk loading fails.  */
 const ThrowChunkError: React.FunctionComponent<React.PropsWithChildren<unknown>> = () => {
     const ChunkError = new Error('Loading chunk 123 failed.')
@@ -37,7 +42,16 @@ describe('ErrorBoundary', () => {
             ).asFragment()
         ).toMatchSnapshot())
 
-    test('renders reload page if chunk error', () =>
+    test('renders reload page if dynamic import error', () =>
+        expect(
+            renderWithBrandedContext(
+                <ErrorBoundary location={null}>
+                    <ThrowDynamicImportError />
+                </ErrorBoundary>
+            ).asFragment()
+        ).toMatchSnapshot())
+
+    test('renders reload page if webpack chunk error', () =>
         expect(
             renderWithBrandedContext(
                 <ErrorBoundary location={null}>

--- a/client/web/src/components/ErrorBoundary.tsx
+++ b/client/web/src/components/ErrorBoundary.tsx
@@ -8,7 +8,7 @@ import { isRouteErrorResponse, useRouteError } from 'react-router-dom'
 import { asError, logger } from '@sourcegraph/common'
 import { Button, Code, Text } from '@sourcegraph/wildcard'
 
-import { isWebpackChunkError } from '../monitoring'
+import { isChunkLoadError } from '../monitoring'
 
 import { HeroPage } from './HeroPage'
 
@@ -120,10 +120,10 @@ interface ErrorBoundaryMessageProps {
     className?: string
 }
 const ErrorBoundaryMessage: React.FC<ErrorBoundaryMessageProps> = ({ error, extraContext, render, className }) => {
-    if (isWebpackChunkError(error)) {
-        // "Loading chunk 123 failed" means that the JavaScript assets that correspond to the deploy
-        // version currently running are no longer available, likely because a redeploy occurred after the
-        // user initially loaded this page.
+    if (isChunkLoadError(error)) {
+        // This means that the JavaScript assets that correspond to the deploy version currently
+        // running are no longer available, likely because a redeploy occurred after the user
+        // initially loaded this page.
         return (
             <HeroPage
                 icon={ReloadIcon}

--- a/client/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
+++ b/client/web/src/components/__snapshots__/ErrorBoundary.test.tsx.snap
@@ -54,7 +54,50 @@ exports[`ErrorBoundary renders error page if error 1`] = `
 </DocumentFragment>
 `;
 
-exports[`ErrorBoundary renders reload page if chunk error 1`] = `
+exports[`ErrorBoundary renders reload page if dynamic import error 1`] = `
+<DocumentFragment>
+  <div
+    class="heroPage defaultPadding"
+  >
+    <div
+      class="iconWrapper"
+    >
+      <reloadicon
+        aria-hidden="true"
+        class="mdi-icon iconInline icon"
+        role="img"
+      />
+    </div>
+    <h1
+      class="h1 title"
+    >
+      Reload required
+    </h1>
+    <div
+      class="subtitle"
+      data-testid="hero-page-subtitle"
+    >
+      <div
+        class="container"
+      >
+        <p
+          class=""
+        >
+          A new version of Sourcegraph is available.
+        </p>
+        <button
+          class="btn btnPrimary"
+          type="button"
+        >
+          Reload to update
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`ErrorBoundary renders reload page if webpack chunk error 1`] = `
 <DocumentFragment>
   <div
     class="heroPage defaultPadding"

--- a/client/web/src/monitoring/index.ts
+++ b/client/web/src/monitoring/index.ts
@@ -1,1 +1,1 @@
-export { isWebpackChunkError } from './shouldErrorBeReported'
+export { isChunkLoadError } from './shouldErrorBeReported'

--- a/client/web/src/monitoring/shouldErrorBeReported.ts
+++ b/client/web/src/monitoring/shouldErrorBeReported.ts
@@ -7,15 +7,27 @@ export function shouldErrorBeReported(error: unknown): boolean {
         return error.status < 500
     }
 
-    if (isWebpackChunkError(error) || isAbortError(error) || isNotAuthenticatedError(error) || isNetworkError(error)) {
+    if (isChunkLoadError(error) || isAbortError(error) || isNotAuthenticatedError(error) || isNetworkError(error)) {
         return false
     }
 
     return true
 }
 
-export function isWebpackChunkError(value: unknown): boolean {
+export function isChunkLoadError(value: unknown): boolean {
+    return isWebpackChunkError(value) || isDynamicImportError(value)
+}
+
+function isWebpackChunkError(value: unknown): boolean {
     return isErrorLike(value) && (value.name === 'ChunkLoadError' || /loading css chunk/gi.test(value.message))
+}
+
+function isDynamicImportError(value: unknown): boolean {
+    return (
+        isErrorLike(value) &&
+        value.name === 'TypeError' &&
+        value.message.startsWith('Failed to fetch dynamically imported module')
+    )
 }
 
 function isAbortError(value: unknown): boolean {


### PR DESCRIPTION
If a frontend chunk fails to load with Webpack, the user sees a message telling them to reload. This change makes it so that users also see this when esbuild is used as the bundler. Esbuild surfaces this error slightly differently.




## Test plan

Use esbuild locally. Set a Chrome devtools network blocker for a chunk file. Confirm the reload page is shown.