### PR TITLE
Update BatchChangesChangelogAlert.tsx

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.tsx
@@ -19,7 +19,7 @@ const CURRENT_VERSION = '5.2'
  * After every release, this will be set back to `false`. Chromatic will also verify
  * changes to this variable via visual regression testing.
  */
-const SHOW_CHANGELOG = true
+const SHOW_CHANGELOG = false
 
 interface BatchChangesChangelogAlertProps {
     className?: string


### PR DESCRIPTION
After every release, this variable should be reverted to `false`. 
We also didn't have any new features on Batch Changes, so we currently show old features in the changelog alert.

![CleanShot 2023-10-11 at 13 06 22@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/d9275e3f-01ab-4864-9eed-9f55d3b3f91c)

## Test plan

The 5.2 changelog shouldn't show up.
