### PR TITLE
migrate from storybook deprecated argTypes.defaultValue

### DIFF
--- a/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
@@ -149,16 +149,18 @@ export const AllOptionsPages: Story = (args = {}) => (
 AllOptionsPages.argTypes = {
     sourcegraphUrl: {
         control: { type: 'text' },
-        defaultValue: 'https://not-sourcegraph.com',
     },
     version: {
         control: { type: 'text' },
-        defaultValue: '0.0.0',
     },
     showSourcegraphComAlert: {
         control: { type: 'boolean' },
-        defaultValue: false,
     },
+}
+AllOptionsPages.args = {
+    sourcegraphUrl: 'https://not-sourcegraph.com',
+    version: '0.0.0',
+    showSourcegraphComAlert: false,
 }
 
 AllOptionsPages.parameters = {

--- a/client/web/src/batches/RepoBatchChangesButton.story.tsx
+++ b/client/web/src/batches/RepoBatchChangesButton.story.tsx
@@ -57,12 +57,14 @@ export const RepoButton: Story = args => (
 RepoButton.argTypes = {
     open: {
         control: { type: 'number' },
-        defaultValue: 2,
     },
     merged: {
         control: { type: 'number' },
-        defaultValue: 47,
     },
+}
+RepoButton.args = {
+    open: 2,
+    merged: 47,
 }
 
 RepoButton.storyName = 'RepoButton'

--- a/client/web/src/components/diff/DiffStat.story.tsx
+++ b/client/web/src/components/diff/DiffStat.story.tsx
@@ -12,12 +12,14 @@ const config: Meta = {
     argTypes: {
         added: {
             type: 'number',
-            defaultValue: 10,
         },
         deleted: {
             type: 'number',
-            defaultValue: 8,
         },
+    },
+    args: {
+        added: 10,
+        deleted: 8,
     },
 }
 

--- a/client/web/src/components/diff/FileDiffHunks.story.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.story.tsx
@@ -60,12 +60,14 @@ const config: Meta = {
     argTypes: {
         persistLines: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
         lineNumbers: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        persistLines: true,
+        lineNumbers: true,
     },
 }
 

--- a/client/web/src/components/diff/FileDiffNode.story.tsx
+++ b/client/web/src/components/diff/FileDiffNode.story.tsx
@@ -200,12 +200,14 @@ const config: Meta = {
     argTypes: {
         persistLines: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
         lineNumbers: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        persistLines: true,
+        lineNumbers: true,
     },
 }
 

--- a/client/web/src/components/time/Duration.story.tsx
+++ b/client/web/src/components/time/Duration.story.tsx
@@ -17,8 +17,10 @@ const config: Meta = {
     argTypes: {
         start: {
             control: { type: 'date' },
-            defaultValue: subDays(now, 1),
         },
+    },
+    args: {
+        start: subDays(now, 1),
     },
 }
 
@@ -30,8 +32,11 @@ export const Fixed: Story = args => (
 Fixed.argTypes = {
     end: {
         control: { type: 'date' },
-        defaultValue: now,
     },
+}
+Fixed.args = {
+    start: now,
+    end: now,
 }
 
 export const Active: Story = args => (

--- a/client/web/src/enterprise/batches/DropdownButton.story.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.story.tsx
@@ -55,8 +55,10 @@ const config: Meta = {
     argTypes: {
         disabled: {
             control: { type: 'boolean' },
-            defaultValue: false,
         },
+    },
+    args: {
+        disabled: false,
     },
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/TabBar.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.story.tsx
@@ -62,8 +62,10 @@ export const ExecuteBatchSpec: Story = args => (
 ExecuteBatchSpec.argTypes = {
     activeTabKey: {
         control: { type: 'select', options: ['configuration', 'spec', 'execution'] },
-        defaultValue: 'execution',
     },
+}
+ExecuteBatchSpec.args = {
+    activeTabKey: 'execution',
 }
 
 ExecuteBatchSpec.storyName = 'executing a batch spec'
@@ -81,8 +83,10 @@ export const PreviewExecutionResult: Story = args => (
 PreviewExecutionResult.argTypes = {
     activeTabKey: {
         control: { type: 'select', options: ['configuration', 'spec', 'execution', 'preview'] },
-        defaultValue: 'preview',
     },
+}
+PreviewExecutionResult.args = {
+    activeTabKey: 'preview',
 }
 
 PreviewExecutionResult.storyName = 'previewing an execution result'
@@ -100,8 +104,10 @@ export const LocallyExecutedSpec: Story = args => (
 LocallyExecutedSpec.argTypes = {
     activeTabKey: {
         control: { type: 'select', options: ['configuration', 'spec', 'preview'] },
-        defaultValue: 'preview',
     },
+}
+LocallyExecutedSpec.args = {
+    activeTabKey: 'preview',
 }
 
 LocallyExecutedSpec.storyName = 'for a locally-executed spec'

--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/EditorFeedbackPanel.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/EditorFeedbackPanel.story.tsx
@@ -13,28 +13,30 @@ const config: Meta = {
         actions: {
             name: 'Actions',
             control: { type: 'text' },
-            defaultValue: '',
         },
         execute: {
             name: 'Execute',
             control: { type: 'text' },
-            defaultValue: '',
         },
         preview: {
             name: 'Preview',
             control: { type: 'text' },
-            defaultValue: '',
         },
         codeUpdate: {
             name: 'Code Update',
             control: { type: 'text' },
-            defaultValue: '',
         },
         codeValidation: {
             name: 'codeValidation',
             control: { type: 'text' },
-            defaultValue: 'The entered spec is invalid:\n  * name must match pattern "^my-batch-change$"',
         },
+    },
+    args: {
+        actions: '',
+        execute: '',
+        preview: '',
+        codeUpdate: '',
+        codeValidation: 'The entered spec is invalid:\n  * name must match pattern "^my-batch-change$"',
     },
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.story.tsx
@@ -15,13 +15,15 @@ const config: Meta = {
         readOnly: {
             name: 'Read Only',
             control: { type: 'boolean' },
-            defaultValue: false,
         },
         autoFocus: {
             name: 'Auto Focus',
             control: { type: 'boolean' },
-            defaultValue: false,
         },
+    },
+    args: {
+        readOnly: false,
+        autoFocus: false,
     },
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/ReplaceSpecModal.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/ReplaceSpecModal.story.tsx
@@ -14,8 +14,10 @@ const config: Meta = {
         libraryItemName: {
             name: 'Name',
             control: { type: 'text' },
-            defaultValue: 'my-batch-change',
         },
+    },
+    args: {
+        libraryItemName: 'my-batch-change',
     },
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.story.tsx
@@ -15,23 +15,25 @@ const config: Meta = {
         count: {
             name: 'Count',
             control: { type: 'number' },
-            defaultValue: 1,
         },
         isStale: {
             name: 'Stale',
             control: { type: 'boolean' },
-            defaultValue: false,
         },
         hasNextPage: {
             name: 'Has Next Page',
             control: { type: 'boolean' },
-            defaultValue: false,
         },
         loading: {
             name: 'Loading',
             control: { type: 'boolean' },
-            defaultValue: false,
         },
+    },
+    args: {
+        count: 1,
+        isStale: false,
+        hasNextPage: false,
+        loading: false,
     },
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
@@ -54,8 +54,10 @@ Unstarted.argTypes = {
     batchSpec: {
         name: 'Valid batch spec?',
         control: { type: 'boolean' },
-        defaultValue: true,
     },
+}
+Unstarted.args = {
+    batchSpec: true,
 }
 
 export const UnstartedWithCachedConnectionResult: Story = args => (
@@ -77,8 +79,10 @@ UnstartedWithCachedConnectionResult.argTypes = {
     batchSpec: {
         name: 'Valid batch spec?',
         control: { type: 'boolean' },
-        defaultValue: true,
     },
+}
+UnstartedWithCachedConnectionResult.args = {
+    batchSpec: true,
 }
 
 UnstartedWithCachedConnectionResult.storyName = 'unstarted, with cached connection result'
@@ -137,12 +141,14 @@ QueuedInProgress.argTypes = {
             type: 'select',
             options: [BatchSpecWorkspaceResolutionState.QUEUED, BatchSpecWorkspaceResolutionState.PROCESSING],
         },
-        defaultValue: BatchSpecWorkspaceResolutionState.QUEUED,
     },
     batchSpec: {
         control: { type: 'boolean' },
-        defaultValue: true,
     },
+}
+QueuedInProgress.args = {
+    inProgressResolution: BatchSpecWorkspaceResolutionState.QUEUED,
+    batchSpec: true,
 }
 
 QueuedInProgress.storyName = 'queued/in progress'
@@ -201,8 +207,10 @@ QueuedInProgressWithCachedConnectionResult.argTypes = {
             type: 'select',
             options: [BatchSpecWorkspaceResolutionState.QUEUED, BatchSpecWorkspaceResolutionState.PROCESSING],
         },
-        defaultValue: BatchSpecWorkspaceResolutionState.QUEUED,
     },
+}
+QueuedInProgressWithCachedConnectionResult.args = {
+    inProgressResolution: BatchSpecWorkspaceResolutionState.QUEUED,
 }
 
 QueuedInProgressWithCachedConnectionResult.storyName = 'queued/in progress, with cached connection result'
@@ -264,8 +272,10 @@ FailedErrored.argTypes = {
             type: 'select',
             options: [BatchSpecWorkspaceResolutionState.FAILED, BatchSpecWorkspaceResolutionState.ERRORED],
         },
-        defaultValue: BatchSpecWorkspaceResolutionState.FAILED,
     },
+}
+FailedErrored.args = {
+    inProgressResolution: BatchSpecWorkspaceResolutionState.FAILED,
 }
 
 FailedErrored.storyName = 'failed/errored'
@@ -327,8 +337,10 @@ FailedErroredWithCachedConnectionResult.argTypes = {
             type: 'select',
             options: [BatchSpecWorkspaceResolutionState.FAILED, BatchSpecWorkspaceResolutionState.ERRORED],
         },
-        defaultValue: BatchSpecWorkspaceResolutionState.FAILED,
     },
+}
+FailedErroredWithCachedConnectionResult.args = {
+    inProgressResolution: BatchSpecWorkspaceResolutionState.FAILED,
 }
 
 FailedErroredWithCachedConnectionResult.storyName = 'failed/errored, with cached connection result'

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.story.tsx
@@ -48,18 +48,20 @@ DefaultStory.argTypes = {
     count: {
         name: 'name',
         control: { type: 'number' },
-        defaultValue: 1,
     },
     isStale: {
         name: 'Stale',
         control: { type: 'boolean' },
-        defaultValue: false,
     },
     hasNextPage: {
         name: 'Has Next Page',
         control: { type: 'boolean' },
-        defaultValue: false,
     },
+}
+DefaultStory.args = {
+    count: 1,
+    isStale: false,
+    hasNextPage: false,
 }
 
 DefaultStory.storyName = 'default'

--- a/client/web/src/enterprise/batches/batch-spec/execute/CancelExecutionModal.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/CancelExecutionModal.story.tsx
@@ -17,8 +17,10 @@ const config: Meta = {
             control: {
                 type: 'boolean',
             },
-            defaultValue: false,
         },
+    },
+    args: {
+        isLoading: false,
     },
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.story.tsx
@@ -12,25 +12,27 @@ const config: Meta = {
     argTypes: {
         errored: {
             control: { type: 'number' },
-            defaultValue: 0,
         },
         completed: {
             control: { type: 'number' },
-            defaultValue: 7,
         },
         processing: {
             control: { type: 'number' },
-            defaultValue: 4,
         },
 
         queued: {
             control: { type: 'number' },
-            defaultValue: 14,
         },
         ignored: {
             control: { type: 'number' },
-            defaultValue: 0,
         },
+    },
+    args: {
+        errored: 0,
+        completed: 7,
+        processing: 4,
+        queued: 14,
+        ignored: 0,
     },
 }
 

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.story.tsx
@@ -37,8 +37,10 @@ Executing.argTypes = {
     state: {
         name: 'batch spec state',
         control: { type: 'select', options: [BatchSpecState.PROCESSING, BatchSpecState.QUEUED] },
-        defaultValue: BatchSpecState.PROCESSING,
     },
+}
+Executing.args = {
+    state: BatchSpecState.PROCESSING,
 }
 
 Executing.storyName = 'while executing'
@@ -70,8 +72,10 @@ ExecutionFinished.argTypes = {
                 BatchSpecState.PENDING,
             ],
         },
