### PR TITLE
Add creator_id and last_updater_id to external_services

### DIFF
--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -27,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -65,10 +67,14 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 		return nil, err
 	}
 
+	userID := actor.FromContext(ctx).UID
+
 	externalService := &types.ExternalService{
-		Kind:        args.Input.Kind,
-		DisplayName: args.Input.DisplayName,
-		Config:      extsvc.NewUnencryptedConfig(args.Input.Config),
+		Kind:          args.Input.Kind,
+		DisplayName:   args.Input.DisplayName,
+		Config:        extsvc.NewUnencryptedConfig(args.Input.Config),
+		CreatorID:     userID,
+		LastUpdaterID: userID,
 	}
 
 	// Create the external service in the database.
@@ -138,11 +144,15 @@ func (r *schemaResolver) UpdateExternalService(ctx context.Context, args *update
 		return nil, err
 	}
 
+	userID := actor.FromContext(ctx).UID
+
 	ps := conf.Get().AuthProviders
 	update := &database.ExternalServiceUpdate{
-		DisplayName: args.Input.DisplayName,
-		Config:      args.Input.Config,
+		DisplayName:   args.Input.DisplayName,
+		Config:        args.Input.Config,
+		LastUpdaterID: pointers.Ptr(userID),
 	}
+
 	// Update the external service in the database.
 	if err = r.db.ExternalServices().Update(ctx, ps, id, update); err != nil {
 		return nil, err

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -13103,6 +13103,19 @@
           "Comment": ""
         },
         {
+          "Name": "creator_id",
+          "Index": 18,
+          "TypeName": "integer",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
           "Name": "deleted_at",
           "Index": 7,
           "TypeName": "timestamp with time zone",
@@ -13184,6 +13197,19 @@
           "Name": "last_sync_at",
           "Index": 8,
           "TypeName": "timestamp with time zone",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "NEVER",
+          "GenerationExpression": "",
+          "Comment": ""
+        },
+        {
+          "Name": "last_updater_id",
+          "Index": 19,
+          "TypeName": "integer",
           "IsNullable": true,
           "Default": "",
           "CharacterMaximumLength": 0,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1,15 +1,15 @@
 # Table "public.access_requests"
 ```
-       Column        |           Type           | Collation | Nullable |                   Default                   
+       Column        |           Type           | Collation | Nullable |                   Default
 ---------------------+--------------------------+-----------+----------+---------------------------------------------
  id                  | integer                  |           | not null | nextval('access_requests_id_seq'::regclass)
  created_at          | timestamp with time zone |           | not null | now()
  updated_at          | timestamp with time zone |           | not null | now()
- name                | text                     |           | not null | 
- email               | text                     |           | not null | 
- additional_info     | text                     |           |          | 
- status              | text                     |           | not null | 
- decision_by_user_id | integer                  |           |          | 
+ name                | text                     |           | not null |
+ email               | text                     |           | not null |
+ additional_info     | text                     |           |          |
+ status              | text                     |           | not null |
+ decision_by_user_id | integer                  |           |          |
 Indexes:
     "access_requests_pkey" PRIMARY KEY, btree (id)
     "access_requests_email_key" UNIQUE CONSTRAINT, btree (email)
@@ -22,17 +22,17 @@ Foreign-key constraints:
 
 # Table "public.access_tokens"
 ```
-     Column      |           Type           | Collation | Nullable |                  Default                  
+     Column      |           Type           | Collation | Nullable |                  Default
 -----------------+--------------------------+-----------+----------+-------------------------------------------
  id              | bigint                   |           | not null | nextval('access_tokens_id_seq'::regclass)
- subject_user_id | integer                  |           | not null | 
- value_sha256    | bytea                    |           | not null | 
- note            | text                     |           | not null | 
+ subject_user_id | integer                  |           | not null |
+ value_sha256    | bytea                    |           | not null |
+ note            | text                     |           | not null |
  created_at      | timestamp with time zone |           | not null | now()
- last_used_at    | timestamp with time zone |           |          | 
- deleted_at      | timestamp with time zone |           |          | 
- creator_user_id | integer                  |           | not null | 
- scopes          | text[]                   |           | not null | 
+ last_used_at    | timestamp with time zone |           |          |
+ deleted_at      | timestamp with time zone |           |          |
+ creator_user_id | integer                  |           | not null |
+ scopes          | text[]                   |           | not null |
  internal        | boolean                  |           |          | false
 Indexes:
     "access_tokens_pkey" PRIMARY KEY, btree (id)
@@ -46,13 +46,13 @@ Foreign-key constraints:
 
 # Table "public.aggregated_user_statistics"
 ```
-       Column        |           Type           | Collation | Nullable | Default 
+       Column        |           Type           | Collation | Nullable | Default
 ---------------------+--------------------------+-----------+----------+---------
- user_id             | bigint                   |           | not null | 
+ user_id             | bigint                   |           | not null |
  created_at          | timestamp with time zone |           | not null | now()
  updated_at          | timestamp with time zone |           | not null | now()
- user_last_active_at | timestamp with time zone |           |          | 
- user_events_count   | bigint                   |           |          | 
+ user_last_active_at | timestamp with time zone |           |          |
+ user_events_count   | bigint                   |           |          |
 Indexes:
     "aggregated_user_statistics_pkey" PRIMARY KEY, btree (user_id)
 Foreign-key constraints:
@@ -62,12 +62,12 @@ Foreign-key constraints:
 
 # Table "public.assigned_owners"
 ```
-        Column        |            Type             | Collation | Nullable |                   Default                   
+        Column        |            Type             | Collation | Nullable |                   Default
 ----------------------+-----------------------------+-----------+----------+---------------------------------------------
  id                   | integer                     |           | not null | nextval('assigned_owners_id_seq'::regclass)
- owner_user_id        | integer                     |           | not null | 
- file_path_id         | integer                     |           | not null | 
- who_assigned_user_id | integer                     |           |          | 
+ owner_user_id        | integer                     |           | not null |
+ file_path_id         | integer                     |           | not null |
+ who_assigned_user_id | integer                     |           |          |
  assigned_at          | timestamp without time zone |           | not null | now()
 Indexes:
     "assigned_owners_pkey" PRIMARY KEY, btree (id)
@@ -83,12 +83,12 @@ Table for ownership assignments, one entry contains an assigned user ID, which r
 
 # Table "public.assigned_teams"
 ```
-        Column        |            Type             | Collation | Nullable |                  Default                   
+        Column        |            Type             | Collation | Nullable |                  Default
 ----------------------+-----------------------------+-----------+----------+--------------------------------------------
  id                   | integer                     |           | not null | nextval('assigned_teams_id_seq'::regclass)
- owner_team_id        | integer                     |           | not null | 
- file_path_id         | integer                     |           | not null | 
- who_assigned_team_id | integer                     |           |          | 
+ owner_team_id        | integer                     |           | not null |
+ file_path_id         | integer                     |           | not null |
+ who_assigned_team_id | integer                     |           |          |
  assigned_at          | timestamp without time zone |           | not null | now()
 Indexes:
     "assigned_teams_pkey" PRIMARY KEY, btree (id)
@@ -104,20 +104,20 @@ Table for team ownership assignments, one entry contains an assigned team ID, wh
 
 # Table "public.batch_changes"
 ```
-      Column       |           Type           | Collation | Nullable |                  Default                  
+      Column       |           Type           | Collation | Nullable |                  Default
 -------------------+--------------------------+-----------+----------+-------------------------------------------
  id                | bigint                   |           | not null | nextval('batch_changes_id_seq'::regclass)
- name              | text                     |           | not null | 
- description       | text                     |           |          | 
- creator_id        | integer                  |           |          | 
- namespace_user_id | integer                  |           |          | 
- namespace_org_id  | integer                  |           |          | 
+ name              | text                     |           | not null |
+ description       | text                     |           |          |
+ creator_id        | integer                  |           |          |
+ namespace_user_id | integer                  |           |          |
+ namespace_org_id  | integer                  |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- closed_at         | timestamp with time zone |           |          | 
- batch_spec_id     | bigint                   |           | not null | 
- last_applier_id   | bigint                   |           |          | 
- last_applied_at   | timestamp with time zone |           |          | 
+ closed_at         | timestamp with time zone |           |          |
+ batch_spec_id     | bigint                   |           | not null |
+ last_applier_id   | bigint                   |           |          |
+ last_applied_at   | timestamp with time zone |           |          |
 Indexes:
     "batch_changes_pkey" PRIMARY KEY, btree (id)
     "batch_changes_unique_org_id" UNIQUE, btree (name, namespace_org_id) WHERE namespace_org_id IS NOT NULL
@@ -145,14 +145,14 @@ Triggers:
 
 # Table "public.batch_changes_site_credentials"
 ```
-        Column         |           Type           | Collation | Nullable |                          Default                           
+        Column         |           Type           | Collation | Nullable |                          Default
 -----------------------+--------------------------+-----------+----------+------------------------------------------------------------
  id                    | bigint                   |           | not null | nextval('batch_changes_site_credentials_id_seq'::regclass)
- external_service_type | text                     |           | not null | 
- external_service_id   | text                     |           | not null | 
+ external_service_type | text                     |           | not null |
+ external_service_id   | text                     |           | not null |
  created_at            | timestamp with time zone |           | not null | now()
  updated_at            | timestamp with time zone |           | not null | now()
- credential            | bytea                    |           | not null | 
+ credential            | bytea                    |           | not null |
  encryption_key_id     | text                     |           | not null | ''::text
 Indexes:
     "batch_changes_site_credentials_pkey" PRIMARY KEY, btree (id)
@@ -163,15 +163,15 @@ Indexes:
 
 # Table "public.batch_spec_execution_cache_entries"
 ```
-    Column    |           Type           | Collation | Nullable |                            Default                             
+    Column    |           Type           | Collation | Nullable |                            Default
 --------------+--------------------------+-----------+----------+----------------------------------------------------------------
  id           | bigint                   |           | not null | nextval('batch_spec_execution_cache_entries_id_seq'::regclass)
- key          | text                     |           | not null | 
- value        | text                     |           | not null | 
- version      | integer                  |           | not null | 
- last_used_at | timestamp with time zone |           |          | 
+ key          | text                     |           | not null |
+ value        | text                     |           | not null |
+ version      | integer                  |           | not null |
+ last_used_at | timestamp with time zone |           |          |
  created_at   | timestamp with time zone |           | not null | now()
- user_id      | integer                  |           | not null | 
+ user_id      | integer                  |           | not null |
 Indexes:
     "batch_spec_execution_cache_entries_pkey" PRIMARY KEY, btree (id)
     "batch_spec_execution_cache_entries_user_id_key_unique" UNIQUE CONSTRAINT, btree (user_id, key)
@@ -182,24 +182,24 @@ Foreign-key constraints:
 
 # Table "public.batch_spec_resolution_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                        Default                         
+      Column       |           Type           | Collation | Nullable |                        Default
 -------------------+--------------------------+-----------+----------+--------------------------------------------------------
  id                | bigint                   |           | not null | nextval('batch_spec_resolution_jobs_id_seq'::regclass)
- batch_spec_id     | integer                  |           | not null | 
+ batch_spec_id     | integer                  |           | not null |
  state             | text                     |           | not null | 'queued'::text
- failure_message   | text                     |           |          | 
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ failure_message   | text                     |           |          |
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- execution_logs    | json[]                   |           |          | 
+ execution_logs    | json[]                   |           |          |
  worker_hostname   | text                     |           | not null | ''::text
- last_heartbeat_at | timestamp with time zone |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
  queued_at         | timestamp with time zone |           |          | now()
- initiator_id      | integer                  |           | not null | 
+ initiator_id      | integer                  |           | not null |
  cancel            | boolean                  |           | not null | false
 Indexes:
     "batch_spec_resolution_jobs_pkey" PRIMARY KEY, btree (id)
@@ -213,25 +213,25 @@ Foreign-key constraints:
 
 # Table "public.batch_spec_workspace_execution_jobs"
 ```
-         Column          |           Type           | Collation | Nullable |                             Default                             
+         Column          |           Type           | Collation | Nullable |                             Default
 -------------------------+--------------------------+-----------+----------+-----------------------------------------------------------------
  id                      | bigint                   |           | not null | nextval('batch_spec_workspace_execution_jobs_id_seq'::regclass)
- batch_spec_workspace_id | integer                  |           | not null | 
+ batch_spec_workspace_id | integer                  |           | not null |
  state                   | text                     |           | not null | 'queued'::text
- failure_message         | text                     |           |          | 
- started_at              | timestamp with time zone |           |          | 
- finished_at             | timestamp with time zone |           |          | 
- process_after           | timestamp with time zone |           |          | 
+ failure_message         | text                     |           |          |
+ started_at              | timestamp with time zone |           |          |
+ finished_at             | timestamp with time zone |           |          |
+ process_after           | timestamp with time zone |           |          |
  num_resets              | integer                  |           | not null | 0
  num_failures            | integer                  |           | not null | 0
- execution_logs          | json[]                   |           |          | 
+ execution_logs          | json[]                   |           |          |
  worker_hostname         | text                     |           | not null | ''::text
- last_heartbeat_at       | timestamp with time zone |           |          | 
+ last_heartbeat_at       | timestamp with time zone |           |          |
  created_at              | timestamp with time zone |           | not null | now()
  updated_at              | timestamp with time zone |           | not null | now()
  cancel                  | boolean                  |           | not null | false
  queued_at               | timestamp with time zone |           |          | now()
- user_id                 | integer                  |           | not null | 
+ user_id                 | integer                  |           | not null |
  version                 | integer                  |           | not null | 1
 Indexes:
     "batch_spec_workspace_execution_jobs_pkey" PRIMARY KEY, btree (id)
@@ -249,10 +249,10 @@ Triggers:
 
 # Table "public.batch_spec_workspace_execution_last_dequeues"
 ```
-     Column     |           Type           | Collation | Nullable | Default 
+     Column     |           Type           | Collation | Nullable | Default
 ----------------+--------------------------+-----------+----------+---------
- user_id        | integer                  |           | not null | 
- latest_dequeue | timestamp with time zone |           |          | 
+ user_id        | integer                  |           | not null |
+ latest_dequeue | timestamp with time zone |           |          |
 Indexes:
     "batch_spec_workspace_execution_last_dequeues_pkey" PRIMARY KEY, btree (user_id)
 Foreign-key constraints:
@@ -262,16 +262,16 @@ Foreign-key constraints:
 
 # Table "public.batch_spec_workspace_files"
 ```
-    Column     |           Type           | Collation | Nullable |                        Default                         
+    Column     |           Type           | Collation | Nullable |                        Default
 ---------------+--------------------------+-----------+----------+--------------------------------------------------------
  id            | integer                  |           | not null | nextval('batch_spec_workspace_files_id_seq'::regclass)
- rand_id       | text                     |           | not null | 
- batch_spec_id | bigint                   |           | not null | 
- filename      | text                     |           | not null | 
- path          | text                     |           | not null | 
- size          | bigint                   |           | not null | 
- content       | bytea                    |           | not null | 
- modified_at   | timestamp with time zone |           | not null | 
+ rand_id       | text                     |           | not null |
+ batch_spec_id | bigint                   |           | not null |
+ filename      | text                     |           | not null |
+ path          | text                     |           | not null |
+ size          | bigint                   |           | not null |
+ content       | bytea                    |           | not null |
+ modified_at   | timestamp with time zone |           | not null |
  created_at    | timestamp with time zone |           | not null | now()
  updated_at    | timestamp with time zone |           | not null | now()
 Indexes:
@@ -285,16 +285,16 @@ Foreign-key constraints:
 
 # Table "public.batch_spec_workspaces"
 ```
-        Column        |           Type           | Collation | Nullable |                      Default                      
+        Column        |           Type           | Collation | Nullable |                      Default
 ----------------------+--------------------------+-----------+----------+---------------------------------------------------
  id                   | bigint                   |           | not null | nextval('batch_spec_workspaces_id_seq'::regclass)
- batch_spec_id        | integer                  |           | not null | 
+ batch_spec_id        | integer                  |           | not null |
  changeset_spec_ids   | jsonb                    |           | not null | '{}'::jsonb
- repo_id              | integer                  |           | not null | 
- branch               | text                     |           | not null | 
- commit               | text                     |           | not null | 
- path                 | text                     |           | not null | 
- file_matches         | text[]                   |           | not null | 
+ repo_id              | integer                  |           | not null |
+ branch               | text                     |           | not null |
+ commit               | text                     |           | not null |
+ path                 | text                     |           | not null |
+ file_matches         | text[]                   |           | not null |
  only_fetch_workspace | boolean                  |           | not null | false
  created_at           | timestamp with time zone |           | not null | now()
  updated_at           | timestamp with time zone |           | not null | now()
@@ -317,22 +317,22 @@ Referenced by:
 
 # Table "public.batch_specs"
 ```
-      Column       |           Type           | Collation | Nullable |                 Default                 
+      Column       |           Type           | Collation | Nullable |                 Default
 -------------------+--------------------------+-----------+----------+-----------------------------------------
  id                | bigint                   |           | not null | nextval('batch_specs_id_seq'::regclass)
- rand_id           | text                     |           | not null | 
- raw_spec          | text                     |           | not null | 
+ rand_id           | text                     |           | not null |
+ raw_spec          | text                     |           | not null |
  spec              | jsonb                    |           | not null | '{}'::jsonb
- namespace_user_id | integer                  |           |          | 
- namespace_org_id  | integer                  |           |          | 
- user_id           | integer                  |           |          | 
+ namespace_user_id | integer                  |           |          |
+ namespace_org_id  | integer                  |           |          |
+ user_id           | integer                  |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
  created_from_raw  | boolean                  |           | not null | false
  allow_unsupported | boolean                  |           | not null | false
  allow_ignored     | boolean                  |           | not null | false
  no_cache          | boolean                  |           | not null | false
- batch_change_id   | bigint                   |           |          | 
+ batch_change_id   | bigint                   |           |          |
 Indexes:
     "batch_specs_pkey" PRIMARY KEY, btree (id)
     "batch_specs_unique_rand_id" UNIQUE, btree (rand_id)
@@ -352,12 +352,12 @@ Referenced by:
 
 # Table "public.cached_available_indexers"
 ```
-       Column       |  Type   | Collation | Nullable |                        Default                        
+       Column       |  Type   | Collation | Nullable |                        Default
 --------------------+---------+-----------+----------+-------------------------------------------------------
  id                 | integer |           | not null | nextval('cached_available_indexers_id_seq'::regclass)
- repository_id      | integer |           | not null | 
- num_events         | integer |           | not null | 
- available_indexers | jsonb   |           | not null | 
+ repository_id      | integer |           | not null |
+ num_events         | integer |           | not null |
+ available_indexers | jsonb   |           | not null |
 Indexes:
     "cached_available_indexers_pkey" PRIMARY KEY, btree (id)
     "cached_available_indexers_repository_id" UNIQUE, btree (repository_id)
@@ -367,12 +367,12 @@ Indexes:
 
 # Table "public.changeset_events"
 ```
-    Column    |           Type           | Collation | Nullable |                   Default                    
+    Column    |           Type           | Collation | Nullable |                   Default
 --------------+--------------------------+-----------+----------+----------------------------------------------
  id           | bigint                   |           | not null | nextval('changeset_events_id_seq'::regclass)
- changeset_id | bigint                   |           | not null | 
- kind         | text                     |           | not null | 
- key          | text                     |           | not null | 
+ changeset_id | bigint                   |           | not null |
+ kind         | text                     |           | not null |
+ key          | text                     |           | not null |
  created_at   | timestamp with time zone |           | not null | now()
  metadata     | jsonb                    |           | not null | '{}'::jsonb
  updated_at   | timestamp with time zone |           | not null | now()
@@ -390,27 +390,27 @@ Foreign-key constraints:
 
 # Table "public.changeset_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                  Default                   
+      Column       |           Type           | Collation | Nullable |                  Default
 -------------------+--------------------------+-----------+----------+--------------------------------------------
  id                | bigint                   |           | not null | nextval('changeset_jobs_id_seq'::regclass)
- bulk_group        | text                     |           | not null | 
- user_id           | integer                  |           | not null | 
- batch_change_id   | integer                  |           | not null | 
- changeset_id      | integer                  |           | not null | 
- job_type          | text                     |           | not null | 
+ bulk_group        | text                     |           | not null |
+ user_id           | integer                  |           | not null |
+ batch_change_id   | integer                  |           | not null |
+ changeset_id      | integer                  |           | not null |
+ job_type          | text                     |           | not null |
  payload           | jsonb                    |           |          | '{}'::jsonb
  state             | text                     |           | not null | 'queued'::text
- failure_message   | text                     |           |          | 
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ failure_message   | text                     |           |          |
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- execution_logs    | json[]                   |           |          | 
+ execution_logs    | json[]                   |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
  worker_hostname   | text                     |           | not null | ''::text
- last_heartbeat_at | timestamp with time zone |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
  queued_at         | timestamp with time zone |           |          | now()
  cancel            | boolean                  |           | not null | false
 Indexes:
@@ -428,31 +428,31 @@ Foreign-key constraints:
 
 # Table "public.changeset_specs"
 ```
-       Column        |           Type           | Collation | Nullable |                   Default                   
+       Column        |           Type           | Collation | Nullable |                   Default
 ---------------------+--------------------------+-----------+----------+---------------------------------------------
  id                  | bigint                   |           | not null | nextval('changeset_specs_id_seq'::regclass)
- rand_id             | text                     |           | not null | 
+ rand_id             | text                     |           | not null |
  spec                | jsonb                    |           |          | '{}'::jsonb
- batch_spec_id       | bigint                   |           |          | 
- repo_id             | integer                  |           | not null | 
- user_id             | integer                  |           |          | 
- diff_stat_added     | integer                  |           |          | 
- diff_stat_deleted   | integer                  |           |          | 
+ batch_spec_id       | bigint                   |           |          |
+ repo_id             | integer                  |           | not null |
+ user_id             | integer                  |           |          |
+ diff_stat_added     | integer                  |           |          |
+ diff_stat_deleted   | integer                  |           |          |
  created_at          | timestamp with time zone |           | not null | now()
  updated_at          | timestamp with time zone |           | not null | now()
- head_ref            | text                     |           |          | 
- title               | text                     |           |          | 
- external_id         | text                     |           |          | 
- fork_namespace      | citext                   |           |          | 
- diff                | bytea                    |           |          | 
- base_rev            | text                     |           |          | 
- base_ref            | text                     |           |          | 
- body                | text                     |           |          | 
- published           | text                     |           |          | 
- commit_message      | text                     |           |          | 
- commit_author_name  | text                     |           |          | 
- commit_author_email | text                     |           |          | 
- type                | text                     |           | not null | 
+ head_ref            | text                     |           |          |
+ title               | text                     |           |          |
+ external_id         | text                     |           |          |
+ fork_namespace      | citext                   |           |          |
+ diff                | bytea                    |           |          |
+ base_rev            | text                     |           |          |
+ base_ref            | text                     |           |          |
+ body                | text                     |           |          |
+ published           | text                     |           |          |
+ commit_message      | text                     |           |          |
+ commit_author_name  | text                     |           |          |
+ commit_author_email | text                     |           |          |
+ type                | text                     |           | not null |
 Indexes:
     "changeset_specs_pkey" PRIMARY KEY, btree (id)
     "changeset_specs_unique_rand_id" UNIQUE, btree (rand_id)
@@ -475,51 +475,51 @@ Referenced by:
 
 # Table "public.changesets"
 ```
-          Column          |                     Type                     | Collation | Nullable |                Default                 
+          Column          |                     Type                     | Collation | Nullable |                Default
 --------------------------+----------------------------------------------+-----------+----------+----------------------------------------
  id                       | bigint                                       |           | not null | nextval('changesets_id_seq'::regclass)
  batch_change_ids         | jsonb                                        |           | not null | '{}'::jsonb
- repo_id                  | integer                                      |           | not null | 
+ repo_id                  | integer                                      |           | not null |
  created_at               | timestamp with time zone                     |           | not null | now()
  updated_at               | timestamp with time zone                     |           | not null | now()
  metadata                 | jsonb                                        |           |          | '{}'::jsonb
- external_id              | text                                         |           |          | 
- external_service_type    | text                                         |           | not null | 
- external_deleted_at      | timestamp with time zone                     |           |          | 
- external_branch          | text                                         |           |          | 
- external_updated_at      | timestamp with time zone                     |           |          | 
- external_state           | text                                         |           |          | 
- external_review_state    | text                                         |           |          | 
- external_check_state     | text                                         |           |          | 
- diff_stat_added          | integer                                      |           |          | 
- diff_stat_deleted        | integer                                      |           |          | 
+ external_id              | text                                         |           |          |
+ external_service_type    | text                                         |           | not null |
+ external_deleted_at      | timestamp with time zone                     |           |          |
+ external_branch          | text                                         |           |          |
+ external_updated_at      | timestamp with time zone                     |           |          |
+ external_state           | text                                         |           |          |
+ external_review_state    | text                                         |           |          |
+ external_check_state     | text                                         |           |          |
+ diff_stat_added          | integer                                      |           |          |
+ diff_stat_deleted        | integer                                      |           |          |
  sync_state               | jsonb                                        |           | not null | '{}'::jsonb
- current_spec_id          | bigint                                       |           |          | 
- previous_spec_id         | bigint                                       |           |          | 
+ current_spec_id          | bigint                                       |           |          |
+ previous_spec_id         | bigint                                       |           |          |
  publication_state        | text                                         |           |          | 'UNPUBLISHED'::text
- owned_by_batch_change_id | bigint                                       |           |          | 
+ owned_by_batch_change_id | bigint                                       |           |          |
  reconciler_state         | text                                         |           |          | 'queued'::text
- failure_message          | text                                         |           |          | 
- started_at               | timestamp with time zone                     |           |          | 
- finished_at              | timestamp with time zone                     |           |          | 
- process_after            | timestamp with time zone                     |           |          | 
+ failure_message          | text                                         |           |          |
+ started_at               | timestamp with time zone                     |           |          |
+ finished_at              | timestamp with time zone                     |           |          |
+ process_after            | timestamp with time zone                     |           |          |
  num_resets               | integer                                      |           | not null | 0
  closing                  | boolean                                      |           | not null | false
  num_failures             | integer                                      |           | not null | 0
- log_contents             | text                                         |           |          | 
- execution_logs           | json[]                                       |           |          | 
- syncer_error             | text                                         |           |          | 
- external_title           | text                                         |           |          | 
+ log_contents             | text                                         |           |          |
+ execution_logs           | json[]                                       |           |          |
+ syncer_error             | text                                         |           |          |
+ external_title           | text                                         |           |          |
  worker_hostname          | text                                         |           | not null | ''::text
- ui_publication_state     | batch_changes_changeset_ui_publication_state |           |          | 
- last_heartbeat_at        | timestamp with time zone                     |           |          | 
- external_fork_namespace  | citext                                       |           |          | 
+ ui_publication_state     | batch_changes_changeset_ui_publication_state |           |          |
+ last_heartbeat_at        | timestamp with time zone                     |           |          |
+ external_fork_namespace  | citext                                       |           |          |
  queued_at                | timestamp with time zone                     |           |          | now()
  cancel                   | boolean                                      |           | not null | false
- detached_at              | timestamp with time zone                     |           |          | 
- computed_state           | text                                         |           | not null | 
- external_fork_name       | citext                                       |           |          | 
- previous_failure_message | text                                         |           |          | 
+ detached_at              | timestamp with time zone                     |           |          |
+ computed_state           | text                                         |           | not null |
+ external_fork_name       | citext                                       |           |          |
+ previous_failure_message | text                                         |           |          |
  commit_verification      | jsonb                                        |           | not null | '{}'::jsonb
 Indexes:
     "changesets_pkey" PRIMARY KEY, btree (id)
@@ -556,24 +556,24 @@ Triggers:
 
 # Table "public.cm_action_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                  Default                   
+      Column       |           Type           | Collation | Nullable |                  Default
 -------------------+--------------------------+-----------+----------+--------------------------------------------
  id                | integer                  |           | not null | nextval('cm_action_jobs_id_seq'::regclass)
- email             | bigint                   |           |          | 
+ email             | bigint                   |           |          |
  state             | text                     |           |          | 'queued'::text
- failure_message   | text                     |           |          | 
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ failure_message   | text                     |           |          |
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- log_contents      | text                     |           |          | 
- trigger_event     | integer                  |           |          | 
+ log_contents      | text                     |           |          |
+ trigger_event     | integer                  |           |          |
  worker_hostname   | text                     |           | not null | ''::text
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
- webhook           | bigint                   |           |          | 
- slack_webhook     | bigint                   |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
+ execution_logs    | json[]                   |           |          |
+ webhook           | bigint                   |           |          |
+ slack_webhook     | bigint                   |           |          |
  queued_at         | timestamp with time zone |           |          | now()
  cancel            | boolean                  |           | not null | false
 Indexes:
@@ -610,16 +610,16 @@ Foreign-key constraints:
 
 # Table "public.cm_emails"
 ```
-     Column      |           Type           | Collation | Nullable |                Default                
+     Column      |           Type           | Collation | Nullable |                Default
 -----------------+--------------------------+-----------+----------+---------------------------------------
  id              | bigint                   |           | not null | nextval('cm_emails_id_seq'::regclass)
- monitor         | bigint                   |           | not null | 
- enabled         | boolean                  |           | not null | 
- priority        | cm_email_priority        |           | not null | 
- header          | text                     |           | not null | 
- created_by      | integer                  |           | not null | 
+ monitor         | bigint                   |           | not null |
+ enabled         | boolean                  |           | not null |
+ priority        | cm_email_priority        |           | not null |
+ header          | text                     |           | not null |
+ created_by      | integer                  |           | not null |
  created_at      | timestamp with time zone |           | not null | now()
- changed_by      | integer                  |           | not null | 
+ changed_by      | integer                  |           | not null |
  changed_at      | timestamp with time zone |           | not null | now()
  include_results | boolean                  |           | not null | false
 Indexes:
@@ -636,11 +636,11 @@ Referenced by:
 
 # Table "public.cm_last_searched"
 ```
-   Column    |  Type   | Collation | Nullable | Default 
+   Column    |  Type   | Collation | Nullable | Default
 -------------+---------+-----------+----------+---------
- monitor_id  | bigint  |           | not null | 
- commit_oids | text[]  |           | not null | 
- repo_id     | integer |           | not null | 
+ monitor_id  | bigint  |           | not null |
+ commit_oids | text[]  |           | not null |
+ repo_id     | integer |           | not null |
 Indexes:
     "cm_last_searched_pkey" PRIMARY KEY, btree (monitor_id, repo_id)
 Foreign-key constraints:
@@ -655,17 +655,17 @@ The last searched commit hashes for the given code monitor and unique set of sea
 
 # Table "public.cm_monitors"
 ```
-      Column       |           Type           | Collation | Nullable |                 Default                 
+      Column       |           Type           | Collation | Nullable |                 Default
 -------------------+--------------------------+-----------+----------+-----------------------------------------
  id                | bigint                   |           | not null | nextval('cm_monitors_id_seq'::regclass)
- created_by        | integer                  |           | not null | 
+ created_by        | integer                  |           | not null |
  created_at        | timestamp with time zone |           | not null | now()
- description       | text                     |           | not null | 
+ description       | text                     |           | not null |
  changed_at        | timestamp with time zone |           | not null | now()
- changed_by        | integer                  |           | not null | 
+ changed_by        | integer                  |           | not null |
  enabled           | boolean                  |           | not null | true
- namespace_user_id | integer                  |           | not null | 
- namespace_org_id  | integer                  |           |          | 
+ namespace_user_id | integer                  |           | not null |
+ namespace_org_id  | integer                  |           |          |
 Indexes:
     "cm_monitors_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -686,17 +686,17 @@ Referenced by:
 
 # Table "public.cm_queries"
 ```
-    Column     |           Type           | Collation | Nullable |                Default                 
+    Column     |           Type           | Collation | Nullable |                Default
 ---------------+--------------------------+-----------+----------+----------------------------------------
  id            | bigint                   |           | not null | nextval('cm_queries_id_seq'::regclass)
- monitor       | bigint                   |           | not null | 
- query         | text                     |           | not null | 
- created_by    | integer                  |           | not null | 
+ monitor       | bigint                   |           | not null |
+ query         | text                     |           | not null |
+ created_by    | integer                  |           | not null |
  created_at    | timestamp with time zone |           | not null | now()
- changed_by    | integer                  |           | not null | 
+ changed_by    | integer                  |           | not null |
  changed_at    | timestamp with time zone |           | not null | now()
  next_run      | timestamp with time zone |           |          | now()
- latest_result | timestamp with time zone |           |          | 
+ latest_result | timestamp with time zone |           |          |
 Indexes:
     "cm_queries_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -710,12 +710,12 @@ Referenced by:
 
 # Table "public.cm_recipients"
 ```
-      Column       |  Type   | Collation | Nullable |                  Default                  
+      Column       |  Type   | Collation | Nullable |                  Default
 -------------------+---------+-----------+----------+-------------------------------------------
  id                | bigint  |           | not null | nextval('cm_recipients_id_seq'::regclass)
- email             | bigint  |           | not null | 
- namespace_user_id | integer |           |          | 
- namespace_org_id  | integer |           |          | 
+ email             | bigint  |           | not null |
+ namespace_user_id | integer |           |          |
+ namespace_org_id  | integer |           |          |
 Indexes:
     "cm_recipients_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -727,15 +727,15 @@ Foreign-key constraints:
 
 # Table "public.cm_slack_webhooks"
 ```
-     Column      |           Type           | Collation | Nullable |                    Default                    
+     Column      |           Type           | Collation | Nullable |                    Default
 -----------------+--------------------------+-----------+----------+-----------------------------------------------
  id              | bigint                   |           | not null | nextval('cm_slack_webhooks_id_seq'::regclass)
- monitor         | bigint                   |           | not null | 
- url             | text                     |           | not null | 
- enabled         | boolean                  |           | not null | 
- created_by      | integer                  |           | not null | 
+ monitor         | bigint                   |           | not null |
+ url             | text                     |           | not null |
+ enabled         | boolean                  |           | not null |
+ created_by      | integer                  |           | not null |
  created_at      | timestamp with time zone |           | not null | now()
- changed_by      | integer                  |           | not null | 
+ changed_by      | integer                  |           | not null |
  changed_at      | timestamp with time zone |           | not null | now()
  include_results | boolean                  |           | not null | false
 Indexes:
@@ -758,23 +758,23 @@ Slack webhook actions configured on code monitors
 
 # Table "public.cm_trigger_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                   Default                   
+      Column       |           Type           | Collation | Nullable |                   Default
 -------------------+--------------------------+-----------+----------+---------------------------------------------
  id                | integer                  |           | not null | nextval('cm_trigger_jobs_id_seq'::regclass)
- query             | bigint                   |           | not null | 
+ query             | bigint                   |           | not null |
  state             | text                     |           |          | 'queued'::text
- failure_message   | text                     |           |          | 
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ failure_message   | text                     |           |          |
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- log_contents      | text                     |           |          | 
- query_string      | text                     |           |          | 
+ log_contents      | text                     |           |          |
+ query_string      | text                     |           |          |
  worker_hostname   | text                     |           | not null | ''::text
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
- search_results    | jsonb                    |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
+ execution_logs    | json[]                   |           |          |
+ search_results    | jsonb                    |           |          |
  queued_at         | timestamp with time zone |           |          | now()
  cancel            | boolean                  |           | not null | false
 Indexes:
@@ -792,15 +792,15 @@ Referenced by:
 
 # Table "public.cm_webhooks"
 ```
-     Column      |           Type           | Collation | Nullable |                 Default                 
+     Column      |           Type           | Collation | Nullable |                 Default
 -----------------+--------------------------+-----------+----------+-----------------------------------------
  id              | bigint                   |           | not null | nextval('cm_webhooks_id_seq'::regclass)
- monitor         | bigint                   |           | not null | 
- url             | text                     |           | not null | 
- enabled         | boolean                  |           | not null | 
- created_by      | integer                  |           | not null | 
+ monitor         | bigint                   |           | not null |
+ url             | text                     |           | not null |
+ enabled         | boolean                  |           | not null |
+ created_by      | integer                  |           | not null |
  created_at      | timestamp with time zone |           | not null | now()
- changed_by      | integer                  |           | not null | 
+ changed_by      | integer                  |           | not null |
  changed_at      | timestamp with time zone |           | not null | now()
  include_results | boolean                  |           | not null | false
 Indexes:
@@ -825,15 +825,15 @@ Webhook actions configured on code monitors
 
 # Table "public.code_hosts"
 ```
-             Column              |           Type           | Collation | Nullable |                Default                 
+             Column              |           Type           | Collation | Nullable |                Default
 ---------------------------------+--------------------------+-----------+----------+----------------------------------------
  id                              | integer                  |           | not null | nextval('code_hosts_id_seq'::regclass)
- kind                            | text                     |           | not null | 
- url                             | text                     |           | not null | 
- api_rate_limit_quota            | integer                  |           |          | 
- api_rate_limit_interval_seconds | integer                  |           |          | 
- git_rate_limit_quota            | integer                  |           |          | 
- git_rate_limit_interval_seconds | integer                  |           |          | 
+ kind                            | text                     |           | not null |
+ url                             | text                     |           | not null |
+ api_rate_limit_quota            | integer                  |           |          |
+ api_rate_limit_interval_seconds | integer                  |           |          |
+ git_rate_limit_quota            | integer                  |           |          |
+ git_rate_limit_interval_seconds | integer                  |           |          |
  created_at                      | timestamp with time zone |           | not null | now()
  updated_at                      | timestamp with time zone |           | not null | now()
 Indexes:
@@ -846,13 +846,13 @@ Referenced by:
 
 # Table "public.codeintel_autoindex_queue"
 ```
-    Column     |           Type           | Collation | Nullable |                        Default                        
+    Column     |           Type           | Collation | Nullable |                        Default
 ---------------+--------------------------+-----------+----------+-------------------------------------------------------
  id            | integer                  |           | not null | nextval('codeintel_autoindex_queue_id_seq'::regclass)
- repository_id | integer                  |           | not null | 
- rev           | text                     |           | not null | 
+ repository_id | integer                  |           | not null |
+ rev           | text                     |           | not null |
  queued_at     | timestamp with time zone |           | not null | now()
- processed_at  | timestamp with time zone |           |          | 
+ processed_at  | timestamp with time zone |           |          |
 Indexes:
     "codeintel_autoindex_queue_pkey" PRIMARY KEY, btree (id)
     "codeintel_autoindex_queue_repository_id_commit" UNIQUE, btree (repository_id, rev)
@@ -861,10 +861,10 @@ Indexes:
 
 # Table "public.codeintel_autoindexing_exceptions"
 ```
-       Column       |  Type   | Collation | Nullable |                            Default                            
+       Column       |  Type   | Collation | Nullable |                            Default
 --------------------+---------+-----------+----------+---------------------------------------------------------------
  id                 | integer |           | not null | nextval('codeintel_autoindexing_exceptions_id_seq'::regclass)
- repository_id      | integer |           | not null | 
+ repository_id      | integer |           | not null |
  disable_scheduling | boolean |           | not null | false
  disable_inference  | boolean |           | not null | false
 Indexes:
@@ -877,11 +877,11 @@ Foreign-key constraints:
 
 # Table "public.codeintel_commit_dates"
 ```
-    Column     |           Type           | Collation | Nullable | Default 
+    Column     |           Type           | Collation | Nullable | Default
 ---------------+--------------------------+-----------+----------+---------
- repository_id | integer                  |           | not null | 
- commit_bytea  | bytea                    |           | not null | 
- committed_at  | timestamp with time zone |           |          | 
+ repository_id | integer                  |           | not null |
+ commit_bytea  | bytea                    |           | not null |
+ committed_at  | timestamp with time zone |           |          |
 Indexes:
     "codeintel_commit_dates_pkey" PRIMARY KEY, btree (repository_id, commit_bytea)
 
@@ -897,10 +897,10 @@ Maps commits within a repository to the commit date as reported by gitserver.
 
 # Table "public.codeintel_inference_scripts"
 ```
-      Column      |           Type           | Collation | Nullable | Default 
+      Column      |           Type           | Collation | Nullable | Default
 ------------------+--------------------------+-----------+----------+---------
  insert_timestamp | timestamp with time zone |           | not null | now()
- script           | text                     |           | not null | 
+ script           | text                     |           | not null |
 
 ```
 
@@ -908,13 +908,13 @@ Contains auto-index job inference Lua scripts as an alternative to setting via e
 
 # Table "public.codeintel_initial_path_ranks"
 ```
-       Column       |  Type   | Collation | Nullable |                         Default                          
+       Column       |  Type   | Collation | Nullable |                         Default
 --------------------+---------+-----------+----------+----------------------------------------------------------
  id                 | bigint  |           | not null | nextval('codeintel_initial_path_ranks_id_seq'::regclass)
  document_path      | text    |           | not null | ''::text
- graph_key          | text    |           | not null | 
+ graph_key          | text    |           | not null |
  document_paths     | text[]  |           | not null | '{}'::text[]
- exported_upload_id | integer |           | not null | 
+ exported_upload_id | integer |           | not null |
 Indexes:
     "codeintel_initial_path_ranks_pkey" PRIMARY KEY, btree (id)
     "codeintel_initial_path_ranks_exported_upload_id" btree (exported_upload_id)
@@ -928,11 +928,11 @@ Referenced by:
 
 # Table "public.codeintel_initial_path_ranks_processed"
 ```
-             Column              |  Type  | Collation | Nullable |                              Default                               
+             Column              |  Type  | Collation | Nullable |                              Default
 ---------------------------------+--------+-----------+----------+--------------------------------------------------------------------
  id                              | bigint |           | not null | nextval('codeintel_initial_path_ranks_processed_id_seq'::regclass)
- graph_key                       | text   |           | not null | 
- codeintel_initial_path_ranks_id | bigint |           | not null | 
+ graph_key                       | text   |           | not null |
+ codeintel_initial_path_ranks_id | bigint |           | not null |
 Indexes:
     "codeintel_initial_path_ranks_processed_pkey" PRIMARY KEY, btree (id)
     "codeintel_initial_path_ranks_processed_cgraph_key_codeintel_ini" UNIQUE, btree (graph_key, codeintel_initial_path_ranks_id)
@@ -944,11 +944,11 @@ Foreign-key constraints:
 
 # Table "public.codeintel_langugage_support_requests"
 ```
-   Column    |  Type   | Collation | Nullable |                             Default                              
+   Column    |  Type   | Collation | Nullable |                             Default
 -------------+---------+-----------+----------+------------------------------------------------------------------
  id          | integer |           | not null | nextval('codeintel_langugage_support_requests_id_seq'::regclass)
- user_id     | integer |           | not null | 
- language_id | text    |           | not null | 
+ user_id     | integer |           | not null |
+ language_id | text    |           | not null |
 Indexes:
     "codeintel_langugage_support_requests_user_id_language" UNIQUE, btree (user_id, language_id)
 
@@ -956,14 +956,14 @@ Indexes:
 
 # Table "public.codeintel_path_ranks"
 ```
-     Column      |           Type           | Collation | Nullable |                     Default                      
+     Column      |           Type           | Collation | Nullable |                     Default
 -----------------+--------------------------+-----------+----------+--------------------------------------------------
- repository_id   | integer                  |           | not null | 
- payload         | jsonb                    |           | not null | 
+ repository_id   | integer                  |           | not null |
+ payload         | jsonb                    |           | not null |
  updated_at      | timestamp with time zone |           | not null | now()
- graph_key       | text                     |           | not null | 
- num_paths       | integer                  |           |          | 
- refcount_logsum | double precision         |           |          | 
+ graph_key       | text                     |           | not null |
+ num_paths       | integer                  |           |          |
+ refcount_logsum | double precision         |           |          |
  id              | bigint                   |           | not null | nextval('codeintel_path_ranks_id_seq'::regclass)
 Indexes:
     "codeintel_path_ranks_pkey" PRIMARY KEY, btree (id)
@@ -979,13 +979,13 @@ Triggers:
 
 # Table "public.codeintel_ranking_definitions"
 ```
-       Column       |  Type   | Collation | Nullable |                          Default                          
+       Column       |  Type   | Collation | Nullable |                          Default
 --------------------+---------+-----------+----------+-----------------------------------------------------------
  id                 | bigint  |           | not null | nextval('codeintel_ranking_definitions_id_seq'::regclass)
- symbol_name        | text    |           | not null | 
- document_path      | text    |           | not null | 
- graph_key          | text    |           | not null | 
- exported_upload_id | integer |           | not null | 
+ symbol_name        | text    |           | not null |
+ document_path      | text    |           | not null |
+ graph_key          | text    |           | not null |
+ exported_upload_id | integer |           | not null |
  symbol_checksum    | bytea   |           | not null | '\x'::bytea
 Indexes:
     "codeintel_ranking_definitions_pkey" PRIMARY KEY, btree (id)
@@ -998,15 +998,15 @@ Foreign-key constraints:
 
 # Table "public.codeintel_ranking_exports"
 ```
-     Column      |           Type           | Collation | Nullable |                        Default                        
+     Column      |           Type           | Collation | Nullable |                        Default
 -----------------+--------------------------+-----------+----------+-------------------------------------------------------
- upload_id       | integer                  |           |          | 
- graph_key       | text                     |           | not null | 
+ upload_id       | integer                  |           |          |
+ graph_key       | text                     |           | not null |
  locked_at       | timestamp with time zone |           | not null | now()
  id              | integer                  |           | not null | nextval('codeintel_ranking_exports_id_seq'::regclass)
- last_scanned_at | timestamp with time zone |           |          | 
- deleted_at      | timestamp with time zone |           |          | 
- upload_key      | text                     |           |          | 
+ last_scanned_at | timestamp with time zone |           |          |
+ deleted_at      | timestamp with time zone |           |          |
+ upload_key      | text                     |           |          |
 Indexes:
     "codeintel_ranking_exports_pkey" PRIMARY KEY, btree (id)
     "codeintel_ranking_exports_graph_key_upload_id" UNIQUE, btree (graph_key, upload_id)
@@ -1023,10 +1023,10 @@ Referenced by:
 
 # Table "public.codeintel_ranking_graph_keys"
 ```
-   Column   |           Type           | Collation | Nullable |                         Default                          
+   Column   |           Type           | Collation | Nullable |                         Default
 ------------+--------------------------+-----------+----------+----------------------------------------------------------
  id         | integer                  |           | not null | nextval('codeintel_ranking_graph_keys_id_seq'::regclass)
- graph_key  | text                     |           | not null | 
+ graph_key  | text                     |           | not null |
  created_at | timestamp with time zone |           |          | now()
 Indexes:
     "codeintel_ranking_graph_keys_pkey" PRIMARY KEY, btree (id)
@@ -1035,13 +1035,13 @@ Indexes:
 
 # Table "public.codeintel_ranking_path_counts_inputs"
 ```
-    Column     |  Type   | Collation | Nullable |                             Default                              
+    Column     |  Type   | Collation | Nullable |                             Default
 ---------------+---------+-----------+----------+------------------------------------------------------------------
  id            | bigint  |           | not null | nextval('codeintel_ranking_path_counts_inputs_id_seq'::regclass)
- count         | integer |           | not null | 
- graph_key     | text    |           | not null | 
+ count         | integer |           | not null |
+ graph_key     | text    |           | not null |
  processed     | boolean |           | not null | false
- definition_id | bigint  |           |          | 
+ definition_id | bigint  |           |          |
 Indexes:
     "codeintel_ranking_path_counts_inputs_pkey" PRIMARY KEY, btree (id)
     "codeintel_ranking_path_counts_inputs_graph_key_unique_definitio" UNIQUE, btree (graph_key, definition_id) WHERE NOT processed
@@ -1051,26 +1051,26 @@ Indexes:
 
 # Table "public.codeintel_ranking_progress"
 ```
-               Column               |           Type           | Collation | Nullable |                        Default                         
+               Column               |           Type           | Collation | Nullable |                        Default
 ------------------------------------+--------------------------+-----------+----------+--------------------------------------------------------
  id                                 | bigint                   |           | not null | nextval('codeintel_ranking_progress_id_seq'::regclass)
- graph_key                          | text                     |           | not null | 
- mappers_started_at                 | timestamp with time zone |           | not null | 
- mapper_completed_at                | timestamp with time zone |           |          | 
- seed_mapper_completed_at           | timestamp with time zone |           |          | 
- reducer_started_at                 | timestamp with time zone |           |          | 
- reducer_completed_at               | timestamp with time zone |           |          | 
- num_path_records_total             | integer                  |           |          | 
- num_reference_records_total        | integer                  |           |          | 
- num_count_records_total            | integer                  |           |          | 
- num_path_records_processed         | integer                  |           |          | 
- num_reference_records_processed    | integer                  |           |          | 
- num_count_records_processed        | integer                  |           |          | 
- max_export_id                      | bigint                   |           | not null | 
- reference_cursor_export_deleted_at | timestamp with time zone |           |          | 
- reference_cursor_export_id         | integer                  |           |          | 
- path_cursor_deleted_export_at      | timestamp with time zone |           |          | 
- path_cursor_export_id              | integer                  |           |          | 
+ graph_key                          | text                     |           | not null |
+ mappers_started_at                 | timestamp with time zone |           | not null |
+ mapper_completed_at                | timestamp with time zone |           |          |
+ seed_mapper_completed_at           | timestamp with time zone |           |          |
+ reducer_started_at                 | timestamp with time zone |           |          |
+ reducer_completed_at               | timestamp with time zone |           |          |
+ num_path_records_total             | integer                  |           |          |
+ num_reference_records_total        | integer                  |           |          |
+ num_count_records_total            | integer                  |           |          |
+ num_path_records_processed         | integer                  |           |          |
+ num_reference_records_processed    | integer                  |           |          |
+ num_count_records_processed        | integer                  |           |          |
+ max_export_id                      | bigint                   |           | not null |
+ reference_cursor_export_deleted_at | timestamp with time zone |           |          |
+ reference_cursor_export_id         | integer                  |           |          |
+ path_cursor_deleted_export_at      | timestamp with time zone |           |          |
+ path_cursor_export_id              | integer                  |           |          |
 Indexes:
     "codeintel_ranking_progress_pkey" PRIMARY KEY, btree (id)
     "codeintel_ranking_progress_graph_key_key" UNIQUE CONSTRAINT, btree (graph_key)
@@ -1079,12 +1079,12 @@ Indexes:
 
 # Table "public.codeintel_ranking_references"
 ```
-       Column       |  Type   | Collation | Nullable |                         Default                          
+       Column       |  Type   | Collation | Nullable |                         Default
 --------------------+---------+-----------+----------+----------------------------------------------------------
  id                 | bigint  |           | not null | nextval('codeintel_ranking_references_id_seq'::regclass)
- symbol_names       | text[]  |           | not null | 
- graph_key          | text    |           | not null | 
- exported_upload_id | integer |           | not null | 
+ symbol_names       | text[]  |           | not null |
+ graph_key          | text    |           | not null |
+ exported_upload_id | integer |           | not null |
  symbol_checksums   | bytea[] |           | not null | '{}'::bytea[]
 Indexes:
     "codeintel_ranking_references_pkey" PRIMARY KEY, btree (id)
@@ -1101,10 +1101,10 @@ References for a given upload proceduced by background job consuming SCIP indexe
 
 # Table "public.codeintel_ranking_references_processed"
 ```
-             Column             |  Type   | Collation | Nullable |                              Default                               
+             Column             |  Type   | Collation | Nullable |                              Default
 --------------------------------+---------+-----------+----------+--------------------------------------------------------------------
- graph_key                      | text    |           | not null | 
- codeintel_ranking_reference_id | integer |           | not null | 
+ graph_key                      | text    |           | not null |
+ codeintel_ranking_reference_id | integer |           | not null |
  id                             | bigint  |           | not null | nextval('codeintel_ranking_references_processed_id_seq'::regclass)
 Indexes:
     "codeintel_ranking_references_processed_pkey" PRIMARY KEY, btree (id)
@@ -1117,12 +1117,12 @@ Foreign-key constraints:
 
 # Table "public.codeowners"
 ```
-     Column     |           Type           | Collation | Nullable |                Default                 
+     Column     |           Type           | Collation | Nullable |                Default
 ----------------+--------------------------+-----------+----------+----------------------------------------
  id             | integer                  |           | not null | nextval('codeowners_id_seq'::regclass)
- contents       | text                     |           | not null | 
- contents_proto | bytea                    |           | not null | 
- repo_id        | integer                  |           | not null | 
+ contents       | text                     |           | not null |
+ contents_proto | bytea                    |           | not null |
+ repo_id        | integer                  |           | not null |
  created_at     | timestamp with time zone |           | not null | now()
  updated_at     | timestamp with time zone |           | not null | now()
 Indexes:
@@ -1135,12 +1135,12 @@ Foreign-key constraints:
 
 # Table "public.codeowners_individual_stats"
 ```
-         Column         |            Type             | Collation | Nullable | Default 
+         Column         |            Type             | Collation | Nullable | Default
 ------------------------+-----------------------------+-----------+----------+---------
- file_path_id           | integer                     |           | not null | 
- owner_id               | integer                     |           | not null | 
- tree_owned_files_count | integer                     |           | not null | 
- updated_at             | timestamp without time zone |           | not null | 
+ file_path_id           | integer                     |           | not null |
+ owner_id               | integer                     |           | not null |
+ tree_owned_files_count | integer                     |           | not null |
+ updated_at             | timestamp without time zone |           | not null |
 Indexes:
     "codeowners_individual_stats_pkey" PRIMARY KEY, btree (file_path_id, owner_id)
 Foreign-key constraints:
@@ -1161,10 +1161,10 @@ we are also indexing on owner_id which is CODEOWNERS-specific.
 
 # Table "public.codeowners_owners"
 ```
-  Column   |  Type   | Collation | Nullable |                    Default                    
+  Column   |  Type   | Collation | Nullable |                    Default
 -----------+---------+-----------+----------+-----------------------------------------------
  id        | integer |           | not null | nextval('codeowners_owners_id_seq'::regclass)
- reference | text    |           | not null | 
+ reference | text    |           | not null |
 Indexes:
     "codeowners_owners_pkey" PRIMARY KEY, btree (id)
     "codeowners_owners_reference" btree (reference)
@@ -1180,11 +1180,11 @@ since the distinction is not relevant for query, and this makes indexing way eas
 
 # Table "public.commit_authors"
 ```
- Column |  Type   | Collation | Nullable |                  Default                   
+ Column |  Type   | Collation | Nullable |                  Default
 --------+---------+-----------+----------+--------------------------------------------
  id     | integer |           | not null | nextval('commit_authors_id_seq'::regclass)
- email  | text    |           | not null | 
- name   | text    |           | not null | 
+ email  | text    |           | not null |
+ name   | text    |           | not null |
 Indexes:
     "commit_authors_pkey" PRIMARY KEY, btree (id)
     "commit_authors_email_name" UNIQUE, btree (email, name)
@@ -1196,14 +1196,14 @@ Referenced by:
 
 # Table "public.configuration_policies_audit_logs"
 ```
-       Column       |           Type           | Collation | Nullable |                          Default                           
+       Column       |           Type           | Collation | Nullable |                          Default
 --------------------+--------------------------+-----------+----------+------------------------------------------------------------
  log_timestamp      | timestamp with time zone |           |          | clock_timestamp()
- record_deleted_at  | timestamp with time zone |           |          | 
- policy_id          | integer                  |           | not null | 
- transition_columns | USER-DEFINED[]           |           |          | 
+ record_deleted_at  | timestamp with time zone |           |          |
+ policy_id          | integer                  |           | not null |
+ transition_columns | USER-DEFINED[]           |           |          |
  sequence           | bigint                   |           | not null | nextval('configuration_policies_audit_logs_seq'::regclass)
- operation          | audit_log_operation      |           | not null | 
+ operation          | audit_log_operation      |           | not null |
 Indexes:
     "configuration_policies_audit_logs_policy_id" btree (policy_id)
     "configuration_policies_audit_logs_timestamp" brin (log_timestamp)
@@ -1218,19 +1218,19 @@ Indexes:
 
 # Table "public.context_detection_embedding_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                           Default                            
+      Column       |           Type           | Collation | Nullable |                           Default
 -------------------+--------------------------+-----------+----------+--------------------------------------------------------------
  id                | integer                  |           | not null | nextval('context_detection_embedding_jobs_id_seq'::regclass)
  state             | text                     |           |          | 'queued'::text
- failure_message   | text                     |           |          | 
+ failure_message   | text                     |           |          |
  queued_at         | timestamp with time zone |           |          | now()
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
+ execution_logs    | json[]                   |           |          |
  worker_hostname   | text                     |           | not null | ''::text
  cancel            | boolean                  |           | not null | false
 Indexes:
@@ -1240,15 +1240,15 @@ Indexes:
 
 # Table "public.critical_and_site_config"
 ```
-      Column       |           Type           | Collation | Nullable |                       Default                        
+      Column       |           Type           | Collation | Nullable |                       Default
 -------------------+--------------------------+-----------+----------+------------------------------------------------------
  id                | integer                  |           | not null | nextval('critical_and_site_config_id_seq'::regclass)
- type              | critical_or_site         |           | not null | 
- contents          | text                     |           | not null | 
+ type              | critical_or_site         |           | not null |
+ contents          | text                     |           | not null |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- author_user_id    | integer                  |           |          | 
- redacted_contents | text                     |           |          | 
+ author_user_id    | integer                  |           |          |
+ redacted_contents | text                     |           |          |
 Indexes:
     "critical_and_site_config_pkey" PRIMARY KEY, btree (id)
     "critical_and_site_config_unique" UNIQUE, btree (id, type)
@@ -1261,15 +1261,15 @@ Indexes:
 
 # Table "public.discussion_comments"
 ```
-     Column     |           Type           | Collation | Nullable |                     Default                     
+     Column     |           Type           | Collation | Nullable |                     Default
 ----------------+--------------------------+-----------+----------+-------------------------------------------------
  id             | bigint                   |           | not null | nextval('discussion_comments_id_seq'::regclass)
- thread_id      | bigint                   |           | not null | 
- author_user_id | integer                  |           | not null | 
- contents       | text                     |           | not null | 
+ thread_id      | bigint                   |           | not null |
+ author_user_id | integer                  |           | not null |
+ contents       | text                     |           | not null |
  created_at     | timestamp with time zone |           | not null | now()
  updated_at     | timestamp with time zone |           | not null | now()
- deleted_at     | timestamp with time zone |           |          | 
+ deleted_at     | timestamp with time zone |           |          |
  reports        | text[]                   |           | not null | '{}'::text[]
 Indexes:
     "discussion_comments_pkey" PRIMARY KEY, btree (id)
@@ -1284,12 +1284,12 @@ Foreign-key constraints:
 
 # Table "public.discussion_mail_reply_tokens"
 ```
-   Column   |           Type           | Collation | Nullable | Default 
+   Column   |           Type           | Collation | Nullable | Default
 ------------+--------------------------+-----------+----------+---------
- token      | text                     |           | not null | 
- user_id    | integer                  |           | not null | 
- thread_id  | bigint                   |           | not null | 
- deleted_at | timestamp with time zone |           |          | 
+ token      | text                     |           | not null |
+ user_id    | integer                  |           | not null |
+ thread_id  | bigint                   |           | not null |
+ deleted_at | timestamp with time zone |           |          |
 Indexes:
     "discussion_mail_reply_tokens_pkey" PRIMARY KEY, btree (token)
     "discussion_mail_reply_tokens_user_id_thread_id_idx" btree (user_id, thread_id)
@@ -1301,16 +1301,16 @@ Foreign-key constraints:
 
 # Table "public.discussion_threads"
 ```
-     Column     |           Type           | Collation | Nullable |                    Default                     
+     Column     |           Type           | Collation | Nullable |                    Default
 ----------------+--------------------------+-----------+----------+------------------------------------------------
  id             | bigint                   |           | not null | nextval('discussion_threads_id_seq'::regclass)
- author_user_id | integer                  |           | not null | 
- title          | text                     |           |          | 
- target_repo_id | bigint                   |           |          | 
+ author_user_id | integer                  |           | not null |
+ title          | text                     |           |          |
+ target_repo_id | bigint                   |           |          |
  created_at     | timestamp with time zone |           | not null | now()
- archived_at    | timestamp with time zone |           |          | 
+ archived_at    | timestamp with time zone |           |          |
  updated_at     | timestamp with time zone |           | not null | now()
- deleted_at     | timestamp with time zone |           |          | 
+ deleted_at     | timestamp with time zone |           |          |
 Indexes:
     "discussion_threads_pkey" PRIMARY KEY, btree (id)
     "discussion_threads_author_user_id_idx" btree (author_user_id)
@@ -1326,21 +1326,21 @@ Referenced by:
 
 # Table "public.discussion_threads_target_repo"
 ```
-     Column      |  Type   | Collation | Nullable |                          Default                           
+     Column      |  Type   | Collation | Nullable |                          Default
 -----------------+---------+-----------+----------+------------------------------------------------------------
  id              | bigint  |           | not null | nextval('discussion_threads_target_repo_id_seq'::regclass)
- thread_id       | bigint  |           | not null | 
- repo_id         | integer |           | not null | 
- path            | text    |           |          | 
- branch          | text    |           |          | 
- revision        | text    |           |          | 
- start_line      | integer |           |          | 
- end_line        | integer |           |          | 
- start_character | integer |           |          | 
- end_character   | integer |           |          | 
- lines_before    | text    |           |          | 
- lines           | text    |           |          | 
- lines_after     | text    |           |          | 
+ thread_id       | bigint  |           | not null |
+ repo_id         | integer |           | not null |
+ path            | text    |           |          |
+ branch          | text    |           |          |
+ revision        | text    |           |          |
+ start_line      | integer |           |          |
+ end_line        | integer |           |          |
+ start_character | integer |           |          |
+ end_character   | integer |           |          |
+ lines_before    | text    |           |          |
+ lines           | text    |           |          |
+ lines_after     | text    |           |          |
 Indexes:
     "discussion_threads_target_repo_pkey" PRIMARY KEY, btree (id)
     "discussion_threads_target_repo_repo_id_path_idx" btree (repo_id, path)
@@ -1354,28 +1354,28 @@ Referenced by:
 
 # Table "public.event_logs"
 ```
-          Column          |           Type           | Collation | Nullable |                Default                 
+          Column          |           Type           | Collation | Nullable |                Default
 --------------------------+--------------------------+-----------+----------+----------------------------------------
  id                       | bigint                   |           | not null | nextval('event_logs_id_seq'::regclass)
- name                     | text                     |           | not null | 
- url                      | text                     |           | not null | 
- user_id                  | integer                  |           | not null | 
- anonymous_user_id        | text                     |           | not null | 
- source                   | text                     |           | not null | 
- argument                 | jsonb                    |           | not null | 
- version                  | text                     |           | not null | 
- timestamp                | timestamp with time zone |           | not null | 
- feature_flags            | jsonb                    |           |          | 
- cohort_id                | date                     |           |          | 
+ name                     | text                     |           | not null |
+ url                      | text                     |           | not null |
+ user_id                  | integer                  |           | not null |
+ anonymous_user_id        | text                     |           | not null |
+ source                   | text                     |           | not null |
+ argument                 | jsonb                    |           | not null |
+ version                  | text                     |           | not null |
+ timestamp                | timestamp with time zone |           | not null |
+ feature_flags            | jsonb                    |           |          |
+ cohort_id                | date                     |           |          |
  public_argument          | jsonb                    |           | not null | '{}'::jsonb
- first_source_url         | text                     |           |          | 
- last_source_url          | text                     |           |          | 
- referrer                 | text                     |           |          | 
- device_id                | text                     |           |          | 
- insert_id                | text                     |           |          | 
- billing_product_category | text                     |           |          | 
- billing_event_id         | text                     |           |          | 
- client                   | text                     |           |          | 
+ first_source_url         | text                     |           |          |
+ last_source_url          | text                     |           |          |
+ referrer                 | text                     |           |          |
+ device_id                | text                     |           |          |
+ insert_id                | text                     |           |          |
+ billing_product_category | text                     |           |          |
+ billing_event_id         | text                     |           |          |
+ client                   | text                     |           |          |
 Indexes:
     "event_logs_pkey" PRIMARY KEY, btree (id)
     "event_logs_anonymous_user_id" btree (anonymous_user_id)
@@ -1395,10 +1395,10 @@ Check constraints:
 
 # Table "public.event_logs_export_allowlist"
 ```
-   Column   |  Type   | Collation | Nullable |                         Default                         
+   Column   |  Type   | Collation | Nullable |                         Default
 ------------+---------+-----------+----------+---------------------------------------------------------
  id         | integer |           | not null | nextval('event_logs_export_allowlist_id_seq'::regclass)
- event_name | text    |           | not null | 
+ event_name | text    |           | not null |
 Indexes:
     "event_logs_export_allowlist_pkey" PRIMARY KEY, btree (id)
     "event_logs_export_allowlist_event_name_idx" UNIQUE, btree (event_name)
@@ -1411,10 +1411,10 @@ An allowlist of events that are approved for export if the scraping job is enabl
 
 # Table "public.event_logs_scrape_state"
 ```
-   Column    |  Type   | Collation | Nullable |                       Default                       
+   Column    |  Type   | Collation | Nullable |                       Default
 -------------+---------+-----------+----------+-----------------------------------------------------
  id          | integer |           | not null | nextval('event_logs_scrape_state_id_seq'::regclass)
- bookmark_id | integer |           | not null | 
+ bookmark_id | integer |           | not null |
 Indexes:
     "event_logs_scrape_state_pk" PRIMARY KEY, btree (id)
 
@@ -1426,11 +1426,11 @@ Contains state for the periodic telemetry job that scrapes events if enabled.
 
 # Table "public.event_logs_scrape_state_own"
 ```
-   Column    |  Type   | Collation | Nullable |                         Default                         
+   Column    |  Type   | Collation | Nullable |                         Default
 -------------+---------+-----------+----------+---------------------------------------------------------
  id          | integer |           | not null | nextval('event_logs_scrape_state_own_id_seq'::regclass)
- bookmark_id | integer |           | not null | 
- job_type    | integer |           | not null | 
+ bookmark_id | integer |           | not null |
+ job_type    | integer |           | not null |
 Indexes:
     "event_logs_scrape_state_own_pk" PRIMARY KEY, btree (id)
 
@@ -1442,21 +1442,21 @@ Contains state for own jobs that scrape events if enabled.
 
 # Table "public.executor_heartbeats"
 ```
-      Column      |           Type           | Collation | Nullable |                     Default                     
+      Column      |           Type           | Collation | Nullable |                     Default
 ------------------+--------------------------+-----------+----------+-------------------------------------------------
  id               | integer                  |           | not null | nextval('executor_heartbeats_id_seq'::regclass)
- hostname         | text                     |           | not null | 
- queue_name       | text                     |           |          | 
- os               | text                     |           | not null | 
- architecture     | text                     |           | not null | 
- docker_version   | text                     |           | not null | 
- executor_version | text                     |           | not null | 
- git_version      | text                     |           | not null | 
- ignite_version   | text                     |           | not null | 
- src_cli_version  | text                     |           | not null | 
+ hostname         | text                     |           | not null |
+ queue_name       | text                     |           |          |
+ os               | text                     |           | not null |
+ architecture     | text                     |           | not null |
+ docker_version   | text                     |           | not null |
+ executor_version | text                     |           | not null |
+ git_version      | text                     |           | not null |
+ ignite_version   | text                     |           | not null |
+ src_cli_version  | text                     |           | not null |
  first_seen_at    | timestamp with time zone |           | not null | now()
  last_seen_at     | timestamp with time zone |           | not null | now()
- queue_names      | text[]                   |           |          | 
+ queue_names      | text[]                   |           |          |
 Indexes:
     "executor_heartbeats_pkey" PRIMARY KEY, btree (id)
     "executor_heartbeats_hostname_key" UNIQUE CONSTRAINT, btree (hostname)
@@ -1493,13 +1493,13 @@ Tracks the most recent activity of executors attached to this Sourcegraph instan
 
 # Table "public.executor_job_tokens"
 ```
-    Column    |           Type           | Collation | Nullable |                     Default                     
+    Column    |           Type           | Collation | Nullable |                     Default
 --------------+--------------------------+-----------+----------+-------------------------------------------------
  id           | integer                  |           | not null | nextval('executor_job_tokens_id_seq'::regclass)
- value_sha256 | bytea                    |           | not null | 
- job_id       | bigint                   |           | not null | 
- queue        | text                     |           | not null | 
- repo_id      | bigint                   |           | not null | 
+ value_sha256 | bytea                    |           | not null |
+ job_id       | bigint                   |           | not null |
+ queue        | text                     |           | not null |
+ repo_id      | bigint                   |           | not null |
  created_at   | timestamp with time zone |           | not null | now()
  updated_at   | timestamp with time zone |           | not null | now()
 Indexes:
@@ -1511,11 +1511,11 @@ Indexes:
 
 # Table "public.executor_secret_access_logs"
 ```
-       Column       |           Type           | Collation | Nullable |                         Default                         
+       Column       |           Type           | Collation | Nullable |                         Default
 --------------------+--------------------------+-----------+----------+---------------------------------------------------------
  id                 | integer                  |           | not null | nextval('executor_secret_access_logs_id_seq'::regclass)
- executor_secret_id | integer                  |           | not null | 
- user_id            | integer                  |           |          | 
+ executor_secret_id | integer                  |           | not null |
+ user_id            | integer                  |           |          |
  created_at         | timestamp with time zone |           | not null | now()
  machine_user       | text                     |           | not null | ''::text
 Indexes:
@@ -1530,18 +1530,18 @@ Foreign-key constraints:
 
 # Table "public.executor_secrets"
 ```
-      Column       |           Type           | Collation | Nullable |                   Default                    
+      Column       |           Type           | Collation | Nullable |                   Default
 -------------------+--------------------------+-----------+----------+----------------------------------------------
  id                | integer                  |           | not null | nextval('executor_secrets_id_seq'::regclass)
- key               | text                     |           | not null | 
- value             | bytea                    |           | not null | 
- scope             | text                     |           | not null | 
- encryption_key_id | text                     |           |          | 
- namespace_user_id | integer                  |           |          | 
- namespace_org_id  | integer                  |           |          | 
+ key               | text                     |           | not null |
+ value             | bytea                    |           | not null |
+ scope             | text                     |           | not null |
+ encryption_key_id | text                     |           |          |
+ namespace_user_id | integer                  |           |          |
+ namespace_org_id  | integer                  |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- creator_id        | integer                  |           |          | 
+ creator_id        | integer                  |           |          |
 Indexes:
     "executor_secrets_pkey" PRIMARY KEY, btree (id)
     "executor_secrets_unique_key_global" UNIQUE, btree (key, scope) WHERE namespace_user_id IS NULL AND namespace_org_id IS NULL
@@ -1560,20 +1560,20 @@ Referenced by:
 
 # Table "public.exhaustive_search_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                      Default                       
+      Column       |           Type           | Collation | Nullable |                      Default
 -------------------+--------------------------+-----------+----------+----------------------------------------------------
  id                | integer                  |           | not null | nextval('exhaustive_search_jobs_id_seq'::regclass)
  state             | text                     |           |          | 'queued'::text
- initiator_id      | integer                  |           | not null | 
- query             | text                     |           | not null | 
- failure_message   | text                     |           |          | 
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ initiator_id      | integer                  |           | not null |
+ query             | text                     |           | not null |
+ failure_message   | text                     |           |          |
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
+ execution_logs    | json[]                   |           |          |
  worker_hostname   | text                     |           | not null | ''::text
  cancel            | boolean                  |           | not null | false
  created_at        | timestamp with time zone |           | not null | now()
@@ -1590,21 +1590,21 @@ Referenced by:
 
 # Table "public.exhaustive_search_repo_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                         Default                         
+      Column       |           Type           | Collation | Nullable |                         Default
 -------------------+--------------------------+-----------+----------+---------------------------------------------------------
  id                | integer                  |           | not null | nextval('exhaustive_search_repo_jobs_id_seq'::regclass)
  state             | text                     |           |          | 'queued'::text
- repo_id           | integer                  |           | not null | 
- ref_spec          | text                     |           | not null | 
- search_job_id     | integer                  |           | not null | 
- failure_message   | text                     |           |          | 
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ repo_id           | integer                  |           | not null |
+ ref_spec          | text                     |           | not null |
+ search_job_id     | integer                  |           | not null |
+ failure_message   | text                     |           |          |
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
+ execution_logs    | json[]                   |           |          |
  worker_hostname   | text                     |           | not null | ''::text
  cancel            | boolean                  |           | not null | false
  created_at        | timestamp with time zone |           | not null | now()
@@ -1622,20 +1622,20 @@ Referenced by:
 
 # Table "public.exhaustive_search_repo_revision_jobs"
 ```
-       Column       |           Type           | Collation | Nullable |                             Default                              
+       Column       |           Type           | Collation | Nullable |                             Default
 --------------------+--------------------------+-----------+----------+------------------------------------------------------------------
  id                 | integer                  |           | not null | nextval('exhaustive_search_repo_revision_jobs_id_seq'::regclass)
  state              | text                     |           |          | 'queued'::text
- search_repo_job_id | integer                  |           | not null | 
- revision           | text                     |           | not null | 
- failure_message    | text                     |           |          | 
- started_at         | timestamp with time zone |           |          | 
- finished_at        | timestamp with time zone |           |          | 
- process_after      | timestamp with time zone |           |          | 
+ search_repo_job_id | integer                  |           | not null |
+ revision           | text                     |           | not null |
+ failure_message    | text                     |           |          |
+ started_at         | timestamp with time zone |           |          |
+ finished_at        | timestamp with time zone |           |          |
+ process_after      | timestamp with time zone |           |          |
  num_resets         | integer                  |           | not null | 0
  num_failures       | integer                  |           | not null | 0
- last_heartbeat_at  | timestamp with time zone |           |          | 
- execution_logs     | json[]                   |           |          | 
+ last_heartbeat_at  | timestamp with time zone |           |          |
+ execution_logs     | json[]                   |           |          |
  worker_hostname    | text                     |           | not null | ''::text
  cancel             | boolean                  |           | not null | false
  created_at         | timestamp with time zone |           | not null | now()
@@ -1650,23 +1650,23 @@ Foreign-key constraints:
 
 # Table "public.explicit_permissions_bitbucket_projects_jobs"
 ```
-       Column        |           Type           | Collation | Nullable |                                 Default                                  
+       Column        |           Type           | Collation | Nullable |                                 Default
 ---------------------+--------------------------+-----------+----------+--------------------------------------------------------------------------
  id                  | integer                  |           | not null | nextval('explicit_permissions_bitbucket_projects_jobs_id_seq'::regclass)
  state               | text                     |           |          | 'queued'::text
- failure_message     | text                     |           |          | 
+ failure_message     | text                     |           |          |
  queued_at           | timestamp with time zone |           |          | now()
- started_at          | timestamp with time zone |           |          | 
- finished_at         | timestamp with time zone |           |          | 
- process_after       | timestamp with time zone |           |          | 
+ started_at          | timestamp with time zone |           |          |
+ finished_at         | timestamp with time zone |           |          |
+ process_after       | timestamp with time zone |           |          |
  num_resets          | integer                  |           | not null | 0
  num_failures        | integer                  |           | not null | 0
- last_heartbeat_at   | timestamp with time zone |           |          | 
- execution_logs      | json[]                   |           |          | 
+ last_heartbeat_at   | timestamp with time zone |           |          |
+ execution_logs      | json[]                   |           |          |
  worker_hostname     | text                     |           | not null | ''::text
- project_key         | text                     |           | not null | 
- external_service_id | integer                  |           | not null | 
- permissions         | json[]                   |           |          | 
+ project_key         | text                     |           | not null |
+ external_service_id | integer                  |           | not null |
+ permissions         | json[]                   |           |          |
  unrestricted        | boolean                  |           | not null | false
  cancel              | boolean                  |           | not null | false
 Indexes:
@@ -1681,13 +1681,13 @@ Check constraints:
 
 # Table "public.external_service_repos"
 ```
-       Column        |           Type           | Collation | Nullable |         Default         
+       Column        |           Type           | Collation | Nullable |         Default
 ---------------------+--------------------------+-----------+----------+-------------------------
- external_service_id | bigint                   |           | not null | 
- repo_id             | integer                  |           | not null | 
- clone_url           | text                     |           | not null | 
- user_id             | integer                  |           |          | 
- org_id              | integer                  |           |          | 
+ external_service_id | bigint                   |           | not null |
+ repo_id             | integer                  |           | not null |
+ clone_url           | text                     |           | not null |
+ user_id             | integer                  |           |          |
+ org_id              | integer                  |           |          |
  created_at          | timestamp with time zone |           | not null | transaction_timestamp()
 Indexes:
     "external_service_repos_repo_id_external_service_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_service_id)
@@ -1705,21 +1705,21 @@ Foreign-key constraints:
 
 # Table "public.external_service_sync_jobs"
 ```
-       Column        |           Type           | Collation | Nullable |                        Default                         
+       Column        |           Type           | Collation | Nullable |                        Default
 ---------------------+--------------------------+-----------+----------+--------------------------------------------------------
  id                  | integer                  |           | not null | nextval('external_service_sync_jobs_id_seq'::regclass)
  state               | text                     |           | not null | 'queued'::text
- failure_message     | text                     |           |          | 
- started_at          | timestamp with time zone |           |          | 
- finished_at         | timestamp with time zone |           |          | 
- process_after       | timestamp with time zone |           |          | 
+ failure_message     | text                     |           |          |
+ started_at          | timestamp with time zone |           |          |
+ finished_at         | timestamp with time zone |           |          |
+ process_after       | timestamp with time zone |           |          |
  num_resets          | integer                  |           | not null | 0
- external_service_id | bigint                   |           | not null | 
+ external_service_id | bigint                   |           | not null |
  num_failures        | integer                  |           | not null | 0
- log_contents        | text                     |           |          | 
- execution_logs      | json[]                   |           |          | 
+ log_contents        | text                     |           |          |
+ execution_logs      | json[]                   |           |          |
  worker_hostname     | text                     |           | not null | ''::text
- last_heartbeat_at   | timestamp with time zone |           |          | 
+ last_heartbeat_at   | timestamp with time zone |           |          |
  queued_at           | timestamp with time zone |           |          | now()
  cancel              | boolean                  |           | not null | false
  repos_synced        | integer                  |           | not null | 0
@@ -1749,25 +1749,27 @@ Foreign-key constraints:
 
 # Table "public.external_services"
 ```
-      Column       |           Type           | Collation | Nullable |                    Default                    
+      Column       |           Type           | Collation | Nullable |                    Default
 -------------------+--------------------------+-----------+----------+-----------------------------------------------
  id                | bigint                   |           | not null | nextval('external_services_id_seq'::regclass)
- kind              | text                     |           | not null | 
- display_name      | text                     |           | not null | 
- config            | text                     |           | not null | 
+ kind              | text                     |           | not null |
+ display_name      | text                     |           | not null |
+ config            | text                     |           | not null |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- deleted_at        | timestamp with time zone |           |          | 
- last_sync_at      | timestamp with time zone |           |          | 
- next_sync_at      | timestamp with time zone |           |          | 
- namespace_user_id | integer                  |           |          | 
+ deleted_at        | timestamp with time zone |           |          |
+ last_sync_at      | timestamp with time zone |           |          |
+ next_sync_at      | timestamp with time zone |           |          |
+ namespace_user_id | integer                  |           |          |
  unrestricted      | boolean                  |           | not null | false
  cloud_default     | boolean                  |           | not null | false
  encryption_key_id | text                     |           | not null | ''::text
- namespace_org_id  | integer                  |           |          | 
- has_webhooks      | boolean                  |           |          | 
- token_expires_at  | timestamp with time zone |           |          | 
- code_host_id      | integer                  |           |          | 
+ namespace_org_id  | integer                  |           |          |
+ has_webhooks      | boolean                  |           |          |
+ token_expires_at  | timestamp with time zone |           |          |
+ code_host_id      | integer                  |           |          |
+ creator_id        | integer                  |           |          |
+ last_updater_id   | integer                  |           |          |
 Indexes:
     "external_services_pkey" PRIMARY KEY, btree (id)
     "external_services_unique_kind_org_id" UNIQUE, btree (kind, namespace_org_id) WHERE deleted_at IS NULL AND namespace_user_id IS NULL AND namespace_org_id IS NOT NULL
@@ -1792,15 +1794,15 @@ Referenced by:
 
 # Table "public.feature_flag_overrides"
 ```
-      Column       |           Type           | Collation | Nullable | Default 
+      Column       |           Type           | Collation | Nullable | Default
 -------------------+--------------------------+-----------+----------+---------
- namespace_org_id  | integer                  |           |          | 
- namespace_user_id | integer                  |           |          | 
- flag_name         | text                     |           | not null | 
- flag_value        | boolean                  |           | not null | 
+ namespace_org_id  | integer                  |           |          |
+ namespace_user_id | integer                  |           |          |
+ flag_name         | text                     |           | not null |
+ flag_value        | boolean                  |           | not null |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- deleted_at        | timestamp with time zone |           |          | 
+ deleted_at        | timestamp with time zone |           |          |
 Indexes:
     "feature_flag_overrides_unique_org_flag" UNIQUE CONSTRAINT, btree (namespace_org_id, flag_name)
     "feature_flag_overrides_unique_user_flag" UNIQUE CONSTRAINT, btree (namespace_user_id, flag_name)
@@ -1817,15 +1819,15 @@ Foreign-key constraints:
 
 # Table "public.feature_flags"
 ```
-   Column   |           Type           | Collation | Nullable | Default 
+   Column   |           Type           | Collation | Nullable | Default
 ------------+--------------------------+-----------+----------+---------
- flag_name  | text                     |           | not null | 
- flag_type  | feature_flag_type        |           | not null | 
- bool_value | boolean                  |           |          | 
- rollout    | integer                  |           |          | 
+ flag_name  | text                     |           | not null |
+ flag_type  | feature_flag_type        |           | not null |
+ bool_value | boolean                  |           |          |
+ rollout    | integer                  |           |          |
  created_at | timestamp with time zone |           | not null | now()
  updated_at | timestamp with time zone |           | not null | now()
- deleted_at | timestamp with time zone |           |          | 
+ deleted_at | timestamp with time zone |           |          |
 Indexes:
     "feature_flags_pkey" PRIMARY KEY, btree (flag_name)
 Check constraints:
@@ -1853,17 +1855,17 @@ Referenced by:
 
 # Table "public.github_app_installs"
 ```
-       Column       |           Type           | Collation | Nullable |                     Default                     
+       Column       |           Type           | Collation | Nullable |                     Default
 --------------------+--------------------------+-----------+----------+-------------------------------------------------
  id                 | integer                  |           | not null | nextval('github_app_installs_id_seq'::regclass)
- app_id             | integer                  |           | not null | 
- installation_id    | integer                  |           | not null | 
+ app_id             | integer                  |           | not null |
+ installation_id    | integer                  |           | not null |
  created_at         | timestamp with time zone |           | not null | now()
- url                | text                     |           |          | 
- account_login      | text                     |           |          | 
- account_avatar_url | text                     |           |          | 
- account_url        | text                     |           |          | 
- account_type       | text                     |           |          | 
+ url                | text                     |           |          |
+ account_login      | text                     |           |          |
+ account_avatar_url | text                     |           |          |
+ account_url        | text                     |           |          |
+ account_type       | text                     |           |          |
  updated_at         | timestamp with time zone |           | not null | now()
 Indexes:
     "github_app_installs_pkey" PRIMARY KEY, btree (id)
@@ -1878,22 +1880,22 @@ Foreign-key constraints:
 
 # Table "public.github_apps"
 ```
-      Column       |           Type           | Collation | Nullable |                 Default                 
+      Column       |           Type           | Collation | Nullable |                 Default
 -------------------+--------------------------+-----------+----------+-----------------------------------------
  id                | integer                  |           | not null | nextval('github_apps_id_seq'::regclass)
- app_id            | integer                  |           | not null | 
- name              | text                     |           | not null | 
- slug              | text                     |           | not null | 
- base_url          | text                     |           | not null | 
- client_id         | text                     |           | not null | 
- client_secret     | text                     |           | not null | 
- private_key       | text                     |           | not null | 
- encryption_key_id | text                     |           | not null | 
- logo              | text                     |           |          | 
+ app_id            | integer                  |           | not null |
+ name              | text                     |           | not null |
+ slug              | text                     |           | not null |
+ base_url          | text                     |           | not null |
+ client_id         | text                     |           | not null |
+ client_secret     | text                     |           | not null |
+ private_key       | text                     |           | not null |
+ encryption_key_id | text                     |           | not null |
+ logo              | text                     |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
  app_url           | text                     |           | not null | ''::text
- webhook_id        | integer                  |           |          | 
+ webhook_id        | integer                  |           |          |
  domain            | text                     |           | not null | 'repos'::text
 Indexes:
     "github_apps_pkey" PRIMARY KEY, btree (id)
@@ -1907,23 +1909,23 @@ Referenced by:
 
 # Table "public.gitserver_relocator_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                       Default                        
+      Column       |           Type           | Collation | Nullable |                       Default
 -------------------+--------------------------+-----------+----------+------------------------------------------------------
  id                | integer                  |           | not null | nextval('gitserver_relocator_jobs_id_seq'::regclass)
  state             | text                     |           |          | 'queued'::text
  queued_at         | timestamp with time zone |           |          | now()
- failure_message   | text                     |           |          | 
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ failure_message   | text                     |           |          |
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
+ execution_logs    | json[]                   |           |          |
  worker_hostname   | text                     |           | not null | ''::text
- repo_id           | integer                  |           | not null | 
- source_hostname   | text                     |           | not null | 
- dest_hostname     | text                     |           | not null | 
+ repo_id           | integer                  |           | not null |
+ source_hostname   | text                     |           | not null |
+ dest_hostname     | text                     |           | not null |
  delete_source     | boolean                  |           | not null | false
  cancel            | boolean                  |           | not null | false
 Indexes:
@@ -1934,17 +1936,17 @@ Indexes:
 
 # Table "public.gitserver_repos"
 ```
-      Column      |           Type           | Collation | Nullable |      Default       
+      Column      |           Type           | Collation | Nullable |      Default
 ------------------+--------------------------+-----------+----------+--------------------
- repo_id          | integer                  |           | not null | 
+ repo_id          | integer                  |           | not null |
  clone_status     | text                     |           | not null | 'not_cloned'::text
- shard_id         | text                     |           | not null | 
- last_error       | text                     |           |          | 
+ shard_id         | text                     |           | not null |
+ last_error       | text                     |           |          |
  updated_at       | timestamp with time zone |           | not null | now()
  last_fetched     | timestamp with time zone |           | not null | now()
  last_changed     | timestamp with time zone |           | not null | now()
- repo_size_bytes  | bigint                   |           |          | 
- corrupted_at     | timestamp with time zone |           |          | 
+ repo_size_bytes  | bigint                   |           |          |
+ corrupted_at     | timestamp with time zone |           |          |
  corruption_logs  | jsonb                    |           | not null | '[]'::jsonb
  cloning_progress | text                     |           |          | ''::text
 Indexes:
@@ -1972,9 +1974,9 @@ Triggers:
 
 # Table "public.gitserver_repos_statistics"
 ```
-    Column    |  Type  | Collation | Nullable | Default 
+    Column    |  Type  | Collation | Nullable | Default
 --------------+--------+-----------+----------+---------
- shard_id     | text   |           | not null | 
+ shard_id     | text   |           | not null |
  total        | bigint |           | not null | 0
  not_cloned   | bigint |           | not null | 0
  cloning      | bigint |           | not null | 0
@@ -2002,9 +2004,9 @@ Indexes:
 
 # Table "public.gitserver_repos_sync_output"
 ```
-   Column    |           Type           | Collation | Nullable | Default  
+   Column    |           Type           | Collation | Nullable | Default
 -------------+--------------------------+-----------+----------+----------
- repo_id     | integer                  |           | not null | 
+ repo_id     | integer                  |           | not null |
  last_output | text                     |           | not null | ''::text
  updated_at  | timestamp with time zone |           | not null | now()
 Indexes:
@@ -2018,9 +2020,9 @@ Contains the most recent output from gitserver repository sync jobs.
 
 # Table "public.global_state"
 ```
-   Column    |  Type   | Collation | Nullable | Default 
+   Column    |  Type   | Collation | Nullable | Default
 -------------+---------+-----------+----------+---------
- site_id     | uuid    |           | not null | 
+ site_id     | uuid    |           | not null |
  initialized | boolean |           | not null | false
 Indexes:
     "global_state_pkey" PRIMARY KEY, btree (site_id)
@@ -2029,28 +2031,28 @@ Indexes:
 
 # Table "public.insights_query_runner_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                        Default                         
+      Column       |           Type           | Collation | Nullable |                        Default
 -------------------+--------------------------+-----------+----------+--------------------------------------------------------
  id                | integer                  |           | not null | nextval('insights_query_runner_jobs_id_seq'::regclass)
- series_id         | text                     |           | not null | 
- search_query      | text                     |           | not null | 
+ series_id         | text                     |           | not null |
+ search_query      | text                     |           | not null |
  state             | text                     |           |          | 'queued'::text
- failure_message   | text                     |           |          | 
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ failure_message   | text                     |           |          |
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- execution_logs    | json[]                   |           |          | 
- record_time       | timestamp with time zone |           |          | 
+ execution_logs    | json[]                   |           |          |
+ record_time       | timestamp with time zone |           |          |
  worker_hostname   | text                     |           | not null | ''::text
- last_heartbeat_at | timestamp with time zone |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
  priority          | integer                  |           | not null | 1
  cost              | integer                  |           | not null | 500
  persist_mode      | persistmode              |           | not null | 'record'::persistmode
  queued_at         | timestamp with time zone |           |          | now()
  cancel            | boolean                  |           | not null | false
- trace_id          | text                     |           |          | 
+ trace_id          | text                     |           |          |
 Indexes:
     "insights_query_runner_jobs_pkey" PRIMARY KEY, btree (id)
     "finished_at_insights_query_runner_jobs_idx" btree (finished_at)
@@ -2075,11 +2077,11 @@ See [internal/insights/background/queryrunner/worker.go:Job](https://sourcegraph
 
 # Table "public.insights_query_runner_jobs_dependencies"
 ```
-     Column     |            Type             | Collation | Nullable |                               Default                               
+     Column     |            Type             | Collation | Nullable |                               Default
 ----------------+-----------------------------+-----------+----------+---------------------------------------------------------------------
  id             | integer                     |           | not null | nextval('insights_query_runner_jobs_dependencies_id_seq'::regclass)
- job_id         | integer                     |           | not null | 
- recording_time | timestamp without time zone |           | not null | 
+ job_id         | integer                     |           | not null |
+ recording_time | timestamp without time zone |           | not null |
 Indexes:
     "insights_query_runner_jobs_dependencies_pkey" PRIMARY KEY, btree (id)
     "insights_query_runner_jobs_dependencies_job_id_fk_idx" btree (job_id)
@@ -2096,40 +2098,40 @@ Stores data points for a code insight that do not need to be queried directly, b
 
 # Table "public.insights_settings_migration_jobs"
 ```
-       Column        |            Type             | Collation | Nullable |                           Default                            
+       Column        |            Type             | Collation | Nullable |                           Default
 ---------------------+-----------------------------+-----------+----------+--------------------------------------------------------------
  id                  | integer                     |           | not null | nextval('insights_settings_migration_jobs_id_seq'::regclass)
- user_id             | integer                     |           |          | 
- org_id              | integer                     |           |          | 
- global              | boolean                     |           |          | 
- settings_id         | integer                     |           | not null | 
+ user_id             | integer                     |           |          |
+ org_id              | integer                     |           |          |
+ global              | boolean                     |           |          |
+ settings_id         | integer                     |           | not null |
  total_insights      | integer                     |           | not null | 0
  migrated_insights   | integer                     |           | not null | 0
  total_dashboards    | integer                     |           | not null | 0
  migrated_dashboards | integer                     |           | not null | 0
  runs                | integer                     |           | not null | 0
- completed_at        | timestamp without time zone |           |          | 
+ completed_at        | timestamp without time zone |           |          |
 
 ```
 
 # Table "public.lsif_configuration_policies"
 ```
-           Column            |           Type           | Collation | Nullable |                         Default                         
+           Column            |           Type           | Collation | Nullable |                         Default
 -----------------------------+--------------------------+-----------+----------+---------------------------------------------------------
  id                          | integer                  |           | not null | nextval('lsif_configuration_policies_id_seq'::regclass)
- repository_id               | integer                  |           |          | 
- name                        | text                     |           |          | 
- type                        | text                     |           | not null | 
- pattern                     | text                     |           | not null | 
- retention_enabled           | boolean                  |           | not null | 
- retention_duration_hours    | integer                  |           |          | 
- retain_intermediate_commits | boolean                  |           | not null | 
- indexing_enabled            | boolean                  |           | not null | 
- index_commit_max_age_hours  | integer                  |           |          | 
- index_intermediate_commits  | boolean                  |           | not null | 
+ repository_id               | integer                  |           |          |
+ name                        | text                     |           |          |
+ type                        | text                     |           | not null |
+ pattern                     | text                     |           | not null |
+ retention_enabled           | boolean                  |           | not null |
+ retention_duration_hours    | integer                  |           |          |
+ retain_intermediate_commits | boolean                  |           | not null |
+ indexing_enabled            | boolean                  |           | not null |
+ index_commit_max_age_hours  | integer                  |           |          |
+ index_intermediate_commits  | boolean                  |           | not null |
  protected                   | boolean                  |           | not null | false
- repository_patterns         | text[]                   |           |          | 
- last_resolved_at            | timestamp with time zone |           |          | 
+ repository_patterns         | text[]                   |           |          |
+ last_resolved_at            | timestamp with time zone |           |          |
  embeddings_enabled          | boolean                  |           | not null | false
 Indexes:
     "lsif_configuration_policies_pkey" PRIMARY KEY, btree (id)
@@ -2165,10 +2167,10 @@ Triggers:
 
 # Table "public.lsif_configuration_policies_repository_pattern_lookup"
 ```
-  Column   |  Type   | Collation | Nullable | Default 
+  Column   |  Type   | Collation | Nullable | Default
 -----------+---------+-----------+----------+---------
- policy_id | integer |           | not null | 
- repo_id   | integer |           | not null | 
+ policy_id | integer |           | not null |
+ repo_id   | integer |           | not null |
 Indexes:
     "lsif_configuration_policies_repository_pattern_lookup_pkey" PRIMARY KEY, btree (policy_id, repo_id)
 
@@ -2182,23 +2184,23 @@ A lookup table to get all the repository patterns by repository id that apply to
 
 # Table "public.lsif_dependency_indexing_jobs"
 ```
-        Column         |           Type           | Collation | Nullable |                          Default                           
+        Column         |           Type           | Collation | Nullable |                          Default
 -----------------------+--------------------------+-----------+----------+------------------------------------------------------------
  id                    | integer                  |           | not null | nextval('lsif_dependency_indexing_jobs_id_seq1'::regclass)
  state                 | text                     |           | not null | 'queued'::text
- failure_message       | text                     |           |          | 
+ failure_message       | text                     |           |          |
  queued_at             | timestamp with time zone |           | not null | now()
- started_at            | timestamp with time zone |           |          | 
- finished_at           | timestamp with time zone |           |          | 
- process_after         | timestamp with time zone |           |          | 
+ started_at            | timestamp with time zone |           |          |
+ finished_at           | timestamp with time zone |           |          |
+ process_after         | timestamp with time zone |           |          |
  num_resets            | integer                  |           | not null | 0
  num_failures          | integer                  |           | not null | 0
- execution_logs        | json[]                   |           |          | 
- last_heartbeat_at     | timestamp with time zone |           |          | 
+ execution_logs        | json[]                   |           |          |
+ last_heartbeat_at     | timestamp with time zone |           |          |
  worker_hostname       | text                     |           | not null | ''::text
- upload_id             | integer                  |           |          | 
+ upload_id             | integer                  |           |          |
  external_service_kind | text                     |           | not null | ''::text
- external_service_sync | timestamp with time zone |           |          | 
+ external_service_sync | timestamp with time zone |           |          |
  cancel                | boolean                  |           | not null | false
 Indexes:
     "lsif_dependency_indexing_jobs_pkey1" PRIMARY KEY, btree (id)
@@ -2214,13 +2216,13 @@ Foreign-key constraints:
 
 # Table "public.lsif_dependency_repos"
 ```
-     Column      |           Type           | Collation | Nullable |                      Default                      
+     Column      |           Type           | Collation | Nullable |                      Default
 -----------------+--------------------------+-----------+----------+---------------------------------------------------
  id              | bigint                   |           | not null | nextval('lsif_dependency_repos_id_seq'::regclass)
- name            | text                     |           | not null | 
- scheme          | text                     |           | not null | 
+ name            | text                     |           | not null |
+ scheme          | text                     |           | not null |
  blocked         | boolean                  |           | not null | false
- last_checked_at | timestamp with time zone |           |          | 
+ last_checked_at | timestamp with time zone |           |          |
 Indexes:
     "lsif_dependency_repos_pkey" PRIMARY KEY, btree (id)
     "lsif_dependency_repos_unique_scheme_name" UNIQUE, btree (scheme, name)
@@ -2236,21 +2238,21 @@ Referenced by:
 
 # Table "public.lsif_dependency_syncing_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                          Default                          
+      Column       |           Type           | Collation | Nullable |                          Default
 -------------------+--------------------------+-----------+----------+-----------------------------------------------------------
  id                | integer                  |           | not null | nextval('lsif_dependency_indexing_jobs_id_seq'::regclass)
  state             | text                     |           | not null | 'queued'::text
- failure_message   | text                     |           |          | 
+ failure_message   | text                     |           |          |
  queued_at         | timestamp with time zone |           | not null | now()
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- execution_logs    | json[]                   |           |          | 
- upload_id         | integer                  |           |          | 
+ execution_logs    | json[]                   |           |          |
+ upload_id         | integer                  |           |          |
  worker_hostname   | text                     |           | not null | ''::text
- last_heartbeat_at | timestamp with time zone |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
  cancel            | boolean                  |           | not null | false
 Indexes:
     "lsif_dependency_indexing_jobs_pkey" PRIMARY KEY, btree (id)
@@ -2267,12 +2269,12 @@ Tracks jobs that scan imports of indexes to schedule auto-index jobs.
 
 # Table "public.lsif_dirty_repositories"
 ```
-    Column     |           Type           | Collation | Nullable | Default 
+    Column     |           Type           | Collation | Nullable | Default
 ---------------+--------------------------+-----------+----------+---------
- repository_id | integer                  |           | not null | 
- dirty_token   | integer                  |           | not null | 
- update_token  | integer                  |           | not null | 
- updated_at    | timestamp with time zone |           |          | 
+ repository_id | integer                  |           | not null |
+ dirty_token   | integer                  |           | not null |
+ update_token  | integer                  |           | not null |
+ updated_at    | timestamp with time zone |           |          |
  set_dirty_at  | timestamp with time zone |           | not null | now()
 Indexes:
     "lsif_dirty_repositories_pkey" PRIMARY KEY, btree (repository_id)
@@ -2289,11 +2291,11 @@ Stores whether or not the nearest upload data for a repository is out of date (w
 
 # Table "public.lsif_index_configuration"
 ```
-      Column       |  Type   | Collation | Nullable |                       Default                        
+      Column       |  Type   | Collation | Nullable |                       Default
 -------------------+---------+-----------+----------+------------------------------------------------------
  id                | bigint  |           | not null | nextval('lsif_index_configuration_id_seq'::regclass)
- repository_id     | integer |           | not null | 
- data              | bytea   |           | not null | 
+ repository_id     | integer |           | not null |
+ data              | bytea   |           | not null |
  autoindex_enabled | boolean |           | not null | true
 Indexes:
     "lsif_index_configuration_pkey" PRIMARY KEY, btree (id)
@@ -2311,33 +2313,33 @@ Stores the configuration used for code intel index jobs for a repository.
 
 # Table "public.lsif_indexes"
 ```
-         Column         |           Type           | Collation | Nullable |                 Default                  
+         Column         |           Type           | Collation | Nullable |                 Default
 ------------------------+--------------------------+-----------+----------+------------------------------------------
  id                     | bigint                   |           | not null | nextval('lsif_indexes_id_seq'::regclass)
- commit                 | text                     |           | not null | 
+ commit                 | text                     |           | not null |
  queued_at              | timestamp with time zone |           | not null | now()
  state                  | text                     |           | not null | 'queued'::text
- failure_message        | text                     |           |          | 
- started_at             | timestamp with time zone |           |          | 
- finished_at            | timestamp with time zone |           |          | 
- repository_id          | integer                  |           | not null | 
- process_after          | timestamp with time zone |           |          | 
+ failure_message        | text                     |           |          |
+ started_at             | timestamp with time zone |           |          |
+ finished_at            | timestamp with time zone |           |          |
+ repository_id          | integer                  |           | not null |
+ process_after          | timestamp with time zone |           |          |
  num_resets             | integer                  |           | not null | 0
  num_failures           | integer                  |           | not null | 0
- docker_steps           | jsonb[]                  |           | not null | 
- root                   | text                     |           | not null | 
- indexer                | text                     |           | not null | 
- indexer_args           | text[]                   |           | not null | 
- outfile                | text                     |           | not null | 
- log_contents           | text                     |           |          | 
- execution_logs         | json[]                   |           |          | 
- local_steps            | text[]                   |           | not null | 
- commit_last_checked_at | timestamp with time zone |           |          | 
+ docker_steps           | jsonb[]                  |           | not null |
+ root                   | text                     |           | not null |
+ indexer                | text                     |           | not null |
+ indexer_args           | text[]                   |           | not null |
+ outfile                | text                     |           | not null |
+ log_contents           | text                     |           |          |
+ execution_logs         | json[]                   |           |          |
+ local_steps            | text[]                   |           | not null |
+ commit_last_checked_at | timestamp with time zone |           |          |
  worker_hostname        | text                     |           | not null | ''::text
- last_heartbeat_at      | timestamp with time zone |           |          | 
+ last_heartbeat_at      | timestamp with time zone |           |          |
  cancel                 | boolean                  |           | not null | false
  should_reindex         | boolean                  |           | not null | false
- requested_envvars      | text[]                   |           |          | 
+ requested_envvars      | text[]                   |           |          |
  enqueuer_user_id       | integer                  |           | not null | 0
 Indexes:
     "lsif_indexes_pkey" PRIMARY KEY, btree (id)
@@ -2373,10 +2375,10 @@ Stores metadata about a code intel index job.
 
 # Table "public.lsif_last_index_scan"
 ```
-       Column       |           Type           | Collation | Nullable | Default 
+       Column       |           Type           | Collation | Nullable | Default
 --------------------+--------------------------+-----------+----------+---------
- repository_id      | integer                  |           | not null | 
- last_index_scan_at | timestamp with time zone |           | not null | 
+ repository_id      | integer                  |           | not null |
+ last_index_scan_at | timestamp with time zone |           | not null |
 Indexes:
     "lsif_last_index_scan_pkey" PRIMARY KEY, btree (repository_id)
 
@@ -2388,10 +2390,10 @@ Tracks the last time repository was checked for auto-indexing job scheduling.
 
 # Table "public.lsif_last_retention_scan"
 ```
-         Column         |           Type           | Collation | Nullable | Default 
+         Column         |           Type           | Collation | Nullable | Default
 ------------------------+--------------------------+-----------+----------+---------
- repository_id          | integer                  |           | not null | 
- last_retention_scan_at | timestamp with time zone |           | not null | 
+ repository_id          | integer                  |           | not null |
+ last_retention_scan_at | timestamp with time zone |           | not null |
 Indexes:
     "lsif_last_retention_scan_pkey" PRIMARY KEY, btree (repository_id)
 
@@ -2403,11 +2405,11 @@ Tracks the last time uploads a repository were checked against data retention po
 
 # Table "public.lsif_nearest_uploads"
 ```
-    Column     |  Type   | Collation | Nullable | Default 
+    Column     |  Type   | Collation | Nullable | Default
 ---------------+---------+-----------+----------+---------
- repository_id | integer |           | not null | 
- commit_bytea  | bytea   |           | not null | 
- uploads       | jsonb   |           | not null | 
+ repository_id | integer |           | not null |
+ commit_bytea  | bytea   |           | not null |
+ uploads       | jsonb   |           | not null |
 Indexes:
     "lsif_nearest_uploads_repository_id_commit_bytea" btree (repository_id, commit_bytea)
     "lsif_nearest_uploads_uploads" gin (uploads)
@@ -2422,12 +2424,12 @@ Associates commits with the complete set of uploads visible from that commit. Ev
 
 # Table "public.lsif_nearest_uploads_links"
 ```
-        Column         |  Type   | Collation | Nullable | Default 
+        Column         |  Type   | Collation | Nullable | Default
 -----------------------+---------+-----------+----------+---------
- repository_id         | integer |           | not null | 
- commit_bytea          | bytea   |           | not null | 
- ancestor_commit_bytea | bytea   |           | not null | 
- distance              | integer |           | not null | 
+ repository_id         | integer |           | not null |
+ commit_bytea          | bytea   |           | not null |
+ ancestor_commit_bytea | bytea   |           | not null |
+ distance              | integer |           | not null |
 Indexes:
     "lsif_nearest_uploads_links_repository_id_ancestor_commit_bytea" btree (repository_id, ancestor_commit_bytea)
     "lsif_nearest_uploads_links_repository_id_commit_bytea" btree (repository_id, commit_bytea)
@@ -2444,13 +2446,13 @@ Associates commits with the closest ancestor commit with usable upload data. Tog
 
 # Table "public.lsif_packages"
 ```
- Column  |  Type   | Collation | Nullable |                  Default                  
+ Column  |  Type   | Collation | Nullable |                  Default
 ---------+---------+-----------+----------+-------------------------------------------
  id      | integer |           | not null | nextval('lsif_packages_id_seq'::regclass)
- scheme  | text    |           | not null | 
- name    | text    |           | not null | 
- version | text    |           |          | 
- dump_id | integer |           | not null | 
+ scheme  | text    |           | not null |
+ name    | text    |           | not null |
+ version | text    |           |          |
+ dump_id | integer |           | not null |
  manager | text    |           | not null | ''::text
 Indexes:
     "lsif_packages_pkey" PRIMARY KEY, btree (id)
@@ -2475,13 +2477,13 @@ Associates an upload with the set of packages they provide within a given packag
 
 # Table "public.lsif_references"
 ```
- Column  |  Type   | Collation | Nullable |                   Default                   
+ Column  |  Type   | Collation | Nullable |                   Default
 ---------+---------+-----------+----------+---------------------------------------------
  id      | integer |           | not null | nextval('lsif_references_id_seq'::regclass)
- scheme  | text    |           | not null | 
- name    | text    |           | not null | 
- version | text    |           |          | 
- dump_id | integer |           | not null | 
+ scheme  | text    |           | not null |
+ name    | text    |           | not null |
+ version | text    |           |          |
+ dump_id | integer |           | not null |
  manager | text    |           | not null | ''::text
 Indexes:
     "lsif_references_pkey" PRIMARY KEY, btree (id)
@@ -2506,12 +2508,12 @@ Associates an upload with the set of packages they require within a given packag
 
 # Table "public.lsif_retention_configuration"
 ```
-                 Column                 |  Type   | Collation | Nullable |                         Default                          
+                 Column                 |  Type   | Collation | Nullable |                         Default
 ----------------------------------------+---------+-----------+----------+----------------------------------------------------------
  id                                     | integer |           | not null | nextval('lsif_retention_configuration_id_seq'::regclass)
- repository_id                          | integer |           | not null | 
- max_age_for_non_stale_branches_seconds | integer |           | not null | 
- max_age_for_non_stale_tags_seconds     | integer |           | not null | 
+ repository_id                          | integer |           | not null |
+ max_age_for_non_stale_branches_seconds | integer |           | not null |
+ max_age_for_non_stale_tags_seconds     | integer |           | not null |
 Indexes:
     "lsif_retention_configuration_pkey" PRIMARY KEY, btree (id)
     "lsif_retention_configuration_repository_id_key" UNIQUE CONSTRAINT, btree (repository_id)
@@ -2528,41 +2530,41 @@ Stores the retention policy of code intellience data for a repository.
 
 # Table "public.lsif_uploads"
 ```
-         Column          |           Type           | Collation | Nullable |                Default                 
+         Column          |           Type           | Collation | Nullable |                Default
 -------------------------+--------------------------+-----------+----------+----------------------------------------
  id                      | integer                  |           | not null | nextval('lsif_dumps_id_seq'::regclass)
- commit                  | text                     |           | not null | 
+ commit                  | text                     |           | not null |
  root                    | text                     |           | not null | ''::text
  uploaded_at             | timestamp with time zone |           | not null | now()
  state                   | text                     |           | not null | 'queued'::text
- failure_message         | text                     |           |          | 
- started_at              | timestamp with time zone |           |          | 
- finished_at             | timestamp with time zone |           |          | 
- repository_id           | integer                  |           | not null | 
- indexer                 | text                     |           | not null | 
- num_parts               | integer                  |           | not null | 
- uploaded_parts          | integer[]                |           | not null | 
- process_after           | timestamp with time zone |           |          | 
+ failure_message         | text                     |           |          |
+ started_at              | timestamp with time zone |           |          |
+ finished_at             | timestamp with time zone |           |          |
+ repository_id           | integer                  |           | not null |
+ indexer                 | text                     |           | not null |
+ num_parts               | integer                  |           | not null |
+ uploaded_parts          | integer[]                |           | not null |
+ process_after           | timestamp with time zone |           |          |
  num_resets              | integer                  |           | not null | 0
- upload_size             | bigint                   |           |          | 
+ upload_size             | bigint                   |           |          |
  num_failures            | integer                  |           | not null | 0
- associated_index_id     | bigint                   |           |          | 
- committed_at            | timestamp with time zone |           |          | 
- commit_last_checked_at  | timestamp with time zone |           |          | 
+ associated_index_id     | bigint                   |           |          |
+ committed_at            | timestamp with time zone |           |          |
+ commit_last_checked_at  | timestamp with time zone |           |          |
  worker_hostname         | text                     |           | not null | ''::text
- last_heartbeat_at       | timestamp with time zone |           |          | 
- execution_logs          | json[]                   |           |          | 
- num_references          | integer                  |           |          | 
+ last_heartbeat_at       | timestamp with time zone |           |          |
+ execution_logs          | json[]                   |           |          |
+ num_references          | integer                  |           |          |
  expired                 | boolean                  |           | not null | false
- last_retention_scan_at  | timestamp with time zone |           |          | 
- reference_count         | integer                  |           |          | 
- indexer_version         | text                     |           |          | 
- queued_at               | timestamp with time zone |           |          | 
+ last_retention_scan_at  | timestamp with time zone |           |          |
+ reference_count         | integer                  |           |          |
+ indexer_version         | text                     |           |          |
+ queued_at               | timestamp with time zone |           |          |
  cancel                  | boolean                  |           | not null | false
- uncompressed_size       | bigint                   |           |          | 
- last_referenced_scan_at | timestamp with time zone |           |          | 
- last_traversal_scan_at  | timestamp with time zone |           |          | 
- last_reconcile_at       | timestamp with time zone |           |          | 
+ uncompressed_size       | bigint                   |           |          |
+ last_referenced_scan_at | timestamp with time zone |           |          |
+ last_traversal_scan_at  | timestamp with time zone |           |          |
+ last_reconcile_at       | timestamp with time zone |           |          |
  content_type            | text                     |           | not null | 'application/x-ndjson+lsif'::text
  should_reindex          | boolean                  |           | not null | false
 Indexes:
@@ -2627,23 +2629,23 @@ Stores metadata about an LSIF index uploaded by a user.
 
 # Table "public.lsif_uploads_audit_logs"
 ```
-       Column        |           Type           | Collation | Nullable |                     Default                      
+       Column        |           Type           | Collation | Nullable |                     Default
 ---------------------+--------------------------+-----------+----------+--------------------------------------------------
  log_timestamp       | timestamp with time zone |           |          | now()
- record_deleted_at   | timestamp with time zone |           |          | 
- upload_id           | integer                  |           | not null | 
- commit              | text                     |           | not null | 
- root                | text                     |           | not null | 
- repository_id       | integer                  |           | not null | 
- uploaded_at         | timestamp with time zone |           | not null | 
- indexer             | text                     |           | not null | 
- indexer_version     | text                     |           |          | 
- upload_size         | bigint                   |           |          | 
- associated_index_id | integer                  |           |          | 
- transition_columns  | USER-DEFINED[]           |           |          | 
+ record_deleted_at   | timestamp with time zone |           |          |
+ upload_id           | integer                  |           | not null |
+ commit              | text                     |           | not null |
+ root                | text                     |           | not null |
+ repository_id       | integer                  |           | not null |
+ uploaded_at         | timestamp with time zone |           | not null |
+ indexer             | text                     |           | not null |
+ indexer_version     | text                     |           |          |
+ upload_size         | bigint                   |           |          |
+ associated_index_id | integer                  |           |          |
+ transition_columns  | USER-DEFINED[]           |           |          |
  reason              | text                     |           |          | ''::text
  sequence            | bigint                   |           | not null | nextval('lsif_uploads_audit_logs_seq'::regclass)
- operation           | audit_log_operation      |           | not null | 
+ operation           | audit_log_operation      |           | not null |
  content_type        | text                     |           | not null | 'application/x-ndjson+lsif'::text
 Indexes:
     "lsif_uploads_audit_logs_timestamp" brin (log_timestamp)
@@ -2661,10 +2663,10 @@ Indexes:
 
 # Table "public.lsif_uploads_reference_counts"
 ```
-     Column      |  Type   | Collation | Nullable | Default 
+     Column      |  Type   | Collation | Nullable | Default
 -----------------+---------+-----------+----------+---------
- upload_id       | integer |           | not null | 
- reference_count | integer |           | not null | 
+ upload_id       | integer |           | not null |
+ reference_count | integer |           | not null |
 Indexes:
     "lsif_uploads_reference_counts_upload_id_key" UNIQUE CONSTRAINT, btree (upload_id)
 Foreign-key constraints:
@@ -2680,10 +2682,10 @@ A less hot-path reference count for upload records.
 
 # Table "public.lsif_uploads_visible_at_tip"
 ```
-       Column       |  Type   | Collation | Nullable | Default  
+       Column       |  Type   | Collation | Nullable | Default
 --------------------+---------+-----------+----------+----------
- repository_id      | integer |           | not null | 
- upload_id          | integer |           | not null | 
+ repository_id      | integer |           | not null |
+ upload_id          | integer |           | not null |
  branch_or_tag_name | text    |           | not null | ''::text
  is_default_branch  | boolean |           | not null | false
 Indexes:
@@ -2702,10 +2704,10 @@ Associates a repository with the set of LSIF upload identifiers that can serve i
 
 # Table "public.lsif_uploads_vulnerability_scan"
 ```
-     Column      |            Type             | Collation | Nullable |                           Default                           
+     Column      |            Type             | Collation | Nullable |                           Default
 -----------------+-----------------------------+-----------+----------+-------------------------------------------------------------
  id              | bigint                      |           | not null | nextval('lsif_uploads_vulnerability_scan_id_seq'::regclass)
- upload_id       | integer                     |           | not null | 
+ upload_id       | integer                     |           | not null |
  last_scanned_at | timestamp without time zone |           | not null | now()
 Indexes:
     "lsif_uploads_vulnerability_scan_pkey" PRIMARY KEY, btree (id)
@@ -2717,17 +2719,17 @@ Foreign-key constraints:
 
 # Table "public.migration_logs"
 ```
-            Column             |           Type           | Collation | Nullable |                  Default                   
+            Column             |           Type           | Collation | Nullable |                  Default
 -------------------------------+--------------------------+-----------+----------+--------------------------------------------
  id                            | integer                  |           | not null | nextval('migration_logs_id_seq'::regclass)
- migration_logs_schema_version | integer                  |           | not null | 
- schema                        | text                     |           | not null | 
- version                       | integer                  |           | not null | 
- up                            | boolean                  |           | not null | 
- started_at                    | timestamp with time zone |           | not null | 
- finished_at                   | timestamp with time zone |           |          | 
- success                       | boolean                  |           |          | 
- error_message                 | text                     |           |          | 
+ migration_logs_schema_version | integer                  |           | not null |
+ schema                        | text                     |           | not null |
+ version                       | integer                  |           | not null |
+ up                            | boolean                  |           | not null |
+ started_at                    | timestamp with time zone |           | not null |
+ finished_at                   | timestamp with time zone |           |          |
+ success                       | boolean                  |           |          |
+ error_message                 | text                     |           |          |
  backfilled                    | boolean                  |           | not null | false
 Indexes:
     "migration_logs_pkey" PRIMARY KEY, btree (id)
@@ -2736,12 +2738,12 @@ Indexes:
 
 # Table "public.names"
 ```
- Column  |  Type   | Collation | Nullable | Default 
+ Column  |  Type   | Collation | Nullable | Default
 ---------+---------+-----------+----------+---------
- name    | citext  |           | not null | 
- user_id | integer |           |          | 
- org_id  | integer |           |          | 
- team_id | integer |           |          | 
+ name    | citext  |           | not null |
+ user_id | integer |           |          |
+ org_id  | integer |           |          |
+ team_id | integer |           |          |
 Indexes:
     "names_pkey" PRIMARY KEY, btree (name)
 Check constraints:
@@ -2755,12 +2757,12 @@ Foreign-key constraints:
 
 # Table "public.namespace_permissions"
 ```
-   Column    |           Type           | Collation | Nullable |                      Default                      
+   Column    |           Type           | Collation | Nullable |                      Default
 -------------+--------------------------+-----------+----------+---------------------------------------------------
  id          | integer                  |           | not null | nextval('namespace_permissions_id_seq'::regclass)
- namespace   | text                     |           | not null | 
- resource_id | integer                  |           | not null | 
- user_id     | integer                  |           | not null | 
+ namespace   | text                     |           | not null |
+ resource_id | integer                  |           | not null |
+ user_id     | integer                  |           | not null |
  created_at  | timestamp with time zone |           | not null | now()
 Indexes:
     "namespace_permissions_pkey" PRIMARY KEY, btree (id)
@@ -2774,10 +2776,10 @@ Foreign-key constraints:
 
 # Table "public.notebook_stars"
 ```
-   Column    |           Type           | Collation | Nullable | Default 
+   Column    |           Type           | Collation | Nullable | Default
 -------------+--------------------------+-----------+----------+---------
- notebook_id | integer                  |           | not null | 
- user_id     | integer                  |           | not null | 
+ notebook_id | integer                  |           | not null |
+ user_id     | integer                  |           | not null |
  created_at  | timestamp with time zone |           | not null | now()
 Indexes:
     "notebook_stars_pkey" PRIMARY KEY, btree (notebook_id, user_id)
@@ -2790,19 +2792,19 @@ Foreign-key constraints:
 
 # Table "public.notebooks"
 ```
-      Column       |           Type           | Collation | Nullable |                                              Default                                              
+      Column       |           Type           | Collation | Nullable |                                              Default
 -------------------+--------------------------+-----------+----------+---------------------------------------------------------------------------------------------------
  id                | bigint                   |           | not null | nextval('notebooks_id_seq'::regclass)
- title             | text                     |           | not null | 
+ title             | text                     |           | not null |
  blocks            | jsonb                    |           | not null | '[]'::jsonb
- public            | boolean                  |           | not null | 
- creator_user_id   | integer                  |           |          | 
+ public            | boolean                  |           | not null |
+ creator_user_id   | integer                  |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
  blocks_tsvector   | tsvector                 |           |          | generated always as (jsonb_to_tsvector('english'::regconfig, blocks, '["string"]'::jsonb)) stored
- namespace_user_id | integer                  |           |          | 
- namespace_org_id  | integer                  |           |          | 
- updater_user_id   | integer                  |           |          | 
+ namespace_user_id | integer                  |           |          |
+ namespace_org_id  | integer                  |           |          |
+ updater_user_id   | integer                  |           |          |
 Indexes:
     "notebooks_pkey" PRIMARY KEY, btree (id)
     "notebooks_blocks_tsvector_idx" gin (blocks_tsvector)
@@ -2824,20 +2826,20 @@ Referenced by:
 
 # Table "public.org_invitations"
 ```
-      Column       |           Type           | Collation | Nullable |                   Default                   
+      Column       |           Type           | Collation | Nullable |                   Default
 -------------------+--------------------------+-----------+----------+---------------------------------------------
  id                | bigint                   |           | not null | nextval('org_invitations_id_seq'::regclass)
- org_id            | integer                  |           | not null | 
- sender_user_id    | integer                  |           | not null | 
- recipient_user_id | integer                  |           |          | 
+ org_id            | integer                  |           | not null |
+ sender_user_id    | integer                  |           | not null |
+ recipient_user_id | integer                  |           |          |
  created_at        | timestamp with time zone |           | not null | now()
- notified_at       | timestamp with time zone |           |          | 
- responded_at      | timestamp with time zone |           |          | 
- response_type     | boolean                  |           |          | 
- revoked_at        | timestamp with time zone |           |          | 
- deleted_at        | timestamp with time zone |           |          | 
- recipient_email   | citext                   |           |          | 
- expires_at        | timestamp with time zone |           |          | 
+ notified_at       | timestamp with time zone |           |          |
+ responded_at      | timestamp with time zone |           |          |
+ response_type     | boolean                  |           |          |
+ revoked_at        | timestamp with time zone |           |          |
+ deleted_at        | timestamp with time zone |           |          |
+ recipient_email   | citext                   |           |          |
+ expires_at        | timestamp with time zone |           |          |
 Indexes:
     "org_invitations_pkey" PRIMARY KEY, btree (id)
     "org_invitations_org_id" btree (org_id) WHERE deleted_at IS NULL
@@ -2855,13 +2857,13 @@ Foreign-key constraints:
 
 # Table "public.org_members"
 ```
-   Column   |           Type           | Collation | Nullable |                 Default                 
+   Column   |           Type           | Collation | Nullable |                 Default
 ------------+--------------------------+-----------+----------+-----------------------------------------
  id         | integer                  |           | not null | nextval('org_members_id_seq'::regclass)
- org_id     | integer                  |           | not null | 
+ org_id     | integer                  |           | not null |
  created_at | timestamp with time zone |           | not null | now()
  updated_at | timestamp with time zone |           | not null | now()
- user_id    | integer                  |           | not null | 
+ user_id    | integer                  |           | not null |
 Indexes:
     "org_members_pkey" PRIMARY KEY, btree (id)
     "org_members_org_id_user_id_key" UNIQUE CONSTRAINT, btree (org_id, user_id)
@@ -2873,9 +2875,9 @@ Foreign-key constraints:
 
 # Table "public.org_stats"
 ```
-        Column        |           Type           | Collation | Nullable | Default 
+        Column        |           Type           | Collation | Nullable | Default
 ----------------------+--------------------------+-----------+----------+---------
- org_id               | integer                  |           | not null | 
+ org_id               | integer                  |           | not null |
  code_host_repo_count | integer                  |           |          | 0
  updated_at           | timestamp with time zone |           | not null | now()
 Indexes:
@@ -2893,15 +2895,15 @@ Business statistics for organizations
 
 # Table "public.orgs"
 ```
-      Column       |           Type           | Collation | Nullable |             Default              
+      Column       |           Type           | Collation | Nullable |             Default
 -------------------+--------------------------+-----------+----------+----------------------------------
  id                | integer                  |           | not null | nextval('orgs_id_seq'::regclass)
- name              | citext                   |           | not null | 
+ name              | citext                   |           | not null |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- display_name      | text                     |           |          | 
- slack_webhook_url | text                     |           |          | 
- deleted_at        | timestamp with time zone |           |          | 
+ display_name      | text                     |           |          |
+ slack_webhook_url | text                     |           |          |
+ deleted_at        | timestamp with time zone |           |          |
 Indexes:
     "orgs_pkey" PRIMARY KEY, btree (id)
     "orgs_name" UNIQUE, btree (name) WHERE deleted_at IS NULL
@@ -2931,11 +2933,11 @@ Referenced by:
 
 # Table "public.orgs_open_beta_stats"
 ```
-   Column   |           Type           | Collation | Nullable |      Default      
+   Column   |           Type           | Collation | Nullable |      Default
 ------------+--------------------------+-----------+----------+-------------------
  id         | uuid                     |           | not null | gen_random_uuid()
- user_id    | integer                  |           |          | 
- org_id     | integer                  |           |          | 
+ user_id    | integer                  |           |          |
+ org_id     | integer                  |           |          |
  created_at | timestamp with time zone |           |          | now()
  data       | jsonb                    |           | not null | '{}'::jsonb
 Indexes:
@@ -2945,22 +2947,22 @@ Indexes:
 
 # Table "public.out_of_band_migrations"
 ```
-          Column          |           Type           | Collation | Nullable |                      Default                       
+          Column          |           Type           | Collation | Nullable |                      Default
 --------------------------+--------------------------+-----------+----------+----------------------------------------------------
  id                       | integer                  |           | not null | nextval('out_of_band_migrations_id_seq'::regclass)
- team                     | text                     |           | not null | 
- component                | text                     |           | not null | 
- description              | text                     |           | not null | 
+ team                     | text                     |           | not null |
+ component                | text                     |           | not null |
+ description              | text                     |           | not null |
  progress                 | double precision         |           | not null | 0
- created                  | timestamp with time zone |           | not null | 
- last_updated             | timestamp with time zone |           |          | 
- non_destructive          | boolean                  |           | not null | 
+ created                  | timestamp with time zone |           | not null |
+ last_updated             | timestamp with time zone |           |          |
+ non_destructive          | boolean                  |           | not null |
  apply_reverse            | boolean                  |           | not null | false
  is_enterprise            | boolean                  |           | not null | false
- introduced_version_major | integer                  |           | not null | 
- introduced_version_minor | integer                  |           | not null | 
- deprecated_version_major | integer                  |           |          | 
- deprecated_version_minor | integer                  |           |          | 
+ introduced_version_major | integer                  |           | not null |
+ introduced_version_minor | integer                  |           | not null |
+ deprecated_version_major | integer                  |           |          |
+ deprecated_version_minor | integer                  |           |          |
  metadata                 | jsonb                    |           | not null | '{}'::jsonb
 Indexes:
     "out_of_band_migrations_pkey" PRIMARY KEY, btree (id)
@@ -3006,11 +3008,11 @@ Stores metadata and progress about an out-of-band migration routine.
 
 # Table "public.out_of_band_migrations_errors"
 ```
-    Column    |           Type           | Collation | Nullable |                          Default                          
+    Column    |           Type           | Collation | Nullable |                          Default
 --------------+--------------------------+-----------+----------+-----------------------------------------------------------
  id           | integer                  |           | not null | nextval('out_of_band_migrations_errors_id_seq'::regclass)
- migration_id | integer                  |           | not null | 
- message      | text                     |           | not null | 
+ migration_id | integer                  |           | not null |
+ message      | text                     |           | not null |
  created      | timestamp with time zone |           | not null | now()
 Indexes:
     "out_of_band_migrations_errors_pkey" PRIMARY KEY, btree (id)
@@ -3033,12 +3035,12 @@ Stores errors that occurred while performing an out-of-band migration.
 
 # Table "public.outbound_webhook_event_types"
 ```
-       Column        |  Type  | Collation | Nullable |                         Default                          
+       Column        |  Type  | Collation | Nullable |                         Default
 ---------------------+--------+-----------+----------+----------------------------------------------------------
  id                  | bigint |           | not null | nextval('outbound_webhook_event_types_id_seq'::regclass)
- outbound_webhook_id | bigint |           | not null | 
- event_type          | text   |           | not null | 
- scope               | text   |           |          | 
+ outbound_webhook_id | bigint |           | not null |
+ event_type          | text   |           | not null |
+ scope               | text   |           |          |
 Indexes:
     "outbound_webhook_event_types_pkey" PRIMARY KEY, btree (id)
     "outbound_webhook_event_types_event_type_idx" btree (event_type, scope)
@@ -3049,23 +3051,23 @@ Foreign-key constraints:
 
 # Table "public.outbound_webhook_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                      Default                      
+      Column       |           Type           | Collation | Nullable |                      Default
 -------------------+--------------------------+-----------+----------+---------------------------------------------------
  id                | bigint                   |           | not null | nextval('outbound_webhook_jobs_id_seq'::regclass)
- event_type        | text                     |           | not null | 
- scope             | text                     |           |          | 
- encryption_key_id | text                     |           |          | 
- payload           | bytea                    |           | not null | 
+ event_type        | text                     |           | not null |
+ scope             | text                     |           |          |
+ encryption_key_id | text                     |           |          |
+ payload           | bytea                    |           | not null |
  state             | text                     |           | not null | 'queued'::text
- failure_message   | text                     |           |          | 
+ failure_message   | text                     |           |          |
  queued_at         | timestamp with time zone |           | not null | now()
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
+ execution_logs    | json[]                   |           |          |
  worker_hostname   | text                     |           | not null | ''::text
  cancel            | boolean                  |           | not null | false
 Indexes:
@@ -3079,17 +3081,17 @@ Referenced by:
 
 # Table "public.outbound_webhook_logs"
 ```
-       Column        |           Type           | Collation | Nullable |                      Default                      
+       Column        |           Type           | Collation | Nullable |                      Default
 ---------------------+--------------------------+-----------+----------+---------------------------------------------------
  id                  | bigint                   |           | not null | nextval('outbound_webhook_logs_id_seq'::regclass)
- job_id              | bigint                   |           | not null | 
- outbound_webhook_id | bigint                   |           | not null | 
+ job_id              | bigint                   |           | not null |
+ outbound_webhook_id | bigint                   |           | not null |
  sent_at             | timestamp with time zone |           | not null | now()
- status_code         | integer                  |           | not null | 
- encryption_key_id   | text                     |           |          | 
- request             | bytea                    |           | not null | 
- response            | bytea                    |           | not null | 
- error               | bytea                    |           | not null | 
+ status_code         | integer                  |           | not null |
+ encryption_key_id   | text                     |           |          |
+ request             | bytea                    |           | not null |
+ response            | bytea                    |           | not null |
+ error               | bytea                    |           | not null |
 Indexes:
     "outbound_webhook_logs_pkey" PRIMARY KEY, btree (id)
     "outbound_webhook_logs_outbound_webhook_id_idx" btree (outbound_webhook_id)
@@ -3102,16 +3104,16 @@ Foreign-key constraints:
 
 # Table "public.outbound_webhooks"
 ```
-      Column       |           Type           | Collation | Nullable |                    Default                    
+      Column       |           Type           | Collation | Nullable |                    Default
 -------------------+--------------------------+-----------+----------+-----------------------------------------------
  id                | bigint                   |           | not null | nextval('outbound_webhooks_id_seq'::regclass)
- created_by        | integer                  |           |          | 
+ created_by        | integer                  |           |          |
  created_at        | timestamp with time zone |           | not null | now()
- updated_by        | integer                  |           |          | 
+ updated_by        | integer                  |           |          |
  updated_at        | timestamp with time zone |           | not null | now()
- encryption_key_id | text                     |           |          | 
- url               | bytea                    |           | not null | 
- secret            | bytea                    |           | not null | 
+ encryption_key_id | text                     |           |          |
+ url               | bytea                    |           | not null |
+ secret            | bytea                    |           | not null |
 Indexes:
     "outbound_webhooks_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -3125,11 +3127,11 @@ Referenced by:
 
 # Table "public.own_aggregate_recent_contribution"
 ```
-        Column        |  Type   | Collation | Nullable |                            Default                            
+        Column        |  Type   | Collation | Nullable |                            Default
 ----------------------+---------+-----------+----------+---------------------------------------------------------------
  id                   | integer |           | not null | nextval('own_aggregate_recent_contribution_id_seq'::regclass)
- commit_author_id     | integer |           | not null | 
- changed_file_path_id | integer |           | not null | 
+ commit_author_id     | integer |           | not null |
+ changed_file_path_id | integer |           | not null |
  contributions_count  | integer |           |          | 0
 Indexes:
     "own_aggregate_recent_contribution_pkey" PRIMARY KEY, btree (id)
@@ -3142,11 +3144,11 @@ Foreign-key constraints:
 
 # Table "public.own_aggregate_recent_view"
 ```
-       Column        |  Type   | Collation | Nullable |                        Default                        
+       Column        |  Type   | Collation | Nullable |                        Default
 ---------------------+---------+-----------+----------+-------------------------------------------------------
  id                  | integer |           | not null | nextval('own_aggregate_recent_view_id_seq'::regclass)
- viewer_id           | integer |           | not null | 
- viewed_file_path_id | integer |           | not null | 
+ viewer_id           | integer |           | not null |
+ viewed_file_path_id | integer |           | not null |
  views_count         | integer |           |          | 0
 Indexes:
     "own_aggregate_recent_view_pkey" PRIMARY KEY, btree (id)
@@ -3161,23 +3163,23 @@ One entry contains a number of views of a single file by a given viewer.
 
 # Table "public.own_background_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                     Default                     
+      Column       |           Type           | Collation | Nullable |                     Default
 -------------------+--------------------------+-----------+----------+-------------------------------------------------
  id                | integer                  |           | not null | nextval('own_background_jobs_id_seq'::regclass)
  state             | text                     |           |          | 'queued'::text
- failure_message   | text                     |           |          | 
+ failure_message   | text                     |           |          |
  queued_at         | timestamp with time zone |           |          | now()
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
+ execution_logs    | json[]                   |           |          |
  worker_hostname   | text                     |           | not null | ''::text
  cancel            | boolean                  |           | not null | false
- repo_id           | integer                  |           | not null | 
- job_type          | integer                  |           | not null | 
+ repo_id           | integer                  |           | not null |
+ job_type          | integer                  |           | not null |
 Indexes:
     "own_background_jobs_pkey" PRIMARY KEY, btree (id)
     "own_background_jobs_repo_id_idx" btree (repo_id)
@@ -3187,12 +3189,12 @@ Indexes:
 
 # Table "public.own_signal_configurations"
 ```
-         Column         |  Type   | Collation | Nullable |                        Default                        
+         Column         |  Type   | Collation | Nullable |                        Default
 ------------------------+---------+-----------+----------+-------------------------------------------------------
  id                     | integer |           | not null | nextval('own_signal_configurations_id_seq'::regclass)
- name                   | text    |           | not null | 
+ name                   | text    |           | not null |
  description            | text    |           | not null | ''::text
- excluded_repo_patterns | text[]  |           |          | 
+ excluded_repo_patterns | text[]  |           |          |
  enabled                | boolean |           | not null | false
 Indexes:
     "own_signal_configurations_pkey" PRIMARY KEY, btree (id)
@@ -3202,13 +3204,13 @@ Indexes:
 
 # Table "public.own_signal_recent_contribution"
 ```
-        Column        |            Type             | Collation | Nullable |                          Default                           
+        Column        |            Type             | Collation | Nullable |                          Default
 ----------------------+-----------------------------+-----------+----------+------------------------------------------------------------
  id                   | integer                     |           | not null | nextval('own_signal_recent_contribution_id_seq'::regclass)
- commit_author_id     | integer                     |           | not null | 
- changed_file_path_id | integer                     |           | not null | 
- commit_timestamp     | timestamp without time zone |           | not null | 
- commit_id            | bytea                       |           | not null | 
+ commit_author_id     | integer                     |           | not null |
+ changed_file_path_id | integer                     |           | not null |
+ commit_timestamp     | timestamp without time zone |           | not null |
+ commit_id            | bytea                       |           | not null |
 Indexes:
     "own_signal_recent_contribution_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -3223,13 +3225,13 @@ One entry per file changed in every commit that classifies as a contribution sig
 
 # Table "public.ownership_path_stats"
 ```
-               Column                |            Type             | Collation | Nullable | Default 
+               Column                |            Type             | Collation | Nullable | Default
 -------------------------------------+-----------------------------+-----------+----------+---------
- file_path_id                        | integer                     |           | not null | 
- tree_codeowned_files_count          | integer                     |           |          | 
- last_updated_at                     | timestamp without time zone |           | not null | 
- tree_assigned_ownership_files_count | integer                     |           |          | 
- tree_any_ownership_files_count      | integer                     |           |          | 
+ file_path_id                        | integer                     |           | not null |
+ tree_codeowned_files_count          | integer                     |           |          |
+ last_updated_at                     | timestamp without time zone |           | not null |
+ tree_assigned_ownership_files_count | integer                     |           |          |
+ tree_any_ownership_files_count      | integer                     |           |          |
 Indexes:
     "ownership_path_stats_pkey" PRIMARY KEY, btree (file_path_id)
 Foreign-key constraints:
@@ -3248,13 +3250,13 @@ or assigned ownership), and perhaps files count by assigned ownership only.
 
 # Table "public.package_repo_filters"
 ```
-   Column   |           Type           | Collation | Nullable |                     Default                      
+   Column   |           Type           | Collation | Nullable |                     Default
 ------------+--------------------------+-----------+----------+--------------------------------------------------
  id         | integer                  |           | not null | nextval('package_repo_filters_id_seq'::regclass)
- behaviour  | text                     |           | not null | 
- scheme     | text                     |           | not null | 
- matcher    | jsonb                    |           | not null | 
- deleted_at | timestamp with time zone |           |          | 
+ behaviour  | text                     |           | not null |
+ scheme     | text                     |           | not null |
+ matcher    | jsonb                    |           | not null |
+ deleted_at | timestamp with time zone |           |          |
  updated_at | timestamp with time zone |           | not null | statement_timestamp()
 Indexes:
     "package_repo_filters_pkey" PRIMARY KEY, btree (id)
@@ -3270,13 +3272,13 @@ Triggers:
 
 # Table "public.package_repo_versions"
 ```
-     Column      |           Type           | Collation | Nullable |                      Default                      
+     Column      |           Type           | Collation | Nullable |                      Default
 -----------------+--------------------------+-----------+----------+---------------------------------------------------
  id              | bigint                   |           | not null | nextval('package_repo_versions_id_seq'::regclass)
- package_id      | bigint                   |           | not null | 
- version         | text                     |           | not null | 
+ package_id      | bigint                   |           | not null |
+ version         | text                     |           | not null |
  blocked         | boolean                  |           | not null | false
- last_checked_at | timestamp with time zone |           |          | 
+ last_checked_at | timestamp with time zone |           |          |
 Indexes:
     "package_repo_versions_pkey" PRIMARY KEY, btree (id)
     "package_repo_versions_unique_version_per_package" UNIQUE, btree (package_id, version)
@@ -3289,33 +3291,33 @@ Foreign-key constraints:
 
 # Table "public.permission_sync_jobs"
 ```
-        Column        |           Type           | Collation | Nullable |                     Default                      
+        Column        |           Type           | Collation | Nullable |                     Default
 ----------------------+--------------------------+-----------+----------+--------------------------------------------------
  id                   | integer                  |           | not null | nextval('permission_sync_jobs_id_seq'::regclass)
  state                | text                     |           |          | 'queued'::text
- reason               | text                     |           | not null | 
- failure_message      | text                     |           |          | 
+ reason               | text                     |           | not null |
+ failure_message      | text                     |           |          |
  queued_at            | timestamp with time zone |           |          | now()
- started_at           | timestamp with time zone |           |          | 
- finished_at          | timestamp with time zone |           |          | 
- process_after        | timestamp with time zone |           |          | 
+ started_at           | timestamp with time zone |           |          |
+ finished_at          | timestamp with time zone |           |          |
+ process_after        | timestamp with time zone |           |          |
  num_resets           | integer                  |           | not null | 0
  num_failures         | integer                  |           | not null | 0
- last_heartbeat_at    | timestamp with time zone |           |          | 
- execution_logs       | json[]                   |           |          | 
+ last_heartbeat_at    | timestamp with time zone |           |          |
+ execution_logs       | json[]                   |           |          |
  worker_hostname      | text                     |           | not null | ''::text
  cancel               | boolean                  |           | not null | false
- repository_id        | integer                  |           |          | 
- user_id              | integer                  |           |          | 
- triggered_by_user_id | integer                  |           |          | 
+ repository_id        | integer                  |           |          |
+ user_id              | integer                  |           |          |
+ triggered_by_user_id | integer                  |           |          |
  priority             | integer                  |           | not null | 0
  invalidate_caches    | boolean                  |           | not null | false
- cancellation_reason  | text                     |           |          | 
+ cancellation_reason  | text                     |           |          |
  no_perms             | boolean                  |           | not null | false
  permissions_added    | integer                  |           | not null | 0
  permissions_removed  | integer                  |           | not null | 0
  permissions_found    | integer                  |           | not null | 0
- code_host_states     | json[]                   |           |          | 
+ code_host_states     | json[]                   |           |          |
  is_partial_success   | boolean                  |           |          | false
 Indexes:
     "permission_sync_jobs_pkey" PRIMARY KEY, btree (id)
@@ -3343,11 +3345,11 @@ Foreign-key constraints:
 
 # Table "public.permissions"
 ```
-   Column   |           Type           | Collation | Nullable |                 Default                 
+   Column   |           Type           | Collation | Nullable |                 Default
 ------------+--------------------------+-----------+----------+-----------------------------------------
  id         | integer                  |           | not null | nextval('permissions_id_seq'::regclass)
- namespace  | text                     |           | not null | 
- action     | text                     |           | not null | 
+ namespace  | text                     |           | not null |
+ action     | text                     |           | not null |
  created_at | timestamp with time zone |           | not null | now()
 Indexes:
     "permissions_pkey" PRIMARY KEY, btree (id)
@@ -3362,14 +3364,14 @@ Referenced by:
 
 # Table "public.phabricator_repos"
 ```
-   Column   |           Type           | Collation | Nullable |                    Default                    
+   Column   |           Type           | Collation | Nullable |                    Default
 ------------+--------------------------+-----------+----------+-----------------------------------------------
  id         | integer                  |           | not null | nextval('phabricator_repos_id_seq'::regclass)
- callsign   | citext                   |           | not null | 
- repo_name  | citext                   |           | not null | 
+ callsign   | citext                   |           | not null |
+ repo_name  | citext                   |           | not null |
  created_at | timestamp with time zone |           | not null | now()
  updated_at | timestamp with time zone |           | not null | now()
- deleted_at | timestamp with time zone |           |          | 
+ deleted_at | timestamp with time zone |           |          |
  url        | text                     |           | not null | ''::text
 Indexes:
     "phabricator_repos_pkey" PRIMARY KEY, btree (id)
@@ -3379,23 +3381,23 @@ Indexes:
 
 # Table "public.product_licenses"
 ```
-         Column          |           Type           | Collation | Nullable | Default 
+         Column          |           Type           | Collation | Nullable | Default
 -------------------------+--------------------------+-----------+----------+---------
- id                      | uuid                     |           | not null | 
- product_subscription_id | uuid                     |           | not null | 
- license_key             | text                     |           | not null | 
+ id                      | uuid                     |           | not null |
+ product_subscription_id | uuid                     |           | not null |
+ license_key             | text                     |           | not null |
  created_at              | timestamp with time zone |           | not null | now()
- license_version         | integer                  |           |          | 
- license_tags            | text[]                   |           |          | 
- license_user_count      | integer                  |           |          | 
- license_expires_at      | timestamp with time zone |           |          | 
+ license_version         | integer                  |           |          |
+ license_tags            | text[]                   |           |          |
+ license_user_count      | integer                  |           |          |
+ license_expires_at      | timestamp with time zone |           |          |
  access_token_enabled    | boolean                  |           | not null | true
- site_id                 | uuid                     |           |          | 
- license_check_token     | bytea                    |           |          | 
- revoked_at              | timestamp with time zone |           |          | 
- salesforce_sub_id       | text                     |           |          | 
- salesforce_opp_id       | text                     |           |          | 
- revoke_reason           | text                     |           |          | 
+ site_id                 | uuid                     |           |          |
+ license_check_token     | bytea                    |           |          |
+ revoked_at              | timestamp with time zone |           |          |
+ salesforce_sub_id       | text                     |           |          |
+ salesforce_opp_id       | text                     |           |          |
+ revoke_reason           | text                     |           |          |
 Indexes:
     "product_licenses_pkey" PRIMARY KEY, btree (id)
     "product_licenses_license_check_token_idx" UNIQUE, btree (license_check_token)
@@ -3408,25 +3410,25 @@ Foreign-key constraints:
 
 # Table "public.product_subscriptions"
 ```
-                      Column                       |           Type           | Collation | Nullable | Default 
+                      Column                       |           Type           | Collation | Nullable | Default
 ---------------------------------------------------+--------------------------+-----------+----------+---------
- id                                                | uuid                     |           | not null | 
- user_id                                           | integer                  |           | not null | 
- billing_subscription_id                           | text                     |           |          | 
+ id                                                | uuid                     |           | not null |
+ user_id                                           | integer                  |           | not null |
+ billing_subscription_id                           | text                     |           |          |
  created_at                                        | timestamp with time zone |           | not null | now()
  updated_at                                        | timestamp with time zone |           | not null | now()
- archived_at                                       | timestamp with time zone |           |          | 
- account_number                                    | text                     |           |          | 
+ archived_at                                       | timestamp with time zone |           |          |
+ account_number                                    | text                     |           |          |
  cody_gateway_enabled                              | boolean                  |           | not null | false
- cody_gateway_chat_rate_limit                      | bigint                   |           |          | 
- cody_gateway_chat_rate_interval_seconds           | integer                  |           |          | 
- cody_gateway_embeddings_api_rate_limit            | bigint                   |           |          | 
- cody_gateway_embeddings_api_rate_interval_seconds | integer                  |           |          | 
- cody_gateway_embeddings_api_allowed_models        | text[]                   |           |          | 
- cody_gateway_chat_rate_limit_allowed_models       | text[]                   |           |          | 
- cody_gateway_code_rate_limit                      | bigint                   |           |          | 
- cody_gateway_code_rate_interval_seconds           | integer                  |           |          | 
- cody_gateway_code_rate_limit_allowed_models       | text[]                   |           |          | 
+ cody_gateway_chat_rate_limit                      | bigint                   |           |          |
+ cody_gateway_chat_rate_interval_seconds           | integer                  |           |          |
+ cody_gateway_embeddings_api_rate_limit            | bigint                   |           |          |
+ cody_gateway_embeddings_api_rate_interval_seconds | integer                  |           |          |
+ cody_gateway_embeddings_api_allowed_models        | text[]                   |           |          |
+ cody_gateway_chat_rate_limit_allowed_models       | text[]                   |           |          |
+ cody_gateway_code_rate_limit                      | bigint                   |           |          |
+ cody_gateway_code_rate_interval_seconds           | integer                  |           |          |
+ cody_gateway_code_rate_limit_allowed_models       | text[]                   |           |          |
 Indexes:
     "product_subscriptions_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -3444,22 +3446,22 @@ Referenced by:
 
 # Table "public.query_runner_state"
 ```
-      Column      |           Type           | Collation | Nullable | Default 
+      Column      |           Type           | Collation | Nullable | Default
 ------------------+--------------------------+-----------+----------+---------
- query            | text                     |           |          | 
- last_executed    | timestamp with time zone |           |          | 
- latest_result    | timestamp with time zone |           |          | 
- exec_duration_ns | bigint                   |           |          | 
+ query            | text                     |           |          |
+ last_executed    | timestamp with time zone |           |          |
+ latest_result    | timestamp with time zone |           |          |
+ exec_duration_ns | bigint                   |           |          |
 
 ```
 
 # Table "public.redis_key_value"
 ```
-  Column   | Type  | Collation | Nullable | Default 
+  Column   | Type  | Collation | Nullable | Default
 -----------+-------+-----------+----------+---------
- namespace | text  |           | not null | 
- key       | text  |           | not null | 
- value     | bytea |           | not null | 
+ namespace | text  |           | not null |
+ key       | text  |           | not null |
+ value     | bytea |           | not null |
 Indexes:
     "redis_key_value_pkey" PRIMARY KEY, btree (namespace, key) INCLUDE (value)
 
@@ -3467,18 +3469,18 @@ Indexes:
 
 # Table "public.registry_extension_releases"
 ```
-        Column         |           Type           | Collation | Nullable |                         Default                         
+        Column         |           Type           | Collation | Nullable |                         Default
 -----------------------+--------------------------+-----------+----------+---------------------------------------------------------
  id                    | bigint                   |           | not null | nextval('registry_extension_releases_id_seq'::regclass)
- registry_extension_id | integer                  |           | not null | 
- creator_user_id       | integer                  |           | not null | 
- release_version       | citext                   |           |          | 
- release_tag           | citext                   |           | not null | 
- manifest              | jsonb                    |           | not null | 
- bundle                | text                     |           |          | 
+ registry_extension_id | integer                  |           | not null |
+ creator_user_id       | integer                  |           | not null |
+ release_version       | citext                   |           |          |
+ release_tag           | citext                   |           | not null |
+ manifest              | jsonb                    |           | not null |
+ bundle                | text                     |           |          |
  created_at            | timestamp with time zone |           | not null | now()
- deleted_at            | timestamp with time zone |           |          | 
- source_map            | text                     |           |          | 
+ deleted_at            | timestamp with time zone |           |          |
+ source_map            | text                     |           |          |
 Indexes:
     "registry_extension_releases_pkey" PRIMARY KEY, btree (id)
     "registry_extension_releases_version" UNIQUE, btree (registry_extension_id, release_version) WHERE release_version IS NOT NULL
@@ -3492,17 +3494,17 @@ Foreign-key constraints:
 
 # Table "public.registry_extensions"
 ```
-      Column       |           Type           | Collation | Nullable |                     Default                     
+      Column       |           Type           | Collation | Nullable |                     Default
 -------------------+--------------------------+-----------+----------+-------------------------------------------------
  id                | integer                  |           | not null | nextval('registry_extensions_id_seq'::regclass)
- uuid              | uuid                     |           | not null | 
- publisher_user_id | integer                  |           |          | 
- publisher_org_id  | integer                  |           |          | 
- name              | citext                   |           | not null | 
- manifest          | text                     |           |          | 
+ uuid              | uuid                     |           | not null |
+ publisher_user_id | integer                  |           |          |
+ publisher_org_id  | integer                  |           |          |
+ name              | citext                   |           | not null |
+ manifest          | text                     |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- deleted_at        | timestamp with time zone |           |          | 
+ deleted_at        | timestamp with time zone |           |          |
 Indexes:
     "registry_extensions_pkey" PRIMARY KEY, btree (id)
     "registry_extensions_publisher_name" UNIQUE, btree (COALESCE(publisher_user_id, 0), COALESCE(publisher_org_id, 0), name) WHERE deleted_at IS NULL
@@ -3521,24 +3523,24 @@ Referenced by:
 
 # Table "public.repo"
 ```
-        Column         |           Type           | Collation | Nullable |             Default              
+        Column         |           Type           | Collation | Nullable |             Default
 -----------------------+--------------------------+-----------+----------+----------------------------------
  id                    | integer                  |           | not null | nextval('repo_id_seq'::regclass)
- name                  | citext                   |           | not null | 
- description           | text                     |           |          | 
- fork                  | boolean                  |           |          | 
+ name                  | citext                   |           | not null |
+ description           | text                     |           |          |
+ fork                  | boolean                  |           |          |
  created_at            | timestamp with time zone |           | not null | now()
- updated_at            | timestamp with time zone |           |          | 
- external_id           | text                     |           |          | 
- external_service_type | text                     |           |          | 
- external_service_id   | text                     |           |          | 
+ updated_at            | timestamp with time zone |           |          |
+ external_id           | text                     |           |          |
+ external_service_type | text                     |           |          |
+ external_service_id   | text                     |           |          |
  archived              | boolean                  |           | not null | false
- uri                   | citext                   |           |          | 
- deleted_at            | timestamp with time zone |           |          | 
+ uri                   | citext                   |           |          |
+ deleted_at            | timestamp with time zone |           |          |
  metadata              | jsonb                    |           | not null | '{}'::jsonb
  private               | boolean                  |           | not null | false
  stars                 | integer                  |           | not null | 0
- blocked               | jsonb                    |           |          | 
+ blocked               | jsonb                    |           |          |
 Indexes:
     "repo_pkey" PRIMARY KEY, btree (id)
     "repo_external_unique_idx" UNIQUE, btree (external_service_type, external_service_id, external_id)
@@ -3600,12 +3602,12 @@ Triggers:
 
 # Table "public.repo_commits_changelists"
 ```
-         Column         |           Type           | Collation | Nullable |                       Default                        
+         Column         |           Type           | Collation | Nullable |                       Default
 ------------------------+--------------------------+-----------+----------+------------------------------------------------------
  id                     | integer                  |           | not null | nextval('repo_commits_changelists_id_seq'::regclass)
- repo_id                | integer                  |           | not null | 
- commit_sha             | bytea                    |           | not null | 
- perforce_changelist_id | integer                  |           | not null | 
+ repo_id                | integer                  |           | not null |
+ commit_sha             | bytea                    |           | not null |
+ perforce_changelist_id | integer                  |           | not null |
  created_at             | timestamp with time zone |           | not null | now()
 Indexes:
     "repo_commits_changelists_pkey" PRIMARY KEY, btree (id)
@@ -3617,9 +3619,9 @@ Foreign-key constraints:
 
 # Table "public.repo_embedding_job_stats"
 ```
-        Column        |  Type   | Collation | Nullable |   Default   
+        Column        |  Type   | Collation | Nullable |   Default
 ----------------------+---------+-----------+----------+-------------
- job_id               | integer |           | not null | 
+ job_id               | integer |           | not null |
  is_incremental       | boolean |           | not null | false
  code_files_total     | integer |           | not null | 0
  code_files_embedded  | integer |           | not null | 0
@@ -3642,23 +3644,23 @@ Foreign-key constraints:
 
 # Table "public.repo_embedding_jobs"
 ```
-      Column       |           Type           | Collation | Nullable |                     Default                     
+      Column       |           Type           | Collation | Nullable |                     Default
 -------------------+--------------------------+-----------+----------+-------------------------------------------------
  id                | integer                  |           | not null | nextval('repo_embedding_jobs_id_seq'::regclass)
  state             | text                     |           |          | 'queued'::text
- failure_message   | text                     |           |          | 
+ failure_message   | text                     |           |          |
  queued_at         | timestamp with time zone |           |          | now()
- started_at        | timestamp with time zone |           |          | 
- finished_at       | timestamp with time zone |           |          | 
- process_after     | timestamp with time zone |           |          | 
+ started_at        | timestamp with time zone |           |          |
+ finished_at       | timestamp with time zone |           |          |
+ process_after     | timestamp with time zone |           |          |
  num_resets        | integer                  |           | not null | 0
  num_failures      | integer                  |           | not null | 0
- last_heartbeat_at | timestamp with time zone |           |          | 
- execution_logs    | json[]                   |           |          | 
+ last_heartbeat_at | timestamp with time zone |           |          |
+ execution_logs    | json[]                   |           |          |
  worker_hostname   | text                     |           | not null | ''::text
  cancel            | boolean                  |           | not null | false
- repo_id           | integer                  |           | not null | 
- revision          | text                     |           | not null | 
+ repo_id           | integer                  |           | not null |
+ revision          | text                     |           | not null |
 Indexes:
     "repo_embedding_jobs_pkey" PRIMARY KEY, btree (id)
 Referenced by:
@@ -3668,11 +3670,11 @@ Referenced by:
 
 # Table "public.repo_kvps"
 ```
- Column  |  Type   | Collation | Nullable | Default 
+ Column  |  Type   | Collation | Nullable | Default
 ---------+---------+-----------+----------+---------
- repo_id | integer |           | not null | 
- key     | text    |           | not null | 
- value   | text    |           |          | 
+ repo_id | integer |           | not null |
+ key     | text    |           | not null |
+ value   | text    |           |          |
 Indexes:
     "repo_kvps_pkey" PRIMARY KEY, btree (repo_id, key) INCLUDE (value)
 Foreign-key constraints:
@@ -3682,14 +3684,14 @@ Foreign-key constraints:
 
 # Table "public.repo_paths"
 ```
-            Column            |            Type             | Collation | Nullable |                Default                 
+            Column            |            Type             | Collation | Nullable |                Default
 ------------------------------+-----------------------------+-----------+----------+----------------------------------------
  id                           | integer                     |           | not null | nextval('repo_paths_id_seq'::regclass)
- repo_id                      | integer                     |           | not null | 
- absolute_path                | text                        |           | not null | 
- parent_id                    | integer                     |           |          | 
- tree_files_count             | integer                     |           |          | 
- tree_files_counts_updated_at | timestamp without time zone |           |          | 
+ repo_id                      | integer                     |           | not null |
+ absolute_path                | text                        |           | not null |
+ parent_id                    | integer                     |           |          |
+ tree_files_count             | integer                     |           |          |
+ tree_files_counts_updated_at | timestamp without time zone |           |          |
 Indexes:
     "repo_paths_pkey" PRIMARY KEY, btree (id)
     "repo_paths_index_absolute_path" UNIQUE, btree (repo_id, absolute_path)
@@ -3716,11 +3718,11 @@ Referenced by:
 
 # Table "public.repo_pending_permissions"
 ```
-    Column     |           Type           | Collation | Nullable |     Default     
+    Column     |           Type           | Collation | Nullable |     Default
 ---------------+--------------------------+-----------+----------+-----------------
- repo_id       | integer                  |           | not null | 
- permission    | text                     |           | not null | 
- updated_at    | timestamp with time zone |           | not null | 
+ repo_id       | integer                  |           | not null |
+ permission    | text                     |           | not null |
+ updated_at    | timestamp with time zone |           | not null |
  user_ids_ints | bigint[]                 |           | not null | '{}'::integer[]
 Indexes:
     "repo_pending_permissions_perm_unique" UNIQUE CONSTRAINT, btree (repo_id, permission)
@@ -3729,12 +3731,12 @@ Indexes:
 
 # Table "public.repo_permissions"
 ```
-    Column     |           Type           | Collation | Nullable |     Default     
+    Column     |           Type           | Collation | Nullable |     Default
 ---------------+--------------------------+-----------+----------+-----------------
- repo_id       | integer                  |           | not null | 
- permission    | text                     |           | not null | 
- updated_at    | timestamp with time zone |           | not null | 
- synced_at     | timestamp with time zone |           |          | 
+ repo_id       | integer                  |           | not null |
+ permission    | text                     |           | not null |
+ updated_at    | timestamp with time zone |           | not null |
+ synced_at     | timestamp with time zone |           |          |
  user_ids_ints | integer[]                |           | not null | '{}'::integer[]
  unrestricted  | boolean                  |           | not null | false
 Indexes:
@@ -3745,7 +3747,7 @@ Indexes:
 
 # Table "public.repo_statistics"
 ```
-    Column    |  Type  | Collation | Nullable | Default 
+    Column    |  Type  | Collation | Nullable | Default
 --------------+--------+-----------+----------+---------
  total        | bigint |           | not null | 0
  soft_deleted | bigint |           | not null | 0
@@ -3773,10 +3775,10 @@ Indexes:
 
 # Table "public.role_permissions"
 ```
-    Column     |           Type           | Collation | Nullable | Default 
+    Column     |           Type           | Collation | Nullable | Default
 ---------------+--------------------------+-----------+----------+---------
- role_id       | integer                  |           | not null | 
- permission_id | integer                  |           | not null | 
+ role_id       | integer                  |           | not null |
+ permission_id | integer                  |           | not null |
  created_at    | timestamp with time zone |           | not null | now()
 Indexes:
     "role_permissions_pkey" PRIMARY KEY, btree (permission_id, role_id)
@@ -3788,12 +3790,12 @@ Foreign-key constraints:
 
 # Table "public.roles"
 ```
-   Column   |           Type           | Collation | Nullable |              Default              
+   Column   |           Type           | Collation | Nullable |              Default
 ------------+--------------------------+-----------+----------+-----------------------------------
  id         | integer                  |           | not null | nextval('roles_id_seq'::regclass)
  created_at | timestamp with time zone |           | not null | now()
  system     | boolean                  |           | not null | false
- name       | citext                   |           | not null | 
+ name       | citext                   |           | not null |
 Indexes:
     "roles_pkey" PRIMARY KEY, btree (id)
     "unique_role_name" UNIQUE, btree (name)
@@ -3807,18 +3809,18 @@ Referenced by:
 
 # Table "public.saved_searches"
 ```
-      Column       |           Type           | Collation | Nullable |                  Default                   
+      Column       |           Type           | Collation | Nullable |                  Default
 -------------------+--------------------------+-----------+----------+--------------------------------------------
  id                | integer                  |           | not null | nextval('saved_searches_id_seq'::regclass)
- description       | text                     |           | not null | 
- query             | text                     |           | not null | 
+ description       | text                     |           | not null |
+ query             | text                     |           | not null |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- notify_owner      | boolean                  |           | not null | 
- notify_slack      | boolean                  |           | not null | 
- user_id           | integer                  |           |          | 
- org_id            | integer                  |           |          | 
- slack_webhook_url | text                     |           |          | 
+ notify_owner      | boolean                  |           | not null |
+ notify_slack      | boolean                  |           | not null |
+ user_id           | integer                  |           |          |
+ org_id            | integer                  |           |          |
+ slack_webhook_url | text                     |           |          |
 Indexes:
     "saved_searches_pkey" PRIMARY KEY, btree (id)
 Check constraints:
@@ -3832,10 +3834,10 @@ Foreign-key constraints:
 
 # Table "public.search_context_default"
 ```
-      Column       |  Type   | Collation | Nullable | Default 
+      Column       |  Type   | Collation | Nullable | Default
 -------------------+---------+-----------+----------+---------
- user_id           | integer |           | not null | 
- search_context_id | bigint  |           | not null | 
+ user_id           | integer |           | not null |
+ search_context_id | bigint  |           | not null |
 Indexes:
     "search_context_default_pkey" PRIMARY KEY, btree (user_id)
 Foreign-key constraints:
@@ -3848,11 +3850,11 @@ When a user sets a search context as default, a row is inserted into this table.
 
 # Table "public.search_context_repos"
 ```
-      Column       |  Type   | Collation | Nullable | Default 
+      Column       |  Type   | Collation | Nullable | Default
 -------------------+---------+-----------+----------+---------
- search_context_id | bigint  |           | not null | 
- repo_id           | integer |           | not null | 
- revision          | text    |           | not null | 
+ search_context_id | bigint  |           | not null |
+ repo_id           | integer |           | not null |
+ revision          | text    |           | not null |
 Indexes:
     "search_context_repos_unique" UNIQUE CONSTRAINT, btree (repo_id, search_context_id, revision)
 Foreign-key constraints:
@@ -3863,10 +3865,10 @@ Foreign-key constraints:
 
 # Table "public.search_context_stars"
 ```
-      Column       |           Type           | Collation | Nullable | Default 
+      Column       |           Type           | Collation | Nullable | Default
 -------------------+--------------------------+-----------+----------+---------
- search_context_id | bigint                   |           | not null | 
- user_id           | integer                  |           | not null | 
+ search_context_id | bigint                   |           | not null |
+ user_id           | integer                  |           | not null |
  created_at        | timestamp with time zone |           | not null | now()
 Indexes:
     "search_context_stars_pkey" PRIMARY KEY, btree (search_context_id, user_id)
@@ -3880,18 +3882,18 @@ When a user stars a search context, a row is inserted into this table. If the us
 
 # Table "public.search_contexts"
 ```
-      Column       |           Type           | Collation | Nullable |                   Default                   
+      Column       |           Type           | Collation | Nullable |                   Default
 -------------------+--------------------------+-----------+----------+---------------------------------------------
  id                | bigint                   |           | not null | nextval('search_contexts_id_seq'::regclass)
- name              | citext                   |           | not null | 
- description       | text                     |           | not null | 
- public            | boolean                  |           | not null | 
- namespace_user_id | integer                  |           |          | 
- namespace_org_id  | integer                  |           |          | 
+ name              | citext                   |           | not null |
+ description       | text                     |           | not null |
+ public            | boolean                  |           | not null |
+ namespace_user_id | integer                  |           |          |
+ namespace_org_id  | integer                  |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- deleted_at        | timestamp with time zone |           |          | 
- query             | text                     |           |          | 
+ deleted_at        | timestamp with time zone |           |          |
+ query             | text                     |           |          |
 Indexes:
     "search_contexts_pkey" PRIMARY KEY, btree (id)
     "search_contexts_name_namespace_org_id_unique" UNIQUE, btree (name, namespace_org_id) WHERE namespace_org_id IS NOT NULL
@@ -3914,17 +3916,17 @@ Referenced by:
 
 # Table "public.security_event_logs"
 ```
-      Column       |           Type           | Collation | Nullable |                     Default                     
+      Column       |           Type           | Collation | Nullable |                     Default
 -------------------+--------------------------+-----------+----------+-------------------------------------------------
  id                | bigint                   |           | not null | nextval('security_event_logs_id_seq'::regclass)
- name              | text                     |           | not null | 
- url               | text                     |           | not null | 
- user_id           | integer                  |           | not null | 
- anonymous_user_id | text                     |           | not null | 
- source            | text                     |           | not null | 
- argument          | jsonb                    |           | not null | 
- version           | text                     |           | not null | 
- timestamp         | timestamp with time zone |           | not null | 
+ name              | text                     |           | not null |
+ url               | text                     |           | not null |
+ user_id           | integer                  |           | not null |
+ anonymous_user_id | text                     |           | not null |
+ source            | text                     |           | not null |
+ argument          | jsonb                    |           | not null |
+ version           | text                     |           | not null |
+ timestamp         | timestamp with time zone |           | not null |
 Indexes:
     "security_event_logs_pkey" PRIMARY KEY, btree (id)
     "security_event_logs_timestamp" btree ("timestamp")
@@ -3954,14 +3956,14 @@ Contains security-relevant events with a long time horizon for storage.
 
 # Table "public.settings"
 ```
-     Column     |           Type           | Collation | Nullable |               Default                
+     Column     |           Type           | Collation | Nullable |               Default
 ----------------+--------------------------+-----------+----------+--------------------------------------
  id             | integer                  |           | not null | nextval('settings_id_seq'::regclass)
- org_id         | integer                  |           |          | 
+ org_id         | integer                  |           |          |
  contents       | text                     |           | not null | '{}'::text
  created_at     | timestamp with time zone |           | not null | now()
- user_id        | integer                  |           |          | 
- author_user_id | integer                  |           |          | 
+ user_id        | integer                  |           |          |
+ author_user_id | integer                  |           |          |
 Indexes:
     "settings_pkey" PRIMARY KEY, btree (id)
     "settings_global_id" btree (id DESC) WHERE user_id IS NULL AND org_id IS NULL
@@ -3978,13 +3980,13 @@ Foreign-key constraints:
 
 # Table "public.sub_repo_permissions"
 ```
-   Column   |           Type           | Collation | Nullable | Default 
+   Column   |           Type           | Collation | Nullable | Default
 ------------+--------------------------+-----------+----------+---------
- repo_id    | integer                  |           | not null | 
- user_id    | integer                  |           | not null | 
+ repo_id    | integer                  |           | not null |
+ user_id    | integer                  |           | not null |
  version    | integer                  |           | not null | 1
  updated_at | timestamp with time zone |           | not null | now()
- paths      | text[]                   |           |          | 
+ paths      | text[]                   |           |          |
 Indexes:
     "sub_repo_permissions_repo_id_user_id_version_uindex" UNIQUE, btree (repo_id, user_id, version)
     "sub_repo_perms_user_id" btree (user_id)
@@ -4000,17 +4002,17 @@ Responsible for storing permissions at a finer granularity than repo
 
 # Table "public.survey_responses"
 ```
-     Column     |           Type           | Collation | Nullable |                   Default                    
+     Column     |           Type           | Collation | Nullable |                   Default
 ----------------+--------------------------+-----------+----------+----------------------------------------------
  id             | bigint                   |           | not null | nextval('survey_responses_id_seq'::regclass)
- user_id        | integer                  |           |          | 
- email          | text                     |           |          | 
- score          | integer                  |           | not null | 
- reason         | text                     |           |          | 
- better         | text                     |           |          | 
+ user_id        | integer                  |           |          |
+ email          | text                     |           |          |
+ score          | integer                  |           | not null |
+ reason         | text                     |           |          |
+ better         | text                     |           |          |
  created_at     | timestamp with time zone |           | not null | now()
- use_cases      | text[]                   |           |          | 
- other_use_case | text                     |           |          | 
+ use_cases      | text[]                   |           |          |
+ other_use_case | text                     |           |          |
 Indexes:
     "survey_responses_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -4020,10 +4022,10 @@ Foreign-key constraints:
 
 # Table "public.team_members"
 ```
-   Column   |           Type           | Collation | Nullable | Default 
+   Column   |           Type           | Collation | Nullable | Default
 ------------+--------------------------+-----------+----------+---------
- team_id    | integer                  |           | not null | 
- user_id    | integer                  |           | not null | 
+ team_id    | integer                  |           | not null |
+ user_id    | integer                  |           | not null |
  created_at | timestamp with time zone |           | not null | now()
  updated_at | timestamp with time zone |           | not null | now()
 Indexes:
@@ -4036,14 +4038,14 @@ Foreign-key constraints:
 
 # Table "public.teams"
 ```
-     Column     |           Type           | Collation | Nullable |              Default              
+     Column     |           Type           | Collation | Nullable |              Default
 ----------------+--------------------------+-----------+----------+-----------------------------------
  id             | integer                  |           | not null | nextval('teams_id_seq'::regclass)
- name           | citext                   |           | not null | 
- display_name   | text                     |           |          | 
+ name           | citext                   |           | not null |
+ display_name   | text                     |           |          |
  readonly       | boolean                  |           | not null | false
- parent_team_id | integer                  |           |          | 
- creator_id     | integer                  |           |          | 
+ parent_team_id | integer                  |           |          |
+ creator_id     | integer                  |           |          |
  created_at     | timestamp with time zone |           | not null | now()
  updated_at     | timestamp with time zone |           | not null | now()
 Indexes:
@@ -4066,12 +4068,12 @@ Referenced by:
 
 # Table "public.telemetry_events_export_queue"
 ```
-   Column    |           Type           | Collation | Nullable | Default 
+   Column    |           Type           | Collation | Nullable | Default
 -------------+--------------------------+-----------+----------+---------
- id          | text                     |           | not null | 
- timestamp   | timestamp with time zone |           | not null | 
- payload_pb  | bytea                    |           | not null | 
- exported_at | timestamp with time zone |           |          | 
+ id          | text                     |           | not null |
+ timestamp   | timestamp with time zone |           | not null |
+ payload_pb  | bytea                    |           | not null |
+ exported_at | timestamp with time zone |           |          |
 Indexes:
     "telemetry_events_export_queue_pkey" PRIMARY KEY, btree (id)
 
@@ -4079,11 +4081,11 @@ Indexes:
 
 # Table "public.temporary_settings"
 ```
-   Column   |           Type           | Collation | Nullable |                    Default                     
+   Column   |           Type           | Collation | Nullable |                    Default
 ------------+--------------------------+-----------+----------+------------------------------------------------
  id         | integer                  |           | not null | nextval('temporary_settings_id_seq'::regclass)
- user_id    | integer                  |           | not null | 
- contents   | jsonb                    |           |          | 
+ user_id    | integer                  |           | not null |
+ contents   | jsonb                    |           |          |
  created_at | timestamp with time zone |           | not null | now()
  updated_at | timestamp with time zone |           | not null | now()
 Indexes:
@@ -4102,16 +4104,16 @@ Stores per-user temporary settings used in the UI, for example, which modals hav
 
 # Table "public.user_credentials"
 ```
-        Column         |           Type           | Collation | Nullable |                   Default                    
+        Column         |           Type           | Collation | Nullable |                   Default
 -----------------------+--------------------------+-----------+----------+----------------------------------------------
  id                    | bigint                   |           | not null | nextval('user_credentials_id_seq'::regclass)
- domain                | text                     |           | not null | 
- user_id               | integer                  |           | not null | 
- external_service_type | text                     |           | not null | 
- external_service_id   | text                     |           | not null | 
+ domain                | text                     |           | not null |
+ user_id               | integer                  |           | not null |
+ external_service_type | text                     |           | not null |
+ external_service_id   | text                     |           | not null |
  created_at            | timestamp with time zone |           | not null | now()
  updated_at            | timestamp with time zone |           | not null | now()
- credential            | bytea                    |           | not null | 
+ credential            | bytea                    |           | not null |
  ssh_migration_applied | boolean                  |           | not null | false
  encryption_key_id     | text                     |           | not null | ''::text
 Indexes:
@@ -4125,14 +4127,14 @@ Foreign-key constraints:
 
 # Table "public.user_emails"
 ```
-          Column           |           Type           | Collation | Nullable | Default 
+          Column           |           Type           | Collation | Nullable | Default
 ---------------------------+--------------------------+-----------+----------+---------
- user_id                   | integer                  |           | not null | 
- email                     | citext                   |           | not null | 
+ user_id                   | integer                  |           | not null |
+ email                     | citext                   |           | not null |
  created_at                | timestamp with time zone |           | not null | now()
- verification_code         | text                     |           |          | 
- verified_at               | timestamp with time zone |           |          | 
- last_verification_sent_at | timestamp with time zone |           |          | 
+ verification_code         | text                     |           |          |
+ verified_at               | timestamp with time zone |           |          |
+ last_verification_sent_at | timestamp with time zone |           |          |
  is_primary                | boolean                  |           | not null | false
 Indexes:
     "user_emails_no_duplicates_per_user" UNIQUE CONSTRAINT, btree (user_id, email)
@@ -4145,21 +4147,21 @@ Foreign-key constraints:
 
 # Table "public.user_external_accounts"
 ```
-      Column       |           Type           | Collation | Nullable |                      Default                       
+      Column       |           Type           | Collation | Nullable |                      Default
 -------------------+--------------------------+-----------+----------+----------------------------------------------------
  id                | integer                  |           | not null | nextval('user_external_accounts_id_seq'::regclass)
- user_id           | integer                  |           | not null | 
- service_type      | text                     |           | not null | 
- service_id        | text                     |           | not null | 
- account_id        | text                     |           | not null | 
- auth_data         | text                     |           |          | 
- account_data      | text                     |           |          | 
+ user_id           | integer                  |           | not null |
+ service_type      | text                     |           | not null |
+ service_id        | text                     |           | not null |
+ account_id        | text                     |           | not null |
+ auth_data         | text                     |           |          |
+ account_data      | text                     |           |          |
  created_at        | timestamp with time zone |           | not null | now()
  updated_at        | timestamp with time zone |           | not null | now()
- deleted_at        | timestamp with time zone |           |          | 
- client_id         | text                     |           | not null | 
- expired_at        | timestamp with time zone |           |          | 
- last_valid_at     | timestamp with time zone |           |          | 
+ deleted_at        | timestamp with time zone |           |          |
+ client_id         | text                     |           | not null |
+ expired_at        | timestamp with time zone |           |          |
+ last_valid_at     | timestamp with time zone |           |          |
  encryption_key_id | text                     |           | not null | ''::text
 Indexes:
     "user_external_accounts_pkey" PRIMARY KEY, btree (id)
@@ -4177,12 +4179,12 @@ Triggers:
 
 # Table "public.user_onboarding_tour"
 ```
-   Column   |            Type             | Collation | Nullable |                     Default                      
+   Column   |            Type             | Collation | Nullable |                     Default
 ------------+-----------------------------+-----------+----------+--------------------------------------------------
  id         | integer                     |           | not null | nextval('user_onboarding_tour_id_seq'::regclass)
- raw_json   | text                        |           | not null | 
+ raw_json   | text                        |           | not null |
  created_at | timestamp without time zone |           | not null | now()
- updated_by | integer                     |           |          | 
+ updated_by | integer                     |           |          |
 Indexes:
     "user_onboarding_tour_pkey" PRIMARY KEY, btree (id)
 Foreign-key constraints:
@@ -4192,15 +4194,15 @@ Foreign-key constraints:
 
 # Table "public.user_pending_permissions"
 ```
-     Column      |           Type           | Collation | Nullable |                       Default                        
+     Column      |           Type           | Collation | Nullable |                       Default
 -----------------+--------------------------+-----------+----------+------------------------------------------------------
  id              | bigint                   |           | not null | nextval('user_pending_permissions_id_seq'::regclass)
- bind_id         | text                     |           | not null | 
- permission      | text                     |           | not null | 
- object_type     | text                     |           | not null | 
- updated_at      | timestamp with time zone |           | not null | 
- service_type    | text                     |           | not null | 
- service_id      | text                     |           | not null | 
+ bind_id         | text                     |           | not null |
+ permission      | text                     |           | not null |
+ object_type     | text                     |           | not null |
+ updated_at      | timestamp with time zone |           | not null |
+ service_type    | text                     |           | not null |
+ service_id      | text                     |           | not null |
  object_ids_ints | integer[]                |           | not null | '{}'::integer[]
 Indexes:
     "user_pending_permissions_service_perm_object_unique" UNIQUE CONSTRAINT, btree (service_type, service_id, permission, object_type, bind_id)
@@ -4209,13 +4211,13 @@ Indexes:
 
 # Table "public.user_permissions"
 ```
-     Column      |           Type           | Collation | Nullable |     Default     
+     Column      |           Type           | Collation | Nullable |     Default
 -----------------+--------------------------+-----------+----------+-----------------
- user_id         | integer                  |           | not null | 
- permission      | text                     |           | not null | 
- object_type     | text                     |           | not null | 
- updated_at      | timestamp with time zone |           | not null | 
- synced_at       | timestamp with time zone |           |          | 
+ user_id         | integer                  |           | not null |
+ permission      | text                     |           | not null |
+ object_type     | text                     |           | not null |
+ updated_at      | timestamp with time zone |           | not null |
+ synced_at       | timestamp with time zone |           |          |
  object_ids_ints | integer[]                |           | not null | '{}'::integer[]
  migrated        | boolean                  |           |          | true
 Indexes:
@@ -4225,11 +4227,11 @@ Indexes:
 
 # Table "public.user_public_repos"
 ```
-  Column  |  Type   | Collation | Nullable | Default 
+  Column  |  Type   | Collation | Nullable | Default
 ----------+---------+-----------+----------+---------
- user_id  | integer |           | not null | 
- repo_uri | text    |           | not null | 
- repo_id  | integer |           | not null | 
+ user_id  | integer |           | not null |
+ repo_uri | text    |           | not null |
+ repo_id  | integer |           | not null |
 Indexes:
     "user_public_repos_user_id_repo_id_key" UNIQUE CONSTRAINT, btree (user_id, repo_id)
 Foreign-key constraints:
@@ -4240,12 +4242,12 @@ Foreign-key constraints:
 
 # Table "public.user_repo_permissions"
 ```
-          Column          |           Type           | Collation | Nullable |                      Default                      
+          Column          |           Type           | Collation | Nullable |                      Default
 --------------------------+--------------------------+-----------+----------+---------------------------------------------------
  id                       | bigint                   |           | not null | nextval('user_repo_permissions_id_seq'::regclass)
- user_id                  | integer                  |           |          | 
- repo_id                  | integer                  |           | not null | 
- user_external_account_id | integer                  |           |          | 
+ user_id                  | integer                  |           |          |
+ repo_id                  | integer                  |           | not null |
+ user_external_account_id | integer                  |           |          |
  created_at               | timestamp with time zone |           | not null | now()
  updated_at               | timestamp with time zone |           | not null | now()
  source                   | text                     |           | not null | 'sync'::text
@@ -4265,10 +4267,10 @@ Foreign-key constraints:
 
 # Table "public.user_roles"
 ```
-   Column   |           Type           | Collation | Nullable | Default 
+   Column   |           Type           | Collation | Nullable | Default
 ------------+--------------------------+-----------+----------+---------
- user_id    | integer                  |           | not null | 
- role_id    | integer                  |           | not null | 
+ user_id    | integer                  |           | not null |
+ role_id    | integer                  |           | not null |
  created_at | timestamp with time zone |           | not null | now()
 Indexes:
     "user_roles_pkey" PRIMARY KEY, btree (user_id, role_id)
@@ -4280,29 +4282,29 @@ Foreign-key constraints:
 
 # Table "public.users"
 ```
-         Column          |           Type           | Collation | Nullable |              Default              
+         Column          |           Type           | Collation | Nullable |              Default
 -------------------------+--------------------------+-----------+----------+-----------------------------------
  id                      | integer                  |           | not null | nextval('users_id_seq'::regclass)
- username                | citext                   |           | not null | 
- display_name            | text                     |           |          | 
- avatar_url              | text                     |           |          | 
+ username                | citext                   |           | not null |
+ display_name            | text                     |           |          |
+ avatar_url              | text                     |           |          |
  created_at              | timestamp with time zone |           | not null | now()
  updated_at              | timestamp with time zone |           | not null | now()
- deleted_at              | timestamp with time zone |           |          | 
+ deleted_at              | timestamp with time zone |           |          |
  invite_quota            | integer                  |           | not null | 100
- passwd                  | text                     |           |          | 
- passwd_reset_code       | text                     |           |          | 
- passwd_reset_time       | timestamp with time zone |           |          | 
+ passwd                  | text                     |           |          |
+ passwd_reset_code       | text                     |           |          |
+ passwd_reset_time       | timestamp with time zone |           |          |
  site_admin              | boolean                  |           | not null | false
  page_views              | integer                  |           | not null | 0
  search_queries          | integer                  |           | not null | 0
  tags                    | text[]                   |           |          | '{}'::text[]
- billing_customer_id     | text                     |           |          | 
+ billing_customer_id     | text                     |           |          |
  invalidated_sessions_at | timestamp with time zone |           | not null | now()
  tos_accepted            | boolean                  |           | not null | false
  searchable              | boolean                  |           | not null | true
- completions_quota       | integer                  |           |          | 
- code_completions_quota  | integer                  |           |          | 
+ completions_quota       | integer                  |           |          |
+ code_completions_quota  | integer                  |           |          |
  completed_post_signup   | boolean                  |           | not null | false
 Indexes:
     "users_pkey" PRIMARY KEY, btree (id)
@@ -4398,12 +4400,12 @@ Triggers:
 
 # Table "public.versions"
 ```
-    Column     |           Type           | Collation | Nullable | Default 
+    Column     |           Type           | Collation | Nullable | Default
 ---------------+--------------------------+-----------+----------+---------
- service       | text                     |           | not null | 
- version       | text                     |           | not null | 
+ service       | text                     |           | not null |
+ version       | text                     |           | not null |
  updated_at    | timestamp with time zone |           | not null | now()
- first_version | text                     |           | not null | 
+ first_version | text                     |           | not null |
  auto_upgrade  | boolean                  |           | not null | false
 Indexes:
     "versions_pkey" PRIMARY KEY, btree (service)
@@ -4414,24 +4416,24 @@ Triggers:
 
 # Table "public.vulnerabilities"
 ```
-    Column    |           Type           | Collation | Nullable |                   Default                   
+    Column    |           Type           | Collation | Nullable |                   Default
 --------------+--------------------------+-----------+----------+---------------------------------------------
  id           | integer                  |           | not null | nextval('vulnerabilities_id_seq'::regclass)
- source_id    | text                     |           | not null | 
- summary      | text                     |           | not null | 
- details      | text                     |           | not null | 
- cpes         | text[]                   |           | not null | 
- cwes         | text[]                   |           | not null | 
- aliases      | text[]                   |           | not null | 
- related      | text[]                   |           | not null | 
- data_source  | text                     |           | not null | 
- urls         | text[]                   |           | not null | 
- severity     | text                     |           | not null | 
- cvss_vector  | text                     |           | not null | 
- cvss_score   | text                     |           | not null | 
- published_at | timestamp with time zone |           | not null | 
- modified_at  | timestamp with time zone |           |          | 
- withdrawn_at | timestamp with time zone |           |          | 
+ source_id    | text                     |           | not null |
+ summary      | text                     |           | not null |
+ details      | text                     |           | not null |
+ cpes         | text[]                   |           | not null |
+ cwes         | text[]                   |           | not null |
+ aliases      | text[]                   |           | not null |
+ related      | text[]                   |           | not null |
+ data_source  | text                     |           | not null |
+ urls         | text[]                   |           | not null |
+ severity     | text                     |           | not null |
+ cvss_vector  | text                     |           | not null |
+ cvss_score   | text                     |           | not null |
+ published_at | timestamp with time zone |           | not null |
+ modified_at  | timestamp with time zone |           |          |
+ withdrawn_at | timestamp with time zone |           |          |
 Indexes:
     "vulnerabilities_pkey" PRIMARY KEY, btree (id)
     "vulnerabilities_source_id" UNIQUE, btree (source_id)
@@ -4442,16 +4444,16 @@ Referenced by:
 
 # Table "public.vulnerability_affected_packages"
 ```
-       Column       |  Type   | Collation | Nullable |                           Default                           
+       Column       |  Type   | Collation | Nullable |                           Default
 --------------------+---------+-----------+----------+-------------------------------------------------------------
  id                 | integer |           | not null | nextval('vulnerability_affected_packages_id_seq'::regclass)
- vulnerability_id   | integer |           | not null | 
- package_name       | text    |           | not null | 
- language           | text    |           | not null | 
- namespace          | text    |           | not null | 
- version_constraint | text[]  |           | not null | 
- fixed              | boolean |           | not null | 
- fixed_in           | text    |           |          | 
+ vulnerability_id   | integer |           | not null |
+ package_name       | text    |           | not null |
+ language           | text    |           | not null |
+ namespace          | text    |           | not null |
+ version_constraint | text[]  |           | not null |
+ fixed              | boolean |           | not null |
+ fixed_in           | text    |           |          |
 Indexes:
     "vulnerability_affected_packages_pkey" PRIMARY KEY, btree (id)
     "vulnerability_affected_packages_vulnerability_id_package_name" UNIQUE, btree (vulnerability_id, package_name)
@@ -4465,12 +4467,12 @@ Referenced by:
 
 # Table "public.vulnerability_affected_symbols"
 ```
-              Column               |  Type   | Collation | Nullable |                          Default                           
+              Column               |  Type   | Collation | Nullable |                          Default
 -----------------------------------+---------+-----------+----------+------------------------------------------------------------
  id                                | integer |           | not null | nextval('vulnerability_affected_symbols_id_seq'::regclass)
- vulnerability_affected_package_id | integer |           | not null | 
- path                              | text    |           | not null | 
- symbols                           | text[]  |           | not null | 
+ vulnerability_affected_package_id | integer |           | not null |
+ path                              | text    |           | not null |
+ symbols                           | text[]  |           | not null |
 Indexes:
     "vulnerability_affected_symbols_pkey" PRIMARY KEY, btree (id)
     "vulnerability_affected_symbols_vulnerability_affected_package_i" UNIQUE, btree (vulnerability_affected_package_id, path)
@@ -4481,11 +4483,11 @@ Foreign-key constraints:
 
 # Table "public.vulnerability_matches"
 ```
-              Column               |  Type   | Collation | Nullable |                      Default                      
+              Column               |  Type   | Collation | Nullable |                      Default
 -----------------------------------+---------+-----------+----------+---------------------------------------------------
  id                                | integer |           | not null | nextval('vulnerability_matches_id_seq'::regclass)
- upload_id                         | integer |           | not null | 
- vulnerability_affected_package_id | integer |           | not null | 
+ upload_id                         | integer |           | not null |
+ vulnerability_affected_package_id | integer |           | not null |
 Indexes:
     "vulnerability_matches_pkey" PRIMARY KEY, btree (id)
     "vulnerability_matches_upload_id_vulnerability_affected_package_" UNIQUE, btree (upload_id, vulnerability_affected_package_id)
@@ -4498,16 +4500,16 @@ Foreign-key constraints:
 
 # Table "public.webhook_logs"
 ```
-       Column        |           Type           | Collation | Nullable |                 Default                  
+       Column        |           Type           | Collation | Nullable |                 Default
 ---------------------+--------------------------+-----------+----------+------------------------------------------
  id                  | bigint                   |           | not null | nextval('webhook_logs_id_seq'::regclass)
  received_at         | timestamp with time zone |           | not null | now()
- external_service_id | integer                  |           |          | 
- status_code         | integer                  |           | not null | 
- request             | bytea                    |           | not null | 
- response            | bytea                    |           | not null | 
- encryption_key_id   | text                     |           | not null | 
- webhook_id          | integer                  |           |          | 
+ external_service_id | integer                  |           |          |
+ status_code         | integer                  |           | not null |
+ request             | bytea                    |           | not null |
+ response            | bytea                    |           | not null |
+ encryption_key_id   | text                     |           | not null |
+ webhook_id          | integer                  |           |          |
 Indexes:
     "webhook_logs_pkey" PRIMARY KEY, btree (id)
     "webhook_logs_external_service_id_idx" btree (external_service_id)
@@ -4521,19 +4523,19 @@ Foreign-key constraints:
 
 # Table "public.webhooks"
 ```
-       Column       |           Type           | Collation | Nullable |               Default                
+       Column       |           Type           | Collation | Nullable |               Default
 --------------------+--------------------------+-----------+----------+--------------------------------------
  id                 | integer                  |           | not null | nextval('webhooks_id_seq'::regclass)
- code_host_kind     | text                     |           | not null | 
- code_host_urn      | text                     |           | not null | 
- secret             | text                     |           |          | 
+ code_host_kind     | text                     |           | not null |
+ code_host_urn      | text                     |           | not null |
+ secret             | text                     |           |          |
  created_at         | timestamp with time zone |           | not null | now()
  updated_at         | timestamp with time zone |           | not null | now()
- encryption_key_id  | text                     |           |          | 
+ encryption_key_id  | text                     |           |          |
  uuid               | uuid                     |           | not null | gen_random_uuid()
- created_by_user_id | integer                  |           |          | 
- updated_by_user_id | integer                  |           |          | 
- name               | text                     |           | not null | 
+ created_by_user_id | integer                  |           |          |
+ updated_by_user_id | integer                  |           |          |
+ name               | text                     |           | not null |
 Indexes:
     "webhooks_pkey" PRIMARY KEY, btree (id)
     "webhooks_uuid_key" UNIQUE CONSTRAINT, btree (uuid)
@@ -4562,14 +4564,14 @@ Webhooks registered in Sourcegraph instance.
 
 # Table "public.zoekt_repos"
 ```
-     Column      |           Type           | Collation | Nullable |       Default       
+     Column      |           Type           | Collation | Nullable |       Default
 -----------------+--------------------------+-----------+----------+---------------------
- repo_id         | integer                  |           | not null | 
+ repo_id         | integer                  |           | not null |
  branches        | jsonb                    |           | not null | '[]'::jsonb
  index_status    | text                     |           | not null | 'not_indexed'::text
  updated_at      | timestamp with time zone |           | not null | now()
  created_at      | timestamp with time zone |           | not null | now()
- last_indexed_at | timestamp with time zone |           |          | 
+ last_indexed_at | timestamp with time zone |           |          |
 Indexes:
     "zoekt_repos_pkey" PRIMARY KEY, btree (repo_id)
     "zoekt_repos_index_status" btree (index_status)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -628,6 +628,8 @@ type ExternalService struct {
 	HasWebhooks    *bool      // Whether this external service has webhooks configured; calculated from Config
 	TokenExpiresAt *time.Time // Whether the token in this external services expires, nil indicates never expires.
 	CodeHostID     *int32
+	CreatorID      int32
+	LastUpdaterID  int32
 }
 
 type ExternalServiceRepo struct {

--- a/migrations/codeinsights/squashed.sql
+++ b/migrations/codeinsights/squashed.sql
@@ -724,3 +724,6 @@ ALTER TABLE ONLY series_points
 
 ALTER TABLE ONLY series_points
     ADD CONSTRAINT series_points_repo_name_id_fkey FOREIGN KEY (repo_name_id) REFERENCES repo_names(id) ON DELETE CASCADE DEFERRABLE;
+
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;

--- a/migrations/codeintel/squashed.sql
+++ b/migrations/codeintel/squashed.sql
@@ -421,3 +421,6 @@ ALTER TABLE ONLY codeintel_scip_document_lookup
 
 ALTER TABLE ONLY codeintel_scip_symbols
     ADD CONSTRAINT codeintel_scip_symbols_document_lookup_id_fk FOREIGN KEY (document_lookup_id) REFERENCES codeintel_scip_document_lookup(id) ON DELETE CASCADE;
+
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;

--- a/migrations/frontend/1697220815_add_creator_and_updater_to_external_services/down.sql
+++ b/migrations/frontend/1697220815_add_creator_and_updater_to_external_services/down.sql
@@ -1,0 +1,2 @@
+-- Undo the changes made in the up migration
+ALTER TABLE external_services DROP COLUMN IF EXISTS creator_id, DROP COLUMN IF EXISTS last_updater_id;

--- a/migrations/frontend/1697220815_add_creator_and_updater_to_external_services/metadata.yaml
+++ b/migrations/frontend/1697220815_add_creator_and_updater_to_external_services/metadata.yaml
@@ -1,0 +1,2 @@
+name: add_creator_and_updater_to_external_services
+parents: [1696003224]

--- a/migrations/frontend/1697220815_add_creator_and_updater_to_external_services/up.sql
+++ b/migrations/frontend/1697220815_add_creator_and_updater_to_external_services/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE external_services ADD COLUMN IF NOT EXISTS creator_id integer, ADD COLUMN IF NOT EXISTS last_updater_id integer;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -2626,6 +2626,8 @@ CREATE TABLE external_services (
     has_webhooks boolean,
     token_expires_at timestamp with time zone,
     code_host_id integer,
+    creator_id integer,
+    last_updater_id integer,
     CONSTRAINT check_non_empty_config CHECK ((btrim(config) <> ''::text)),
     CONSTRAINT external_services_max_1_namespace CHECK ((((namespace_user_id IS NULL) AND (namespace_org_id IS NULL)) OR ((namespace_user_id IS NULL) <> (namespace_org_id IS NULL))))
 );
@@ -7008,6 +7010,9 @@ ALTER TABLE ONLY webhooks
 
 ALTER TABLE ONLY zoekt_repos
     ADD CONSTRAINT zoekt_repos_repo_id_fkey FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE;
+
+REVOKE USAGE ON SCHEMA public FROM PUBLIC;
+GRANT ALL ON SCHEMA public TO PUBLIC;
 
 INSERT INTO lsif_configuration_policies VALUES (1, NULL, 'Default tip-of-branch retention policy', 'GIT_TREE', '*', true, 2016, false, false, 0, false, true, NULL, NULL, false);
 INSERT INTO lsif_configuration_policies VALUES (2, NULL, 'Default tag retention policy', 'GIT_TAG', '*', true, 8064, false, false, 0, false, true, NULL, NULL, false);


### PR DESCRIPTION
This PR adds creator_id and last_updater_id to external_services. 

## Test plan

Updating and creating new tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
