### PR TITLE
Repo page: Add new repo link picker UI

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1246,6 +1246,7 @@ ts_project(
         "src/repo/RepoContainerError.tsx",
         "src/repo/RepoHeader.tsx",
         "src/repo/RepoHeaderContributionPortal.tsx",
+        "src/repo/RepoLinkPicker.tsx",
         "src/repo/RepoMetadataPage/AddMetadataForm.tsx",
         "src/repo/RepoMetadataPage/index.tsx",
         "src/repo/RepoMetadataPage/query.ts",

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -1,6 +1,5 @@
 import React, { type FC, Suspense, useEffect, useMemo, useState } from 'react'
 
-import { mdiSourceRepository } from '@mdi/js'
 import classNames from 'classnames'
 import { escapeRegExp } from 'lodash'
 import { type Location, useLocation, Route, Routes } from 'react-router-dom'
@@ -15,7 +14,6 @@ import {
     isRevisionNotFoundErrorLike,
 } from '@sourcegraph/shared/src/backend/errors'
 import { RepoQuestionIcon } from '@sourcegraph/shared/src/components/icons'
-import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import type { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -27,7 +25,7 @@ import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/sett
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { makeRepoURI } from '@sourcegraph/shared/src/util/url'
-import { Button, Icon, Link, Panel, useObservable } from '@sourcegraph/wildcard'
+import { Panel, useObservable } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../auth'
 import type { BatchChangesProps } from '../batches'
@@ -55,6 +53,7 @@ import { AskCodyButton } from './cody/AskCodyButton'
 import { RepoContainerError } from './RepoContainerError'
 import { RepoHeader, type RepoHeaderActionButton, type RepoHeaderContributionsLifecycleProps } from './RepoHeader'
 import { RepoHeaderContributionPortal } from './RepoHeaderContributionPortal'
+import { RepoLinkPicker } from './RepoLinkPicker'
 import {
     RepoRevisionContainer,
     type RepoRevisionContainerContext,
@@ -232,23 +231,15 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                 return
             }
 
-            const button = (
-                <Button
-                    to={resolvedRevisionOrError?.rootTreeURL || repoOrError?.url || ''}
-                    disabled={!resolvedRevisionOrError}
-                    className="text-nowrap test-repo-header-repo-link"
-                    variant="secondary"
-                    outline={true}
-                    size="sm"
-                    as={Link}
-                >
-                    <Icon aria-hidden={true} svgPath={mdiSourceRepository} /> {displayRepoName(repoName)}
-                </Button>
-            )
-
             return {
                 key: 'repository',
-                element: button,
+                element: (
+                    <RepoLinkPicker
+                        repositoryName={repoName}
+                        repositoryURL={resolvedRevisionOrError?.rootTreeURL || repoOrError?.url || ''}
+                        disabled={!resolvedRevisionOrError}
+                    />
+                ),
             }
         }, [resolvedRevisionOrError, repoOrError, repoName])
     )