-        defaultValue: BatchSpecState.COMPLETED,
     },
+}
+ExecutionFinished.args = {
+    state: BatchSpecState.COMPLETED,
 }
 
 ExecutionFinished.storyName = 'after execution finishes'

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.story.tsx
@@ -15,8 +15,10 @@ const config: Meta = {
         cachedResultFound: {
             name: 'Cache Found',
             control: { type: 'boolean' },
-            defaultValue: false,
         },
+    },
+    args: {
+        cachedResultFound: false,
     },
 }
 

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
@@ -18,8 +18,10 @@ const config: Meta = {
     argTypes: {
         viewerCanAdminister: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        viewerCanAdminister: true,
     },
 }
 
@@ -47,8 +49,10 @@ export const HasOpenChangesets: Story = args => {
 HasOpenChangesets.argTypes = {
     totalCount: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
+}
+HasOpenChangesets.args = {
+    totalCount: 10,
 }
 
 HasOpenChangesets.storyName = 'Has open changesets'

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -294,8 +294,10 @@ export const Overview: Story = args => {
 Overview.argTypes = {
     viewerCanAdminister: {
         control: { type: 'boolean' },
-        defaultValue: true,
     },
+}
+Overview.args = {
+    viewerCanAdminister: true,
 }
 
 export const NoOpenChangesets: Story = () => {

--- a/client/web/src/enterprise/batches/detail/ActiveExecutionNotice.story.tsx
+++ b/client/web/src/enterprise/batches/detail/ActiveExecutionNotice.story.tsx
@@ -15,15 +15,17 @@ const config: Meta = {
         numberActive: {
             name: 'number of specs executing',
             control: { type: 'number' },
-            defaultValue: 1,
             min: 0,
         },
         numberComplete: {
             name: 'number of specs completed',
             control: { type: 'number' },
-            defaultValue: 1,
             min: 0,
         },
+    },
+    args: {
+        numberActive: 1,
+        numberComplete: 1,
     },
 }
 

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -50,12 +50,14 @@ const config: Meta = {
         },
         viewerCanAdminister: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
         isClosed: {
             control: { type: 'boolean' },
-            defaultValue: false,
         },
+    },
+    args: {
+        viewerCanAdminister: true,
+        isClosed: false,
     },
 }
 
