### PR TITLE
Autogenerate pull requests for base image hash updates

### DIFF
--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -197,10 +197,14 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 	case runtype.WolfiBaseRebuild:
 		// If this is a Wolfi base image rebuild, rebuild all Wolfi base images and push to registry
-		baseImageOps := wolfiRebuildAllBaseImages(c)
-		if baseImageOps != nil {
-			ops.Merge(baseImageOps)
-		}
+		// TODO: Uncomment after debugging
+		// baseImageOps := wolfiRebuildAllBaseImages(c)
+		// if baseImageOps != nil {
+		// 	ops.Merge(baseImageOps)
+		// 	ops.Merge(wolfiGenerateBaseImagePR(c))
+		// }
+		// TODO: Remove after debugging
+		ops.Merge(wolfiGenerateBaseImagePR(c))
 
 	case runtype.CandidatesNoTest:
 		imageBuildOps := operations.NewNamedSet("Image builds")

--- a/dev/ci/internal/ci/wolfi_operations.go
+++ b/dev/ci/internal/ci/wolfi_operations.go
@@ -325,3 +325,23 @@ func wolfiRebuildAllBaseImages(c Config) *operations.Set {
 
 	return baseImageOps
 }
+
+// wolfiGenerateBaseImagePR updates base image hashes and creates a PR in GitHub
+func wolfiGenerateBaseImagePR(c Config) *operations.Set {
+	ops := operations.NewNamedSet("Base Image Update PR")
+
+	ops.Append(
+		func(pipeline *bk.Pipeline) {
+			pipeline.AddStep(":whale::hash: Update Base Image Hashes",
+				bk.Cmd("./dev/ci/scripts/wolfi/update-base-image-hashes.sh"),
+				bk.Agent("queue", "bazel"),
+				// Depends on wolfiRebuildAllBaseImages
+				// TODO: Re-enable after debugging
+				// bk.DependsOn("buildAllBaseImages"),
+				bk.Key("updateBaseImageHashes"),
+			)
+		},
+	)
+
+	return ops
+}

--- a/dev/ci/scripts/wolfi/update-base-image-hashes.sh
+++ b/dev/ci/scripts/wolfi/update-base-image-hashes.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
+
+# Set up sg
+./dev/ci/integration/setup-deps.sh
+
+# Update hashes for all base images
+sg wolfi update-hashes
+
+# DEBUG: Print oci_deps
+cat dev/oci_deps.bzl


### PR DESCRIPTION
Following on from https://github.com/sourcegraph/security/issues/986 and as part of https://github.com/sourcegraph/security/issues/987, we want to automatically generate a PR that includes the latest set of base image hashes. This PR can then be merged either manually, or potentially automated with sufficient checks.

## Test plan

- Manually test CI pipeline
- Manually test scripts locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
