### PR TITLE
source: Use automated project board workflows

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -4,8 +4,9 @@ team/code-exploration:
   - '@lrhacker'
   - '@philipp-spiess'
 
-team/iam:
+team/source:
   - '@ryphil'
   - '@mrnugget'
   - '@pjlast'
-  - '@thenamankumar'
+  - '@eseliger'
+  - '@ggilmore'

--- a/.github/workflows/label-move.yml
+++ b/.github/workflows/label-move.yml
@@ -247,33 +247,6 @@ jobs:
                 }
               }
             }' -f project=$PROJECT_ID -f issue=$NODE_ID
-  source-board:
-    runs-on: ubuntu-latest
-    env:
-      PROJECT_ID: PVT_kwDOADy5QM0Pnw # https://github.com/orgs/sourcegraph/projects/209
-      GITHUB_TOKEN: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
-    steps:
-      - name: Get issue if relevant # checking for "source",  but also "iam" and "repo-management" for backwards compatibility. See https://github.com/sourcegraph/sourcegraph/issues/54705
-        if: ${{ contains(github.event.issue.labels.*.name, 'team/source') || contains(github.event.issue.labels.*.name, 'iam') || contains(github.event.issue.labels.*.name, 'repo-management') }}
-        env:
-          NODE_ID: ${{ github.event.issue.node_id }}
-        run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
-      - name: Get pull request if relevant
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'team/source') }}
-        env:
-          NODE_ID: ${{ github.event.pull_request.node_id }}
-        run: echo 'NODE_ID='$NODE_ID >> $GITHUB_ENV
-      - name: Add to Source board
-        if: ${{ env.NODE_ID != '' }}
-        run: |
-          gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
-                item {
-                  id
-                }
-              }
-            }' -f project=$PROJECT_ID -f issue=$NODE_ID
   grpc-board:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -22,8 +22,6 @@ jobs:
                   team/security=@dcomas
                   team/dev-experience=@jhchabran @kstretch9
                   team/devops=@sourcegraph/cloud-devops
-                  repo-management=@sourcegraph/source
-                  iam=@sourcegraph/source
-                  team/source=@sourcegraph/source
+                  team/source=@mrnugget
                   cody-gateway=@unknwon @eseliger @bobheadxi @ggilmore
                   team/search-platform=@sourcegraph/search-platform

--- a/.github/workflows/move-labled-issues-to-project.yml
+++ b/.github/workflows/move-labled-issues-to-project.yml
@@ -20,14 +20,6 @@ jobs:
           labeled: team/cloud
           label-operator: OR
 
-      - name: Move team/source issues
-        uses: actions/add-to-project@main
-        with:
-          project-url: https://github.com/orgs/sourcegraph/projects/209
-          github-token: ${{ secrets.GH_PROJECTS_ACTION_TOKEN }}
-          labeled: team/source
-          label-operator: OR
-
       - name: Move team/code-exploration issues
         uses: actions/add-to-project@main
         with:


### PR DESCRIPTION
We added an [automated workflow](https://github.com/orgs/sourcegraph/projects/209/workflows/12532815) that adds team/source tickets to our triage inbox. We will check this column regularly instead of creating massive email spam for each of us each time an issue is labeled with team/source. This also allows us to retire some old GitHub actions workflows.

## Test plan

GH actions logs will tell. 