### PR TITLE
rename {WEBPACK => WEB_BUILDER}_SERVE_INDEX env var

### DIFF
--- a/client/web/README.md
+++ b/client/web/README.md
@@ -10,7 +10,7 @@ Our local development server runs by starting both a [Caddy](https://caddyserver
 
 Environment variables important for the web server:
 
-1. `WEBPACK_SERVE_INDEX` should be set to `true` to enable `HTMLWebpackPlugin`.
+1. `WEB_BUILDER_SERVE_INDEX` should be set to `true` to enable `HTMLWebpackPlugin`.
 2. `SOURCEGRAPH_API_URL` is used as a proxied API url. By default it points to the [https://k8s.sgdev.org](https://k8s.sgdev.org).
 
 It's possible to overwrite these variables by creating `sg.config.overwrite.yaml` in the root folder and adjusting the `env` section of the relevant command.

--- a/client/web/dev/server/production.server.ts
+++ b/client/web/dev/server/production.server.ts
@@ -41,7 +41,7 @@ function startProductionServer(): void {
 
     const { proxyRoutes, ...proxyConfig } = getAPIProxySettings({
         apiURL: SOURCEGRAPH_API_URL,
-        ...(ENVIRONMENT_CONFIG.WEBPACK_SERVE_INDEX && {
+        ...(ENVIRONMENT_CONFIG.WEB_BUILDER_SERVE_INDEX && {
             getLocalIndexHTML(jsContextScript) {
                 const manifestFile = getWebpackManifest()
                 return getIndexHTML({ manifestFile, jsContextScript })

--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -13,7 +13,7 @@ export const builtinAuthProvider = {
     authenticationURL: '',
 }
 
-// Create dummy JS context that will be added to index.html when `WEBPACK_SERVE_INDEX` is set to true.
+// Create dummy JS context that will be added to index.html when `WEB_BUILDER_SERVE_INDEX` is set to true.
 export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: string }): SourcegraphContext => {
     const siteConfig = getSiteConfig()
 

--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -31,11 +31,11 @@ export const ENVIRONMENT_CONFIG = {
     // Can be used to expose global variables to integration tests (e.g., CodeMirror API).
     // Enabled in the dev environment to allow debugging integration tests with the dev server.
     INTEGRATION_TESTS: getEnvironmentBoolean('INTEGRATION_TESTS') || IS_DEVELOPMENT,
-    // Enables `embed` Webpack entry point.
+    // Enables `embed` entrypoint.
     EMBED_DEVELOPMENT: getEnvironmentBoolean('EMBED_DEVELOPMENT'),
 
-    // Should Webpack serve `index.html` with `HTMLWebpackPlugin`.
-    WEBPACK_SERVE_INDEX: getEnvironmentBoolean('WEBPACK_SERVE_INDEX'),
+    // Should the web builder serve `index.html` with `HTMLWebpackPlugin`.
+    WEB_BUILDER_SERVE_INDEX: getEnvironmentBoolean('WEB_BUILDER_SERVE_INDEX'),
     // Enables `StatoscopeWebpackPlugin` that allows to analyze application bundle.
     WEBPACK_BUNDLE_ANALYZER: getEnvironmentBoolean('WEBPACK_BUNDLE_ANALYZER'),
     // The name used to generate Statoscope JSON stats and HTML report in the `/ui/assets` folder.

--- a/client/web/webpack.bazel.config.js
+++ b/client/web/webpack.bazel.config.js
@@ -38,7 +38,7 @@ const {
   SOURCEGRAPH_API_URL,
   WEBPACK_BUNDLE_ANALYZER,
   WEBPACK_EXPORT_STATS,
-  WEBPACK_SERVE_INDEX,
+  WEB_BUILDER_SERVE_INDEX,
   WEBPACK_STATS_NAME,
   WEBPACK_USE_NAMED_CHUNKS,
   WEBPACK_DEVELOPMENT_DEVTOOL,
@@ -60,7 +60,7 @@ const RUNTIME_ENV_VARIABLES = {
   ENABLE_OPEN_TELEMETRY,
   INTEGRATION_TESTS,
   COMMIT_SHA,
-  ...(WEBPACK_SERVE_INDEX && { SOURCEGRAPH_API_URL }),
+  ...(WEB_BUILDER_SERVE_INDEX && { SOURCEGRAPH_API_URL }),
 }
 
 const hotLoadablePaths = ['branded', 'shared', 'web', 'wildcard'].map(workspace =>
@@ -86,7 +86,7 @@ const config = {
   stats: {
     // Minimize logging in case if Webpack is used along with multiple other services.
     // Use `normal` output preset in case of running standalone web server.
-    preset: WEBPACK_SERVE_INDEX || IS_PRODUCTION ? 'normal' : 'errors',
+    preset: WEB_BUILDER_SERVE_INDEX || IS_PRODUCTION ? 'normal' : 'errors',
     errorDetails: true,
     timings: true,
   },
@@ -173,7 +173,7 @@ const config = {
       filter: ({ isInitial, name }) =>
         isInitial || Object.values(initialChunkNames).some(initialChunkName => name?.includes(initialChunkName)),
     }),
-    ...(WEBPACK_SERVE_INDEX && IS_PRODUCTION ? [writeIndexHTMLPlugin] : []),
+    ...(WEB_BUILDER_SERVE_INDEX && IS_PRODUCTION ? [writeIndexHTMLPlugin] : []),
     WEBPACK_BUNDLE_ANALYZER && getStatoscopePlugin(WEBPACK_STATS_NAME),
     isHotReloadEnabled && new ReactRefreshWebpackPlugin({ overlay: false }),
     IS_PRODUCTION &&

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -40,7 +40,7 @@ const {
   SOURCEGRAPH_API_URL,
   WEBPACK_BUNDLE_ANALYZER,
   WEBPACK_EXPORT_STATS,
-  WEBPACK_SERVE_INDEX,
+  WEB_BUILDER_SERVE_INDEX,
   WEBPACK_STATS_NAME,
   WEBPACK_USE_NAMED_CHUNKS,
   WEBPACK_DEVELOPMENT_DEVTOOL,
@@ -63,7 +63,7 @@ const RUNTIME_ENV_VARIABLES = {
   ENABLE_OPEN_TELEMETRY,
   INTEGRATION_TESTS,
   COMMIT_SHA,
-  ...(WEBPACK_SERVE_INDEX && { SOURCEGRAPH_API_URL }),
+  ...(WEB_BUILDER_SERVE_INDEX && { SOURCEGRAPH_API_URL }),
 }
 
 const hotLoadablePaths = ['branded', 'shared', 'web', 'wildcard'].map(workspace =>
@@ -86,7 +86,7 @@ const config = {
   stats: {
     // Minimize logging in case if Webpack is used along with multiple other services.
     // Use `normal` output preset in case of running standalone web server.
-    preset: WEBPACK_SERVE_INDEX || IS_PRODUCTION ? 'normal' : 'errors-warnings',
+    preset: WEB_BUILDER_SERVE_INDEX || IS_PRODUCTION ? 'normal' : 'errors-warnings',
     errorDetails: true,
     timings: true,
   },
@@ -172,7 +172,7 @@ const config = {
       filter: ({ isInitial, name }) =>
         isInitial || Object.values(initialChunkNames).some(initialChunkName => name?.includes(initialChunkName)),
     }),
-    ...(WEBPACK_SERVE_INDEX && IS_PRODUCTION ? [writeIndexHTMLPlugin] : []),
+    ...(WEB_BUILDER_SERVE_INDEX && IS_PRODUCTION ? [writeIndexHTMLPlugin] : []),
     WEBPACK_BUNDLE_ANALYZER && getStatoscopePlugin(WEBPACK_STATS_NAME),
     isHotReloadEnabled && new ReactRefreshWebpackPlugin({ overlay: false }),
     IS_PRODUCTION &&

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -397,7 +397,7 @@ commands:
       pnpm install
       pnpm generate
     env:
-      WEBPACK_SERVE_INDEX: true
+      WEB_BUILDER_SERVE_INDEX: true
       SOURCEGRAPH_API_URL: https://k8s.sgdev.org
 
   web-standalone-http-prod:
@@ -406,7 +406,7 @@ commands:
     install: pnpm --filter @sourcegraph/web run build
     env:
       NODE_ENV: production
-      WEBPACK_SERVE_INDEX: true
+      WEB_BUILDER_SERVE_INDEX: true
       SOURCEGRAPH_API_URL: https://k8s.sgdev.org
 
   web-integration-build:


### PR DESCRIPTION
This is not Webpack-specific, and now many/most people would actually use this with esbuild.

fastmod -e yaml,ts,js,md,tsx WEBPACK_SERVE_INDEX WEB_BUILDER_SERVE_INDEX




## Test plan

CI