### PR TITLE
event_logs, telemetry_export: do not interrupt insert on context cancel

### DIFF
--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -149,6 +149,7 @@ go_library(
         "//internal/trace",
         "//internal/types",
         "//internal/version",
+        "//internal/xcontext",
         "//lib/errors",
         "//lib/pointers",
         "//schema",

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/version"
+	"github.com/sourcegraph/sourcegraph/internal/xcontext"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -294,9 +295,9 @@ func (l *eventLogStore) BulkInsert(ctx context.Context, events []*Event) error {
 	close(rowValues)
 
 	return batch.InsertValues(
-		// Create a background context with trace details to avoid interrupting
-		// the insert when the parent context is cancelled.
-		trace.BackgroundContext(ctx),
+		// Create a cancel-free context to avoid interrupting the insert when
+		// the parent context is cancelled.
+		xcontext.Detach(ctx),
 		l.Handle(),
 		"event_logs",
 		batch.MaxNumPostgresParameters,

--- a/internal/database/telemetry_export_store.go
+++ b/internal/database/telemetry_export_store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/sensitivemetadataallowlist"
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/xcontext"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -95,9 +96,9 @@ func (s *telemetryEventsExportQueueStore) QueueForExport(ctx context.Context, ev
 	}
 
 	err := batch.InsertValues(
-		// Create a background context with trace details to avoid interrupting
-		// the insert when the parent context is cancelled.
-		trace.BackgroundContext(ctx),
+		// Create a cancel-free context to avoid interrupting the insert when
+		// the parent context is cancelled.
+		xcontext.Detach(ctx),
 		s.Handle(),
 		"telemetry_events_export_queue",
 		batch.MaxNumPostgresParameters,

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -32,6 +32,9 @@ func CopyContext(ctx context.Context, from context.Context) context.Context {
 //
 // 🚨 SECURITY: The returned context does NOT retain any other context baggage,
 // including Actor context.
+//
+// 🔔 TODO(go1.21): Replace all callsites with https://pkg.go.dev/context#WithoutCancel
+// when we upgrade to Go .21
 func BackgroundContext(from context.Context) context.Context {
 	return CopyContext(context.Background(), from)
 }

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -22,23 +22,6 @@ func CopyContext(ctx context.Context, from context.Context) context.Context {
 	return ctx
 }
 
-// BackgroundContext returns a background context with the same tracing
-// policy and trace ID associated with from, if available. It is a convenience
-// alias for CopyContext(context.Background(), from).
-//
-// Using context.Background() is desirable in scenarios where we don't want an
-// action to be cancelled if the parent action is cancelled, while retaining a
-// trace hierarchy.
-//
-// 🚨 SECURITY: The returned context does NOT retain any other context baggage,
-// including Actor context.
-//
-// 🔔 TODO(go1.21): Replace all callsites with https://pkg.go.dev/context#WithoutCancel
-// when we upgrade to Go .21
-func BackgroundContext(from context.Context) context.Context {
-	return CopyContext(context.Background(), from)
-}
-
 // ID returns a trace ID, if any, found in the given context. If you need both trace and
 // span ID, use trace.Context.
 func ID(ctx context.Context) string {

--- a/internal/trace/context.go
+++ b/internal/trace/context.go
@@ -22,6 +22,20 @@ func CopyContext(ctx context.Context, from context.Context) context.Context {
 	return ctx
 }
 
+// BackgroundContext returns a background context with the same tracing
+// policy and trace ID associated with from, if available. It is a convenience
+// alias for CopyContext(context.Background(), from).
+//
+// Using context.Background() is desirable in scenarios where we don't want an
+// action to be cancelled if the parent action is cancelled, while retaining a
+// trace hierarchy.
+//
+// 🚨 SECURITY: The returned context does NOT retain any other context baggage,
+// including Actor context.
+func BackgroundContext(from context.Context) context.Context {
+	return CopyContext(context.Background(), from)
+}
+
 // ID returns a trace ID, if any, found in the given context. If you need both trace and
 // span ID, use trace.Context.
 func ID(ctx context.Context) string {


### PR DESCRIPTION
When a request context is cancelled, the [corresponding event database insert can fail on context cancellation](https://sourcegraph.slack.com/archives/C03V51C8K53/p1697072391851359) - but this is highly unlikely to be desirable behaviour, since we probably want to proceed with persisting the event regardless.

This change introduces a new helper in `internal/trace`, `BackgroundContext`, which aliases `CopyContext(context.Background(), from)` with some more docstrings on when to use it and how to use it correctly. We use this new background context in the most inner part of `(TelemetryEventsExportQueueStore).QueueForExport` and `(EventLogStore).BulkInsert` to ensure we don't interrupt database inserts.

## Test plan

CI