### PR TITLE
wolfi: Rebuild wolfi base images when env WOLFI_BASE_REBUILD=true

### DIFF
--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -65,9 +65,10 @@ func NewConfig(now time.Time) Config {
 		tag    = os.Getenv("BUILDKITE_TAG")
 		// evaluates what type of pipeline run this is
 		runType = runtype.Compute(tag, branch, map[string]string{
-			"BEXT_NIGHTLY":    os.Getenv("BEXT_NIGHTLY"),
-			"RELEASE_NIGHTLY": os.Getenv("RELEASE_NIGHTLY"),
-			"VSCE_NIGHTLY":    os.Getenv("VSCE_NIGHTLY"),
+			"BEXT_NIGHTLY":       os.Getenv("BEXT_NIGHTLY"),
+			"RELEASE_NIGHTLY":    os.Getenv("RELEASE_NIGHTLY"),
+			"VSCE_NIGHTLY":       os.Getenv("VSCE_NIGHTLY"),
+			"WOLFI_BASE_REBUILD": os.Getenv("WOLFI_BASE_REBUILD"),
 		})
 		// defaults to 0
 		buildNumber, _ = strconv.Atoi(os.Getenv("BUILDKITE_BUILD_NUMBER"))

--- a/dev/ci/internal/ci/operations.go
+++ b/dev/ci/internal/ci/operations.go
@@ -88,9 +88,10 @@ func addSgLints(targets []string) func(pipeline *bk.Pipeline) {
 		tag    = os.Getenv("BUILDKITE_TAG")
 		// evaluates what type of pipeline run this is
 		runType = runtype.Compute(tag, branch, map[string]string{
-			"BEXT_NIGHTLY":    os.Getenv("BEXT_NIGHTLY"),
-			"RELEASE_NIGHTLY": os.Getenv("RELEASE_NIGHTLY"),
-			"VSCE_NIGHTLY":    os.Getenv("VSCE_NIGHTLY"),
+			"BEXT_NIGHTLY":       os.Getenv("BEXT_NIGHTLY"),
+			"RELEASE_NIGHTLY":    os.Getenv("RELEASE_NIGHTLY"),
+			"VSCE_NIGHTLY":       os.Getenv("VSCE_NIGHTLY"),
+			"WOLFI_BASE_REBUILD": os.Getenv("WOLFI_BASE_REBUILD"),
 		})
 	)
 

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -440,33 +439,4 @@ func addWolfiOps(c Config, ops *operations.Set) {
 		)
 		ops.Merge(baseImageOps)
 	}
-}
-
-// wolfiRebuildAllBaseImages adds operations to rebuild all Wolfi base images and push to registry
-func wolfiRebuildAllBaseImages(c Config) *operations.Set {
-	// List all YAML files in wolfi-images/
-	dir := "wolfi-images"
-	files, err := os.ReadDir(dir)
-	if err != nil {
-		panic(err)
-	}
-
-	var wolfiBaseImages []string
-	for _, f := range files {
-		if filepath.Ext(f.Name()) == ".yaml" {
-			fullPath := filepath.Join(dir, f.Name())
-			wolfiBaseImages = append(wolfiBaseImages, fullPath)
-		}
-	}
-
-	// Rebuild all images
-	var baseImageOps *operations.Set
-	if len(wolfiBaseImages) > 0 {
-		baseImageOps, _ = WolfiBaseImagesOperations(
-			wolfiBaseImages,
-			c.Version,
-			false,
-		)
-	}
-	return baseImageOps
 }

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -143,7 +143,13 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		ops.Merge(securityOps)
 
 		// Wolfi package and base images
-		addWolfiOps(c, ops)
+		packageOps, baseImageOps := addWolfiOps(c)
+		if packageOps != nil {
+			ops.Merge(packageOps)
+		}
+		if baseImageOps != nil {
+			ops.Merge(baseImageOps)
+		}
 
 		// Now we set up conditional operations that only apply to pull requests.
 		if c.Diff.Has(changed.Client) {
@@ -309,7 +315,13 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		))
 
 		// Wolfi package and base images
