### PR TITLE
Pass through logprobs from completions model

### DIFF
--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -65,6 +65,9 @@ func (c *fireworksClient) Stream(
 	requestParams types.CompletionRequestParameters,
 	sendEvent types.SendCompletionEvent,
 ) error {
+	logprobsInclude := uint8(0)
+	requestParams.Logprobs = &logprobsInclude
+
 	// HACK: Cody Gateway expects model names in <provider>/<model> format, but if we're connecting directly to
 	// the Fireworks API, we need to strip the "fireworks" provider prefix
 	if components := strings.Split(requestParams.Model, "/"); components[0] == "fireworks" {

--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -64,6 +65,12 @@ func (c *fireworksClient) Stream(
 	requestParams types.CompletionRequestParameters,
 	sendEvent types.SendCompletionEvent,
 ) error {
+	// HACK: Cody Gateway expects model names in <provider>/<model> format, but if we're connecting directly to
+	// the Fireworks API, we need to strip the "fireworks" provider prefix
+	if components := strings.Split(requestParams.Model, "/"); components[0] == "fireworks" {
+		requestParams.Model = strings.Join(components[1:], "/")
+	}
+
 	resp, err := c.makeRequest(ctx, requestParams, true)
 	if err != nil {
 		return err

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -60,6 +60,7 @@ type CompletionRequestParameters struct {
 	TopP              float32   `json:"topP,omitempty"`
 	Model             string    `json:"model,omitempty"`
 	Stream            *bool     `json:"stream,omitempty"`
+	Logprobs          *uint8    `json:"logprobs,omitempty"`
 }
 
 // IsStream returns whether a streaming response is requested. For backwards
@@ -98,8 +99,42 @@ func (p *CompletionRequestParameters) Attrs(feature CompletionsFeature) []attrib
 }
 
 type CompletionResponse struct {
-	Completion string `json:"completion"`
-	StopReason string `json:"stopReason"`
+	Completion string    `json:"completion"`
+	StopReason string    `json:"stopReason"`
+	Logprobs   *Logprobs `json:"logprobs,omitempty"`
+}
+
+type Logprobs struct {
+	Tokens        []string             `json:"tokens"`
+	TokenLogprobs []float32            `json:"token_logprobs"`
+	TopLogprobs   []map[string]float32 `json:"top_logprobs"`
+	TextOffset    []int32              `json:"text_offset"`
+}
+
+// Append concatenates the additional logprobs to the original ones
+// and returns a reference to the mutated original logprobs. Note
+// this mutates the receiver. If the receiver is nil, a shallow
+// copy of additional is returned.
+//
+// Intended usage: original = original.Append(additional)
+func (original *Logprobs) Append(additional *Logprobs) *Logprobs {
+	if original == nil {
+		if additional == nil {
+			return nil
+		} else {
+			newLogprobs := *additional
+			return &newLogprobs
+		}
+	}
+	if additional == nil {
+		return original
+	}
+
+	original.Tokens = append(original.Tokens, additional.Tokens...)
+	original.TokenLogprobs = append(original.TokenLogprobs, additional.TokenLogprobs...)
+	original.TopLogprobs = append(original.TopLogprobs, additional.TopLogprobs...)
+	original.TextOffset = append(original.TextOffset, additional.TextOffset...)
+	return original
 }
 
 type SendCompletionEvent func(event CompletionResponse) error

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -60,7 +60,7 @@ type CompletionRequestParameters struct {
 	TopP              float32   `json:"topP,omitempty"`
 	Model             string    `json:"model,omitempty"`
 	Stream            *bool     `json:"stream,omitempty"`
-	Logprobs          *uint8    `json:"logprobs,omitempty"`
+	Logprobs          *uint8    `json:"logprobs"`
 }
 
 // IsStream returns whether a streaming response is requested. For backwards

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2742,7 +2742,7 @@
           "type": "string",
           "description": "The external completions provider. Defaults to 'sourcegraph'.",
           "default": "sourcegraph",
-          "enum": ["anthropic", "openai", "sourcegraph", "azure-openai", "aws-bedrock"]
+          "enum": ["anthropic", "openai", "sourcegraph", "azure-openai", "aws-bedrock", "fireworks"]
         },
         "endpoint": {
           "type": "string",


### PR DESCRIPTION
Forward the log probabilities from the Fireworks API to the client. This will enable us to use the log probabilities as a signal for completions.

## Test plan

- [ ] Test this works with Fireworks with the following additions to `site-config.json`:

```
-    "provider": "sourcegraph",
+    "provider": "fireworks",
-    "accessToken": "<CODE GATEAWY TOKEN>",
+    "accessToken": "<FIREWORKS API TOKEN",
-    "endpoint": "https://cody-gateway.sgdev.org"
+    "endpoint": "https://api.fireworks.ai/inference/v1/completions",
```
- [ ] Test this works with normal `site-config.json` to ensure no regressions with other configurations
- [ ] Note that the model naming is different with Cody Gateway (there's an additional `"fireworks/"` prepended to the model name), so test against this configuration, as well.