### PR TITLE
e2e tests: update sourcegraph group name

### DIFF
--- a/client/browser/src/end-to-end/gitlab.test.ts
+++ b/client/browser/src/end-to-end/gitlab.test.ts
@@ -32,9 +32,9 @@ describe('Sourcegraph browser extension on Gitlab Server', () => {
                 config: JSON.stringify({
                     url: GITLAB_BASE_URL,
                     token: GITLAB_TOKEN,
-                    projectQuery: ['groups/sourcegraph/projects?search=jsonrpc2'],
+                    projectQuery: ['groups/SourcegraphCody/projects?search=jsonrpc2'],
                 }),
-                ensureRepos: [REPO_PATH_PREFIX + '/sourcegraph/jsonrpc2'],
+                ensureRepos: [REPO_PATH_PREFIX + '/SourcegraphCody/jsonrpc2'],
             })
             await driver.ensureHasCORSOrigin({ corsOriginURL: GITLAB_BASE_URL })
         }
@@ -58,7 +58,7 @@ describe('Sourcegraph browser extension on Gitlab Server', () => {
         url: url.href,
         // Other than GitHub, the URL must not include the column in the hash.
         goToDefinitionURL: new URL('#L5', url.href).href,
-        repoName: `${REPO_PATH_PREFIX}/sourcegraph/jsonrpc2`,
+        repoName: `${REPO_PATH_PREFIX}/SourcegraphCody/jsonrpc2`,
         commitID: 'dbf20885e7ff39b0d5b64878148113e8433571f1',
         sourcegraphBaseUrl,
         getLineSelector: lineNumber => `#LC${lineNumber}`,


### PR DESCRIPTION
It looks like our tests are failing because we added an alias for the sourcegraph org.

# Test plan

This just fixes a test