### PR TITLE
Remove GitHub Proxy from dev/ci/images list

### DIFF
--- a/dev/ci/images/images.go
+++ b/dev/ci/images/images.go
@@ -89,7 +89,6 @@ var DeploySourcegraphDockerImages = []string{
 	"codeintel-db",
 	"embeddings",
 	"frontend",
-	"github-proxy",
 	"gitserver",
 	"grafana",
 	"indexed-searcher",


### PR DESCRIPTION
This service is in the process of being removed, so we're dropping it from this list.

## Test plan

CI.