### PR TITLE
Fix explicit perms label being missing on repo permissions page

### DIFF
--- a/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -260,6 +260,10 @@ const PermissionReasonBadgeProps: { [reason: string]: BadgeProps } = {
     },
     Unrestricted: { variant: 'primary', tooltip: 'The repository is accessible to all the users. ' },
     'Site Admin': { variant: 'secondary', tooltip: 'The user is site admin and has access to all the repositories.' },
+    'Explicit API': {
+        variant: 'success',
+        tooltip: 'The permission was granted through explicit permissions API.',
+    },
 }
 
 interface ScheduleRepositoryPermissionsSyncActionContainerProps {

--- a/internal/database/perms_store.go
+++ b/internal/database/perms_store.go
@@ -2075,7 +2075,7 @@ func (s *permsStore) ListRepoPermissions(ctx context.Context, repoID api.RepoID,
 
 	perms := make([]*RepoPermission, 0)
 	for rows.Next() {
-		user, updatedAt, source, err := s.scanUsersPermissionsInfo(rows)
+		user, updatedAt, source, err := scanUsersPermissionsInfo(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -2097,7 +2097,7 @@ func (s *permsStore) ListRepoPermissions(ctx context.Context, repoID api.RepoID,
 	return perms, nil
 }
 
-func (s *permsStore) scanUsersPermissionsInfo(rows dbutil.Scanner) (*types.User, time.Time, authz.PermsSource, error) {
+func scanUsersPermissionsInfo(rows dbutil.Scanner) (*types.User, time.Time, authz.PermsSource, error) {
 	var u types.User
 	var updatedAt time.Time
 	var source *string

--- a/internal/database/perms_store.go
+++ b/internal/database/perms_store.go
@@ -2075,7 +2075,7 @@ func (s *permsStore) ListRepoPermissions(ctx context.Context, repoID api.RepoID,
 
 	perms := make([]*RepoPermission, 0)
 	for rows.Next() {
-		user, updatedAt, err := s.scanUsersPermissionsInfo(rows)
+		user, updatedAt, source, err := s.scanUsersPermissionsInfo(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -2087,6 +2087,8 @@ func (s *permsStore) ListRepoPermissions(ctx context.Context, repoID api.RepoID,
 		} else if user.SiteAdmin && !authzParams.AuthzEnforceForSiteAdmins {
 			reason = UserRepoPermissionReasonSiteAdmin
 			updatedAt = time.Time{}
+		} else if source == authz.SourceAPI {
+			reason = UserRepoPermissionReasonExplicitPerms
 		}
 
 		perms = append(perms, &RepoPermission{User: user, Reason: reason, UpdatedAt: updatedAt})
@@ -2095,9 +2097,10 @@ func (s *permsStore) ListRepoPermissions(ctx context.Context, repoID api.RepoID,
 	return perms, nil
 }
 
-func (s *permsStore) scanUsersPermissionsInfo(rows dbutil.Scanner) (*types.User, time.Time, error) {
+func (s *permsStore) scanUsersPermissionsInfo(rows dbutil.Scanner) (*types.User, time.Time, authz.PermsSource, error) {
 	var u types.User
 	var updatedAt time.Time
+	var source *string
 	var displayName, avatarURL sql.NullString
 
 	err := rows.Scan(
@@ -2112,15 +2115,21 @@ func (s *permsStore) scanUsersPermissionsInfo(rows dbutil.Scanner) (*types.User,
 		&u.InvalidatedSessionsAt,
 		&u.TosAccepted,
 		&dbutil.NullTime{Time: &updatedAt},
+		&source,
 	)
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, time.Time{}, "", err
 	}
 
 	u.DisplayName = displayName.String
 	u.AvatarURL = avatarURL.String
 
-	return &u, updatedAt, nil
+	var permsSource authz.PermsSource
+	if source != nil {
+		permsSource = authz.PermsSource(*source)
+	}
+
+	return &u, updatedAt, permsSource, nil
 }
 
 const usersPermissionsInfoQueryFmt = `
@@ -2135,7 +2144,8 @@ SELECT
 	users.passwd IS NOT NULL,
 	users.invalidated_sessions_at,
 	users.tos_accepted,
-	urp.updated_at AS permissions_updated_at
+	urp.updated_at AS permissions_updated_at,
+	urp.source
 FROM
 	users
 	LEFT JOIN user_repo_permissions urp ON urp.user_id = users.id AND urp.repo_id = %d

--- a/internal/database/perms_store_test.go
+++ b/internal/database/perms_store_test.go
@@ -4126,7 +4126,7 @@ func TestPermsStore_ListRepoPermissions(t *testing.T) {
 		}
 	}
 
-	q := sqlf.Sprintf(`INSERT INTO user_repo_permissions(user_id, repo_id) VALUES(555, 1), (666, 1), (NULL, 3), (666, 4)`)
+	q := sqlf.Sprintf(`INSERT INTO user_repo_permissions(user_id, repo_id, source) VALUES(555, 1, 'user_sync'), (666, 1, 'api'), (NULL, 3, 'api'), (666, 4, 'user_sync')`)
 	if err := s.execute(ctx, q); err != nil {
 		t.Fatal(err)
 	}
@@ -4145,7 +4145,7 @@ func TestPermsStore_ListRepoPermissions(t *testing.T) {
 				{
 					// have access
 					UserID: 666,
-					Reason: UserRepoPermissionReasonPermissionsSync,
+					Reason: UserRepoPermissionReasonExplicitPerms,
 				},
 				{
 					// have access
@@ -4184,7 +4184,7 @@ func TestPermsStore_ListRepoPermissions(t *testing.T) {
 			WantResults: []*listRepoPermissionsResult{
 				{
 					UserID: 666,
-					Reason: UserRepoPermissionReasonPermissionsSync,
+					Reason: UserRepoPermissionReasonExplicitPerms,
 				},
 			},
 		},
@@ -4197,7 +4197,7 @@ func TestPermsStore_ListRepoPermissions(t *testing.T) {
 			WantResults: []*listRepoPermissionsResult{
 				{
 					UserID: 666,
-					Reason: UserRepoPermissionReasonPermissionsSync,
+					Reason: UserRepoPermissionReasonExplicitPerms,
 				},
 			},
 		},
@@ -4290,7 +4290,7 @@ func TestPermsStore_ListRepoPermissions(t *testing.T) {
 				{
 					// have access
 					UserID: 666,
-					Reason: UserRepoPermissionReasonPermissionsSync,
+					Reason: UserRepoPermissionReasonExplicitPerms,
 				},
 				{
 					// have access


### PR DESCRIPTION
Fixes an issue I encountered while confirming something else on the repo permissions page.

Explicit permissions aren't represented on the repo permissions pages at all. They're represented as "permission syncs" which isn't true.

This PR fixes that.

Before:

![Screenshot 2023-10-13 at 11 30 09](https://github.com/sourcegraph/sourcegraph/assets/6427795/478cfbe1-92c1-43b0-9712-b255eab0ba3c)

After:

![Screenshot 2023-10-13 at 11 36 55](https://github.com/sourcegraph/sourcegraph/assets/6427795/454a22ac-20dd-4fea-a7d8-a05b3487cc18)


## Test plan

Updated unit test to test for these cases

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
