### PR TITLE
Perf: improve speed of `FetchCommits`

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -300,6 +300,9 @@ func (r *GitCommitResolver) path(ctx context.Context, path string, validate func
 	return NewGitTreeEntryResolver(r.db, r.gitserverClient, opts), nil
 }
 
+// rootTreeFileInfo is an implements FileInfo for the
+// root tree of a commit, which is guaranteed to be a directory
+// and is guaranteed to exist.
 type rootTreeFileInfo struct{}
 
 var _ os.FileInfo = (*rootTreeFileInfo)(nil)

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -270,9 +270,6 @@ func (r *GitCommitResolver) Path(ctx context.Context, args *struct {
 }
 
 func (r *GitCommitResolver) path(ctx context.Context, path string, validate func(fs.FileInfo) error) (_ *GitTreeEntryResolver, err error) {
-	tr, ctx := trace.New(ctx, "GitCommitResolver.path", attribute.String("path", path))
-	defer tr.EndWithErr(&err)
-
 	if path == "" {
 		// This is referring to the root tree, will always exist, and will always be a directory,
 		// so we can skip the gitserver call to resolve the tree object. This is a common operation,
@@ -282,6 +279,10 @@ func (r *GitCommitResolver) path(ctx context.Context, path string, validate func
 			Stat:   &rootTreeFileInfo{},
 		}), nil
 	}
+
+	tr, ctx := trace.New(ctx, "GitCommitResolver.path", attribute.String("path", path))
+	defer tr.EndWithErr(&err)
+
 
 	stat, err := r.gitserverClient.Stat(ctx, r.gitRepo, api.CommitID(r.oid), path)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -300,7 +300,7 @@ func (r *GitCommitResolver) path(ctx context.Context, path string, validate func
 	return NewGitTreeEntryResolver(r.db, r.gitserverClient, opts), nil
 }
 
-// rootTreeFileInfo is an implements FileInfo for the
+// rootTreeFileInfo implements the  FileInfo interface for the
 // root tree of a commit, which is guaranteed to be a directory
 // and is guaranteed to exist.
 type rootTreeFileInfo struct{}

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -283,7 +283,6 @@ func (r *GitCommitResolver) path(ctx context.Context, path string, validate func
 	tr, ctx := trace.New(ctx, "GitCommitResolver.path", attribute.String("path", path))
 	defer tr.EndWithErr(&err)
 
-
 	stat, err := r.gitserverClient.Stat(ctx, r.gitRepo, api.CommitID(r.oid), path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -129,12 +129,7 @@ func (r *GitCommitResolver) AbbreviatedOID() string {
 }
 
 func (r *GitCommitResolver) PerforceChangelist(ctx context.Context) (*PerforceChangelistResolver, error) {
-	commit, err := r.resolveCommit(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return toPerforceChangelistResolver(ctx, r.repoResolver, commit)
+	return toPerforceChangelistResolver(ctx, r)
 }
 
 func (r *GitCommitResolver) Author(ctx context.Context) (*signatureResolver, error) {
@@ -202,11 +197,7 @@ func (r *GitCommitResolver) Parents(ctx context.Context) ([]*GitCommitResolver, 
 	// TODO(tsenart): We can get the parent commits in batch from gitserver instead of doing
 	// N roundtrips. We already have a git.Commits method. Maybe we can use that.
 	for i, parent := range commit.Parents {
-		var err error
-		resolvers[i], err = r.repoResolver.Commit(ctx, &RepositoryCommitArgs{Rev: string(parent)})
-		if err != nil {
-			return nil, err
-		}
+		resolvers[i] = NewGitCommitResolver(r.db, r.gitserverClient, r.repoResolver, parent, nil)
 	}
 	return resolvers, nil
 }

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -54,11 +54,16 @@ func newPerforceChangelistResolver(r *RepositoryResolver, changelistID, commitSH
 	}
 }
 
-func toPerforceChangelistResolver(ctx context.Context, r *RepositoryResolver, commit *gitdomain.Commit) (*PerforceChangelistResolver, error) {
-	if source, err := r.SourceType(ctx); err != nil {
+func toPerforceChangelistResolver(ctx context.Context, gcr *GitCommitResolver) (*PerforceChangelistResolver, error) {
+	if source, err := gcr.repoResolver.SourceType(ctx); err != nil {
 		return nil, err
 	} else if *source != PerforceDepotSourceType {
 		return nil, nil
+	}
+
+	commit, err := gcr.resolveCommit(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	changelistID, err := perforce.GetP4ChangelistID(commit.Message.Body())
@@ -66,7 +71,7 @@ func toPerforceChangelistResolver(ctx context.Context, r *RepositoryResolver, co
 		return nil, errors.Wrap(err, "failed to generate perforceChangelistID")
 	}
 
-	return newPerforceChangelistResolver(r, changelistID, string(commit.ID)), nil
+	return newPerforceChangelistResolver(gcr.repoResolver, changelistID, string(commit.ID)), nil
 }
 
 func (r *PerforceChangelistResolver) CID() string {

--- a/cmd/frontend/graphqlbackend/perforce_changelist_test.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist_test.go
@@ -77,7 +77,8 @@ foo bar`,
 	ctx := context.Background()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotResolver, gotErr := toPerforceChangelistResolver(ctx, repoResolver, tc.inputCommit)
+			gcr := NewGitCommitResolver(db, nil, repoResolver, tc.inputCommit.ID, tc.inputCommit)
+			gotResolver, gotErr := toPerforceChangelistResolver(ctx, gcr)
 
 			if !errors.Is(gotErr, tc.expectedErr) {
 				t.Fatalf("mismatched errors, \nwant: %v\n got: %v", tc.expectedErr, gotErr)


### PR DESCRIPTION
The `FetchCommits` query is used to list the commit history of a file. That particular operation is quite slow, so we spent some time digging into why. 

Traces indicated that there were a _ton_ of followup requests to gitserver after resolving initial list of commits. We tracked this down to two sources:
1) Do not do a followup request to resolve the root tree of a commit. We can just assume this exists.
2) Do not resolve the parent commits for the sake of Perforce when we are not in a perforce repo.

## Test plan

Updated existing test and manually compared the results of a few queries.
