### PR TITLE
JetBrains: Persist repository URL in project settings

### DIFF
--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -4,32 +4,45 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.sourcegraph.cody.CodyToolWindowContent
+import com.sourcegraph.cody.config.CodyProjectSettings
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.vcs.RepoUtil
 
-class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Project) {
+class CodyAgentCodebase(
+  private val underlying: CodyAgentServer,
+  private val project: Project
+) {
 
-  // TODO: This should ideally be persisted as a project-wide setting. Down the road, it should also
-  // support a list of repository names instead of only a single codebase.
-  private var inferredCodebase: String = ""
-  private var explicitCodebase: String = ""
+  // TODO: Support list of repository names instead of just one.
+  private val application = ApplicationManager.getApplication()
+  private val settings = CodyProjectSettings.getInstance(project)
 
   init {
-    ApplicationManager.getApplication().executeOnPooledThread {
-      onRepositoryName(RepoUtil.findRepositoryName(project, null))
+    application.executeOnPooledThread {
+      onRepositoryName(settings.remoteUrl ?: RepoUtil.findRepositoryName(project, null))
     }
   }
 
-  fun onNewExplicitCodebase(codebase: String) {
-    explicitCodebase = codebase
+  fun setUrl(url: String) {
+    settings.remoteUrl = url
     onPropagateConfiguration()
   }
 
-  fun currentCodebase(): String? = explicitCodebase.ifEmpty { inferredCodebase }.ifEmpty { null }
+  fun getUrl(): String? =
+    settings.remoteUrl
 
   fun onFileOpened(project: Project, file: VirtualFile) {
-    ApplicationManager.getApplication().executeOnPooledThread {
-      onRepositoryName(RepoUtil.findRepositoryName(project, file))
+    application.executeOnPooledThread {
+      onRepositoryName(settings.remoteUrl ?: RepoUtil.findRepositoryName(project, file))
+    }
+  }
+
+  private fun onRepositoryName(url: String?) {
+    application.invokeLater {
+      if (url != null) {
+        settings.remoteUrl = url
+        onPropagateConfiguration()
+      }
     }
   }
 
@@ -38,12 +51,4 @@ class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Pr
     underlying.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
   }
 
-  private fun onRepositoryName(repositoryName: String?) {
-    ApplicationManager.getApplication().invokeLater {
-      if (repositoryName != null && inferredCodebase != repositoryName) {
-        inferredCodebase = repositoryName
-        onPropagateConfiguration()
-      }
-    }
-  }
 }

--- a/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
+++ b/client/jetbrains/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
@@ -54,7 +54,7 @@ class EmbeddingStatusView(private val project: Project) : JPanel() {
 
   fun updateEmbeddingStatus() {
     val client = CodyAgent.getClient(project)
-    val repoName = client.codebase?.currentCodebase()
+    val repoName = client.codebase?.getUrl()
     if (repoName == null) {
       setEmbeddingStatus(NoGitRepositoryEmbeddingStatus())
     } else {

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -28,7 +28,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
 
   private inner class EditCodebaseDialog : DialogWrapper(null, true) {
     val gitURL =
-        ExtendableTextField(CodyAgent.getClient(project).codebase?.currentCodebase() ?: "", 40)
+        ExtendableTextField(CodyAgent.getClient(project).codebase?.getUrl() ?: "", 40)
     val loadingLayerUI = LoadingLayerUI()
     val layeredGitURL = JLayer(gitURL, loadingLayerUI)
 
@@ -93,7 +93,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
     }
 
     override fun doOKAction() {
-      CodyAgent.getClient(project).codebase?.onNewExplicitCodebase(gitURL.text)
+      CodyAgent.getClient(project).codebase?.setUrl(gitURL.text)
       super.doOKAction()
     }
 
@@ -105,10 +105,6 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
             }
             .rowComment("Example: github.com/sourcegraph/cody")
         row { text("The URL will be used to retrieve the code context from the Cody API.") }
-        row {
-          text(
-              "If left empty, Cody will automatically infer the URL from your project's Git metadata.")
-        }
       }
     }
   }

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectSettings.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectSettings.kt
@@ -13,6 +13,7 @@ import com.sourcegraph.find.Search
 @Service(Service.Level.PROJECT)
 data class CodyProjectSettings(
     var defaultBranchName: String = "main",
+    var remoteUrl: String? = null,
     var remoteUrlReplacements: String = "",
     var lastSearchQuery: String? = null,
     var lastSearchCaseSensitive: Boolean = false,
@@ -23,6 +24,7 @@ data class CodyProjectSettings(
 
   override fun loadState(state: CodyProjectSettings) {
     this.defaultBranchName = state.defaultBranchName
+    this.remoteUrl = state.remoteUrl
     this.remoteUrlReplacements = state.remoteUrlReplacements
     this.lastSearchQuery = state.lastSearchQuery
     this.lastSearchCaseSensitive = state.lastSearchCaseSensitive

--- a/client/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/client/jetbrains/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -43,7 +43,7 @@ object ConfigUtil {
             autocompleteAdvancedEmbeddings = UserLevelConfig.getAutocompleteAdvancedEmbeddings(),
             debug = isCodyDebugEnabled(),
             verboseDebug = isCodyVerboseDebugEnabled(),
-            codebase = codyAgentCodebase?.currentCodebase(),
+            codebase = codyAgentCodebase?.getUrl(),
         )
 
     UserLevelConfig.getAutocompleteProviderType()?.let {


### PR DESCRIPTION
Fixes #56948

The value is computed only at the start and/or while the file is open. I'm not certain why the original implementation updates "on file," so I've kept this implementation detail as is.

Additionally, I've removed the line stating that leaving the address empty would result in an inferred URL from the Git repository. This is not true: the dialog does not allow you to leave it blank.

## Test plan

- `./gradlew :runIde`
- Open project.
- (optional) Expect new value `<option name="remoteUrl" value="github.com/user/repo"/>` in `cody_project_settings.xml`.
- Open repository dialog. Change address and click OK.
- Restart IDE.
- Expect address should be same as before restart.
- (optional) Expect updated value in `cody_project_settings.xml`.