-		addWolfiOps(c, ops)
+		packageOps, baseImageOps := addWolfiOps(c)
+		if packageOps != nil {
+			ops.Merge(packageOps)
+		}
+		if baseImageOps != nil {
+			ops.Merge(baseImageOps)
+		}
 
 		// All operations before this point are required
 		ops.Append(wait)
@@ -409,34 +421,4 @@ func withAgentLostRetries(s *bk.Step) {
 		Limit:      1,
 		ExitStatus: -1,
 	})
-}
-
-// addWolfiOps adds operations to rebuild modified Wolfi packages and base images.
-func addWolfiOps(c Config, ops *operations.Set) {
-	// Rebuild Wolfi packages that have config changes
-	var updatedPackages []string
-	if c.Diff.Has(changed.WolfiPackages) {
-		var packageOps *operations.Set
-		packageOps, updatedPackages = WolfiPackagesOperations(c.ChangedFiles[changed.WolfiPackages])
-		ops.Merge(packageOps)
-	}
-
-	// Rebuild Wolfi base images
-	// Inspect package dependencies, and rebuild base images with updated packages
-	_, imagesWithChangedPackages, err := GetDependenciesOfPackages(updatedPackages, "sourcegraph")
-	if err != nil {
-		panic(err)
-	}
-	// Rebuild base images with package changes AND with config changes
-	imagesToRebuild := append(imagesWithChangedPackages, c.ChangedFiles[changed.WolfiBaseImages]...)
-	imagesToRebuild = sortUniq(imagesToRebuild)
-
-	if len(imagesToRebuild) > 0 {
-		baseImageOps, _ := WolfiBaseImagesOperations(
-			imagesToRebuild,
-			c.Version,
-			(len(updatedPackages) > 0),
-		)
-		ops.Merge(baseImageOps)
-	}
 }

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -192,7 +192,10 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 	case runtype.WolfiBaseRebuild:
 		// If this is a Wolfi base image rebuild, rebuild all Wolfi base images and push to registry
-		addWolfiRebuildAllBaseImagesOps(c, ops)
+		baseImageOps := wolfiRebuildAllBaseImages(c)
+		if baseImageOps != nil {
+			ops.Merge(baseImageOps)
+		}
 
 	case runtype.CandidatesNoTest:
 		imageBuildOps := operations.NewNamedSet("Image builds")
@@ -439,8 +442,8 @@ func addWolfiOps(c Config, ops *operations.Set) {
 	}
 }
 