@@ -161,63 +163,57 @@ const Template: Story<{
 }
 
 export const Overview = Template.bind({})
-Overview.args = { url: '/users/alice/batch-changes/awesome-batch-change' }
+Overview.args = { url: '/users/alice/batch-changes/awesome-batch-change', supersedingBatchSpec: false }
 Overview.argTypes = {
-    supersedingBatchSpec: {
-        defaultValue: false,
-    },
+    supersedingBatchSpec: {},
 }
 
 export const BurndownChart = Template.bind({})
-BurndownChart.args = { url: '/users/alice/batch-changes/awesome-batch-change?tab=chart' }
+BurndownChart.args = { url: '/users/alice/batch-changes/awesome-batch-change?tab=chart', supersedingBatchSpec: false }
 BurndownChart.storyName = 'Burndown chart'
 BurndownChart.argTypes = {
-    supersedingBatchSpec: {
-        defaultValue: false,
-    },
+    supersedingBatchSpec: {},
 }
 
 export const SpecFile = Template.bind({})
-SpecFile.args = { url: '/users/alice/batch-changes/awesome-batch-change?tab=spec' }
+SpecFile.args = {
+    url: '/users/alice/batch-changes/awesome-batch-change?tab=spec',
+    supersedingBatchSpec: false,
+    viewerCanAdminister: false,
+}
 SpecFile.storyName = 'Spec file'
 SpecFile.argTypes = {
-    supersedingBatchSpec: {
-        defaultValue: false,
-    },
-    viewerCanAdminister: {
-        defaultValue: false,
-    },
+    supersedingBatchSpec: {},
+    viewerCanAdminister: {},
 }
 
 export const Archived = Template.bind({})
