### PR TITLE
sveltekit: Fix prototype due to external package changes

### DIFF
--- a/client/web-sveltekit/src/lib/branded.ts
+++ b/client/web-sveltekit/src/lib/branded.ts
@@ -4,7 +4,8 @@ export {
     basicSyntaxColumns,
     exampleQueryColumns,
 } from '@sourcegraph/branded/src/search-ui/components/QueryExamples.constants'
-export { createDefaultSuggestions, singleLine } from '@sourcegraph/branded/src/search-ui/input/codemirror'
+export { createDefaultSuggestions } from '@sourcegraph/branded/src/search-ui/input/codemirror'
+export { multiline } from '@sourcegraph/branded/src/search-ui/input/codemirror/multiline'
 export { parseInputAsQuery } from '@sourcegraph/branded/src/search-ui/input/codemirror/parsedQuery'
 export { querySyntaxHighlighting } from '@sourcegraph/branded/src/search-ui/input/codemirror/syntax-highlighting'
 export { decorateQuery } from '@sourcegraph/branded/src/search-ui/util/query'

--- a/client/web-sveltekit/src/lib/search/CodeMirrorQueryInput.svelte
+++ b/client/web-sveltekit/src/lib/search/CodeMirrorQueryInput.svelte
@@ -7,7 +7,7 @@
 
     import { browser } from '$app/environment'
     import { goto } from '$app/navigation'
-    import { createDefaultSuggestions, singleLine, parseInputAsQuery, querySyntaxHighlighting } from '$lib/branded'
+    import { createDefaultSuggestions, multiline, parseInputAsQuery, querySyntaxHighlighting } from '$lib/branded'
     import type { SearchPatternType } from '$lib/graphql-operations'
     import { fetchStreamSuggestions, QueryChangeSource, type QueryState } from '$lib/shared'
 
@@ -46,7 +46,6 @@
                 fetchSuggestions: query => fetchStreamSuggestions(query),
                 isSourcegraphDotCom: false,
                 navigate: url => goto(url.toString()),
-                applyOnEnter: true,
             }),
         ]
 
@@ -84,7 +83,7 @@
                     },
                 ])
             ),
-            singleLine,
+            multiline(false),
             EditorView.updateListener.of(update => {
                 const { state } = update
                 if (update.docChanged) {


### PR DESCRIPTION
Because the prototype (intentionally) isn't "verified" when changes to other packages are made, it's possible that it breaks when code in other packages changes.

This commit brings the prototype up-to-date. The `singleLine` extension was recently refactored and the `applyOnEnter` option was removed.



## Test plan

`pnpm build` builds the app successfully