### PR TITLE
ci: add flag to run browser extensions tests

### DIFF
--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -231,14 +231,18 @@ type MessageFlags struct {
 
 	// NoBazel, if true prevents automatic replacement of job with their Bazel equivalents.
 	NoBazel bool
+
+	// RunBrowserExtensionTests
+	RunBrowserExtensionTests bool
 }
 
 // parseMessageFlags gets MessageFlags from the given commit message.
 func parseMessageFlags(msg string) MessageFlags {
 	return MessageFlags{
-		ProfilingEnabled:    strings.Contains(msg, "[buildkite-enable-profiling]"),
-		SkipHashCompare:     strings.Contains(msg, "[skip-hash-compare]"),
-		ForceReadyForReview: strings.Contains(msg, "[review-ready]"),
+		ProfilingEnabled:         strings.Contains(msg, "[buildkite-enable-profiling]"),
+		SkipHashCompare:          strings.Contains(msg, "[skip-hash-compare]"),
+		ForceReadyForReview:      strings.Contains(msg, "[review-ready]"),
+		RunBrowserExtensionTests: strings.Contains(msg, "[browser-extension-tests]"),
 	}
 }
 

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -143,6 +143,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			bops.Append(
 				addBrowserExtensionUnitTests,
 				addBrowserExtensionIntegrationTests(0), // we pass 0 here as we don't have other pipeline steps to contribute to the resulting Percy build
+				addBrowserExtensionE2ESteps,
 			)
 			ops.Merge(bops)
 		}

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -138,6 +138,15 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			CreateBundleSizeDiff:      true,
 		}))
 
+		if c.MessageFlags.RunBrowserExtensionTests {
+			bops := operations.NewNamedSet("Browser Extensions Tests")
+			bops.Append(
+				addBrowserExtensionUnitTests,
+				addBrowserExtensionIntegrationTests(0), // we pass 0 here as we don't have other pipeline steps to contribute to the resulting Percy build
+			)
+			ops.Merge(bops)
+		}
+
 		securityOps := operations.NewNamedSet("Security Scanning")
 		securityOps.Append(sonarcloudScan())
 		ops.Merge(securityOps)


### PR DESCRIPTION
Add the capability for browser extensions tests to be executed if the commit msg contains `[browser-extension-tests]`

## Test plan
This PR
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
