### PR TITLE
Fix build: revert globals change

### DIFF
--- a/cmd/frontend/globals/BUILD.bazel
+++ b/cmd/frontend/globals/BUILD.bazel
@@ -8,6 +8,6 @@ go_library(
     deps = [
         "//internal/conf",
         "//schema",
-        "@com_github_sourcegraph_log//:log",
+        "@com_github_inconshreveable_log15//:log15",
     ],
 )

--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/inconshreveable/log15"
+	"github.com/inconshreveable/log15" //nolint:go
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/cmd/frontend/globals/globals.go
+++ b/cmd/frontend/globals/globals.go
@@ -2,13 +2,12 @@
 package globals
 
 import (
-	"fmt"
 	"net/url"
 	"reflect"
 	"sync"
 	"sync/atomic"
 
-	"github.com/sourcegraph/log"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -30,15 +29,13 @@ var watchExternalURLOnce sync.Once
 // WatchExternalURL watches for changes in the `externalURL` site configuration
 // so that changes are reflected in what is returned by the ExternalURL function.
 func WatchExternalURL() {
-	logger := log.Scoped("externalURLWatcher", "")
-
 	watchExternalURLOnce.Do(func() {
 		conf.Watch(func() {
 			after := defaultExternalURL
 			if val := conf.Get().ExternalURL; val != "" {
 				var err error
 				if after, err = url.Parse(val); err != nil {
-					logger.Error("globals.ExternalURL", log.String("value", val), log.Error(err))
+					log15.Error("globals.ExternalURL", "value", val, "error", err)
 					return
 				}
 			}
@@ -46,11 +43,11 @@ func WatchExternalURL() {
 			if before := ExternalURL(); !reflect.DeepEqual(before, after) {
 				SetExternalURL(after)
 				if before.Host != "example.com" {
-					logger.Info(
+					log15.Info(
 						"globals.ExternalURL",
-						log.Bool("updated", true),
-						log.String("before", before.String()),
-						log.String("after", after.String()),
+						"updated", true,
+						"before", before,
+						"after", after,
 					)
 				}
 			}
@@ -87,25 +84,23 @@ var watchPermissionsUserMappingOnce sync.Once
 // WatchPermissionsUserMapping watches for changes in the `permissions.userMapping` site configuration
 // so that changes are reflected in what is returned by the PermissionsUserMapping function.
 func WatchPermissionsUserMapping() {
-	logger := log.Scoped("permissionsUserMapWatcher", "")
-
 	watchPermissionsUserMappingOnce.Do(func() {
 		conf.Watch(func() {
 			after := conf.Get().PermissionsUserMapping
 			if after == nil {
 				after = defaultPermissionsUserMapping
 			} else if after.BindID != "email" && after.BindID != "username" {
-				logger.Error("globals.PermissionsUserMapping", log.String("BindID", after.BindID), log.String("error", "not a valid value"))
+				log15.Error("globals.PermissionsUserMapping", "BindID", after.BindID, "error", "not a valid value")
 				return
 			}
 
 			if before := PermissionsUserMapping(); !reflect.DeepEqual(before, after) {
 				SetPermissionsUserMapping(after)
-				logger.Info(
+				log15.Info(
 					"globals.PermissionsUserMapping",
-					log.Bool("updated", true),
-					log.String("before", fmt.Sprint(before)),
-					log.String("after", fmt.Sprint(after)),
+					"updated", true,
+					"before", before,
+					"after", after,
 				)
 			}
 		})
@@ -145,8 +140,6 @@ func WatchBranding() {
 		panic("WatchBranding called more than once")
 	}
 
-	logger := log.Scoped("brandingWatcher", "")
-
 	conf.Watch(func() {
 		after := conf.Get().Branding
 		if after == nil {
@@ -159,11 +152,11 @@ func WatchBranding() {
 
 		if before := Branding(); !reflect.DeepEqual(before, after) {
 			SetBranding(after)
-			logger.Debug(
+			log15.Debug(
 				"globals.Branding",
-				log.Bool("updated", true),
-				log.String("before", fmt.Sprint(before)),
-				log.String("after", fmt.Sprint(after)),
+				"updated", true,
+				"before", before,
+				"after", after,
 			)
 		}
 	})


### PR DESCRIPTION
Asking for a stamp because this is blocking main.

For some reason, changing this file was causing backend integration tests to fail. I have not figured out why. I assume it's something like the global logger isn't being initialized on some startup paths, and these are being called during init time, but I also didn't see a panic message in the test logs, so I have no idea. In any case, these are causing test failures, so I'm partially reverting the change.

## Test plan

Ran the `backend-integration` tests on this PR.
