### PR TITLE
globally disable the id-length rule (long live vars named `i`)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ const config = {
     // This rule doesn't understand type imports and we already have
     // import/no-duplicates enabled as well, which does understand type imports
     'no-duplicate-imports': 'off',
+    'id-length': 'off',
     '@typescript-eslint/consistent-type-exports': 'warn',
     '@typescript-eslint/consistent-type-imports': [
       'warn',

--- a/client/branded/src/components/ToggleBig.story.tsx
+++ b/client/branded/src/components/ToggleBig.story.tsx
@@ -34,7 +34,6 @@ Interactive.parameters = {
     },
 }
 
-// eslint-disable-next-line id-length
 export const On: Story = () => <ToggleBig value={true} onToggle={onToggle} />
 export const Off: Story = () => <ToggleBig value={false} onToggle={onToggle} />
 export const DisabledOn: Story = () => <ToggleBig value={true} disabled={true} onToggle={onToggle} />

--- a/client/branded/src/search-ui/input/codemirror/active-filter.ts
+++ b/client/branded/src/search-ui/input/codemirror/active-filter.ts
@@ -46,7 +46,6 @@ class PlaceholderWidget extends WidgetType {
         super()
     }
 
-    /* eslint-disable-next-line id-length */
     public eq(other: PlaceholderWidget): boolean {
         return this.placeholder === other.placeholder
     }

--- a/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
+++ b/client/branded/src/search-ui/input/experimental/suggestionsExtension.ts
@@ -274,7 +274,6 @@ class Result {
         return new Result(result.result, result.valid)
     }
 
-    // eslint-disable-next-line id-length
     public at(index: number): Option | undefined {
         return this.allOptions[index]
     }

--- a/client/branded/src/search-ui/results/AnnotatedSearchExample.tsx
+++ b/client/branded/src/search-ui/results/AnnotatedSearchExample.tsx
@@ -23,7 +23,7 @@ const belowArrowY = 150
  * the input (above/below) as argument and computes the position and dimensions
  * of the four <line>s that make up this "arrow".
  */
-// eslint-disable-next-line id-length
+
 function arrow(x: number, width: number, position: 'above' | 'below'): React.ReactElement {
     const pointerLine = <line x1={width / 2} x2={width / 2} y1="0" y2={arrowHeight} />
     const centerLine = <line x1="0" x2={width} y1={arrowHeight} y2={arrowHeight} />

--- a/client/shared/src/search/query/patternMatcher.test.ts
+++ b/client/shared/src/search/query/patternMatcher.test.ts
@@ -2,8 +2,6 @@
 // verifier that patterns are properly typed against their input value.
 // Usage of the @ts-expect-error is intentional and should be kept in place
 
-/* eslint-disable id-length */
-
 import { every, matchesValue, some, oneOf, allOf, not, type PatternOfNoInfer } from './patternMatcher'
 
 declare global {

--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -68,7 +68,6 @@ class BlameDecorationWidget extends WidgetType {
         this.state = { navigate: blobProps.navigate }
     }
 
-    /* eslint-disable-next-line id-length*/
     public eq(other: BlameDecorationWidget): boolean {
         return isEqual(this.hunk, other.hunk)
     }

--- a/client/wildcard/src/components/Typography/Heading/H1.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H1.tsx
@@ -6,7 +6,6 @@ import { Heading, type HeadingProps } from './Heading'
 
 type H1Props = HeadingProps
 
-// eslint-disable-next-line id-length
 export const H1 = React.forwardRef(({ children, as = 'h1', ...props }, reference) => (
     <Heading as={as} styleAs="h1" {...props} ref={reference}>
         {children}

--- a/client/wildcard/src/components/Typography/Heading/H2.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H2.tsx
@@ -6,7 +6,6 @@ import { Heading, type HeadingProps } from './Heading'
 
 type H2Props = HeadingProps
 
-// eslint-disable-next-line id-length
 export const H2 = React.forwardRef(({ children, as = 'h2', ...props }, reference) => (
     <Heading as={as} styleAs="h2" {...props} ref={reference}>
         {children}

--- a/client/wildcard/src/components/Typography/Heading/H3.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H3.tsx
@@ -6,7 +6,6 @@ import { Heading, type HeadingProps } from './Heading'
 
 type H3Props = HeadingProps
 
-// eslint-disable-next-line id-length
 export const H3 = React.forwardRef(function H3({ children, as = 'h3', ...props }, reference) {
     return (
         <Heading as={as} styleAs="h3" {...props} ref={reference}>

--- a/client/wildcard/src/components/Typography/Heading/H4.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H4.tsx
@@ -6,7 +6,6 @@ import { Heading, type HeadingProps } from './Heading'
 
 type H4Props = HeadingProps
 
-// eslint-disable-next-line id-length
 export const H4 = React.forwardRef(({ children, as = 'h4', ...props }, reference) => (
     <Heading as={as} styleAs="h4" {...props} ref={reference}>
         {children}

--- a/client/wildcard/src/components/Typography/Heading/H5.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H5.tsx
@@ -6,7 +6,6 @@ import { Heading, type HeadingProps } from './Heading'
 
 type H5Props = HeadingProps
 
-// eslint-disable-next-line id-length
 export const H5 = React.forwardRef(({ children, as = 'h5', ...props }, reference) => (
     <Heading as={as} styleAs="h5" {...props} ref={reference}>
         {children}

--- a/client/wildcard/src/components/Typography/Heading/H6.tsx
+++ b/client/wildcard/src/components/Typography/Heading/H6.tsx
@@ -6,7 +6,6 @@ import { Heading, type HeadingProps } from './Heading'
 
 type H6Props = HeadingProps
 
-// eslint-disable-next-line id-length
 export const H6 = React.forwardRef(({ children, as = 'h6', ...props }, reference) => (
     <Heading as={as} styleAs="h6" {...props} ref={reference}>
         {children}

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -216,7 +216,6 @@ const steps: Step[] = [
             ]
 
             if (next.patches) {
-                // eslint-disable-next-line id-length
                 for (let i = 0; i < next.patches.length; i++) {
                     events.push({
                         title: `Scheduled Patch #${i + 1} Sourcegraph ${name}`,


### PR DESCRIPTION
The `id-length` eslint rule forbids short variable names (3 chars or less). This is a bad rule IMO because it leads to needlessly long var names (`index` instead of `i`). It's also really annoying, and I know I'm not alone in feeling that (https://registerspill.thorstenball.com/p/who-removes-rules).




## Test plan

CI