### PR TITLE
Allow HEAD requests on non-dotcom instances

### DIFF
--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -138,20 +138,15 @@ func newRouter() *mux.Router {
 	r := mux.NewRouter()
 	r.StrictSlash(true)
 
-	homeRouteMethods := []string{"GET"}
-	if envvar.SourcegraphDotComMode() {
-		homeRouteMethods = append(homeRouteMethods, "HEAD")
-	}
-
 	// Top-level routes.
-	r.Path("/").Methods(homeRouteMethods...).Name(routeHome)
+	r.Path("/").Methods(http.MethodGet, http.MethodHead).Name(routeHome)
 	r.PathPrefix("/threads").Methods("GET").Name(routeThreads)
 	r.Path("/search").Methods("GET").Name(routeSearch)
 	r.Path("/search/badge").Methods("GET").Name(routeSearchBadge)
 	r.Path("/search/stream").Methods("GET").Name(routeSearchStream)
 	r.Path("/search/console").Methods("GET").Name(routeSearchConsole)
 	r.Path("/search/cody").Methods("GET").Name(routeCodySearch)
-	r.Path("/sign-in").Methods("GET").Name(uirouter.RouteSignIn)
+	r.Path("/sign-in").Methods(http.MethodGet, http.MethodHead).Name(uirouter.RouteSignIn)
 	r.Path("/sign-up").Methods("GET").Name(uirouter.RouteSignUp)
 	r.PathPrefix("/request-access").Methods("GET").Name(uirouter.RouteRequestAccess)
 	r.Path("/unlock-account/{token}").Methods("GET").Name(uirouter.RouteUnlockAccount)


### PR DESCRIPTION
This fixes #56624 by implementing the solution described in this comment: https://github.com/sourcegraph/sourcegraph/issues/56624#issuecomment-1720266424

Before the copy&paste allegations: I independently arrived at the same thing after trying to figure out where the loop comes from.

## Test plan

- Manual testing locally as described in the ticket.