### PR TITLE
Chore: require go 1.20 for main repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sourcegraph/sourcegraph
 
-go 1.19
+go 1.20
 
 // Permanent replace directives
 // ============================


### PR DESCRIPTION
This just upgrades the minimum go version for the main module to go 1.20, which allows us to take advantage of new go 1.20 features. Technically, this is just "advisory" until go 1.21, so it shouldn't break anything. We're actually already using [some go 1.20 features](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@f17dd8bd03cb53cd4142a1012e1ae7c544e31f46/-/blob/cmd/frontend/internal/guardrails/attribution/attribution.go?L93-93), which was surprising to me.

I tried to upgrade build to use go 1.21, but `rules_go` currently has an issue because the go project changed its version string format in its archives, so we'll have to wait until the next release.

## Test plan

CI.
