### PR TITLE
ranking: remove old code path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a bug where site admins could not view a user's permissions if they didn't have access to all of the repositories the user has. Admins still won't be able to see repositories they don't have access to, but they will now be able to view the rest of the user's repository permissions. [#57375](https://github.com/sourcegraph/sourcegraph/pull/57375)
 
 ### Removed
-
--
+- The following experimental settings in site-configuration have not been used by the backend since version 5.1 and are now deprecated: `maxReorderQueueSize`, `maxQueueMatchCount`, `maxReorderDurationMS`. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
+- The feature-flag `search-ranking`, which allowed to disable the improved ranking introduced in 5.1, is now deprecated. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
 
 ## 5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - The experimental GraphQL query `User.invitableCollaborators`.
+- The following experimental settings in site-configuration are now deprecated and will not be read anymore: `maxReorderQueueSize`, `maxQueueMatchCount`, `maxReorderDurationMS`. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
+- The feature-flag `search-ranking`, which allowed to disable the improved ranking introduced in 5.1, is now deprecated and will not be read anymore. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
 
 ## Unreleased 5.2.1
 
@@ -47,8 +49,6 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a bug where site admins could not view a user's permissions if they didn't have access to all of the repositories the user has. Admins still won't be able to see repositories they don't have access to, but they will now be able to view the rest of the user's repository permissions. [#57375](https://github.com/sourcegraph/sourcegraph/pull/57375)
 
 ### Removed
-- The following experimental settings in site-configuration are now deprecated and will not be read anymore: `maxReorderQueueSize`, `maxQueueMatchCount`, `maxReorderDurationMS`. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
-- The feature-flag `search-ranking`, which allowed to disable the improved ranking introduced in 5.1, is now deprecated and will not be read anymore. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
 
 ## 5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a bug where site admins could not view a user's permissions if they didn't have access to all of the repositories the user has. Admins still won't be able to see repositories they don't have access to, but they will now be able to view the rest of the user's repository permissions. [#57375](https://github.com/sourcegraph/sourcegraph/pull/57375)
 
 ### Removed
-- The following experimental settings in site-configuration have not been used by the backend since version 5.1 and are now deprecated: `maxReorderQueueSize`, `maxQueueMatchCount`, `maxReorderDurationMS`. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
-- The feature-flag `search-ranking`, which allowed to disable the improved ranking introduced in 5.1, is now deprecated. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
+- The following experimental settings in site-configuration are now deprecated and will not be read anymore: `maxReorderQueueSize`, `maxQueueMatchCount`, `maxReorderDurationMS`. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
+- The feature-flag `search-ranking`, which allowed to disable the improved ranking introduced in 5.1, is now deprecated and will not be read anymore. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
 
 ## 5.2.0
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -370,6 +370,14 @@ func SearchDocumentRanksWeight() float64 {
 	}
 }
 
+func RankingMaxQueueSizeBytes() int {
+	ranking := ExperimentalFeatures().Ranking
+	if ranking == nil || ranking.MaxQueueSizeBytes == nil {
+		return -1
+	}
+	return *ranking.MaxQueueSizeBytes
+}
+
 // SearchFlushWallTime controls the amount of time that Zoekt shards collect and rank results. For
 // larger codebases, it can be helpful to increase this to improve the ranking stability and quality.
 func SearchFlushWallTime(keywordScoring bool) time.Duration {

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -91,6 +91,23 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, _ []*zoekt.SearchResult, 
 	return agg, overflow, true
 }
 
+type FlushCollector interface {
+	Flush()
+	Send(endpoint string, event *zoekt.SearchResult)
+	SendDone(endpoint string)
+}
+
+type nopFlushCollector struct {
+	sender zoekt.Sender
+}
+
+func (n *nopFlushCollector) Send(_ string, event *zoekt.SearchResult) {
+	n.sender.Send(event)
+}
+
+func (n *nopFlushCollector) SendDone(_ string) {}
+func (n *nopFlushCollector) Flush()            {}
+
 type flushCollectSender struct {
 	mu            sync.Mutex
 	collectSender *collectSender

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -91,7 +91,7 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, _ []*zoekt.SearchResult, 
 	return agg, overflow, true
 }
 
