### PR TITLE
wolfi: update base-images (CVE-2023-38545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a user's Permissions page being inaccessible if the user has had no permission syncs with an external account connected. [#57372](https://github.com/sourcegraph/sourcegraph/pull/57372)
 - Fixed a bug where site admins could not view a user's permissions if they didn't have access to all of the repositories the user has. Admins still won't be able to see repositories they don't have access to, but they will now be able to view the rest of the user's repository permissions. [#57375](https://github.com/sourcegraph/sourcegraph/pull/57375)
 - Fixed a bug where gitserver statistics would not be properly decoded / reported when using REST (i.e. `experimentalFeatures.enableGRPC = false` in site configuration). [#57318](https://github.com/sourcegraph/sourcegraph/pull/57318)
+- Updated the `curl` and `libcurl` dependencies to `8.4.0-r0` to fix [CVE-2023-38545](https://curl.se/docs/CVE-2023-38545.html). [#57533](https://github.com/sourcegraph/sourcegraph/pull/57533)
 
 ### Removed
 

--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -1,3 +1,7 @@
+"""
+Load external dependencies for base images
+"""
+
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 # Quick script to get the latest tags for each of the base images from GCR:
@@ -32,33 +36,36 @@ load("@rules_oci//oci:pull.bzl", "oci_pull")
 # done
 
 def oci_deps():
+    """
+    The image definitions and their digests
+    """
     oci_pull(
         name = "wolfi_base",
-        digest = "sha256:f7d19d251a65471e5c96114823b480fa6ee2649e4d30041b8a75bf84fbdc9293",
+        digest = "sha256:7765ccf698d40dd46b1b69599728680313ac993e3b8ee2292faf99f9acfadfae",
         image = "index.docker.io/sourcegraph/wolfi-sourcegraph-base",
     )
 
     oci_pull(
         name = "wolfi_cadvisor_base",
-        digest = "sha256:c98bb71adef2e6412ba6b15a8d75e9cd2aa761238458afbc08011a66fd73a536",
+        digest = "sha256:17ff4201bf1904e679017d08c0d0216a8b10f85e096c64f26efaf73006849146",
         image = "index.docker.io/sourcegraph/wolfi-cadvisor-base",
     )
 
     oci_pull(
         name = "wolfi_symbols_base",
-        digest = "sha256:e1707ffae8627bfabb972a31bc2d08973c8b05f344812d6095f670957c27a503",
+        digest = "sha256:2972e10f5dca979930a5b1bd2a9cd63eb277e9b95a77a00a8c2e63d52022c1d8",
         image = "index.docker.io/sourcegraph/wolfi-symbols-base",
     )
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:79fa14df95a902dd5f9d3c5391cc46664277e3ce8e3c7d1f2f3059066af55f6f",
+        digest = "sha256:259ddda8d0d4297fe4231c017b39b90dfa0fb8fcf28aca61f69fddba16fd8474",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:1b63c61ff9d704d1f271e9b480ee63a40da3933b06852870f251a16141c39f7e",
+        digest = "sha256:5fa1bf66f3f90791ecbd28ca51dac748d72c37abdc49ba63b728258414128c61",
         image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
     )
 
@@ -70,133 +77,133 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_postgres_exporter_base",
-        digest = "sha256:d4dc495c3724b7035a42563c6af1287f3bd50c7c38157555ae82c4990fc17433",
+        digest = "sha256:c22f0a99899c29a6bdd3d59f7c1c83d5aff180a0baba6bca4c2f28950da952a9",
         image = "index.docker.io/sourcegraph/wolfi-postgres-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_all_in_one_base",
-        digest = "sha256:bc045404452e77f29be50c127ed6747e6e036d3dd2c0fe4def0e9dd3b033f887",
+        digest = "sha256:080ede778a1a7e009a45a17ce60ace5431df8e589ce611d8f52033024cc64410",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-all-in-one-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_agent_base",
-        digest = "sha256:f3d3860d57d4371c578ff8f4a828b4834f65b2149dafff76821416051842671e",
+        digest = "sha256:4e1ffceab92819d6eafa785c4e2b00da1930c89361888623a735a1d317a0c74c",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-agent-base",
     )
 
     oci_pull(
         name = "wolfi_redis_base",
-        digest = "sha256:5521667b1f3b196851eb802923db563ebdd1834d2ba079f5b80225369c849e8e",
+        digest = "sha256:143082fa39dc9cd510d5c9011fafceaefe05ea194098d71ec3e61189660b39fe",
         image = "index.docker.io/sourcegraph/wolfi-redis-base",
     )
 
     oci_pull(
         name = "wolfi_redis_exporter_base",
-        digest = "sha256:3c56394e8e307d56937601b3fc6835aa70e9c135ae2602794f1df460dca07879",
+        digest = "sha256:1caa8489778b89a8bf326f4092f37886b6e454243a2771b792d0ab086be2deab",
         image = "index.docker.io/sourcegraph/wolfi-redis-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_syntax_highlighter_base",
-        digest = "sha256:8281dda4aeee958da686f6f0b12ae7fdeec964a2cc5c87f2c26c63fcc323201c",
+        digest = "sha256:ed78d0d25c93c8c67742214a7a07a9e2e33d27727af6f6c0a234159bccc919f7",
         image = "index.docker.io/sourcegraph/wolfi-syntax-highlighter-base",
     )
 
     oci_pull(
         name = "wolfi_search_indexer_base",
-        digest = "sha256:6a559d14325ebb6a322fc7153e4e2320a4959dcbba65e3a203a25363bec162bc",
+        digest = "sha256:337282a47ae438a2a4124c23e65e7d5953354dcb31a6c5d53fde6001df237e2b",
         image = "index.docker.io/sourcegraph/wolfi-search-indexer-base",
     )
 
     oci_pull(
         name = "wolfi_repo_updater_base",
-        digest = "sha256:e66998c123cd46de5121b29c0badc24c8e51283b553b23465a709d3d3e467691",
+        digest = "sha256:9589a1c4ecc573b0f126beb46a8418fd14c7add9e11db839d7f7bfc24b36ec3f",
         image = "index.docker.io/sourcegraph/wolfi-repo-updater-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:e7ea5dfdcd4d9d272727a7a984f020f5ee1be30eed98d498bf30e5a89f9d47de",
+        digest = "sha256:d05443bbeba35b46b93e7d69377eb1789e22df5ec0e019497b8f8441bae1c186",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_executor_base",
-        digest = "sha256:ecd37a5f55bca3bbf090bc1402f49a8ffc1935007b76a9d896b1a728bb665301",
+        digest = "sha256:2826c9fd3a0e33cfbc8df2dca3ad53c31bd6a5ed921144e2f93f41ac8663ece1",
         image = "index.docker.io/sourcegraph/wolfi-executor-base",
     )
 
     # ???
     oci_pull(
         name = "wolfi_bundled_executor_base",
-        digest = "sha256:6e8f04b1fe43e89f8978c7b24e1c9b45879e69005dac59a881fba5d04d780860",
+        digest = "sha256:b22f6175da2d6124183bc39e41adac8cc106ab2d0d71b141ef0bcd84185b1f52",
         image = "index.docker.io/sourcegraph/wolfi-bundled-executor-base",
     )
 
     oci_pull(
         name = "wolfi_executor_kubernetes_base",
-        digest = "sha256:406b30df34df4de6276d28d46d8026dc5c253cabbca5354032fd5f8134136de0",
+        digest = "sha256:a5d60c3a889a0d99b41c241d56f309db00db3cda6cfd5bf145706c18b661b29f",
         image = "index.docker.io/sourcegraph/wolfi-executor-kubernetes-base",
     )
 
     oci_pull(
         name = "wolfi_batcheshelper_base",
-        digest = "sha256:7e73e28af8537559a10ddd7a6257f39c62ccb94c596c3c2969e5184bca8e4c7a",
+        digest = "sha256:184eba7fd8e298a81f6e44895a4e64fe14b5bf0240018ccc2997c410abd9f63f",
         image = "index.docker.io/sourcegraph/wolfi-batcheshelper-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_base",
-        digest = "sha256:8caa94d4c935c9a62b03f6ae5f731badc4a4eab9f4e5a0bf53ac5605a8c40439",
+        digest = "sha256:8c497e05ed35fa07de08b558f2641389dd82168845dbbda8ffdfaa843b1ac6ab",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_gcp_base",
-        digest = "sha256:40b3ea43e94266f61d086c05cde5ef46c4a7a6317fc5862455133cbf4b7afb65",
+        digest = "sha256:c9b1c8f4b62588b924ae791a4948186c0fb8029c7bfa4c925df69cb0561bb4fe",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-gcp-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12_base",
-        digest = "sha256:60b6197f9ecb38de089b64e6c44966809b4b5e659be527369dec86cc2070b6c4",
+        digest = "sha256:ba71a8c994c7b6e677a0cc4d897309ed93f38bc26e829fac3ee1f28eb3d8b898",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12-codeinsights_base",
-        digest = "sha256:6c77b2d4c08850814969aa7232bb3b3c65c7f560abeee27c3558fdda3b210bae",
+        digest = "sha256:779ec1695a677d633c1adf43a8e137ba475754809ef07835cf3ecfad23a3c868",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-codeinsights-base",
     )
 
     oci_pull(
         name = "wolfi_node_exporter_base",
-        digest = "sha256:6ccdbd6e573b17a701eaf458a1e5608406a0d227c2e8d8e13426393991c05eda",
+        digest = "sha256:4563d813a54a5da0dd2c4ce12e62e24a1c5372d557a6684e6b2333ecb4f6ee17",
         image = "index.docker.io/sourcegraph/wolfi-node-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_opentelemetry_collector_base",
-        digest = "sha256:eccb80a850a322b064cbdfcb34a36b8e67e8ead7e5fdff9a209449e029937985",
+        digest = "sha256:438052c65d55f04138a45bfbadd399d0412c914ac7059cf068e84a6edf4fbe42",
         image = "index.docker.io/sourcegraph/wolfi-opentelemetry-collector-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:e7ea5dfdcd4d9d272727a7a984f020f5ee1be30eed98d498bf30e5a89f9d47de",
+        digest = "sha256:d05443bbeba35b46b93e7d69377eb1789e22df5ec0e019497b8f8441bae1c186",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_s3proxy_base",
-        digest = "sha256:db975d47101afc417ab434d7869599b08103438df9744967d156361b43543e46",
+        digest = "sha256:cf83ed9f5c274d756d30149c922836b86902d8b0cb7a50f6e2f57a1cccc80d56",
         image = "index.docker.io/sourcegraph/wolfi-blobstore-base",
     )
 
     oci_pull(
         name = "wolfi_qdrant_base",
-        digest = "sha256:3ff70f00bb5ffcb0521e89b92c9b746b0d25ce778c4a0f00a3a24407e7c466e1",
+        digest = "sha256:959adb714604ee9908724e6da9da620c0ddbabba772cd6448d2d35ffa7474adb",
         image = "index.docker.io/sourcegraph/wolfi-qdrant-base",
     )


### PR DESCRIPTION
 We ran `sg wolfi update-hashes`. This makes sure we are using the latest version of `curl` and other dependencies that have been updated.

Related to: https://github.com/sourcegraph/sourcegraph/pull/57529.

## Test plan
CI tests will verify the builds. Verified versions locally, see [comment below](https://github.com/sourcegraph/sourcegraph/pull/57533#issuecomment-1757439310).
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