-Archived.args = { url: '/users/alice/batch-changes/awesome-batch-change?tab=archived' }
+Archived.args = { url: '/users/alice/batch-changes/awesome-batch-change?tab=archived', supersedingBatchSpec: false }
 Archived.argTypes = {
-    supersedingBatchSpec: {
-        defaultValue: false,
-    },
+    supersedingBatchSpec: {},
 }
 
 export const BulkOperations = Template.bind({})
-BulkOperations.args = { url: '/users/alice/batch-changes/awesome-batch-change?tab=bulkoperations' }
+BulkOperations.args = {
+    url: '/users/alice/batch-changes/awesome-batch-change?tab=bulkoperations',
+    supersedingBatchSpec: false,
+}
 BulkOperations.storyName = 'Bulk operations'
 BulkOperations.argTypes = {
-    supersedingBatchSpec: {
-        defaultValue: false,
-    },
+    supersedingBatchSpec: {},
 }
 
 export const SupersededBatchSpec = Template.bind({})
 SupersededBatchSpec.args = { url: '/users/alice/batch-changes/awesome-batch-change', supersedingBatchSpec: true }
 SupersededBatchSpec.storyName = 'Superseded batch-spec'
 SupersededBatchSpec.argTypes = {
-    supersedingBatchSpec: {
-        defaultValue: true,
-    },
+    supersedingBatchSpec: {},
 }
 
 export const UnpublishableBatchSpec = Template.bind({})
 UnpublishableBatchSpec.args = {
     url: '/users/alice/batch-changes/awesome-batch-change',
+    supersedingBatchSpec: true,
     currentBatchSpec: {
         ...MOCK_BATCH_CHANGE.currentSpec,
         viewerBatchChangesCodeHosts: {
@@ -234,9 +230,7 @@ UnpublishableBatchSpec.args = {
 }
 UnpublishableBatchSpec.storyName = 'Batch spec with unpublishable changesets'
 UnpublishableBatchSpec.argTypes = {
-    supersedingBatchSpec: {
-        defaultValue: true,
-    },
+    supersedingBatchSpec: {},
 }
 
 export const EmptyChangesets: Story = args => {

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -72,48 +72,50 @@ export const Draft: Story<MockStatsArgs> = args => {
 Draft.argTypes = {
     closed: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     deleted: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     merged: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     draft: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     open: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     archived: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     unpublished: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     failed: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     retrying: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     scheduled: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     processing: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
+}
+Draft.args = {
+    closed: 0,
+    deleted: 0,
+    merged: 0,
+    draft: 0,
+    open: 0,
+    archived: 0,
+    unpublished: 0,
+    failed: 0,
+    retrying: 0,
+    scheduled: 0,
+    processing: 0,
 }
 
 export const Open: Story<MockStatsArgs> = args => {
@@ -153,48 +155,50 @@ export const Open: Story<MockStatsArgs> = args => {
 Open.argTypes = {
     closed: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     deleted: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     merged: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     draft: {
         control: { type: 'number' },
-        defaultValue: 5,
     },
     open: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     archived: {
         control: { type: 'number' },
-        defaultValue: 18,
     },
     unpublished: {
         control: { type: 'number' },
-        defaultValue: 55,
     },
     failed: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     retrying: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     scheduled: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     processing: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
+}
+Open.args = {
+    closed: 10,
+    deleted: 10,
+    merged: 10,
+    draft: 5,
+    open: 10,
+    archived: 18,
+    unpublished: 55,
+    failed: 0,
+    retrying: 0,
+    scheduled: 0,
+    processing: 0,
 }
 
 export const OpenAndComplete: Story<MockStatsArgs> = args => {
@@ -234,48 +238,50 @@ export const OpenAndComplete: Story<MockStatsArgs> = args => {
 OpenAndComplete.argTypes = {
     closed: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     deleted: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     merged: {
         control: { type: 'number' },
-        defaultValue: 80,
     },
     draft: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     open: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     archived: {
         control: { type: 'number' },
-        defaultValue: 18,
     },
     unpublished: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     failed: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     retrying: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     scheduled: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     processing: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
+}
+OpenAndComplete.args = {
+    closed: 10,
+    deleted: 10,
+    merged: 80,
+    draft: 0,
+    open: 0,
+    archived: 18,
+    unpublished: 0,
+    failed: 0,
+    retrying: 0,
+    scheduled: 0,
+    processing: 0,
 }
 
 OpenAndComplete.storyName = 'open and complete'
@@ -317,46 +323,48 @@ export const Closed: Story<MockStatsArgs> = args => {
 Closed.argTypes = {
     closed: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     deleted: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     merged: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     draft: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     open: {
         control: { type: 'number' },
-        defaultValue: 10,
     },
     archived: {
         control: { type: 'number' },
-        defaultValue: 18,
     },
     unpublished: {
         control: { type: 'number' },
-        defaultValue: 60,
     },
     failed: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     retrying: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     scheduled: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
     processing: {
         control: { type: 'number' },
-        defaultValue: 0,
     },
+}
+Closed.args = {
+    closed: 10,
+    deleted: 10,
+    merged: 10,
+    draft: 0,
+    open: 10,
+    archived: 18,
+    unpublished: 60,
+    failed: 0,
+    retrying: 0,
+    scheduled: 0,
+    processing: 0,
 }

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
@@ -21,8 +21,10 @@ const config: Meta = {
     argTypes: {
         viewerCanAdminister: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        viewerCanAdminister: true,
     },
 }
 
@@ -137,17 +139,19 @@ export const DraftWithoutChangesets: Story = args => {
 DraftWithoutChangesets.argTypes = {
     batchChangeState: {
         control: { type: 'select', options: Object.keys(BatchChangeState) },
-        defaultValue: BatchChangeState.DRAFT,
     },
     isExecutionEnabled: {
         control: { type: 'boolean' },
-        defaultValue: true,
     },
     viewerCanAdminister: {
         table: {
             disable: true,
         },
     },
+}
+DraftWithoutChangesets.args = {
+    batchChangeState: BatchChangeState.DRAFT,
+    isExecutionEnabled: true,
 }
 
 DraftWithoutChangesets.storyName = 'Draft without changesets'

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -24,18 +24,20 @@ const config: Meta = {
         visibleChangesets: {
             name: 'Visible changesets',
             control: { type: 'range', min: 0, max: MAX_CHANGESETS },
-            defaultValue: 10,
         },
         selectableChangesets: {
             name: 'Selectable changesets',
             control: { type: 'range', min: 0, max: MAX_CHANGESETS },
-            defaultValue: 100,
         },
         selectedChangesets: {
             name: 'Selected changesets',
             control: { type: 'range', min: 0, max: MAX_CHANGESETS },
-            defaultValue: 0,
         },
+    },
+    args: {
+        visibleChangesets: 10,
+        selectableChangesets: 100,
+        selectedChangesets: 0,
     },
 }
 

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
@@ -25,16 +25,18 @@ const config: Meta = {
     argTypes: {
         viewerCanAdminister: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
         labeled: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
         commitsSigned: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        viewerCanAdminister: true,
+        labeled: true,
+        commitsSigned: true,
     },
 }
 

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -114,13 +114,15 @@ ListOfBatchChanges.argTypes = {
     canCreate: {
         name: 'can create batch changes',
         control: { type: 'boolean' },
-        defaultValue: true,
     },
     isDotCom: {
         name: 'is sourcegraph.com',
         control: { type: 'boolean' },
-        defaultValue: false,
     },
+}
+ListOfBatchChanges.args = {
+    canCreate: true,
+    isDotCom: false,
 }
 
 ListOfBatchChanges.storyName = 'List of batch changes'

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
@@ -22,13 +22,15 @@ const config: Meta = {
         displayNamespace: {
             name: 'Display namespace',
             control: { type: 'boolean' },
-            defaultValue: true,
         },
         node: {
             table: {
                 disable: true,
             },
         },
+    },
+    args: {
+        displayNamespace: true,
     },
 }
 

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
@@ -13,8 +13,10 @@ const config: Meta = {
         viewerIsAdmin: {
             name: 'Viewer is admin?',
             control: { type: 'boolean' },
-            defaultValue: false,
         },
+    },
+    args: {
+        viewerIsAdmin: false,
     },
 }
 

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
@@ -49,17 +49,17 @@ const Template: Story = ({ state, ...args }) => (
 export const Licensed = Template.bind({})
 Licensed.args = { state: LicensingState.Licensed }
 Licensed.argTypes = {
-    licensed: { defaultValue: LicensingState.Licensed },
+    licensed: {},
 }
 
 export const Unlicensed = Template.bind({})
 Unlicensed.args = { state: LicensingState.Unlicensed }
 Unlicensed.argTypes = {
-    licensed: { defaultValue: LicensingState.Unlicensed },
+    licensed: {},
 }
 
 export const Loading = Template.bind({})
 Loading.args = { state: LicensingState.Loading }
 Loading.argTypes = {
-    licensed: { defaultValue: LicensingState.Loading },
+    licensed: {},
 }

--- a/client/web/src/enterprise/batches/list/GettingStarted.story.tsx
+++ b/client/web/src/enterprise/batches/list/GettingStarted.story.tsx
@@ -17,12 +17,14 @@ const config: Meta = {
     argTypes: {
         isSourcegraphDotCom: {
             control: { type: 'boolean' },
-            defaultValue: false,
         },
         canCreateBatchChanges: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        isSourcegraphDotCom: false,
+        canCreateBatchChanges: true,
     },
 }
 

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
@@ -37,12 +37,14 @@ const config: Meta = {
     argTypes: {
         supersedingBatchSpec: {
             control: { type: 'boolean' },
-            defaultValue: false,
         },
         viewerCanAdminister: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        supersedingBatchSpec: false,
+        viewerCanAdminister: true,
     },
 }
 

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
@@ -18,8 +18,10 @@ const config: Meta = {
     argTypes: {
         viewerCanAdminister: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        viewerCanAdminister: true,
     },
 }
 

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -18,8 +18,10 @@ const config: Meta = {
         publicationStateSet: {
             name: 'publication state set by spec file',
             control: { type: 'boolean' },
-            defaultValue: false,
         },
+    },
+    args: {
+        publicationStateSet: false,
     },
 }
 

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
@@ -70,8 +70,10 @@ RequiresSSHstep1.argTypes = {
     externalServiceKind: {
         name: 'External service kind',
         control: { type: 'select', options: Object.values(ExternalServiceKind) },
-        defaultValue: ExternalServiceKind.GITHUB,
     },
+}
+RequiresSSHstep1.args = {
+    externalServiceKind: ExternalServiceKind.GITHUB,
 }
 
 RequiresSSHstep1.storyName = 'Requires SSH - step 1'
@@ -97,8 +99,10 @@ RequiresSSHstep2.argTypes = {
     externalServiceKind: {
         name: 'External service kind',
         control: { type: 'select', options: Object.values(ExternalServiceKind) },
-        defaultValue: ExternalServiceKind.GITHUB,
     },
+}
+RequiresSSHstep2.args = {
+    externalServiceKind: ExternalServiceKind.GITHUB,
 }
 
 RequiresSSHstep2.storyName = 'Requires SSH - step 2'

--- a/client/web/src/nav/UserNavItem.story.tsx
+++ b/client/web/src/nav/UserNavItem.story.tsx
@@ -25,8 +25,10 @@ const config: Meta = {
     argTypes: {
         isSourcegraphDotCom: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        isSourcegraphDotCom: true,
     },
 }
 

--- a/client/web/src/repo/commits/GitCommitNode.story.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.story.tsx
@@ -94,24 +94,26 @@ export const FullCustomizable: Story = args => (
 FullCustomizable.argTypes = {
     compact: {
         control: { type: 'boolean' },
-        defaultValue: false,
     },
     expandCommitMessageBody: {
         control: { type: 'boolean' },
-        defaultValue: false,
     },
     showSHAAndParentsRow: {
         control: { type: 'boolean' },
-        defaultValue: false,
     },
     hideExpandCommitMessageBody: {
         control: { type: 'boolean' },
-        defaultValue: false,
     },
     preferAbsoluteTimestamps: {
         control: { type: 'boolean' },
-        defaultValue: false,
     },
+}
+FullCustomizable.args = {
+    compact: false,
+    expandCommitMessageBody: false,
+    showSHAAndParentsRow: false,
+    hideExpandCommitMessageBody: false,
+    preferAbsoluteTimestamps: false,
 }
 
 FullCustomizable.storyName = 'Full customizable'

--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
@@ -58,9 +58,10 @@ export const ExternalServicesAndErrors: Story = args => (
 ExternalServicesAndErrors.storyName = 'has errors'
 
 ExternalServicesAndErrors.argTypes = {
-    erroredWebhookCount: {
-        defaultValue: 500,
-    },
+    erroredWebhookCount: {},
+}
+ExternalServicesAndErrors.args = {
+    erroredWebhookCount: 500,
 }
 
 const buildHeaderMock = (webhookLogCount: number): MockedResponse<WebhookByIDLogPageHeaderResult>[] => [

--- a/client/web/src/site-admin/webhooks/MessagePanel.story.tsx
+++ b/client/web/src/site-admin/webhooks/MessagePanel.story.tsx
@@ -59,8 +59,10 @@ export const JSONResponse: Story = args => (
 JSONResponse.argTypes = {
     requestOrStatusCode: {
         control: { type: 'number', min: 100, max: 599 },
-        defaultValue: 200,
     },
+}
+JSONResponse.args = {
+    requestOrStatusCode: 200,
 }
 
 JSONResponse.storyName = 'JSON response'
@@ -101,8 +103,10 @@ export const PlainResponse: Story = args => (
 PlainResponse.argTypes = {
     requestOrStatusCode: {
         control: { type: 'number', min: 100, max: 599 },
-        defaultValue: 200,
     },
+}
+PlainResponse.args = {
+    requestOrStatusCode: 200,
 }
 
 PlainResponse.storyName = 'plain response'

--- a/client/web/src/site-admin/webhooks/StatusCode.story.tsx
+++ b/client/web/src/site-admin/webhooks/StatusCode.story.tsx
@@ -22,14 +22,18 @@ export const Success: Story = args => <WebStory>{() => <StatusCode code={args.co
 Success.argTypes = {
     code: {
         control: { type: 'number', min: 100, max: 399 },
-        defaultValue: 204,
     },
+}
+Success.args = {
+    code: 204,
 }
 
 export const Failure: Story = args => <WebStory>{() => <StatusCode code={args.code} />}</WebStory>
 Failure.argTypes = {
     code: {
         control: { type: 'number', min: 400, max: 599 },
-        defaultValue: 418,
     },
+}
+Failure.args = {
+    code: 418,
 }

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
@@ -35,13 +35,15 @@ const config: Meta = {
         receivedAt: {
             name: 'received at',
             control: { type: 'text' },
-            defaultValue: 'Sun Nov 07 2021 14:31:00 GMT-0500 (Eastern Standard Time)',
         },
         statusCode: {
             name: 'status code',
             control: { type: 'number', min: 100, max: 599 },
-            defaultValue: 204,
         },
+    },
+    args: {
+        receivedAt: 'Sun Nov 07 2021 14:31:00 GMT-0500 (Eastern Standard Time)',
+        statusCode: 204,
     },
 }
 

--- a/client/web/src/site-admin/webhooks/WebhookLogPage.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPage.story.tsx
@@ -25,13 +25,15 @@ const config: Meta = {
         externalServiceCount: {
             name: 'external service count',
             control: { type: 'number' },
-            defaultValue: 2,
         },
         erroredWebhookCount: {
             name: 'errored webhook count',
             control: { type: 'number' },
-            defaultValue: 2,
         },
+    },
+    args: {
+        externalServiceCount: 2,
+        erroredWebhookCount: 2,
     },
 }
 

--- a/client/web/src/site-admin/webhooks/WebhookLogPageHeader.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPageHeader.story.tsx
@@ -70,12 +70,12 @@ export const AllZeroes: Story = args => (
     </WebStory>
 )
 AllZeroes.argTypes = {
-    externalServiceCount: {
-        defaultValue: 0,
-    },
-    erroredWebhookCount: {
-        defaultValue: 0,
-    },
+    externalServiceCount: {},
+    erroredWebhookCount: {},
+}
+AllZeroes.args = {
+    externalServiceCount: 0,
+    erroredWebhookCount: 0,
 }
 
 AllZeroes.storyName = 'all zeroes'
@@ -91,12 +91,12 @@ export const ExternalServices: Story = args => (
 )
 
 ExternalServices.argTypes = {
-    externalServiceCount: {
-        defaultValue: 10,
-    },
-    erroredWebhookCount: {
-        defaultValue: 0,
-    },
+    externalServiceCount: {},
+    erroredWebhookCount: {},
+}
+ExternalServices.args = {
+    externalServiceCount: 10,
+    erroredWebhookCount: 0,
 }
 
 ExternalServices.storyName = 'external services'
@@ -112,12 +112,12 @@ export const ExternalServicesAndErrors: Story = args => (
 )
 
 ExternalServicesAndErrors.argTypes = {
-    externalServiceCount: {
-        defaultValue: 20,
-    },
-    erroredWebhookCount: {
-        defaultValue: 500,
-    },
+    externalServiceCount: {},
+    erroredWebhookCount: {},
+}
+ExternalServicesAndErrors.args = {
+    externalServiceCount: 20,
+    erroredWebhookCount: 500,
 }
 
 ExternalServicesAndErrors.storyName = 'external services and errors'
@@ -132,12 +132,12 @@ export const OnlyErrorsTurnedOn: Story = args => (
     </WebStory>
 )
 OnlyErrorsTurnedOn.argTypes = {
-    externalServiceCount: {
-        defaultValue: 20,
-    },
-    erroredWebhookCount: {
-        defaultValue: 500,
-    },
+    externalServiceCount: {},
+    erroredWebhookCount: {},
+}
+OnlyErrorsTurnedOn.args = {
+    externalServiceCount: 20,
+    erroredWebhookCount: 500,
 }
 
 OnlyErrorsTurnedOn.storyName = 'only errors turned on'
@@ -154,14 +154,14 @@ export const SpecificExternalServiceSelected: Story = args => (
 SpecificExternalServiceSelected.argTypes = {
     initialExternalService: {
         control: { type: 'number', min: 0, max: 19 },
-        defaultValue: 2,
     },
-    externalServiceCount: {
-        defaultValue: 20,
-    },
-    erroredWebhookCount: {
-        defaultValue: 500,
-    },
+    externalServiceCount: {},
+    erroredWebhookCount: {},
+}
+SpecificExternalServiceSelected.args = {
+    initialExternalService: 2,
+    externalServiceCount: 20,
+    erroredWebhookCount: 500,
 }
 
 SpecificExternalServiceSelected.storyName = 'specific external service selected'
@@ -177,12 +177,12 @@ export const UnmatchedExternalServiceSelected: Story = args => (
 )
 
 UnmatchedExternalServiceSelected.argTypes = {
-    externalServiceCount: {
-        defaultValue: 20,
-    },
-    erroredWebhookCount: {
-        defaultValue: 500,
-    },
+    externalServiceCount: {},
+    erroredWebhookCount: {},
+}
+UnmatchedExternalServiceSelected.args = {
+    externalServiceCount: 20,
+    erroredWebhookCount: 500,
 }
 
 UnmatchedExternalServiceSelected.storyName = 'unmatched external service selected'

--- a/client/wildcard/src/components/Button/story/Button.story.tsx
+++ b/client/wildcard/src/components/Button/story/Button.story.tsx
@@ -46,23 +46,25 @@ Simple.argTypes = {
     variant: {
         name: 'Variant',
         control: { type: 'select', options: BUTTON_VARIANTS },
-        defaultValue: 'primary',
     },
     size: {
         name: 'Name',
         control: { type: 'select', options: BUTTON_SIZES },
-        defaultValue: 'sm',
     },
     disabled: {
         name: 'Disabled',
         control: { type: 'boolean' },
-        defaultValue: false,
     },
     outline: {
         name: 'Outline',
         control: { type: 'boolean' },
-        defaultValue: false,
     },
+}
+Simple.args = {
+    variant: 'primary',
+    size: 'sm',
+    disabled: false,
+    outline: false,
 }
 
 export const AllButtons: Story = () => (

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.story.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.story.tsx
@@ -14,8 +14,10 @@ const StoryConfig: Meta = {
     argTypes: {
         useMaxValuesForYScale: {
             type: 'boolean',
-            defaultValue: false,
         },
+    },
+    args: {
+        useMaxValuesForYScale: false,
     },
     parameters: { chromatic: { disableSnapshots: false } },
 }

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.story.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.story.tsx
@@ -33,12 +33,14 @@ const config: Meta = {
     argTypes: {
         authenticatedUser: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
         productResearchEnabled: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        authenticatedUser: true,
+        productResearchEnabled: true,
     },
 }
 

--- a/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.story.tsx
+++ b/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.story.tsx
@@ -20,8 +20,10 @@ const config: Meta = {
     argTypes: {
         inline: {
             control: { type: 'boolean' },
-            defaultValue: true,
         },
+    },
+    args: {
+        inline: true,
     },
 }
 

--- a/client/wildcard/src/components/PageSelector/PageSelector.story.tsx
+++ b/client/wildcard/src/components/PageSelector/PageSelector.story.tsx
@@ -27,8 +27,10 @@ Simple.argTypes = {
     totalPages: {
         name: 'maxPages',
         control: { type: 'number' },
-        defaultValue: 5,
     },
+}
+Simple.args = {
+    totalPages: 5,
 }
 
 export const AllPageSelectors: Story = () => (

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
@@ -76,13 +76,15 @@ Simple.argTypes = {
     totalCount: {
         name: 'totalCount',
         control: { type: 'number' },
-        defaultValue: 5,
     },
     totalLabel: {
         name: 'totalLabel',
         control: { type: 'string' },
-        defaultValue: 'pages',
     },
+}
+Simple.args = {
+    totalCount: 5,
+    totalLabel: 'pages',
 }
 
 Simple.parameters = {

--- a/client/wildcard/src/components/Popover/story/Popover.story.tsx
+++ b/client/wildcard/src/components/Popover/story/Popover.story.tsx
@@ -440,8 +440,10 @@ export const WithNestedScrollParents: Story = (args = {}) => {
 WithNestedScrollParents.argTypes = {
     constrainToScrollParents: {
         control: { type: 'boolean' },
-        defaultValue: true,
     },
+}
+WithNestedScrollParents.args = {
+    constrainToScrollParents: true,
 }
 
 export const WithVirtualTarget: Story = () => {
@@ -521,8 +523,10 @@ WithTail.argTypes = {
     size: {
         control: 'radio',
         options: ['sm', 'md', 'lg'],
-        defaultValue: 'sm',
     },
+}
+WithTail.args = {
+    size: 'sm',
 }
 
 interface ScrollCenterBoxProps extends React.HTMLAttributes<HTMLDivElement> {

--- a/client/wildcard/src/components/Typography/Typography.story.tsx
+++ b/client/wildcard/src/components/Typography/Typography.story.tsx
@@ -248,12 +248,14 @@ export const Simple: Story = (args = {}) => (
 Simple.argTypes = {
     mode: {
         control: { type: 'select', options: TYPOGRAPHY_MODES },
-        defaultValue: 'default',
     },
     alignment: {
         control: { type: 'select', options: TYPOGRAPHY_ALIGNMENTS },
-        defaultValue: 'left',
     },
+}
+Simple.args = {
+    mode: 'default',
+    alignment: 'left',
 }
 
 export const CrossingStyles: Story = () => (

--- a/client/wildcard/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
+++ b/client/wildcard/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
@@ -442,26 +442,28 @@ export const Meter: Story = args => (
 Meter.argTypes = {
     min: {
         type: 'number',
-        defaultValue: 0,
     },
     max: {
         type: 'number',
-        defaultValue: 1,
     },
     high: {
         type: 'number',
-        defaultValue: 0.8,
     },
     low: {
         type: 'number',
-        defaultValue: 0.2,
     },
     optimum: {
         type: 'number',
-        defaultValue: 1,
     },
     value: {
         type: 'number',
-        defaultValue: 0.1,
     },
+}
+Meter.args = {
+    min: 0,
+    max: 1,
+    high: 0.8,
+    low: 0.2,
+    optimum: 1,
+    value: 0.1,
 }


### PR DESCRIPTION
argTypes.defaultValue is removed in Storybook 7. For forward-compat, migrate to the new way of specifying an arg's default value (https://github.com/storybookjs/storybook/issues/21016#issuecomment-1556306865).




## Test plan

CI