### PR TITLE
Cleanup: simplify commit parsing

### DIFF
--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1914,7 +1914,6 @@ func parseCommitLogOutput(r io.Reader) ([]*wrappedCommit, error) {
 	var commits []*wrappedCommit
 	for commitScanner.Scan() {
 		rawCommit := commitScanner.Bytes()
-
 		parts := bytes.Split(rawCommit, []byte{'\x00'})
 		if len(parts) != partsPerCommit {
 			return nil, errors.Newf("internal error: expected %d parts, got %d", partsPerCommit, len(parts))
@@ -2189,7 +2188,22 @@ func checkError(err error) (string, bool, error) {
 const (
 	partsPerCommit = 10 // number of \x00-separated fields per commit
 
-	// don't include refs (faster, should be used if refs are not needed)
+	// This format string has 10 parts:
+	//  1) oid
+	//  2) author name
+	//  3) author email
+	//  4) author time
+	//  5) committer name
+	//  6) committer email
+	//  7) committer time
+	//  8) message body
+	//  9) parent hashes
+	// 10) modified files (optional)
+	//
+	// Each commit starts with an ASCII record separator byte (0x1E), and
+	// each field of the commit is separated by a null byte (0x00).
+	//
+	// Refs are slow, and are intentionally not included because they are usually not needed.
 	logFormatWithoutRefs = "--format=format:%x1e%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00"
 )
 

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1894,17 +1894,17 @@ func joinCommits(previous, next []*gitdomain.Commit, desiredTotal uint) []*gitdo
 // runCommitLog sends the git command to gitserver. It interprets missing
 // revision responses and converts them into RevisionNotFoundError.
 // It is declared as a variable so that we can swap it out in tests
-var runCommitLog = func(ctx context.Context, cmd GitCommand, opt CommitsOptions) ([]*wrappedCommit, error) {
+var runCommitLog = func(ctx context.Context, cmd GitCommand, opts CommitsOptions) ([]*wrappedCommit, error) {
 	r, err := cmd.StdoutReader(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer r.Close()
 
-	return parseCommitLogOutput(r, opt.NameOnly)
+	return parseCommitLogOutput(r)
 }
 
-func parseCommitLogOutput(r io.Reader, nameOnly bool) ([]*wrappedCommit, error) {
+func parseCommitLogOutput(r io.Reader) ([]*wrappedCommit, error) {
 	commitScanner := bufio.NewScanner(r)
 	commitScanner.Split(commitSplitFunc)
 
@@ -2112,7 +2112,7 @@ func (c *clientImplementor) GetCommits(ctx context.Context, repoCommits []api.Re
 			return errors.Wrap(err, "failed to perform git log")
 		}
 
-		wrappedCommits, err := parseCommitLogOutput(strings.NewReader(rawResult.Stdout), true)
+		wrappedCommits, err := parseCommitLogOutput(strings.NewReader(rawResult.Stdout))
 		if err != nil {
 			if ignoreErrors {
 				// Treat as not-found

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -2224,7 +2224,7 @@ func parseCommitFromLog(parts [][]byte) (*wrappedCommit, error) {
 		}
 	}
 
-	fileNames := parseCommitFileNames(parts[9])
+	fileNames := strings.Split(string(bytes.TrimSpace(parts[0])), "\n")
 
 	return &wrappedCommit{
 		Commit: &gitdomain.Commit{
@@ -2235,22 +2235,6 @@ func parseCommitFromLog(parts [][]byte) (*wrappedCommit, error) {
 			Parents:   parents,
 		}, files: fileNames,
 	}, nil
-}
-
-// If the commit has filenames, parse those and return as a list.
-func parseCommitFileNames(rawNames []byte) []string {
-	rawNames = bytes.TrimPrefix(rawNames, []byte{'\n'})
-	fileNameParts := bytes.Split(rawNames, []byte{'\n'})
-	fileNames := make([]string, 0, len(fileNameParts))
-	for _, name := range fileNameParts {
-		// Skip any files names that are empty strings.
-		// TODO(camdencheek): check if this is actually necessary. I'm just copying
-		// what the old code appeared to do.
-		if len(name) > 0 {
-			fileNames = append(fileNames, string(name))
-		}
-	}
-	return fileNames
 }
 
 // BranchesContaining returns a map from branch names to branch tip hashes for

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -1157,7 +1157,7 @@ var (
 )
 
 func TestLogPartsPerCommitInSync(t *testing.T) {
-	require.Equal(t, partsPerCommit, strings.Count(logFormatWithoutRefs, "%x00"))
+	require.Equal(t, partsPerCommit-1, strings.Count(logFormatWithoutRefs, "%x00"))
 }
 
 func TestRepository_GetCommit(t *testing.T) {
@@ -1879,7 +1879,7 @@ func TestRepository_Commits_options(t *testing.T) {
 			if err == nil {
 				t.Error("expected error, got nil")
 			}
-			wantErr := `git command [git log --format=format:%x00%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00 --after=` + after + " --date-order"
+			wantErr := `git command [git log --format=format:%x1e%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00 --after=` + after + " --date-order"
 			if subRepo != "" {
 				wantErr += " --name-only"
 			}

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -1157,7 +1157,7 @@ var (
 )
 
 func TestLogPartsPerCommitInSync(t *testing.T) {
-	require.Equal(t, 2*partsPerCommit, strings.Count(logFormatWithoutRefs, "%"))
+	require.Equal(t, partsPerCommit, strings.Count(logFormatWithoutRefs, "%x00"))
 }
 
 func TestRepository_GetCommit(t *testing.T) {
@@ -1878,7 +1878,7 @@ func TestRepository_Commits_options(t *testing.T) {
 			if err == nil {
 				t.Error("expected error, got nil")
 			}
-			wantErr := `git command [git log --format=format:%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00 --after=` + after + " --date-order"
+			wantErr := `git command [git log --format=format:%x00%H%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00 --after=` + after + " --date-order"
 			if subRepo != "" {
 				wantErr += " --name-only"
 			}

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -1797,6 +1797,7 @@ func TestRepository_Commits_options(t *testing.T) {
 	ClientMocks.LocalGitserver = true
 	defer ResetClientMocks()
 	ctx := context.Background()
+	ctx = actor.WithActor(ctx, actor.FromUser(42))
 
 	gitCommands := []string{
 		"git commit --allow-empty -m foo",

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -1157,9 +1157,7 @@ var (
 )
 
 func TestLogPartsPerCommitInSync(t *testing.T) {
-	require.Equal(t, 2*partsPerCommitBasic, strings.Count(logFormatWithoutRefs, "%"),
-		"Expected (2 * %0d) %% signs in log format string (%0d fields, %0d %%x00 separators)",
-		partsPerCommitBasic)
+	require.Equal(t, 2*partsPerCommit, strings.Count(logFormatWithoutRefs, "%"))
 }
 
 func TestRepository_GetCommit(t *testing.T) {


### PR DESCRIPTION
I was hopeful that I could improve commit parsing speed because I saw a span that took 600ms to run a git command compared to the 200ms I was getting when I ran the command in the terminal. However, after going through the trouble of cleaning this all up, it turns out my baseline number was very skewed and now I'm measuring ~200ms with the code in `main`. So this doesn't actually seem to improve performance much (though it does reduce allocations).

_However_, this dramatically simplifies our parsing logic for streaming commits, so I think it's still worth merging even without a measurable perf improvement. See inline comments and diffs.

## Test plan

Existing tests cover the parsing quite well. Manual sanity checks of the areas of our UI which use commit history.