-type FlushCollector interface {
+type FlushSender interface {
 	Flush()
 	Send(endpoint string, event *zoekt.SearchResult)
 	SendDone(endpoint string)
@@ -124,7 +124,11 @@ type flushCollectSender struct {
 //
 // If it has not heard back from every endpoint by a certain timeout, then it will
 // flush as a 'fallback plan' to avoid delaying the search too much.
-func newFlushCollectSender(opts *zoekt.SearchOptions, endpoints []string, maxSizeBytes int, sender zoekt.Sender) *flushCollectSender {
+func newFlushCollectSender(opts *zoekt.SearchOptions, endpoints []string, maxSizeBytes int, sender zoekt.Sender) FlushSender {
+	if opts == nil {
+		return &nopFlushCollector{sender}
+	}
+
 	firstResults := map[string]bool{}
 	for _, endpoint := range endpoints {
 		firstResults[endpoint] = true

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -125,6 +125,9 @@ type flushCollectSender struct {
 // If it has not heard back from every endpoint by a certain timeout, then it will
 // flush as a 'fallback plan' to avoid delaying the search too much.
 func newFlushCollectSender(opts *zoekt.SearchOptions, endpoints []string, maxSizeBytes int, sender zoekt.Sender) FlushSender {
+	// Nil options are permitted by Zoekt's "Streamer" interface. There are a few
+	// callers within Sourcegraph that call search with nil options (tests,
+	// insights), so we have to handle this case.
 	if opts == nil {
 		return &nopFlushCollector{sender}
 	}

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -74,12 +74,7 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 		endpoints = append(endpoints, endpoint) //nolint:staticcheck
 	}
 
-	var flushSender FlushCollector
-	if opts == nil {
-		flushSender = &nopFlushCollector{streamer}
-	} else {
-		flushSender = newFlushCollectSender(opts, endpoints, conf.RankingMaxQueueSizeBytes(), streamer)
-	}
+	flushSender := newFlushCollectSender(opts, endpoints, conf.RankingMaxQueueSizeBytes(), streamer)
 	defer flushSender.Flush()
 
 	// During re-balancing a repository can appear on more than one replica.

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -22,31 +22,10 @@ import (
 )
 
 var (
-	metricReorderQueueSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "src_zoekt_reorder_queue_size",
-		Help:    "Maximum size of result reordering buffer for a request.",
-		Buckets: prometheus.ExponentialBuckets(4, 2, 10),
-	}, nil)
 	metricIgnoredError = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "src_zoekt_ignored_error_total",
 		Help: "Total number of errors ignored from Zoekt.",
 	}, []string{"reason"})
-	// temporary metric so we can check if we are encountering non-empty
-	// queues once streaming is complete.
-	metricFinalQueueSize = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "src_zoekt_final_queue_size",
-		Help: "the size of the results queue once streaming is done.",
-	})
-	metricMaxMatchCount = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "src_zoekt_queue_max_match_count",
-		Help:    "Maximum number of matches in the queue.",
-		Buckets: prometheus.ExponentialBuckets(4, 2, 20),
-	}, nil)
-	metricMaxSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "src_zoekt_queue_max_size_bytes",
-		Help:    "Maximum number of bytes in the queue.",
-		Buckets: prometheus.ExponentialBuckets(1000, 2, 20), // 1kb -> 500mb
-	}, nil)
 )
 
 // HorizontalSearcher is a Streamer which aggregates searches over

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -1,10 +1,8 @@
 package backend
 
 import (
-	"container/heap"
 	"context"
 	"fmt"
-	"math"
 	"net"
 	"sort"
 	"strings"
@@ -21,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 var (
@@ -66,141 +63,7 @@ type HorizontalSearcher struct {
 	clients map[string]zoekt.Streamer // addr -> client
 }
 
-// StreamSearch does a search which merges the stream from every endpoint in Map, reordering results to produce a sorted stream.
 func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, streamer zoekt.Sender) error {
-	// We check for nil opts for convenience in tests. Must fix once we rely
-	// on this.
-	if opts != nil && opts.UseDocumentRanks {
-		return s.streamSearchExperimentalRanking(ctx, q, opts, streamer)
-	}
-
-	clients, err := s.searchers()
-	if err != nil {
-		return err
-	}
-
-	endpoints := make([]string, 0, len(clients))
-	for endpoint := range clients {
-		endpoints = append(endpoints, endpoint)
-	}
-
-	siteConfig := newRankingSiteConfig(conf.Get().SiteConfiguration)
-
-	// rq is used to re-order results by priority.
-	var mu sync.Mutex
-	rq := newResultQueue(siteConfig, endpoints)
-
-	// Flush the queue latest after maxReorderDuration. The longer
-	// maxReorderDuration, the more stable the ranking and the more MEM pressure we
-	// put on frontend. maxReorderDuration is effectively the budget we give each
-	// Zoekt to produce its highest ranking result. It should be large enough to
-	// give each Zoekt the chance to search at least 1 maximum size simple shard
-	// plus time spent on network.
-	//
-	// At the same time maxReorderDuration guarantees a minimum response time. It
-	// protects us from waiting on slow Zoekts for too long.
-	//
-	// maxReorderDuration and maxQueueDepth are tightly connected: If the queue is
-	// too short we will always flush before reaching maxReorderDuration and if the
-	// queue is too long we risk OOMs of frontend for queries with a lot of results.
-	//
-	// maxQueueDepth should be chosen as large as possible given the available
-	// resources.
-	if siteConfig.maxReorderDuration > 0 {
-		done := make(chan struct{})
-		defer close(done)
-
-		// we can race with done being closed and as such call FlushAll after
-		// the return of the function. So track if the function has exited.
-		searchDone := false
-		defer func() {
-			mu.Lock()
-			searchDone = true
-			mu.Unlock()
-		}()
-
-		go func() {
-			select {
-			case <-done:
-			case <-time.After(siteConfig.maxReorderDuration):
-				mu.Lock()
-				defer mu.Unlock()
-				if searchDone {
-					return
-				}
-				rq.FlushAll(streamer)
-			}
-		}()
-	}
-
-	// During rebalancing a repository can appear on more than one replica.
-	dedupper := dedupper{}
-
-	// GobCache exists so we only pay the cost of marshalling a query once
-	// when we aggregate it out over all the replicas. Zoekt's RPC layers
-	// unwrap this before passing it on to the Zoekt evaluation layers.
-	if !conf.IsGRPCEnabled(ctx) {
-		q = &query.GobCache{Q: q}
-	}
-
-	ch := make(chan error, len(clients))
-	for endpoint, c := range clients {
-		go func(endpoint string, c zoekt.Streamer) {
-			err := c.StreamSearch(ctx, q, opts, stream.SenderFunc(func(sr *zoekt.SearchResult) {
-				// This shouldn't happen, but skip event if sr is nil.
-				if sr == nil {
-					return
-				}
-
-				mu.Lock()
-				defer mu.Unlock()
-
-				sr.Files = dedupper.Dedup(endpoint, sr.Files)
-
-				rq.Enqueue(endpoint, sr)
-				rq.FlushReady(streamer)
-			}))
-
-			mu.Lock()
-			if isZoektRolloutError(ctx, err) {
-				rq.Enqueue(endpoint, crashEvent())
-				err = nil
-			}
-			rq.Done(endpoint)
-			mu.Unlock()
-
-			ch <- err
-		}(endpoint, c)
-	}
-
-	var errs errors.MultiError
-	for i := 0; i < cap(ch); i++ {
-		errs = errors.Append(errs, <-ch)
-	}
-	if errs != nil {
-		return errs
-	}
-
-	mu.Lock()
-	metricReorderQueueSize.WithLabelValues().Observe(float64(rq.metricMaxLength))
-	metricMaxMatchCount.WithLabelValues().Observe(float64(rq.metricMaxMatchCount))
-	metricFinalQueueSize.Add(float64(rq.queue.Len()))
-	metricMaxSizeBytes.WithLabelValues().Observe(float64(rq.metricMaxSizeBytes))
-
-	rq.FlushAll(streamer)
-	mu.Unlock()
-
-	return nil
-}
-
-type rankingSiteConfig struct {
-	maxQueueDepth      int
-	maxMatchCount      int
-	maxSizeBytes       int
-	maxReorderDuration time.Duration
-}
-
-func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, streamer zoekt.Sender) error {
 	clients, err := s.searchers()
 	if err != nil {
 		return err
@@ -211,9 +74,12 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 		endpoints = append(endpoints, endpoint) //nolint:staticcheck
 	}
 
-	siteConfig := newRankingSiteConfig(conf.Get().SiteConfiguration)
-
-	flushSender := newFlushCollectSender(opts, endpoints, siteConfig.maxSizeBytes, streamer)
+	var flushSender FlushCollector
+	if opts == nil {
+		flushSender = &nopFlushCollector{streamer}
+	} else {
+		flushSender = newFlushCollectSender(opts, endpoints, conf.RankingMaxQueueSizeBytes(), streamer)
+	}
 	defer flushSender.Flush()
 
 	// During re-balancing a repository can appear on more than one replica.
@@ -261,249 +127,12 @@ func (s *HorizontalSearcher) streamSearchExperimentalRanking(ctx context.Context
 	return errs
 }
 
-func newRankingSiteConfig(siteConfig schema.SiteConfiguration) *rankingSiteConfig {
-	// defaults
-	c := &rankingSiteConfig{
-		maxQueueDepth:      24,
-		maxMatchCount:      -1,
-		maxReorderDuration: 0,
-		maxSizeBytes:       -1,
-	}
-
-	if siteConfig.ExperimentalFeatures == nil || siteConfig.ExperimentalFeatures.Ranking == nil {
-		return c
-	}
-
-	if siteConfig.ExperimentalFeatures.Ranking.MaxReorderQueueSize != nil {
-		c.maxQueueDepth = *siteConfig.ExperimentalFeatures.Ranking.MaxReorderQueueSize
-	}
-
-	if siteConfig.ExperimentalFeatures.Ranking.MaxQueueMatchCount != nil {
-		c.maxMatchCount = *siteConfig.ExperimentalFeatures.Ranking.MaxQueueMatchCount
-	}
-
-	if siteConfig.ExperimentalFeatures.Ranking.MaxQueueSizeBytes != nil {
-		c.maxSizeBytes = *siteConfig.ExperimentalFeatures.Ranking.MaxQueueSizeBytes
-	}
-
-	c.maxReorderDuration = time.Duration(siteConfig.ExperimentalFeatures.Ranking.MaxReorderDurationMS) * time.Millisecond
-
-	return c
-}
-
-// The results from each endpoint are mostly sorted by priority, with bounded
-// errors described by SearchResult.Stats.MaxPendingPriority. Each backend
-// will dispatch searches in parallel against its shards in priority order,
-// but the actual return order of those searches is not constrained.
-//
-// Instead, the backend will report the maximum priority shard that it still
-// has pending along with the results that it returns, so we accumulate
-// results in a heap and only pop when the top item has a priority greater
-// than the maximum of all endpoints' pending results.
-type resultQueue struct {
-	// maxQueueDepth will flush any items in the queue such that we never
-	// exceed maxQueueDepth. This is used to prevent aggregating too many
-	// results in memory.
-	maxQueueDepth int
-
-	// maxMatchCount will flush any items in the queue such that we never exceed
-	// maxMatchCount. This is used to prevent aggregating too many results in
-	// memory.
-	maxMatchCount int
-
-	// The number of matches currently in the queue. We keep track of the current
-	// matchCount separately from the stats, because the stats are reset with
-	// every event we sent.
-	matchCount          int
-	metricMaxMatchCount int
-
-	// The approximate size of the queue's content in memory.
-	sizeBytes uint64
-
-	// Set by site-config, which does not support uint64. In practice this should be
-	// fine. We flush once we reach the threshold of maxSizeBytes.
-	maxSizeBytes       int
-	metricMaxSizeBytes uint64
-
-	queue           priorityQueue
-	metricMaxLength int // for a prometheus metric
-
-	endpointMaxPendingPriority map[string]float64
-
-	// We aggregate statistics independently of matches. Everytime we
-	// encounter matches to send we send the current aggregated stats then
-	// reset them. This is because in a lot of cases we only get stats and no
-	// matches. By aggregating we avoid spamming the sender and the
-	// resultQueue with pure stats events.
-	stats zoekt.Stats
-}
-
-func newResultQueue(siteConfig *rankingSiteConfig, endpoints []string) *resultQueue {
-	// To start, initialize every endpoint's maxPending to +inf since we don't yet know the bounds.
-	endpointMaxPendingPriority := map[string]float64{}
-	for _, endpoint := range endpoints {
-		endpointMaxPendingPriority[endpoint] = math.Inf(1)
-	}
-
-	return &resultQueue{
-		maxQueueDepth:              siteConfig.maxQueueDepth,
-		maxMatchCount:              siteConfig.maxMatchCount,
-		maxSizeBytes:               siteConfig.maxSizeBytes,
-		endpointMaxPendingPriority: endpointMaxPendingPriority,
-	}
-}
-
-// Enqueue adds the result to the queue and updates the max pending priority
-// for endpoint based on sr.
-func (q *resultQueue) Enqueue(endpoint string, sr *zoekt.SearchResult) {
-	// Update aggregate stats
-	q.stats.Add(sr.Stats)
-
-	q.matchCount += sr.MatchCount
-	if q.matchCount > q.metricMaxMatchCount {
-		q.metricMaxMatchCount = q.matchCount
-	}
-
-	sb := sr.SizeBytes()
-	q.sizeBytes += sb
-	if q.sizeBytes >= q.metricMaxSizeBytes {
-		q.metricMaxSizeBytes = q.sizeBytes
-	}
-
-	// Note the endpoint's updated MaxPendingPriority
-	q.endpointMaxPendingPriority[endpoint] = sr.Progress.MaxPendingPriority
-
-	// Don't add empty results to the heap.
-	if len(sr.Files) != 0 {
-		q.queue.add(&queueSearchResult{SearchResult: sr, sizeBytes: sb})
-		if q.queue.Len() > q.metricMaxLength {
-			q.metricMaxLength = q.queue.Len()
-		}
-	}
-}
-
-// Done must be called once per endpoint once it has finished streaming.
-func (q *resultQueue) Done(endpoint string) {
-	// Clear pending priority because the endpoint is done sending results--
-	// otherwise, an endpoint with 0 results could delay results returning,
-	// because it would never set its maxPendingPriority to 0 in the
-	// StreamSearch callback.
-	delete(q.endpointMaxPendingPriority, endpoint)
-}
-
-// FlushReady sends results that are ready to be sent.
-func (q *resultQueue) FlushReady(streamer zoekt.Sender) {
-	// we can send any results such that priority > maxPending. Need to
-	// calculate maxPending.
-	maxPending := math.Inf(-1)
-	for _, pri := range q.endpointMaxPendingPriority {
-		if pri > maxPending {
-			maxPending = pri
-		}
-	}
-
-	for q.hasResultsToSend(maxPending) {
-		streamer.Send(q.pop())
-	}
-}
-
-// FlushAll will send all results in the queue and any aggregate statistics.
-func (q *resultQueue) FlushAll(streamer zoekt.Sender) {
-	for q.queue.Len() > 0 {
-		streamer.Send(q.pop())
-	}
-
-	// We may have had no matches but had stats. Send the final stats if there
-	// is any.
-	if !q.stats.Zero() {
-		streamer.Send(&zoekt.SearchResult{
-			Stats: q.stats,
-		})
-		q.stats = zoekt.Stats{}
-	}
-}
-
-// pop returns 1 search result from q. The search result contains the current
-// aggregate stats. After the call to pop() we reset q's aggregate stats
-func (q *resultQueue) pop() *zoekt.SearchResult {
-	sr := heap.Pop(&q.queue).(*queueSearchResult)
-	q.matchCount -= sr.MatchCount
-	q.sizeBytes -= sr.sizeBytes
-
-	// We attach the current aggregate stats to the event and then reset them.
-	sr.Stats = q.stats
-	q.stats = zoekt.Stats{}
-
-	return sr.SearchResult
-}
-
-// hasResultsToSend returns true if there are search results in the queue that
-// should be sent up the stream. Retrieve search results by calling pop() on
-// resultQueue.
-func (q *resultQueue) hasResultsToSend(maxPending float64) bool {
-	if q.queue.Len() == 0 {
-		return false
-	}
-
-	if q.maxQueueDepth >= 0 && q.queue.Len() > q.maxQueueDepth {
-		return true
-	}
-
-	if q.maxMatchCount >= 0 && q.matchCount > q.maxMatchCount {
-		return true
-	}
-
-	if q.maxSizeBytes >= 0 && q.sizeBytes > uint64(q.maxSizeBytes) {
-		return true
-	}
-
-	return q.queue.isTopAbove(maxPending)
-}
-
 type queueSearchResult struct {
 	*zoekt.SearchResult
 
 	// optimization: It can be expensive to calculate sizeBytes, hence we cache it
 	// in the queue.
 	sizeBytes uint64
-}
-
-// priorityQueue modified from https://golang.org/pkg/container/heap/
-// A priorityQueue implements heap.Interface and holds Items.
-// All Exported methods are part of the container.heap interface, and
-// unexported methods are local helpers.
-type priorityQueue []*queueSearchResult
-
-func (pq *priorityQueue) add(sr *queueSearchResult) {
-	heap.Push(pq, sr)
-}
-
-func (pq *priorityQueue) isTopAbove(limit float64) bool {
-	return len(*pq) > 0 && (*pq)[0].Progress.Priority >= limit
-}
-
-func (pq priorityQueue) Len() int { return len(pq) }
-
-func (pq priorityQueue) Less(i, j int) bool {
-	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
-	return pq[i].Progress.Priority > pq[j].Progress.Priority
-}
-
-func (pq priorityQueue) Swap(i, j int) {
-	pq[i], pq[j] = pq[j], pq[i]
-}
-
-func (pq *priorityQueue) Push(x any) {
-	*pq = append(*pq, x.(*queueSearchResult))
-}
-
-func (pq *priorityQueue) Pop() any {
-	old := *pq
-	n := len(old)
-	item := old[n-1]
-	old[n-1] = nil // avoid memory leak
-	*pq = old[0 : n-1]
-	return item
 }
 
 // Search aggregates search over every endpoint in Map.

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestHorizontalSearcher(t *testing.T) {
@@ -403,85 +402,6 @@ func TestZoektRolloutErrors(t *testing.T) {
 	_, err = searcher.List(context.Background(), nil, nil)
 	if err == nil {
 		t.Fatal("List: expected error")
-	}
-}
-
-func TestResultQueueSettingsFromConfig(t *testing.T) {
-	dummy := 100
-
-	cases := []struct {
-		name                   string
-		siteConfig             schema.SiteConfiguration
-		wantMaxQueueDepth      int
-		wantMaxReorderDuration time.Duration
-		wantMaxQueueMatchCount int
-		wantMaxSizeBytes       int
-	}{
-		{
-			name:                   "defaults",
-			siteConfig:             schema.SiteConfiguration{},
-			wantMaxQueueDepth:      24,
-			wantMaxQueueMatchCount: -1,
-			wantMaxSizeBytes:       -1,
-		},
-		{
-			name: "MaxReorderDurationMS",
-			siteConfig: schema.SiteConfiguration{ExperimentalFeatures: &schema.ExperimentalFeatures{Ranking: &schema.Ranking{
-				MaxReorderDurationMS: 5,
-			}}},
-			wantMaxQueueDepth:      24,
-			wantMaxReorderDuration: 5 * time.Millisecond,
-			wantMaxQueueMatchCount: -1,
-			wantMaxSizeBytes:       -1,
-		},
-		{
-			name: "MaxReorderQueueSize",
-			siteConfig: schema.SiteConfiguration{ExperimentalFeatures: &schema.ExperimentalFeatures{Ranking: &schema.Ranking{
-				MaxReorderQueueSize: &dummy}}},
-			wantMaxQueueDepth:      dummy,
-			wantMaxQueueMatchCount: -1,
-			wantMaxSizeBytes:       -1,
-		},
-		{
-			name: "MaxQueueMatchCount",
-			siteConfig: schema.SiteConfiguration{ExperimentalFeatures: &schema.ExperimentalFeatures{Ranking: &schema.Ranking{
-				MaxQueueMatchCount: &dummy,
-			}}},
-			wantMaxQueueDepth:      24,
-			wantMaxQueueMatchCount: dummy,
-			wantMaxSizeBytes:       -1,
-		},
-		{
-			name: "MaxSizeBytes",
-			siteConfig: schema.SiteConfiguration{ExperimentalFeatures: &schema.ExperimentalFeatures{Ranking: &schema.Ranking{
-				MaxQueueSizeBytes: &dummy,
-			}}},
-			wantMaxQueueDepth:      24,
-			wantMaxQueueMatchCount: -1,
-			wantMaxSizeBytes:       dummy,
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			settings := newRankingSiteConfig(tt.siteConfig)
-
-			if settings.maxQueueDepth != tt.wantMaxQueueDepth {
-				t.Fatalf("want %d, got %d", tt.wantMaxQueueDepth, settings.maxQueueDepth)
-			}
-
-			if settings.maxReorderDuration != tt.wantMaxReorderDuration {
-				t.Fatalf("want %d, got %d", tt.wantMaxReorderDuration, settings.maxReorderDuration)
-			}
-
-			if settings.maxMatchCount != tt.wantMaxQueueMatchCount {
-				t.Fatalf("want %d, got %d", tt.wantMaxQueueMatchCount, settings.maxMatchCount)
-			}
-
-			if settings.maxSizeBytes != tt.wantMaxSizeBytes {
-				t.Fatalf("want %d, got %d", tt.wantMaxSizeBytes, settings.maxSizeBytes)
-			}
-		})
 	}
 }
 

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -85,7 +85,6 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 			attribute.Int64("opts.max_wall_time_ms", opts.MaxWallTime.Milliseconds()),
 			attribute.Int64("opts.flush_wall_time_ms", opts.FlushWallTime.Milliseconds()),
 			attribute.Int("opts.max_doc_display_count", opts.MaxDocDisplayCount),
-			attribute.Bool("opts.use_document_ranks", opts.UseDocumentRanks),
 		}
 		tr.AddEvent("begin", fields...)
 		event.AddAttributes(fields)

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -296,7 +296,6 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 	return &search.Features{
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
 		HybridSearch:            flagSet.GetBoolOr("search-hybrid", true), // can remove flag in 4.5
-		Ranking:                 flagSet.GetBoolOr("search-ranking", true),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),
 	}
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -245,15 +245,13 @@ func (o *ZoektParameters) ToSearchOptions(ctx context.Context) *zoekt.SearchOpti
 		searchOpts.DebugScore = true
 	}
 
