### PR TITLE
Adding loading messages and buttons to Cody App loading screen

### DIFF
--- a/client/app-shell/static/index.html
+++ b/client/app-shell/static/index.html
@@ -59,7 +59,7 @@
                 }
             }
 
-            svg path {
+            .loading-animation svg path {
                 stroke-width: 3;
                 stroke-linecap: round;
                 stroke-dasharray: 1;
@@ -172,6 +172,52 @@
                 96% { opacity: 1; }
                 to { opacity: var(--final-opacity); }
             }
+
+            .show-logs {
+                display: flex;
+                flex-direction: column;
+                width: 100%;
+                gap: 5px;
+                position: absolute;
+                text-align: center;
+                bottom: 50px;
+                font-size: 12px;
+                opacity: 0;
+                transform: scale(0);
+                animation: 5s show-log-link 30s forwards;
+            }
+
+            @keyframes show-log-link {
+                from { opacity: 0; transform: scale(1); }
+                to { opacity: 1; transform: scale(1); }
+            }
+
+            .show-logs p {
+                margin: 0;
+            }
+
+            .show-logs a {
+                display: inline-block;
+                border-radius: 6px;
+                line-height: 1;
+                padding: 6px 8px;
+            }
+
+            .show-logs a, .show-logs a:visited {
+                color: var(--blue);
+                text-decoration: none;
+                font-weight: 600;
+                opacity: 1;
+                background-color: rgba(0, 203, 236, 0);
+            }
+            .show-logs a:hover {
+                background-color: rgba(0, 203, 236, 0.2);
+                color: rgb(109, 236, 255);
+            }
+            .show-logs a svg {
+                margin-right: 2px;
+                vertical-align: middle;
+            }
         </style>
     </head>
     <body>
@@ -183,7 +229,6 @@
                     <path class="right-eye" d="M16.4,5.7v2v2" pathLength="1" />
                 </svg>
             </div>
-
             <div class="messages">
                 <p class="messages__message">Initializing</p>
                 <p class="messages__message">Starting Embeddings Service</p>
@@ -191,7 +236,29 @@
                 <p class="messages__message">Starting Git Service</p>
                 <p class="messages__message">Initializing</p>
             </div>
+            <div class="show-logs">
+                <p>
+                    <a href="" onclick="__TAURI__.invoke('show_logs').catch(console.error)">
+                        <svg viewBox="0 0 20 20" fill="currentColor" width="20px" height="20px">
+                            <path fill-rule="evenodd"
+                                d="M4.5 2A1.5 1.5 0 003 3.5v13A1.5 1.5 0 004.5 18h11a1.5 1.5 0 001.5-1.5V7.621a1.5 1.5 0 00-.44-1.06l-4.12-4.122A1.5 1.5 0 0011.378 2H4.5zm2.25 8.5a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5zm0 3a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5z"
+                                clip-rule="evenodd" />
+                        </svg>
+                        <span>Show Logs</span>
+                    </a>
+                </p>
+                <p>
+                    <a href="mailto:support@sourcegraph.com?subject=Cody%20App%20loading">
+                        <svg viewBox="0 0 20 20" fill="currentColor" width="20px" height="20px">
+                            <path fill-rule="evenodd"
+                                d="M10 2c-2.236 0-4.43.18-6.57.524C1.993 2.755 1 4.014 1 5.426v5.148c0 1.413.993 2.67 2.43 2.902.848.137 1.705.248 2.57.331v3.443a.75.75 0 001.28.53l3.58-3.579a.78.78 0 01.527-.224 41.202 41.202 0 005.183-.5c1.437-.232 2.43-1.49 2.43-2.903V5.426c0-1.413-.993-2.67-2.43-2.902A41.289 41.289 0 0010 2zm0 7a1 1 0 100-2 1 1 0 000 2zM8 8a1 1 0 11-2 0 1 1 0 012 0zm5 1a1 1 0 100-2 1 1 0 000 2z"
+                                clip-rule="evenodd" />
+                        </svg>
+                        <span>Contact Support</span>
+                    </a>
+                </p>
             </div>
+        </div>
         <script type="module" src="/scripts/app-shell.js"></script>
     </body>
 </html>

--- a/client/app-shell/static/index.html
+++ b/client/app-shell/static/index.html
@@ -164,6 +164,7 @@
             .messages__message:nth-child(3) { animation-delay: calc(var(--initial-delay) + (var(--duration) * 2)); }
             .messages__message:nth-child(4) { animation-delay: calc(var(--initial-delay) + (var(--duration) * 3)); }
             .messages__message:nth-child(5) { animation-delay: calc(var(--initial-delay) + (var(--duration) * 4)); }
+            .messages__message:nth-child(6) { animation-delay: calc(var(--initial-delay) + (var(--duration) * 5)); }
             .messages__message:last-child { --final-opacity: 1; }
             
             @keyframes message-appear {
@@ -184,7 +185,7 @@
                 font-size: 12px;
                 opacity: 0;
                 transform: scale(0);
-                animation: 5s show-log-link 30s forwards;
+                animation: 1s show-log-link 30s forwards;
             }
 
             @keyframes show-log-link {
@@ -234,6 +235,7 @@
                 <p class="messages__message">Starting Embeddings Service</p>
                 <p class="messages__message">Starting Chat Service</p>
                 <p class="messages__message">Starting Git Service</p>
+                <p class="messages__message">Reticulating Splines</p>
                 <p class="messages__message">Initializing</p>
             </div>
             <div class="show-logs">

--- a/client/app-shell/static/index.html
+++ b/client/app-shell/static/index.html
@@ -22,6 +22,8 @@
                 --bg-purple: rgb(161, 18, 255, 0.075);
                 --red: rgb(255, 85, 67);
                 --blue: rgb(0, 203, 236);
+                font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+                text-align: center;
             }
 
             :root,
@@ -36,6 +38,25 @@
                 align-items: center;
                 justify-content: center;
                 background: var(--bg-purple);
+            }
+
+            body > div {
+                width: 100%;
+            }
+
+            .loading-animation {
+                transform: translateY(0px);
+                /* Cody autocompleted both the timing function and keyframes! */
+                animation: 250ms shove-face-up 5s cubic-bezier(0.17, 0.67, 0.83, 0.67) forwards;
+            }
+
+            @keyframes shove-face-up {
+                from {
+                    transform: translateY(0px);
+                }
+                to {
+                    transform: translateY(-10px);
+                }
             }
 
             svg path {
@@ -114,15 +135,63 @@
                 --translate-y-to: -6.8px;
                 --pulse-delay-offset: 0.222s;
             }
