### PR TITLE
Pass IDE prop to new CodyInstall HubSpot event

### DIFF
--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -171,7 +171,11 @@ func (r *schemaResolver) LogEvents(ctx context.Context, args *EventBatch) (*Empt
 				}
 			}
 
-			hubspotutil.SyncUserWithEventParams(userPrimaryEmail, hubspotutil.CodyClientInstalledEventID, &hubspot.ContactProperties{
+			hubspotutil.SyncUser(userPrimaryEmail, hubspotutil.CodyClientInstalledEventID, &hubspot.ContactProperties{
+				DatabaseID: userID,
+			})
+
+			hubspotutil.SyncUserWithEventParams(userPrimaryEmail, hubspotutil.NewCodyClientInstalledEventID, &hubspot.ContactProperties{
 				DatabaseID:                   userID,
 				VSCodyInstalledEmailsEnabled: emailsEnabled,
 			}, map[string]string{"ide": ide, "emailsEnabled": strconv.FormatBool(emailsEnabled)})

--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -41,6 +41,9 @@ var SelfHostedSiteInitEventID = "000010399089"
 // CodyClientInstalledEventID is the HubSpot Event ID for when a user reports installing a Cody client.
 var CodyClientInstalledEventID = "000018021981"
 
+// NewCodyClientInstalledEventID is the HubSpot ID for the new event which support custom properties.
+var NewCodyClientInstalledEventID = "pe2762526_codyinstall"
+
 // AppDownloadButtonClickedEventID is the HubSpot Event ID for when a user clicks on a button to download Cody App.
 var AppDownloadButtonClickedEventID = "000019179879"
 


### PR DESCRIPTION
Passing the IDE and emailsEnabled args to the old event does nothing. Passing a new event to HubSpot which supports custom properties. 

## Test plan
- https://knowledge.hubspot.com/analytics-tools/create-custom-behavioral-events-with-the-code-wizard