### PR TITLE
Display commits/changelists even if graphql error occurs

### DIFF
--- a/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
+++ b/client/web/src/components/FilteredConnection/hooks/useShowMorePagination.ts
@@ -33,6 +33,8 @@ interface UseShowMorePaginationConfig<TResult> {
     useURL?: boolean
     /** Allows modifying how the query interacts with the Apollo cache */
     fetchPolicy?: WatchQueryFetchPolicy
+    /** Allows specifying the Apollo error policy */
+    errorPolicy?: 'all' | 'none' | 'ignore'
     /**
      * Set to enable polling of all the nodes currently loaded in the connection.
      *
@@ -139,6 +141,7 @@ export const useShowMorePagination = <TResult, TVariables extends {}, TData>({
         fetchPolicy: options?.fetchPolicy,
         onCompleted: options?.onCompleted,
         onError: options?.onError,
+        errorPolicy: options?.errorPolicy,
     })
 
     /**

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -53,6 +53,7 @@ export const RepositoryCommitPage: React.FunctionComponent<RepositoryCommitPageP
             repo: props.repo.id,
             revspec: params.revspec,
         },
+        errorPolicy: 'all',
     })
 
     const commit = useMemo(
@@ -87,6 +88,7 @@ export const RepositoryChangelistPage: React.FunctionComponent<RepositoryCommitP
                 repo: props.repo.id,
                 changelistID: params.changelistID,
             },
+            errorPolicy: 'all',
         }
     )
 
@@ -163,43 +165,44 @@ const RepositoryRevisionNodes: React.FunctionComponent<RepositoryRevisionNodesPr
     return (
         <div data-testid="repository-commit-page" className={classNames('p-3', styles.repositoryCommitPage)}>
             <PageTitle title={pageTitle} />
+            {error && <ErrorAlert className="mt-2" error={error ?? new Error(pageError)} />}
             {loading ? (
                 <LoadingSpinner className="mt-2" />
-            ) : error || !commit ? (
-                <ErrorAlert className="mt-2" error={error ?? new Error(pageError)} />
             ) : (
-                <>
-                    <div className="border-bottom pb-2">
-                        <div>
-                            <GitCommitNode
-                                node={commit}
-                                expandCommitMessageBody={true}
-                                showSHAAndParentsRow={true}
-                                diffMode={diffMode}
-                                onHandleDiffMode={setDiffMode}
-                                className={styles.gitCommitNode}
-                            />
+                commit && (
+                    <>
+                        <div className="border-bottom pb-2">
+                            <div>
+                                <GitCommitNode
+                                    node={commit}
+                                    expandCommitMessageBody={true}
+                                    showSHAAndParentsRow={true}
+                                    diffMode={diffMode}
+                                    onHandleDiffMode={setDiffMode}
+                                    className={styles.gitCommitNode}
+                                />
+                            </div>
                         </div>
-                    </div>
-                    <FilteredConnection<FileDiffFields, Omit<FileDiffNodeProps, 'node'>>
-                        listClassName="list-group list-group-flush"
-                        noun="changed file"
-                        pluralNoun="changed files"
-                        queryConnection={queryDiffs}
-                        nodeComponent={FileDiffNode}
-                        nodeComponentProps={{
-                            ...props,
-                            lineNumbers: true,
-                            diffMode,
-                        }}
-                        updateOnChange={`${repo.id}:${commit.oid}`}
-                        defaultFirst={15}
-                        hideSearch={true}
-                        noSummaryIfAllNodesVisible={true}
-                        withCenteredSummary={true}
-                        cursorPaging={true}
-                    />
-                </>
+                        <FilteredConnection<FileDiffFields, Omit<FileDiffNodeProps, 'node'>>
+                            listClassName="list-group list-group-flush"
+                            noun="changed file"
+                            pluralNoun="changed files"
+                            queryConnection={queryDiffs}
+                            nodeComponent={FileDiffNode}
+                            nodeComponentProps={{
+                                ...props,
+                                lineNumbers: true,
+                                diffMode,
+                            }}
+                            updateOnChange={`${repo.id}:${commit.oid}`}
+                            defaultFirst={15}
+                            hideSearch={true}
+                            noSummaryIfAllNodesVisible={true}
+                            withCenteredSummary={true}
+                            cursorPaging={true}
+                        />
+                    </>
+                )
             )}
         </div>
     )

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -168,6 +168,7 @@ export const RepositoryCommitsPage: FC<RepositoryCommitsPageProps> = props => {
         options: {
             fetchPolicy: 'cache-first',
             useAlternateAfterCursor: true,
+            errorPolicy: 'all',
         },
     })
 

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -751,6 +751,7 @@ const Commits: React.FC<CommitsProps> = ({ repo, revision, filePath, tree }) => 
             after,
             filePath,
         },
+        errorPolicy: 'all',
     })
 
     const node = data?.node && data?.node.__typename === 'Repository' ? data.node : null


### PR DESCRIPTION
(partially) Closes #57324 

This PR makes some Apollo query changes, setting error policies to 'all'. This allows changelists/commits to render even when the GraphQL resolvers have errors.

This at least makes the pages functional, but I created a follow-up ticket to review our GraphQL resolvers [here](https://github.com/sourcegraph/sourcegraph/issues/57556). We're very error happy in the resolvers, and it brings down the whole page, even when not having access to something is completely expected.

## Test plan

Manual tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