-	if o.Features.Ranking {
-		// This enables our stream based ranking, where we wait a certain amount
-		// of time to collect results before ranking.
-		searchOpts.FlushWallTime = conf.SearchFlushWallTime(o.KeywordScoring)
+	// This enables our stream based ranking, where we wait a certain amount
+	// of time to collect results before ranking.
+	searchOpts.FlushWallTime = conf.SearchFlushWallTime(o.KeywordScoring)
 
-		// This enables the use of document ranks in scoring, if they are available.
-		searchOpts.UseDocumentRanks = true
-		searchOpts.DocumentRanksWeight = conf.SearchDocumentRanksWeight()
-	}
+	// This enables the use of document ranks in scoring, if they are available.
+	searchOpts.UseDocumentRanks = true
+	searchOpts.DocumentRanksWeight = conf.SearchDocumentRanksWeight()
 
 	return searchOpts
 }
@@ -422,10 +420,6 @@ type Features struct {
 	// unindexed searches. Searcher (unindexed search) will the only search
 	// what has changed since the indexed commit.
 	HybridSearch bool `json:"search-hybrid"`
-
-	// Ranking when true will use a our new #ranking signals and code paths
-	// for ranking results from Zoekt.
-	Ranking bool `json:"ranking"`
 
 	// Debug when true will set the Debug field on FileMatches. This may grow
 	// from here. For now we treat this like a feature flag for convenience.

--- a/internal/search/types_test.go
+++ b/internal/search/types_test.go
@@ -30,29 +30,12 @@ func TestZoektParameters(t *testing.T) {
 				FileMatchLimit: limits.DefaultMaxSearchResultsStreaming,
 			},
 			want: &zoekt.SearchOptions{
-				ShardMaxMatchCount: 10000,
-				TotalMaxMatchCount: 100000,
-				MaxWallTime:        20000000000,
-				MaxDocDisplayCount: 500,
-				ChunkMatches:       true,
-			},
-		},
-		{
-			name:    "test defaults with ranking feature enabled",
-			context: context.Background(),
-			params: &ZoektParameters{
-				FileMatchLimit: limits.DefaultMaxSearchResultsStreaming,
-				Features: Features{
-					Ranking: true,
-				},
-			},
-			want: &zoekt.SearchOptions{
 				ShardMaxMatchCount:  10000,
 				TotalMaxMatchCount:  100000,
 				MaxWallTime:         20000000000,
-				FlushWallTime:       500000000,
 				MaxDocDisplayCount:  500,
 				ChunkMatches:        true,
+				FlushWallTime:       500000000,
 				UseDocumentRanks:    true,
 				DocumentRanksWeight: 4500,
 			},
@@ -63,9 +46,6 @@ func TestZoektParameters(t *testing.T) {
 			params: &ZoektParameters{
 				Select:         []string{filter.Repository},
 				FileMatchLimit: limits.DefaultMaxSearchResultsStreaming,
-				Features: Features{
-					Ranking: true,
-				},
 			},
 			// Most important is ShardRepoMaxMatchCount=1. Otherwise we still
 			// want to set normal limits so we respect things like low file
@@ -85,9 +65,6 @@ func TestZoektParameters(t *testing.T) {
 			params: &ZoektParameters{
 				Select:         []string{filter.Repository},
 				FileMatchLimit: 5,
-				Features: Features{
-					Ranking: true,
-				},
 			},
 			// This is like the above test, but we are testing
 			// MaxDocDisplayCount is adjusted to 5.
@@ -107,11 +84,14 @@ func TestZoektParameters(t *testing.T) {
 				FileMatchLimit: 100_000,
 			},
 			want: &zoekt.SearchOptions{
-				ShardMaxMatchCount: 100_000,
-				TotalMaxMatchCount: 100_000,
-				MaxWallTime:        20000000000,
-				MaxDocDisplayCount: 100_000,
-				ChunkMatches:       true,
+				ShardMaxMatchCount:  100_000,
+				TotalMaxMatchCount:  100_000,
+				MaxWallTime:         20000000000,
+				MaxDocDisplayCount:  100_000,
+				ChunkMatches:        true,
+				FlushWallTime:       500000000,
+				UseDocumentRanks:    true,
+				DocumentRanksWeight: 4500,
 			},
 		},
 		{
@@ -122,9 +102,6 @@ func TestZoektParameters(t *testing.T) {
 			},
 			params: &ZoektParameters{
 				FileMatchLimit: limits.DefaultMaxSearchResultsStreaming,
-				Features: Features{
-					Ranking: true,
-				},
 			},
 			want: &zoekt.SearchOptions{
 				ShardMaxMatchCount:  10000,
@@ -145,9 +122,6 @@ func TestZoektParameters(t *testing.T) {
 			},
 			params: &ZoektParameters{
 				FileMatchLimit: limits.DefaultMaxSearchResultsStreaming,
-				Features: Features{
-					Ranking: true,
-				},
 			},
 			want: &zoekt.SearchOptions{
 				ShardMaxMatchCount:  10000,
@@ -165,9 +139,6 @@ func TestZoektParameters(t *testing.T) {
 			context: context.Background(),
 			params: &ZoektParameters{
 				FileMatchLimit: limits.DefaultMaxSearchResultsStreaming,
-				Features: Features{
-					Ranking: true,
-				},
 				KeywordScoring: true,
 			},
 			want: &zoekt.SearchOptions{

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1976,13 +1976,13 @@ type Ranking struct {
 	DocumentRanksWeight *float64 `json:"documentRanksWeight,omitempty"`
 	// FlushWallTimeMS description: Controls the amount of time that Zoekt shards collect and rank results. Larger values give a more stable ranking, but searches can take longer to return an initial result.
 	FlushWallTimeMS int `json:"flushWallTimeMS,omitempty"`
-	// MaxQueueMatchCount description: The maximum number of matches that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs for queries with extremely high count of matches per repository.
+	// MaxQueueMatchCount description: DEPRECATED: This setting has no effect.
 	MaxQueueMatchCount *int `json:"maxQueueMatchCount,omitempty"`
 	// MaxQueueSizeBytes description: The maximum number of bytes that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs.
 	MaxQueueSizeBytes *int `json:"maxQueueSizeBytes,omitempty"`
-	// MaxReorderDurationMS description: The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.
+	// MaxReorderDurationMS description: DEPRECATED: This setting has no effect.
 	MaxReorderDurationMS int `json:"maxReorderDurationMS,omitempty"`
-	// MaxReorderQueueSize description: The maximum number of search results that can be buffered to sort results. -1 is unbounded. The default is 24. Set this to small integers to limit latency increases from slow backends.
+	// MaxReorderQueueSize description: DEPRECATED: This setting has no effect.
 	MaxReorderQueueSize *int `json:"maxReorderQueueSize,omitempty"`
 	// RepoScores description: a map of URI directories to numeric scores for specifying search result importance, like {"github.com": 500, "github.com/sourcegraph": 300, "github.com/sourcegraph/sourcegraph": 100}. Would rank "github.com/sourcegraph/sourcegraph" as 500+300+100=900, and "github.com/other/foo" as 500.
 	RepoScores map[string]float64 `json:"repoScores,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -429,7 +429,7 @@
               }
             },
             "maxReorderQueueSize": {
-              "description": "The maximum number of search results that can be buffered to sort results. -1 is unbounded. The default is 24. Set this to small integers to limit latency increases from slow backends.",
+              "description": "DEPRECATED: This setting has no effect.",
               "default": 24,
               "type": "integer",
               "group": "Search",
@@ -438,7 +438,7 @@
               }
             },
             "maxQueueMatchCount": {
-              "description": "The maximum number of matches that can be buffered to sort results. The default is -1 (unbounded). Setting this to a positive integer protects frontend against OOMs for queries with extremely high count of matches per repository.",
+              "description": "DEPRECATED: This setting has no effect.",
               "default": -1,
               "type": "integer",
               "group": "Search",
@@ -456,7 +456,7 @@
               }
             },
             "maxReorderDurationMS": {
-              "description": "The maximum time in milliseconds we wait until we flush the results queue. The default is 0 (unbounded). The larger the value the more stable the ranking and the higher the MEM pressure on frontend.",
+              "description": "DEPRECATED: This setting has no effect.",
               "type": "integer",
               "default": 0,
               "group": "Search"


### PR DESCRIPTION
The enhanced ranking logic is GA since 5.1. So far we haven't had any issue so we should remove the old code path with 5.3.

Test plan:
CI