-// addWolfiRebuildAllBaseImagesOps adds operations to rebuild all Wolfi base images and push to registry
-func addWolfiRebuildAllBaseImagesOps(c Config, ops *operations.Set) {
+// wolfiRebuildAllBaseImages adds operations to rebuild all Wolfi base images and push to registry
+func wolfiRebuildAllBaseImages(c Config) *operations.Set {
 	// List all YAML files in wolfi-images/
 	dir := "wolfi-images"
 	files, err := os.ReadDir(dir)
@@ -457,12 +460,13 @@ func addWolfiRebuildAllBaseImagesOps(c Config, ops *operations.Set) {
 	}
 
 	// Rebuild all images
+	var baseImageOps *operations.Set
 	if len(wolfiBaseImages) > 0 {
-		baseImageOps, _ := WolfiBaseImagesOperations(
+		baseImageOps, _ = WolfiBaseImagesOperations(
 			wolfiBaseImages,
 			c.Version,
 			false,
 		)
-		ops.Merge(baseImageOps)
 	}
+	return baseImageOps
 }

--- a/dev/ci/internal/ci/wolfi_operations.go
+++ b/dev/ci/internal/ci/wolfi_operations.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	bk "github.com/sourcegraph/sourcegraph/dev/ci/internal/buildkite"
+	"github.com/sourcegraph/sourcegraph/dev/ci/internal/ci/changed"
 	"github.com/sourcegraph/sourcegraph/dev/ci/internal/ci/operations"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -266,6 +267,35 @@ func getPackagesFromBaseImageConfig(configFile string) ([]string, error) {
 	return config.Contents.Packages, nil
 }
 
+// addWolfiOps adds operations to rebuild modified Wolfi packages and base images.
+func addWolfiOps(c Config) (packageOps, baseImageOps *operations.Set) {
+	// Rebuild Wolfi packages that have config changes
+	var updatedPackages []string
+	if c.Diff.Has(changed.WolfiPackages) {
+		packageOps, updatedPackages = WolfiPackagesOperations(c.ChangedFiles[changed.WolfiPackages])
+	}
+
+	// Rebuild Wolfi base images
+	// Inspect package dependencies, and rebuild base images with updated packages
+	_, imagesWithChangedPackages, err := GetDependenciesOfPackages(updatedPackages, "sourcegraph")
+	if err != nil {
+		panic(err)
+	}
+	// Rebuild base images with package changes AND with config changes
+	imagesToRebuild := append(imagesWithChangedPackages, c.ChangedFiles[changed.WolfiBaseImages]...)
+	imagesToRebuild = sortUniq(imagesToRebuild)
+
+	if len(imagesToRebuild) > 0 {
+		baseImageOps, _ = WolfiBaseImagesOperations(
+			imagesToRebuild,
+			c.Version,
+			(len(updatedPackages) > 0),
+		)
+	}
+
+	return packageOps, baseImageOps
+}
+
 // wolfiRebuildAllBaseImages adds operations to rebuild all Wolfi base images and push to registry
 func wolfiRebuildAllBaseImages(c Config) *operations.Set {
 	// List all YAML files in wolfi-images/
@@ -292,5 +322,6 @@ func wolfiRebuildAllBaseImages(c Config) *operations.Set {
 			false,
 		)
 	}
+
 	return baseImageOps
 }

--- a/dev/ci/internal/ci/wolfi_operations.go
+++ b/dev/ci/internal/ci/wolfi_operations.go
@@ -265,3 +265,32 @@ func getPackagesFromBaseImageConfig(configFile string) ([]string, error) {
 
 	return config.Contents.Packages, nil
 }
+
+// wolfiRebuildAllBaseImages adds operations to rebuild all Wolfi base images and push to registry
+func wolfiRebuildAllBaseImages(c Config) *operations.Set {
+	// List all YAML files in wolfi-images/
+	dir := "wolfi-images"
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	var wolfiBaseImages []string
+	for _, f := range files {
+		if filepath.Ext(f.Name()) == ".yaml" {
+			fullPath := filepath.Join(dir, f.Name())
+			wolfiBaseImages = append(wolfiBaseImages, fullPath)
+		}
+	}
+
+	// Rebuild all images
+	var baseImageOps *operations.Set
+	if len(wolfiBaseImages) > 0 {
+		baseImageOps, _ = WolfiBaseImagesOperations(
+			wolfiBaseImages,
+			c.Version,
+			false,
+		)
+	}
+	return baseImageOps
+}

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -18,11 +18,12 @@ const (
 
 	// Nightly builds - must be first because they take precedence
 
-	ReleaseNightly // release branch nightly healthcheck builds
-	BextNightly    // browser extension nightly build
-	VsceNightly    // vs code extension nightly build
-	AppRelease     // app release build
-	AppInsiders    // app insiders build
+	ReleaseNightly   // release branch nightly healthcheck builds
+	BextNightly      // browser extension nightly build
+	VsceNightly      // vs code extension nightly build
+	AppRelease       // app release build
+	AppInsiders      // app insiders build
+	WolfiBaseRebuild // wolfi base image build
 
 	// Release branches
 
@@ -108,6 +109,12 @@ func (t RunType) Matcher() *RunTypeMatcher {
 			Branch:      "vsce/release",
 			BranchExact: true,
 		}
+	case WolfiBaseRebuild:
+		return &RunTypeMatcher{
+			EnvIncludes: map[string]string{
+				"WOLFI_BASE_REBUILD": "true",
+			},
+		}
 
 	case AppRelease:
 		return &RunTypeMatcher{
@@ -192,6 +199,8 @@ func (t RunType) String() string {
 		return "Browser extension nightly release build"
 	case VsceNightly:
 		return "VS Code extension nightly release build"
+	case WolfiBaseRebuild:
+		return "Wolfi base images rebuild"
 	case AppRelease:
 		return "App release build"
 	case AppInsiders:

--- a/dev/ci/runtype/runtype_test.go
+++ b/dev/ci/runtype/runtype_test.go
@@ -61,6 +61,15 @@ func TestComputeRunType(t *testing.T) {
 		},
 		want: VsceNightly,
 	}, {
+		name: "wolfi base image rebuild",
+		args: args{
+			branch: "main",
+			env: map[string]string{
+				"WOLFI_BASE_REBUILD": "true",
+			},
+		},
+		want: WolfiBaseRebuild,
+	}, {
 		name: "vsce release",
 		args: args{
 			branch: "vsce/release",

--- a/doc/dev/how-to/wolfi/add_update_images.md
+++ b/doc/dev/how-to/wolfi/add_update_images.md
@@ -16,14 +16,16 @@ These configuration files can be processed with apko, which will generate a base
 
 Before each release, we should update the base images to ensure we include any updated packages and vulnerability fixes.
 
-This is currently a two-step process, which will be further automated in the future:
-
-- Run [`wolfi-images/rebuild-images.sh`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@588463afbb0904c125cdcf78c7b182f43328504e/-/blob/wolfi-images/rebuild-images.sh) script, commit the updated YAML files, and merge to main.
-- Wait for the `main` branch's Buildkite run to complete.
-  - Buildkite will rebuild the base images and publish them to Dockerhub.
 - Run `sg wolfi update-hashes` locally to update the base image hashes in `dev/oci_deps.bzl`. Commit these changes and merge to `main`.
-  - This fetches the updated base image hashes from the images that were pushed to Dockerhub in the previous step.
-- Backport the PR that updated `dev/oci_deps.bzl` to the release branch.
+- Backport the PR to the release branch.
+
+#### Automation
+
+This process is partially automated by Buildkite. A scheduled build runs daily to rebuild Wolfi base images - pulling in any updated dependencies - then push them to Docker Hub. When `sg wolfi update-hashes` is run, it pulls these latest image hashes from Docker Hub to update the references in `dev/oci_deps.bzl`.
+
+To rebuild the images (perhaps to pick up a just-released package version), [find a scheduled build](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main) in Buildkite named "Nightly Rebuild of Wolfi Base Images", and hit "Rebuild".
+
+It is also possible to manually rebuild individual images by running `wolfi-images/rebuild-images.sh` locally, then pushing and merging.
 
 ### Modify an existing base image
 


### PR DESCRIPTION
Allow us to automatically rebuild Wolfi base images periodically. This can be triggered using a Buildkite scheduled build.

Implements https://github.com/sourcegraph/security/issues/986 to rebuild Wolfi base images automatically, speeding up dependency upgrades.

When run against a branch, newly built images will be pushed to GCR. When run against `main`, they will be pushed to Dockerhub.

## Post-merge checklist

- [ ] Perform test run against `main` with env set
- [ ] Update Buildkite schedule to run daily against `main`.

## Test plan

- Tested locally with `WOLFI_BASE_REBUILD=true sg ci preview --format yaml`
- Scheduled run against `will/wolfi-base-rebuild-auto` branch: https://buildkite.com/sourcegraph/sourcegraph/builds/246765#018b1f59-2f46-469d-89da-e73a19b999da

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
