### PR TITLE
sg: ops - only replace registry if there is an existing reg

### DIFF
--- a/dev/sg/internal/images/helm.go
+++ b/dev/sg/internal/images/helm.go
@@ -55,11 +55,14 @@ func UpdateHelmManifest(ctx context.Context, registry Registry, path string, op 
 			std.Out.WriteLine(output.Styled(output.StyleWarning, fmt.Sprintf("skipping updating registry as it's public which we assume is the default, %q", err.Error())))
 		}
 	}
-	valuesFileString = strings.ReplaceAll(
-		valuesFileString,
-		existingReg,
-		filepath.Join(registry.Host(), registry.Org()),
-	)
+
+	if existingReg != "" {
+		valuesFileString = strings.ReplaceAll(
+			valuesFileString,
+			existingReg,
+			filepath.Join(registry.Host(), registry.Org()),
+		)
+	}
 
 	// Collect all images.
 	var imgs []string

--- a/dev/sg/sg_ops.go
+++ b/dev/sg/sg_ops.go
@@ -155,7 +155,7 @@ func opsUpdateImages(
 	path string,
 	registryType string,
 	deploymentType string,
-	pintag string,
+	pinTag string,
 	dockerUsername string,
 	dockerPassword string,
 	skipImages []string,
@@ -190,15 +190,15 @@ func opsUpdateImages(
 			return false
 		}
 
-		if pintag != "" {
-			std.Out.WriteNoticef("pinning images to tag %q", pintag)
+		if pinTag != "" {
+			std.Out.WriteNoticef("pinning images to tag %q", pinTag)
 			// We're pinning a tag.
 			op = func(registry images.Registry, r *images.Repository) (*images.Repository, error) {
 				if !images.IsSourcegraph(r) || shouldSkip(r) {
 					return nil, images.ErrNoUpdateNeeded
 				}
 
-				newR, err := registry.GetByTag(r.Name(), pintag)
+				newR, err := registry.GetByTag(r.Name(), pinTag)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
`sg ops update-images` went a bit haywire on `https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s/pulls` creating PRs where the resulting values file was screwed up.

This happening because the existingReg value was an empty string, which made `strings.ReplaceAll` match the start of the string and yielding a lot replacements.

The doc string on `ReplaceAll` descrines the empty string behaviour
```
// If old is empty, it matches at the beginning of the string
// and after each UTF-8 sequence, yielding up to k+1 replacements
// for a k-rune string.
```

Closes https://github.com/sourcegraph/devx-support/issues/299
## Test plan
`go run ./dev/sg ops update-images -kind helm ~/deploy-sourcegraph-dogfood-k8s/dogfood-helm/.`
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