+
+            .messages {
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translateY(-50%) translateX(-50%);
+                font-size: 13px;
+                font-weight: 500;
+                opacity: 0.8;
+                width: 100%;
+                --final-opacity: 0;
+                --duration: 4s;
+                --initial-delay: 5s;
+            }
+
+            .messages__message {
+                position: absolute;
+                top: 0;
+                left: 50%;
+                transform: translateX(-50%);
+                opacity: 0;
+                animation: var(--duration) ease-in-out 0s forwards message-appear;
+                margin: 0;
+            }
+            .messages__message:nth-child(1) { animation-delay: var(--initial-delay); }
+            .messages__message:nth-child(2) { animation-delay: calc(var(--initial-delay) + (var(--duration) * 1)); }
+            .messages__message:nth-child(3) { animation-delay: calc(var(--initial-delay) + (var(--duration) * 2)); }
+            .messages__message:nth-child(4) { animation-delay: calc(var(--initial-delay) + (var(--duration) * 3)); }
+            .messages__message:nth-child(5) { animation-delay: calc(var(--initial-delay) + (var(--duration) * 4)); }
+            .messages__message:last-child { --final-opacity: 1; }
+            
+            @keyframes message-appear {
+                from { opacity: 0; }
+                4% { opacity: 1; }
+                96% { opacity: 1; }
+                to { opacity: var(--final-opacity); }
+            }
         </style>
     </head>
     <body>
-        <svg viewbox="0 0 24 24" width="32" height="32" aria-label="Starting up Cody...">
-            <path class="mouth" d="M5.2,14.8c0,0,1.6,3.6,6.9,3.6s6.9-3.6,6.9-3.6" pathLength="1" />
-            <path class="left-eye" d="M6.2,8.3h2h2" pathLength="1" />
-            <path class="right-eye" d="M16.4,5.7v2v2" pathLength="1" />
-        </svg>
+        <div>
+            <div class="loading-animation">
+                <svg viewbox="0 0 24 24" width="32" height="32" aria-label="Starting up Cody...">
+                    <path class="mouth" d="M5.2,14.8c0,0,1.6,3.6,6.9,3.6s6.9-3.6,6.9-3.6" pathLength="1" />
+                    <path class="left-eye" d="M6.2,8.3h2h2" pathLength="1" />
+                    <path class="right-eye" d="M16.4,5.7v2v2" pathLength="1" />
+                </svg>
+            </div>
 
+            <div class="messages">
+                <p class="messages__message">Initializing</p>
+                <p class="messages__message">Starting Embeddings Service</p>
+                <p class="messages__message">Starting Chat Service</p>
+                <p class="messages__message">Starting Git Service</p>
+                <p class="messages__message">Initializing</p>
+            </div>
+            </div>
         <script type="module" src="/scripts/app-shell.js"></script>
     </body>
 </html>


### PR DESCRIPTION
In recent user testing of sourcegraph/cody#1275 all the users mentioned App’s loading time, and many showed some discomfort as to whether it was loading correctly. Loading also stalled for one of the users.

This updates the App’s loading screen to:
- After 5 seconds, start showing some messages (ala Slack & Discord) to give people a bit more confidence that things are happening
- After 30s says "Initializing" and includes a link to show the logs and to email support

https://github.com/sourcegraph/sourcegraph/assets/153/13ffa3c5-7679-4ca6-b77f-56b4c1113229

## Test plan

- Tested in browser
- Test links in Tauri wrapper