### PR TITLE
tracking-issue: only trigger periodically

### DIFF
--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -2,29 +2,6 @@ name: Tracking Issue Syncer
 on:
   schedule:
   - cron: '*/15 * * * *'
-  issues:
-    types:
-    - opened
-    - edited
-    - deleted
-    - closed
-    - reopened
-    - assigned
-    - unassigned
-    - labeled
-    - unlabeled
-    - milestoned
-    - demilestoned
-  pull_request:
-    types:
-    - opened
-    - edited
-    - closed
-    - reopened
-    - assigned
-    - unassigned
-    - labeled
-    - unlabeled
 jobs:
   sync-tracking-issues:
     if: github.repository == 'sourcegraph/sourcegraph' || 'sourcegraph/security'


### PR DESCRIPTION
We're triggering that workflow on a ton of events, and each run crawls a ton of issues for nothing, very often soft-failing because it triggers the limits for making requests. 

Nobody needs the tracking issues to be updated instantly, every 15m is perfectly fine. 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