--- a/client/web/src/repo/RepoLinkPicker.module.scss
+++ b/client/web/src/repo/RepoLinkPicker.module.scss
@@ -1,0 +1,47 @@
+.root {
+    display: flex;
+
+    &--active {
+        .link-button,
+        .dropdown-button {
+            background-color: var(--color-bg-1);
+        }
+    }
+}
+
+.link-button {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+}
+
+.dropdown-button {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: none;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+}
+
+.popover {
+    padding: 0.5rem;
+}
+
+.combobox {
+    min-width: 20rem;
+}
+
+.loading {
+    min-height: 5rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.list {
+    margin-top: 0.5rem;
+}
+
+.item {
+    border-radius: var(--border-radius);
+}

--- a/client/web/src/repo/RepoLinkPicker.module.scss
+++ b/client/web/src/repo/RepoLinkPicker.module.scss
@@ -13,6 +13,7 @@
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
     border-right: none;
+    white-space: nowrap;
 }
 
 .dropdown-button {

--- a/client/web/src/repo/RepoLinkPicker.tsx
+++ b/client/web/src/repo/RepoLinkPicker.tsx
@@ -1,0 +1,187 @@
+import { FC, useRef, useState } from 'react'
+
+import {
+    mdiAws,
+    mdiBitbucket,
+    mdiChevronDown,
+    mdiGit,
+    mdiGithub,
+    mdiGitlab,
+    mdiMicrosoftAzure,
+    mdiSourceRepository,
+} from '@mdi/js'
+import classNames from 'classnames'
+import { useNavigate } from 'react-router-dom'
+
+import { useQuery, gql } from '@sourcegraph/http-client'
+import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
+import {
+    Button,
+    Icon,
+    Link,
+    Popover,
+    PopoverTrigger,
+    PopoverContent,
+    Combobox,
+    ComboboxInput,
+    ComboboxList,
+    ComboboxOption,
+    ComboboxOptionText,
+    LoadingSpinner,
+    ErrorAlert,
+    useDebounce,
+} from '@sourcegraph/wildcard'
+
+import {
+    ExternalServiceKind,
+    RepositoriesSuggestionsResult,
+    RepositoriesSuggestionsVariables,
+} from '../graphql-operations'
+
+import styles from './RepoLinkPicker.module.scss'
+
+const REPOSITORIES_QUERY = gql`
+    query RepositoriesSuggestions($query: String) {
+        repositories(first: 15, query: $query) {
+            nodes {
+                id
+                name
+                url
+                externalServices(first: 1) {
+                    nodes {
+                        id
+                        kind
+                    }
+                }
+            }
+            pageInfo {
+                hasNextPage
+            }
+        }
+    }
+`
+
+interface RepoLinkPickerProps {
+    repositoryURL: string
+    repositoryName: string
+    disabled?: boolean
+    className?: string
+}
+
+export const RepoLinkPicker: FC<RepoLinkPickerProps> = props => {
+    const { repositoryURL, repositoryName, disabled, className } = props
+
+    const navigate = useNavigate()
+
+    const rootRef = useRef<HTMLDivElement>(null)
+    const [isSuggestionOpen, setSuggestionOpen] = useState<boolean>(false)
+    const [searchTerm, setSearchTerm] = useState<string>('')
+    const debouncedSearchTerm = useDebounce(searchTerm, 500)
+
+    const {
+        data: currentData,
+        previousData,
+        error,
+        loading,
+    } = useQuery<RepositoriesSuggestionsResult, RepositoriesSuggestionsVariables>(REPOSITORIES_QUERY, {
+        skip: !isSuggestionOpen,
+        variables: { query: debouncedSearchTerm },
+        fetchPolicy: 'cache-and-network',
+    })
+
+    const handleSelect = (selectedValue: string): void => {
+        navigate(`/${selectedValue}`)
+        setSuggestionOpen(false)
+    }
+
+    const data = currentData ?? previousData
+    const suggestions = data?.repositories.nodes ?? []
+
+    return (
+        <div ref={rootRef} className={classNames(styles.root, className, { [styles.rootActive]: isSuggestionOpen })}>
+            <Button
+                as={Link}
+                to={repositoryURL}
+                disabled={disabled}
+                size="sm"
+                variant="secondary"
+                outline={true}
+                className={classNames('test-repo-header-repo-link', styles.linkButton)}
+            >
+                <Icon aria-hidden={true} svgPath={mdiSourceRepository} /> {displayRepoName(repositoryName)}
+            </Button>
+            <Popover isOpen={isSuggestionOpen} onOpenChange={state => setSuggestionOpen(state.isOpen)}>
+                <PopoverTrigger
+                    as={Button}
+                    size="sm"
+                    variant="secondary"
+                    outline={true}
+                    className={styles.dropdownButton}
+                >
+                    <Icon svgPath={mdiChevronDown} aria-label="Show repository picker" />
+                </PopoverTrigger>
+                <PopoverContent target={rootRef.current} className={styles.popover}>
+                    <Combobox aria-label="Choose a repo" className={styles.combobox} onSelect={handleSelect}>
+                        <ComboboxInput
+                            value={searchTerm}
+                            placeholder="Search repository..."
+                            status={loading ? 'loading' : 'initial'}
+                            autoFocus={true}
+                            onChange={event => setSearchTerm(event.target.value)}
+                        />
+
+                        {!error && loading && suggestions.length === 0 && (
+                            <div className={styles.loading}>
+                                <LoadingSpinner />
+                            </div>
+                        )}
+                        {error && <ErrorAlert error={error} className="mt-3 mb-0" />}
+
+                        {!error && suggestions.length > 0 && (
+                            <ComboboxList className={styles.list}>
+                                {suggestions.map(suggestion => (
+                                    <ComboboxOption
+                                        key={suggestion.name}
+                                        value={suggestion.name}
+                                        className={styles.item}
+                                    >
+                                        <Icon
+                                            svgPath={getCodeHostIconPath(suggestion.externalServices.nodes[0]?.kind)}
+                                            height="1rem"
+                                            width="1rem"
+                                            inline={false}
+                                            aria-hidden={true}
+                                            className="mr-1"
+                                        />
+                                        <ComboboxOptionText />
+                                    </ComboboxOption>
+                                ))}
+                            </ComboboxList>
+                        )}
+                    </Combobox>
+                </PopoverContent>
+            </Popover>
+        </div>
+    )
+}
+
+export const getCodeHostIconPath = (codeHostType?: ExternalServiceKind): string => {
+    switch (codeHostType) {
+        case ExternalServiceKind.GITHUB:
+            return mdiGithub
+        case ExternalServiceKind.BITBUCKETCLOUD:
+            return mdiBitbucket
+        case ExternalServiceKind.BITBUCKETSERVER:
+            return mdiBitbucket
+        case ExternalServiceKind.GITLAB:
+            return mdiGitlab
+        case ExternalServiceKind.GITOLITE:
+            return mdiGit
+        case ExternalServiceKind.AWSCODECOMMIT:
+            return mdiAws
+        case ExternalServiceKind.AZUREDEVOPS:
+            return mdiMicrosoftAzure
+        default:
+            return mdiSourceRepository
+    }
+}


### PR DESCRIPTION
This PR simply extends existing UI about repository button/breadcrumb. With new repository picker it should be very easy to switch between different repositories. 

https://github.com/sourcegraph/sourcegraph/assets/18492575/c4f18276-77a2-487c-ab43-0976d9dacd6d

## Test plan
- Check that main repository button is still a link and steal leads to the repository root page
- Check that you can quickly switch repositories with newly added picker UI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
