### PR TITLE
bazelignore storybook static files

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -40,3 +40,5 @@ cmd/sitemap
 # temporary ignores
 
 internal/cmd/progress-bot
+
+client/storybook/storybook-static


### PR DESCRIPTION
These sometimes contain BUILD.bazel files that confuse local working copies.




## Test plan

CI