### PR TITLE
Chore: construct logger inside `dbtest.NewDB`

### DIFF
--- a/cmd/frontend/backend/external_services_test.go
+++ b/cmd/frontend/backend/external_services_test.go
@@ -392,8 +392,7 @@ func TestExternalService_ListNamespaces(t *testing.T) {
 
 			logger := logtest.Scoped(t)
 
-			sqlDB := dbtest.NewDB(logger, t)
-			db := database.NewDB(logger, sqlDB)
+			db := database.NewDB(logger, dbtest.NewDB(t))
 
 			var store internalrepos.Store
 			if tc.externalService != nil {
@@ -626,8 +625,7 @@ func TestExternalService_DiscoverRepos(t *testing.T) {
 
 			logger := logtest.Scoped(t)
 
-			sqlDB := dbtest.NewDB(logger, t)
-			db := database.NewDB(logger, sqlDB)
+			db := database.NewDB(logger, dbtest.NewDB(t))
 
 			var store internalrepos.Store
 			if tc.externalService != nil {

--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -288,7 +288,7 @@ func TestSendUserEmailOnTokenChange(t *testing.T) {
 
 func TestUserEmailsAddRemove(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	txemail.DisableSilently()
 
@@ -357,7 +357,7 @@ func TestUserEmailsAddRemove(t *testing.T) {
 
 func TestUserEmailsSetPrimary(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	txemail.DisableSilently()
 
@@ -398,7 +398,7 @@ func TestUserEmailsSetPrimary(t *testing.T) {
 
 func TestUserEmailsSetVerified(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	txemail.DisableSilently()
 
@@ -447,7 +447,7 @@ func TestUserEmailsSetVerified(t *testing.T) {
 
 func TestUserEmailsResendVerificationEmail(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	txemail.DisableSilently()
 
@@ -520,7 +520,7 @@ func TestUserEmailsResendVerificationEmail(t *testing.T) {
 
 func TestRemoveStalePerforceAccount(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	txemail.DisableSilently()
 

--- a/cmd/frontend/backend/webhooks_test.go
+++ b/cmd/frontend/backend/webhooks_test.go
@@ -123,7 +123,7 @@ func TestCreateWebhook(t *testing.T) {
 
 func TestCreateUpdateDeleteWebhook(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	users := dbmocks.NewMockUserStore()

--- a/cmd/frontend/graphqlbackend/executor_secrets_test.go
+++ b/cmd/frontend/graphqlbackend/executor_secrets_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestSchemaResolver_CreateExecutorSecret(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	r := &schemaResolver{logger: logger, db: db}
 	ctx := context.Background()
 
@@ -112,7 +112,7 @@ func TestSchemaResolver_CreateExecutorSecret(t *testing.T) {
 
 func TestSchemaResolver_UpdateExecutorSecret(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	r := &schemaResolver{logger: logger, db: db}
 	ctx := context.Background()
 	internalCtx := actor.WithInternalActor(ctx)
@@ -202,7 +202,7 @@ func TestSchemaResolver_UpdateExecutorSecret(t *testing.T) {
 
 func TestSchemaResolver_DeleteExecutorSecret(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	r := &schemaResolver{logger: logger, db: db}
 	ctx := context.Background()
 	internalCtx := actor.WithInternalActor(ctx)
@@ -279,7 +279,7 @@ func TestSchemaResolver_DeleteExecutorSecret(t *testing.T) {
 
 func TestSchemaResolver_ExecutorSecrets(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	r := &schemaResolver{logger: logger, db: db}
 	ctx := context.Background()
 	internalCtx := actor.WithInternalActor(ctx)
@@ -349,7 +349,7 @@ func TestSchemaResolver_ExecutorSecrets(t *testing.T) {
 
 func TestUserResolver_ExecutorSecrets(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	internalCtx := actor.WithInternalActor(ctx)
 
@@ -423,7 +423,7 @@ func TestUserResolver_ExecutorSecrets(t *testing.T) {
 
 func TestOrgResolver_ExecutorSecrets(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	internalCtx := actor.WithInternalActor(ctx)
 
@@ -507,7 +507,7 @@ func TestOrgResolver_ExecutorSecrets(t *testing.T) {
 
 func TestExecutorSecretsIntegration(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, database.NewUser{Username: "test-1"})

--- a/cmd/frontend/graphqlbackend/external_accounts_test.go
+++ b/cmd/frontend/graphqlbackend/external_accounts_test.go
@@ -37,7 +37,7 @@ func TestExternalAccounts_DeleteExternalAccount(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	t.Run("has github account", func(t *testing.T) {
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 		act := actor.Actor{UID: 1}
 		ctx := actor.WithActor(context.Background(), &act)
 		sr := newSchemaResolver(db, gitserver.NewClient())

--- a/cmd/frontend/graphqlbackend/gitserver_test.go
+++ b/cmd/frontend/graphqlbackend/gitserver_test.go
@@ -24,7 +24,7 @@ func TestGitserverResolver(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	user := createTestUser(t, db, false)
 	admin := createTestUser(t, db, true)

--- a/cmd/frontend/graphqlbackend/permission_test.go
+++ b/cmd/frontend/graphqlbackend/permission_test.go
@@ -26,7 +26,7 @@ func TestPermissionResolver(t *testing.T) {
 
 	ctx := context.Background()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	user := createTestUser(t, db, false)
 	admin := createTestUser(t, db, true)

--- a/cmd/frontend/graphqlbackend/permissions_test.go
+++ b/cmd/frontend/graphqlbackend/permissions_test.go
@@ -25,7 +25,7 @@ func TestPermissionsResolver(t *testing.T) {
 
 	ctx := context.Background()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	admin := createTestUser(t, db, true)
 	user := createTestUser(t, db, false)
@@ -136,7 +136,7 @@ func TestUserPermissionsListing(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := createTestUser(t, db, false).ID
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -710,7 +710,7 @@ func TestRepositories_Integration(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	schema := mustParseGraphQLSchema(t, db)
@@ -1125,17 +1125,17 @@ func runRepositoriesQuery(t *testing.T, ctx context.Context, schema *graphql.Sch
 	}
 
 	query := fmt.Sprintf(`
-	{ 
-		repositories(%s) { 
-			nodes { 
-				name 
-			} 
-			totalCount 
-			pageInfo { 
-				hasNextPage 
-				hasPreviousPage 
-				startCursor 
-				endCursor 
+	{
+		repositories(%s) {
+			nodes {
+				name
+			}
+			totalCount
+			pageInfo {
+				hasNextPage
+				hasPreviousPage
+				startCursor
+				endCursor
 			}
 		}
 	}`, want.args)

--- a/cmd/frontend/graphqlbackend/repository_metadata_test.go
+++ b/cmd/frontend/graphqlbackend/repository_metadata_test.go
@@ -27,7 +27,7 @@ func TestRepositoryMetadata(t *testing.T) {
 	ctx := context.Background()
 
 	logger := logtest.Scoped(t)
-	db := dbmocks.NewMockDBFrom(database.NewDB(logger, dbtest.NewDB(logger, t)))
+	db := dbmocks.NewMockDBFrom(database.NewDB(logger, dbtest.NewDB(t)))
 
 	users := dbmocks.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)

--- a/cmd/frontend/graphqlbackend/role_test.go
+++ b/cmd/frontend/graphqlbackend/role_test.go
@@ -25,7 +25,7 @@ func TestRoleResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := createTestUser(t, db, false).ID
 	userCtx := actor.WithActor(ctx, actor.FromUser(userID))

--- a/cmd/frontend/graphqlbackend/roles_test.go
+++ b/cmd/frontend/graphqlbackend/roles_test.go
@@ -24,7 +24,7 @@ func TestRoleConnectionResolver(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := createTestUser(t, db, false).ID
 	userCtx := actor.WithActor(ctx, actor.FromUser(userID))
@@ -132,7 +132,7 @@ func TestUserRoleListing(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := createTestUser(t, db, false).ID
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))

--- a/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
+++ b/cmd/frontend/graphqlbackend/site_config_change_connection_test.go
@@ -30,7 +30,7 @@ func toStringPtr(n int) *string {
 
 func setupSiteConfigStubs(t *testing.T) *siteConfigStubs {
 	logger := log.NoOp()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	usersToCreate := []database.NewUser{

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -162,7 +162,7 @@ func TestUsers_Pagination_Integration(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	schema := mustParseGraphQLSchema(t, db)
@@ -345,7 +345,7 @@ func TestUsers_InactiveSince(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	schema := mustParseGraphQLSchema(t, db)

--- a/cmd/frontend/internal/app/one_click_export_test.go
+++ b/cmd/frontend/internal/app/one_click_export_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestOneClickExportHandler(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	t.Run("non-admins cannot download the archive", func(t *testing.T) {
 		req, _ := http.NewRequest("POST", "", nil)

--- a/cmd/frontend/internal/app/usage_stats_test.go
+++ b/cmd/frontend/internal/app/usage_stats_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestUsageStatsArchiveHandler(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	t.Run("non-admins can't download archive", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "", nil)

--- a/cmd/frontend/internal/auth/azureoauth/provider_test.go
+++ b/cmd/frontend/internal/auth/azureoauth/provider_test.go
@@ -33,7 +33,7 @@ func newUnifiedConfig(s schema.SiteConfiguration) conf.Unified {
 
 func TestParseConfig(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	testCases := []struct {
 		name          string

--- a/cmd/frontend/internal/auth/bitbucketcloudoauth/config_test.go
+++ b/cmd/frontend/internal/auth/bitbucketcloudoauth/config_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestParseConfig(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	type args struct {
 		cfg *conf.Unified

--- a/cmd/frontend/internal/auth/githuboauth/config_test.go
+++ b/cmd/frontend/internal/auth/githuboauth/config_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestParseConfig(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	spew.Config.DisablePointerAddresses = true
 	spew.Config.SortKeys = true

--- a/cmd/frontend/internal/auth/githuboauth/middleware_test.go
+++ b/cmd/frontend/internal/auth/githuboauth/middleware_test.go
@@ -33,7 +33,7 @@ func TestMiddleware(t *testing.T) {
 	cleanup := session.ResetMockSessionStore(t)
 	defer cleanup()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	const mockUserID = 123
 

--- a/cmd/frontend/internal/auth/gitlaboauth/config_test.go
+++ b/cmd/frontend/internal/auth/gitlaboauth/config_test.go
@@ -25,7 +25,7 @@ func TestParseConfig(t *testing.T) {
 	spew.Config.SortKeys = true
 	spew.Config.SpewKeys = true
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	type args struct {
 		cfg *conf.Unified

--- a/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -36,7 +36,7 @@ func TestMiddleware(t *testing.T) {
 
 	const mockUserID = 123
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte("got through"))

--- a/cmd/frontend/internal/auth/httpheader/middleware_test.go
+++ b/cmd/frontend/internal/auth/httpheader/middleware_test.go
@@ -26,7 +26,7 @@ func TestMiddleware(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	handler := middleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		actor := sgactor.FromContext(r.Context())
@@ -197,7 +197,7 @@ func TestMiddleware_stripPrefix(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	handler := middleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		actor := sgactor.FromContext(r.Context())

--- a/cmd/frontend/internal/auth/sourcegraphoperator/associate_test.go
+++ b/cmd/frontend/internal/auth/sourcegraphoperator/associate_test.go
@@ -127,7 +127,7 @@ func TestAddSourcegraphOperatorExternalAccount(t *testing.T) {
 				t.Cleanup(func() { providers.MockProviders = nil })
 
 				logger := logtest.NoOp(t)
-				db := database.NewDB(logger, dbtest.NewDB(logger, t))
+				db := database.NewDB(logger, dbtest.NewDB(t))
 
 				// We ensure the GlobalState is initialized so that the first user isn't
 				// a site administrator.
@@ -182,7 +182,7 @@ func TestAddSourcegraphOperatorExternalAccount(t *testing.T) {
 				t.Cleanup(func() { providers.MockProviders = nil })
 
 				logger := logtest.NoOp(t)
-				db := database.NewDB(logger, dbtest.NewDB(logger, t))
+				db := database.NewDB(logger, dbtest.NewDB(t))
 
 				// We ensure the GlobalState is initialized so that the first user isn't
 				// a site administrator.

--- a/cmd/frontend/internal/authz/webhooks/github_test.go
+++ b/cmd/frontend/internal/authz/webhooks/github_test.go
@@ -57,7 +57,7 @@ func TestGitHubWebhooks(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	whStore := db.Webhooks(keyring.Default().WebhookKey)
 	esStore := db.ExternalServices()
 

--- a/cmd/frontend/internal/batches/httpapi/file_handler_test.go
+++ b/cmd/frontend/internal/batches/httpapi/file_handler_test.go
@@ -39,7 +39,7 @@ func TestFileHandler_ServeHTTP(t *testing.T) {
 	operations := httpapi.NewOperations(&observation.TestContext)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	creatorID := bt.CreateTestUser(t, db, false).ID
 	adminID := bt.CreateTestUser(t, db, true).ID

--- a/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_change_connection_test.go
@@ -29,7 +29,7 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 	}
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 
@@ -182,7 +182,7 @@ func TestBatchChangesListing(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, false).ID
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))

--- a/cmd/frontend/internal/batches/resolvers/batch_change_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_change_test.go
@@ -31,7 +31,7 @@ func TestBatchChangeResolver(t *testing.T) {
 	}
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	orgName := "test-batch-change-resolver-org"
@@ -148,7 +148,7 @@ func TestBatchChangeResolver_BatchSpecs(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, false).ID
 	userCtx := actor.WithActor(ctx, actor.FromUser(userID))

--- a/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_spec_test.go
@@ -40,7 +40,7 @@ func TestBatchSpecResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bstore := store.New(db, &observation.TestContext, nil)
 	repoStore := database.ReposWith(logger, bstore)
@@ -266,7 +266,7 @@ func TestBatchSpecResolver_BatchSpecCreatedFromRaw(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	now := timeutil.Now().Truncate(time.Second)
 	minAgo := func(min int) time.Time { return now.Add(time.Duration(-min) * time.Minute) }
@@ -506,7 +506,7 @@ func TestBatchSpecResolver_Files(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	resolver := batchSpecResolver{

--- a/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_file_connection_test.go
@@ -27,7 +27,7 @@ func TestBatchSpecWorkspaceFileConnectionResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bstore := store.New(db, &observation.TestContext, nil)
 	specID, err := createBatchSpec(t, db, ctx, bstore)

--- a/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
+++ b/cmd/frontend/internal/batches/resolvers/batch_spec_workspace_test.go
@@ -30,7 +30,7 @@ func TestBatchSpecWorkspaceResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bstore := store.New(db, &observation.TestContext, nil)
 	repo, _ := bt.CreateTestRepo(t, ctx, db)

--- a/cmd/frontend/internal/batches/resolvers/bulk_operation_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/bulk_operation_connection_test.go
@@ -28,7 +28,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	now := timeutil.Now()

--- a/cmd/frontend/internal/batches/resolvers/bulk_operation_test.go
+++ b/cmd/frontend/internal/batches/resolvers/bulk_operation_test.go
@@ -29,7 +29,7 @@ func TestBulkOperationResolver(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, false).ID
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -35,7 +35,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 	}
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, false).ID
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -35,7 +35,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 	}
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, false).ID
 
@@ -266,7 +266,7 @@ func TestChangesetApplyPreviewResolverWithPublicationStates(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, false).ID
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_connection_test.go
@@ -28,7 +28,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, false).ID
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_counts_test.go
@@ -77,7 +77,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	rcache.SetupForTest(t)
 	ratelimit.SetupForTest(t)
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_event_connection_test.go
@@ -30,7 +30,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_spec_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_spec_connection_test.go
@@ -28,7 +28,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, false).ID
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_spec_test.go
@@ -31,7 +31,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, false).ID
 

--- a/cmd/frontend/internal/batches/resolvers/changeset_test.go
+++ b/cmd/frontend/internal/batches/resolvers/changeset_test.go
@@ -34,7 +34,7 @@ func TestChangesetResolver(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 

--- a/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
+++ b/cmd/frontend/internal/batches/resolvers/code_host_connection_test.go
@@ -29,7 +29,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	pruneUserCredentials(t, db, nil)
 

--- a/cmd/frontend/internal/batches/resolvers/permissions_test.go
+++ b/cmd/frontend/internal/batches/resolvers/permissions_test.go
@@ -46,7 +46,7 @@ func TestPermissionLevels(t *testing.T) {
 	bt.MockRSAKeygen(t)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	key := et.TestKey{}
 
 	bstore := store.New(db, &observation.TestContext, key)
@@ -1359,7 +1359,7 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bstore := store.New(db, &observation.TestContext, nil)
 	gitserverClient := gitserver.NewMockClient()

--- a/cmd/frontend/internal/batches/resolvers/resolver_test.go
+++ b/cmd/frontend/internal/batches/resolvers/resolver_test.go
@@ -51,7 +51,7 @@ func TestNullIDResilience(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	sr := New(db, store.New(db, &observation.TestContext, nil), gitserver.NewMockClient(), logger)
 
 	s, err := newSchema(db, sr)
@@ -139,7 +139,7 @@ func TestCreateBatchSpec(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	user := bt.CreateTestUser(t, db, true)
 	userID := user.ID
@@ -343,7 +343,7 @@ func TestCreateBatchSpecFromRaw(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	user := bt.CreateTestUser(t, db, true)
 	userID := user.ID
@@ -479,7 +479,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
@@ -573,7 +573,7 @@ func TestCreateChangesetSpecs(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
@@ -679,7 +679,7 @@ func TestApplyBatchChange(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	// Ensure our site configuration doesn't have rollout windows so we get a
 	// consistent initial state.
@@ -864,7 +864,7 @@ func TestCreateEmptyBatchChange(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bstore := store.New(db, &observation.TestContext, nil)
 
@@ -972,7 +972,7 @@ func TestUpsertEmptyBatchChange(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bstore := store.New(db, &observation.TestContext, nil)
 
@@ -1061,7 +1061,7 @@ func TestCreateBatchChange(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	// We give this user the `BATCH_CHANGES#WRITE` permission so they're authorized
@@ -1158,7 +1158,7 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	// Ensure our site configuration doesn't have rollout windows so we get a
 	// consistent initial state.
@@ -1373,7 +1373,7 @@ func TestApplyBatchChangeWithLicenseFail(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
@@ -1518,7 +1518,7 @@ func TestMoveBatchChange(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	user := bt.CreateTestUser(t, db, true)
 	userID := user.ID
@@ -1828,7 +1828,7 @@ func TestCreateBatchChangesCredential(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	pruneUserCredentials(t, db, nil)
 
@@ -1958,7 +1958,7 @@ func TestDeleteBatchChangesCredential(t *testing.T) {
 	bt.MockRSAKeygen(t)
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	pruneUserCredentials(t, db, nil)
 
@@ -2049,7 +2049,7 @@ func TestCreateChangesetComments(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
@@ -2169,7 +2169,7 @@ func TestReenqueueChangesets(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
@@ -2298,7 +2298,7 @@ func TestMergeChangesets(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
@@ -2428,7 +2428,7 @@ func TestCloseChangesets(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
@@ -2558,7 +2558,7 @@ func TestPublishChangesets(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bstore := store.New(db, &observation.TestContext, nil)
 
 	userID := bt.CreateTestUser(t, db, true).ID
@@ -2703,7 +2703,7 @@ func TestCheckBatchChangesCredential(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	pruneUserCredentials(t, db, nil)
 
@@ -2800,7 +2800,7 @@ func TestMaxUnlicensedChangesets(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	userID := bt.CreateTestUser(t, db, true).ID
 
 	var response struct{ MaxUnlicensedChangesets int32 }
@@ -2825,7 +2825,7 @@ query {
 func TestListBatchSpecs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	user := bt.CreateTestUser(t, db, true)
 	userID := user.ID

--- a/cmd/frontend/internal/batches/webhooks/webhooks_integration_test.go
+++ b/cmd/frontend/internal/batches/webhooks/webhooks_integration_test.go
@@ -17,7 +17,7 @@ func TestWebhooksIntegration(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 
 	user := bt.CreateTestUser(t, db, false)

--- a/cmd/frontend/internal/bg/update_permissions_test.go
+++ b/cmd/frontend/internal/bg/update_permissions_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestUpdatePermissions(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	allPerms := []*types.Permission{

--- a/cmd/frontend/internal/cli/config_test.go
+++ b/cmd/frontend/internal/cli/config_test.go
@@ -65,7 +65,7 @@ func TestWriteSiteConfig(t *testing.T) {
 
 func TestOverrideSiteConfig(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	conf := db.Conf()
 	ctx := context.Background()
 

--- a/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/codemonitors/resolvers/resolvers_test.go
@@ -30,7 +30,7 @@ import (
 func TestCreateCodeMonitor(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	r := newTestResolver(t, db)
 
 	settings.MockCurrentUserFinal = &schema.Settings{}
@@ -106,7 +106,7 @@ func TestCreateCodeMonitor(t *testing.T) {
 func TestListCodeMonitors(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	r := newTestResolver(t, db)
 
 	user := insertTestUser(t, db, "cm-user1", true)
@@ -152,7 +152,7 @@ func TestListCodeMonitors(t *testing.T) {
 
 func TestIsAllowedToEdit(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	// Setup users and org
 	owner := insertTestUser(t, db, "cm-user1", false)
@@ -213,7 +213,7 @@ func TestIsAllowedToEdit(t *testing.T) {
 
 func TestIsAllowedToCreate(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	// Setup users and org
 	member := insertTestUser(t, db, "cm-user1", false)
@@ -283,7 +283,7 @@ func TestQueryMonitor(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	r := newTestResolver(t, db)
 
 	// Create 2 test users.
@@ -662,7 +662,7 @@ func TestEditCodeMonitor(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	r := newTestResolver(t, db)
 
 	// Create 2 test users.
@@ -1274,7 +1274,7 @@ func TestTriggerTestEmailAction(t *testing.T) {
 	}
 
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	r := newTestResolver(t, db)
 
 	namespaceID := relay.MarshalID("User", actor.FromContext(ctx).UID)

--- a/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/cmd/frontend/internal/context/resolvers/context_test.go
@@ -33,7 +33,7 @@ func TestContextResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repo1 := types.Repo{Name: "repo1"}
 	repo2 := types.Repo{Name: "repo2"}
 	// Create populates the IDs in the passed in types.Repo

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user_test.go
@@ -48,7 +48,7 @@ func TestCodyGatewayDotcomUserResolver(t *testing.T) {
 	}()
 
 	ctx := context.Background()
-	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(logtest.Scoped(t), t))
+	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(t))
 
 	// User with default rate limits
 	adminUser, err := db.Users().Create(ctx, database.NewUser{Username: "admin", EmailIsVerified: true, Email: "admin@test.com"})
@@ -158,7 +158,7 @@ func TestCodyGatewayDotcomUserResolver(t *testing.T) {
 
 func TestCodyGatewayDotcomUserResolverUserNotFound(t *testing.T) {
 	ctx := context.Background()
-	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(logtest.Scoped(t), t))
+	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(t))
 
 	// admin user to make request
 	adminUser, err := db.Users().Create(ctx, database.NewUser{Username: "admin", EmailIsVerified: true, Email: "admin@test.com"})
@@ -176,7 +176,7 @@ func TestCodyGatewayDotcomUserResolverUserNotFound(t *testing.T) {
 
 func TestCodyGatewayDotcomUserResolverRequestAccess(t *testing.T) {
 	ctx := context.Background()
-	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(logtest.Scoped(t), t))
+	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(t))
 
 	// Admin
 	adminUser, err := db.Users().Create(ctx, database.NewUser{Username: "admin", EmailIsVerified: true, Email: "admin@test.com"})

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_graphql_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_graphql_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestCodeGatewayAccessResolverRateLimit(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	u, err := db.Users().Create(ctx, database.NewUser{Username: "u"})

--- a/cmd/frontend/internal/dotcom/productsubscription/license_anomaly_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_anomaly_test.go
@@ -120,7 +120,7 @@ func TestCheckAnomalies(t *testing.T) {
 	})
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	eventJSON, err := json.Marshal(struct {

--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestProductLicenses_Create(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subscriptionStore := dbSubscriptions{db: db}
@@ -103,7 +103,7 @@ func TestProductLicenses_Create(t *testing.T) {
 
 func TestGetByToken(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := dbLicenses{db: db}
@@ -154,7 +154,7 @@ func TestAssignSiteID(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := dbLicenses{db: db}
@@ -200,7 +200,7 @@ func TestProductLicenses_List(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	subscriptionStore := dbSubscriptions{db: db}
 	store := dbLicenses{db: db}
@@ -350,7 +350,7 @@ func TestRevokeLicense(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subscriptionStore := dbSubscriptions{db: db}

--- a/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestProductSubscriptions_Create(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subscriptions := dbSubscriptions{db: db}
@@ -66,7 +66,7 @@ func TestProductSubscriptions_Create(t *testing.T) {
 
 func TestProductSubscriptions_List(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	u1, err := db.Users().Create(ctx, database.NewUser{Username: "u1"})
@@ -107,7 +107,7 @@ func TestProductSubscriptions_List(t *testing.T) {
 
 func TestProductSubscriptions_Update(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	u, err := db.Users().Create(ctx, database.NewUser{Username: "u"})

--- a/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql_test.go
@@ -39,7 +39,7 @@ func TestProductSubscription_Account(t *testing.T) {
 // better cover more scenarios.
 func TestProductSubscriptionActiveLicense(t *testing.T) {
 	ctx := context.Background()
-	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(logtest.Scoped(t), t))
+	db := database.NewDB(logtest.Scoped(t), dbtest.NewDB(t))
 	subscriptionsDB := dbSubscriptions{db: db}
 	licensesDB := dbLicenses{db: db}
 

--- a/cmd/frontend/internal/dotcom/productsubscription/tokens_db_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/tokens_db_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestLookupProductSubscriptionIDByAccessToken(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	u, err := db.Users().Create(ctx, database.NewUser{Username: "u"})

--- a/cmd/frontend/internal/dotcom/productsubscription/tokens_graphql_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/tokens_graphql_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestProductSubscriptionByAccessToken(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	r := ProductSubscriptionLicensingResolver{Logger: logger, DB: db}
 

--- a/cmd/frontend/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/cmd/frontend/internal/insights/resolvers/insight_series_resolver_test.go
@@ -35,7 +35,7 @@ func TestResolver_InsightSeries(t *testing.T) {
 		logger := logtest.Scoped(t)
 		clock := func() time.Time { return now }
 		insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-		postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+		postgres := database.NewDB(logger, dbtest.NewDB(t))
 		resolver := newWithClock(insightsDB, postgres, clock)
 		insightStore := store.NewInsightStore(insightsDB)
 
@@ -234,7 +234,7 @@ func TestInsightStatusResolver_IncompleteDatapoints(t *testing.T) {
 	now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond)
 	logger := logtest.Scoped(t)
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	insightStore := store.NewInsightStore(insightsDB)
 	tss := store.New(insightsDB, store.NewInsightPermissionStore(postgres))
 
@@ -291,7 +291,7 @@ func Test_NumSamplesFiltering(t *testing.T) {
 	// now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond)
 	logger := logtest.Scoped(t)
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	insightStore := store.NewInsightStore(insightsDB)
 	tss := store.New(insightsDB, store.NewInsightPermissionStore(postgres))
 

--- a/cmd/frontend/internal/insights/resolvers/insight_view_resolvers_test.go
+++ b/cmd/frontend/internal/insights/resolvers/insight_view_resolvers_test.go
@@ -36,7 +36,7 @@ func TestFrozenInsightDataSeriesResolver(t *testing.T) {
 	})
 	t.Run("insight_is_not_frozen_returns_real_resolvers", func(t *testing.T) {
 		insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-		postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+		postgres := database.NewDB(logger, dbtest.NewDB(t))
 		permStore := store.NewInsightPermissionStore(postgres)
 		clock := timeutil.Now
 		timeseriesStore := store.NewWithClock(insightsDB, permStore, clock)
@@ -101,7 +101,7 @@ func TestInsightViewDashboardConnections(t *testing.T) {
 	logger := logtest.Scoped(t)
 
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgresDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgresDB := database.NewDB(logger, dbtest.NewDB(t))
 	base := baseInsightResolver{
 		insightStore:   store.NewInsightStore(insightsDB),
 		dashboardStore: store.NewDashboardStore(insightsDB),

--- a/cmd/frontend/internal/insights/resolvers/resolver_test.go
+++ b/cmd/frontend/internal/insights/resolvers/resolver_test.go
@@ -23,7 +23,7 @@ func TestResolver_Insights(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	clock := func() time.Time { return now }
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	resolver := newWithClock(insightsDB, postgres, clock)
 
 	insightsConnection, err := resolver.InsightViews(ctx, nil)

--- a/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/notebooks/resolvers/resolvers_test.go
@@ -174,7 +174,7 @@ func compareNotebookAPIResponses(t *testing.T, wantNotebookResponse notebooksapi
 func TestSingleNotebookCRUD(t *testing.T) {
 	logger := logtest.Scoped(t)
 	internalCtx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	u := db.Users()
 	o := db.Orgs()
 	om := db.OrgMembers()
@@ -543,7 +543,7 @@ func createNotebookStars(t *testing.T, db database.DB, notebookID int64, userIDs
 
 func TestListNotebooks(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	o := db.Orgs()
@@ -704,7 +704,7 @@ func TestListNotebooks(t *testing.T) {
 
 func TestGetNotebookWithSoftDeletedUserColumns(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	n := notebooks.Notebooks(db)

--- a/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
+++ b/cmd/frontend/internal/notebooks/resolvers/stars_resolvers_test.go
@@ -63,7 +63,7 @@ query NotebookStars($id: ID!, $first: Int!, $after: String) {
 
 func TestCreateAndDeleteNotebookStars(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 
@@ -139,7 +139,7 @@ func createAPINotebookStars(t *testing.T, schema *graphql.Schema, notebookID int
 
 func TestListNotebookStars(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 

--- a/cmd/frontend/internal/own/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/own/resolvers/resolvers_test.go
@@ -1248,7 +1248,7 @@ func TestCommitOwnershipSignals(t *testing.T) {
 
 func Test_SignalConfigurations(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	git := fakeGitserver{}
 	own := fakeOwnService{}
 
@@ -1698,7 +1698,7 @@ func TestOwnership_WithAssignedOwnersAndTeams(t *testing.T) {
 
 func TestAssignOwner(t *testing.T) {
 	logger := logtest.Scoped(t)
-	testDB := dbtest.NewDB(logger, t)
+	testDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, testDB)
 	git := fakeGitserver{}
 	own := fakeOwnService{}
@@ -1825,7 +1825,7 @@ func TestAssignOwner(t *testing.T) {
 
 func TestDeleteAssignedOwner(t *testing.T) {
 	logger := logtest.Scoped(t)
-	testDB := dbtest.NewDB(logger, t)
+	testDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, testDB)
 	git := fakeGitserver{}
 	own := fakeOwnService{}
@@ -1962,7 +1962,7 @@ func TestDeleteAssignedOwner(t *testing.T) {
 
 func TestAssignTeam(t *testing.T) {
 	logger := logtest.Scoped(t)
-	testDB := dbtest.NewDB(logger, t)
+	testDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, testDB)
 	git := fakeGitserver{}
 	own := fakeOwnService{}
@@ -2091,7 +2091,7 @@ func TestAssignTeam(t *testing.T) {
 
 func TestDeleteAssignedTeam(t *testing.T) {
 	logger := logtest.Scoped(t)
-	testDB := dbtest.NewDB(logger, t)
+	testDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, testDB)
 	git := fakeGitserver{}
 	own := fakeOwnService{}

--- a/cmd/frontend/internal/rbac/resolvers/resolver_test.go
+++ b/cmd/frontend/internal/rbac/resolvers/resolver_test.go
@@ -26,7 +26,7 @@ func TestDeleteRole(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := createTestUser(t, db, false).ID
 	actorCtx := actor.WithActor(ctx, actor.FromMockUser(userID))
@@ -93,7 +93,7 @@ func TestCreateRole(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := createTestUser(t, db, false).ID
 	actorCtx := actor.WithActor(ctx, actor.FromMockUser(userID))
@@ -199,7 +199,7 @@ func TestSetPermissions(t *testing.T) {
 
 	ctx := context.Background()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	admin := createTestUser(t, db, true)
 	user := createTestUser(t, db, false)
@@ -315,7 +315,7 @@ func TestSetRoles(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	uID := createTestUser(t, db, false).ID
 	userID := gql.MarshalUserID(uID)

--- a/cmd/frontend/internal/repos/webhooks/handlers_test.go
+++ b/cmd/frontend/internal/repos/webhooks/handlers_test.go
@@ -56,7 +56,7 @@ func TestGitHubHandler(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := repos.NewStore(logger, db)
 	repoStore := store.RepoStore()
 	esStore := store.ExternalServiceStore()

--- a/cmd/frontend/internal/search/httpapi/export_test.go
+++ b/cmd/frontend/internal/search/httpapi/export_test.go
@@ -40,7 +40,7 @@ func TestServeSearchJobDownload(t *testing.T) {
 			return iterator.From([]string{}), nil
 		})
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bs := basestore.NewWithHandle(db.Handle())
 	s := store.New(db, observation.TestContextTB(t))
 	svc := service.New(observationCtx, s, mockUploadStore, service.NewSearcherFake())

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -114,7 +114,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	secret := "secret"

--- a/cmd/frontend/webhooks/webhooks_test.go
+++ b/cmd/frontend/webhooks/webhooks_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestWebhooksHandler(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	u, err := db.Users().Create(context.Background(), database.NewUser{
 		Email:           "test@user.com",
 		Username:        "testuser",

--- a/cmd/gitserver/internal/cleanup_test.go
+++ b/cmd/gitserver/internal/cleanup_test.go
@@ -69,7 +69,7 @@ func TestCleanup_computeStats(t *testing.T) {
 	wantGitDirBytes := gitserverfs.DirSize(root)
 
 	logger, capturedLogs := logtest.Captured(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	if _, err := db.ExecContext(context.Background(), `
 INSERT INTO repo(id, name, private) VALUES (1, 'a', false), (2, 'b/d', false), (3, 'c', true);
@@ -385,7 +385,7 @@ func TestCleanupExpired(t *testing.T) {
 			return vcssyncer.NewGitRepoSyncer(wrexec.NewNoOpRecordingCommandFactory()), nil
 		},
 		Hostname:                "test-gitserver",
-		DB:                      database.NewDB(logger, dbtest.NewDB(logger, t)),
+		DB:                      database.NewDB(logger, dbtest.NewDB(t)),
 		RecordingCommandFactory: wrexec.NewNoOpRecordingCommandFactory(),
 		Locker:                  NewRepositoryLocker(),
 		RPSLimiter:              ratelimit.NewInstrumentedLimiter("test", rate.NewLimiter(100, 10)),

--- a/cmd/gitserver/internal/gitserverfs/fs_test.go
+++ b/cmd/gitserver/internal/gitserverfs/fs_test.go
@@ -51,7 +51,7 @@ func TestRemoveRepoDirectory(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	idMapping := make(map[api.RepoName]api.RepoID)
 
@@ -156,7 +156,7 @@ func TestRemoveRepoDirectory_Empty(t *testing.T) {
 func TestRemoveRepoDirectory_UpdateCloneStatus(t *testing.T) {
 	logger := logtest.Scoped(t)
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -337,7 +337,7 @@ func TestCloneRepo(t *testing.T) {
 	reposDir := t.TempDir()
 
 	repoName := api.RepoName("example.com/foo/bar")
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	if _, err := db.FeatureFlags().CreateBool(ctx, "clone-progress-logging", true); err != nil {
 		t.Fatal(err)
 	}
@@ -447,7 +447,7 @@ func TestCloneRepoRecordsFailures(t *testing.T) {
 	logger := logtest.Scoped(t)
 	remote := t.TempDir()
 	repoName := api.RepoName("example.com/foo/bar")
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	dbRepo := &types.Repo{
 		Name:        repoName,
@@ -544,7 +544,7 @@ func testHandleRepoDelete(t *testing.T, deletedInDB bool) {
 
 	remote := t.TempDir()
 	repoName := api.RepoName("example.com/foo/bar")
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	dbRepo := &types.Repo{
 		Name:        repoName,
@@ -658,7 +658,7 @@ func TestHandleRepoUpdate(t *testing.T) {
 
 	remote := t.TempDir()
 	repoName := api.RepoName("example.com/foo/bar")
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	dbRepo := &types.Repo{
 		Name:        repoName,
@@ -993,7 +993,7 @@ func TestSyncRepoState(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	remoteDir := t.TempDir()
 
 	cmd := func(name string, arg ...string) {
@@ -1324,7 +1324,7 @@ func TestLogIfCorrupt(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	remoteDir := t.TempDir()
 
 	reposDir := t.TempDir()

--- a/cmd/gitserver/internal/vcssyncer/jvm_packages_test.go
+++ b/cmd/gitserver/internal/vcssyncer/jvm_packages_test.go
@@ -201,7 +201,7 @@ func TestJVMCloneCommand(t *testing.T) {
 
 	coursier.CoursierBinary = coursierScript(t, dir)
 
-	depsSvc := dependencies.TestService(database.NewDB(logger, dbtest.NewDB(logger, t)))
+	depsSvc := dependencies.TestService(database.NewDB(logger, dbtest.NewDB(t)))
 	cacheDir := filepath.Join(dir, "cache")
 	s := NewJVMPackagesSyncer(&schema.JVMPackagesConnection{Maven: schema.Maven{Dependencies: []string{}}}, depsSvc, cacheDir).(*vcsPackagesSyncer)
 	bareGitDirectory := path.Join(dir, "git")

--- a/cmd/gitserver/internal/vcssyncer/npm_packages_test.go
+++ b/cmd/gitserver/internal/vcssyncer/npm_packages_test.go
@@ -104,7 +104,7 @@ func TestNpmCloneCommand(t *testing.T) {
 		},
 	}
 
-	depsSvc := dependencies.TestService(database.NewDB(logger, dbtest.NewDB(logger, t)))
+	depsSvc := dependencies.TestService(database.NewDB(logger, dbtest.NewDB(t)))
 
 	s := NewNpmPackagesSyncer(
 		schema.NpmPackagesConnection{Dependencies: []string{}},

--- a/cmd/repo-updater/internal/authz/integration_test.go
+++ b/cmd/repo-updater/internal/authz/integration_test.go
@@ -137,7 +137,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 		Username:        "sourcegraph-vcr-bob",
 		EmailIsVerified: true,
 	}
-	testDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	testDB := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	reposStore := repos.NewStore(logtest.Scoped(t), testDB)
@@ -309,7 +309,7 @@ func TestIntegration_GitHubInternalRepositories(t *testing.T) {
 
 	cli := newTestRecorderClient(t, uri.String(), apiURI, token)
 
-	testDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	testDB := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	reposStore := repos.NewStore(logtest.Scoped(t), testDB)
@@ -452,7 +452,7 @@ func TestIntegration_GitLabPermissions(t *testing.T) {
 		doer, err := cf.Doer()
 		require.NoError(t, err)
 
-		testDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+		testDB := database.NewDB(logger, dbtest.NewDB(t))
 
 		ctx := actor.WithInternalActor(context.Background())
 

--- a/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
+++ b/cmd/repo-updater/internal/authz/perms_syncer_worker_test.go
@@ -28,7 +28,7 @@ func TestPermsSyncerWorker_Handle(t *testing.T) {
 	ctx := context.Background()
 	dummySyncer := &dummyPermsSyncer{}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	syncJobsStore := db.PermissionSyncJobs()
 
 	t.Run("user sync request", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestPermsSyncerWorker_RepoSyncJobs(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating users and repos.
@@ -219,7 +219,7 @@ func TestPermsSyncerWorker_UserSyncJobs(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating users and repos.
@@ -378,7 +378,7 @@ loop:
 
 func TestPermsSyncerWorker_Store_Dequeue_Order(t *testing.T) {
 	logger := logtest.Scoped(t)
-	dbt := dbtest.NewDB(logger, t)
+	dbt := dbtest.NewDB(t)
 	db := database.NewDB(logger, dbt)
 
 	if _, err := dbt.ExecContext(context.Background(), `DELETE FROM permission_sync_jobs;`); err != nil {

--- a/cmd/repo-updater/internal/repoupdater/server_test.go
+++ b/cmd/repo-updater/internal/repoupdater/server_test.go
@@ -219,7 +219,7 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 		ctx := context.Background()
 
 		t.Run(tc.name, func(t *testing.T) {
-			sqlDB := dbtest.NewDB(logger, t)
+			sqlDB := dbtest.NewDB(t)
 			store := tc.init(database.NewDB(logger, sqlDB))
 
 			s := &Server{Logger: logger, Store: store, Scheduler: &fakeScheduler{}}
@@ -248,7 +248,7 @@ func TestServer_EnqueueRepoUpdate(t *testing.T) {
 
 func TestServer_RepoLookup(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	store := repos.NewStore(logger, database.NewDB(logger, db))
 	ctx := context.Background()
 	clock := timeutil.NewFakeClock(time.Now(), 0)

--- a/cmd/worker/internal/auth/sourcegraph_operator_cleaner_test.go
+++ b/cmd/worker/internal/auth/sourcegraph_operator_cleaner_test.go
@@ -36,7 +36,7 @@ func TestSourcegraphOperatorCleanHandler(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.NoOp(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	handler := sourcegraphOperatorCleanHandler{
 		db:                db,
 		lifecycleDuration: 60 * time.Minute,

--- a/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
+++ b/cmd/worker/internal/batches/workers/batch_spec_workspace_creator_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestBatchSpecWorkspaceCreatorProcess(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	repos, _ := bt.CreateTestRepos(t, context.Background(), db, 4)
 
@@ -175,7 +175,7 @@ func TestBatchSpecWorkspaceCreatorProcess(t *testing.T) {
 
 func TestBatchSpecWorkspaceCreatorProcess_Caching(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 
@@ -801,7 +801,7 @@ changesetTemplate:
 
 func TestBatchSpecWorkspaceCreatorProcess_Importing(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	repos, _ := bt.CreateTestRepos(t, context.Background(), db, 1)
 
@@ -859,7 +859,7 @@ importChangesets:
 
 func TestBatchSpecWorkspaceCreatorProcess_NoDiff(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	repos, _ := bt.CreateTestRepos(t, context.Background(), db, 1)
 
@@ -918,7 +918,7 @@ importChangesets:
 func TestBatchSpecWorkspaceCreatorProcess_Secrets(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	user := bt.CreateTestUser(t, db, true)
 	userCtx := actor.WithActor(ctx, actor.FromUser(user.ID))

--- a/cmd/worker/internal/batches/workers/reconciler_worker_test.go
+++ b/cmd/worker/internal/batches/workers/reconciler_worker_test.go
@@ -28,7 +28,7 @@ func TestReconcilerWorkerView(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }

--- a/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -28,7 +28,7 @@ import (
 func TestStore(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	jobID, err := db.BitbucketProjectPermissions().Enqueue(ctx, "project1", 2, []types.UserPermission{
@@ -97,7 +97,7 @@ func TestSetPermissionsForUsers(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	// create 3 users
 	users := db.Users()
@@ -284,7 +284,7 @@ func TestHandleRestricted(t *testing.T) {
 
 	ctx := context.Background()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}
@@ -398,7 +398,7 @@ func TestHandleUnrestricted(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}

--- a/cmd/worker/internal/permissions/perms_syncer_cleaner_test.go
+++ b/cmd/worker/internal/permissions/perms_syncer_cleaner_test.go
@@ -22,7 +22,7 @@ func TestPermsSyncerWorkerCleaner(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	store := database.PermissionSyncJobsWith(logger, db)
 

--- a/cmd/worker/internal/permissions/perms_syncer_scheduler_test.go
+++ b/cmd/worker/internal/permissions/perms_syncer_scheduler_test.go
@@ -48,7 +48,7 @@ func TestPermsSyncerScheduler_scheduleJobs(t *testing.T) {
 	t.Run("schedule jobs", func(t *testing.T) {
 		t.Helper()
 
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 
 		store := database.PermissionSyncJobsWith(logger, db)
 		usersStore := database.UsersWith(logger, db)

--- a/cmd/worker/internal/ratelimit/handler_test.go
+++ b/cmd/worker/internal/ratelimit/handler_test.go
@@ -25,7 +25,7 @@ import (
 func TestHandler_Handle(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	prefix := "__test__" + t.Name()
 	redisHost := "127.0.0.1:6379"

--- a/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/cmd/worker/internal/search/exhaustive_search_test.go
@@ -44,7 +44,7 @@ func TestExhaustiveSearch(t *testing.T) {
 	logger := observationCtx.Logger
 
 	mockUploadStore, bucket := newMockUploadStore(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	s := store.New(db, observation.TestContextTB(t))
 	svc := service.New(observationCtx, s, mockUploadStore, service.NewSearcherFake())
 

--- a/cmd/worker/internal/telemetry/telemetry_job_test.go
+++ b/cmd/worker/internal/telemetry/telemetry_job_test.go
@@ -107,7 +107,7 @@ func TestHandlerEnabledDisabled(t *testing.T) {
 
 func TestHandlerLoadsEvents(t *testing.T) {
 	logger := logtest.Scoped(t)
-	dbHandle := dbtest.NewDB(logger, t)
+	dbHandle := dbtest.NewDB(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbHandle)
 
@@ -242,7 +242,7 @@ func TestHandlerLoadsEvents(t *testing.T) {
 
 func TestHandlerLoadsEventsWithBookmarkState(t *testing.T) {
 	logger := logtest.Scoped(t)
-	dbHandle := dbtest.NewDB(logger, t)
+	dbHandle := dbtest.NewDB(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbHandle)
 
@@ -352,7 +352,7 @@ func TestHandlerLoadsEventsWithBookmarkState(t *testing.T) {
 
 func TestHandlerLoadsEventsWithAllowlist(t *testing.T) {
 	logger := logtest.Scoped(t)
-	dbHandle := dbtest.NewDB(logger, t)
+	dbHandle := dbtest.NewDB(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbHandle)
 
@@ -451,7 +451,7 @@ func validConfiguration() schema.SiteConfiguration {
 
 func TestHandleInvalidConfig(t *testing.T) {
 	logger := logtest.Scoped(t)
-	dbHandle := dbtest.NewDB(logger, t)
+	dbHandle := dbtest.NewDB(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbHandle)
 	bookmarkStore := newBookmarkStore(db)
@@ -613,7 +613,7 @@ func Test_getBatchSize(t *testing.T) {
 
 func TestGetBookmark(t *testing.T) {
 	logger := logtest.Scoped(t)
-	dbHandle := dbtest.NewDB(logger, t)
+	dbHandle := dbtest.NewDB(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbHandle)
 	store := newBookmarkStore(db)
@@ -672,7 +672,7 @@ func TestGetBookmark(t *testing.T) {
 
 func TestUpdateBookmark(t *testing.T) {
 	logger := logtest.Scoped(t)
-	dbHandle := dbtest.NewDB(logger, t)
+	dbHandle := dbtest.NewDB(t)
 	ctx := context.Background()
 	db := database.NewDB(logger, dbHandle)
 	store := newBookmarkStore(db)

--- a/internal/adminanalytics/users_test.go
+++ b/internal/adminanalytics/users_test.go
@@ -67,7 +67,7 @@ func createEmployees(db database.DB) ([]*types.User, error) {
 func TestUserActivityLastMonth(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	now := bod(time.Now())
 
 	eventLogs := []EventLogRow{
@@ -165,7 +165,7 @@ func TestUserActivityLastMonth(t *testing.T) {
 func TestUserFrequencyLastMonth(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	now := bod(time.Now())
 
 	eventLogs := []EventLogRow{
@@ -255,7 +255,7 @@ func TestMonthlyActiveUsersLast3Month(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	now := bod(time.Now())
 
 	eventLogs := []EventLogRow{

--- a/internal/auth/accessrequest/handlers_test.go
+++ b/internal/auth/accessrequest/handlers_test.go
@@ -26,7 +26,7 @@ func TestRequestAccess(t *testing.T) {
 	}
 
 	logger := logtest.NoOp(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	handler := HandleRequestAccess(logger, db)
 
 	t.Run("accessRequest feature is disabled", func(t *testing.T) {

--- a/internal/batches/processor/bulk_processor_test.go
+++ b/internal/batches/processor/bulk_processor_test.go
@@ -61,7 +61,7 @@ func TestBulkProcessor(t *testing.T) {
 	t.Cleanup(func() { httpcli.InternalDoer = orig })
 
 	ctx := context.Background()
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	tx := dbtest.NewTx(t, sqlDB)
 	db := database.NewDB(logger, sqlDB)
 	bstore := store.New(database.NewDBWith(logger, basestore.NewWithHandle(basestore.NewHandleWithTx(tx, sql.TxOptions{}))), &observation.TestContext, nil)

--- a/internal/batches/reconciler/executor_test.go
+++ b/internal/batches/reconciler/executor_test.go
@@ -77,7 +77,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
@@ -876,7 +876,7 @@ func TestExecutor_ExecutePlan_PublishedChangesetDuplicateBranch(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bstore := store.New(db, &observation.TestContext, et.TestKey{})
 
@@ -919,7 +919,7 @@ func TestExecutor_ExecutePlan_PublishedChangesetDuplicateBranch(t *testing.T) {
 func TestExecutor_ExecutePlan_AvoidLoadingChangesetSource(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bstore := store.New(db, &observation.TestContext, et.TestKey{})
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 
@@ -997,7 +997,7 @@ func TestLoadChangesetSource(t *testing.T) {
 func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bstore := store.New(db, &observation.TestContext, et.TestKey{})
 

--- a/internal/batches/reconciler/reconciler_test.go
+++ b/internal/batches/reconciler/reconciler_test.go
@@ -29,7 +29,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 
 	ctx := actor.WithInternalActor(context.Background())
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	store := bstore.New(db, &observation.TestContext, nil)
 

--- a/internal/batches/service/service_apply_batch_change_test.go
+++ b/internal/batches/service/service_apply_batch_change_test.go
@@ -29,7 +29,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	admin := bt.CreateTestUser(t, db, true)
 	adminCtx := actor.WithActor(context.Background(), actor.FromUser(admin.ID))

--- a/internal/batches/service/service_test.go
+++ b/internal/batches/service/service_test.go
@@ -44,7 +44,7 @@ func TestServicePermissionLevels(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	s := store.New(db, &observation.TestContext, nil)
 	svc := New(s)
@@ -292,7 +292,7 @@ func TestService(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	admin := bt.CreateTestUser(t, db, true)
 	user := bt.CreateTestUser(t, db, false)

--- a/internal/batches/service/workspace_resolver_test.go
+++ b/internal/batches/service/workspace_resolver_test.go
@@ -58,7 +58,7 @@ func TestService_ResolveWorkspacesForBatchSpec(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	s := store.New(db, &observation.TestContext, nil)
 
 	u := bt.CreateTestUser(t, db, false)

--- a/internal/batches/store/author/author_test.go
+++ b/internal/batches/store/author/author_test.go
@@ -15,7 +15,7 @@ func TestGetChangesetAuthorForUser(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userStore := db.Users()
 

--- a/internal/batches/store/batch_spec_execution_cache_entry_test.go
+++ b/internal/batches/store/batch_spec_execution_cache_entry_test.go
@@ -149,7 +149,7 @@ func TestStore_CleanBatchSpecExecutionCacheEntries(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	c := &bt.TestClock{Time: timeutil.Now()}
 	s := NewWithClock(db, &observation.TestContext, nil, c.Now)
 	user := bt.CreateTestUser(t, db, true)

--- a/internal/batches/store/batch_spec_resolution_jobs_test.go
+++ b/internal/batches/store/batch_spec_resolution_jobs_test.go
@@ -158,7 +158,7 @@ func TestBatchSpecResolutionJobs_BatchSpecIDUnique(t *testing.T) {
 	c := &bt.TestClock{Time: timeutil.Now()}
 	logger := logtest.Scoped(t)
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	s := NewWithClock(db, &observation.TestContext, nil, c.Now)
 
 	user := bt.CreateTestUser(t, db, true)

--- a/internal/batches/store/batch_specs_test.go
+++ b/internal/batches/store/batch_specs_test.go
@@ -709,7 +709,7 @@ func TestStoreGetBatchSpecStats(t *testing.T) {
 	c := &bt.TestClock{Time: timeutil.Now()}
 	minAgo := func(m int) time.Time { return c.Now().Add(-time.Duration(m) * time.Minute) }
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	s := NewWithClock(db, &observation.TestContext, nil, c.Now)
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
@@ -884,7 +884,7 @@ func TestStore_ListBatchSpecRepoIDs(t *testing.T) {
 	ctx := context.Background()
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	s := New(db, &observation.TestContext, nil)
 
 	// Create two repos, one of which will be visible to everyone, and one which

--- a/internal/batches/store/changesets_test.go
+++ b/internal/batches/store/changesets_test.go
@@ -2371,7 +2371,7 @@ func TestCancelQueuedBatchChangeChangesets(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	s := New(db, &observation.TestContext, nil)
 
@@ -2514,7 +2514,7 @@ func TestEnqueueChangesetsToClose(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	s := New(db, &observation.TestContext, nil)
 
@@ -2645,7 +2645,7 @@ func TestEnqueueChangesetsToClose(t *testing.T) {
 func TestCleanDetachedChangesets(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	s := New(db, &observation.TestContext, nil)
 	rs := database.ReposWith(logger, s)

--- a/internal/batches/store/integration_test.go
+++ b/internal/batches/store/integration_test.go
@@ -3,8 +3,6 @@ package store
 import (
 	"testing"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
@@ -17,9 +15,7 @@ func TestIntegration(t *testing.T) {
 
 	t.Parallel()
 
-	logger := logtest.Scoped(t)
-
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 
 	t.Run("Store", func(t *testing.T) {
 		t.Run("BatchChanges", storeTest(db, nil, testStoreBatchChanges))

--- a/internal/batches/store/worker_workspace_execution_test.go
+++ b/internal/batches/store/worker_workspace_execution_test.go
@@ -27,7 +27,7 @@ import (
 func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	user := bt.CreateTestUser(t, db, true)
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
@@ -221,7 +221,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 func TestBatchSpecWorkspaceExecutionWorkerStore_MarkFailed(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	user := bt.CreateTestUser(t, db, true)
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
@@ -376,7 +376,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 func TestBatchSpecWorkspaceExecutionWorkerStore_MarkComplete_EmptyDiff(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	user := bt.CreateTestUser(t, db, true)
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
@@ -461,7 +461,7 @@ stdout: {"operation":"CACHE_AFTER_STEP_RESULT","timestamp":"2021-11-04T12:43:19.
 func TestBatchSpecWorkspaceExecutionWorkerStore_Dequeue_RoundRobin(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 
@@ -510,7 +510,7 @@ func TestBatchSpecWorkspaceExecutionWorkerStore_Dequeue_RoundRobin(t *testing.T)
 func TestBatchSpecWorkspaceExecutionWorkerStore_Dequeue_RoundRobin_NoDoubleDequeue(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	repo, _ := bt.CreateTestRepo(t, ctx, db)
 

--- a/internal/batches/webhooks/batch_change_test.go
+++ b/internal/batches/webhooks/batch_change_test.go
@@ -27,7 +27,7 @@ import (
 func TestMarshalBatchChange(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	marshalledUserID := gql.MarshalUserID(userID)

--- a/internal/batches/webhooks/changeset_test.go
+++ b/internal/batches/webhooks/changeset_test.go
@@ -32,7 +32,7 @@ import (
 func TestMarshalChangeset(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	userID := bt.CreateTestUser(t, db, true).ID
 	now := timeutil.Now()

--- a/internal/codeintel/autoindexing/internal/background/dependencies/index_worker_store_test.go
+++ b/internal/codeintel/autoindexing/internal/background/dependencies/index_worker_store_test.go
@@ -26,7 +26,7 @@ func Test_AutoIndexingManualEnqueuedDequeueOrder(t *testing.T) {
 		t.Skip()
 	}
 
-	raw := dbtest.NewDB(logtest.Scoped(t), t)
+	raw := dbtest.NewDB(t)
 	db := database.NewDB(logtest.Scoped(t), raw)
 
 	opts := IndexWorkerStoreOptions

--- a/internal/codeintel/autoindexing/internal/store/config_inference_test.go
+++ b/internal/codeintel/autoindexing/internal/store/config_inference_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSetInferenceScript(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	for _, testCase := range []struct {

--- a/internal/codeintel/autoindexing/internal/store/config_repo_test.go
+++ b/internal/codeintel/autoindexing/internal/store/config_repo_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRepositoryExceptions(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	query := sqlf.Sprintf(
@@ -55,7 +55,7 @@ func TestRepositoryExceptions(t *testing.T) {
 
 func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	expectedConfigurationData := []byte(`{
@@ -97,7 +97,7 @@ func TestGetIndexConfigurationByRepositoryID(t *testing.T) {
 
 func TestUpdateIndexConfigurationByRepositoryID(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	query := sqlf.Sprintf(

--- a/internal/codeintel/autoindexing/internal/store/coverage_test.go
+++ b/internal/codeintel/autoindexing/internal/store/coverage_test.go
@@ -20,7 +20,7 @@ import (
 func TestTopRepositoriesToConfigure(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 
@@ -71,7 +71,7 @@ func TestTopRepositoriesToConfigure(t *testing.T) {
 func TestRepositoryIDsWithConfiguration(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 
@@ -118,7 +118,7 @@ func TestRepositoryIDsWithConfiguration(t *testing.T) {
 func TestGetLastIndexScanForRepository(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	ts, err := store.GetLastIndexScanForRepository(ctx, 50)

--- a/internal/codeintel/autoindexing/internal/store/dependencies_test.go
+++ b/internal/codeintel/autoindexing/internal/store/dependencies_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestInsertDependencyIndexingJob(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertRepo(t, db, 50, "")
@@ -45,7 +45,7 @@ func TestInsertDependencyIndexingJob(t *testing.T) {
 func TestGetQueuedRepoRev(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	expected := []RepoRev{

--- a/internal/codeintel/autoindexing/internal/store/enqueuer_test.go
+++ b/internal/codeintel/autoindexing/internal/store/enqueuer_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestIsQueued(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, RepositoryID: 1, Commit: makeCommit(1)})
@@ -63,7 +63,7 @@ func TestIsQueued(t *testing.T) {
 
 func TestIsQueuedRootIndexer(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	now := time.Now()
@@ -105,7 +105,7 @@ func TestIsQueuedRootIndexer(t *testing.T) {
 func TestInsertIndexes(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertRepo(t, db, 50, "")
@@ -230,7 +230,7 @@ func TestInsertIndexes(t *testing.T) {
 
 func TestInsertIndexWithActor(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertRepo(t, db, 50, "")

--- a/internal/codeintel/autoindexing/internal/store/scheduler_test.go
+++ b/internal/codeintel/autoindexing/internal/store/scheduler_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestSelectRepositoriesForIndexScan(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	now := timeutil.Now()
@@ -125,7 +125,7 @@ func TestSelectRepositoriesForIndexScan(t *testing.T) {
 
 func TestSelectRepositoriesForIndexScanWithGlobalPolicy(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	now := timeutil.Now()
@@ -198,7 +198,7 @@ func TestSelectRepositoriesForIndexScanWithGlobalPolicy(t *testing.T) {
 func TestMarkRepoRevsAsProcessed(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	expected := []RepoRev{

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
@@ -315,7 +315,7 @@ func TestDatabaseReferences(t *testing.T) {
 
 func populateTestStore(t testing.TB) LsifStore {
 	logger := logtest.Scoped(t)
-	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, codeIntelDB)
 
 	loadTestFile(t, codeIntelDB, "./testdata/code-intel-extensions@7802976b.sql")

--- a/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
+++ b/internal/codeintel/dependencies/internal/background/job_packages_filter_test.go
@@ -21,7 +21,7 @@ func TestPackageRepoFiltersBlockOnly(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	s := store.New(&observation.TestContext, db)
 
 	deps := []shared.MinimalPackageRepoRef{
@@ -113,7 +113,7 @@ func TestPackageRepoFiltersBlockAllow(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	s := store.New(&observation.TestContext, db)
 
 	deps := []shared.MinimalPackageRepoRef{

--- a/internal/codeintel/dependencies/internal/store/store_test.go
+++ b/internal/codeintel/dependencies/internal/store/store_test.go
@@ -21,7 +21,7 @@ func TestInsertDependencyRepo(t *testing.T) {
 	instant := timeutil.Now()
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	batches := [][]shared.MinimalPackageRepoRef{
@@ -102,7 +102,7 @@ func TestListPackageRepoRefs(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	batches := [][]shared.MinimalPackageRepoRef{
@@ -192,7 +192,7 @@ func TestListPackageRepoRefsFuzzy(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	pkgs := []shared.MinimalPackageRepoRef{
@@ -316,7 +316,7 @@ func TestDeletePackageRepoRefsByID(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	repos := []shared.MinimalPackageRepoRef{

--- a/internal/codeintel/policies/internal/store/configurations_test.go
+++ b/internal/codeintel/policies/internal/store/configurations_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetConfigurationPolicies(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 	ctx := context.Background()
 
@@ -168,7 +168,7 @@ func TestGetConfigurationPolicies(t *testing.T) {
 
 func TestDeleteConfigurationPolicyByID(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	repositoryID := 42
@@ -212,7 +212,7 @@ func TestDeleteConfigurationPolicyByID(t *testing.T) {
 
 func TestDeleteConfigurationProtectedPolicy(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 
 	repositoryID := 42

--- a/internal/codeintel/policies/internal/store/repository_matches_test.go
+++ b/internal/codeintel/policies/internal/store/repository_matches_test.go
@@ -20,7 +20,7 @@ import (
 func TestRepoIDsByGlobPatterns(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertRepo(t, db, 50, "Darth Vader", true)
@@ -92,7 +92,7 @@ func TestRepoIDsByGlobPatterns(t *testing.T) {
 func TestUpdateReposMatchingPatterns(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertRepo(t, db, 50, "r1", false)
@@ -159,7 +159,7 @@ func TestUpdateReposMatchingPatterns(t *testing.T) {
 func TestUpdateReposMatchingPatternsOverLimit(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	limit := 50
@@ -198,7 +198,7 @@ func TestUpdateReposMatchingPatternsOverLimit(t *testing.T) {
 
 func TestSelectPoliciesForRepositoryMembershipUpdate(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStoreWithoutConfigurationPolicies(t, db)
 	ctx := context.Background()
 

--- a/internal/codeintel/ranking/internal/store/coordinator_test.go
+++ b/internal/codeintel/ranking/internal/store/coordinator_test.go
@@ -23,7 +23,7 @@ func TestCoordinateAndSummaries(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	store := New(&observation.TestContext, database.NewDB(logger, db))
 
 	now1 := timeutil.Now().UTC()

--- a/internal/codeintel/ranking/internal/store/definitions_test.go
+++ b/internal/codeintel/ranking/internal/store/definitions_test.go
@@ -19,7 +19,7 @@ import (
 func TestInsertDefinition(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Insert uploads

--- a/internal/codeintel/ranking/internal/store/graph_keys_test.go
+++ b/internal/codeintel/ranking/internal/store/graph_keys_test.go
@@ -14,7 +14,7 @@ import (
 func TestDerivativeGraphKey(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if _, _, err := DerivativeGraphKey(ctx, store); err != nil {

--- a/internal/codeintel/ranking/internal/store/mapper_test.go
+++ b/internal/codeintel/ranking/internal/store/mapper_test.go
@@ -24,7 +24,7 @@ func TestInsertPathCountInputs(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
@@ -197,7 +197,7 @@ func TestInsertInitialPathCounts(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
@@ -255,7 +255,7 @@ func TestInsertInitialPathCounts(t *testing.T) {
 func TestVacuumStaleProcessedReferences(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
@@ -319,7 +319,7 @@ func TestVacuumStaleProcessedReferences(t *testing.T) {
 func TestVacuumStaleProcessedPaths(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
@@ -383,7 +383,7 @@ func TestVacuumStaleProcessedPaths(t *testing.T) {
 func TestVacuumStaleGraphs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")

--- a/internal/codeintel/ranking/internal/store/paths_test.go
+++ b/internal/codeintel/ranking/internal/store/paths_test.go
@@ -22,7 +22,7 @@ func TestInsertInitialPathRanks(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Insert uploads

--- a/internal/codeintel/ranking/internal/store/reducer_test.go
+++ b/internal/codeintel/ranking/internal/store/reducer_test.go
@@ -26,7 +26,7 @@ func TestInsertPathRanks(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
@@ -136,7 +136,7 @@ func TestInsertPathRanks(t *testing.T) {
 func TestVacuumStaleRanks(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if _, err := db.ExecContext(ctx, `

--- a/internal/codeintel/ranking/internal/store/references_test.go
+++ b/internal/codeintel/ranking/internal/store/references_test.go
@@ -20,7 +20,7 @@ import (
 func TestInsertReferences(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Insert uploads

--- a/internal/codeintel/ranking/internal/store/retrieval_test.go
+++ b/internal/codeintel/ranking/internal/store/retrieval_test.go
@@ -25,7 +25,7 @@ func TestGetStarRank(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if _, err := db.ExecContext(ctx, `
@@ -72,7 +72,7 @@ func TestDocumentRanks(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 	repoName := api.RepoName("foo")
 
@@ -129,7 +129,7 @@ func TestGetReferenceCountStatistics(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	key := rankingshared.NewDerivativeGraphKey(mockRankingGraphKey, "123")
@@ -174,7 +174,7 @@ func TestCoverageCounts(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Create three visible uploads and export a pair
@@ -238,7 +238,7 @@ func TestLastUpdatedAt(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	now := time.Unix(1686695462, 0)

--- a/internal/codeintel/ranking/internal/store/uploads_test.go
+++ b/internal/codeintel/ranking/internal/store/uploads_test.go
@@ -23,7 +23,7 @@ func TestGetUploadsForRanking(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if _, err := db.ExecContext(ctx, `
@@ -73,7 +73,7 @@ func TestGetUploadsForRanking(t *testing.T) {
 func TestVacuumAbandonedExportedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Insert uploads
@@ -126,7 +126,7 @@ func TestVacuumAbandonedExportedUploads(t *testing.T) {
 func TestSoftDeleteStaleExportedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Insert uploads
@@ -185,7 +185,7 @@ func TestSoftDeleteStaleExportedUploads(t *testing.T) {
 func TestVacuumDeletedExportedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Insert uploads

--- a/internal/codeintel/sentinel/internal/store/matches_test.go
+++ b/internal/codeintel/sentinel/internal/store/matches_test.go
@@ -23,7 +23,7 @@ import (
 func TestVulnerabilityMatchByID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	setupReferences(t, db)
@@ -58,7 +58,7 @@ func TestVulnerabilityMatchByID(t *testing.T) {
 func TestGetVulnerabilityMatches(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	/*
@@ -199,7 +199,7 @@ func TestGetVulnerabilityMatches(t *testing.T) {
 func TestGetVulberabilityMatchesCountByRepository(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	/*
@@ -271,7 +271,7 @@ func TestGetVulberabilityMatchesCountByRepository(t *testing.T) {
 func TestGetVulnerabilityMatchesSummaryCount(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 	handle := basestore.NewWithHandle(db.Handle())
 

--- a/internal/codeintel/sentinel/internal/store/vulnerabilities_test.go
+++ b/internal/codeintel/sentinel/internal/store/vulnerabilities_test.go
@@ -36,7 +36,7 @@ var testVulnerabilities = []shared.Vulnerability{
 func TestVulnerabilityByID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if _, err := store.InsertVulnerabilities(ctx, testVulnerabilities); err != nil {
@@ -58,7 +58,7 @@ func TestVulnerabilityByID(t *testing.T) {
 func TestGetVulnerabilitiesByIDs(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if _, err := store.InsertVulnerabilities(ctx, testVulnerabilities); err != nil {
@@ -77,7 +77,7 @@ func TestGetVulnerabilitiesByIDs(t *testing.T) {
 func TestGetVulnerabilities(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if _, err := store.InsertVulnerabilities(ctx, testVulnerabilities); err != nil {

--- a/internal/codeintel/uploads/internal/lsifstore/cleanup_test.go
+++ b/internal/codeintel/uploads/internal/lsifstore/cleanup_test.go
@@ -22,7 +22,7 @@ func TestDeleteLsifDataByUploadIds(t *testing.T) {
 	logger := logtest.ScopedWith(t, logtest.LoggerOptions{
 		Level: log.LevelError,
 	})
-	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, codeIntelDB)
 
 	t.Run("scip", func(t *testing.T) {
@@ -53,7 +53,7 @@ func TestDeleteAbandonedSchemaVersionsRecords(t *testing.T) {
 	logger := logtest.ScopedWith(t, logtest.LoggerOptions{
 		Level: log.LevelError,
 	})
-	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, codeIntelDB)
 	ctx := context.Background()
 
@@ -124,7 +124,7 @@ func TestDeleteAbandonedSchemaVersionsRecords(t *testing.T) {
 
 func TestDeleteUnreferencedDocuments(t *testing.T) {
 	logger := logtest.Scoped(t)
-	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	internalStore := basestore.NewWithHandle(codeIntelDB.Handle())
 	store := New(&observation.TestContext, codeIntelDB)
 
@@ -221,7 +221,7 @@ func TestDeleteUnreferencedDocuments(t *testing.T) {
 
 func TestIDsWithMeta(t *testing.T) {
 	logger := logtest.Scoped(t)
-	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, codeIntelDB)
 	ctx := context.Background()
 
@@ -256,7 +256,7 @@ func TestIDsWithMeta(t *testing.T) {
 
 func TestReconcileCandidates(t *testing.T) {
 	logger := logtest.Scoped(t)
-	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, codeIntelDB)
 
 	ctx := context.Background()

--- a/internal/codeintel/uploads/internal/lsifstore/insert_test.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestInsertMetadata(t *testing.T) {
 	logger := logtest.Scoped(t)
-	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, codeIntelDB)
 	ctx := context.Background()
 
@@ -32,7 +32,7 @@ func TestInsertMetadata(t *testing.T) {
 
 func TestInsertSharedDocumentsConcurrently(t *testing.T) {
 	logger := logtest.Scoped(t)
-	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	store := newInternal(&observation.TestContext, codeIntelDB)
 	ctx := context.Background()
 
@@ -109,7 +109,7 @@ func TestInsertSharedDocumentsConcurrently(t *testing.T) {
 
 func TestInsertDocumentWithSymbols(t *testing.T) {
 	logger := logtest.Scoped(t)
-	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(logger, t))
+	codeIntelDB := codeintelshared.NewCodeIntelDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, codeIntelDB)
 	ctx := context.Background()
 

--- a/internal/codeintel/uploads/internal/store/cleanup_test.go
+++ b/internal/codeintel/uploads/internal/store/cleanup_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestHardDeleteUploadsByIDs(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db,
@@ -50,7 +50,7 @@ func TestHardDeleteUploadsByIDs(t *testing.T) {
 
 func TestDeleteUploadsStuckUploading(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -98,7 +98,7 @@ func TestDeleteUploadsStuckUploading(t *testing.T) {
 
 func TestDeleteUploadsWithoutRepository(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	var uploads []shared.Upload
@@ -158,7 +158,7 @@ func TestDeleteUploadsWithoutRepository(t *testing.T) {
 
 func TestDeleteOldAuditLogs(t *testing.T) {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 
@@ -170,7 +170,7 @@ func TestDeleteOldAuditLogs(t *testing.T) {
 
 func TestReconcileCandidates(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 	ctx := context.Background()
 
@@ -220,7 +220,7 @@ func TestReconcileCandidates(t *testing.T) {
 
 func TestProcessStaleSourcedCommits(t *testing.T) {
 	log := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(log, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(log, sqlDB)
 	store := &store{
 		db:         basestore.NewWithHandle(db.Handle()),
@@ -335,7 +335,7 @@ type s2 interface {
 
 func TestGetStaleSourcedCommits(t *testing.T) {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db).(s2)
 
@@ -389,7 +389,7 @@ func TestGetStaleSourcedCommits(t *testing.T) {
 
 func TestUpdateSourcedCommits(t *testing.T) {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db).(s2)
 
@@ -431,7 +431,7 @@ func TestUpdateSourcedCommits(t *testing.T) {
 
 func TestGetQueuedUploadRank(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -481,7 +481,7 @@ func TestGetQueuedUploadRank(t *testing.T) {
 
 func TestDeleteSourcedCommits(t *testing.T) {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db).(s2)
 
@@ -528,7 +528,7 @@ func TestDeleteSourcedCommits(t *testing.T) {
 
 func TestDeleteIndexesWithoutRepository(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	var indexes []uploadsshared.Index
@@ -567,7 +567,7 @@ func TestDeleteIndexesWithoutRepository(t *testing.T) {
 
 func TestExpireFailedRecords(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	ctx := context.Background()

--- a/internal/codeintel/uploads/internal/store/commitdate_test.go
+++ b/internal/codeintel/uploads/internal/store/commitdate_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetOldestCommitDate(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -101,7 +101,7 @@ func TestGetOldestCommitDate(t *testing.T) {
 
 func TestSourcedCommitsWithoutCommittedAt(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	now := time.Unix(1587396557, 0).UTC()

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestSetRepositoryAsDirty(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	for _, id := range []int{50, 51, 52} {
@@ -61,7 +61,7 @@ func TestSetRepositoryAsDirty(t *testing.T) {
 
 func TestSkipsDeletedRepositories(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertRepo(t, db, 50, "should not be dirty", false)
@@ -94,7 +94,7 @@ func TestSkipsDeletedRepositories(t *testing.T) {
 
 func TestCalculateVisibleUploadsResetsDirtyFlagTransactionTimestamp(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	uploads := []shared.Upload{
@@ -129,7 +129,7 @@ func TestCalculateVisibleUploadsResetsDirtyFlagTransactionTimestamp(t *testing.T
 
 func TestCalculateVisibleUploadsNonDefaultBranches(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -222,7 +222,7 @@ func TestCalculateVisibleUploadsNonDefaultBranches(t *testing.T) {
 
 func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfiguration(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -332,7 +332,7 @@ func TestCalculateVisibleUploadsNonDefaultBranchesWithCustomRetentionConfigurati
 
 func TestUpdateUploadsVisibleToCommits(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -391,7 +391,7 @@ func TestUpdateUploadsVisibleToCommits(t *testing.T) {
 
 func TestUpdateUploadsVisibleToCommitsAlternateCommitGraph(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -444,7 +444,7 @@ func TestUpdateUploadsVisibleToCommitsAlternateCommitGraph(t *testing.T) {
 
 func TestUpdateUploadsVisibleToCommitsDistinctRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -487,7 +487,7 @@ func TestUpdateUploadsVisibleToCommitsDistinctRoots(t *testing.T) {
 
 func TestUpdateUploadsVisibleToCommitsOverlappingRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -562,7 +562,7 @@ func TestUpdateUploadsVisibleToCommitsOverlappingRoots(t *testing.T) {
 
 func TestUpdateUploadsVisibleToCommitsIndexerName(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -618,7 +618,7 @@ func TestUpdateUploadsVisibleToCommitsIndexerName(t *testing.T) {
 
 func TestUpdateUploadsVisibleToCommitsResetsDirtyFlag(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	uploads := []shared.Upload{
@@ -685,7 +685,7 @@ func TestUpdateUploadsVisibleToCommitsResetsDirtyFlag(t *testing.T) {
 
 func TestFindClosestDumps(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -751,7 +751,7 @@ func TestFindClosestDumps(t *testing.T) {
 
 func TestFindClosestDumpsAlternateCommitGraph(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -811,7 +811,7 @@ func TestFindClosestDumpsAlternateCommitGraph(t *testing.T) {
 
 func TestFindClosestDumpsAlternateCommitGraphWithOverwrittenVisibleUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -864,7 +864,7 @@ func TestFindClosestDumpsAlternateCommitGraphWithOverwrittenVisibleUploads(t *te
 
 func TestFindClosestDumpsDistinctRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -914,7 +914,7 @@ func TestFindClosestDumpsDistinctRoots(t *testing.T) {
 
 func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -994,7 +994,7 @@ func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
 
 func TestFindClosestDumpsIndexerName(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -1083,7 +1083,7 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 
 func TestFindClosestDumpsIntersectingPath(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -1127,7 +1127,7 @@ func TestFindClosestDumpsIntersectingPath(t *testing.T) {
 
 func TestFindClosestDumpsFromGraphFragment(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// This database has the following commit graph:
@@ -1193,7 +1193,7 @@ func TestFindClosestDumpsFromGraphFragment(t *testing.T) {
 
 func TestGetRepositoriesMaxStaleAge(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	for _, id := range []int{50, 51, 52} {
@@ -1227,7 +1227,7 @@ func TestGetRepositoriesMaxStaleAge(t *testing.T) {
 
 func TestCommitGraphMetadata(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if err := store.SetRepositoryAsDirty(context.Background(), 50); err != nil {
@@ -1534,7 +1534,7 @@ func keysOf(m map[string][]int) (keys []string) {
 
 func BenchmarkCalculateVisibleUploads(b *testing.B) {
 	logger := logtest.Scoped(b)
-	db := database.NewDB(logger, dbtest.NewDB(logger, b))
+	db := database.NewDB(logger, dbtest.NewDB(b))
 	store := New(&observation.TestContext, db)
 
 	graph, err := readBenchmarkCommitGraph()

--- a/internal/codeintel/uploads/internal/store/dependencies_test.go
+++ b/internal/codeintel/uploads/internal/store/dependencies_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestReferencesForUpload(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db,
@@ -58,7 +58,7 @@ func TestReferencesForUpload(t *testing.T) {
 
 func TestUpdatePackages(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// for foreign key relation
@@ -90,7 +90,7 @@ func TestUpdatePackages(t *testing.T) {
 
 func TestUpdatePackagesEmpty(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if err := store.UpdatePackages(context.Background(), 0, nil); err != nil {
@@ -108,7 +108,7 @@ func TestUpdatePackagesEmpty(t *testing.T) {
 
 func TestUpdatePackageReferences(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// for foreign key relation

--- a/internal/codeintel/uploads/internal/store/expiration_test.go
+++ b/internal/codeintel/uploads/internal/store/expiration_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestSoftDeleteExpiredUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db,
@@ -96,7 +96,7 @@ func TestSoftDeleteExpiredUploads(t *testing.T) {
 
 func TestSoftDeleteExpiredUploadsViaTraversal(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// The packages in this test reference each other in the following way:

--- a/internal/codeintel/uploads/internal/store/indexes_test.go
+++ b/internal/codeintel/uploads/internal/store/indexes_test.go
@@ -24,7 +24,7 @@ import (
 func TestGetIndexes(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -156,7 +156,7 @@ func TestGetIndexes(t *testing.T) {
 func TestGetIndexByID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Index does not exist initially
@@ -229,7 +229,7 @@ func TestGetIndexByID(t *testing.T) {
 
 func TestGetQueuedIndexRank(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -280,7 +280,7 @@ func TestGetQueuedIndexRank(t *testing.T) {
 func TestGetIndexesByIDs(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	indexID1, indexID2, indexID3, indexID4 := 1, 3, 5, 5 // note the duplication
@@ -342,7 +342,7 @@ func TestGetIndexesByIDs(t *testing.T) {
 
 func TestDeleteIndexByID(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1})
@@ -363,7 +363,7 @@ func TestDeleteIndexByID(t *testing.T) {
 
 func TestDeleteIndexes(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, State: "completed"})
@@ -387,7 +387,7 @@ func TestDeleteIndexes(t *testing.T) {
 
 func TestDeleteIndexesWithIndexerKey(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, Indexer: "sourcegraph/scip-go@sha256:123456"})
@@ -422,7 +422,7 @@ func TestDeleteIndexesWithIndexerKey(t *testing.T) {
 
 func TestReindexIndexByID(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, State: "completed"})
@@ -444,7 +444,7 @@ func TestReindexIndexByID(t *testing.T) {
 
 func TestReindexIndexes(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, State: "completed"})
@@ -470,7 +470,7 @@ func TestReindexIndexes(t *testing.T) {
 
 func TestReindexIndexesWithIndexerKey(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertIndexes(t, db, uploadsshared.Index{ID: 1, Indexer: "sourcegraph/scip-go@sha256:123456"})
@@ -503,7 +503,7 @@ func TestReindexIndexesWithIndexerKey(t *testing.T) {
 
 func TestDeleteIndexByIDMissingRow(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if found, err := store.DeleteIndexByID(context.Background(), 1); err != nil {

--- a/internal/codeintel/uploads/internal/store/misc_test.go
+++ b/internal/codeintel/uploads/internal/store/misc_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestHasRepository(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	testCases := []struct {
@@ -48,7 +48,7 @@ func TestHasRepository(t *testing.T) {
 
 func TestHasCommit(t *testing.T) {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 
@@ -82,7 +82,7 @@ func TestHasCommit(t *testing.T) {
 
 func TestInsertDependencySyncingJob(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	uploadID := 42

--- a/internal/codeintel/uploads/internal/store/processing_test.go
+++ b/internal/codeintel/uploads/internal/store/processing_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestInsertUploadUploading(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertRepo(t, db, 50, "", false)
@@ -67,7 +67,7 @@ func TestInsertUploadUploading(t *testing.T) {
 
 func TestInsertUploadQueued(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertRepo(t, db, 50, "", false)
@@ -120,7 +120,7 @@ func TestInsertUploadQueued(t *testing.T) {
 
 func TestInsertUploadWithAssociatedIndexID(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertRepo(t, db, 50, "", false)
@@ -177,7 +177,7 @@ func TestInsertUploadWithAssociatedIndexID(t *testing.T) {
 
 func TestAddUploadPart(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "uploading"})
@@ -201,7 +201,7 @@ func TestAddUploadPart(t *testing.T) {
 
 func TestMarkQueued(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "uploading"})
@@ -228,7 +228,7 @@ func TestMarkQueued(t *testing.T) {
 
 func TestMarkQueuedNoSize(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "uploading"})
@@ -250,7 +250,7 @@ func TestMarkQueuedNoSize(t *testing.T) {
 
 func TestMarkFailed(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "uploading"})
@@ -279,7 +279,7 @@ func TestMarkFailed(t *testing.T) {
 
 func TestDeleteOverlappingDumps(t *testing.T) {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 
@@ -305,7 +305,7 @@ func TestDeleteOverlappingDumps(t *testing.T) {
 
 func TestDeleteOverlappingDumpsNoMatches(t *testing.T) {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 
@@ -343,7 +343,7 @@ func TestDeleteOverlappingDumpsNoMatches(t *testing.T) {
 
 func TestDeleteOverlappingDumpsIgnoresIncompleteUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 

--- a/internal/codeintel/uploads/internal/store/summary_test.go
+++ b/internal/codeintel/uploads/internal/store/summary_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetIndexers(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 	ctx := context.Background()
 
@@ -63,7 +63,7 @@ func TestGetIndexers(t *testing.T) {
 func TestRecentUploadsSummary(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	t0 := time.Unix(1587396557, 0).UTC()
@@ -122,7 +122,7 @@ func TestRecentUploadsSummary(t *testing.T) {
 func TestRecentIndexesSummary(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	t0 := time.Unix(1587396557, 0).UTC()
@@ -182,7 +182,7 @@ func TestRecentIndexesSummary(t *testing.T) {
 func TestRepositoryIDsWithErrors(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 
@@ -262,7 +262,7 @@ func TestRepositoryIDsWithErrors(t *testing.T) {
 func TestNumRepositoriesWithCodeIntelligence(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 

--- a/internal/codeintel/uploads/internal/store/uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/uploads_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestGetUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 	ctx := context.Background()
 
@@ -239,7 +239,7 @@ func TestGetUploads(t *testing.T) {
 func TestGetUploadByID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Upload does not exist initially
@@ -301,7 +301,7 @@ func TestGetUploadByID(t *testing.T) {
 
 func TestGetUploadByIDDeleted(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Upload does not exist initially
@@ -343,7 +343,7 @@ func TestGetUploadByIDDeleted(t *testing.T) {
 
 func TestGetDumpsByIDs(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Dumps do not exist initially
@@ -415,7 +415,7 @@ func TestGetDumpsByIDs(t *testing.T) {
 func TestGetUploadsByIDs(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db,
@@ -468,7 +468,7 @@ func TestGetUploadsByIDs(t *testing.T) {
 
 func TestGetVisibleUploadsMatchingMonikers(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db,
@@ -589,7 +589,7 @@ func TestGetVisibleUploadsMatchingMonikers(t *testing.T) {
 
 func TestDefinitionDumps(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	moniker1 := precise.QualifiedMonikerData{
@@ -728,7 +728,7 @@ func TestDefinitionDumps(t *testing.T) {
 
 func TestUploadAuditLogs(t *testing.T) {
 	logger := logtest.Scoped(t)
-	sqlDB := dbtest.NewDB(logger, t)
+	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
 	store := New(&observation.TestContext, db)
 
@@ -762,7 +762,7 @@ func transitionForColumn(t *testing.T, key string, transitions []map[string]*str
 
 func TestDeleteUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	t1 := time.Unix(1587396557, 0).UTC()
@@ -811,7 +811,7 @@ func TestDeleteUploads(t *testing.T) {
 
 func TestDeleteUploadsWithIndexerKey(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// note: queued so we delete, not go to deleting state first (makes assertion simpler)
@@ -852,7 +852,7 @@ func TestDeleteUploadsWithIndexerKey(t *testing.T) {
 
 func TestDeleteUploadByID(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db,
@@ -890,7 +890,7 @@ func TestDeleteUploadByID(t *testing.T) {
 
 func TestDeleteUploadByIDMissingRow(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	if found, err := store.DeleteUploadByID(context.Background(), 1); err != nil {
@@ -902,7 +902,7 @@ func TestDeleteUploadByIDMissingRow(t *testing.T) {
 
 func TestDeleteUploadByIDNotCompleted(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db,
@@ -940,7 +940,7 @@ func TestDeleteUploadByIDNotCompleted(t *testing.T) {
 
 func TestReindexUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "completed"})
@@ -966,7 +966,7 @@ func TestReindexUploads(t *testing.T) {
 
 func TestReindexUploadsWithIndexerKey(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, Indexer: "sourcegraph/scip-go@sha256:123456"})
@@ -999,7 +999,7 @@ func TestReindexUploadsWithIndexerKey(t *testing.T) {
 
 func TestReindexUploadByID(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	insertUploads(t, db, shared.Upload{ID: 1, State: "completed"})

--- a/internal/codeintel/uploads/transport/http/handler_test.go
+++ b/internal/codeintel/uploads/transport/http/handler_test.go
@@ -34,7 +34,7 @@ func TestHandleEnqueueAuth(t *testing.T) {
 	setupRepoMocks(t)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := backend.NewRepos(logger, db, gitserver.NewMockClient())
 	mockDBStore := NewMockDBStore[uploads.UploadMetadata]()
 	mockUploadStore := uploadstoremocks.NewMockStore()

--- a/internal/codemonitors/background/workers_test.go
+++ b/internal/codemonitors/background/workers_test.go
@@ -48,7 +48,7 @@ func TestActionRunner(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			db := database.NewDB(logger, dbtest.NewDB(logger, t))
+			db := database.NewDB(logger, dbtest.NewDB(t))
 			testQuery := "test patternType:literal"
 			externalURL := "https://www.sourcegraph.com"
 

--- a/internal/codemonitors/search_test.go
+++ b/internal/codemonitors/search_test.go
@@ -121,7 +121,7 @@ func TestCodeMonitorHook(t *testing.T) {
 		return testFixtures{User: u, Monitor: m, Repo: r}
 	}
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	fixtures := populateFixtures(db)
 	ctx := context.Background()
 

--- a/internal/database/access_requests_test.go
+++ b/internal/database/access_requests_test.go
@@ -18,7 +18,7 @@ func TestAccessRequests_Create(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	store := db.AccessRequests()
 
@@ -82,7 +82,7 @@ func TestAccessRequests_Update(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	accessRequestsStore := db.AccessRequests()
 	usersStore := db.Users()
 	user, _ := usersStore.Create(ctx, NewUser{Username: "u1", Email: "u1@email", EmailIsVerified: true})
@@ -119,7 +119,7 @@ func TestAccessRequests_GetByID(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.AccessRequests()
 
 	t.Run("non-existing access request", func(t *testing.T) {
@@ -146,7 +146,7 @@ func TestAccessRequests_GetByEmail(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.AccessRequests()
 
 	t.Run("non-existing access request", func(t *testing.T) {
@@ -173,7 +173,7 @@ func TestAccessRequests_Count(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	accessRequestStore := db.AccessRequests()
 
 	usersStore := db.Users()
@@ -221,7 +221,7 @@ func TestAccessRequests_List(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	accessRequestStore := db.AccessRequests()
 
 	usersStore := db.Users()

--- a/internal/database/access_tokens_test.go
+++ b/internal/database/access_tokens_test.go
@@ -47,7 +47,7 @@ func TestAccessTokens(t *testing.T) {
 func testAccessTokens_Create(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subject, err := db.Users().Create(ctx, NewUser{
@@ -129,7 +129,7 @@ func testAccessTokens_Create(t *testing.T) {
 func testAccessTokens_Delete(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subject, err := db.Users().Create(ctx, NewUser{
@@ -204,7 +204,7 @@ func assertSecurityEventCount(t *testing.T, db DB, event SecurityEventName, expe
 func testAccessTokens_CreateInternal_DoesNotCaptureSecurityEvent(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subject, err := db.Users().Create(ctx, NewUser{
@@ -243,7 +243,7 @@ func testAccessTokens_List(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subject1, err := db.Users().Create(ctx, NewUser{
@@ -324,7 +324,7 @@ func testAccessTokens_Lookup(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	subject, err := db.Users().Create(ctx, NewUser{
@@ -395,7 +395,7 @@ func testAccessTokens_Lookup_deletedUser(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	t.Run("subject", func(t *testing.T) {

--- a/internal/database/assigned_owners_test.go
+++ b/internal/database/assigned_owners_test.go
@@ -21,7 +21,7 @@ func TestAssignedOwnersStore_ListAssignedOwnersForRepo(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating 2 users.
@@ -82,7 +82,7 @@ func TestAssignedOwnersStore_Insert(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating a user.
@@ -117,7 +117,7 @@ func TestAssignedOwnersStore_Delete(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating users.
@@ -170,7 +170,7 @@ func TestAssignedOwnersStore_Count(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating users.

--- a/internal/database/assigned_teams_test.go
+++ b/internal/database/assigned_teams_test.go
@@ -25,7 +25,7 @@ func TestAssignedTeamsStore_ListAssignedTeamsForRepo(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating a user and 2 teams.
@@ -86,7 +86,7 @@ func TestAssignedTeamsStore_Insert(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating a user and a team.
@@ -122,7 +122,7 @@ func TestAssignedTeamsStore_Delete(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating a user and 2 teams.

--- a/internal/database/authz_test.go
+++ b/internal/database/authz_test.go
@@ -30,7 +30,7 @@ func clock() time.Time {
 
 func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create repos needed
@@ -246,7 +246,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 
 func TestAuthzStore_AuthorizedRepos(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	s := NewAuthzStore(logger, db, clock).(*authzStore)
@@ -357,7 +357,7 @@ func TestAuthzStore_AuthorizedRepos(t *testing.T) {
 
 func TestAuthzStore_RevokeUserPermissions(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	s := NewAuthzStore(logger, db, clock).(*authzStore)

--- a/internal/database/batch/BUILD.bazel
+++ b/internal/database/batch/BUILD.bazel
@@ -35,6 +35,5 @@ go_test(
         "//internal/database/dbtest",
         "//internal/database/dbutil",
         "@com_github_google_go_cmp//cmp",
-        "@com_github_sourcegraph_log//logtest",
     ],
 )

--- a/internal/database/batch/batch_test.go
+++ b/internal/database/batch/batch_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
@@ -18,8 +16,7 @@ func init() {
 }
 
 func TestBatchInserter(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	setupTestTable(t, db)
 
 	tableSizeFactor := 2
@@ -49,8 +46,7 @@ func TestBatchInserter(t *testing.T) {
 }
 
 func TestBatchInserterThin(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	setupTestTableThin(t, db)
 
 	tableSizeFactor := 2
@@ -82,8 +78,7 @@ func TestBatchInserterThin(t *testing.T) {
 }
 
 func TestBatchInserterWithReturn(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	setupTestTable(t, db)
 
 	tableSizeFactor := 2
@@ -101,8 +96,7 @@ func TestBatchInserterWithReturn(t *testing.T) {
 }
 
 func TestBatchInserterWithReturnWithConflicts(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	setupTestTable(t, db)
 
 	tableSizeFactor := 2
@@ -121,8 +115,7 @@ func TestBatchInserterWithReturnWithConflicts(t *testing.T) {
 }
 
 func TestBatchInserterWithConflict(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	setupTestTable(t, db)
 
 	tableSizeFactor := 2
@@ -153,8 +146,7 @@ func TestBatchInserterWithConflict(t *testing.T) {
 }
 
 func BenchmarkBatchInserter(b *testing.B) {
-	logger := logtest.Scoped(b)
-	db := dbtest.NewDB(logger, b)
+	db := dbtest.NewDB(b)
 	setupTestTable(b, db)
 	expectedValues := makeTestValues(10, 0)
 
@@ -167,8 +159,7 @@ func BenchmarkBatchInserter(b *testing.B) {
 }
 
 func BenchmarkBatchInserterLargePayload(b *testing.B) {
-	logger := logtest.Scoped(b)
-	db := dbtest.NewDB(logger, b)
+	db := dbtest.NewDB(b)
 	setupTestTable(b, db)
 	expectedValues := makeTestValues(10, 4096)
 

--- a/internal/database/bitbucket_project_permissions_test.go
+++ b/internal/database/bitbucket_project_permissions_test.go
@@ -24,7 +24,7 @@ func TestBitbucketProjectPermissionsEnqueue(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	check := func(jobID int, projectKey string, permissions []types.UserPermission, unrestricted bool) {
@@ -112,7 +112,7 @@ func TestScanFirstBitbucketProjectPermissionsJob(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	_, err := db.ExecContext(ctx, `--sql
@@ -230,7 +230,7 @@ func TestListJobs(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	_, err := db.ExecContext(ctx, `--sql

--- a/internal/database/code_hosts_test.go
+++ b/internal/database/code_hosts_test.go
@@ -19,7 +19,7 @@ func TestCodeHostStore_CRUDCodeHost(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ten := int32(10)
 	twenty := int32(20)
@@ -122,7 +122,7 @@ func TestCodeHostStore_List(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ten := int32(10)
 	twenty := int32(20)
@@ -293,7 +293,7 @@ func TestCodeHostStore_Count(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	quotaOne := int32(10)
 	quotaTwo := int32(20)

--- a/internal/database/code_monitor_last_searched_test.go
+++ b/internal/database/code_monitor_last_searched_test.go
@@ -18,7 +18,7 @@ func TestCodeMonitorStoreLastSearched(t *testing.T) {
 	t.Run("insert get upsert get", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		fixtures := populateCodeMonitorFixtures(t, db)
 		cm := db.CodeMonitors()
 
@@ -46,7 +46,7 @@ func TestCodeMonitorStoreLastSearched(t *testing.T) {
 	t.Run("no error for missing get", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		fixtures := populateCodeMonitorFixtures(t, db)
 		cm := db.CodeMonitors()
 
@@ -60,7 +60,7 @@ func TestCodeMonitorStoreLastSearched(t *testing.T) {
 	t.Run("no error for missing get", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		fixtures := populateCodeMonitorFixtures(t, db)
 		cm := db.CodeMonitors()
 
@@ -91,7 +91,7 @@ func TestCodeMonitorHasAnyLastSearched(t *testing.T) {
 	t.Run("has none", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		fixtures := populateCodeMonitorFixtures(t, db)
 		cm := db.CodeMonitors()
 
@@ -103,7 +103,7 @@ func TestCodeMonitorHasAnyLastSearched(t *testing.T) {
 	t.Run("has some", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		fixtures := populateCodeMonitorFixtures(t, db)
 		cm := db.CodeMonitors()
 

--- a/internal/database/code_monitor_slack_webhook_test.go
+++ b/internal/database/code_monitor_slack_webhook_test.go
@@ -22,7 +22,7 @@ func TestCodeMonitorStoreSlackWebhooks(t *testing.T) {
 	t.Run("CreateThenGet", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)
@@ -39,7 +39,7 @@ func TestCodeMonitorStoreSlackWebhooks(t *testing.T) {
 	t.Run("CreateUpdateGet", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)
@@ -60,7 +60,7 @@ func TestCodeMonitorStoreSlackWebhooks(t *testing.T) {
 	t.Run("ErrorOnUpdateNonexistent", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 
@@ -71,7 +71,7 @@ func TestCodeMonitorStoreSlackWebhooks(t *testing.T) {
 	t.Run("CreateDeleteGet", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)
@@ -95,7 +95,7 @@ func TestCodeMonitorStoreSlackWebhooks(t *testing.T) {
 	t.Run("CountCreateCount", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)
@@ -115,7 +115,7 @@ func TestCodeMonitorStoreSlackWebhooks(t *testing.T) {
 	t.Run("ListCreateList", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)

--- a/internal/database/code_monitor_trigger_jobs_test.go
+++ b/internal/database/code_monitor_trigger_jobs_test.go
@@ -74,7 +74,7 @@ func TestUpdateTriggerJob(t *testing.T) {
 	logger := logtest.Scoped(t)
 	t.Run("handles null results", func(t *testing.T) {
 		ctx := context.Background()
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_ = populateCodeMonitorFixtures(t, db)
 		jobs, err := db.CodeMonitors().EnqueueQueryTriggerJobs(ctx)
 		require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestListTriggerJobs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	t.Run("handles null results", func(t *testing.T) {
 		ctx := context.Background()
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		f := populateCodeMonitorFixtures(t, db)
 		jobs, err := db.CodeMonitors().EnqueueQueryTriggerJobs(ctx)
 		require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestEnqueueTriggerJobs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	t.Run("does not enqueue jobs for deleted users", func(t *testing.T) {
 		ctx := context.Background()
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		f := populateCodeMonitorFixtures(t, db)
 
 		err := db.Users().Delete(ctx, f.User.ID)

--- a/internal/database/code_monitor_webhook_test.go
+++ b/internal/database/code_monitor_webhook_test.go
@@ -22,7 +22,7 @@ func TestCodeMonitorStoreWebhooks(t *testing.T) {
 	t.Run("CreateThenGet", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)
@@ -39,7 +39,7 @@ func TestCodeMonitorStoreWebhooks(t *testing.T) {
 	t.Run("CreateUpdateGet", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)
@@ -60,7 +60,7 @@ func TestCodeMonitorStoreWebhooks(t *testing.T) {
 	t.Run("ErrorOnUpdateNonexistent", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 
@@ -71,7 +71,7 @@ func TestCodeMonitorStoreWebhooks(t *testing.T) {
 	t.Run("CreateDeleteGet", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)
@@ -95,7 +95,7 @@ func TestCodeMonitorStoreWebhooks(t *testing.T) {
 	t.Run("CountCreateCount", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)
@@ -115,7 +115,7 @@ func TestCodeMonitorStoreWebhooks(t *testing.T) {
 	t.Run("ListCreateList", func(t *testing.T) {
 		t.Parallel()
 
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		_, _, ctx := newTestUser(ctx, t, db)
 		s := CodeMonitorsWith(db)
 		fixtures := s.insertTestMonitor(ctx, t)

--- a/internal/database/code_monitors.go
+++ b/internal/database/code_monitors.go
@@ -260,7 +260,7 @@ const (
 func newTestStore(t *testing.T) (context.Context, DB, *codeMonitorStore) {
 	logger := logtest.Scoped(t)
 	ctx := actor.WithInternalActor(context.Background())
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	now := time.Now().Truncate(time.Microsecond)
 	return ctx, db, CodeMonitorsWithClock(db, func() time.Time { return now })
 }

--- a/internal/database/codeowners_test.go
+++ b/internal/database/codeowners_test.go
@@ -35,7 +35,7 @@ func TestCodeowners_CreateUpdateDelete(t *testing.T) {
 	ctx := context.Background()
 
 	logger := logtest.NoOp(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	createRepos(t, ctx, db.Repos(), 6)
 	store := db.Codeowners()
@@ -103,7 +103,7 @@ func TestCodeowners_GetListCount(t *testing.T) {
 	ctx := context.Background()
 
 	logger := logtest.NoOp(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	createRepos(t, ctx, db.Repos(), 2)
 

--- a/internal/database/conf_test.go
+++ b/internal/database/conf_test.go
@@ -23,7 +23,7 @@ func TestSiteGetLatestDefault(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	latest, err := db.Conf().SiteGetLatest(ctx)
@@ -42,7 +42,7 @@ func TestSiteCreate_RejectInvalidJSON(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	malformedJSON := "[This is malformed.}"
@@ -278,7 +278,7 @@ func TestSiteCreateIfUpToDate(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			db := NewDB(logger, dbtest.NewDB(logger, t))
+			db := NewDB(logger, dbtest.NewDB(t))
 			ctx := context.Background()
 			for _, p := range test.sequence {
 				output, err := db.Conf().SiteCreateIfUpToDate(ctx, &p.input.lastID, 0, p.input.contents, false)
@@ -367,7 +367,7 @@ func TestGetSiteConfigCount(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	s := db.Conf()
@@ -390,7 +390,7 @@ func TestListSiteConfigs(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	s := db.Conf()

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -22,7 +22,7 @@ func TestDBTransactions(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	t.Run("no transaction works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		err := db.Repos().Create(ctx, &types.Repo{ID: 1, Name: "test1"})
@@ -34,7 +34,7 @@ func TestDBTransactions(t *testing.T) {
 	})
 
 	t.Run("basic transaction works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		// Lifetime of tx
@@ -66,7 +66,7 @@ func TestDBTransactions(t *testing.T) {
 	})
 
 	t.Run("rolled back transaction works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		// Lifetime of tx
@@ -97,7 +97,7 @@ func TestDBTransactions(t *testing.T) {
 	})
 
 	t.Run("nested transaction works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		// Lifetime of tx1
@@ -159,7 +159,7 @@ func TestDBTransactions(t *testing.T) {
 	})
 
 	t.Run("nested transaction rollback works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		// Lifetime of tx1
@@ -228,7 +228,7 @@ func TestDBWithTransact(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	t.Run("no transaction works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		err := db.Repos().Create(ctx, &types.Repo{ID: 1, Name: "test1"})
@@ -240,7 +240,7 @@ func TestDBWithTransact(t *testing.T) {
 	})
 
 	t.Run("basic transaction works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		err := db.WithTransact(ctx, func(tx DB) error {
@@ -271,7 +271,7 @@ func TestDBWithTransact(t *testing.T) {
 	})
 
 	t.Run("rolled back transaction works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		err := db.WithTransact(ctx, func(tx DB) error {
@@ -301,7 +301,7 @@ func TestDBWithTransact(t *testing.T) {
 	})
 
 	t.Run("nested transaction works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		err := db.WithTransact(ctx, func(tx1 DB) error {
@@ -357,7 +357,7 @@ func TestDBWithTransact(t *testing.T) {
 	})
 
 	t.Run("nested transaction rollback works", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		err := db.WithTransact(ctx, func(tx1 DB) error {
@@ -416,7 +416,7 @@ func TestDBWithTransact(t *testing.T) {
 	})
 
 	t.Run("panic during transaction rolls back", func(t *testing.T) {
-		sqlDB := dbtest.NewDB(logger, t)
+		sqlDB := dbtest.NewDB(t)
 		db := NewDB(logger, sqlDB)
 
 		// Panic should be propagated

--- a/internal/database/dbcache/cached_indexable_repos_test.go
+++ b/internal/database/dbcache/cached_indexable_repos_test.go
@@ -12,7 +12,7 @@ import (
 
 func BenchmarkIndexableRepos_List_Empty(b *testing.B) {
 	logger := logtest.Scoped(b)
-	db := database.NewDB(logger, dbtest.NewDB(logger, b))
+	db := database.NewDB(logger, dbtest.NewDB(b))
 
 	ctx := context.Background()
 	select {

--- a/internal/database/dbtest/BUILD.bazel
+++ b/internal/database/dbtest/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//internal/database/postgresdsn",
         "@com_github_lib_pq//:pq",
         "@com_github_sourcegraph_log//:log",
+        "@com_github_sourcegraph_log//logtest",
     ],
 )
 

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/migration/schemas"
 
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
 )
 
 // NewTx opens a transaction off of the given database, returning that
@@ -63,7 +64,8 @@ var rngLock sync.Mutex
 
 // NewDB returns a connection to a clean, new temporary testing database with
 // the same schema as Sourcegraph's production Postgres database.
-func NewDB(logger log.Logger, t testing.TB) *sql.DB {
+func NewDB(t testing.TB) *sql.DB {
+	logger := logtest.Scoped(t)
 	return newDB(logger, t, "migrated", schemas.Frontend, schemas.CodeIntel)
 }
 

--- a/internal/database/encryption_test.go
+++ b/internal/database/encryption_test.go
@@ -23,7 +23,7 @@ func TestRecordEncrypter(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	key := &base64Key{}
 	encrypter := NewRecordEncrypter(db)
 

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -85,7 +85,7 @@ func TestEventLogs_ValidInfo(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	var testCases = []struct {
@@ -131,7 +131,7 @@ func TestEventLogs_CountUsersWithSetting(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	usersStore := db.Users()
@@ -200,7 +200,7 @@ func TestEventLogs_SiteUsageMultiplePeriods(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Several of the events will belong to Sourcegraph employee admin user and Sourcegraph Operator user account
@@ -279,7 +279,7 @@ func TestEventLogs_UsersUsageCounts(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	now := time.Now()
@@ -337,7 +337,7 @@ func TestEventLogs_SiteUsage(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// This unix timestamp is equivalent to `Friday, May 15, 2020 10:30:00 PM GMT` and is set to
@@ -450,7 +450,7 @@ func TestEventLogs_SiteUsage_ExcludeSourcegraphAdmins(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// This unix timestamp is equivalent to `Friday, May 15, 2020 10:30:00 PM GMT` and is set to
@@ -595,7 +595,7 @@ func TestEventLogs_codeIntelligenceWeeklyUsersCount(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	names := []string{"codeintel.lsifHover", "codeintel.searchReferences", "unknown event"}
@@ -659,7 +659,7 @@ func TestEventLogs_TestCodeIntelligenceRepositoryCounts(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	now := time.Now()
 
@@ -802,7 +802,7 @@ func TestEventLogs_CodeIntelligenceSettingsPageViewCounts(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	names := []string{
@@ -871,7 +871,7 @@ func TestEventLogs_AggregatedCodeIntelEvents(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	names := []string{"codeintel.lsifHover", "codeintel.searchReferences.xrepo", "unknown event"}
@@ -951,7 +951,7 @@ func TestEventLogs_AggregatedSparseCodeIntelEvents(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// This unix timestamp is equivalent to `Friday, May 15, 2020 10:30:00 PM GMT` and is set to
@@ -1003,7 +1003,7 @@ func TestEventLogs_AggregatedCodeIntelInvestigationEvents(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	names := []string{
@@ -1080,7 +1080,7 @@ func TestEventLogs_AggregatedSparseSearchEvents(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// This unix timestamp is equivalent to `Friday, May 15, 2020 10:30:00 PM GMT` and is set to
@@ -1140,7 +1140,7 @@ func TestEventLogs_AggregatedSearchEvents(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	names := []string{"search.latencies.literal", "search.latencies.structural", "unknown event"}
@@ -1307,7 +1307,7 @@ func TestEventLogs_AggregatedCodyEvents(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// This unix timestamp is equivalent to `Friday, May 15, 2020 10:30:00 PM GMT` and is set to
@@ -1404,7 +1404,7 @@ func TestEventLogs_ListAll(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	now := time.Now()
@@ -1482,7 +1482,7 @@ func TestEventLogs_LatestPing(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	t.Run("with no pings in database", func(t *testing.T) {
 		ctx := context.Background()
@@ -1594,7 +1594,7 @@ func TestEventLogs_RequestsByLanguage(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	if _, err := db.Handle().ExecContext(ctx, `
@@ -1864,7 +1864,7 @@ func TestEventLogs_OwnershipFeatureActivity(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			logger := logtest.Scoped(t)
-			db := NewDB(logger, dbtest.NewDB(logger, t))
+			db := NewDB(logger, dbtest.NewDB(t))
 			ctx := context.Background()
 			for _, e := range testCase.events {
 				if err := db.EventLogs().Insert(ctx, e); err != nil {
@@ -1928,7 +1928,7 @@ func TestEventLogs_AggregatedRepoMetadataStats(t *testing.T) {
 		},
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	for _, e := range events {
 		if err := db.EventLogs().Insert(ctx, e); err != nil {
@@ -2029,7 +2029,7 @@ func TestMakeDateTruncExpression(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	cases := []struct {

--- a/internal/database/executor_secret_access_logs_test.go
+++ b/internal/database/executor_secret_access_logs_test.go
@@ -17,7 +17,7 @@ import (
 func TestExecutorSecretAccessLogs_Create(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.NoOp(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	user, err := db.Users().Create(ctx, NewUser{Username: "johndoe"})
 	if err != nil {
 		t.Fatal(err)
@@ -48,7 +48,7 @@ func TestExecutorSecretAccessLogs_Create(t *testing.T) {
 func TestExecutorSecretAccessLogs_GetListCount(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.NoOp(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	user, err := db.Users().Create(ctx, NewUser{Username: "johndoe"})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/database/executor_secrets_internal_test.go
+++ b/internal/database/executor_secrets_internal_test.go
@@ -15,7 +15,7 @@ func TestExecutorSecret_Value(t *testing.T) {
 	logger := logtest.NoOp(t)
 	ctx := context.Background()
 
-	sqldb := dbtest.NewDB(logger, t)
+	sqldb := dbtest.NewDB(t)
 	db := NewDB(logger, sqldb)
 
 	u, err := db.Users().Create(ctx, NewUser{Username: "testuser"})

--- a/internal/database/executor_secrets_test.go
+++ b/internal/database/executor_secrets_test.go
@@ -164,7 +164,7 @@ func TestExecutorSecrets_CreateUpdateDelete(t *testing.T) {
 	// tested further down separately.
 	ctx := actor.WithInternalActor(context.Background())
 	logger := logtest.NoOp(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	user, err := db.Users().Create(ctx, database.NewUser{Username: "johndoe"})
 	if err != nil {
 		t.Fatal(err)
@@ -388,7 +388,7 @@ func TestExecutorSecrets_CreateUpdateDelete(t *testing.T) {
 func TestExecutorSecrets_GetListCount(t *testing.T) {
 	internalCtx := actor.WithInternalActor(context.Background())
 	logger := logtest.NoOp(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	user, err := db.Users().Create(internalCtx, database.NewUser{Username: "johndoe"})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/database/executors_test.go
+++ b/internal/database/executors_test.go
@@ -24,7 +24,7 @@ func TestExecutorsList(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Executors().(*executorStore)
 	ctx := context.Background()
 
@@ -147,7 +147,7 @@ func TestExecutorsGetByID(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Executors().(*executorStore)
 	ctx := context.Background()
 
@@ -211,7 +211,7 @@ func TestExecutorsGetByHostname(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Executors().(*executorStore)
 	ctx := context.Background()
 
@@ -277,7 +277,7 @@ func TestExecutorsDeleteInactiveHeartbeats(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Executors().(*executorStore)
 	ctx := context.Background()
 
@@ -325,7 +325,7 @@ func TestExecutorsUpsertHeartbeat(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	tests := []struct {

--- a/internal/database/external_accounts_test.go
+++ b/internal/database/external_accounts_test.go
@@ -25,7 +25,7 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	spec := extsvc.AccountSpec{
@@ -54,7 +54,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{Username: "u"})
@@ -106,7 +106,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	spec := extsvc.AccountSpec{
@@ -164,7 +164,7 @@ func TestExternalAccounts_CreateUserAndSave_NilData(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	spec := extsvc.AccountSpec{
@@ -208,7 +208,7 @@ func TestExternalAccounts_List(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	specs := []extsvc.AccountSpec{
@@ -341,7 +341,7 @@ func TestExternalAccounts_ListForUsers(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	specs := []extsvc.AccountSpec{
 		{ServiceType: "xa", ServiceID: "xb", ClientID: "xc", AccountID: "11"},
@@ -415,7 +415,7 @@ func TestExternalAccounts_Encryption(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := db.UserExternalAccounts().WithEncryptionKey(et.TestKey{})
@@ -509,7 +509,7 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	spec := extsvc.AccountSpec{
@@ -647,7 +647,7 @@ func TestExternalAccounts_DeleteList(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	spec := extsvc.AccountSpec{
@@ -690,7 +690,7 @@ func TestExternalAccounts_TouchExpiredList(t *testing.T) {
 	t.Parallel()
 	t.Run("non-empty list", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		ctx := context.Background()
 
 		spec := extsvc.AccountSpec{
@@ -732,7 +732,7 @@ func TestExternalAccounts_TouchExpiredList(t *testing.T) {
 	})
 	t.Run("empty list", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		ctx := context.Background()
 
 		acctIds := []int32{}

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -126,7 +126,7 @@ func TestExternalServicesStore_Create(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	envvar.MockSourcegraphDotComMode(true)
@@ -280,7 +280,7 @@ func TestExternalServicesStore_CreateWithTierEnforcement(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	confGet := func() *conf.Unified { return &conf.Unified{} }
@@ -304,7 +304,7 @@ func TestExternalServicesStore_Update(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	now := timeutil.Now()
@@ -632,7 +632,7 @@ func TestExternalServicesStore_DisablePermsSyncingForExternalService(t *testing.
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	envvar.MockSourcegraphDotComMode(true)
@@ -702,7 +702,7 @@ func TestCountRepoCount(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	// Create a new external service
@@ -753,7 +753,7 @@ func TestExternalServicesStore_Delete(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	// Create a new external service
@@ -848,7 +848,7 @@ func TestExternalServiceStore_Delete_WithSyncJobs(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := &externalServiceStore{Store: basestore.NewWithHandle(db.Handle())}
 	ctx := context.Background()
 
@@ -935,7 +935,7 @@ func TestExternalServicesStore_DeleteExtServiceWithManyRepos(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	// Create a new external service
@@ -1069,7 +1069,7 @@ func TestExternalServicesStore_GetByID(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -1113,7 +1113,7 @@ func TestExternalServicesStore_GetByID_Encrypted(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -1171,7 +1171,7 @@ func TestGetLatestSyncErrors(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	createService := func(name string) *types.ExternalService {
@@ -1261,7 +1261,7 @@ func TestGetLastSyncError(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -1337,7 +1337,7 @@ func TestExternalServiceStore_HasRunningSyncJobs(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := &externalServiceStore{Store: basestore.NewWithHandle(db.Handle())}
 	ctx := context.Background()
 
@@ -1384,7 +1384,7 @@ func TestExternalServiceStore_CancelSyncJob(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.ExternalServices()
 	ctx := context.Background()
 
@@ -1484,7 +1484,7 @@ func TestExternalServicesStore_List(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create new external services
@@ -1667,7 +1667,7 @@ func TestExternalServicesStore_DistinctKinds(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	t.Run("no external service won't blow up", func(t *testing.T) {
@@ -1736,7 +1736,7 @@ func TestExternalServicesStore_Count(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -1774,14 +1774,14 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	clock := timeutil.NewFakeClock(time.Now(), 0)
 
 	t.Run("no external services", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		if err := db.ExternalServices().Upsert(ctx); err != nil {
 			t.Fatalf("Upsert error: %s", err)
 		}
 	})
 
 	t.Run("validation", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		store := db.ExternalServices()
 
 		t.Run("config can't be empty", func(t *testing.T) {
@@ -1805,7 +1805,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("one external service", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		store := db.ExternalServices()
 
 		svc := typestest.MakeGitLabExternalService()
@@ -1832,7 +1832,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("many external services", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		store := db.ExternalServices()
 
 		svcs := typestest.MakeExternalServices()
@@ -1904,7 +1904,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("with encryption key", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		store := db.ExternalServices().WithEncryptionKey(et.TestKey{})
 
 		svcs := typestest.MakeExternalServices()
@@ -1987,7 +1987,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("check code hosts created with many external services", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 		store := db.ExternalServices()
 
 		svcs := typestest.MakeExternalServices()
@@ -2036,7 +2036,7 @@ func TestExternalServiceStore_GetSyncJobs(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -2082,7 +2082,7 @@ func TestExternalServiceStore_CountSyncJobs(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -2123,7 +2123,7 @@ func TestExternalServiceStore_GetSyncJobByID(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -2184,7 +2184,7 @@ func TestExternalServiceStore_UpdateSyncJobCounters(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service
@@ -2260,7 +2260,7 @@ func TestExternalServicesStore_OneCloudDefaultPerKind(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	now := time.Now()
@@ -2306,7 +2306,7 @@ func TestExternalServiceStore_SyncDue(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	now := time.Now()
@@ -2493,7 +2493,7 @@ func TestExternalServiceStore_ListRepos(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create a new external service

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -72,7 +72,7 @@ func setupClearRedisCacheTest(t *testing.T, expectedFlagName string) *bool {
 func testNewFeatureFlagRoundtrip(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	flagStore := NewDB(logger, dbtest.NewDB(logger, t)).FeatureFlags()
+	flagStore := NewDB(logger, dbtest.NewDB(t)).FeatureFlags()
 	ctx := actor.WithInternalActor(context.Background())
 
 	cases := []struct {
@@ -129,7 +129,7 @@ func testNewFeatureFlagRoundtrip(t *testing.T) {
 func testListFeatureFlags(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := &featureFlagStore{Store: basestore.NewWithHandle(db.Handle())}
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -165,7 +165,7 @@ func testListFeatureFlags(t *testing.T) {
 func testNewOverrideRoundtrip(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := db.FeatureFlags()
 	users := db.Users()
 	ctx := actor.WithInternalActor(context.Background())
@@ -215,7 +215,7 @@ func testNewOverrideRoundtrip(t *testing.T) {
 func testListUserOverrides(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := &featureFlagStore{Store: basestore.NewWithHandle(db.Handle())}
 	users := db.Users()
 	ctx := actor.WithInternalActor(context.Background())
@@ -295,7 +295,7 @@ func testListUserOverrides(t *testing.T) {
 func testListOrgOverrides(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := &featureFlagStore{Store: basestore.NewWithHandle(db.Handle())}
 	users := db.Users()
 	orgs := db.Orgs()
@@ -381,7 +381,7 @@ func testListOrgOverrides(t *testing.T) {
 func testUserFlags(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := db.FeatureFlags()
 	users := db.Users()
 	orgs := db.Orgs()
@@ -558,7 +558,7 @@ func testUserFlags(t *testing.T) {
 func testAnonymousUserFlags(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := db.FeatureFlags()
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -603,7 +603,7 @@ func testAnonymousUserFlags(t *testing.T) {
 func testUserlessFeatureFlags(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := db.FeatureFlags()
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -652,7 +652,7 @@ func testUserlessFeatureFlags(t *testing.T) {
 func testOrgFeatureFlag(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := db.FeatureFlags()
 	orgs := db.Orgs()
 	ctx := actor.WithInternalActor(context.Background())
@@ -728,7 +728,7 @@ func testOrgFeatureFlag(t *testing.T) {
 func testGetFeatureFlag(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := db.FeatureFlags()
 	ctx := context.Background()
 	t.Run("no value", func(t *testing.T) {
@@ -755,7 +755,7 @@ func testGetFeatureFlag(t *testing.T) {
 func testUpdateFeatureFlag(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	flagStore := db.FeatureFlags()
 	ctx := context.Background()
 	t.Run("invalid input", func(t *testing.T) {

--- a/internal/database/gitserver_localclone_jobs_test.go
+++ b/internal/database/gitserver_localclone_jobs_test.go
@@ -16,7 +16,7 @@ func TestGitserverLocalCloneEnqueue(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	jobid, err := db.GitserverLocalClone().Enqueue(ctx, 1, "gitserver1", "gitserver2", true)

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -31,7 +31,7 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	repos := types.Repos{
@@ -111,7 +111,7 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 func TestIteratePurgeableRepos(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := basestore.NewWithHandle(db.Handle())
 
 	normalRepo := &types.Repo{Name: "normal"}
@@ -268,7 +268,7 @@ func TestListReposWithLastError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			logger := logtest.Scoped(t)
-			db := NewDB(logger, dbtest.NewDB(logger, t))
+			db := NewDB(logger, dbtest.NewDB(t))
 			now := time.Now()
 
 			cloudDefaultService := createTestExternalService(ctx, t, now, db, true)
@@ -350,7 +350,7 @@ func TestReposWithLastOutput(t *testing.T) {
 	}
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	now := time.Now()
 	cloudDefaultService := createTestExternalService(ctx, t, now, db, true)
 	for i, tr := range testRepos {
@@ -414,7 +414,7 @@ func TestGitserverReposGetByID(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -440,7 +440,7 @@ func TestGitserverReposGetByName(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -466,7 +466,7 @@ func TestGitserverReposGetByNames(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	gitserverRepoStore := &gitserverRepoStore{Store: basestore.NewWithHandle(db.Handle())}
@@ -507,7 +507,7 @@ func TestSetCloneStatus(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -575,7 +575,7 @@ func TestCloningProgress(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	t.Run("Default", func(t *testing.T) {
@@ -620,7 +620,7 @@ func TestLogCorruption(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	t.Run("log repo corruption sets corrupted_at time", func(t *testing.T) {
@@ -774,7 +774,7 @@ func TestSetLastError(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -853,7 +853,7 @@ func TestSetRepoSize(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -930,7 +930,7 @@ func TestGitserverRepo_Update(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create one test repo
@@ -994,7 +994,7 @@ func TestGitserverRepoUpdateMany(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create two test repos
@@ -1058,7 +1058,7 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	repo1, gitserverRepo1 := createTestRepo(ctx, t, db, &createTestRepoPayload{
@@ -1229,7 +1229,7 @@ func TestGitserverRepos_GetGitserverGitDirSize(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	assertSize := func(want int64) {

--- a/internal/database/global_state_test.go
+++ b/internal/database/global_state_test.go
@@ -115,5 +115,5 @@ func testGlobalStateStore(t *testing.T) GlobalStateStore {
 	}
 
 	logger := logtest.Scoped(t)
-	return NewDB(logger, dbtest.NewDB(logger, t)).GlobalState()
+	return NewDB(logger, dbtest.NewDB(t)).GlobalState()
 }

--- a/internal/database/locker/locker_test.go
+++ b/internal/database/locker/locker_test.go
@@ -19,7 +19,7 @@ func TestLock(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	handle := basestore.NewWithHandle(basestore.NewHandleWithDB(logger, db, sql.TxOptions{}))
 	locker := NewWith(handle, "test")
 
@@ -63,7 +63,7 @@ func TestLockBlockingAcquire(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	handle := basestore.NewWithHandle(basestore.NewHandleWithDB(logger, db, sql.TxOptions{}))
 	locker := NewWith(handle, "test")
 
@@ -121,7 +121,7 @@ func TestLockBadTransactionState(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	handle := basestore.NewWithHandle(basestore.NewHandleWithDB(logger, db, sql.TxOptions{}))
 	locker := NewWith(handle, "test")
 

--- a/internal/database/migration/store/store_test.go
+++ b/internal/database/migration/store/store_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -25,8 +23,7 @@ import (
 )
 
 func TestEnsureSchemaTable(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -110,8 +107,7 @@ func testBackfillSchemaVersion(
 	expectedVersions []int,
 	setup func(ctx context.Context, store *Store),
 ) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	store := testStoreWithName(db, schemaName)
 	ctx := context.Background()
 
@@ -151,8 +147,7 @@ func TestHumanizeSchemaName(t *testing.T) {
 }
 
 func TestVersions(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	store := testStore(db)
 	ctx := context.Background()
 	if err := store.EnsureSchemaTable(ctx); err != nil {
@@ -241,8 +236,7 @@ func TestVersions(t *testing.T) {
 }
 
 func TestTryLock(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -287,8 +281,7 @@ func TestTryLock(t *testing.T) {
 }
 
 func TestWrappedUp(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -404,8 +397,7 @@ func TestWrappedUp(t *testing.T) {
 }
 
 func TestWrappedDown(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	store := testStore(db)
 	ctx := context.Background()
 
@@ -532,8 +524,7 @@ func TestWrappedDown(t *testing.T) {
 }
 
 func TestIndexStatus(t *testing.T) {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	store := testStore(db)
 	ctx := context.Background()
 

--- a/internal/database/namespace_permissions_test.go
+++ b/internal/database/namespace_permissions_test.go
@@ -17,7 +17,7 @@ func TestCreateNamespacePermission(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.NamespacePermissions()
 
 	user := createUserForNamespacePermission(ctx, t, db, "TestUser")
@@ -89,7 +89,7 @@ func TestDeleteNamespacePermission(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.NamespacePermissions()
 
 	user := createUserForNamespacePermission(ctx, t, db, "user1")
@@ -134,7 +134,7 @@ func TestGetNamespacePermission(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.NamespacePermissions()
 
 	user := createUserForNamespacePermission(ctx, t, db, "user1")

--- a/internal/database/namespaces_test.go
+++ b/internal/database/namespaces_test.go
@@ -16,7 +16,7 @@ func TestNamespaces(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create user and organization to test lookups.

--- a/internal/database/org_invitations_test.go
+++ b/internal/database/org_invitations_test.go
@@ -21,7 +21,7 @@ func TestOrgInvitations(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	sender, err := db.Users().Create(ctx, NewUser{

--- a/internal/database/org_members_db_test.go
+++ b/internal/database/org_members_db_test.go
@@ -19,7 +19,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create fixtures.
@@ -118,7 +118,7 @@ func TestOrgMembers_MemberCount(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	// Create fixtures.
 	org1, err := db.Orgs().Create(ctx, "org1", nil)
@@ -197,7 +197,7 @@ func TestOrgMembers_AutocompleteMembersSearch(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	tests := []struct {

--- a/internal/database/orgs_test.go
+++ b/internal/database/orgs_test.go
@@ -64,7 +64,7 @@ var orgnamesForTests = []struct {
 func TestOrgs_ValidNames(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	for _, test := range orgnamesForTests {
@@ -87,7 +87,7 @@ func TestOrgs_ValidNames(t *testing.T) {
 func TestOrgs_Count(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	org, err := db.Orgs().Create(ctx, "a", nil)
@@ -115,7 +115,7 @@ func TestOrgs_Count(t *testing.T) {
 func TestOrgs_Delete(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	displayName := "a"
@@ -152,7 +152,7 @@ func TestOrgs_Delete(t *testing.T) {
 func TestOrgs_HardDelete(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	displayName := "org1"
@@ -226,7 +226,7 @@ func TestOrgs_GetByID(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	createOrg(ctx, db, "org1", "org1")
@@ -250,7 +250,7 @@ func TestOrgs_GetByID(t *testing.T) {
 func TestOrgs_AddOrgsOpenBetaStats(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	userID := int32(42)
@@ -290,7 +290,7 @@ func TestOrgs_AddOrgsOpenBetaStats(t *testing.T) {
 func TestOrgs_UpdateOrgsOpenBetaStats(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	userID := int32(42)

--- a/internal/database/outbound_webhooks_test.go
+++ b/internal/database/outbound_webhooks_test.go
@@ -440,11 +440,11 @@ func runBothEncryptionStates(t *testing.T, f func(t *testing.T, logger log.Logge
 	var key encryption.Key
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Run("unencrypted", func(t *testing.T) { f(t, logger, db, key) })
 
 	logger = logtest.Scoped(t)
-	db = NewDB(logger, dbtest.NewDB(logger, t))
+	db = NewDB(logger, dbtest.NewDB(t))
 	key = et.ByteaTestKey{}
 	t.Run("encrypted", func(t *testing.T) { f(t, logger, db, key) })
 }

--- a/internal/database/own_signal_configurations_test.go
+++ b/internal/database/own_signal_configurations_test.go
@@ -14,7 +14,7 @@ import (
 
 func Test_LoadConfigurations(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := db.OwnSignalConfigurations()

--- a/internal/database/ownership_stats_test.go
+++ b/internal/database/ownership_stats_test.go
@@ -32,7 +32,7 @@ func TestUpdateIndividualCountsSuccess(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	// 1. Setup repo and paths:
 	repo := mustCreate(ctx, t, db, &types.Repo{Name: "a/b"})
@@ -64,7 +64,7 @@ func TestQueryIndividualCountsAggregation(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	// 1. Setup repos and paths:
 	repo1 := mustCreate(ctx, t, db, &types.Repo{Name: "a/b"})
@@ -161,7 +161,7 @@ func TestUpdateAggregateCountsSuccess(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	// 1. Setup repo and paths:
 	repo := mustCreate(ctx, t, db, &types.Repo{Name: "a/b"})
@@ -204,7 +204,7 @@ func TestQueryAggregateCounts(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	// 1. Setup repo and paths:
 	repo1 := mustCreate(ctx, t, db, &types.Repo{Name: "a/b"})

--- a/internal/database/permission_sync_jobs_test.go
+++ b/internal/database/permission_sync_jobs_test.go
@@ -27,7 +27,7 @@ func TestPermissionSyncJobs_CreateAndList(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	user, err := db.Users().Create(ctx, NewUser{Username: "horse"})
 	require.NoError(t, err)
 
@@ -293,7 +293,7 @@ func TestPermissionSyncJobs_GetLatestSyncJob(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	store := PermissionSyncJobsWith(logger, db)
 	usersStore := UsersWith(logger, db)
@@ -396,7 +396,7 @@ func TestPermissionSyncJobs_Deduplication(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	user1, err := db.Users().Create(ctx, NewUser{Username: "horse"})
 	require.NoError(t, err)
 
@@ -553,7 +553,7 @@ func TestPermissionSyncJobs_CancelQueuedJob(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := PermissionSyncJobsWith(logger, db)
@@ -602,7 +602,7 @@ func TestPermissionSyncJobs_SaveSyncResult(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := PermissionSyncJobsWith(logger, db)
@@ -663,7 +663,7 @@ func TestPermissionSyncJobs_CascadeOnRepoDelete(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := PermissionSyncJobsWith(logger, db)
@@ -699,7 +699,7 @@ func TestPermissionSyncJobs_CascadeOnUserDelete(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := PermissionSyncJobsWith(logger, db)
@@ -735,7 +735,7 @@ func TestPermissionSyncJobs_Pagination(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	user, err := db.Users().Create(ctx, NewUser{Username: "horse"})
 	require.NoError(t, err)
 
@@ -797,7 +797,7 @@ func TestPermissionSyncJobs_Count(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	user, err := db.Users().Create(ctx, NewUser{Username: "horse"})
 	require.NoError(t, err)
 
@@ -841,7 +841,7 @@ func TestPermissionSyncJobs_CountUsersWithFailingSyncJob(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	store := PermissionSyncJobsWith(logger, db)
 	usersStore := UsersWith(logger, db)
@@ -915,7 +915,7 @@ func TestPermissionSyncJobs_CountReposWithFailingSyncJob(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	store := PermissionSyncJobsWith(logger, db)
 	reposStore := ReposWith(logger, db)

--- a/internal/database/permissions_test.go
+++ b/internal/database/permissions_test.go
@@ -18,7 +18,7 @@ func TestPermissionGetByID(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Permissions()
 
 	created, err := store.Create(ctx, CreatePermissionOpts{
@@ -57,7 +57,7 @@ func TestPermissionCreate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Permissions()
 
 	t.Run("invalid namespace", func(t *testing.T) {
@@ -105,7 +105,7 @@ func TestPermissionCreate(t *testing.T) {
 func TestPermissionList(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Permissions()
 
 	role, user, totalPerms := seedPermissionDataForList(ctx, t, store, db)
@@ -164,7 +164,7 @@ func TestPermissionDelete(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Permissions()
 
 	p, err := store.Create(ctx, CreatePermissionOpts{
@@ -201,7 +201,7 @@ func TestPermissionBulkCreate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Permissions()
 
 	t.Run("invalid namespace", func(t *testing.T) {
@@ -236,7 +236,7 @@ func TestPermissionBulkDelete(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Permissions()
 
 	var perms []CreatePermissionOpts
@@ -286,7 +286,7 @@ func TestPermissionBulkDelete(t *testing.T) {
 func TestPermissionCount(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Permissions()
 
 	role, user, totalPerms := seedPermissionDataForList(ctx, t, store, db)
@@ -320,7 +320,7 @@ func TestPermissionCount(t *testing.T) {
 func TestGetPermissionForUser(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Permissions()
 
 	u1, err := db.Users().Create(ctx, NewUser{Username: "username-1"})

--- a/internal/database/perms_store_test.go
+++ b/internal/database/perms_store_test.go
@@ -82,7 +82,7 @@ func TestPermsStore_LoadUserPermissions(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	ctx := context.Background()
 
@@ -180,7 +180,7 @@ func TestPermsStore_LoadRepoPermissions(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	ctx := context.Background()
 
@@ -235,7 +235,7 @@ func TestPermsStore_SetUserExternalAccountPerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	const countToExceedParameterLimit = 17000 // ~ 65535 / 4 parameters per row
@@ -593,7 +593,7 @@ func TestPermsStore_SetUserRepoPermissions(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	source := authz.SourceUserSync
@@ -756,7 +756,7 @@ func TestPermsStore_UnionExplicitAndSyncedPermissions(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	tests := []struct {
@@ -897,7 +897,7 @@ func TestPermsStore_FetchReposByExternalAccount(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	source := authz.SourceRepoSync
@@ -992,7 +992,7 @@ func TestPermsStore_SetRepoPermissionsUnrestricted(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	ctx := context.Background()
@@ -1159,7 +1159,7 @@ func TestPermsStore_SetRepoPerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	type testUpdate struct {
@@ -1419,7 +1419,7 @@ func TestPermsStore_LoadUserPendingPermissions(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	t.Run("no matching with different account ID", func(t *testing.T) {
@@ -1716,7 +1716,7 @@ func TestPermsStore_SetRepoPendingPermissions(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	alice := extsvc.AccountSpec{
@@ -1999,7 +1999,7 @@ func TestPermsStore_ListPendingUsers(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	type update struct {
@@ -2117,7 +2117,7 @@ func TestPermsStore_GrantPendingPermissions(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	ctx := context.Background()
@@ -2759,7 +2759,7 @@ func TestPermsStore_SetPendingPermissionsAfterGrant(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	defer cleanupPermsTables(t, s)
@@ -2831,7 +2831,7 @@ func TestPermsStore_DeleteAllUserPermissions(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	t.Cleanup(func() {
@@ -2916,7 +2916,7 @@ func TestPermsStore_DeleteAllUserPendingPermissions(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	t.Cleanup(func() {
@@ -2978,7 +2978,7 @@ func TestPermsStore_DatabaseDeadlocks(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, time.Now)
 	t.Cleanup(func() {
@@ -3093,7 +3093,7 @@ func TestPermsStore_GetUserIDsByExternalAccounts(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	s := perms(logger, db, time.Now)
@@ -3175,7 +3175,7 @@ func TestPermsStore_UserIDsWithNoPerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, time.Now)
 
@@ -3237,7 +3237,7 @@ func TestPermsStore_CountUsersWithNoPerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, time.Now)
 
@@ -3292,7 +3292,7 @@ func TestPermsStore_RepoIDsWithNoPerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, time.Now)
 
@@ -3351,7 +3351,7 @@ func TestPermsStore_CountReposWithNoPerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, time.Now)
 
@@ -3398,7 +3398,7 @@ func TestPermsStore_UserIDsWithOldestPerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	ctx := context.Background()
@@ -3503,7 +3503,7 @@ func TestPermsStore_CountUsersWithStalePerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	ctx := context.Background()
@@ -3571,7 +3571,7 @@ func TestPermsStore_ReposIDsWithOldestPerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	ctx := context.Background()
@@ -3674,7 +3674,7 @@ func TestPermsStore_CountReposWithStalePerms(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	ctx := context.Background()
@@ -3740,7 +3740,7 @@ func TestPermsStore_MapUsers(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	ctx := context.Background()
@@ -3812,7 +3812,7 @@ func TestPermsStore_Metrics(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 
@@ -3923,7 +3923,7 @@ func TestPermsStore_ListUserPermissions(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 	s := perms(logger, db, clock)
 	ctx := context.Background()
@@ -4084,7 +4084,7 @@ func TestPermsStore_ListRepoPermissions(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	testDb := dbtest.NewDB(logger, t)
+	testDb := dbtest.NewDB(t)
 	db := NewDB(logger, testDb)
 
 	s := perms(logtest.Scoped(t), db, clock)

--- a/internal/database/phabricator_test.go
+++ b/internal/database/phabricator_test.go
@@ -18,7 +18,7 @@ import (
 func TestCreation(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	p, err := db.Phabricator().Create(ctx, "callsign", "repo", "url")
@@ -49,7 +49,7 @@ func TestCreation(t *testing.T) {
 func TestCreateIfNotExistsAndGetByName(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	config := &schema.PhabricatorConnection{

--- a/internal/database/recent_contribution_signal_test.go
+++ b/internal/database/recent_contribution_signal_test.go
@@ -23,7 +23,7 @@ func TestRecentContributionSignalStore(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := RecentContributionSignalStoreWith(db)
 
 	ctx := context.Background()

--- a/internal/database/recent_view_signal_test.go
+++ b/internal/database/recent_view_signal_test.go
@@ -24,7 +24,7 @@ func TestRecentViewSignalStore_BuildAggregateFromEvents(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating 2 users.
@@ -136,7 +136,7 @@ func TestRecentViewSignalStore_BuildAggregateFromEvents_WithExcludedRepos(t *tes
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating 2 users.
@@ -258,7 +258,7 @@ func TestRecentViewSignalStore_Insert(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating a user.
@@ -342,7 +342,7 @@ func TestRecentViewSignalStore_InsertPaths(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating a user.
@@ -406,7 +406,7 @@ func TestRecentViewSignalStore_InsertPaths_OverBatchSize(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating a user.
@@ -446,7 +446,7 @@ func TestRecentViewSignalStore_List(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	d := NewDB(logger, dbtest.NewDB(logger, t))
+	d := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating 2 users.

--- a/internal/database/redis_key_value_test.go
+++ b/internal/database/redis_key_value_test.go
@@ -12,7 +12,7 @@ import (
 func TestRedisKeyValue(t *testing.T) {
 	require := require.New(t)
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	kv := db.RedisKeyValue()
 

--- a/internal/database/repo_commits_changelists_test.go
+++ b/internal/database/repo_commits_changelists_test.go
@@ -22,7 +22,7 @@ import (
 func TestRepoCommitsChangelists(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	repos := db.Repos()
 	err := repos.Create(ctx, &types.Repo{ID: 1, Name: "foo"})

--- a/internal/database/repo_kvps_test.go
+++ b/internal/database/repo_kvps_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRepoKVPs(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	kvps := db.RepoKVPs()
 

--- a/internal/database/repo_paths_test.go
+++ b/internal/database/repo_paths_test.go
@@ -30,7 +30,7 @@ func TestUpdateFileCounts(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	// Create repo
 	repo := mustCreate(ctx, t, db, &types.Repo{Name: "a/b"})
@@ -55,7 +55,7 @@ func TestAggregateFileCounts(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Create repos.

--- a/internal/database/repo_statistics_test.go
+++ b/internal/database/repo_statistics_test.go
@@ -21,7 +21,7 @@ func TestRepoStatistics(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
 
@@ -174,7 +174,7 @@ func TestRepoStatistics_RecloneAndCorruption(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
 
@@ -263,7 +263,7 @@ func TestRepoStatistics_DeleteAndUndelete(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
 
@@ -359,7 +359,7 @@ func TestRepoStatistics_AvoidZeros(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
 
@@ -414,7 +414,7 @@ func TestRepoStatistics_Compaction(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
 

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -71,7 +71,7 @@ func TestAuthzQueryConds(t *testing.T) {
 	cmpOpts := cmp.AllowUnexported(sqlf.Query{})
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	t.Run("When permissions user mapping is enabled", func(t *testing.T) {
 		authz.SetProviders(false, []authz.Provider{&fakeProvider{}})
@@ -288,7 +288,7 @@ func TestRepoStore_userCanSeeUnrestricedRepo(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	alice, unrestrictedRepo := setupUnrestrictedDB(t, ctx, db)
 
@@ -357,7 +357,7 @@ func TestRepoStore_userCanSeePublicRepo(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	alice, publicRepo := setupPublicRepo(t, db)
@@ -513,7 +513,7 @@ func TestRepoStore_List_checkPermissions(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	users, repos := setupDB(t, ctx, db)
@@ -596,7 +596,7 @@ func TestRepoStore_List_permissionsUserMapping(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Set up three users: alice, bob and admin
@@ -821,7 +821,7 @@ func benchmarkAuthzQuery(b *testing.B, numRepos, numUsers, reposPerUser int) {
 	})
 
 	logger := logtest.Scoped(b)
-	db := NewDB(logger, dbtest.NewDB(logger, b))
+	db := NewDB(logger, dbtest.NewDB(b))
 	ctx := context.Background()
 
 	b.Logf("Creating %d repositories...", numRepos)

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -288,7 +288,7 @@ func TestRepos_createRepo_dupe(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	// Add a repo.
@@ -306,7 +306,7 @@ func TestRepos_createRepo(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	// Add a repo.
@@ -335,7 +335,7 @@ func TestRepos_Get(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	now := time.Now()
@@ -397,7 +397,7 @@ func TestRepos_GetByIDs(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	want := mustCreate(ctx, t, db, &types.Repo{
@@ -429,7 +429,7 @@ func TestRepos_GetByIDs_EmptyIDs(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	repos, err := db.Repos().GetByIDs(ctx, []api.RepoID{}...)
@@ -445,7 +445,7 @@ func TestRepos_GetByIDs_EmptyIDs(t *testing.T) {
 func TestRepos_GetRepoDescriptionsByIDs(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	created := mustCreate(ctx, t, db, &types.Repo{
@@ -481,7 +481,7 @@ func TestRepos_List(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	now := time.Now()
@@ -543,7 +543,7 @@ func TestRepos_List_fork(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	mine := mustCreate(ctx, t, db, &types.Repo{Name: "a/r", Fork: false})
@@ -573,7 +573,7 @@ func TestRepos_List_FailedSync(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	assertCount := func(t *testing.T, opts ReposListOptions, want int) {
@@ -604,7 +604,7 @@ func TestRepos_List_OnlyCorrupted(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	assertCount := func(t *testing.T, opts ReposListOptions, want int) {
@@ -635,7 +635,7 @@ func TestRepos_List_cloned(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	var repos []*types.Repo
@@ -687,7 +687,7 @@ func TestRepos_List_indexed(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	var repos []*types.Repo
@@ -734,7 +734,7 @@ func TestRepos_List_LastChanged(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	repos := db.Repos()
@@ -871,7 +871,7 @@ func TestRepos_List_ids(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	mine := types.Repos{mustCreate(ctx, t, db, typestest.MakeGithubRepo())}
@@ -908,7 +908,7 @@ func TestRepos_List_pagination(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	createdRepos := []*types.Repo{
@@ -957,7 +957,7 @@ func TestRepos_List_query1(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	createdRepos := []*types.Repo{
@@ -1007,7 +1007,7 @@ func TestRepos_List_correct_ranking(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	createdRepos := []*types.Repo{
@@ -1055,7 +1055,7 @@ func TestRepos_List_sort(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	reposAndSizes := []*repoAndSize{
@@ -1134,7 +1134,7 @@ func TestRepos_List_patterns(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	createdRepos := []*types.Repo{
@@ -1201,7 +1201,7 @@ func TestRepos_List_queryAndPatternsMutuallyExclusive(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	t.Run("Query and IncludePatterns", func(t *testing.T) {
 		_, err := db.Repos().List(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}})
@@ -1225,7 +1225,7 @@ func TestRepos_List_useOr(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	archived := mustCreate(ctx, t, db, types.Repos{typestest.MakeGitlabRepo()}.With(func(r *types.Repo) { r.Archived = true })[0])
@@ -1265,7 +1265,7 @@ func TestRepos_List_externalServiceID(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	confGet := func() *conf.Unified {
@@ -1316,7 +1316,7 @@ func TestRepos_List_externalServiceID(t *testing.T) {
 func TestRepos_List_topics(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 	confGet := func() *conf.Unified { return &conf.Unified{} }
 
@@ -1392,7 +1392,7 @@ func TestRepos_ListMinimalRepos(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	now := time.Now()
@@ -1436,7 +1436,7 @@ func TestRepos_ListMinimalRepos_fork(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	mine := repoNamesFromRepos([]*types.Repo{mustCreate(ctx, t, db, &types.Repo{Name: "a/r", Fork: false})})
@@ -1479,7 +1479,7 @@ func TestRepos_ListMinimalRepos_cloned(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	mine := repoNamesFromRepos([]*types.Repo{mustCreate(ctx, t, db, &types.Repo{Name: "a/r"})})
@@ -1516,7 +1516,7 @@ func TestRepos_ListMinimalRepos_ids(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	mine := types.Repos{mustCreate(ctx, t, db, typestest.MakeGithubRepo())}
@@ -1553,7 +1553,7 @@ func TestRepos_ListMinimalRepos_pagination(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	createdRepos := []*types.Repo{
@@ -1602,7 +1602,7 @@ func TestRepos_ListMinimalRepos_correctFiltering(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	createdRepos := []*types.Repo{
@@ -1642,7 +1642,7 @@ func TestRepos_ListMinimalRepos_query2(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	createdRepos := []*types.Repo{
@@ -1685,7 +1685,7 @@ func TestRepos_ListMinimalRepos_sort(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	createdRepos := []*types.Repo{
@@ -1756,7 +1756,7 @@ func TestRepos_ListMinimalRepos_patterns(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	createdRepos := []*types.Repo{
@@ -1811,7 +1811,7 @@ func TestRepos_ListMinimalRepos_queryAndPatternsMutuallyExclusive(t *testing.T) 
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Run("Query and IncludePatterns", func(t *testing.T) {
 		_, err := db.Repos().ListMinimalRepos(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}})
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
@@ -1833,7 +1833,7 @@ func TestRepos_ListMinimalRepos_SearchContextIDAndExternalServiceIDsMutuallyExcl
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	_, err := db.Repos().ListMinimalRepos(ctx, ReposListOptions{SearchContextID: 1, ExternalServiceIDs: []int64{2}})
 	if err == nil || !strings.Contains(err.Error(), wantErr) {
 		t.Fatalf("got error %v, want it to contain %q", err, wantErr)
@@ -1847,7 +1847,7 @@ func TestRepos_ListMinimalRepos_useOr(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	archived := mustCreate(ctx, t, db, types.Repos{typestest.MakeGitlabRepo()}.With(func(r *types.Repo) { r.Archived = true })[0])
@@ -1887,7 +1887,7 @@ func TestRepos_ListMinimalRepos_externalServiceID(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	confGet := func() *conf.Unified {
@@ -1944,7 +1944,7 @@ func TestRepos_ListMinimalRepos_externalRepoContains(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	confGet := func() *conf.Unified {
@@ -2269,7 +2269,7 @@ func TestGetFirstRepoNamesByCloneURL(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
 	confGet := func() *conf.Unified {
@@ -2427,7 +2427,7 @@ func TestRepos_Count(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -2480,7 +2480,7 @@ func TestRepos_Delete(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -2515,7 +2515,7 @@ func TestRepos_DeleteReconcilesName(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 	repo := mustCreate(ctx, t, db, &types.Repo{Name: "myrepo"})
@@ -2554,7 +2554,7 @@ func TestRepos_MultipleDeletesKeepTheSameTombstoneData(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 	repo := mustCreate(ctx, t, db, &types.Repo{Name: "myrepo"})
@@ -2603,7 +2603,7 @@ func TestRepos_Upsert(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -2687,7 +2687,7 @@ func TestRepos_UpsertForkAndArchivedFields(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -2722,7 +2722,7 @@ func TestRepos_Create(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -2773,7 +2773,7 @@ func TestListSourcegraphDotComIndexableRepos(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	reposToAdd := []types.Repo{
 		{
@@ -2889,7 +2889,7 @@ func TestRepoStore_Metadata(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 

--- a/internal/database/role_permissions_test.go
+++ b/internal/database/role_permissions_test.go
@@ -21,7 +21,7 @@ func TestRolePermissionAssign(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 	roleStore := db.Roles()
 
@@ -97,7 +97,7 @@ func TestRolePermissionAssignToSystemRole(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 
 	_, p := createRoleAndPermission(ctx, t, db)
@@ -152,7 +152,7 @@ func TestRolePermissionBulkAssignPermissionsToSystemRoles(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 
 	_, p := createRoleAndPermission(ctx, t, db)
@@ -196,7 +196,7 @@ func TestRolePermissionBulkAssignPermissionsToSystemRoles(t *testing.T) {
 func TestRolePermissionGetByRoleIDAndPermissionID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 
 	r, p := createRoleAndPermission(ctx, t, db)
@@ -254,7 +254,7 @@ func TestRolePermissionGetByRoleIDAndPermissionID(t *testing.T) {
 func TestRolePermissionGetByRoleID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 
 	r := createTestRoleForRolePermission(ctx, "TEST ROLE", t, db)
@@ -298,7 +298,7 @@ func TestRolePermissionGetByRoleID(t *testing.T) {
 func TestRolePermissionGetByPermissionID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 
 	p := createTestPermissionForRolePermission(ctx, "READ", t, db)
@@ -343,7 +343,7 @@ func TestRolePermissionRevoke(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 	roleStore := db.Roles()
 
@@ -435,7 +435,7 @@ func TestBulkAssignPermissionsToRole(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 	roleStore := db.Roles()
 
@@ -511,7 +511,7 @@ func TestBulkRevokePermissionsForRole(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 	roleStore := db.Roles()
 
@@ -580,7 +580,7 @@ func TestSetPermissionsForRole(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.RolePermissions()
 	roleStore := db.Roles()
 

--- a/internal/database/roles_test.go
+++ b/internal/database/roles_test.go
@@ -23,7 +23,7 @@ var numberOfSystemRoles = 2
 func TestRoleGet(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Roles()
 
 	roleName := "OPERATOR"
@@ -58,7 +58,7 @@ func TestRoleGet(t *testing.T) {
 func TestRoleList(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Roles()
 
 	roles, total := createTestRoles(ctx, t, store)
@@ -125,7 +125,7 @@ func TestRoleCreate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Roles()
 
 	_, err := store.Create(ctx, "TESTOLE", true)
@@ -135,7 +135,7 @@ func TestRoleCreate(t *testing.T) {
 func TestRoleCount(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Roles()
 
 	user := createTestUserWithoutRoles(t, db, "test-user-1", false)
@@ -178,7 +178,7 @@ func TestRoleUpdate(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Roles()
 
 	t.Run("non-existent role", func(t *testing.T) {
@@ -207,7 +207,7 @@ func TestRoleDelete(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Roles()
 
 	t.Run("no ID", func(t *testing.T) {

--- a/internal/database/saved_searches_test.go
+++ b/internal/database/saved_searches_test.go
@@ -21,7 +21,7 @@ func TestSavedSearchesIsEmpty(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	isEmpty, err := db.SavedSearches().IsEmpty(ctx)
 	if err != nil {
@@ -65,7 +65,7 @@ func TestSavedSearchesCreate(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := db.Users().Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -105,7 +105,7 @@ func TestSavedSearchesUpdate(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := db.Users().Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -148,7 +148,7 @@ func TestSavedSearchesDelete(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := db.Users().Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -188,7 +188,7 @@ func TestSavedSearchesGetByUserID(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := db.Users().Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -232,7 +232,7 @@ func TestSavedSearchesGetByID(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := db.Users().Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
@@ -277,7 +277,7 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	_, err := db.Users().Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {

--- a/internal/database/search_contexts_test.go
+++ b/internal/database/search_contexts_test.go
@@ -31,7 +31,7 @@ func createSearchContexts(ctx context.Context, store SearchContextsStore, search
 
 func TestSearchContexts_Get(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := db.Users()
@@ -84,7 +84,7 @@ func TestSearchContexts_Get(t *testing.T) {
 
 func TestSearchContexts_Update(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := db.Users()
@@ -157,7 +157,7 @@ func TestSearchContexts_Update(t *testing.T) {
 
 func TestSearchContexts_List(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := db.Users()
@@ -205,7 +205,7 @@ func TestSearchContexts_List(t *testing.T) {
 
 func TestSearchContexts_PaginationAndCount(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := db.Users()
@@ -304,7 +304,7 @@ func TestSearchContexts_PaginationAndCount(t *testing.T) {
 
 func TestSearchContexts_CaseInsensitiveNames(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	u := db.Users()
@@ -366,7 +366,7 @@ func TestSearchContexts_CaseInsensitiveNames(t *testing.T) {
 
 func TestSearchContexts_CreateAndSetRepositoryRevisions(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	ctx := actor.WithInternalActor(context.Background())
 	sc := db.SearchContexts()
@@ -429,7 +429,7 @@ func TestSearchContexts_CreateAndSetRepositoryRevisions(t *testing.T) {
 
 func TestSearchContexts_Permissions(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
@@ -633,7 +633,7 @@ func TestSearchContexts_Permissions(t *testing.T) {
 
 func TestSearchContexts_Delete(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	ctx := context.Background()
 	sc := db.SearchContexts()
@@ -667,7 +667,7 @@ func TestSearchContexts_Delete(t *testing.T) {
 
 func TestSearchContexts_Count(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	ctx := context.Background()
 	sc := db.SearchContexts()
@@ -734,7 +734,7 @@ func getSearchContextNames(s []*types.SearchContext) []string {
 
 func TestSearchContexts_OrderBy(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
@@ -849,7 +849,7 @@ func TestSearchContexts_OrderBy(t *testing.T) {
 
 func TestSearchContexts_OrderByWithDefaultAndStarred(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
@@ -935,7 +935,7 @@ func TestSearchContexts_OrderByWithDefaultAndStarred(t *testing.T) {
 
 func TestSearchContexts_GetAllRevisionsForRepos(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	// Required for this DB query.
 	internalCtx := actor.WithInternalActor(context.Background())
@@ -1010,7 +1010,7 @@ func TestSearchContexts_GetAllRevisionsForRepos(t *testing.T) {
 
 func TestSearchContexts_DefaultContexts(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
@@ -1134,7 +1134,7 @@ func getStarredContexts(searchContexts []*types.SearchContext) []*types.SearchCo
 
 func TestSearchContexts_StarringContexts(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	t.Parallel()
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -31,7 +31,7 @@ func TestSecurityEventLogs_ValidInfo(t *testing.T) {
 	}})
 
 	logger, exportLogs := logtest.Captured(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	var testCases = []struct {
 		name  string

--- a/internal/database/settings_test.go
+++ b/internal/database/settings_test.go
@@ -16,7 +16,7 @@ func TestSettings_ListAll(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user1, err := db.Users().Create(ctx, NewUser{Username: "u1"})
@@ -63,7 +63,7 @@ func TestSettings_ListAll(t *testing.T) {
 func TestCreateIfUpToDate(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	u, err := db.Users().Create(ctx, NewUser{Username: "test"})
 	if err != nil {
@@ -125,7 +125,7 @@ func TestCreateIfUpToDate(t *testing.T) {
 
 func TestGetLatestSchemaSettings(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user1, err := db.Users().Create(ctx, NewUser{Username: "u1"})

--- a/internal/database/sub_repo_perms_store_test.go
+++ b/internal/database/sub_repo_perms_store_test.go
@@ -25,7 +25,7 @@ func TestSubRepoPermsInsert(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	prepareSubRepoTestData(ctx, t, db)
@@ -57,7 +57,7 @@ func TestSubRepoPermsDeleteByUser(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	prepareSubRepoTestData(ctx, t, db)
@@ -92,7 +92,7 @@ func TestSubRepoPermsUpsert(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	prepareSubRepoTestData(ctx, t, db)
@@ -133,7 +133,7 @@ func TestSubRepoPermsUpsertWithSpec(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	prepareSubRepoTestData(ctx, t, db)
@@ -181,7 +181,7 @@ func TestSubRepoPermsGetByUser(t *testing.T) {
 	t.Cleanup(func() { conf.Mock(nil) })
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	s := db.SubRepoPerms()
@@ -264,7 +264,7 @@ func TestSubRepoPermsGetByUserAndService(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	s := db.SubRepoPerms()
@@ -342,7 +342,7 @@ func TestSubRepoPermsSupportedForRepoId(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 	s := db.SubRepoPerms()

--- a/internal/database/survey_responses_test.go
+++ b/internal/database/survey_responses_test.go
@@ -16,7 +16,7 @@ func TestSurveyResponses_Create_Count(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	count, err := SurveyResponses(db).Count(ctx)

--- a/internal/database/teams_test.go
+++ b/internal/database/teams_test.go
@@ -20,7 +20,7 @@ import (
 func TestTeams_CreateUpdateDelete(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	logger := logtest.NoOp(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	user, err := db.Users().Create(ctx, NewUser{Username: "johndoe"})
 	if err != nil {
 		t.Fatal(err)
@@ -153,7 +153,7 @@ func TestTeams_CreateUpdateDelete(t *testing.T) {
 func TestTeams_GetListCount(t *testing.T) {
 	internalCtx := actor.WithInternalActor(context.Background())
 	logger := logtest.NoOp(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	johndoe, err := db.Users().Create(internalCtx, NewUser{Username: "johndoe"})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/database/telemetry_export_store_test.go
+++ b/internal/database/telemetry_export_store_test.go
@@ -24,7 +24,7 @@ func TestTelemetryEventsExportQueueLifecycle(t *testing.T) {
 	ctx := featureflag.WithFlags(context.Background(), ff)
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	store := TelemetryEventsExportQueueWith(logger, db)
 

--- a/internal/database/temporary_settings_test.go
+++ b/internal/database/temporary_settings_test.go
@@ -26,7 +26,7 @@ func TestTemporarySettingsStore(t *testing.T) {
 func testGetEmpty(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	temporarySettingsStore := NewDB(logger, dbtest.NewDB(logger, t)).TemporarySettings()
+	temporarySettingsStore := NewDB(logger, dbtest.NewDB(t)).TemporarySettings()
 
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -41,7 +41,7 @@ func testGetEmpty(t *testing.T) {
 func testInsertAndGet(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	usersStore := db.Users()
 	temporarySettingsStore := db.TemporarySettings()
 
@@ -65,7 +65,7 @@ func testInsertAndGet(t *testing.T) {
 func testUpdateAndGet(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	usersStore := db.Users()
 	temporarySettingsStore := db.TemporarySettings()
 
@@ -94,7 +94,7 @@ func testUpdateAndGet(t *testing.T) {
 func testInsertWithInvalidData(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	usersStore := db.Users()
 	temporarySettingsStore := db.TemporarySettings()
 
@@ -112,7 +112,7 @@ func testInsertWithInvalidData(t *testing.T) {
 func testEdit(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	usersStore := db.Users()
 	temporarySettingsStore := db.TemporarySettings()
 

--- a/internal/database/user_credentials_test.go
+++ b/internal/database/user_credentials_test.go
@@ -171,7 +171,7 @@ func TestUserCredential_SetAuthenticator(t *testing.T) {
 
 func TestUserCredentials_CreateUpdate(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	fx := setUpUserCredentialTest(t, db)
 
 	// Authorisation failure tests. (We'll test the happy path below.)
@@ -252,7 +252,7 @@ func TestUserCredentials_CreateUpdate(t *testing.T) {
 
 func TestUserCredentials_Delete(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	fx := setUpUserCredentialTest(t, db)
 
 	t.Run("nonextant", func(t *testing.T) {
@@ -305,7 +305,7 @@ func TestUserCredentials_Delete(t *testing.T) {
 
 func TestUserCredentials_GetByID(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	fx := setUpUserCredentialTest(t, db)
 
 	t.Run("nonextant", func(t *testing.T) {
@@ -357,7 +357,7 @@ func TestUserCredentials_GetByID(t *testing.T) {
 
 func TestUserCredentials_GetByScope(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	fx := setUpUserCredentialTest(t, db)
 
 	scope := UserCredentialScope{
@@ -405,7 +405,7 @@ func TestUserCredentials_GetByScope(t *testing.T) {
 
 func TestUserCredentials_List(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	fx := setUpUserCredentialTest(t, db)
 
 	githubScope := UserCredentialScope{
@@ -529,7 +529,7 @@ func TestUserCredentials_List(t *testing.T) {
 
 func TestUserCredentials_Invalid(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	fx := setUpUserCredentialTest(t, db)
 	ctx := fx.internalCtx
 	key := fx.key

--- a/internal/database/user_emails_test.go
+++ b/internal/database/user_emails_test.go
@@ -60,7 +60,7 @@ func TestUserEmails_Get(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -110,7 +110,7 @@ func TestUserEmails_GetPrimary(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -164,7 +164,7 @@ func TestUserEmails_HasVerifiedEmail(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -222,7 +222,7 @@ func TestUserEmails_SetPrimary(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -268,7 +268,7 @@ func TestUserEmails_ListByUser(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -337,7 +337,7 @@ func TestUserEmails_Add_Remove(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	const emailA = "a@example.com"
@@ -422,7 +422,7 @@ func TestUserEmails_SetVerified(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	const email = "a@example.com"
@@ -539,7 +539,7 @@ func TestUserEmails_SetLastVerificationSentAt(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	const addr = "alice@example.com"
@@ -589,7 +589,7 @@ func TestUserEmails_GetLatestVerificationSentEmail(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	const addr = "alice@example.com"
@@ -650,7 +650,7 @@ func TestUserEmails_GetVerifiedEmails(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	newUsers := []NewUser{

--- a/internal/database/user_roles_test.go
+++ b/internal/database/user_roles_test.go
@@ -19,7 +19,7 @@ func TestUserRoleAssign(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	user, role := createUserAndRole(ctx, t, db)
@@ -70,7 +70,7 @@ func TestUserRoleBulkAssignForUser(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	user, role := createUserAndRole(ctx, t, db)
@@ -126,7 +126,7 @@ func TestUserRoleAssignSysemRole(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	user, _ := createUserAndRole(ctx, t, db)
@@ -171,7 +171,7 @@ func TestUserRoleBulkAssignSystemRolesToUsers(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	user, _ := createUserAndRole(ctx, t, db)
@@ -217,7 +217,7 @@ func TestUserRoleRevoke(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	user, role := createUserAndRole(ctx, t, db)
@@ -280,7 +280,7 @@ func TestUserRoleRevoke(t *testing.T) {
 func TestUserRoleGetByRoleID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	role := createTestRoleForUserRole(ctx, "TESTROLE", t, db)
@@ -323,7 +323,7 @@ func TestUserRoleGetByRoleID(t *testing.T) {
 func TestUserRoleGetByUserID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	user := createTestUserWithoutRoles(t, db, "ANOTHERTESTUSER", false)
@@ -366,7 +366,7 @@ func TestUserRoleGetByUserID(t *testing.T) {
 func TestUserRoleGetByRoleIDAndUserID(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	user, role := createUserAndRole(ctx, t, db)
@@ -413,7 +413,7 @@ func TestSetRolesForUser(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	u1 := createTestUserWithoutRoles(t, db, "u1", false)
@@ -499,7 +499,7 @@ func TestBulkRevokeRolesForUser(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.UserRoles()
 
 	user, role := createUserAndRole(ctx, t, db)

--- a/internal/database/users_builtin_auth_test.go
+++ b/internal/database/users_builtin_auth_test.go
@@ -19,7 +19,7 @@ func TestUsers_BuiltinAuth(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	if _, err := db.Users().Create(ctx, NewUser{
@@ -119,7 +119,7 @@ func TestUsers_BuiltinAuth_VerifiedEmail(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -146,7 +146,7 @@ func TestUsers_BuiltinAuthPasswordResetRateLimit(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	oldPasswordResetRateLimit := passwordResetRateLimit
@@ -187,7 +187,7 @@ func TestUsers_UpdatePassword(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	usr, err := db.Users().Create(ctx, NewUser{
@@ -236,7 +236,7 @@ func TestUsers_CreatePassword(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// User without a password
@@ -303,7 +303,7 @@ func TestUsers_PasswordResetExpiry(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// We setup the configuration so that password reset links are valid for 60s

--- a/internal/database/users_test.go
+++ b/internal/database/users_test.go
@@ -83,7 +83,7 @@ func TestUsers_ValidUsernames(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	for _, test := range usernamesForTests {
@@ -106,7 +106,7 @@ func TestUsers_ValidUsernames(t *testing.T) {
 
 func TestUsers_Create_SiteAdmin(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	if _, err := db.GlobalState().Get(ctx); err != nil {
@@ -218,7 +218,7 @@ func TestUsers_CheckAndDecrementInviteQuota(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -269,7 +269,7 @@ func TestUsers_ListCount(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -400,7 +400,7 @@ func TestUsers_List_Query(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	users := map[string]int32{}
@@ -476,7 +476,7 @@ func TestUsers_ListForSCIM_Query(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	userToSoftDelete := NewUserForSCIM{NewUser: NewUser{Email: "notactive@example.com", Username: "notactive", EmailIsVerified: true}, SCIMExternalID: "notactive"}
@@ -534,7 +534,7 @@ func TestUsers_Update(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -631,7 +631,7 @@ func TestUsers_GetByVerifiedEmail(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -667,7 +667,7 @@ func TestUsers_GetByUsername(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	newUsers := []NewUser{
@@ -713,7 +713,7 @@ func TestUsers_GetByUsernames(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	newUsers := []NewUser{
@@ -761,7 +761,7 @@ func TestUsers_Delete(t *testing.T) {
 			}
 			t.Parallel()
 			logger := logtest.Scoped(t)
-			db := NewDB(logger, dbtest.NewDB(logger, t))
+			db := NewDB(logger, dbtest.NewDB(t))
 			ctx := context.Background()
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -916,7 +916,7 @@ func TestUsers_RecoverUsers(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
@@ -1041,7 +1041,7 @@ func TestUsers_InvalidateSessions(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	newUsers := []NewUser{
@@ -1085,7 +1085,7 @@ func TestUsers_SetIsSiteAdmin(t *testing.T) {
 	}
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	adminUser, err := db.Users().Create(ctx, NewUser{Username: "u"})
@@ -1153,7 +1153,7 @@ func TestUsers_GetSetChatCompletionsQuota(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{
@@ -1212,7 +1212,7 @@ func TestUsers_GetSetCodeCompletionsQuota(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	user, err := db.Users().Create(ctx, NewUser{

--- a/internal/database/webhook_logs_test.go
+++ b/internal/database/webhook_logs_test.go
@@ -26,7 +26,7 @@ func TestWebhookLogStore(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	t.Run("Create", func(t *testing.T) {
 		t.Parallel()

--- a/internal/database/webhooks_test.go
+++ b/internal/database/webhooks_test.go
@@ -33,7 +33,7 @@ func TestWebhookCreate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	for _, encrypted := range []bool{true, false} {
 		t.Run(fmt.Sprintf("encrypted=%t", encrypted), func(t *testing.T) {
 			store := db.Webhooks(nil)
@@ -148,7 +148,7 @@ func TestWebhookDelete(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Webhooks(nil)
 
 	// Test that delete with wrong UUID returns an error
@@ -192,7 +192,7 @@ func TestWebhookUpdate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	newCodeHostURN, err := extsvc.NewCodeHostBaseURL("https://new.github.com")
 	require.NoError(t, err)
@@ -271,7 +271,7 @@ func TestWebhookUpdate(t *testing.T) {
 		webhook := types.Webhook{ID: 100, UUID: nonExistentUUID}
 
 		logger := logtest.Scoped(t)
-		db := NewDB(logger, dbtest.NewDB(logger, t))
+		db := NewDB(logger, dbtest.NewDB(t))
 
 		store := db.Webhooks(nil)
 		_, err := store.Update(ctx, &webhook)
@@ -294,7 +294,7 @@ func createWebhookWithActorUID(ctx context.Context, t *testing.T, actorUID int32
 
 func TestWebhookCount(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Webhooks(et.ByteaTestKey{})
 	ctx := context.Background()
 
@@ -315,7 +315,7 @@ func TestWebhookCount(t *testing.T) {
 
 func TestWebhookList(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Webhooks(et.ByteaTestKey{})
 	ctx := context.Background()
 
@@ -414,7 +414,7 @@ func TestGetByID(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Webhooks(nil)
 
 	// Test that non-existent webhook cannot be found
@@ -445,7 +445,7 @@ func TestGetByUUID(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	store := db.Webhooks(nil)
 
 	// Test that non-existent webhook cannot be found

--- a/internal/database/zoekt_repos_test.go
+++ b/internal/database/zoekt_repos_test.go
@@ -24,7 +24,7 @@ func TestZoektRepos_GetZoektRepo(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	s := &zoektReposStore{Store: basestore.NewWithHandle(db.Handle())}
 
@@ -45,7 +45,7 @@ func TestZoektRepos_UpdateIndexStatuses(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(logger, t))
+	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	s := &zoektReposStore{Store: basestore.NewWithHandle(db.Handle())}
 	timeUnix := int64(1686763487)
@@ -212,7 +212,7 @@ func assertZoektRepos(t *testing.T, ctx context.Context, s *zoektReposStore, wan
 
 func benchmarkUpdateIndexStatus(b *testing.B, numRepos int) {
 	logger := logtest.Scoped(b)
-	db := NewDB(logger, dbtest.NewDB(logger, b))
+	db := NewDB(logger, dbtest.NewDB(b))
 	ctx := context.Background()
 	s := &zoektReposStore{Store: basestore.NewWithHandle(db.Handle())}
 

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -24,7 +24,7 @@ func TestRepoEmbeddingJobsStore(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 
 	ctx := context.Background()
@@ -145,7 +145,7 @@ func TestRescheduleAll(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 	ctx := context.Background()
 
@@ -189,7 +189,7 @@ func TestCancelRepoEmbeddingJob(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 
 	ctx := context.Background()
@@ -245,7 +245,7 @@ func TestGetEmbeddableRepos(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 	ctx := context.Background()
 
@@ -290,7 +290,7 @@ func TestEmbeddingsPolicyWithFailures(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 	ctx := context.Background()
 
@@ -333,7 +333,7 @@ func TestEmbeddingsPolicyWithFailures(t *testing.T) {
 
 func TestGetEmbeddableReposLimit(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 	ctx := context.Background()
 

--- a/internal/embeddings/schedule_test.go
+++ b/internal/embeddings/schedule_test.go
@@ -21,7 +21,7 @@ func TestScheduleRepositoriesForEmbedding(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 
 	createdRepo := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}
@@ -57,7 +57,7 @@ func TestScheduleRepositoriesForEmbeddingRepoNotFound(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 
 	createdRepo0 := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}
@@ -89,7 +89,7 @@ func TestScheduleRepositoriesForEmbeddingInvalidDefaultBranch(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 
 	createdRepo0 := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}
@@ -121,7 +121,7 @@ func TestScheduleRepositoriesForEmbeddingFailed(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
 
 	createdRepo0 := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}

--- a/internal/executor/store/store_test.go
+++ b/internal/executor/store/store_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestJobTokenStore_Create(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
 
 	repoStore := database.ReposWith(logger, db)
@@ -80,7 +80,7 @@ func TestJobTokenStore_Create(t *testing.T) {
 
 func TestJobTokenStore_Create_Duplicate(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
 
 	repoStore := database.ReposWith(logger, db)
@@ -102,7 +102,7 @@ func TestJobTokenStore_Create_Duplicate(t *testing.T) {
 
 func TestJobTokenStore_Regenerate(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
 
 	repoStore := database.ReposWith(logger, db)
@@ -147,7 +147,7 @@ func TestJobTokenStore_Regenerate(t *testing.T) {
 
 func TestJobTokenStore_Exists(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
 
 	repoStore := database.ReposWith(logger, db)
@@ -200,7 +200,7 @@ func TestJobTokenStore_Exists(t *testing.T) {
 
 func TestJobTokenStore_Get(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
 
 	repoStore := database.ReposWith(logger, db)
@@ -267,7 +267,7 @@ func TestJobTokenStore_Get(t *testing.T) {
 
 func TestJobTokenStore_GetByToken(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
 
 	repoStore := database.ReposWith(logger, db)
@@ -332,7 +332,7 @@ func TestJobTokenStore_GetByToken(t *testing.T) {
 
 func TestJobTokenStore_Delete(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	tokenStore := store.NewJobTokenStore(&observation.TestContext, db)
 
 	repoStore := database.ReposWith(logger, db)

--- a/internal/github_apps/store/store_test.go
+++ b/internal/github_apps/store/store_test.go
@@ -21,7 +21,7 @@ import (
 
 func newTestStore(t *testing.T) *gitHubAppsStore {
 	logger := logtest.Scoped(t)
-	return &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(logger, t), sql.TxOptions{}))}
+	return &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(t), sql.TxOptions{}))}
 
 }
 
@@ -73,7 +73,7 @@ func TestDeleteGitHubApp(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(logger, t), sql.TxOptions{}))}
+	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(t), sql.TxOptions{}))}
 	ctx := context.Background()
 
 	app := &ghtypes.GitHubApp{
@@ -107,7 +107,7 @@ func TestUpdateGitHubApp(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(logger, t), sql.TxOptions{}))}
+	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(t), sql.TxOptions{}))}
 	ctx := context.Background()
 
 	app := &ghtypes.GitHubApp{
@@ -165,7 +165,7 @@ func TestGetByID(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(logger, t), sql.TxOptions{}))}
+	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(t), sql.TxOptions{}))}
 	ctx := context.Background()
 
 	app1 := &ghtypes.GitHubApp{
@@ -227,7 +227,7 @@ func TestGetByAppID(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(logger, t), sql.TxOptions{}))}
+	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(t), sql.TxOptions{}))}
 	ctx := context.Background()
 
 	app1 := &ghtypes.GitHubApp{
@@ -288,7 +288,7 @@ func TestGetBySlug(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(logger, t), sql.TxOptions{}))}
+	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(t), sql.TxOptions{}))}
 	ctx := context.Background()
 
 	app1 := &ghtypes.GitHubApp{
@@ -350,7 +350,7 @@ func TestGetByDomain(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(logger, t), sql.TxOptions{}))}
+	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(t), sql.TxOptions{}))}
 	ctx := context.Background()
 
 	repoApp := &ghtypes.GitHubApp{
@@ -807,7 +807,7 @@ func TestTrailingSlashesInBaseURL(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(logger, t), sql.TxOptions{}))}
+	store := &gitHubAppsStore{Store: basestore.NewWithHandle(basestore.NewHandleWithDB(logger, dbtest.NewDB(t), sql.TxOptions{}))}
 	ctx := context.Background()
 
 	app := &ghtypes.GitHubApp{

--- a/internal/insights/background/data_prune_test.go
+++ b/internal/insights/background/data_prune_test.go
@@ -31,7 +31,7 @@ func TestPerformPurge(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := store.NewInsightPermissionStore(postgres)
 	timeseriesStore := store.NewWithClock(insightsDB, permStore, clock)
 	insightStore := store.NewInsightStore(insightsDB)

--- a/internal/insights/background/queryrunner/work_handler_test.go
+++ b/internal/insights/background/queryrunner/work_handler_test.go
@@ -83,7 +83,7 @@ func TestGetSeries(t *testing.T) {
 func Test_HandleWithTerminalError(t *testing.T) {
 	logger := logtest.Scoped(t)
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	now := time.Date(2021, 12, 1, 0, 0, 0, 0, time.UTC).Truncate(time.Microsecond).Round(0)
 	metadataStore := store.NewInsightStore(insightsDB)
 	metadataStore.Now = func() time.Time {

--- a/internal/insights/background/queryrunner/worker_test.go
+++ b/internal/insights/background/queryrunner/worker_test.go
@@ -24,7 +24,7 @@ import (
 func TestJobQueue(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	mainAppDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	mainAppDB := database.NewDB(logger, dbtest.NewDB(t))
 
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -83,7 +83,7 @@ func TestJobQueue(t *testing.T) {
 func TestJobQueueDependencies(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	mainAppDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	mainAppDB := database.NewDB(logger, dbtest.NewDB(t))
 
 	ctx := actor.WithInternalActor(context.Background())
 	workerBaseStore := basestore.NewWithHandle(mainAppDB.Handle())
@@ -162,7 +162,7 @@ func TestQueryJobsStatus(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	workerBaseStore := basestore.NewWithHandle(db.Handle())
 
 	_, err := db.ExecContext(ctx, `

--- a/internal/insights/background/retention/worker_test.go
+++ b/internal/insights/background/retention/worker_test.go
@@ -24,7 +24,7 @@ func Test_archiveOldSeriesPoints(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	mainDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	mainDB := database.NewDB(logger, dbtest.NewDB(t))
 
 	insightStore := store.NewInsightStore(insightsDB)
 	seriesStore := store.New(insightsDB, store.NewInsightPermissionStore(mainDB))
@@ -84,7 +84,7 @@ func Test_archiveOldRecordingTimes(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	mainDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	mainDB := database.NewDB(logger, dbtest.NewDB(t))
 
 	insightStore := store.NewInsightStore(insightsDB)
 	seriesStore := store.New(insightsDB, store.NewInsightPermissionStore(mainDB))
@@ -127,7 +127,7 @@ func TestHandle_ErrorDuringTransaction(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	mainDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	mainDB := database.NewDB(logger, dbtest.NewDB(t))
 
 	insightStore := store.NewInsightStore(insightsDB)
 	seriesStore := store.New(insightsDB, store.NewInsightPermissionStore(mainDB))

--- a/internal/insights/discovery/scoped_repo_iterator_test.go
+++ b/internal/insights/discovery/scoped_repo_iterator_test.go
@@ -66,7 +66,7 @@ func TestScopedRepoIteratorForEach(t *testing.T) {
 
 func TestScopedRepoIterator_PrivateRepos(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := db.Repos()

--- a/internal/insights/store/insight_store_test.go
+++ b/internal/insights/store/insight_store_test.go
@@ -2644,7 +2644,7 @@ func TestHardDeleteSeries(t *testing.T) {
 	clock := timeutil.Now
 	insightsdb := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
 
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	insightStore := NewInsightStore(insightsdb)
 	timeseriesStore := NewWithClock(insightsdb, permStore, clock)

--- a/internal/insights/store/store_benchs_test.go
+++ b/internal/insights/store/store_benchs_test.go
@@ -129,7 +129,7 @@ func TestCompareLoadMethods(t *testing.T) {
 			ctx := context.Background()
 			clock := timeutil.Now
 			insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-			postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+			postgres := database.NewDB(logger, dbtest.NewDB(t))
 			permStore := NewInsightPermissionStore(postgres)
 			store := NewWithClock(insightsDB, permStore, clock)
 
@@ -209,7 +209,7 @@ func BenchmarkLoadTimes(b *testing.B) {
 		ctx := context.Background()
 		clock := timeutil.Now
 		insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, b), logger)
-		postgres := database.NewDB(logger, dbtest.NewDB(logger, b))
+		postgres := database.NewDB(logger, dbtest.NewDB(b))
 		permStore := NewInsightPermissionStore(postgres)
 		store := NewWithClock(insightsDB, permStore, clock)
 

--- a/internal/insights/store/store_test.go
+++ b/internal/insights/store/store_test.go
@@ -32,7 +32,7 @@ func TestSeriesPoints(t *testing.T) {
 	clock := timeutil.Now
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
 
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -137,7 +137,7 @@ func TestCountData(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -228,7 +228,7 @@ func TestRecordSeriesPoints(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -323,7 +323,7 @@ func TestRecordSeriesPointsSnapshotOnly(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -386,7 +386,7 @@ func TestRecordSeriesPointsRecordingOnly(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	store := NewWithClock(insightsDB, permStore, clock)
 
@@ -449,7 +449,7 @@ func TestDeleteSnapshots(t *testing.T) {
 	ctx := context.Background()
 	clock := timeutil.Now
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	insightStore := NewInsightStore(insightsDB)
 	store := NewWithClock(insightsDB, permStore, clock)
@@ -562,7 +562,7 @@ func TestDelete(t *testing.T) {
 	repoName := "reallygreatrepo"
 	repoId := api.RepoID(5)
 
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	timeseriesStore := NewWithClock(insightsdb, permStore, clock)
 
@@ -671,7 +671,7 @@ func TestInsightSeriesRecordingTimes(t *testing.T) {
 	clock := timeutil.Now
 	insightsdb := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
 
-	postgres := database.NewDB(logger, dbtest.NewDB(logger, t))
+	postgres := database.NewDB(logger, dbtest.NewDB(t))
 	permStore := NewInsightPermissionStore(postgres)
 	insightStore := NewInsightStore(insightsdb)
 	timeseriesStore := NewWithClock(insightsdb, permStore, clock)
@@ -926,7 +926,7 @@ func TestGetOffsetNRecordingTime(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
 	insightsDB := edb.NewInsightsDB(dbtest.NewInsightsDB(logger, t), logger)
-	mainDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	mainDB := database.NewDB(logger, dbtest.NewDB(t))
 
 	insightStore := NewInsightStore(insightsDB)
 	seriesStore := New(insightsDB, NewInsightPermissionStore(mainDB))

--- a/internal/notebooks/store_test.go
+++ b/internal/notebooks/store_test.go
@@ -42,7 +42,7 @@ func notebookByOrg(notebook *Notebook, creatorID int32, orgID int32) *Notebook {
 func TestCreateAndGetNotebook(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	n := Notebooks(db)
@@ -80,7 +80,7 @@ func TestCreateAndGetNotebook(t *testing.T) {
 func TestUpdateNotebook(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	n := Notebooks(db)
@@ -118,7 +118,7 @@ func TestUpdateNotebook(t *testing.T) {
 func TestDeleteNotebook(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	n := Notebooks(db)
@@ -192,7 +192,7 @@ func createNotebookStars(ctx context.Context, store NotebooksStore, userID int32
 func TestListingAndCountingNotebooks(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	o := db.Orgs()
@@ -451,7 +451,7 @@ func TestListingAndCountingNotebooks(t *testing.T) {
 func TestCreatingNotebookWithInvalidBlock(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	n := Notebooks(db)
@@ -476,7 +476,7 @@ func TestCreatingNotebookWithInvalidBlock(t *testing.T) {
 func TestNotebookPermissions(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	o := db.Orgs()
@@ -547,7 +547,7 @@ func TestNotebookPermissions(t *testing.T) {
 func TestListingNotebookStars(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	n := Notebooks(db)
@@ -634,7 +634,7 @@ func TestListingNotebookStars(t *testing.T) {
 func TestCreatingAndDeletingNotebookStars(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	internalCtx := actor.WithInternalActor(context.Background())
 	u := db.Users()
 	n := Notebooks(db)

--- a/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
+++ b/internal/oobmigration/migrations/batches/empty_spec_id_migrator_test.go
@@ -21,7 +21,7 @@ import (
 func TestEmptySpecIDMigrator(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	s := bstore.New(db, &observation.TestContext, nil)
 
 	migrator := NewEmptySpecIDMigrator(s.Store)

--- a/internal/oobmigration/migrations/batches/external_fork_name_migrator_test.go
+++ b/internal/oobmigration/migrations/batches/external_fork_name_migrator_test.go
@@ -25,7 +25,7 @@ import (
 func TestExternalForkNameMigrator(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	s := bstore.New(db, &observation.TestContext, nil)
 
 	migrator := NewExternalForkNameMigrator(s.Store, 100)

--- a/internal/oobmigration/migrations/batches/extsvc_webhook_migrator_test.go
+++ b/internal/oobmigration/migrations/batches/extsvc_webhook_migrator_test.go
@@ -134,7 +134,7 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 	}
 
 	t.Run("Progress", func(t *testing.T) {
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 		store := basestore.NewWithHandle(db.Handle())
 		createExternalServices(t, ctx, store)
 
@@ -155,7 +155,7 @@ func TestExternalServiceWebhookMigrator(t *testing.T) {
 	})
 
 	t.Run("Up", func(t *testing.T) {
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 		store := basestore.NewWithHandle(db.Handle())
 		createExternalServices(t, ctx, store)
 		// Count the invalid JSON, not the deleted one

--- a/internal/oobmigration/migrations/batches/role_assignment_migrator_test.go
+++ b/internal/oobmigration/migrations/batches/role_assignment_migrator_test.go
@@ -20,7 +20,7 @@ import (
 func TestUserRoleAssignmentMigrator(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := basestore.NewWithHandle(db.Handle())
 
 	migrator := NewUserRoleAssignmentMigrator(store, 5)

--- a/internal/oobmigration/migrations/batches/ssh_migrator_test.go
+++ b/internal/oobmigration/migrations/batches/ssh_migrator_test.go
@@ -20,7 +20,7 @@ import (
 func TestSSHMigrator(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := basestore.NewWithHandle(db.Handle())
 	key := et.TestKey{}
 

--- a/internal/oobmigration/migrations/iam/license_key_field_migrator_test.go
+++ b/internal/oobmigration/migrations/iam/license_key_field_migrator_test.go
@@ -19,7 +19,7 @@ import (
 func TestLicenseKeyFieldsMigrator(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := basestore.NewWithHandle(db.Handle())
 
 	// Set up test data

--- a/internal/oobmigration/migrations/iam/subscription_account_number_migrator_test.go
+++ b/internal/oobmigration/migrations/iam/subscription_account_number_migrator_test.go
@@ -17,7 +17,7 @@ import (
 func TestSubscriptionAccountNumberMigrator(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := basestore.NewWithHandle(db.Handle())
 
 	// Set up test data

--- a/internal/oobmigration/migrations/iam/unified_permissions_migrator_test.go
+++ b/internal/oobmigration/migrations/iam/unified_permissions_migrator_test.go
@@ -124,7 +124,7 @@ func cleanUpTables(ctx context.Context, store *basestore.Store) error {
 func TestUnifiedPermissionsMigrator(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := basestore.NewWithHandle(db.Handle())
 
 	t.Run("Migrator uses default values for params", func(t *testing.T) {

--- a/internal/oobmigration/migrations/insights/migrator_test.go
+++ b/internal/oobmigration/migrations/insights/migrator_test.go
@@ -31,7 +31,7 @@ func TestInsightsMigrator(t *testing.T) {
 
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	frontendDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	frontendDB := database.NewDB(logger, dbtest.NewDB(t))
 	insightsDB := dbtest.NewInsightsDB(logger, t)
 	frontendStore := basestore.NewWithHandle(frontendDB.Handle())
 	insightsStore := basestore.NewWithHandle(basestore.NewHandleWithDB(logger, insightsDB, sql.TxOptions{}))

--- a/internal/oobmigration/store_test.go
+++ b/internal/oobmigration/store_test.go
@@ -21,7 +21,7 @@ import (
 func TestSynchronizeMetadata(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := NewStoreWithDB(db)
 
 	compareMigrations := func() {
@@ -91,7 +91,7 @@ func TestSynchronizeMetadata(t *testing.T) {
 func TestSynchronizeMetadataFallback(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := NewStoreWithDB(db)
 
 	if err := store.Exec(ctx, sqlf.Sprintf(`
@@ -161,7 +161,7 @@ func TestList(t *testing.T) {
 	withMigrationIDs(t, []int{1, 2, 3, 4, 5})
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	migrations, err := store.List(context.Background())
@@ -183,7 +183,7 @@ func TestList(t *testing.T) {
 func TestGetMultiple(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	migrations, err := store.GetByIDs(context.Background(), []int{1, 2, 3, 4, 5})
@@ -210,7 +210,7 @@ func TestGetMultiple(t *testing.T) {
 func TestUpdateDirection(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	if err := store.UpdateDirection(context.Background(), 3, true); err != nil {
@@ -237,7 +237,7 @@ func TestUpdateProgress(t *testing.T) {
 	t.Parallel()
 	now := testTime.Add(time.Hour * 7)
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	if err := store.updateProgress(context.Background(), 3, 0.7, now); err != nil {
@@ -265,7 +265,7 @@ func TestUpdateMetadata(t *testing.T) {
 	t.Parallel()
 	now := testTime.Add(time.Hour * 7)
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	type sampleMeta = struct {
@@ -314,7 +314,7 @@ func TestAddError(t *testing.T) {
 	t.Parallel()
 	now := testTime.Add(time.Hour * 8)
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	if err := store.addError(context.Background(), 2, "oops", now); err != nil {
@@ -347,7 +347,7 @@ func TestAddErrorBounded(t *testing.T) {
 
 	now := testTime.Add(time.Hour * 9)
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := testStore(t, db)
 
 	var expectedErrors []MigrationError

--- a/internal/own/background/analytics_test.go
+++ b/internal/own/background/analytics_test.go
@@ -49,7 +49,7 @@ func TestAnalyticsIndexerSuccess(t *testing.T) {
 	rcache.SetupForTest(t)
 	obsCtx := observation.TestContextTB(t)
 	logger := obsCtx.Logger
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	user, err := db.Users().Create(ctx, database.NewUser{Username: "test"})
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestAnalyticsIndexerSkipsReposWithSubRepoPerms(t *testing.T) {
 	rcache.SetupForTest(t)
 	obsCtx := observation.TestContextTB(t)
 	logger := obsCtx.Logger
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	var repoID api.RepoID = 1
 	err := db.Repos().Create(ctx, &types.Repo{Name: "repo", ID: repoID})
@@ -127,7 +127,7 @@ func TestAnalyticsIndexerNoCodeowners(t *testing.T) {
 	rcache.SetupForTest(t)
 	obsCtx := observation.TestContextTB(t)
 	logger := obsCtx.Logger
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	var repoID api.RepoID = 1
 	err := db.Repos().Create(ctx, &types.Repo{Name: "repo", ID: repoID})

--- a/internal/own/background/background_test.go
+++ b/internal/own/background/background_test.go
@@ -19,7 +19,7 @@ import (
 func Test_Handle(t *testing.T) {
 	obsCtx := observation.TestContextTB(t)
 	logger := obsCtx.Logger
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	err := db.Repos().Create(ctx, &types.Repo{Name: "fakerepo", ID: 1})
@@ -58,7 +58,7 @@ func Test_Handle(t *testing.T) {
 func Test_JanitorTable(t *testing.T) {
 	obsCtx := observation.TestContextTB(t)
 	logger := obsCtx.Logger
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	store := basestore.NewWithHandle(db.Handle())

--- a/internal/own/background/recent_contributors_test.go
+++ b/internal/own/background/recent_contributors_test.go
@@ -26,7 +26,7 @@ import (
 func Test_RecentContributorIndexFromGitserver(t *testing.T) {
 	rcache.SetupForTest(t)
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 
@@ -116,7 +116,7 @@ func Test_RecentContributorIndexFromGitserver(t *testing.T) {
 func Test_RecentContributorIndex_CanSeePrivateRepos(t *testing.T) {
 	rcache.SetupForTest(t)
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	err := db.Repos().Create(ctx, &types.Repo{
@@ -163,7 +163,7 @@ func Test_RecentContributorIndex_CanSeePrivateRepos(t *testing.T) {
 func Test_RecentContributorIndexSkipsSubrepoPermsRepos(t *testing.T) {
 	rcache.SetupForTest(t)
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	ctx := context.Background()
 

--- a/internal/own/background/recent_views_test.go
+++ b/internal/own/background/recent_views_test.go
@@ -23,7 +23,7 @@ func TestRecentViewsIndexer(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating a user.

--- a/internal/own/background/scheduler_test.go
+++ b/internal/own/background/scheduler_test.go
@@ -33,7 +33,7 @@ func verifyCount(t *testing.T, ctx context.Context, db database.DB, signaName st
 func TestOwnRepoIndexSchedulerJob_JobsAutoIndex(t *testing.T) {
 	obsCtx := observation.TestContextTB(t)
 	logger := obsCtx.Logger
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	insertRepo(t, db, 500, "great-repo-1", true)
@@ -59,7 +59,7 @@ func TestOwnRepoIndexSchedulerJob_JobsAutoIndex(t *testing.T) {
 func TestOwnRepoIndexSchedulerJob_AnalyticsEnabled(t *testing.T) {
 	obsCtx := observation.TestContextTB(t)
 	logger := obsCtx.Logger
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	insertRepo(t, db, 500, "great-repo-1", true)
@@ -87,7 +87,7 @@ func TestOwnRepoIndexSchedulerJob_AnalyticsEnabled(t *testing.T) {
 func TestOwnRepoIndexSchedulerJob_JobsAreExcluded(t *testing.T) {
 	obsCtx := observation.TestContextTB(t)
 	logger := obsCtx.Logger
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	store := basestore.NewWithHandle(db.Handle())
 

--- a/internal/own/ownref_test.go
+++ b/internal/own/ownref_test.go
@@ -32,7 +32,7 @@ func TestSearchFilteringExample(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	user, err := initUser(ctx, t, db)
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestBagNoUser(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	bag := ByTextReference(ctx, db, "userdoesnotexist")
 	for name, r := range map[string]Reference{
@@ -185,7 +185,7 @@ func TestBagUserFoundNoMatches(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	user, err := initUser(ctx, t, db)
 	require.NoError(t, err)
@@ -259,7 +259,7 @@ func TestBagUnverifiedEmailOnlyMatchesWithItself(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	user, err := initUser(ctx, t, db)
 	require.NoError(t, err)
@@ -304,7 +304,7 @@ func TestBagRetrievesTeamsByName(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	team, err := db.Teams().CreateTeam(ctx, &types.Team{Name: "team-name"})
 	require.NoError(t, err)
@@ -318,7 +318,7 @@ func TestBagManyUsers(t *testing.T) {
 		t.Skip()
 	}
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	user1, err := db.Users().Create(ctx, database.NewUser{
 		Email:           "john.doe@example.com",

--- a/internal/own/service_test.go
+++ b/internal/own/service_test.go
@@ -170,7 +170,7 @@ func TestAssignedOwners(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating 2 users.
@@ -346,7 +346,7 @@ func TestAssignedTeams(t *testing.T) {
 
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	// Creating a user and 2 teams.

--- a/internal/rbac/permission_test.go
+++ b/internal/rbac/permission_test.go
@@ -116,7 +116,7 @@ func TestCheckGivenUserHasPermission(t *testing.T) {
 func setup(t *testing.T, ctx context.Context) (database.DB, *types.User, *types.User, *types.Permission) {
 	t.Helper()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	newUser1 := database.NewUser{Username: "username-1"}
 	u1, err := db.Users().Create(ctx, newUser1)

--- a/internal/redispool/naive_test.go
+++ b/internal/redispool/naive_test.go
@@ -58,7 +58,7 @@ func TestDBKeyValue(t *testing.T) {
 
 func dbStoreTransact(t *testing.T) redispool.DBStoreTransact {
 	logger := logtest.Scoped(t)
-	kvNoTX := database.NewDB(logger, dbtest.NewDB(logger, t)).RedisKeyValue()
+	kvNoTX := database.NewDB(logger, dbtest.NewDB(t)).RedisKeyValue()
 
 	return func(ctx context.Context, f func(redispool.DBStore) error) error {
 		return kvNoTX.WithTransact(ctx, func(tx database.RedisKeyValueStore) error {

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -1385,7 +1385,7 @@ EyAO2RYQG7mSE6w6CtTFiCjjmELpvdD2s1ygvPdCO1MJlCX264E3og==
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ghAppsStore := db.GitHubApps().WithEncryptionKey(keyring.Default().GitHubAppKey)
 	_, err := ghAppsStore.Create(context.Background(), &ghtypes.GitHubApp{
 		AppID:        350528,

--- a/internal/repos/npm_packages_test.go
+++ b/internal/repos/npm_packages_test.go
@@ -101,7 +101,7 @@ func TestGetNpmDependencyRepos(t *testing.T) {
 func testDependenciesService(ctx context.Context, t *testing.T, dependencyRepos []dependencies.MinimalPackageRepoRef) *dependencies.Service {
 	t.Helper()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	depsSvc := dependencies.TestService(db)
 
 	_, _, err := depsSvc.InsertPackageRepoRefs(ctx, dependencyRepos)

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -39,7 +39,7 @@ func TestStatusMessages(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
 
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := NewStore(logtest.Scoped(t), db)
 
 	mockGitserverClient := gitserver.NewMockClient()

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -520,7 +520,7 @@ func getTestRepoStore(t *testing.T) repos.Store {
 	}
 
 	logger := logtest.Scoped(t)
-	store := repos.NewStore(logtest.Scoped(t), database.NewDB(logger, dbtest.NewDB(logger, t)))
+	store := repos.NewStore(logtest.Scoped(t), database.NewDB(logger, dbtest.NewDB(t)))
 	store.SetMetrics(repos.NewStoreMetrics())
 	return store
 }

--- a/internal/rockskip/BUILD.bazel
+++ b/internal/rockskip/BUILD.bazel
@@ -62,6 +62,5 @@ go_test(
         "//lib/pointers",
         "@com_github_google_go_cmp//cmp",
         "@com_github_sourcegraph_go_ctags//:go-ctags",
-        "@com_github_sourcegraph_log//logtest",
     ],
 )

--- a/internal/rockskip/server_test.go
+++ b/internal/rockskip/server_test.go
@@ -15,8 +15,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/go-ctags"
-	"github.com/sourcegraph/log/logtest"
-
 	"github.com/sourcegraph/sourcegraph/cmd/symbols/fetcher"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -51,8 +49,6 @@ func TestIndex(t *testing.T) {
 			t.Fatal(errors.Wrap(err, message))
 		}
 	}
-
-	logger := logtest.Scoped(t)
 
 	gitDir, err := os.MkdirTemp("", "rockskip-test-index")
 	fatalIfError(err, "faiMkdirTemp")
@@ -111,7 +107,7 @@ func TestIndex(t *testing.T) {
 	fatalIfError(err, "NewSubprocessGit")
 	defer git.Close()
 
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 	defer db.Close()
 
 	createParser := func() (ctags.Parser, error) { return mockParser{}, nil }

--- a/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_jobs_test.go
@@ -28,7 +28,7 @@ func TestStore_CreateExhaustiveSearchJob(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bs := basestore.NewWithHandle(db.Handle())
 
@@ -137,7 +137,7 @@ func TestStore_GetAndListSearchJobs(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bs := basestore.NewWithHandle(db.Handle())
 
 	userID, err := createUser(bs, "alice")
@@ -288,7 +288,7 @@ func TestStore_AggregateStatus(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	bs := basestore.NewWithHandle(db.Handle())
 
 	_, err := createRepo(db, "repo1")

--- a/internal/search/exhaustive/store/exhaustive_search_repo_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_jobs_test.go
@@ -24,7 +24,7 @@ func TestStore_CreateExhaustiveSearchRepoJob(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bs := basestore.NewWithHandle(db.Handle())
 

--- a/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs_test.go
+++ b/internal/search/exhaustive/store/exhaustive_search_repo_revision_jobs_test.go
@@ -24,7 +24,7 @@ func TestStore_CreateExhaustiveSearchRepoRevisionJob(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	bs := basestore.NewWithHandle(db.Handle())
 

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -272,7 +272,7 @@ func BenchmarkGetRevsForMatchedRepo(b *testing.B) {
 func TestResolverIterator(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	for i := 1; i <= 5; i++ {
 		r := types.MinimalRepo{
@@ -426,7 +426,7 @@ func TestResolverIterator(t *testing.T) {
 func TestResolverIterateRepoRevs(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	// intentionally nil so it panics if we call it
 	var gsClient gitserver.Client = nil

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -195,7 +195,7 @@ func TestResolvingSearchContextRepoNames(t *testing.T) {
 
 	internalCtx := actor.WithInternalActor(context.Background())
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	u := db.Users()
 	r := db.Repos()
 
@@ -235,7 +235,7 @@ func TestSearchContextWriteAccessValidation(t *testing.T) {
 
 	internalCtx := actor.WithInternalActor(context.Background())
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	u := db.Users()
 
 	org, err := db.Orgs().Create(internalCtx, "myorg", nil)
@@ -356,7 +356,7 @@ func TestCreatingSearchContexts(t *testing.T) {
 
 	internalCtx := actor.WithInternalActor(context.Background())
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	u := db.Users()
 
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})
@@ -496,7 +496,7 @@ func TestUpdatingSearchContexts(t *testing.T) {
 
 	internalCtx := actor.WithInternalActor(context.Background())
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	u := db.Users()
 
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})
@@ -581,7 +581,7 @@ func TestDeletingAutoDefinedSearchContext(t *testing.T) {
 
 	internalCtx := actor.WithInternalActor(context.Background())
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	u := db.Users()
 
 	user1, err := u.Create(internalCtx, database.NewUser{Username: "u1", Password: "p"})

--- a/internal/service/servegit/extsvc_test.go
+++ b/internal/service/servegit/extsvc_test.go
@@ -13,7 +13,7 @@ import (
 // insert into the DB.
 func TestEnsureExtSVC(t *testing.T) {
 	logger := logtest.Scoped(t)
-	testDB := database.NewDB(logger, dbtest.NewDB(logger, t))
+	testDB := database.NewDB(logger, dbtest.NewDB(t))
 	store := testDB.ExternalServices()
 
 	err := doEnsureExtSVC(context.Background(), store, "http://test", "/fake")

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -19,7 +19,7 @@ import (
 func TestRelevantSettings(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	settingsService := NewService(db)
 
 	createOrg := func(name string) *types.Org {

--- a/internal/telemetry/teestore/teestore_test.go
+++ b/internal/telemetry/teestore/teestore_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestToEventLogs(t *testing.T) {
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	testCases := []struct {
 		name            string

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -42,7 +42,7 @@ func TestRecorderEndToEnd(t *testing.T) {
 	ctx = featureflag.WithFlags(ctx, ff)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	recorder := telemetry.NewEventRecorder(teestore.NewStore(db.TelemetryEventsExportQueue(), db.EventLogs()))
 

--- a/internal/usagestats/aggregated_repo_metadata_test.go
+++ b/internal/usagestats/aggregated_repo_metadata_test.go
@@ -19,7 +19,7 @@ func TestAggregatedRepoMetadataSummary(t *testing.T) {
 	}
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
 	err := db.Repos().Create(ctx, &types.Repo{

--- a/internal/usagestats/batches_test.go
+++ b/internal/usagestats/batches_test.go
@@ -22,7 +22,7 @@ import (
 func TestGetBatchChangesUsageStatistics(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	// Create stub repo.
 	repoStore := db.Repos()

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -27,7 +27,7 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 	mockTimeNow(now)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	_, err := db.ExecContext(context.Background(), `
 		INSERT INTO event_logs
@@ -133,7 +133,7 @@ func TestWithCreationPings(t *testing.T) {
 	now := time.Date(2021, 1, 28, 0, 0, 0, 0, time.UTC)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	user1 := "420657f0-d443-4d16-ac7d-003d8cdc91ef"
 	user2 := "55555555-5555-5555-5555-555555555555"

--- a/internal/usagestats/code_monitoring_test.go
+++ b/internal/usagestats/code_monitoring_test.go
@@ -24,7 +24,7 @@ func TestCodeMonitoringUsageStatistics(t *testing.T) {
 	}()
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO event_logs

--- a/internal/usagestats/codehost_integration_test.go
+++ b/internal/usagestats/codehost_integration_test.go
@@ -26,7 +26,7 @@ func TestGetCodeHostIntegrationUsageStatistics(t *testing.T) {
 	mockTimeNow(now)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	_, err := db.ExecContext(context.Background(), `
 		INSERT INTO event_logs

--- a/internal/usagestats/extensions_test.go
+++ b/internal/usagestats/extensions_test.go
@@ -26,7 +26,7 @@ func TestExtensionsUsageStatistics(t *testing.T) {
 	mockTimeNow(now)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	_, err := db.ExecContext(context.Background(), `
 		INSERT INTO event_logs

--- a/internal/usagestats/growth_test.go
+++ b/internal/usagestats/growth_test.go
@@ -27,7 +27,7 @@ func TestGrowthStatistics(t *testing.T) {
 	mockTimeNow(now)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	t.Run("getUsersGrowthStatistics", func(t *testing.T) {
 		createUsersQuery := `

--- a/internal/usagestats/ide_extensions_test.go
+++ b/internal/usagestats/ide_extensions_test.go
@@ -24,7 +24,7 @@ func TestIDEExtensionsUsageStatistics(t *testing.T) {
 	now := time.Date(2022, 2, 9, 12, 55, 0, 0, time.UTC) // Feb 16 2022, Wednesday
 	mockTimeNow(now)
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO event_logs

--- a/internal/usagestats/migrated_extensions_test.go
+++ b/internal/usagestats/migrated_extensions_test.go
@@ -17,7 +17,7 @@ func TestMigratedExtensionsUsageStatistics(t *testing.T) {
 	ctx := context.Background()
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO event_logs

--- a/internal/usagestats/notebooks_test.go
+++ b/internal/usagestats/notebooks_test.go
@@ -17,7 +17,7 @@ import (
 func TestGetNotebooksUsageStatistics(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	now := time.Now()
 
 	_, err := db.ExecContext(context.Background(), `

--- a/internal/usagestats/own_test.go
+++ b/internal/usagestats/own_test.go
@@ -20,7 +20,7 @@ import (
 func TestGetOwnershipUsageStatsReposCount(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	if err := db.Repos().Create(ctx, &types.Repo{Name: "does-not-have-codeowners"}); err != nil {
 		t.Fatalf("failed to create test repo: %s", err)
@@ -57,7 +57,7 @@ func TestGetOwnershipUsageStatsReposCount(t *testing.T) {
 func TestGetOwnershipUsageStatsReposCountNoCodeowners(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	if err := db.Repos().Create(ctx, &types.Repo{Name: "does-not-have-codeowners"}); err != nil {
 		t.Fatalf("failed to create test repo: %s", err)
@@ -81,7 +81,7 @@ func TestGetOwnershipUsageStatsReposCountNoCodeowners(t *testing.T) {
 func TestGetOwnershipUsageStatsReposCountNoRepos(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	if err := db.RepoStatistics().CompactRepoStatistics(ctx); err != nil {
 		t.Fatalf("failed to compact repo stats: %s", err)
@@ -105,7 +105,7 @@ func TestGetOwnershipUsageStatsReposCountNoRepos(t *testing.T) {
 func TestGetOwnershipUsageStatsReposCountStatsNotCompacted(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	if err := db.Repos().Create(ctx, &types.Repo{Name: "does-not-have-codeowners"}); err != nil {
 		t.Fatalf("failed to create test repo: %s", err)
@@ -159,7 +159,7 @@ func TestGetOwnershipUsageStatsAggregatedStats(t *testing.T) {
 	} {
 		t.Run(eventName, func(t *testing.T) {
 			t.Parallel()
-			db := database.NewDB(logger, dbtest.NewDB(logger, t))
+			db := database.NewDB(logger, dbtest.NewDB(t))
 			ctx := context.Background()
 			if err := db.EventLogs().Insert(ctx, &database.Event{
 				UserID: 1,
@@ -198,7 +198,7 @@ func TestGetOwnershipUsageStatsAggregatedStats(t *testing.T) {
 func TestGetOwnershipUsageStatsAssignedOwnersCount(t *testing.T) {
 	t.Parallel()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	var repoID api.RepoID = 1
 	require.NoError(t, db.Repos().Create(ctx, &types.Repo{

--- a/internal/usagestats/retention_test.go
+++ b/internal/usagestats/retention_test.go
@@ -26,7 +26,7 @@ func TestRetentionUsageStatistics(t *testing.T) {
 
 	mockTimeNow(eventDate)
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	events := []database.Event{{
 		Name:      "ViewHome",

--- a/internal/usagestats/search_jobs_test.go
+++ b/internal/usagestats/search_jobs_test.go
@@ -25,7 +25,7 @@ func TestSearchJobsUsageStatistics(t *testing.T) {
 	mockTimeNow(now)
 
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	_, err := db.ExecContext(context.Background(), `
 		INSERT INTO event_logs

--- a/internal/usagestats/usage_stats_test.go
+++ b/internal/usagestats/usage_stats_test.go
@@ -702,7 +702,7 @@ func TestUserUsageStatistics_DAUs_WAUs_MAUs(t *testing.T) {
 
 func setupForTest(t *testing.T) database.DB {
 	logger := logtest.Scoped(t)
-	return database.NewDB(logger, dbtest.NewDB(logger, t))
+	return database.NewDB(logger, dbtest.NewDB(t))
 }
 
 func mockTimeNow(t time.Time) {

--- a/internal/version/upgradestore/store_test.go
+++ b/internal/version/upgradestore/store_test.go
@@ -21,7 +21,7 @@ import (
 func TestGetServiceVersion(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	store := New(db)
 
@@ -76,7 +76,7 @@ func TestGetServiceVersion(t *testing.T) {
 func TestSetServiceVersion(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	store := New(db)
 
@@ -100,7 +100,7 @@ func TestSetServiceVersion(t *testing.T) {
 func TestGetFirstServiceVersion(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	store := New(db)
 
@@ -155,7 +155,7 @@ func TestGetFirstServiceVersion(t *testing.T) {
 func TestUpdateServiceVersion(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	store := New(db)
 
@@ -213,7 +213,7 @@ func TestUpdateServiceVersion(t *testing.T) {
 func TestValidateUpgrade(t *testing.T) {
 	ctx := context.Background()
 	logger := logtest.Scoped(t)
-	db := database.NewDB(logger, dbtest.NewDB(logger, t))
+	db := database.NewDB(logger, dbtest.NewDB(t))
 
 	store := New(db)
 
@@ -233,7 +233,7 @@ func TestClaimAutoUpgrade(t *testing.T) {
 
 	t.Run("basic", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 
 		store := New(db)
 
@@ -253,7 +253,7 @@ func TestClaimAutoUpgrade(t *testing.T) {
 
 	t.Run("basic sequential (first in-progress)", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 
 		store := New(db)
 
@@ -282,7 +282,7 @@ func TestClaimAutoUpgrade(t *testing.T) {
 
 	t.Run("basic sequential (first failed)", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 
 		store := New(db)
 
@@ -315,7 +315,7 @@ func TestClaimAutoUpgrade(t *testing.T) {
 
 	t.Run("basic sequential (first succeeded)", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 
 		store := New(db)
 
@@ -348,7 +348,7 @@ func TestClaimAutoUpgrade(t *testing.T) {
 
 	t.Run("basic sequential (first succeeded, older version)", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 
 		store := New(db)
 
@@ -381,7 +381,7 @@ func TestClaimAutoUpgrade(t *testing.T) {
 
 	t.Run("stale heartbeat", func(t *testing.T) {
 		logger := logtest.Scoped(t)
-		db := database.NewDB(logger, dbtest.NewDB(logger, t))
+		db := database.NewDB(logger, dbtest.NewDB(t))
 		clock := glock.NewMockClock()
 		store := newStore(basestore.NewWithHandle(db.Handle()), clock)
 

--- a/internal/workerutil/dbworker/store/BUILD.bazel
+++ b/internal/workerutil/dbworker/store/BUILD.bazel
@@ -52,7 +52,6 @@ go_test(
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
         "@com_github_sourcegraph_log//:log",
-        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/workerutil/dbworker/store/helpers_test.go
+++ b/internal/workerutil/dbworker/store/helpers_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/lib/pq"
 
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -83,8 +82,7 @@ func testScanRecordRetry(sc dbutil.Scanner) (*TestRecordRetry, error) {
 }
 
 func setupStoreTest(t *testing.T) *sql.DB {
-	logger := logtest.Scoped(t)
-	db := dbtest.NewDB(logger, t)
+	db := dbtest.NewDB(t)
 
 	if _, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS workerutil_test (


### PR DESCRIPTION
This simplifies the construction of a test database by creating a logger inside `dbtest.NewDB` with `logtest.Scoped(t)` rather than relying on the caller passing on in. There were no callers that needed to capture the logs from a test db (which is unsurprising), and if someone ever wants to test the logs emitted, they can create a new constructor like `dbtest.NewDBWithLogger()`. 

## Test plan

It builds. It's just a very repetitive removal of the first argument of `dbtest.NewDB()`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
