### PR TITLE
wolfi: Improve auto-update image docs and PR body

### DIFF
--- a/dev/ci/scripts/wolfi/update-base-image-hashes.sh
+++ b/dev/ci/scripts/wolfi/update-base-image-hashes.sh
@@ -33,6 +33,8 @@ PR_TITLE="Auto-update Wolfi base images to latest"
 # PR_REVIEWER="sourcegraph/security"
 PR_LABELS="SSDLC,wolfi-auto-update,backport 5.2"
 PR_BODY="Automatically generated PR to update Wolfi base images to the latest hashes.
+
+Built from Buildkite run [#${BUILDKITE_BUILD_NUMBER}](https://buildkite.com/sourcegraph/sourcegraph/builds/${BUILDKITE_BUILD_NUMBER}).
 ## Test Plan
 - CI build verifies image functionality
 - [ ] Confirm PR should be backported to release branch"
@@ -48,7 +50,8 @@ echo ":git: Successfully commited changes and pushed to branch ${BRANCH_NAME}"
 
 # Check if an update PR already exists
 if gh pr list --head "${BRANCH_NAME}" --state open | grep -q "${PR_TITLE}"; then
-  echo ":github: A pull request already exists - no action required"
+  echo ":github: A pull request already exists - editing it"
+  gh pr edit "${BRANCH_NAME}" --body "${PR_BODY}"
 else
   # If not, create a new PR from the branch foobar-day
   # TODO: Once validated add '--reviewer "${PR_REVIEWER}"'

--- a/doc/dev/how-to/wolfi/add_update_images.md
+++ b/doc/dev/how-to/wolfi/add_update_images.md
@@ -16,7 +16,7 @@ These configuration files can be processed with apko, which will generate a base
 
 Before each release, we should update the base images to ensure we include any updated packages and vulnerability fixes.
 
-- Review the [auto-update pull request](https://github.com/sourcegraph/sourcegraph/pulls?q=is:pr+head:wolfi-autoupdate/main+is:open) opened by Buildkite, and merge it
+- Review the [auto-update pull request](https://github.com/sourcegraph/sourcegraph/pulls?q=is:pr+head:wolfi-auto-update/main+is:open) opened by Buildkite, and merge it
 
 #### Automation
 

--- a/doc/dev/how-to/wolfi/add_update_images.md
+++ b/doc/dev/how-to/wolfi/add_update_images.md
@@ -14,7 +14,7 @@ These configuration files can be processed with apko, which will generate a base
 
 ### Update base images for a new release
 
-Before each release, we should update the base images to ensure we include any updated packages and vulnerability fixes.
+Before each release, we should update the base images to ensure we include any updated packages and vulnerability fixes. To update the images:
 
 - Review the [auto-update pull request](https://github.com/sourcegraph/sourcegraph/pulls?q=is:pr+head:wolfi-auto-update/main+is:open) opened by Buildkite, and merge it
 
@@ -27,7 +27,7 @@ This process is automated by Buildkite, which runs a daily scheduled build to:
 - Update the base image hashes in `dev/oci_deps.bzl`.
 - Open, or update the already open pull request updating the hashes.
 
-To update the images (perhaps to pick up a just-released package version), [find a scheduled build](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main) in Buildkite named "Nightly Rebuild of Wolfi Base Images", and hit "Rebuild".
+To rerun the automation (perhaps to pick up a just-released package version), click the Buildkite run link in the [auto-update pull request](https://github.com/sourcegraph/sourcegraph/pulls?q=is:pr+head:wolfi-autoupdate/main+is:open) and hit "Rebuild". Alternatively, look for the latest "Nightly Rebuild of Wolfi Base Images" run [on Buildkite](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main).
 
 #### Manual image updates
 


### PR DESCRIPTION
- Update docs: improve instructions; fix URL as branch name has changed
- Include buildkite build # in PR, and update on rebuilds

## Test plan

- Docs change - green CI
- Run CI pipeline manually with `WOLFI_BASE_REBUILD=true` https://buildkite.com/sourcegraph/sourcegraph/builds/247084#018b2933-639c-458c-ba20-f35b4cf9a62c
- Confirm PR body is updated with link: https://github.com/sourcegraph/sourcegraph/pull/57570

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@will/wolfi-auto-update-docfix)