### PR TITLE
app: fix script paths

### DIFF
--- a/dev/app/app-version.sh
+++ b/dev/app/app-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
+cd "$(dirname "${BASH_SOURCE[0]}")"/../.. || exit 1
 
 create_version() {
     local sha

--- a/dev/app/build-backend.sh
+++ b/dev/app/build-backend.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
+cd "$(dirname "${BASH_SOURCE[0]}")"/../.. || exit 1
 
 # We need the current go build since when cross compiling using bazel
 # the zig compiler or bazel is unable to find system libraries

--- a/dev/app/build.sh
+++ b/dev/app/build.sh
@@ -2,7 +2,7 @@
 set -eu
 
 GCLOUD_APP_CREDENTIALS_FILE=${GCLOUD_APP_CREDENTIALS_FILE-$HOME/.config/gcloud/application_default_credentials.json}
-cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
+cd "$(dirname "${BASH_SOURCE[0]}")"/../.. || exit 1
 
 ./dev/app/build-backend.sh
 ./dev/app/tauri-build.sh

--- a/dev/app/create-github-release.sh
+++ b/dev/app/create-github-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
+cd "$(dirname "${BASH_SOURCE[0]}")"/../.. || exit 1
 
 download_artifacts() {
   src=$1

--- a/dev/app/create-update-manifest.sh
+++ b/dev/app/create-update-manifest.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
+cd "$(dirname "${BASH_SOURCE[0]}")"/../.. || exit 1
 
 SUPPORTED_PLATFORMS=("aarch64-apple-darwin" "x86_64-apple-darwin" "x86_64-unknown-linux-gnu")
 

--- a/dev/app/tauri-build.sh
+++ b/dev/app/tauri-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-cd "$(dirname "${BASH_SOURCE[0]}")"/../../.. || exit 1
+cd "$(dirname "${BASH_SOURCE[0]}")"/../.. || exit 1
 
 BIN_DIR=".bin"
 DIST_DIR="dist"


### PR DESCRIPTION
With the move of the scripts from `enterprise` to `dev` the scripts had the wrong cwd. This fixes it

## Test plan
* Pushing this branch to `app-release/debug`
* https://buildkite.com/sourcegraph/cody-app-release/builds/1401#018b18f3-5542-4f18-9da5-fe6b44968afa
