### PR TITLE
remove storybook addon-docs

### DIFF
--- a/client/storybook/src/main.ts
+++ b/client/storybook/src/main.ts
@@ -41,7 +41,6 @@ const config: StorybookConfig & StorybookConfigVite & ReactViteStorybookConfig =
         'storybook-dark-mode',
         '@storybook/addon-a11y',
         '@storybook/addon-toolbars',
-        '@storybook/addon-docs',
         '@storybook/addon-controls',
         '@storybook/addon-storysource',
     ],
@@ -112,10 +111,6 @@ const config: StorybookConfig & StorybookConfigVite & ReactViteStorybookConfig =
         }
 
         return config
-    },
-
-    docs: {
-        autodocs: true,
     },
 }
 

--- a/client/storybook/src/preview.ts
+++ b/client/storybook/src/preview.ts
@@ -31,16 +31,8 @@ export const parameters: Parameters = {
         light: themeLight,
         dark: themeDark,
     },
-    previewTabs: {
-        'storybook/docs/panel': {
-            hidden: true,
-        },
-    },
     // disables snapshotting for all stories by default
     chromatic: { disableSnapshot: true },
-    // This fixes an issue where some stories with knobs wound up in a state of infinite recursion
-    // See https://github.com/storybookjs/storybook/issues/15051
-    docs: { source: { type: 'code' } },
 }
 
 configureActions({ depth: 100, limit: 20 })

--- a/client/web-sveltekit/.storybook/main.ts
+++ b/client/web-sveltekit/.storybook/main.ts
@@ -13,9 +13,6 @@ const config: StorybookConfig = {
         name: '@storybook/sveltekit',
         options: {},
     },
-    docs: {
-        autodocs: 'tag',
-    },
     staticDirs: ['../static'],
 }
 export default config

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "@storybook/addon-console": "^2.0.0",
     "@storybook/addon-controls": "^7.4.6",
     "@storybook/addon-designs": "^7.0.5",
-    "@storybook/addon-docs": "^7.4.6",
     "@storybook/addon-links": "^7.4.6",
     "@storybook/addon-storyshots": "^7.4.6",
     "@storybook/addon-storyshots-puppeteer": "^7.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,9 +603,6 @@ importers:
       '@storybook/addon-designs':
         specifier: ^7.0.5
         version: 7.0.5(@storybook/addon-docs@7.4.6)(@storybook/addons@7.4.6)(@storybook/components@7.4.6)(@storybook/manager-api@7.4.6)(@storybook/preview-api@7.4.6)(@storybook/theming@7.4.6)(react-dom@18.1.0)(react@18.1.0)
-      '@storybook/addon-docs':
-        specifier: ^7.4.6
-        version: 7.4.6(@types/react-dom@18.0.2)(@types/react@18.0.8)(react-dom@18.1.0)(react@18.1.0)
       '@storybook/addon-links':
         specifier: ^7.4.6
         version: 7.4.6(react-dom@18.1.0)(react@18.1.0)


### PR DESCRIPTION
This was not being used. It was there previously, but for some reason the upgrade to Storybook 7 made it more prominent.




## Test plan

CI