### PR TITLE
Doc: update doc link for release.channel and pings

### DIFF
--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -248,7 +248,7 @@ The most common scenario in which Sourcegraph stops sending pings is a change to
 ```
 "update.channel": "release",
 ```
-*This setting [must be set to "release"](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Ecmd/frontend/internal/app/updatecheck/client%5C.go+channel+%21%3D+%22release%22&patternType=literal) in order for the telemetry goroutine to run.*
+*This setting [must be set to "release"](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/updatecheck/client.go?L803-806) in order for the telemetry goroutine to run.*
 
 
 ### Check if the goroutine is running


### PR DESCRIPTION
This code path moved

## Test plan

Doc

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@wg/fix-ping-channel-link)