### PR TITLE
Bump base images for 5.2.1 (CVE-2023-38545)

### DIFF
--- a/dev/ci/scripts/wolfi/build-base-image.sh
+++ b/dev/ci/scripts/wolfi/build-base-image.sh
@@ -56,7 +56,7 @@ fi
 name=${1%/}
 # Soft-fail if file doesn't exist, as CI step is triggered whenever base image configs are changed - including deletions/renames
 if [ ! -f "wolfi-images/${name}.yaml" ]; then
-  echo "File '$name.yaml' does not exist"
+  echo "File '${name}.yaml' does not exist cwd: '${PWD}'"
   exit 222
 fi
 

--- a/dev/ci/scripts/wolfi/build-base-image.sh
+++ b/dev/ci/scripts/wolfi/build-base-image.sh
@@ -2,7 +2,7 @@
 
 set -euf -o pipefail
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 REPO_DIR=$(pwd)
 
 GCP_PROJECT="sourcegraph-ci"

--- a/dev/ci/scripts/wolfi/build-package.sh
+++ b/dev/ci/scripts/wolfi/build-package.sh
@@ -2,7 +2,7 @@
 
 set -euf -o pipefail
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
 tmpdir=$(mktemp -d -t melange-bin.XXXXXXXX)
 function cleanup() {

--- a/dev/ci/scripts/wolfi/build-repo-index.sh
+++ b/dev/ci/scripts/wolfi/build-repo-index.sh
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
 # TODO: Manage these variables properly
 GCP_PROJECT="sourcegraph-ci"

--- a/dev/ci/scripts/wolfi/upload-package.sh
+++ b/dev/ci/scripts/wolfi/upload-package.sh
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.."
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
 # TODO: Manage these variables properly
 GCP_PROJECT="sourcegraph-ci"

--- a/wolfi-images/batcheshelper.yaml
+++ b/wolfi-images/batcheshelper.yaml
@@ -9,4 +9,4 @@ contents:
     ## batcheshelper packages
     - 'git'
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/blobstore.yaml
+++ b/wolfi-images/blobstore.yaml
@@ -18,4 +18,4 @@ paths:
 
 work-dir: /opt/s3proxy
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/bundled-executor.yaml
+++ b/wolfi-images/bundled-executor.yaml
@@ -22,4 +22,4 @@ paths:
     type: directory
     permissions: 0o755
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/cadvisor.yaml
+++ b/wolfi-images/cadvisor.yaml
@@ -9,4 +9,4 @@ contents:
     ## cadvisor dependencies
     - cadvisor
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/cloud-mi2.yaml
+++ b/wolfi-images/cloud-mi2.yaml
@@ -24,4 +24,4 @@ contents:
 accounts:
   run-as: root
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/executor-kubernetes.yaml
+++ b/wolfi-images/executor-kubernetes.yaml
@@ -9,4 +9,4 @@ contents:
     ## executor-kubernetes packages
     - git
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/executor.yaml
+++ b/wolfi-images/executor.yaml
@@ -16,4 +16,4 @@ paths:
     type: directory
     permissions: 0o755
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/gitserver.yaml
+++ b/wolfi-images/gitserver.yaml
@@ -27,4 +27,4 @@ paths:
 
 work-dir: /
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/jaeger-agent.yaml
+++ b/wolfi-images/jaeger-agent.yaml
@@ -20,4 +20,4 @@ accounts:
       uid: 10001
       gid: 10002
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/jaeger-all-in-one.yaml
+++ b/wolfi-images/jaeger-all-in-one.yaml
@@ -26,4 +26,4 @@ paths:
     uid: 10001
     permissions: 0o755
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/node-exporter.yaml
+++ b/wolfi-images/node-exporter.yaml
@@ -5,4 +5,4 @@ contents:
     ## node-exporter-specific packages
     - 'prometheus-node-exporter=1.6.0-r1' # IMPORTANT: Pinned version for managed updates
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/opentelemetry-collector.yaml
+++ b/wolfi-images/opentelemetry-collector.yaml
@@ -16,4 +16,4 @@ paths:
 
 work-dir: /otel-collector
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/postgres-exporter.yaml
+++ b/wolfi-images/postgres-exporter.yaml
@@ -19,4 +19,4 @@ accounts:
       uid: 20001
       gid: 102
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/postgresql-12-codeinsights.yaml
+++ b/wolfi-images/postgresql-12-codeinsights.yaml
@@ -33,4 +33,4 @@ accounts:
       uid: 70
       gid: 70
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/postgresql-12.yaml
+++ b/wolfi-images/postgresql-12.yaml
@@ -59,4 +59,4 @@ paths:
     gid: 999
     permissions: 0o755
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/prometheus-gcp.yaml
+++ b/wolfi-images/prometheus-gcp.yaml
@@ -20,4 +20,4 @@ paths:
 
 work-dir: /prometheus
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/prometheus.yaml
+++ b/wolfi-images/prometheus.yaml
@@ -24,4 +24,4 @@ paths:
 
 work-dir: /prometheus
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/qdrant.yaml
+++ b/wolfi-images/qdrant.yaml
@@ -17,4 +17,4 @@ paths:
 entrypoint:
   command: /sbin/tini -- /usr/local/bin/qdrant --config-path /etc/qdrant/config.yaml
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/redis-exporter.yaml
+++ b/wolfi-images/redis-exporter.yaml
@@ -9,4 +9,4 @@ contents:
     ## redis_exporter packages
     - redis_exporter@sourcegraph
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/redis.yaml
+++ b/wolfi-images/redis.yaml
@@ -31,4 +31,4 @@ work-dir: /redis-data
 entrypoint:
   command: redis-server
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/repo-updater.yaml
+++ b/wolfi-images/repo-updater.yaml
@@ -9,4 +9,4 @@ contents:
     ## repo-updater packages
     - coursier@sourcegraph
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/search-indexer.yaml
+++ b/wolfi-images/search-indexer.yaml
@@ -23,4 +23,4 @@ paths:
     gid: 101
     permissions: 0o755
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/searcher.yaml
+++ b/wolfi-images/searcher.yaml
@@ -19,4 +19,4 @@ paths:
     gid: 101
     permissions: 0o755
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -81,4 +81,4 @@ paths:
     type: directory
     permissions: 0o755
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/sourcegraph-base.yaml
+++ b/wolfi-images/sourcegraph-base.yaml
@@ -42,4 +42,4 @@ annotations:
   org.opencontainers.image.source: https://github.com/sourcegraph/sourcegraph/
   org.opencontainers.image.documentation: https://docs.sourcegraph.com/
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/sourcegraph-dev.yaml
+++ b/wolfi-images/sourcegraph-dev.yaml
@@ -9,4 +9,4 @@ contents:
     ## Dev-specific tools
     - apk-tools
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/sourcegraph.yaml
+++ b/wolfi-images/sourcegraph.yaml
@@ -37,4 +37,4 @@ paths:
     gid: 101
     permissions: 0o755
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/symbols.yaml
+++ b/wolfi-images/symbols.yaml
@@ -19,4 +19,4 @@ paths:
     gid: 101
     permissions: 0o755
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/syntax-highlighter.yaml
+++ b/wolfi-images/syntax-highlighter.yaml
@@ -10,4 +10,4 @@ contents:
     - libstdc++
     - http-server-stabilizer@sourcegraph
 
-# MANUAL REBUILD: Fri 29 Sep 2023 11:16:10 EDT
+# MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023


### PR DESCRIPTION
Bump base images to pull in latest package versions. To patch CVE-2023-38545.

## Test plan

- Green CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
