### PR TITLE
update go to 1.20.9

### DIFF
--- a/.github/workflows/sg-setup.yml
+++ b/.github/workflows/sg-setup.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.8
+          go-version: 1.20.9
 
       - name: Install asdf plugins
         uses: asdf-vm/actions/install@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.20.8
+golang 1.20.9
 nodejs 18.17.1
 fd 8.6.0
 shfmt 3.5.0

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -314,7 +314,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//:sg_nogo",
-    version = "1.20.8",
+    version = "1.20.9",
 )
 
 linter_dependencies()

--- a/dev/sg/checks.go
+++ b/dev/sg/checks.go
@@ -34,7 +34,7 @@ var checks = map[string]check.CheckFunc{
 	"asdf":                  check.CommandOutputContains("asdf", "version"),
 	"git":                   check.Combine(check.InPath("git"), checkGitVersion(">= 2.34.1")),
 	"pnpm":                  check.Combine(check.InPath("pnpm"), checkPnpmVersion(">= 8.3.0")),
-	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.20.8")),
+	"go":                    check.Combine(check.InPath("go"), checkGoVersion("~> 1.20.9")),
 	"node":                  check.Combine(check.InPath("node"), check.CommandOutputContains(`node -e "console.log(\"foobar\")"`, "foobar")),
 	"rust":                  check.Combine(check.InPath("cargo"), check.CommandOutputContains(`cargo version`, "1.58.0")),
 	"docker-installed":      check.WrapErrMessage(check.InPath("docker"), "if Docker is installed and the check fails, you might need to start Docker.app and restart terminal and 'sg setup'"),


### PR DESCRIPTION
Update go to 1.20.9 which fixes https://github.com/sourcegraph/devx-support/issues/241
## Test plan
CI
