### PR TITLE
fix `installSrc` in executors

### DIFF
--- a/cmd/executor/internal/run/install.go
+++ b/cmd/executor/internal/run/install.go
@@ -13,7 +13,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/executor/internal/apiclient"
-	"github.com/sourcegraph/sourcegraph/cmd/executor/internal/apiclient/queue"
 	"github.com/sourcegraph/sourcegraph/cmd/executor/internal/config"
 	"github.com/sourcegraph/sourcegraph/cmd/executor/internal/util"
 	"github.com/sourcegraph/sourcegraph/internal/download"
@@ -220,16 +219,10 @@ func installSrc(cliCtx *cli.Context, logger log.Logger, config *config.Config) e
 		binDir = "/usr/local/bin"
 	}
 
-	copts := queueOptions(
-		config,
-		// We don't need telemetry here as we only use the client to talk to the Sourcegraph
-		// instance to see what src-cli version it recommends. This saves a few exec calls
-		// and confusing error messages.
-		queue.TelemetryOptions{},
-	)
+	copts := baseClientOptions(config, "")
 	srcVersion := srccli.MinimumVersion
-	if copts.BaseClientOptions.EndpointOptions.URL != "" {
-		client, err := apiclient.NewBaseClient(logger, copts.BaseClientOptions)
+	if copts.EndpointOptions.URL != "" {
+		client, err := apiclient.NewBaseClient(logger, copts)
 		if err != nil {
 			return err
 		}

--- a/cmd/executor/internal/run/install.go
+++ b/cmd/executor/internal/run/install.go
@@ -227,13 +227,13 @@ func installSrc(cliCtx *cli.Context, logger log.Logger, config *config.Config) e
 		// and confusing error messages.
 		queue.TelemetryOptions{},
 	)
-	client, err := apiclient.NewBaseClient(logger, copts.BaseClientOptions)
-	if err != nil {
-		return err
-	}
 	srcVersion := srccli.MinimumVersion
 	if copts.BaseClientOptions.EndpointOptions.URL != "" {
-		srcVersion, err = util.LatestSrcCLIVersion(cliCtx.Context, client, copts.BaseClientOptions.EndpointOptions)
+		client, err := apiclient.NewBaseClient(logger, copts.BaseClientOptions)
+		if err != nil {
+			return err
+		}
+		srcVersion, err = util.LatestSrcCLIVersion(cliCtx.Context, client)
 		if err != nil {
 			logger.Warn("Failed to fetch latest src version, falling back to minimum version required by this executor", log.Error(err))
 		}

--- a/cmd/executor/internal/run/run.go
+++ b/cmd/executor/internal/run/run.go
@@ -66,7 +66,7 @@ func StandaloneRun(ctx context.Context, runner util.CmdRunner, logger log.Logger
 		if err != nil {
 			return err
 		}
-		if err = util.ValidateSrcCLIVersion(ctx, runner, client, opts.QueueOptions.BaseClientOptions.EndpointOptions); err != nil {
+		if err = util.ValidateSrcCLIVersion(ctx, runner, client); err != nil {
 			if errors.Is(err, util.ErrSrcPatchBehind) {
 				// This is ok. The patch just doesn't match but still works.
 				logger.Warn("A newer patch release version of src-cli is available, consider running executor install src-cli to upgrade", log.Error(err))

--- a/cmd/executor/internal/run/validate.go
+++ b/cmd/executor/internal/run/validate.go
@@ -40,7 +40,7 @@ func Validate(cliCtx *cli.Context, runner util.CmdRunner, logger log.Logger, con
 
 		// Validate src-cli is of a good version, rely on the connected instance to tell
 		// us what "good" means.
-		if err = util.ValidateSrcCLIVersion(cliCtx.Context, runner, client, copts.BaseClientOptions.EndpointOptions); err != nil {
+		if err = util.ValidateSrcCLIVersion(cliCtx.Context, runner, client); err != nil {
 			if errors.Is(err, util.ErrSrcPatchBehind) {
 				// This is ok. The patch just doesn't match but still works.
 				logger.Warn("A newer patch release version of src-cli is available, consider running executor install src-cli to upgrade", log.Error(err))

--- a/cmd/executor/internal/util/srccli.go
+++ b/cmd/executor/internal/util/srccli.go
@@ -8,8 +8,8 @@ import (
 )
 
 // LatestSrcCLIVersion returns the latest src-cli version.
-func LatestSrcCLIVersion(ctx context.Context, client *apiclient.BaseClient, options apiclient.EndpointOptions) (string, error) {
-	req, err := apiclient.NewRequest(http.MethodGet, options.URL, ".api/src-cli/version", nil)
+func LatestSrcCLIVersion(ctx context.Context, client *apiclient.BaseClient) (string, error) {
+	req, err := client.NewJSONRequest(http.MethodGet, ".api/src-cli/version", nil)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/executor/internal/util/srccli_test.go
+++ b/cmd/executor/internal/util/srccli_test.go
@@ -48,7 +48,7 @@ func TestLatestSrcCLIVersion(t *testing.T) {
 			client, err := apiclient.NewBaseClient(logtest.Scoped(t), apiclient.BaseClientOptions{EndpointOptions: apiclient.EndpointOptions{URL: server.URL}})
 			require.NoError(t, err)
 
-			version, err := util.LatestSrcCLIVersion(context.Background(), client, apiclient.EndpointOptions{URL: server.URL})
+			version, err := util.LatestSrcCLIVersion(context.Background(), client)
 			if test.expectedError != nil {
 				require.Error(t, err)
 				require.EqualError(t, err, test.expectedError.Error())

--- a/cmd/executor/internal/util/validate.go
+++ b/cmd/executor/internal/util/validate.go
@@ -33,8 +33,8 @@ func ValidateGitVersion(ctx context.Context, runner CmdRunner) error {
 // ValidateSrcCLIVersion queries the latest recommended version of src-cli and makes sure it
 // matches what is installed. If not, an error recommending to use a different
 // version is returned.
-func ValidateSrcCLIVersion(ctx context.Context, runner CmdRunner, client *apiclient.BaseClient, options apiclient.EndpointOptions) error {
-	latestVersion, err := LatestSrcCLIVersion(ctx, client, options)
+func ValidateSrcCLIVersion(ctx context.Context, runner CmdRunner, client *apiclient.BaseClient) error {
+	latestVersion, err := LatestSrcCLIVersion(ctx, client)
 	if err != nil {
 		return errors.Wrap(err, "cannot retrieve latest compatible src-cli version")
 	}

--- a/cmd/executor/internal/util/validate_test.go
+++ b/cmd/executor/internal/util/validate_test.go
@@ -146,7 +146,7 @@ func TestValidateSrcCLIVersion(t *testing.T) {
 			runner.On("CombinedOutput", mock.Anything, "src", []string{"version", "-client-only"}).
 				Return(0, fmt.Sprintf("Current version: %s", test.currentVersion))
 
-			err = util.ValidateSrcCLIVersion(context.Background(), runner, client, apiclient.EndpointOptions{URL: server.URL})
+			err = util.ValidateSrcCLIVersion(context.Background(), runner, client)
 			if test.expectedErr != nil {
 				assert.NotNil(t, err)
 				assert.Equal(t, errors.Is(err, util.ErrSrcPatchBehind), test.isSrcPatchErr)


### PR DESCRIPTION
Use client for auth in HTTP request not options apiclient.EndpointOptions
Correctly adds auth header to request
internal context: [https://sourcegraph.slack.com/archives/C01JR51JR5J/p1697050361943039](https://sourcegraph.slack.com/archives/C01JR51JR5J/p1697050361943039)

## Test plan

Tested the request construction locally against `sgdev`:
```
λ ~/sourcegraph/ wg/fix-executor-installSrc EXECUTOR_FRONTEND_URL=https://k8s.sgdev.org EXECUTOR_FRONTEND_PASSWORD=REDACTED go run ./cmd/executor install src-cli --bin-dir ~
λ ~/sourcegraph/ wg/fix-executor-installSrc ~/src version
Current version: 5.2.0
Recommended version: 5.2.0 or later
```
Printing the new request
```
λ ~/sourcegraph/ wg/fix-executor-installSrc EXECUTOR_FRONTEND_URL=https://k8s.sgdev.org/ EXECUTOR_FRONTEND_PASSWORD=REDACTED go run ./cmd/executor install src-cli --bin-dir ~
Request:  &{GET https://k8s.sgdev.org/.api/src-cli/version HTTP/1.1 1 1 map[Authorization:[token-executor REDACTED] Content-Type:[application/json]] {0xc0002cf470} 0x1321dc0 4 [] false k8s.sgdev.org map[] map[] <nil> map[]   <nil> <nil> <nil> 0xc000124010}
```
Printing the old request
```
λ ~/sourcegraph/ main EXECUTOR_FRONTEND_URL=https://k8s.sgdev.org/ EXECUTOR_FRONTEND_PASSWORD=REDACTED go run ./cmd/executor install src-cli --bin-dir ~
Request:  &{GET https://k8s.sgdev.org/.api/src-cli/version HTTP/1.1 1 1 map[Content-Type:[application/json]] {0xc0002a2f30} 0x1321dc0 4 [] false k8s.sgdev.org map[] map[] <nil> map[]   <nil> <nil> <nil> 0xc00011c010}
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
