### PR TITLE
add back bazel dep for postcss-focus-visible

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -70,6 +70,7 @@ js_library(
     deps = [
         "//:node_modules/autoprefixer",
         "//:node_modules/postcss-custom-media",
+        "//:node_modules/postcss-focus-visible",
         "//:node_modules/postcss-inset",
     ],
 )


### PR DESCRIPTION
This was erroneously removed in https://github.com/sourcegraph/sourcegraph/pull/57387/files#r1349473876.




## Test plan

CI