### PR TITLE
Replace deprecated storybook types (Story & DecoratorFn)

### DIFF
--- a/client/branded/src/components/CodeSnippet.story.tsx
+++ b/client/branded/src/components/CodeSnippet.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { Container, Text, Code } from '@sourcegraph/wildcard'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -14,7 +14,7 @@ const config: Meta = {
 
 export default config
 
-export const Simple: Story = () => (
+export const Simple: StoryFn = () => (
     <Container>
         <Text>
             Highlighted code pieces should go in a panel separating it from the surrounding content. Use{' '}

--- a/client/branded/src/components/Toggle.story.tsx
+++ b/client/branded/src/components/Toggle.story.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { action } from '@storybook/addon-actions'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { Label } from '@sourcegraph/wildcard'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -28,7 +28,7 @@ const config: Meta = {
 
 export default config
 
-export const Interactive: Story = () => {
+export const Interactive: StoryFn = () => {
     const [value, setValue] = useState(false)
 
     const onToggle = (value: boolean) => setValue(value)
@@ -42,7 +42,7 @@ Interactive.parameters = {
     },
 }
 
-export const Variants: Story = () => (
+export const Variants: StoryFn = () => (
     <>
         <ToggleExample value={true} onToggle={onToggle} />
         <ToggleExample value={false} onToggle={onToggle} />

--- a/client/branded/src/components/ToggleBig.story.tsx
+++ b/client/branded/src/components/ToggleBig.story.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { action } from '@storybook/addon-actions'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
 
@@ -16,7 +16,7 @@ const config: Meta = {
 
 export default config
 
-export const Interactive: Story = () => {
+export const Interactive: StoryFn = () => {
     const [value, setValue] = useState(false)
 
     const onToggle = (value: boolean) => setValue(value)
@@ -34,12 +34,12 @@ Interactive.parameters = {
     },
 }
 
-export const On: Story = () => <ToggleBig value={true} onToggle={onToggle} />
-export const Off: Story = () => <ToggleBig value={false} onToggle={onToggle} />
-export const DisabledOn: Story = () => <ToggleBig value={true} disabled={true} onToggle={onToggle} />
+export const On: StoryFn = () => <ToggleBig value={true} onToggle={onToggle} />
+export const Off: StoryFn = () => <ToggleBig value={false} onToggle={onToggle} />
+export const DisabledOn: StoryFn = () => <ToggleBig value={true} disabled={true} onToggle={onToggle} />
 
 DisabledOn.storyName = 'Disabled & on'
 
-export const DisabledOff: Story = () => <ToggleBig value={false} disabled={true} onToggle={onToggle} />
+export const DisabledOff: StoryFn = () => <ToggleBig value={false} disabled={true} onToggle={onToggle} />
 
 DisabledOff.storyName = 'Disabled & off'

--- a/client/branded/src/components/panel/TabbedPanelContent.story.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
 
 import { TabbedPanelContent } from './TabbedPanelContent'
 import { panels, panelProps } from './TabbedPanelContent.fixtures'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory initialEntries={[{ pathname: '/', hash: `#tab=${panels[0].id}` }]}>
         {() => <div className="p-4">{story()}</div>}
     </BrandedStory>
@@ -22,6 +22,6 @@ const config: Meta = {
 
 export default config
 
-export const Simple: Story = () => <TabbedPanelContent {...panelProps} />
+export const Simple: StoryFn = () => <TabbedPanelContent {...panelProps} />
 
 Simple.storyName = 'Simple'

--- a/client/branded/src/search-ui/components/RepoMetadata.story.tsx
+++ b/client/branded/src/search-ui/components/RepoMetadata.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { Card, Grid, H2, H3 } from '@sourcegraph/wildcard'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -28,7 +28,7 @@ const mockItems: RepoMetadataItem[] = [
     },
 ]
 
-export const RepoMetadataStory: Story = () => (
+export const RepoMetadataStory: StoryFn = () => (
     <BrandedStory>
         {() => (
             <Card className="p-3">

--- a/client/branded/src/search-ui/components/SyntaxHighlightedSearchQuery.story.tsx
+++ b/client/branded/src/search-ui/components/SyntaxHighlightedSearchQuery.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { Text } from '@sourcegraph/wildcard'
@@ -15,7 +15,7 @@ const config: Meta = {
 
 export default config
 
-export const SyntaxHighlightedSearchQueryStory: Story = () => (
+export const SyntaxHighlightedSearchQueryStory: StoryFn = () => (
     <BrandedStory>
         {() => (
             <Text>

--- a/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.story.tsx
+++ b/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.story.tsx
@@ -1,6 +1,6 @@
 import { type FC, useState } from 'react'
 
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { H2 } from '@sourcegraph/wildcard'
@@ -97,4 +97,4 @@ const QueryInputStory: FC<{}> = () => {
     )
 }
 
-export const Default: Story = () => <BrandedStory>{QueryInputStory}</BrandedStory>
+export const Default: StoryFn = () => <BrandedStory>{QueryInputStory}</BrandedStory>

--- a/client/branded/src/search-ui/input/SearchBox.story.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchMode } from '@sourcegraph/shared/src/search'
@@ -49,7 +49,7 @@ const defaultProps: SearchBoxProps = {
     platformContext: NOOP_PLATFORM_CONTEXT,
 }
 
-export const SearchBoxStory: Story = () => (
+export const SearchBoxStory: StoryFn = () => (
     <BrandedStory>
         {props => (
             <div>

--- a/client/branded/src/search-ui/input/SearchContextMenu.story.tsx
+++ b/client/branded/src/search-ui/input/SearchContextMenu.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 import { type Observable, of } from 'rxjs'
 
 import type { ListSearchContextsResult } from '@sourcegraph/shared/src/graphql-operations'
@@ -12,7 +12,7 @@ import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
 
 import { SearchContextMenu, type SearchContextMenuProps } from './SearchContextMenu'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="dropdown-menu show" style={{ position: 'static' }}>
         {story()}
     </div>
@@ -58,19 +58,19 @@ const emptySearchContexts = {
         }),
 }
 
-export const Default: Story = () => <BrandedStory>{() => <SearchContextMenu {...defaultProps} />}</BrandedStory>
+export const Default: StoryFn = () => <BrandedStory>{() => <SearchContextMenu {...defaultProps} />}</BrandedStory>
 
-export const Empty: Story = () => (
+export const Empty: StoryFn = () => (
     <BrandedStory>{() => <SearchContextMenu {...defaultProps} {...emptySearchContexts} />}</BrandedStory>
 )
 
-export const WithManageLink: Story = () => (
+export const WithManageLink: StoryFn = () => (
     <BrandedStory>{() => <SearchContextMenu {...defaultProps} showSearchContextManagement={true} />}</BrandedStory>
 )
 
 WithManageLink.storyName = 'with manage link'
 
-export const WithCTALink: Story = () => (
+export const WithCTALink: StoryFn = () => (
     <BrandedStory>
         {() => <SearchContextMenu {...defaultProps} showSearchContextManagement={true} isSourcegraphDotCom={true} />}
     </BrandedStory>

--- a/client/branded/src/search-ui/input/SearchContextMenuItem.story.tsx
+++ b/client/branded/src/search-ui/input/SearchContextMenuItem.story.tsx
@@ -1,11 +1,11 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { Combobox } from '@sourcegraph/wildcard'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
 
 import { SearchContextMenuItem } from './SearchContextMenu'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="dropdown-menu show" style={{ position: 'static' }}>
         {story()}
     </div>
@@ -21,7 +21,7 @@ const config: Meta = {
 
 export default config
 
-export const SelectedDefaultItem: Story = () => (
+export const SelectedDefaultItem: StoryFn = () => (
     <BrandedStory>
         {() => (
             <Combobox>
@@ -40,7 +40,7 @@ export const SelectedDefaultItem: Story = () => (
 
 SelectedDefaultItem.storyName = 'selected default item'
 
-export const StarredItem: Story = () => (
+export const StarredItem: StoryFn = () => (
     <BrandedStory>
         {() => (
             <Combobox>

--- a/client/branded/src/search-ui/results/progress/StreamingProgress.story.tsx
+++ b/client/branded/src/search-ui/results/progress/StreamingProgress.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { spy } from 'sinon'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -325,6 +325,6 @@ const render = () => (
     </>
 )
 
-export const StreamingProgressStory: Story = () => <BrandedStory>{() => <>{render()}</>}</BrandedStory>
+export const StreamingProgressStory: StoryFn = () => <BrandedStory>{() => <>{render()}</>}</BrandedStory>
 
 StreamingProgressStory.storyName = 'StreamingProgress'

--- a/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.story.tsx
+++ b/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { Progress } from '@sourcegraph/shared/src/search/stream'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -19,7 +19,7 @@ const config: Meta = {
 
 export default config
 
-export const Popover: Story = () => {
+export const Popover: StoryFn = () => {
     const progress: Progress = {
         durationMs: 1500,
         matchCount: 2,
@@ -80,7 +80,7 @@ export const Popover: Story = () => {
     )
 }
 
-export const ShouldCloseAllInfo: Story = () => {
+export const ShouldCloseAllInfo: StoryFn = () => {
     const progress: Progress = {
         durationMs: 1500,
         matchCount: 2,
@@ -125,7 +125,7 @@ export const ShouldCloseAllInfo: Story = () => {
 
 ShouldCloseAllInfo.storyName = 'only info, all should be closed'
 
-export const ShouldOpenOneInfo: Story = () => {
+export const ShouldOpenOneInfo: StoryFn = () => {
     const progress: Progress = {
         durationMs: 1500,
         matchCount: 2,

--- a/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.story.tsx
+++ b/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
 
@@ -18,4 +18,4 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => <BrandedStory styles={brandedStyles}>{AfterInstallPageContent}</BrandedStory>
+export const Default: StoryFn = () => <BrandedStory styles={brandedStyles}>{AfterInstallPageContent}</BrandedStory>

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 
 import { action } from '@storybook/addon-actions'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import GithubIcon from 'mdi-react/GithubIcon'
 import { type Observable, of } from 'rxjs'
 
@@ -17,7 +17,7 @@ const invalidSourcegraphUrl = (): Observable<string | undefined> => of('Arbitrar
 
 const requestPermissionsHandler = action('requestPermission')
 
-const decorator: DecoratorFn = story => <BrandedStory styles={brandedStyles}>{() => story()}</BrandedStory>
+const decorator: Decorator = story => <BrandedStory styles={brandedStyles}>{() => story()}</BrandedStory>
 
 const config: Meta = {
     title: 'browser/Options/OptionsPage',

--- a/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
@@ -51,12 +51,12 @@ const OptionsPageWrapper: React.FunctionComponent<React.PropsWithChildren<Partia
     )
 }
 
-const Interactive: Story = args => {
+const Interactive: StoryFn = args => {
     const [isActivated, setIsActivated] = useState(false)
     return <OptionsPageWrapper isActivated={isActivated} onToggleActivated={setIsActivated} {...args} />
 }
 
-const WithAdvancedSettings: Story = args => {
+const WithAdvancedSettings: StoryFn = args => {
     const [optionFlagValues, setOptionFlagValues] = useState([
         { key: 'allowErrorReporting', label: 'Allow error reporting', value: false },
     ])
@@ -74,7 +74,7 @@ const WithAdvancedSettings: Story = args => {
     )
 }
 
-export const AllOptionsPages: Story = (args = {}) => (
+export const AllOptionsPages: StoryFn = (args = {}) => (
     <div>
         <H1 className="text-center mb-3">All Options Pages</H1>
         <Grid columnCount={3}>

--- a/client/browser/src/shared/components/HoverOverlay.story.tsx
+++ b/client/browser/src/shared/components/HoverOverlay.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 import { BrowserRouter } from 'react-router-dom'
 
@@ -15,7 +15,7 @@ import browserExtensionStyles from '../../app.scss'
 import bitbucketCodeHostStyles from '../code-hosts/bitbucket/codeHost.module.scss'
 import bitbucketStyles from '@atlassian/aui/dist/aui/css/aui.css'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <>
         <style>{bitbucketStyles}</style>
         <style>{browserExtensionStyles}</style>
@@ -62,4 +62,4 @@ export const BitbucketStyles: Story = (props = {}) => (
 )
 BitbucketStyles.storyName = 'Bitbucket styles'
 
-export const Branded: Story = () => <BitbucketStyles useBrandedLogo={true} />
+export const Branded: StoryFn = () => <BitbucketStyles useBrandedLogo={true} />

--- a/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.story.tsx
+++ b/client/jetbrains/webview/src/search/input/JetBrainsSearchBox.story.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { BrowserRouter } from 'react-router-dom'
 import { EMPTY, NEVER } from 'rxjs'
 import { useDarkMode } from 'storybook-dark-mode'
@@ -20,7 +20,7 @@ import { JetBrainsSearchBox } from './JetBrainsSearchBox'
 
 import globalStyles from '../../index.scss'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'jetbrains/JetBrainsSearchBox',
@@ -29,7 +29,7 @@ const config: Meta = {
 
 export default config
 
-export const JetBrainsSearchBoxStory: Story = () => {
+export const JetBrainsSearchBoxStory: StoryFn = () => {
     const rootElementRef = useRef<HTMLDivElement>(null)
     const isDarkTheme = useDarkMode()
 

--- a/client/jetbrains/webview/src/search/results/SearchResultList.story.tsx
+++ b/client/jetbrains/webview/src/search/results/SearchResultList.story.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subMonths } from 'date-fns'
 import { useDarkMode } from 'storybook-dark-mode'
 
@@ -17,7 +17,7 @@ import { SearchResultList } from './SearchResultList'
 
 import globalStyles from '../../index.scss'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'jetbrains/SearchResultList',
@@ -29,7 +29,7 @@ export default config
 // Use a consistent diff for date to avoid monthly snapshot failures
 const AUTHOR_DATE = subMonths(new Date(), 7).toISOString()
 
-export const JetBrainsSearchResultListStory: Story = () => {
+export const JetBrainsSearchResultListStory: StoryFn = () => {
     const rootElementRef = useRef<HTMLDivElement>(null)
     const isDarkTheme = useDarkMode()
 

--- a/client/shared/src/actions/ActionItem.story.tsx
+++ b/client/shared/src/actions/ActionItem.story.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import type * as H from 'history'
 import { NEVER } from 'rxjs'
 
@@ -37,7 +37,7 @@ const commonProps = subtypeOf<Partial<ActionItemProps>>()({
     active: true,
 })
 
-const decorator: DecoratorFn = story => <BrandedStory>{() => <div className="p-4">{story()}</div>}</BrandedStory>
+const decorator: Decorator = story => <BrandedStory>{() => <div className="p-4">{story()}</div>}</BrandedStory>
 
 const config: Meta = {
     title: 'shared/ActionItem',
@@ -45,7 +45,7 @@ const config: Meta = {
 }
 export default config
 
-export const NoopAction: Story = () => (
+export const NoopAction: StoryFn = () => (
     <ActionItem
         {...commonProps}
         action={{ id: 'a', command: undefined, actionItem: { label: 'Hello' } }}
@@ -55,7 +55,7 @@ export const NoopAction: Story = () => (
 
 NoopAction.storyName = 'Noop action'
 
-export const CommandAction: Story = () => (
+export const CommandAction: StoryFn = () => (
     <ActionItem
         {...commonProps}
         action={{ id: 'a', command: 'c', title: 'Hello', iconURL: ICON_URL }}
@@ -74,7 +74,7 @@ CommandAction.parameters = {
     },
 }
 
-export const LinkAction: Story = () => (
+export const LinkAction: StoryFn = () => (
     <ActionItem
         {...commonProps}
         action={{
@@ -90,7 +90,7 @@ export const LinkAction: Story = () => (
 
 LinkAction.storyName = 'Link action'
 
-export const Executing: Story = () => {
+export const Executing: StoryFn = () => {
     class ActionItemExecuting extends ActionItem {
         constructor(props: ActionItem['props']) {
             super(props)
@@ -108,7 +108,7 @@ export const Executing: Story = () => {
     )
 }
 
-export const _Error: Story = () => {
+export const _Error: StoryFn = () => {
     class ActionItemWithError extends ActionItem {
         constructor(props: ActionItem['props']) {
             super(props)

--- a/client/shared/src/symbols/SymbolTag.story.tsx
+++ b/client/shared/src/symbols/SymbolTag.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
 
@@ -6,7 +6,7 @@ import { SymbolKind } from '../graphql-operations'
 
 import { SymbolTag } from './SymbolTag'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'shared/SymbolTag',
@@ -20,7 +20,7 @@ export default config
 
 const symbolKinds = Object.values(SymbolKind)
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <BrandedStory>
         {() => (
             <div>

--- a/client/web/src/auth/CloudSignUpPage.story.tsx
+++ b/client/web/src/auth/CloudSignUpPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import sinon from 'sinon'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -48,7 +48,7 @@ const context: Pick<SourcegraphContext, 'authProviders' | 'experimentalFeatures'
     authMinPasswordLength: 0,
 }
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {({ isLightTheme }) => (
             <CloudSignUpPage
@@ -64,7 +64,7 @@ export const Default: Story = () => (
     </WebStory>
 )
 
-export const EmailForm: Story = () => (
+export const EmailForm: StoryFn = () => (
     <WebStory>
         {({ isLightTheme }) => (
             <CloudSignUpPage
@@ -80,7 +80,7 @@ export const EmailForm: Story = () => (
     </WebStory>
 )
 
-export const InvalidSource: Story = () => (
+export const InvalidSource: StoryFn = () => (
     <WebStory>
         {({ isLightTheme }) => (
             <CloudSignUpPage
@@ -96,7 +96,7 @@ export const InvalidSource: Story = () => (
     </WebStory>
 )
 
-export const OptimizationSignup: Story = () => (
+export const OptimizationSignup: StoryFn = () => (
     <WebStory>
         {({ isLightTheme }) => (
             <CloudSignUpPage

--- a/client/web/src/auth/OrDivider.story.tsx
+++ b/client/web/src/auth/OrDivider.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { Card } from '@sourcegraph/wildcard'
 
@@ -6,7 +6,7 @@ import { WebStory } from '../components/WebStory'
 
 import { OrDivider } from './OrDivider'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/auth/OrDivider',
@@ -15,7 +15,7 @@ const config: Meta = {
 
 export default config
 
-export const Alone: Story = () => (
+export const Alone: StoryFn = () => (
     <WebStory>
         {() => (
             <Card className="border-0">

--- a/client/web/src/auth/PostSignUpPage.story.tsx
+++ b/client/web/src/auth/PostSignUpPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { AuthenticatedUser } from '../auth'
 import { WebStory } from '../components/WebStory'
@@ -20,8 +20,8 @@ const mockUser = {
     completedPostSignup: false,
 } as AuthenticatedUser
 
-export const UnverifiedEmail: Story = () => <WebStory>{() => <PostSignUpPage authenticatedUser={mockUser} />}</WebStory>
+export const UnverifiedEmail: StoryFn = () => <WebStory>{() => <PostSignUpPage authenticatedUser={mockUser} />}</WebStory>
 
-export const VerifiedEmail: Story = () => (
+export const VerifiedEmail: StoryFn = () => (
     <WebStory>{() => <PostSignUpPage authenticatedUser={{ ...mockUser, hasVerifiedEmail: true }} />}</WebStory>
 )

--- a/client/web/src/auth/PostSignUpPage.story.tsx
+++ b/client/web/src/auth/PostSignUpPage.story.tsx
@@ -20,7 +20,9 @@ const mockUser = {
     completedPostSignup: false,
 } as AuthenticatedUser
 
-export const UnverifiedEmail: StoryFn = () => <WebStory>{() => <PostSignUpPage authenticatedUser={mockUser} />}</WebStory>
+export const UnverifiedEmail: StoryFn = () => (
+    <WebStory>{() => <PostSignUpPage authenticatedUser={mockUser} />}</WebStory>
+)
 
 export const VerifiedEmail: StoryFn = () => (
     <WebStory>{() => <PostSignUpPage authenticatedUser={{ ...mockUser, hasVerifiedEmail: true }} />}</WebStory>

--- a/client/web/src/auth/RequestAccessPage.story.tsx
+++ b/client/web/src/auth/RequestAccessPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'
 
@@ -13,8 +13,8 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => <WebStory>{() => <RequestAccessPage />}</WebStory>
+export const Default: StoryFn = () => <WebStory>{() => <RequestAccessPage />}</WebStory>
 
-export const Done: Story = () => (
+export const Done: StoryFn = () => (
     <WebStory initialEntries={[{ pathname: '/done' }]}>{() => <RequestAccessPage />}</WebStory>
 )

--- a/client/web/src/auth/ResetPasswordPage.story.tsx
+++ b/client/web/src/auth/ResetPasswordPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { AuthenticatedUser } from '../auth'
 import { WebStory } from '../components/WebStory'
@@ -14,7 +14,7 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {() => (
             <ResetPasswordPage
@@ -25,7 +25,7 @@ export const Default: Story = () => (
     </WebStory>
 )
 
-export const WithCode: Story = () => (
+export const WithCode: StoryFn = () => (
     <WebStory initialEntries={[{ pathname: '/reset-password', search: '?code=123123&userID=123' }]}>
         {() => (
             <ResetPasswordPage
@@ -36,7 +36,7 @@ export const WithCode: Story = () => (
     </WebStory>
 )
 
-export const LoggedInUser: Story = () => (
+export const LoggedInUser: StoryFn = () => (
     <WebStory>
         {() => (
             <ResetPasswordPage
@@ -47,7 +47,7 @@ export const LoggedInUser: Story = () => (
     </WebStory>
 )
 
-export const Disabled: Story = () => (
+export const Disabled: StoryFn = () => (
     <WebStory>
         {() => (
             <ResetPasswordPage
@@ -58,7 +58,7 @@ export const Disabled: Story = () => (
     </WebStory>
 )
 
-export const Dotcom: Story = () => (
+export const Dotcom: StoryFn = () => (
     <WebStory>
         {() => (
             <ResetPasswordPage

--- a/client/web/src/auth/SignInPage.story.tsx
+++ b/client/web/src/auth/SignInPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'
 import type { SourcegraphContext } from '../jscontext'
@@ -54,43 +54,43 @@ const context: SignInPageProps['context'] = {
     resetPasswordEnabled: true,
 }
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>{() => <SignInPage context={context} authenticatedUser={null} />}</WebStory>
 )
 
-export const ShowMore: Story = () => (
+export const ShowMore: StoryFn = () => (
     <WebStory initialEntries={[{ pathname: '/sign-in', search: '?showMore' }]}>
         {() => <SignInPage context={{ ...context, primaryLoginProvidersCount: 1 }} authenticatedUser={null} />}
     </WebStory>
 )
 
-export const Dotcom: Story = () => (
+export const Dotcom: StoryFn = () => (
     <WebStory>
         {() => <SignInPage context={{ ...context, sourcegraphDotComMode: true }} authenticatedUser={null} />}
     </WebStory>
 )
 
-export const NoProviders: Story = () => (
+export const NoProviders: StoryFn = () => (
     <WebStory>{() => <SignInPage context={{ ...context, authProviders: [] }} authenticatedUser={null} />}</WebStory>
 )
 
-export const NoBuiltIn: Story = () => (
+export const NoBuiltIn: StoryFn = () => (
     <WebStory>
         {() => <SignInPage context={{ ...context, authProviders: noBuiltInAuthProviders }} authenticatedUser={null} />}
     </WebStory>
 )
 
-export const NoResetPassword: Story = () => (
+export const NoResetPassword: StoryFn = () => (
     <WebStory>
         {() => <SignInPage context={{ ...context, resetPasswordEnabled: false }} authenticatedUser={null} />}
     </WebStory>
 )
 
-export const NoSignUp: Story = () => (
+export const NoSignUp: StoryFn = () => (
     <WebStory>{() => <SignInPage context={{ ...context, allowSignup: false }} authenticatedUser={null} />}</WebStory>
 )
 
-export const NoAccessRequest: Story = () => (
+export const NoAccessRequest: StoryFn = () => (
     <WebStory>
         {() => (
             <SignInPage
@@ -101,19 +101,19 @@ export const NoAccessRequest: Story = () => (
     </WebStory>
 )
 
-export const DotComSignUp: Story = () => (
+export const DotComSignUp: StoryFn = () => (
     <WebStory>
         {() => <SignInPage context={{ ...context, sourcegraphDotComMode: true }} authenticatedUser={null} />}
     </WebStory>
 )
 
-export const OnlyOnePrimaryProvider: Story = () => (
+export const OnlyOnePrimaryProvider: StoryFn = () => (
     <WebStory>
         {() => <SignInPage context={{ ...context, primaryLoginProvidersCount: 1 }} authenticatedUser={null} />}
     </WebStory>
 )
 
-export const OnlyOnePrimaryProviderWithoutBuiltIn: Story = () => (
+export const OnlyOnePrimaryProviderWithoutBuiltIn: StoryFn = () => (
     <WebStory>
         {() => (
             <SignInPage
@@ -124,13 +124,13 @@ export const OnlyOnePrimaryProviderWithoutBuiltIn: Story = () => (
     </WebStory>
 )
 
-export const ShowMoreProviders: Story = () => (
+export const ShowMoreProviders: StoryFn = () => (
     <WebStory initialEntries={['/sign-in?showMore']}>
         {() => <SignInPage context={{ ...context, primaryLoginProvidersCount: 1 }} authenticatedUser={null} />}
     </WebStory>
 )
 
-export const ShowMoreProvidersWithoutBuiltIn: Story = () => (
+export const ShowMoreProvidersWithoutBuiltIn: StoryFn = () => (
     <WebStory initialEntries={['/sign-in?showMore']}>
         {() => (
             <SignInPage
@@ -141,13 +141,13 @@ export const ShowMoreProvidersWithoutBuiltIn: Story = () => (
     </WebStory>
 )
 
-export const OnlyBuiltInAuthProvider: Story = () => (
+export const OnlyBuiltInAuthProvider: StoryFn = () => (
     <WebStory>
         {() => <SignInPage context={{ ...context, authProviders: onlyBuiltInAuthProvider }} authenticatedUser={null} />}
     </WebStory>
 )
 
-export const PrefixCanBeChanged: Story = () => {
+export const PrefixCanBeChanged: StoryFn = () => {
     const providers = noBuiltInAuthProviders.map(provider => ({ ...provider, displayPrefix: 'Just login with' }))
 
     return (

--- a/client/web/src/auth/SignUpPage.story.tsx
+++ b/client/web/src/auth/SignUpPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -43,7 +43,7 @@ const authProviders: SourcegraphContext['authProviders'] = [
     },
 ]
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {() => (
             <SignUpPage

--- a/client/web/src/auth/UnlockAccount.story.tsx
+++ b/client/web/src/auth/UnlockAccount.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'
 import { SourcegraphContext } from '../jscontext'
@@ -41,7 +41,7 @@ const authProviders: SourcegraphContext['authProviders'] = [
     },
 ]
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {() => (
             <UnlockAccountPage

--- a/client/web/src/auth/VsCodeSignUpPage.story.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -48,7 +48,7 @@ const context: VsCodeSignUpPageProps['context'] = {
     authMinPasswordLength: 12,
 }
 
-export const WithoutEmailForm: Story = () => (
+export const WithoutEmailForm: StoryFn = () => (
     <WebStory>
         {() => (
             <VsCodeSignUpPage
@@ -62,7 +62,7 @@ export const WithoutEmailForm: Story = () => (
     </WebStory>
 )
 
-export const WithEmailForm: Story = () => (
+export const WithEmailForm: StoryFn = () => (
     <WebStory>
         {() => (
             <VsCodeSignUpPage

--- a/client/web/src/batches/RepoBatchChangesButton.story.tsx
+++ b/client/web/src/batches/RepoBatchChangesButton.story.tsx
@@ -20,7 +20,7 @@ export default config
 let openValue = 0
 let mergedValue = 0
 
-export const RepoButton: Story = args => (
+export const RepoButton: StoryFn = args => (
     <WebStory>
         {() => {
             openValue = args.open

--- a/client/web/src/batches/RepoBatchChangesButton.story.tsx
+++ b/client/web/src/batches/RepoBatchChangesButton.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -9,7 +9,7 @@ import { WebStory } from '../components/WebStory'
 import { REPO_CHANGESETS_STATS } from './backend'
 import { RepoBatchChangesButton } from './RepoBatchChangesButton'
 
-const decorator: DecoratorFn = story => <div className="p-3 container web-content">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container web-content">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/repo',

--- a/client/web/src/codeintel/ReferencesPanel.story.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -22,7 +22,7 @@ const config: Meta = {
 
 export default config
 
-export const Simple: Story = () => {
+export const Simple: StoryFn = () => {
     const { url, requestMocks } = buildReferencePanelMocks()
 
     return (

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.story.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { AuthenticatedUser } from '../../../auth'
 import { WebStory } from '../../../components/WebStory'
@@ -33,18 +33,18 @@ const context: Pick<SourcegraphContext, 'authProviders'> = {
     ],
 }
 
-export const SourcegraphDotCom: Story = () => (
+export const SourcegraphDotCom: StoryFn = () => (
     <WebStory>
         {() => <CodyMarketingPage context={context} isSourcegraphDotCom={true} authenticatedUser={null} />}
     </WebStory>
 )
-export const Enterprise: Story = () => (
+export const Enterprise: StoryFn = () => (
     <WebStory>
         {() => <CodyMarketingPage context={context} isSourcegraphDotCom={false} authenticatedUser={null} />}
     </WebStory>
 )
 
-export const EnterpriseSiteAdmin: Story = () => (
+export const EnterpriseSiteAdmin: StoryFn = () => (
     <WebStory>
         {() => (
             <CodyMarketingPage

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.story.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { EMPTY, NEVER, type Observable, of } from 'rxjs'
 
@@ -131,11 +131,11 @@ const commonProps = () =>
         fetchSearchContextBySpec: fetchCommunitySearchContext,
     })
 
-export const Temporal: Story = () => (
+export const Temporal: StoryFn = () => (
     <WebStory>{webProps => <CommunitySearchContextPage {...webProps} {...commonProps()} />}</WebStory>
 )
 
-export const CNCFStory: Story = () => (
+export const CNCFStory: StoryFn = () => (
     <WebStory>
         {webProps => (
             <CommunitySearchContextPage {...webProps} {...commonProps()} communitySearchContextMetadata={cncf} />

--- a/client/web/src/components/Breadcrumbs.story.tsx
+++ b/client/web/src/components/Breadcrumbs.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { Link } from '@sourcegraph/wildcard'
 
 import { Breadcrumbs } from './Breadcrumbs'
 import { WebStory } from './WebStory'
 
-const decorator: DecoratorFn = story => <div className="container mt-3">{story()}</div>
+const decorator: Decorator = story => <div className="container mt-3">{story()}</div>
 
 const config: Meta = {
     title: 'web/Breadcrumbs',
@@ -14,7 +14,7 @@ const config: Meta = {
 
 export default config
 
-export const Example: Story = () => (
+export const Example: StoryFn = () => (
     <WebStory>
         {webProps => (
             <Breadcrumbs

--- a/client/web/src/components/Byline/CreatedByAndUpdatedByInfoByline.story.tsx
+++ b/client/web/src/components/Byline/CreatedByAndUpdatedByInfoByline.story.tsx
@@ -1,11 +1,11 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { WebStory } from '../WebStory'
 
 import { CreatedByAndUpdatedByInfoByline } from './CreatedByAndUpdatedByInfoByline'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/src/components/Byline',
@@ -16,7 +16,7 @@ export default config
 
 const THREE_DAYS_AGO = subDays(new Date(), 3).toISOString()
 
-export const NeverUpdated: Story = () => (
+export const NeverUpdated: StoryFn = () => (
     <WebStory>
         {props => (
             <CreatedByAndUpdatedByInfoByline
@@ -32,7 +32,7 @@ export const NeverUpdated: Story = () => (
 
 NeverUpdated.storyName = 'Never updated'
 
-export const CreatedByDeletedUser: Story = () => (
+export const CreatedByDeletedUser: StoryFn = () => (
     <WebStory>
         {props => (
             <CreatedByAndUpdatedByInfoByline
@@ -48,7 +48,7 @@ export const CreatedByDeletedUser: Story = () => (
 
 CreatedByDeletedUser.storyName = 'Created by deleted user'
 
-export const NeverUpdatedSSBC: Story = () => (
+export const NeverUpdatedSSBC: StoryFn = () => (
     <WebStory>
         {props => (
             <CreatedByAndUpdatedByInfoByline
@@ -64,7 +64,7 @@ export const NeverUpdatedSSBC: Story = () => (
 
 NeverUpdatedSSBC.storyName = 'Never updated (SSBC)'
 
-export const UpdatedSameUser: Story = () => (
+export const UpdatedSameUser: StoryFn = () => (
     <WebStory>
         {props => (
             <CreatedByAndUpdatedByInfoByline
@@ -80,7 +80,7 @@ export const UpdatedSameUser: Story = () => (
 
 UpdatedSameUser.storyName = 'Updated (same user)'
 
-export const UpdatedDifferentUser: Story = () => (
+export const UpdatedDifferentUser: StoryFn = () => (
     <WebStory>
         {props => (
             <CreatedByAndUpdatedByInfoByline
@@ -96,7 +96,7 @@ export const UpdatedDifferentUser: Story = () => (
 
 UpdatedDifferentUser.storyName = 'Updated (different users)'
 
-export const DatesWithoutAuthors: Story = () => (
+export const DatesWithoutAuthors: StoryFn = () => (
     <WebStory>
         {props => (
             <CreatedByAndUpdatedByInfoByline

--- a/client/web/src/components/CopyableText.story.tsx
+++ b/client/web/src/components/CopyableText.story.tsx
@@ -1,9 +1,9 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { CopyableText } from './CopyableText'
 import { WebStory } from './WebStory'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="container mt-3" style={{ width: 800 }}>
         {story()}
     </div>
@@ -16,10 +16,10 @@ const config: Meta = {
 
 export default config
 
-export const WithoutSecret: Story = () => <WebStory>{() => <CopyableText text="text that can be copied" />}</WebStory>
+export const WithoutSecret: StoryFn = () => <WebStory>{() => <CopyableText text="text that can be copied" />}</WebStory>
 
 WithoutSecret.storyName = 'Without secret'
 
-export const WithSecret: Story = () => <WebStory>{() => <CopyableText secret={true} text="secret text" />}</WebStory>
+export const WithSecret: StoryFn = () => <WebStory>{() => <CopyableText secret={true} text="secret text" />}</WebStory>
 
 WithSecret.storyName = 'With secret'

--- a/client/web/src/components/DismissibleAlert/DismissibleAlert.story.tsx
+++ b/client/web/src/components/DismissibleAlert/DismissibleAlert.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { Link } from '@sourcegraph/wildcard'
 
@@ -6,7 +6,7 @@ import { WebStory } from '../WebStory'
 
 import { DismissibleAlert } from './DismissibleAlert'
 
-const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => story()}</WebStory>
 
 const config: Meta = {
     title: 'web/DismissibleAlert',
@@ -15,7 +15,7 @@ const config: Meta = {
 
 export default config
 
-export const OneLineAlert: Story = () => (
+export const OneLineAlert: StoryFn = () => (
     <DismissibleAlert variant="info" partialStorageKey="dismissible-alert-one-line">
         <span>
             1 bulk operation has recently failed running. Click the <Link to="?">bulk operations tab</Link> to view.
@@ -25,7 +25,7 @@ export const OneLineAlert: Story = () => (
 
 OneLineAlert.storyName = 'One-line alert'
 
-export const MultilineAlert: Story = () => (
+export const MultilineAlert: StoryFn = () => (
     <DismissibleAlert variant="info" partialStorageKey="dismissible-alert-multiline">
         WebAssembly (sometimes abbreviated Wasm) is an open standard that defines a portable binary-code format for
         executable programs, and a corresponding textual assembly language, as well as interfaces for facilitating

--- a/client/web/src/components/LoaderButton.story.tsx
+++ b/client/web/src/components/LoaderButton.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { Text } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from './LoaderButton'
 import { WebStory } from './WebStory'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="container mt-3" style={{ width: 800 }}>
         {story()}
     </div>
@@ -18,7 +18,7 @@ const config: Meta = {
 
 export default config
 
-export const Inline: Story = () => (
+export const Inline: StoryFn = () => (
     <WebStory>
         {() => (
             <Text>
@@ -28,11 +28,11 @@ export const Inline: Story = () => (
     </WebStory>
 )
 
-export const Block: Story = () => (
+export const Block: StoryFn = () => (
     <WebStory>{() => <LoaderButton loading={true} label="loader button" display="block" variant="primary" />}</WebStory>
 )
 
-export const WithLabel: Story = () => (
+export const WithLabel: StoryFn = () => (
     <WebStory>
         {() => (
             <LoaderButton

--- a/client/web/src/components/MarketingBlock/MarketingBlock.story.tsx
+++ b/client/web/src/components/MarketingBlock/MarketingBlock.story.tsx
@@ -1,5 +1,5 @@
 import { mdiArrowRight } from '@mdi/js'
-import type { DecoratorFn, Meta } from '@storybook/react'
+import type { Decorator, Meta } from '@storybook/react'
 
 import { Link, Icon, H2, H3, Grid } from '@sourcegraph/wildcard'
 
@@ -7,7 +7,7 @@ import { WebStory } from '../WebStory'
 
 import { MarketingBlock } from './MarketingBlock'
 
-const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
 
 const config: Meta = {
     title: 'web/marketing/MarketingBlock',

--- a/client/web/src/components/SelfHostedCta/SelfHostedCta.story.tsx
+++ b/client/web/src/components/SelfHostedCta/SelfHostedCta.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import type { DecoratorFn, Meta } from '@storybook/react'
+import type { Decorator, Meta } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Text } from '@sourcegraph/wildcard'
@@ -9,7 +9,7 @@ import { WebStory } from '../WebStory'
 
 import { SelfHostedCta, type SelfHostedCtaProps } from './SelfHostedCta'
 
-const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
 
 const config: Meta = {
     title: 'web/marketing/SelfHostedCta',

--- a/client/web/src/components/Timeline.story.tsx
+++ b/client/web/src/components/Timeline.story.tsx
@@ -1,5 +1,5 @@
 import { mdiCheck, mdiAlertCircle } from '@mdi/js'
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 import { parseISO } from 'date-fns'
 
 import { Icon, Text } from '@sourcegraph/wildcard'
@@ -7,7 +7,7 @@ import { Icon, Text } from '@sourcegraph/wildcard'
 import { Timeline } from './Timeline'
 import { WebStory } from './WebStory'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="container mt-3" style={{ maxWidth: 600 }}>
         {story()}
     </div>
@@ -20,7 +20,7 @@ const config: Meta = {
 
 export default config
 
-export const Basic: Story = () => (
+export const Basic: StoryFn = () => (
     <WebStory>
         {() => (
             <Timeline
@@ -62,7 +62,7 @@ export const Basic: Story = () => (
     </WebStory>
 )
 
-export const Details: Story = () => (
+export const Details: StoryFn = () => (
     <WebStory>
         {() => (
             <Timeline

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { registerHighlightContributions } from '@sourcegraph/common'
 import {
@@ -22,7 +22,7 @@ import styles from './WebHoverOverlay.story.module.scss'
 
 registerHighlightContributions()
 
-const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => story()}</WebStory>
 
 const config: Meta = {
     title: 'web/WebHoverOverlay',
@@ -41,11 +41,11 @@ const config: Meta = {
 
 export default config
 
-export const Loading: Story = () => (
+export const Loading: StoryFn = () => (
     <WebHoverOverlay {...commonProps()} hoverOrError="loading" actionsOrError={FIXTURE_ACTIONS} />
 )
 
-export const _Error: Story = () => (
+export const _Error: StoryFn = () => (
     <WebHoverOverlay
         {...commonProps()}
         hoverOrError={
@@ -59,19 +59,19 @@ export const _Error: Story = () => (
 
 _Error.storyName = 'Error'
 
-export const NoHoverInformation: Story = () => (
+export const NoHoverInformation: StoryFn = () => (
     <WebHoverOverlay {...commonProps()} hoverOrError={null} actionsOrError={FIXTURE_ACTIONS} />
 )
 
 NoHoverInformation.storyName = 'No hover information'
 
-export const CommonContentWithoutActions: Story = () => (
+export const CommonContentWithoutActions: StoryFn = () => (
     <WebHoverOverlay {...commonProps()} hoverOrError={{ contents: [FIXTURE_CONTENT] }} />
 )
 
 CommonContentWithoutActions.storyName = 'Common content without actions'
 
-export const CommonContentWithActions: Story = () => (
+export const CommonContentWithActions: StoryFn = () => (
     <WebHoverOverlay
         {...commonProps()}
         hoverOrError={{
@@ -83,7 +83,7 @@ export const CommonContentWithActions: Story = () => (
 
 CommonContentWithActions.storyName = 'Common content with actions'
 
-export const AggregatedBadges: Story = () => (
+export const AggregatedBadges: StoryFn = () => (
     <WebHoverOverlay
         {...commonProps()}
         hoverOrError={{
@@ -94,7 +94,7 @@ export const AggregatedBadges: Story = () => (
     />
 )
 
-export const LongCode: Story = () => (
+export const LongCode: StoryFn = () => (
     <WebHoverOverlay
         {...commonProps()}
         hoverOrError={{
@@ -107,7 +107,7 @@ export const LongCode: Story = () => (
 
 LongCode.storyName = 'Long code'
 
-export const LongTextOnly: Story = () => (
+export const LongTextOnly: StoryFn = () => (
     <WebHoverOverlay
         {...commonProps()}
         hoverOrError={{
@@ -119,7 +119,7 @@ export const LongTextOnly: Story = () => (
 
 LongTextOnly.storyName = 'Long text only'
 
-export const LongMarkdownWithDiv: Story = () => (
+export const LongMarkdownWithDiv: StoryFn = () => (
     <WebHoverOverlay
         {...commonProps()}
         hoverOrError={{
@@ -131,7 +131,7 @@ export const LongMarkdownWithDiv: Story = () => (
 
 LongMarkdownWithDiv.storyName = 'Long markdown with <div>'
 
-export const MultipleMarkupContents: Story = () => (
+export const MultipleMarkupContents: StoryFn = () => (
     <WebHoverOverlay
         {...commonProps()}
         hoverOrError={{
@@ -144,7 +144,7 @@ export const MultipleMarkupContents: Story = () => (
 
 MultipleMarkupContents.storyName = 'Multiple MarkupContents'
 
-export const WithLongMarkdownTextIcon: Story = () => (
+export const WithLongMarkdownTextIcon: StoryFn = () => (
     <WebHoverOverlay
         {...commonProps()}
         hoverOrError={{
@@ -157,7 +157,7 @@ export const WithLongMarkdownTextIcon: Story = () => (
 
 WithLongMarkdownTextIcon.storyName = 'With long markdown text and icon.'
 
-export const MultipleMarkupContentsWithBadges: Story = () => (
+export const MultipleMarkupContentsWithBadges: StoryFn = () => (
     <div className={styles.container}>
         <WebHoverOverlay
             {...commonProps()}
@@ -172,7 +172,7 @@ export const MultipleMarkupContentsWithBadges: Story = () => (
 
 MultipleMarkupContentsWithBadges.storyName = 'Multiple MarkupContents with badges'
 
-export const WithCloseButton: Story = () => (
+export const WithCloseButton: StoryFn = () => (
     <WebHoverOverlay
         {...commonProps()}
         hoverOrError={{

--- a/client/web/src/components/diff/DiffStat.story.tsx
+++ b/client/web/src/components/diff/DiffStat.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../WebStory'
 
 import { DiffStat, DiffStatSquares, DiffStatStack } from './DiffStat'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/diffs/DiffStat',

--- a/client/web/src/components/diff/DiffStat.story.tsx
+++ b/client/web/src/components/diff/DiffStat.story.tsx
@@ -25,25 +25,25 @@ const config: Meta = {
 
 export default config
 
-export const CollapsedCounts: Story<React.ComponentProps<typeof DiffStat>> = args => (
+export const CollapsedCounts: StoryFn<React.ComponentProps<typeof DiffStat>> = args => (
     <WebStory>{() => <DiffStat {...args} />}</WebStory>
 )
 
 CollapsedCounts.storyName = 'Collapsed counts'
 
-export const ExpandedCounts: Story<React.ComponentProps<typeof DiffStat>> = args => (
+export const ExpandedCounts: StoryFn<React.ComponentProps<typeof DiffStat>> = args => (
     <WebStory>{() => <DiffStat {...args} expandedCounts={true} />}</WebStory>
 )
 
 ExpandedCounts.storyName = 'Expanded counts'
 
-export const DiffStatSquaresStory: Story<React.ComponentProps<typeof DiffStatSquares>> = args => (
+export const DiffStatSquaresStory: StoryFn<React.ComponentProps<typeof DiffStatSquares>> = args => (
     <WebStory>{() => <DiffStatSquares {...args} />}</WebStory>
 )
 
 DiffStatSquaresStory.storyName = 'DiffStatSquares'
 
-export const DiffStatStackStory: Story<React.ComponentProps<typeof DiffStatStack>> = args => (
+export const DiffStatStackStory: StoryFn<React.ComponentProps<typeof DiffStatStack>> = args => (
     <WebStory>{() => <DiffStatStack {...args} />}</WebStory>
 )
 

--- a/client/web/src/components/diff/FileDiffHunks.story.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { type FileDiffHunkFields, DiffHunkLineType } from '../../graphql-operations'
 import { WebStory } from '../WebStory'
@@ -51,7 +51,7 @@ export const DEMO_HUNKS: FileDiffHunkFields[] = [
     },
 ]
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/diffs/FileDiffHunks',

--- a/client/web/src/components/diff/FileDiffHunks.story.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.story.tsx
@@ -73,7 +73,7 @@ const config: Meta = {
 
 export default config
 
-export const OneDiffUnifiedHunk: Story = args => (
+export const OneDiffUnifiedHunk: StoryFn = args => (
     <WebStory>
         {webProps => (
             <FileDiffHunks
@@ -91,7 +91,7 @@ export const OneDiffUnifiedHunk: Story = args => (
 
 OneDiffUnifiedHunk.storyName = 'One diff unified hunk'
 
-export const OneDiffSplitHunk: Story = args => (
+export const OneDiffSplitHunk: StoryFn = args => (
     <WebStory>
         {webProps => (
             <FileDiffHunks

--- a/client/web/src/components/diff/FileDiffNode.story.tsx
+++ b/client/web/src/components/diff/FileDiffNode.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import type { FileDiffFields } from '../../graphql-operations'
 import { WebStory } from '../WebStory'
@@ -191,7 +191,7 @@ export const FILE_DIFF_NODES: FileDiffFields[] = [
     },
 ]
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/diffs/FileDiffNode',

--- a/client/web/src/components/diff/FileDiffNode.story.tsx
+++ b/client/web/src/components/diff/FileDiffNode.story.tsx
@@ -213,7 +213,7 @@ const config: Meta = {
 
 export default config
 
-export const AllUnifiedFileNode: Story = args => (
+export const AllUnifiedFileNode: StoryFn = args => (
     <WebStory>
         {webProps => (
             <ul className="list-unstyled">
@@ -235,7 +235,7 @@ export const AllUnifiedFileNode: Story = args => (
 
 AllUnifiedFileNode.storyName = 'All unified file node states overview'
 
-export const AllSplitFileNode: Story = args => (
+export const AllSplitFileNode: StoryFn = args => (
     <WebStory>
         {webProps => (
             <ul className="list-unstyled">

--- a/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -7,7 +7,7 @@ import { WebStory } from '../WebStory'
 import { AddExternalServicesPage } from './AddExternalServicesPage'
 import { codeHostExternalServices, nonCodeHostExternalServices } from './externalServices'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/External services/AddExternalServicesPage',
@@ -22,7 +22,7 @@ const config: Meta = {
 
 export default config
 
-export const Overview: Story = () => (
+export const Overview: StoryFn = () => (
     <WebStory>
         {webProps => (
             <AddExternalServicesPage
@@ -39,7 +39,7 @@ export const Overview: Story = () => (
     </WebStory>
 )
 
-export const OverviewWithBusinessLicense: Story = () => {
+export const OverviewWithBusinessLicense: StoryFn = () => {
     window.context.licenseInfo = { currentPlan: 'business-0' }
     return (
         <WebStory>
@@ -59,7 +59,7 @@ export const OverviewWithBusinessLicense: Story = () => {
     )
 }
 
-export const AddConnectionBykind: Story = () => (
+export const AddConnectionBykind: StoryFn = () => (
     <WebStory initialEntries={['/page?id=github']}>
         {webProps => (
             <AddExternalServicesPage

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
@@ -79,7 +79,7 @@ function newFetchMock(node: ExternalServiceFields): WildcardMockLink {
     ])
 }
 
-export const ViewConfig: Story<WebStoryChildrenProps> = props => (
+export const ViewConfig: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={newFetchMock(externalService)}>
         <ExternalServiceEditPage
             telemetryService={NOOP_TELEMETRY_SERVICE}
@@ -92,7 +92,7 @@ export const ViewConfig: Story<WebStoryChildrenProps> = props => (
 
 ViewConfig.storyName = 'View external service config'
 
-export const ConfigWithInvalidUrl: Story<WebStoryChildrenProps> = props => (
+export const ConfigWithInvalidUrl: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={newFetchMock({ ...externalService, config: '{"url": "invalid-url"}' })}>
         <ExternalServiceEditPage
             telemetryService={NOOP_TELEMETRY_SERVICE}
@@ -105,7 +105,7 @@ export const ConfigWithInvalidUrl: Story<WebStoryChildrenProps> = props => (
 
 ConfigWithInvalidUrl.storyName = 'External service config with invalid url'
 
-export const ConfigWithWarning: Story<WebStoryChildrenProps> = props => (
+export const ConfigWithWarning: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={newFetchMock({ ...externalService, warning: 'Invalid config we could not sync stuff' })}>
         <ExternalServiceEditPage
             telemetryService={NOOP_TELEMETRY_SERVICE}
@@ -118,7 +118,7 @@ export const ConfigWithWarning: Story<WebStoryChildrenProps> = props => (
 
 ConfigWithWarning.storyName = 'External service config with warning after update'
 
-export const EditingDisabled: Story<WebStoryChildrenProps> = props => (
+export const EditingDisabled: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={newFetchMock({ ...externalService, warning: 'Invalid config we could not sync stuff' })}>
         <ExternalServiceEditPage
             telemetryService={NOOP_TELEMETRY_SERVICE}

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -11,7 +11,7 @@ import { WebStory, type WebStoryChildrenProps } from '../WebStory'
 import { FETCH_EXTERNAL_SERVICE } from './backend'
 import { ExternalServiceEditPage } from './ExternalServiceEditPage'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3 container">
         <WebStory
             path="/site-admin/external-services/:externalServiceID/edit"

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -139,7 +139,7 @@ function newFetchMock(node: ExternalServiceFields): WildcardMockLink {
     ])
 }
 
-export const ExternalServiceWithRepos: Story<WebStoryChildrenProps> = props => (
+export const ExternalServiceWithRepos: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={newFetchMock(externalService)}>
         <ExternalServicePage
             queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { subMinutes } from 'date-fns'
 import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
@@ -13,7 +13,7 @@ import { WebStory, type WebStoryChildrenProps } from '../WebStory'
 import { FETCH_EXTERNAL_SERVICE, type queryExternalServiceSyncJobs as _queryExternalServiceSyncJobs } from './backend'
 import { ExternalServicePage } from './ExternalServicePage'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3 container">
         <WebStory
             path="/site-admin/external-services/:externalServiceID"

--- a/client/web/src/components/externalServices/ExternalServiceSyncJobNode.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceSyncJobNode.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { Subject } from 'rxjs'
 
 import { ExternalServiceSyncJobState } from '../../graphql-operations'
@@ -6,7 +6,7 @@ import { WebStory } from '../WebStory'
 
 import { ExternalServiceSyncJobNode } from './ExternalServiceSyncJobNode'
 
-const decorator: DecoratorFn = story => <WebStory>{() => <div className="p-3 container">{story()}</div>}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => <div className="p-3 container">{story()}</div>}</WebStory>
 
 const config: Meta = {
     title: 'web/External services/ExternalServiceSyncJobNode',
@@ -18,7 +18,7 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <div>
         {Object.values(ExternalServiceSyncJobState).map(state => (
             <ExternalServiceSyncJobNode

--- a/client/web/src/components/externalServices/ExternalServiceWebhook.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceWebhook.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { ExternalServiceKind } from '../../graphql-operations'
 import { WebStory } from '../WebStory'
 
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 
-const decorator: DecoratorFn = story => <WebStory>{() => <div className="p-3 container">{story()}</div>}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => <div className="p-3 container">{story()}</div>}</WebStory>
 
 const config: Meta = {
     title: 'web/External services/ExternalServiceWebhook',
@@ -14,19 +14,19 @@ const config: Meta = {
 
 export default config
 
-export const BitbucketServer: Story = () => (
+export const BitbucketServer: StoryFn = () => (
     <ExternalServiceWebhook
         externalService={{ webhookURL: 'http://test.test/webhook', kind: ExternalServiceKind.BITBUCKETSERVER }}
     />
 )
 
-export const GitHub: Story = () => (
+export const GitHub: StoryFn = () => (
     <ExternalServiceWebhook
         externalService={{ webhookURL: 'http://test.test/webhook', kind: ExternalServiceKind.GITHUB }}
     />
 )
 
-export const GitLab: Story = () => (
+export const GitLab: StoryFn = () => (
     <ExternalServiceWebhook
         externalService={{ webhookURL: 'http://test.test/webhook', kind: ExternalServiceKind.GITLAB }}
     />

--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subMinutes } from 'date-fns'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
@@ -12,7 +12,7 @@ import { WebStory } from '../WebStory'
 import { EXTERNAL_SERVICES } from './backend'
 import { ExternalServicesPage } from './ExternalServicesPage'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3 container">
         <WebStory>{story}</WebStory>
     </div>
@@ -25,7 +25,7 @@ const config: Meta = {
 
 export default config
 
-export const ListOfExternalServices: Story = () => (
+export const ListOfExternalServices: StoryFn = () => (
     <MockedTestProvider
         link={
             new WildcardMockLink([

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.story.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -6,7 +6,7 @@ import { WebStory } from '../WebStory'
 
 import { FuzzyWrapper, FUZZY_FILES_MOCK } from './FuzzyFinder.mocks'
 
-const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => story()}</WebStory>
 
 const config: Meta = {
     title: 'web/FuzzyFinder',
@@ -20,13 +20,13 @@ const config: Meta = {
 
 export default config
 
-export const ReadyStory: Story = () => (
+export const ReadyStory: StoryFn = () => (
     <MockedTestProvider mocks={[FUZZY_FILES_MOCK]}>
         <FuzzyWrapper url="/github.com/sourcegraph/sourcegraph@main" experimentalFeatures={{}} initialQuery="clientb" />
     </MockedTestProvider>
 )
 
-export const ReadyFileLineStory: Story = () => (
+export const ReadyFileLineStory: StoryFn = () => (
     <MockedTestProvider mocks={[FUZZY_FILES_MOCK]}>
         <FuzzyWrapper
             url="/github.com/sourcegraph/sourcegraph@main"
@@ -37,7 +37,7 @@ export const ReadyFileLineStory: Story = () => (
     </MockedTestProvider>
 )
 
-export const TabsStory: Story = () => (
+export const TabsStory: StoryFn = () => (
     <MockedTestProvider mocks={[FUZZY_FILES_MOCK]}>
         <FuzzyWrapper
             url="/github.com/sourcegraph/sourcegraph@main"

--- a/client/web/src/components/time/Duration.story.tsx
+++ b/client/web/src/components/time/Duration.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { H3, Code } from '@sourcegraph/wildcard'
@@ -7,7 +7,7 @@ import { WebStory } from '../WebStory'
 
 import { Duration } from './Duration'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const now = new Date()
 

--- a/client/web/src/components/time/Duration.story.tsx
+++ b/client/web/src/components/time/Duration.story.tsx
@@ -26,7 +26,7 @@ const config: Meta = {
 
 export default config
 
-export const Fixed: Story = args => (
+export const Fixed: StoryFn = args => (
     <WebStory>{props => <Duration {...props} start={new Date(args.start)} end={new Date(args.end)} />}</WebStory>
 )
 Fixed.argTypes = {
@@ -39,7 +39,7 @@ Fixed.args = {
     end: now,
 }
 
-export const Active: Story = args => (
+export const Active: StoryFn = args => (
     <WebStory>
         {props => (
             <>

--- a/client/web/src/enterprise/batches/BatchSpecNode.story.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecNode.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 import { addDays } from 'date-fns'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
@@ -16,7 +16,7 @@ import styles from './BatchSpecsPage.module.scss'
 
 const NOW = () => addDays(new Date(), 1)
 
-const decorator: DecoratorFn = story => <div className={classNames(styles.specsGrid, 'p-3 container')}>{story()}</div>
+const decorator: Decorator = story => <div className={classNames(styles.specsGrid, 'p-3 container')}>{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec',
@@ -25,7 +25,7 @@ const config: Meta = {
 
 export default config
 
-export const BatchSpecNodeStory: Story = () => {
+export const BatchSpecNodeStory: StoryFn = () => {
     const mocks = new WildcardMockLink([
         {
             request: {

--- a/client/web/src/enterprise/batches/BatchSpecsPage.story.tsx
+++ b/client/web/src/enterprise/batches/BatchSpecsPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { addDays } from 'date-fns'
 import { of } from 'rxjs'
 
@@ -8,7 +8,7 @@ import type { queryBatchSpecs as _queryBatchSpecs } from './backend'
 import { BatchSpecsPage } from './BatchSpecsPage'
 import { NODES, successNode } from './testData'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/settings/specs/BatchSpecsPage',
@@ -47,13 +47,13 @@ const queryNoBatchSpecs: typeof _queryBatchSpecs = () =>
         nodes: [],
     })
 
-export const ListOfSpecs: Story = () => (
+export const ListOfSpecs: StoryFn = () => (
     <WebStory>{props => <BatchSpecsPage {...props} queryBatchSpecs={queryBatchSpecs} now={NOW} />}</WebStory>
 )
 
 ListOfSpecs.storyName = 'List of specs'
 
-export const NoSpecs: Story = () => (
+export const NoSpecs: StoryFn = () => (
     <WebStory>{props => <BatchSpecsPage {...props} queryBatchSpecs={queryNoBatchSpecs} now={NOW} />}</WebStory>
 )
 

--- a/client/web/src/enterprise/batches/Branch.story.tsx
+++ b/client/web/src/enterprise/batches/Branch.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
@@ -10,13 +10,13 @@ const config: Meta = {
 
 export default config
 
-export const Forked: Story = () => (
+export const Forked: StoryFn = () => (
     <WebStory>
         {() => <BranchMerge baseRef="main" forkTarget={{ pushUser: false, namespace: 'org' }} headRef="branch" />}
     </WebStory>
 )
 
-export const WillBeForkedIntoTheUser: Story = () => (
+export const WillBeForkedIntoTheUser: StoryFn = () => (
     <WebStory>
         {() => <BranchMerge baseRef="main" forkTarget={{ pushUser: true, namespace: 'org' }} headRef="branch" />}
     </WebStory>
@@ -24,4 +24,4 @@ export const WillBeForkedIntoTheUser: Story = () => (
 
 WillBeForkedIntoTheUser.storyName = 'Will be forked into the user'
 
-export const Unforked: Story = () => <WebStory>{() => <BranchMerge baseRef="main" headRef="branch" />}</WebStory>
+export const Unforked: StoryFn = () => <WebStory>{() => <BranchMerge baseRef="main" headRef="branch" />}</WebStory>

--- a/client/web/src/enterprise/batches/Description.story.tsx
+++ b/client/web/src/enterprise/batches/Description.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
 import { Description } from './Description'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/Description',
@@ -13,7 +13,7 @@ const config: Meta = {
 
 export default config
 
-export const Overview: Story = () => (
+export const Overview: StoryFn = () => (
     <WebStory>
         {props => (
             <Description

--- a/client/web/src/enterprise/batches/DropdownButton.story.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.story.tsx
@@ -64,7 +64,7 @@ const config: Meta = {
 
 export default config
 
-export const NoActions: Story = args => <WebStory>{() => <DropdownButton actions={[]} {...args} />}</WebStory>
+export const NoActions: StoryFn = args => <WebStory>{() => <DropdownButton actions={[]} {...args} />}</WebStory>
 NoActions.argTypes = {
     disabled: {
         table: {
@@ -75,11 +75,11 @@ NoActions.argTypes = {
 
 NoActions.storyName = 'No actions'
 
-export const SingleAction: Story = args => <WebStory>{() => <DropdownButton actions={[action]} {...args} />}</WebStory>
+export const SingleAction: StoryFn = args => <WebStory>{() => <DropdownButton actions={[action]} {...args} />}</WebStory>
 
 SingleAction.storyName = 'Single action'
 
-export const MultipleActionsWithoutDefault: Story = args => (
+export const MultipleActionsWithoutDefault: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider
@@ -100,7 +100,7 @@ export const MultipleActionsWithoutDefault: Story = args => (
 
 MultipleActionsWithoutDefault.storyName = 'Multiple actions without default'
 
-export const MultipleActionsWithDefault: Story = args => (
+export const MultipleActionsWithDefault: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider
@@ -121,7 +121,7 @@ export const MultipleActionsWithDefault: Story = args => (
 
 MultipleActionsWithDefault.storyName = 'Multiple actions with default'
 
-export const PublishActionWithRolloutWindowConfigured: Story = args => (
+export const PublishActionWithRolloutWindowConfigured: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider

--- a/client/web/src/enterprise/batches/DropdownButton.story.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -47,7 +47,7 @@ const publishAction: Action = {
     experimental: false,
 }
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/DropdownButton',

--- a/client/web/src/enterprise/batches/DropdownButton.story.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.story.tsx
@@ -75,7 +75,9 @@ NoActions.argTypes = {
 
 NoActions.storyName = 'No actions'
 
-export const SingleAction: StoryFn = args => <WebStory>{() => <DropdownButton actions={[action]} {...args} />}</WebStory>
+export const SingleAction: StoryFn = args => (
+    <WebStory>{() => <DropdownButton actions={[action]} {...args} />}</WebStory>
+)
 
 SingleAction.storyName = 'Single action'
 

--- a/client/web/src/enterprise/batches/batch-spec/TabBar.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/TabBar.story.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { TabBar, type TabsConfig, type TabKey } from './TabBar'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/TabBar',
@@ -17,13 +17,13 @@ export default config
 
 const CREATE_TABS: TabsConfig[] = [{ key: 'configuration', isEnabled: true }]
 
-export const CreateNewBatchChange: Story = () => (
+export const CreateNewBatchChange: StoryFn = () => (
     <WebStory>{props => <TabBar {...props} activeTabKey="configuration" tabsConfig={CREATE_TABS} />}</WebStory>
 )
 
 CreateNewBatchChange.storyName = 'creating a new batch change'
 
-export const EditUnexecutedBatchSpec: Story = () => {
+export const EditUnexecutedBatchSpec: StoryFn = () => {
     const [activeTabKey, setActiveTabKey] = useState<TabKey>('spec')
 
     const tabsConfig: TabsConfig[] = [

--- a/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/DownloadSpecModal.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { DownloadSpecModal } from './DownloadSpecModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit',
@@ -13,7 +13,7 @@ const config: Meta = {
 
 export default config
 
-export const DownloadSpecModalStory: Story = () => (
+export const DownloadSpecModalStory: StoryFn = () => (
     <WebStory>
         {props => (
             <DownloadSpecModal

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
@@ -108,7 +108,7 @@ const mockAuthenticatedUser = {
     },
 } as AuthenticatedUser
 
-export const EditFirstTime: Story<WebStoryChildrenProps> = props => (
+export const EditFirstTime: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={FIRST_TIME_MOCKS}>
         <EditBatchSpecPage
             {...props}
@@ -150,7 +150,7 @@ const MULTIPLE_SPEC_MOCKS = new WildcardMockLink([
     ...UNSTARTED_WITH_CACHE_CONNECTION_MOCKS,
 ])
 
-export const EditLatestBatchSpec: Story<WebStoryChildrenProps> = props => (
+export const EditLatestBatchSpec: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={MULTIPLE_SPEC_MOCKS}>
         <EditBatchSpecPage
             {...props}
@@ -176,7 +176,7 @@ const NOT_FOUND_MOCKS = new WildcardMockLink([
     ...UNSTARTED_CONNECTION_MOCKS,
 ])
 
-export const BatchChangeNotFound: Story<WebStoryChildrenProps> = props => (
+export const BatchChangeNotFound: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={NOT_FOUND_MOCKS}>
         <EditBatchSpecPage
             {...props}
@@ -202,7 +202,7 @@ const INVALID_SPEC_MOCKS = new WildcardMockLink([
 
 BatchChangeNotFound.storyName = 'batch change not found'
 
-export const InvalidBatchSpec: Story<WebStoryChildrenProps> = props => (
+export const InvalidBatchSpec: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={INVALID_SPEC_MOCKS}>
         <EditBatchSpecPage
             {...props}
@@ -228,7 +228,7 @@ const NO_EXECUTORS_MOCKS = new WildcardMockLink([
     ...UNSTARTED_CONNECTION_MOCKS,
 ])
 
-export const ExecutorsNotActive: Story<WebStoryChildrenProps> = props => (
+export const ExecutorsNotActive: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={NO_EXECUTORS_MOCKS}>
         <EditBatchSpecPage
             {...props}

--- a/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/EditBatchSpecPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -22,7 +22,7 @@ import { insertNameIntoLibraryItem } from '../yaml-util'
 import { EditBatchSpecPage } from './EditBatchSpecPage'
 import goImportsSample from './library/go-imports.batch.yaml'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3" style={{ height: '95vh', width: '100%' }}>
         <WebStory initialEntries={['/batch-changes/hello-world/edit']} path="/batch-changes/:batchChangeName/edit">
             {story}

--- a/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunBatchSpecButton.story.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 import type { ExecutionOptions } from '../BatchSpecContext'
 
 import { RunBatchSpecButton } from './RunBatchSpecButton'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit/RunBatchSpecButton',
@@ -16,7 +16,7 @@ const config: Meta = {
 
 export default config
 
-export const Disabled: Story = () => {
+export const Disabled: StoryFn = () => {
     const [options, setOptions] = useState<ExecutionOptions>({ runWithoutCache: false })
     return (
         <WebStory>
@@ -33,7 +33,7 @@ export const Disabled: Story = () => {
     )
 }
 
-export const Enabled: Story = () => {
+export const Enabled: StoryFn = () => {
     const [options, setOptions] = useState<ExecutionOptions>({ runWithoutCache: false })
     return (
         <WebStory>

--- a/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/RunServerSideModal.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { RunServerSideModal } from './RunServerSideModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit',
@@ -13,7 +13,7 @@ const config: Meta = {
 
 export default config
 
-export const RunServerSideModalStory: Story = () => (
+export const RunServerSideModalStory: StoryFn = () => (
     <WebStory>
         {props => (
             <RunServerSideModal

--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/EditorFeedbackPanel.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/EditorFeedbackPanel.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../components/WebStory'
 
 import { EditorFeedbackPanel } from './EditorFeedbackPanel'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit/editor/EditorFeedbackPanel',

--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/EditorFeedbackPanel.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/EditorFeedbackPanel.story.tsx
@@ -42,7 +42,7 @@ const config: Meta = {
 
 export default config
 
-export const EditorFeedbackPanelStory: Story = args => (
+export const EditorFeedbackPanelStory: StoryFn = args => (
     <WebStory>
         {props => (
             <EditorFeedbackPanel

--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.story.tsx
@@ -29,7 +29,7 @@ const config: Meta = {
 
 export default config
 
-export const MonacoBatchSpecEditorStory: Story = args => (
+export const MonacoBatchSpecEditorStory: StoryFn = args => (
     <WebStory>
         {props => (
             <MonacoBatchSpecEditor

--- a/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/editor/MonacoBatchSpecEditor.story.tsx
@@ -1,12 +1,12 @@
 import { action } from '@storybook/addon-actions'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../components/WebStory'
 import sample from '../library/hello-world.batch.yaml'
 
 import { MonacoBatchSpecEditor } from './MonacoBatchSpecEditor'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit/editor/MonacoBatchSpecEditor',

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/LibraryPane.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../components/WebStory'
 
 import { LibraryPane } from './LibraryPane'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit/LibraryPane',
@@ -13,13 +13,13 @@ const config: Meta = {
 
 export default config
 
-export const Editable: Story = () => (
+export const Editable: StoryFn = () => (
     <WebStory>
         {props => <LibraryPane {...props} name="my-batch-change" onReplaceItem={() => alert('batch spec replaced!')} />}
     </WebStory>
 )
 
-export const ReadOnly: Story = () => (
+export const ReadOnly: StoryFn = () => (
     <WebStory>{props => <LibraryPane {...props} name="my-batch-change" isReadOnly={true} />}</WebStory>
 )
 

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/ReplaceSpecModal.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/ReplaceSpecModal.story.tsx
@@ -23,7 +23,7 @@ const config: Meta = {
 
 export default config
 
-export const ReplaceSpecModalStory: Story = args => (
+export const ReplaceSpecModalStory: StoryFn = args => (
     <WebStory>
         {props => (
             <ReplaceSpecModal

--- a/client/web/src/enterprise/batches/batch-spec/edit/library/ReplaceSpecModal.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/library/ReplaceSpecModal.story.tsx
@@ -1,11 +1,11 @@
 import { action } from '@storybook/addon-actions'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../components/WebStory'
 
 import { ReplaceSpecModal } from './ReplaceSpecModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit/library/ReplaceSpecModal',

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.story.tsx
@@ -1,12 +1,12 @@
 import { action } from '@storybook/addon-actions'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../components/WebStory'
 import { mockImportingChangesets } from '../../batch-spec.mock'
 
 import { ImportingChangesetsPreviewList } from './ImportingChangesetsPreviewList'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList',

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/ImportingChangesetsPreviewList.story.tsx
@@ -39,7 +39,7 @@ const config: Meta = {
 
 export default config
 
-export const ImportingChangesetsPreviewListStory: Story = args => {
+export const ImportingChangesetsPreviewListStory: StoryFn = args => {
     const count = args.count
     return (
         <WebStory>

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreview.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
@@ -24,7 +24,7 @@ import { BatchSpecContextProvider } from '../../BatchSpecContext'
 
 import { WorkspacesPreview } from './WorkspacesPreview'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3 container d-flex flex-column align-items-center">{story()}</div>
 )
 
@@ -345,7 +345,7 @@ FailedErroredWithCachedConnectionResult.args = {
 
 FailedErroredWithCachedConnectionResult.storyName = 'failed/errored, with cached connection result'
 
-export const Succeeded: Story = () => (
+export const Succeeded: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink(UNSTARTED_WITH_CACHE_CONNECTION_MOCKS)}>
@@ -374,7 +374,7 @@ export const Succeeded: Story = () => (
     </WebStory>
 )
 
-export const CacheDisabled: Story = () => (
+export const CacheDisabled: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink(UNSTARTED_WITH_CACHE_CONNECTION_MOCKS)}>
@@ -403,7 +403,7 @@ export const CacheDisabled: Story = () => (
     </WebStory>
 )
 
-export const ReadOnly: Story = () => (
+export const ReadOnly: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink(UNSTARTED_WITH_CACHE_CONNECTION_MOCKS)}>
@@ -421,7 +421,7 @@ export const ReadOnly: Story = () => (
 
 ReadOnly.storyName = 'read-only'
 
-export const SucceededWithScaleAlert: Story = () => (
+export const SucceededWithScaleAlert: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink(LARGE_SUCCESS_CONNECTION_MOCKS)}>
@@ -452,7 +452,7 @@ export const SucceededWithScaleAlert: Story = () => (
 
 SucceededWithScaleAlert.storyName = 'succeeded, with size alert'
 
-export const ReadOnlyWithScaleAlert: Story = () => (
+export const ReadOnlyWithScaleAlert: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={new WildcardMockLink(LARGE_SUCCESS_CONNECTION_MOCKS)}>
@@ -470,7 +470,7 @@ export const ReadOnlyWithScaleAlert: Story = () => (
 
 ReadOnlyWithScaleAlert.storyName = 'read-only, with size alert'
 
-export const UnstartedWithLicenseAlertConnectionResult: Story = () => (
+export const UnstartedWithLicenseAlertConnectionResult: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
@@ -490,7 +490,7 @@ export const UnstartedWithLicenseAlertConnectionResult: Story = () => (
 
 UnstartedWithLicenseAlertConnectionResult.storyName = 'unstarted, with license alert'
 
-export const ReadOnlyWithLicenseAlert: Story = () => (
+export const ReadOnlyWithLicenseAlert: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList.story.tsx
@@ -1,12 +1,12 @@
 import { action } from '@storybook/addon-actions'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../components/WebStory'
 import { mockPreviewWorkspaces } from '../../batch-spec.mock'
 
 import { WorkspacesPreviewList } from './WorkspacesPreviewList'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewList',
@@ -66,7 +66,7 @@ DefaultStory.args = {
 
 DefaultStory.storyName = 'default'
 
-export const ErrorStory: Story = () => (
+export const ErrorStory: StoryFn = () => (
     <WebStory>
         {props => (
             <WorkspacesPreviewList

--- a/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewListItem.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewListItem.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../../../components/WebStory'
@@ -6,7 +6,7 @@ import { mockPreviewWorkspace } from '../../batch-spec.mock'
 
 import { WorkspacesPreviewListItem } from './WorkspacesPreviewListItem'
 
-const decorator: DecoratorFn = story => <div className="list-group d-flex flex-column w-100">{story()}</div>
+const decorator: Decorator = story => <div className="list-group d-flex flex-column w-100">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/edit/workspaces-preview/WorkspacesPreviewListItem',
@@ -15,7 +15,7 @@ const config: Meta = {
 
 export default config
 
-export const Basic: Story = () => (
+export const Basic: StoryFn = () => (
     <WebStory>
         {props => (
             <>
@@ -36,7 +36,7 @@ export const Basic: Story = () => (
     </WebStory>
 )
 
-export const Cached: Story = () => (
+export const Cached: StoryFn = () => (
     <WebStory>
         {props => (
             <>
@@ -57,7 +57,7 @@ export const Cached: Story = () => (
     </WebStory>
 )
 
-export const Stale: Story = () => (
+export const Stale: StoryFn = () => (
     <WebStory>
         {props => (
             <>
@@ -78,7 +78,7 @@ export const Stale: Story = () => (
     </WebStory>
 )
 
-export const ReadOnly: Story = () => (
+export const ReadOnly: StoryFn = () => (
     <WebStory>
         {props => (
             <>

--- a/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ActionsMenu.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 import { EXECUTING_BATCH_SPEC, mockBatchChange } from '../batch-spec.mock'
@@ -6,7 +6,7 @@ import { BatchSpecContextProvider } from '../BatchSpecContext'
 
 import { ActionsMenu, ActionsMenuMode } from './ActionsMenu'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/execute/ActionsMenu',
@@ -15,7 +15,7 @@ const config: Meta = {
 
 export default config
 
-export const Preview: Story = () => (
+export const Preview: StoryFn = () => (
     <WebStory>
         {() => (
             <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={EXECUTING_BATCH_SPEC}>
@@ -25,7 +25,7 @@ export const Preview: Story = () => (
     </WebStory>
 )
 
-export const Actions: Story = () => (
+export const Actions: StoryFn = () => (
     <WebStory>
         {() => (
             <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={EXECUTING_BATCH_SPEC}>
@@ -35,7 +35,7 @@ export const Actions: Story = () => (
     </WebStory>
 )
 
-export const ActionsOnlyClose: Story = () => (
+export const ActionsOnlyClose: StoryFn = () => (
     <WebStory>
         {() => (
             <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={EXECUTING_BATCH_SPEC}>
@@ -45,7 +45,7 @@ export const ActionsOnlyClose: Story = () => (
     </WebStory>
 )
 
-export const ActionsWithPreview: Story = () => (
+export const ActionsWithPreview: StoryFn = () => (
     <WebStory>
         {() => (
             <BatchSpecContextProvider batchChange={mockBatchChange()} batchSpec={EXECUTING_BATCH_SPEC}>

--- a/client/web/src/enterprise/batches/batch-spec/execute/BatchSpecStateBadge.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/BatchSpecStateBadge.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { BatchSpecState } from '@sourcegraph/shared/src/graphql-operations'
 
@@ -6,7 +6,7 @@ import { WebStory } from '../../../../components/WebStory'
 
 import { BatchSpecStateBadge } from './BatchSpecStateBadge'
 
-const decorator: DecoratorFn = story => <div className="p-3">{story()}</div>
+const decorator: Decorator = story => <div className="p-3">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/execute/BatchSpecStateBadge',
@@ -15,7 +15,7 @@ const config: Meta = {
 
 export default config
 
-export const BatchSpecStateBadgeStory: Story = () => (
+export const BatchSpecStateBadgeStory: StoryFn = () => (
     <WebStory>
         {props => (
             <>

--- a/client/web/src/enterprise/batches/batch-spec/execute/CancelExecutionModal.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/CancelExecutionModal.story.tsx
@@ -26,7 +26,7 @@ const config: Meta = {
 
 export default config
 
-export const CancelExecutionModalStory: Story = args => (
+export const CancelExecutionModalStory: StoryFn = args => (
     <WebStory>
         {props => (
             <CancelExecutionModal

--- a/client/web/src/enterprise/batches/batch-spec/execute/CancelExecutionModal.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/CancelExecutionModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { Text } from '@sourcegraph/wildcard'
@@ -7,7 +7,7 @@ import { WebStory } from '../../../../components/WebStory'
 
 import { CancelExecutionModal } from './CancelExecutionModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/execute',

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { addMinutes } from 'date-fns'
 import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, type MockedResponses, WildcardMockLink } from 'wildcard-mock-link'
@@ -34,7 +34,7 @@ import {
 } from './backend'
 import { ExecuteBatchSpecPage } from './ExecuteBatchSpecPage'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3" style={{ height: '95vh', width: '100%' }}>
         {story()}
     </div>
@@ -117,7 +117,7 @@ const EXECUTING_BATCH_SPEC_WITH_END_TIME = {
     finishedAt: addMinutes(Date.parse(EXECUTING_BATCH_SPEC.startedAt!), 15).toISOString(),
 }
 
-export const Executing: Story = () => (
+export const Executing: StoryFn = () => (
     <WebStory
         path="/users/:username/batch-changes/:batchChangeName/executions/:batchSpecID/*"
         initialEntries={['/users/my-username/batch-changes/my-batch-change/executions/spec1234']}
@@ -153,7 +153,7 @@ const PROCESSING_WORKSPACE_WITH_END_TIMES = {
     /* eslint-enable @typescript-eslint/no-non-null-assertion */
 }
 
-export const ExecuteWithAWorkspaceSelected: Story = () => (
+export const ExecuteWithAWorkspaceSelected: StoryFn = () => (
     <WebStory
         path="/users/:username/batch-changes/:batchChangeName/executions/:batchSpecID/*"
         initialEntries={[
@@ -191,7 +191,7 @@ ExecuteWithAWorkspaceSelected.storyName = 'executing, with a workspace selected'
 
 const COMPLETED_MOCKS = buildMocks(COMPLETED_BATCH_SPEC)
 
-export const Completed: Story = () => (
+export const Completed: StoryFn = () => (
     <WebStory initialEntries={['/my-batch-change/spec1234/execution']} path="/:batchChangeName/:batchSpecID/*">
         {props => (
             <MockedTestProvider link={new WildcardMockLink(COMPLETED_MOCKS)}>
@@ -208,7 +208,7 @@ export const Completed: Story = () => (
 
 const COMPLETED_WITH_ERRORS_MOCKS = buildMocks(COMPLETED_WITH_ERRORS_BATCH_SPEC)
 
-export const CompletedWithErrors: Story = () => (
+export const CompletedWithErrors: StoryFn = () => (
     <WebStory initialEntries={['/my-batch-change/spec1234/execution']} path="/:batchChangeName/:batchSpecID/*">
         {props => (
             <MockedTestProvider link={new WildcardMockLink(COMPLETED_WITH_ERRORS_MOCKS)}>
@@ -227,7 +227,7 @@ CompletedWithErrors.storyName = 'completed with errors'
 
 const LOCAL_MOCKS = buildMocks(mockFullBatchSpec({ source: BatchSpecSource.LOCAL }))
 
-export const LocallyExecutedSpec: Story = () => (
+export const LocallyExecutedSpec: StoryFn = () => (
     <WebStory initialEntries={['/my-local-batch-change/spec1234/execution']} path="/:batchChangeName/:batchSpecID/*">
         {props => (
             <MockedTestProvider link={new WildcardMockLink(LOCAL_MOCKS)}>

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { ExecutionStatsBar } from './ExecutionStatsBar'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/execute',

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecutionStatsBar.story.tsx
@@ -38,7 +38,7 @@ const config: Meta = {
 
 export default config
 
-export const ExecutionStatsBarStory: Story = args => (
+export const ExecutionStatsBarStory: StoryFn = args => (
     <WebStory>
         {props => (
             <ExecutionStatsBar

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecAlert.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecAlert.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { Button } from '@sourcegraph/wildcard'
 
@@ -6,7 +6,7 @@ import { WebStory } from '../../../../components/WebStory'
 
 import { ReadOnlyBatchSpecAlert } from './ReadOnlyBatchSpecAlert'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/execute',
@@ -15,7 +15,7 @@ const config: Meta = {
 
 export default config
 
-export const ReadOnlyBatchSpecAlertStory: Story = () => (
+export const ReadOnlyBatchSpecAlertStory: StoryFn = () => (
     <WebStory>
         {props => (
             <ReadOnlyBatchSpecAlert

--- a/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ReadOnlyBatchSpecForm.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 import { BatchSpecSource, BatchSpecState } from '../../../../graphql-operations'
@@ -7,7 +7,7 @@ import { BatchSpecContextProvider } from '../BatchSpecContext'
 
 import { ReadOnlyBatchSpecForm } from './ReadOnlyBatchSpecForm'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3 d-flex" style={{ height: '95vh', width: '100%' }}>
         {story()}
     </div>
@@ -80,7 +80,7 @@ ExecutionFinished.args = {
 
 ExecutionFinished.storyName = 'after execution finishes'
 
-export const LocallyExecutedSpec: Story = () => (
+export const LocallyExecutedSpec: StoryFn = () => (
     <WebStory>
         {props => (
             <BatchSpecContextProvider

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/ExecutionWorkspaces.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
@@ -24,7 +24,7 @@ import {
 
 import { ExecutionWorkspaces } from './ExecutionWorkspaces'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3 d-flex" style={{ height: '95vh', width: '100%' }}>
         {story()}
     </div>
@@ -78,7 +78,7 @@ const queryWorkspacesList: typeof _queryWorkspacesList = () =>
 
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
 
-export const List: Story = () => (
+export const List: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={MOCKS}>
@@ -90,7 +90,7 @@ export const List: Story = () => (
     </WebStory>
 )
 
-export const WorkspaceSelected: Story = () => (
+export const WorkspaceSelected: StoryFn = () => (
     <WebStory path="/:workspaceID" initialEntries={['/workspace2']}>
         {props => (
             <MockedTestProvider link={MOCKS}>
@@ -108,7 +108,7 @@ export const WorkspaceSelected: Story = () => (
 
 WorkspaceSelected.storyName = 'with workspace selected'
 
-export const LocallyExecutedSpec: Story = () => (
+export const LocallyExecutedSpec: StoryFn = () => (
     <WebStory path="/:workspaceID" initialEntries={['/"spec1234"']}>
         {props => (
             <MockedTestProvider link={MOCKS}>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/StepStateIcon.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/StepStateIcon.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../components/WebStory'
 
 import { StepStateIcon } from './StepStateIcon'
 
-const decorator: DecoratorFn = story => <div className="p-3">{story()}</div>
+const decorator: Decorator = story => <div className="p-3">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/execute/workspaces/StepStateIcon',
@@ -22,7 +22,7 @@ const options = [
     { label: 'Success', value: { startedAt: 'start-time', finishedAt: 'start-time', exitCode: 0 } },
 ]
 
-export const StepStateIconStory: Story = () => (
+export const StepStateIconStory: StoryFn = () => (
     <WebStory>
         {props => (
             <>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceDetails.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
@@ -43,7 +43,7 @@ const MOCK_FILE_DIFF_QUERIES = {
     queryChangesetSpecFileDiffs,
 }
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="d-flex w-100" style={{ height: '95vh' }}>
         <Card className="w-100 overflow-auto flex-grow-1" style={{ backgroundColor: 'var(--color-bg-1)' }}>
             <div className="w-100">
@@ -121,41 +121,41 @@ const BaseStory: React.FunctionComponent<BaseStoryProps> = ({ node, queries = {}
     )
 }
 
-export const WorkspaceNotFound: Story = () => <BaseStory />
+export const WorkspaceNotFound: StoryFn = () => <BaseStory />
 WorkspaceNotFound.storyName = 'Workspace not found'
 
-export const VisibleWorkspaceComplete: Story = () => (
+export const VisibleWorkspaceComplete: StoryFn = () => (
     <BaseStory node={mockWorkspace()} queries={MOCK_FILE_DIFF_QUERIES} />
 )
 VisibleWorkspaceComplete.storyName = 'Visible workspace: complete'
 
-export const HiddenWorkspace: Story = () => <BaseStory node={HIDDEN_WORKSPACE} />
+export const HiddenWorkspace: StoryFn = () => <BaseStory node={HIDDEN_WORKSPACE} />
 HiddenWorkspace.storyName = 'Hidden workspace'
 
-export const VisibleWorkspaceProcessing: Story = () => <BaseStory node={PROCESSING_WORKSPACE} />
+export const VisibleWorkspaceProcessing: StoryFn = () => <BaseStory node={PROCESSING_WORKSPACE} />
 VisibleWorkspaceProcessing.storyName = 'Visible workspace: processing'
 
-export const VisibleWorkspaceQueued: Story = () => <BaseStory node={QUEUED_WORKSPACE} />
+export const VisibleWorkspaceQueued: StoryFn = () => <BaseStory node={QUEUED_WORKSPACE} />
 VisibleWorkspaceQueued.storyName = 'Visible workspace: queued'
 
-export const VisibleWorkspaceSkipped: Story = () => <BaseStory node={SKIPPED_WORKSPACE} />
+export const VisibleWorkspaceSkipped: StoryFn = () => <BaseStory node={SKIPPED_WORKSPACE} />
 VisibleWorkspaceSkipped.storyName = 'Visible workspace: skipped'
 
-export const VisibleWorkspaceUnsupported: Story = () => <BaseStory node={UNSUPPORTED_WORKSPACE} />
+export const VisibleWorkspaceUnsupported: StoryFn = () => <BaseStory node={UNSUPPORTED_WORKSPACE} />
 VisibleWorkspaceUnsupported.storyName = 'Visible workspace: unsupported'
 
-export const VisibleWorkspaceCompleteWithLotsOfSteps: Story = () => (
+export const VisibleWorkspaceCompleteWithLotsOfSteps: StoryFn = () => (
     <BaseStory node={LOTS_OF_STEPS_WORKSPACE} queries={MOCK_FILE_DIFF_QUERIES} />
 )
 VisibleWorkspaceCompleteWithLotsOfSteps.storyName = 'Visible workspace: complete with lots of steps'
 
-export const VisibleWorkspaceFailed: Story = () => (
+export const VisibleWorkspaceFailed: StoryFn = () => (
     <BaseStory node={FAILED_WORKSPACE} queries={MOCK_FILE_DIFF_QUERIES} />
 )
 VisibleWorkspaceFailed.storyName = 'Visible workspace: failed'
 
-export const VisibleWorkspaceCanceling: Story = () => <BaseStory node={CANCELING_WORKSPACE} />
+export const VisibleWorkspaceCanceling: StoryFn = () => <BaseStory node={CANCELING_WORKSPACE} />
 VisibleWorkspaceCanceling.storyName = 'Visible workspace: canceling'
 
-export const VisibleWorkspaceCanceled: Story = () => <BaseStory node={CANCELED_WORKSPACE} />
+export const VisibleWorkspaceCanceled: StoryFn = () => <BaseStory node={CANCELED_WORKSPACE} />
 VisibleWorkspaceCanceled.storyName = 'Visible workspace: canceled'

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.story.tsx
@@ -24,7 +24,7 @@ const config: Meta = {
 
 export default config
 
-export const WorkspaceStateIconStory: Story = args => (
+export const WorkspaceStateIconStory: StoryFn = args => (
     <WebStory>
         {props => (
             <>

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspaceStateIcon.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { BatchSpecWorkspaceState } from '@sourcegraph/shared/src/graphql-operations'
 
@@ -6,7 +6,7 @@ import { WebStory } from '../../../../../components/WebStory'
 
 import { WorkspaceStateIcon } from './WorkspaceStateIcon'
 
-const decorator: DecoratorFn = story => <div className="p-3">{story()}</div>
+const decorator: Decorator = story => <div className="p-3">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/execute/workspaces/WorkspaceStateIcon',

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/Workspaces.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/Workspaces.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { of } from 'rxjs'
 
 import { WebStory } from '../../../../../components/WebStory'
@@ -7,7 +7,7 @@ import type { queryWorkspacesList as _queryWorkspacesList } from '../backend'
 
 import { Workspaces } from './Workspaces'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/execute/workspaces/Workspaces',
@@ -20,7 +20,7 @@ const queryWorkspacesList: typeof _queryWorkspacesList = () =>
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     of(mockWorkspaces(50).node.workspaceResolution!.workspaces)
 
-export const WorkspacesStory: Story = () => (
+export const WorkspacesStory: StoryFn = () => (
     <WebStory>
         {props => (
             <Workspaces

--- a/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesListItem.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/workspaces/WorkspacesListItem.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../components/WebStory'
 import { BatchSpecWorkspaceState } from '../../../../../graphql-operations'
@@ -6,7 +6,7 @@ import { mockWorkspace } from '../../batch-spec.mock'
 
 import { WorkspacesListItem } from './WorkspacesListItem'
 
-const decorator: DecoratorFn = story => <div className="list-group d-flex flex-column w-100">{story()}</div>
+const decorator: Decorator = story => <div className="list-group d-flex flex-column w-100">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/execute/workspaces',
@@ -27,7 +27,7 @@ const WORKSPACE_STATES: [key: string, state: BatchSpecWorkspaceState, isCached: 
     ['completed-cached', BatchSpecWorkspaceState.COMPLETED, true],
 ]
 
-export const WorkspacesListItemStory: Story = () => (
+export const WorkspacesListItemStory: StoryFn = () => (
     <WebStory>
         {props => (
             <>

--- a/client/web/src/enterprise/batches/batch-spec/header/BatchChangeHeader.story.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/header/BatchChangeHeader.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { BatchChangeHeader } from './BatchChangeHeader'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/batch-spec/header/BatchChangeHeader',
@@ -13,13 +13,13 @@ const config: Meta = {
 
 export default config
 
-export const CreateNewBatchChange: Story = () => (
+export const CreateNewBatchChange: StoryFn = () => (
     <WebStory>{props => <BatchChangeHeader {...props} title={{ text: 'Create batch change' }} />}</WebStory>
 )
 
 CreateNewBatchChange.storyName = 'creating a new batch change'
 
-export const BatchChangeExists: Story = () => (
+export const BatchChangeExists: StoryFn = () => (
     <WebStory>
         {props => (
             <BatchChangeHeader

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
@@ -27,7 +27,7 @@ const config: Meta = {
 
 export default config
 
-export const HasOpenChangesets: Story = args => {
+export const HasOpenChangesets: StoryFn = args => {
     const [closeChangesets, setCloseChangesets] = useState(false)
     return (
         <WebStory>
@@ -57,7 +57,7 @@ HasOpenChangesets.args = {
 
 HasOpenChangesets.storyName = 'Has open changesets'
 
-export const NoOpenChangesets: Story = args => {
+export const NoOpenChangesets: StoryFn = args => {
     const [closeChangesets, setCloseChangesets] = useState(false)
     return (
         <WebStory>

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseAlert.story.tsx
@@ -1,11 +1,11 @@
 import { useState } from '@storybook/addons'
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { BatchChangeCloseAlert } from './BatchChangeCloseAlert'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/close/BatchChangeCloseAlert',

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useCallback } from '@storybook/addons'
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { of } from 'rxjs'
 
@@ -22,7 +22,7 @@ import type {
 
 import { BatchChangeClosePage } from './BatchChangeClosePage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/close/BatchChangeClosePage',
@@ -300,7 +300,7 @@ Overview.args = {
     viewerCanAdminister: true,
 }
 
-export const NoOpenChangesets: Story = () => {
+export const NoOpenChangesets: StoryFn = () => {
     const batchChange: BatchChangeFields = useMemo(() => batchChangeDefaults, [])
     const fetchBatchChange: typeof fetchBatchChangeByNamespace = useCallback(() => of(batchChange), [batchChange])
     const queryEmptyChangesets = useCallback(

--- a/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
+++ b/client/web/src/enterprise/batches/create/ConfigurationForm.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -11,7 +11,7 @@ import { getLicenseAndUsageInfoResult } from '../list/testData'
 
 import { ConfigurationForm } from './ConfigurationForm'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/create/ConfigurationForm',
@@ -51,7 +51,7 @@ const buildMocks = (isLicensed = true, hasBatchChanges = true) =>
         },
     ])
 
-export const NewBatchChange: Story = () => (
+export const NewBatchChange: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={buildMocks()}>
@@ -63,7 +63,7 @@ export const NewBatchChange: Story = () => (
 
 NewBatchChange.storyName = 'New batch change'
 
-export const NewOrgBatchChange: Story = () => (
+export const NewOrgBatchChange: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={buildMocks()}>
@@ -79,7 +79,7 @@ export const NewOrgBatchChange: Story = () => (
 
 NewOrgBatchChange.storyName = 'New batch change with new Org'
 
-export const ExistingBatchChange: Story = () => (
+export const ExistingBatchChange: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={buildMocks()}>
@@ -106,7 +106,7 @@ export const ExistingBatchChange: Story = () => (
 
 ExistingBatchChange.storyName = 'Read-only for existing batch change'
 
-export const LicenseAlert: Story = () => (
+export const LicenseAlert: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider link={buildMocks(false)}>

--- a/client/web/src/enterprise/batches/create/CreateBatchChangePage.story.tsx
+++ b/client/web/src/enterprise/batches/create/CreateBatchChangePage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import type { OrgSettingFields, UserSettingFields } from '@sourcegraph/shared/src/graphql-operations'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
@@ -8,7 +8,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { CreateBatchChangePage } from './CreateBatchChangePage'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3" style={{ height: '95vh', width: '100%' }}>
         {story()}
     </div>
@@ -43,7 +43,7 @@ const mockAuthenticatedUser = {
     },
 } as AuthenticatedUser
 
-export const ExperimentalExecutionDisabled: Story = () => (
+export const ExperimentalExecutionDisabled: StoryFn = () => (
     <WebStory>
         {props => (
             <CreateBatchChangePage
@@ -81,7 +81,7 @@ const FIXTURE_USER: UserSettingFields = {
     latestSettings: null,
 }
 
-export const ExperimentalExecutionEnabled: Story = () => (
+export const ExperimentalExecutionEnabled: StoryFn = () => (
     <WebStory>
         {props => (
             <CreateBatchChangePage
@@ -102,7 +102,7 @@ export const ExperimentalExecutionEnabled: Story = () => (
 
 ExperimentalExecutionEnabled.storyName = 'Experimental execution enabled'
 
-export const ExperimentalExecutionEnabledFromOrgNamespace: Story = () => (
+export const ExperimentalExecutionEnabledFromOrgNamespace: StoryFn = () => (
     <WebStory>
         {props => (
             <CreateBatchChangePage
@@ -127,7 +127,7 @@ export const ExperimentalExecutionEnabledFromOrgNamespace: Story = () => (
 
 ExperimentalExecutionEnabledFromOrgNamespace.storyName = 'Experimental execution enabled from org namespace'
 
-export const ExperimentalExecutionEnabledFromUserNamespace: Story = () => (
+export const ExperimentalExecutionEnabledFromUserNamespace: StoryFn = () => (
     <WebStory>
         {props => (
             <CreateBatchChangePage

--- a/client/web/src/enterprise/batches/create/InsightTemplatesBanner.story.tsx
+++ b/client/web/src/enterprise/batches/create/InsightTemplatesBanner.story.tsx
@@ -1,10 +1,10 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { InsightTemplatesBanner } from './InsightTemplatesBanner'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/create/InsightTemplatesBanner',
@@ -13,13 +13,13 @@ const config: Meta = {
 
 export default config
 
-export const CreatingNewBatchChangeFromInsight: Story = () => (
+export const CreatingNewBatchChangeFromInsight: StoryFn = () => (
     <WebStory>{props => <InsightTemplatesBanner {...props} insightTitle="My Go Insight" type="create" />}</WebStory>
 )
 
 CreatingNewBatchChangeFromInsight.storyName = 'Creating new batch change from insight'
 
-export const EditingBatchSpecFromInsightTemplate: Story = () => (
+export const EditingBatchSpecFromInsightTemplate: StoryFn = () => (
     <WebStory>{props => <InsightTemplatesBanner {...props} insightTitle="My Go Insight" type="edit" />}</WebStory>
 )
 

--- a/client/web/src/enterprise/batches/create/SearchTemplatesBanner.story.tsx
+++ b/client/web/src/enterprise/batches/create/SearchTemplatesBanner.story.tsx
@@ -1,10 +1,10 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { SearchTemplatesBanner } from './SearchTemplatesBanner'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/create/SearchTemplatesBanner',
@@ -13,6 +13,6 @@ const config: Meta = {
 
 export default config
 
-export const CreatingNewBatchChangeFromSearch: Story = () => <WebStory>{() => <SearchTemplatesBanner />}</WebStory>
+export const CreatingNewBatchChangeFromSearch: StoryFn = () => <WebStory>{() => <SearchTemplatesBanner />}</WebStory>
 
 CreatingNewBatchChangeFromSearch.storyName = 'Creating new batch change from search'

--- a/client/web/src/enterprise/batches/create/TemplateBanner.story.tsx
+++ b/client/web/src/enterprise/batches/create/TemplateBanner.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { TemplateBanner } from './TemplateBanner'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/create',
@@ -13,7 +13,7 @@ const config: Meta = {
 
 export default config
 
-export const TemplateBannerStory: Story = () => (
+export const TemplateBannerStory: StoryFn = () => (
     <WebStory>
         {props => (
             <TemplateBanner

--- a/client/web/src/enterprise/batches/detail/ActiveExecutionNotice.story.tsx
+++ b/client/web/src/enterprise/batches/detail/ActiveExecutionNotice.story.tsx
@@ -34,7 +34,7 @@ export default config
 const PROCESSING_BATCH_SPEC = { state: BatchSpecState.PROCESSING }
 const COMPLETE_BATCH_SPEC = { state: BatchSpecState.COMPLETED }
 
-export const ActiveExecutionNoticeStory: Story = args => {
+export const ActiveExecutionNoticeStory: StoryFn = args => {
     const numberActive = args.numberActive
     const numberComplete = args.numberComplete
 

--- a/client/web/src/enterprise/batches/detail/ActiveExecutionNotice.story.tsx
+++ b/client/web/src/enterprise/batches/detail/ActiveExecutionNotice.story.tsx
@@ -1,13 +1,13 @@
 import { useMemo } from 'react'
 
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 import { BatchSpecState } from '../../../graphql-operations'
 
 import { ActiveExecutionNotice } from './ActiveExecutionNotice'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 const config: Meta = {
     title: 'web/batches/details',
     decorators: [decorator],

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -7,7 +7,7 @@ import { WebStory } from '../../../components/WebStory'
 import { BatchChangeBurndownChart } from './BatchChangeBurndownChart'
 import { CHANGESET_COUNTS_OVER_TIME_MOCK } from './testdata'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 const config: Meta = {
     title: 'web/batches/BurndownChart',
     decorators: [decorator],
@@ -15,7 +15,7 @@ const config: Meta = {
 
 export default config
 
-export const AllStates: Story = () => (
+export const AllStates: StoryFn = () => (
     <WebStory>
         {webProps => (
             <MockedTestProvider mocks={[CHANGESET_COUNTS_OVER_TIME_MOCK]}>

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from '@storybook/addons'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
@@ -31,7 +31,7 @@ import {
 } from './BatchChangeDetailsPage.mock'
 import { CHANGESET_COUNTS_OVER_TIME_MOCK } from './testdata'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 const config: Meta = {
     title: 'web/batches/details/BatchChangeDetailsPage',
     decorators: [decorator],

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -86,7 +86,7 @@ const queryEmptyExternalChangesetWithFileDiffs: typeof queryExternalChangesetWit
 
 const deleteBatchChange = () => Promise.resolve(undefined)
 
-const Template: Story<{
+const Template: StoryFn<{
     url: string
     supersedingBatchSpec?: boolean
     currentBatchSpec?: BatchChangeFields['currentSpec']
@@ -233,7 +233,7 @@ UnpublishableBatchSpec.argTypes = {
     supersedingBatchSpec: {},
 }
 
-export const EmptyChangesets: Story = args => {
+export const EmptyChangesets: StoryFn = args => {
     const mocks = new WildcardMockLink([
         {
             request: {

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -1,11 +1,11 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 import { BatchChangeState, type ChangesetsStatsFields } from '../../../graphql-operations'
 
 import { BatchChangeStatsCard } from './BatchChangeStatsCard'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/BatchChangeStatsCard',

--- a/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeStatsCard.story.tsx
@@ -35,7 +35,7 @@ const calculatePercentComplete = <T extends MockStatsArgs>(stats: T, total: numb
 const calculateTotal = <T extends MockStatsArgs>(stats: T): number =>
     stats.closed + stats.deleted + stats.merged + stats.draft + stats.open + stats.archived + stats.unpublished
 
-export const Draft: Story<MockStatsArgs> = args => {
+export const Draft: StoryFn<MockStatsArgs> = args => {
     const total = calculateTotal(args)
     return (
         <WebStory>
@@ -118,7 +118,7 @@ Draft.args = {
     processing: 0,
 }
 
-export const Open: Story<MockStatsArgs> = args => {
+export const Open: StoryFn<MockStatsArgs> = args => {
     const total = calculateTotal(args)
     return (
         <WebStory>
@@ -201,7 +201,7 @@ Open.args = {
     processing: 0,
 }
 
-export const OpenAndComplete: Story<MockStatsArgs> = args => {
+export const OpenAndComplete: StoryFn<MockStatsArgs> = args => {
     const total = calculateTotal(args)
     return (
         <WebStory>
@@ -286,7 +286,7 @@ OpenAndComplete.args = {
 
 OpenAndComplete.storyName = 'open and complete'
 
-export const Closed: Story<MockStatsArgs> = args => {
+export const Closed: StoryFn<MockStatsArgs> = args => {
     const total = calculateTotal(args)
     return (
         <WebStory>

--- a/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.story.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from '@storybook/addons'
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { BulkOperationState } from '@sourcegraph/shared/src/graphql-operations'
 
@@ -7,7 +7,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { BulkOperationsAlerts } from './BulkOperationsAlerts'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/BulkOperationsAlerts',
@@ -16,7 +16,7 @@ const config: Meta = {
 
 export default config
 
-export const Processing: Story = () => {
+export const Processing: StoryFn = () => {
     const bulkOperations = useMemo(
         () => ({
             __typename: 'BulkOperationConnection' as const,
@@ -28,7 +28,7 @@ export const Processing: Story = () => {
     return <WebStory>{props => <BulkOperationsAlerts {...props} bulkOperations={bulkOperations} />}</WebStory>
 }
 
-export const Failed: Story = () => {
+export const Failed: StoryFn = () => {
     const bulkOperations = useMemo(
         () => ({
             __typename: 'BulkOperationConnection' as const,
@@ -40,7 +40,7 @@ export const Failed: Story = () => {
     return <WebStory>{props => <BulkOperationsAlerts {...props} bulkOperations={bulkOperations} />}</WebStory>
 }
 
-export const Completed: Story = () => {
+export const Completed: StoryFn = () => {
     const bulkOperations = useMemo(
         () => ({
             __typename: 'BulkOperationConnection' as const,

--- a/client/web/src/enterprise/batches/detail/ClosedNotice.story.tsx
+++ b/client/web/src/enterprise/batches/detail/ClosedNotice.story.tsx
@@ -1,10 +1,10 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { ClosedNotice } from './ClosedNotice'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/ClosedNotice',
@@ -13,6 +13,6 @@ const config: Meta = {
 
 export default config
 
-export const BatchChangeClosed: Story = () => <WebStory>{() => <ClosedNotice closedAt="2021-02-02" />}</WebStory>
+export const BatchChangeClosed: StoryFn = () => <WebStory>{() => <ClosedNotice closedAt="2021-02-02" />}</WebStory>
 
 BatchChangeClosed.storyName = 'Batch change closed'

--- a/client/web/src/enterprise/batches/detail/SupersedingBatchSpecAlert.story.tsx
+++ b/client/web/src/enterprise/batches/detail/SupersedingBatchSpecAlert.story.tsx
@@ -1,11 +1,11 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { SupersedingBatchSpecAlert } from './SupersedingBatchSpecAlert'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/SupersedingBatchSpecAlert',
@@ -14,7 +14,7 @@ const config: Meta = {
 
 export default config
 
-export const NonePublished: Story = () => (
+export const NonePublished: StoryFn = () => (
     <WebStory>
         {() => (
             <SupersedingBatchSpecAlert

--- a/client/web/src/enterprise/batches/detail/UnpublishedNotice.story.tsx
+++ b/client/web/src/enterprise/batches/detail/UnpublishedNotice.story.tsx
@@ -1,10 +1,10 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { UnpublishedNotice } from './UnpublishedNotice'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/UnpublishedNotice',
@@ -13,6 +13,6 @@ const config: Meta = {
 
 export default config
 
-export const NonePublished: Story = () => <WebStory>{() => <UnpublishedNotice unpublished={10} total={10} />}</WebStory>
+export const NonePublished: StoryFn = () => <WebStory>{() => <UnpublishedNotice unpublished={10} total={10} />}</WebStory>
 
 NonePublished.storyName = 'None published'

--- a/client/web/src/enterprise/batches/detail/UnpublishedNotice.story.tsx
+++ b/client/web/src/enterprise/batches/detail/UnpublishedNotice.story.tsx
@@ -13,6 +13,8 @@ const config: Meta = {
 
 export default config
 
-export const NonePublished: StoryFn = () => <WebStory>{() => <UnpublishedNotice unpublished={10} total={10} />}</WebStory>
+export const NonePublished: StoryFn = () => (
+    <WebStory>{() => <UnpublishedNotice unpublished={10} total={10} />}</WebStory>
+)
 
 NonePublished.storyName = 'None published'

--- a/client/web/src/enterprise/batches/detail/WebhookAlert.story.tsx
+++ b/client/web/src/enterprise/batches/detail/WebhookAlert.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import type { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 
@@ -7,7 +7,7 @@ import { BatchSpecSource } from '../../../graphql-operations'
 
 import { WebhookAlert } from './WebhookAlert'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/WebhookAlert',
@@ -59,25 +59,25 @@ const batchChange = (totalCount: number, hasNextPage: boolean) => ({
     },
 })
 
-export const SiteAdmin: Story = () => (
+export const SiteAdmin: StoryFn = () => (
     <WebStory>{() => <WebhookAlert batchChange={batchChange(3, false)} isSiteAdmin={true} />}</WebStory>
 )
 
 SiteAdmin.storyName = 'Site admin'
 
-export const RegularUser: Story = () => (
+export const RegularUser: StoryFn = () => (
     <WebStory>{() => <WebhookAlert batchChange={batchChange(3, false)} />}</WebStory>
 )
 
 RegularUser.storyName = 'Regular user'
 
-export const RegularUserWithMoreThanThreeCodeHosts: Story = () => (
+export const RegularUserWithMoreThanThreeCodeHosts: StoryFn = () => (
     <WebStory>{() => <WebhookAlert batchChange={batchChange(4, true)} />}</WebStory>
 )
 
 RegularUserWithMoreThanThreeCodeHosts.storyName = 'Regular user with more than three code hosts'
 
-export const AllCodeHostsHaveWebhooks: Story = () => (
+export const AllCodeHostsHaveWebhooks: StoryFn = () => (
     <WebStory>
         {() => (
             <WebhookAlert

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
@@ -73,7 +73,7 @@ const queryEmptyExternalChangesetWithFileDiffs: typeof queryExternalChangesetWit
     }
 }
 
-export const ListOfChangesets: Story = args => (
+export const ListOfChangesets: StoryFn = args => (
     <WebStory>
         {props => (
             <MockedTestProvider link={mocks}>
@@ -93,7 +93,7 @@ export const ListOfChangesets: Story = args => (
 
 ListOfChangesets.storyName = 'List of changesets'
 
-export const ListOfExpandedChangesets: Story = args => (
+export const ListOfExpandedChangesets: StoryFn = args => (
     <WebStory>
         {props => (
             <MockedTestProvider link={mocks}>
@@ -114,7 +114,7 @@ export const ListOfExpandedChangesets: Story = args => (
 
 ListOfExpandedChangesets.storyName = 'List of expanded changesets'
 
-export const DraftWithoutChangesets: Story = args => {
+export const DraftWithoutChangesets: StoryFn = args => {
     const batchChangeState = args.batchChangeState
 
     return (

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.story.tsx
@@ -1,4 +1,4 @@
-import type { Story, Meta, DecoratorFn } from '@storybook/react'
+import type { StoryFn, Meta, Decorator } from '@storybook/react'
 import { noop } from 'lodash'
 import { of } from 'rxjs'
 import { WildcardMockLink, MATCH_ANY_PARAMETERS } from 'wildcard-mock-link'
@@ -13,7 +13,7 @@ import { CHANGESETS, type queryExternalChangesetWithFileDiffs } from '../backend
 import { BatchChangeChangesets } from './BatchChangeChangesets'
 import { BATCH_CHANGE_CHANGESETS_RESULT, EMPTY_BATCH_CHANGE_CHANGESETS_RESULT } from './BatchChangeChangesets.mock'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/BatchChangeChangesets',

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetCheckStatusCell.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetCheckStatusCell.story.tsx
@@ -14,7 +14,7 @@ const config: Meta = {
 
 export default config
 
-const Template: Story<{ checkState: ChangesetCheckState }> = ({ checkState }) => (
+const Template: StoryFn<{ checkState: ChangesetCheckState }> = ({ checkState }) => (
     <WebStory>{props => <ChangesetCheckStatusCell {...props} checkState={checkState} />}</WebStory>
 )
 

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetCheckStatusCell.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetCheckStatusCell.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 import { ChangesetCheckState } from '../../../../graphql-operations'
 
 import { ChangesetCheckStatusCell } from './ChangesetCheckStatusCell'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/ChangesetCheckStatusCell',

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetLabel.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetLabel.story.tsx
@@ -1,10 +1,10 @@
-import type { Story, DecoratorFn, Meta } from '@storybook/react'
+import type { StoryFn, Decorator, Meta } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { ChangesetLabel } from './ChangesetLabel'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/ChangesetLabel',
@@ -13,7 +13,7 @@ const config: Meta = {
 
 export default config
 
-export const VariousLabels: Story = () => (
+export const VariousLabels: StoryFn = () => (
     <WebStory>
         {() => (
             <>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.story.tsx
@@ -14,7 +14,7 @@ const config: Meta = {
 
 export default config
 
-const Template: Story<{ reviewState: ChangesetReviewState }> = ({ reviewState }) => (
+const Template: StoryFn<{ reviewState: ChangesetReviewState }> = ({ reviewState }) => (
     <WebStory>{props => <ChangesetReviewStatusCell {...props} reviewState={reviewState} />}</WebStory>
 )
 

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetReviewStatusCell.story.tsx
@@ -1,11 +1,11 @@
-import type { Meta, DecoratorFn, Story } from '@storybook/react'
+import type { Meta, Decorator, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 import { ChangesetReviewState } from '../../../../graphql-operations'
 
 import { ChangesetReviewStatusCell } from './ChangesetReviewStatusCell'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/ChangesetReviewStatusCell',

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 import { of } from 'rxjs'
 
 import { BulkOperationType } from '@sourcegraph/shared/src/graphql-operations'
@@ -13,7 +13,7 @@ import type {
 
 import { ChangesetSelectRow } from './ChangesetSelectRow'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const MAX_CHANGESETS = 100
 

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -52,7 +52,7 @@ const queryAll50ChangesetIDs: typeof _queryAllChangesetIDs = () => of(CHANGESET_
 
 const allBulkOperations = Object.keys(BulkOperationType) as BulkOperationType[]
 
-export const AllStates: Story = args => {
+export const AllStates: StoryFn = args => {
     const queryAllChangesetIDs: typeof _queryAllChangesetIDs = () =>
         of(CHANGESET_IDS.slice(0, args.selectableChangesets))
     const initialSelected = CHANGESET_IDS.slice(0, args.selectedChangesets)

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.story.tsx
@@ -13,7 +13,7 @@ const config: Meta = {
 
 export default config
 
-const Template: Story<{ state: ChangesetState }> = ({ state }) => (
+const Template: StoryFn<{ state: ChangesetState }> = ({ state }) => (
     <WebStory>{() => <ChangesetStatusCell state={state} className="d-flex text-muted" />}</WebStory>
 )
 

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetStatusCell.story.tsx
@@ -1,11 +1,11 @@
-import type { Meta, DecoratorFn, Story } from '@storybook/react'
+import type { Meta, Decorator, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../components/WebStory'
 import { ChangesetState } from '../../../../graphql-operations'
 
 import { ChangesetStatusCell } from './ChangesetStatusCell'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 const config: Meta = {
     title: 'web/batches/ChangesetStatusCell',
     decorators: [decorator],

--- a/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CloseChangesetsModal.story.tsx
@@ -1,12 +1,12 @@
 import { action } from '@storybook/addon-actions'
-import type { Story, DecoratorFn, Meta } from '@storybook/react'
+import type { StoryFn, Decorator, Meta } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { CloseChangesetsModal } from './CloseChangesetsModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/CloseChangesetsModal',
@@ -20,7 +20,7 @@ const closeChangesets = () => {
     return Promise.resolve()
 }
 
-export const Confirmation: Story = () => (
+export const Confirmation: StoryFn = () => (
     <WebStory>
         {props => (
             <CloseChangesetsModal

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.story.tsx
@@ -1,12 +1,12 @@
 import { action } from '@storybook/addon-actions'
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { CreateCommentModal } from './CreateCommentModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/CreateCommentModal',
@@ -20,7 +20,7 @@ const createChangesetCommentsAction = () => {
     return Promise.resolve()
 }
 
-export const Confirmation: Story = () => (
+export const Confirmation: StoryFn = () => (
     <WebStory>
         {props => (
             <CreateCommentModal

--- a/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.story.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import type { Story, Meta, DecoratorFn } from '@storybook/react'
+import type { StoryFn, Meta, Decorator } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -8,7 +8,7 @@ import { WebStory } from '../../../../components/WebStory'
 
 import { DetachChangesetsModal } from './DetachChangesetsModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/DetachChangesetsModal',
@@ -22,7 +22,7 @@ const detachAction = () => {
     return Promise.resolve()
 }
 
-export const Confirmation: Story = () => (
+export const Confirmation: StoryFn = () => (
     <WebStory>
         {props => (
             <DetachChangesetsModal

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
@@ -42,7 +42,7 @@ const config: Meta = {
 
 export default config
 
-export const AllStates: Story = args => {
+export const AllStates: StoryFn = args => {
     const now = new Date()
     return (
         <WebStory>
@@ -136,7 +136,7 @@ export const AllStates: Story = args => {
 
 AllStates.storyName = 'All states'
 
-export const Unpublished: Story = args => {
+export const Unpublished: StoryFn = args => {
     const now = new Date()
     return (
         <WebStory>
@@ -211,7 +211,7 @@ export const Unpublished: Story = args => {
     )
 }
 
-export const Importing: Story = args => {
+export const Importing: StoryFn = args => {
     const now = new Date()
     return (
         <WebStory>
@@ -274,7 +274,7 @@ export const Importing: Story = args => {
     )
 }
 
-export const ImportingFailed: Story = args => {
+export const ImportingFailed: StoryFn = args => {
     const now = new Date()
     return (
         <WebStory>
@@ -329,7 +329,7 @@ export const ImportingFailed: Story = args => {
 
 ImportingFailed.storyName = 'Importing failed'
 
-export const SyncFailed: Story = args => {
+export const SyncFailed: StoryFn = args => {
     const now = new Date()
     return (
         <WebStory>

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
@@ -1,4 +1,4 @@
-import type { Story, Meta, DecoratorFn } from '@storybook/react'
+import type { StoryFn, Meta, Decorator } from '@storybook/react'
 import classNames from 'classnames'
 import { addHours } from 'date-fns'
 import { of } from 'rxjs'
@@ -15,7 +15,7 @@ import { ExternalChangesetNode } from './ExternalChangesetNode'
 
 import gridStyles from './BatchChangeChangesets.module.scss'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className={classNames(gridStyles.batchChangeChangesetsGrid, 'p-3 container')}>{story()}</div>
 )
 

--- a/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.story.tsx
@@ -1,4 +1,4 @@
-import type { Story, Meta, DecoratorFn } from '@storybook/react'
+import type { StoryFn, Meta, Decorator } from '@storybook/react'
 import classNames from 'classnames'
 import { addHours } from 'date-fns'
 
@@ -9,7 +9,7 @@ import { HiddenExternalChangesetNode } from './HiddenExternalChangesetNode'
 
 import gridStyles from './BatchChangeChangesets.module.scss'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className={classNames(gridStyles.batchChangeChangesetsGrid, 'p-3 container')}>{story()}</div>
 )
 
@@ -20,7 +20,7 @@ const config: Meta = {
 
 export default config
 
-export const AllStates: Story = () => {
+export const AllStates: StoryFn = () => {
     const now = new Date()
     return (
         <WebStory>

--- a/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.story.tsx
@@ -1,12 +1,12 @@
 import { action } from '@storybook/addon-actions'
-import type { Story, Meta, DecoratorFn } from '@storybook/react'
+import type { StoryFn, Meta, Decorator } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { MergeChangesetsModal } from './MergeChangesetsModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/MergeChangesetsModal',
@@ -20,7 +20,7 @@ const mergeChangesets = () => {
     return Promise.resolve()
 }
 
-export const Confirmation: Story = () => (
+export const Confirmation: StoryFn = () => (
     <WebStory>
         {props => (
             <MergeChangesetsModal

--- a/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/PublishChangesetsModal.story.tsx
@@ -1,12 +1,12 @@
 import { action } from '@storybook/addon-actions'
-import type { Story, Meta, DecoratorFn } from '@storybook/react'
+import type { StoryFn, Meta, Decorator } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { PublishChangesetsModal } from './PublishChangesetsModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/PublishChangesetsModal',
@@ -20,7 +20,7 @@ const publishChangesets = () => {
     return Promise.resolve()
 }
 
-export const Confirmation: Story = () => (
+export const Confirmation: StoryFn = () => (
     <WebStory>
         {props => (
             <PublishChangesetsModal

--- a/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.story.tsx
@@ -1,12 +1,12 @@
 import { action } from '@storybook/addon-actions'
-import type { Story, Meta, DecoratorFn } from '@storybook/react'
+import type { StoryFn, Meta, Decorator } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../../components/WebStory'
 
 import { ReenqueueChangesetsModal } from './ReenqueueChangesetsModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/details/ReenqueueChangesetsModal',
@@ -20,7 +20,7 @@ const reenqueueChangesets = () => {
     return Promise.resolve()
 }
 
-export const Confirmation: Story = () => (
+export const Confirmation: StoryFn = () => (
     <WebStory>
         {props => (
             <ReenqueueChangesetsModal

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -90,7 +90,7 @@ interface Args {
     isApp: boolean
 }
 
-export const ListOfBatchChanges: Story<Args> = args => {
+export const ListOfBatchChanges: StoryFn<Args> = args => {
     updateJSContextBatchChangesLicense('full')
 
     return (

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { WildcardMockLink, MATCH_ANY_PARAMETERS } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -23,7 +23,7 @@ import {
     getLicenseAndUsageInfoResult,
 } from './testData'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/list/BatchChangeListPage',
@@ -127,7 +127,7 @@ ListOfBatchChanges.args = {
 
 ListOfBatchChanges.storyName = 'List of batch changes'
 
-export const ListOfBatchChangesSpecificNamespace: Story = () => {
+export const ListOfBatchChangesSpecificNamespace: StoryFn = () => {
     updateJSContextBatchChangesLicense('full')
 
     return (
@@ -151,7 +151,7 @@ export const ListOfBatchChangesSpecificNamespace: Story = () => {
 
 ListOfBatchChangesSpecificNamespace.storyName = 'List of batch changes, for a specific namespace'
 
-export const ListOfBatchChangesServerSideExecutionEnabled: Story = () => {
+export const ListOfBatchChangesServerSideExecutionEnabled: StoryFn = () => {
     updateJSContextBatchChangesLicense('full')
 
     return (
@@ -179,7 +179,7 @@ export const ListOfBatchChangesServerSideExecutionEnabled: Story = () => {
 
 ListOfBatchChangesServerSideExecutionEnabled.storyName = 'List of batch changes, server-side execution enabled'
 
-export const LicensingNotEnforced: Story = () => {
+export const LicensingNotEnforced: StoryFn = () => {
     updateJSContextBatchChangesLicense('limited')
 
     return (
@@ -202,7 +202,7 @@ export const LicensingNotEnforced: Story = () => {
 
 LicensingNotEnforced.storyName = 'Licensing not enforced'
 
-export const NoBatchChanges: Story = () => {
+export const NoBatchChanges: StoryFn = () => {
     updateJSContextBatchChangesLicense('full')
 
     return (
@@ -225,7 +225,7 @@ export const NoBatchChanges: Story = () => {
 
 NoBatchChanges.storyName = 'No batch changes'
 
-export const AllBatchChangesTabEmpty: Story = () => {
+export const AllBatchChangesTabEmpty: StoryFn = () => {
     updateJSContextBatchChangesLicense('full')
 
     return (

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, DecoratorFn, Story } from '@storybook/react'
+import type { Meta, Decorator, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 import { subDays } from 'date-fns'
 
@@ -11,7 +11,7 @@ import { nodes, now } from './testData'
 
 import styles from './BatchChangeListPage.module.scss'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className={classNames(styles.grid, styles.narrow, 'p-3 container')}>{story()}</div>
 )
 

--- a/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeNode.story.tsx
@@ -36,7 +36,7 @@ const config: Meta = {
 
 export default config
 
-const Template: Story /* <{ node: ListBatchChange }>*/ = ({ node, ...args }) => (
+const Template: StoryFn /* <{ node: ListBatchChange }>*/ = ({ node, ...args }) => (
     <WebStory>
         {props => (
             <BatchChangeNode

--- a/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatePill.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { upperFirst } from 'lodash'
 
 import { H3 } from '@sourcegraph/wildcard'
@@ -10,7 +10,7 @@ import { BatchChangeState, BatchSpecState } from '../../../graphql-operations'
 
 import { BatchChangeStatePill, type BatchChangeStatePillProps } from './BatchChangeStatePill'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/list',
@@ -44,7 +44,7 @@ const STATE_COMBINATIONS: BatchChangeStatePillProps[] = Object.values(BatchChang
     ])
 )
 
-export const BatchChangeStatePillStory: Story = () => (
+export const BatchChangeStatePillStory: StoryFn = () => (
     <WebStory>
         {props => (
             <div className="d-flex flex-column align-items-start">

--- a/client/web/src/enterprise/batches/list/BatchChangeStatsBar.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeStatsBar.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, DecoratorFn, Story } from '@storybook/react'
+import type { Meta, Decorator, StoryFn } from '@storybook/react'
 import { WildcardMockLink, MATCH_ANY_PARAMETERS } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -10,7 +10,7 @@ import type { GlobalChangesetsStatsResult } from '../../../graphql-operations'
 import { GLOBAL_CHANGESETS_STATS } from './backend'
 import { BatchChangeStatsBar } from './BatchChangeStatsBar'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/list/BatchChangeStatsBar',
@@ -25,7 +25,7 @@ const statBarData: GlobalChangesetsStatsResult = {
     globalChangesetsStats: { __typename: 'GlobalChangesetsStats', open: 7, closed: 5, merged: 21 },
 }
 
-export const BatchChangeStatsBarStory: Story = () => (
+export const BatchChangeStatsBarStory: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
@@ -22,6 +22,6 @@ const config: Meta = {
 
 export default config
 
-export const Changelog: Story = args => (
+export const Changelog: StoryFn = args => (
     <WebStory>{() => <BatchChangesChangelogAlert viewerIsAdmin={args.viewerIsAdmin} />}</WebStory>
 )

--- a/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesChangelogAlert.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { BatchChangesChangelogAlert } from './BatchChangesChangelogAlert'
 
-const decorator: DecoratorFn = story => <div className="p-3 container web-content">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container web-content">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/BatchChangesChangelogAlert',

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
@@ -1,10 +1,10 @@
-import type { Meta, DecoratorFn, Story } from '@storybook/react'
+import type { Meta, Decorator, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { BatchChangesListIntro } from './BatchChangesListIntro'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 enum LicensingState {
     Licensed = 'Licensed',

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.story.tsx
@@ -40,7 +40,7 @@ function stateToInput(state: LicensingState): boolean | undefined {
     }
 }
 
-const Template: Story = ({ state, ...args }) => (
+const Template: StoryFn = ({ state, ...args }) => (
     <WebStory>
         {() => <BatchChangesListIntro viewerIsAdmin={false} isLicensed={stateToInput(args.licensed)} />}
     </WebStory>

--- a/client/web/src/enterprise/batches/list/GettingStarted.story.tsx
+++ b/client/web/src/enterprise/batches/list/GettingStarted.story.tsx
@@ -30,7 +30,7 @@ const config: Meta = {
 
 export default config
 
-export const Overview: Story = args => (
+export const Overview: StoryFn = args => (
     <WebStory>
         {() => <GettingStarted isSourcegraphDotCom={args.isSourcegraphDotCom} canCreate={args.canCreateBatchChanges} />}
     </WebStory>

--- a/client/web/src/enterprise/batches/list/GettingStarted.story.tsx
+++ b/client/web/src/enterprise/batches/list/GettingStarted.story.tsx
@@ -1,10 +1,10 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { GettingStarted } from './GettingStarted'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/GettingStarted',

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
@@ -1,5 +1,5 @@
 import { type Args, useMemo } from '@storybook/addons'
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { addDays, subDays } from 'date-fns'
 import { type Observable, of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
@@ -22,7 +22,7 @@ import { BATCH_SPEC_BY_ID } from './backend'
 import { BatchChangePreviewPage, NewBatchChangePreviewPage } from './BatchChangePreviewPage'
 import { hiddenChangesetApplyPreviewStories, visibleChangesetApplyPreviewNodeStories } from './list/storyData'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/preview/BatchChangePreviewPage',

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.story.tsx
@@ -1,5 +1,5 @@
-import { type Args, useMemo } from '@storybook/addons'
-import type { Decorator, StoryFn, Meta } from '@storybook/react'
+import { useMemo } from '@storybook/addons'
+import type { Decorator, StoryFn, Meta, Args } from '@storybook/react'
 import { addDays, subDays } from 'date-fns'
 import { type Observable, of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
@@ -226,7 +226,7 @@ const queryEmptyChangesetApplyPreview = (): Observable<BatchSpecApplyPreviewConn
 
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
 
-export const Create: Story = args => {
+export const Create: StoryFn = args => {
     const link = useMemo(() => fetchBatchSpecCreate(args), [args])
     return (
         <WebStory path="/:batchSpecID" initialEntries={['/123123']}>
@@ -251,7 +251,7 @@ export const Create: Story = args => {
     )
 }
 
-export const Update: Story = args => {
+export const Update: StoryFn = args => {
     const link = useMemo(() => fetchBatchSpecUpdate(args), [args])
     return (
         <WebStory path="/:batchSpecID" initialEntries={['/123123']}>
@@ -276,7 +276,7 @@ export const Update: Story = args => {
     )
 }
 
-export const MissingCredentials: Story = args => {
+export const MissingCredentials: StoryFn = args => {
     const link = useMemo(() => fetchBatchSpecMissingCredentials(args), [args])
     return (
         <WebStory path="/:batchSpecID" initialEntries={['/123123']}>
@@ -303,7 +303,7 @@ export const MissingCredentials: Story = args => {
 
 MissingCredentials.storyName = 'Missing credentials'
 
-export const SpecFile: Story = args => {
+export const SpecFile: StoryFn = args => {
     const link = useMemo(() => fetchBatchSpecCreate(args), [args])
     return (
         <WebStory path="/:batchSpecID" initialEntries={['/123123?tab=spec']}>
@@ -330,7 +330,7 @@ export const SpecFile: Story = args => {
 
 SpecFile.storyName = 'Spec file'
 
-export const NoChangesets: Story = args => {
+export const NoChangesets: StoryFn = args => {
     const link = useMemo(() => fetchBatchSpecCreate(args), [args])
     return (
         <WebStory path="/:batchSpecID" initialEntries={['/123123']}>
@@ -357,7 +357,7 @@ export const NoChangesets: Story = args => {
 
 NoChangesets.storyName = 'No changesets'
 
-export const CreateNewStory: Story = args => {
+export const CreateNewStory: StoryFn = args => {
     const link = useMemo(() => fetchBatchSpecCreate(args), [args])
     return (
         <WebStory path="/:batchSpecID" initialEntries={['/123123']}>
@@ -384,7 +384,7 @@ export const CreateNewStory: Story = args => {
 
 CreateNewStory.storyName = 'Create (New)'
 
-export const ExceedsLicenseStory: Story = args => {
+export const ExceedsLicenseStory: StoryFn = args => {
     const link = useMemo(() => fetchExceedsLicense(args), [args])
     return (
         <WebStory path="/:batchSpecID" initialEntries={['/123123']}>

--- a/client/web/src/enterprise/batches/preview/BatchSpecInfoByline.story.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchSpecInfoByline.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { BatchSpecInfoByline } from './BatchSpecInfoByline'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/preview/BatchSpecInfoByline',
@@ -14,7 +14,7 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {() => (
             <BatchSpecInfoByline

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 import { MultiSelectContextProvider } from '../MultiSelectContext'
 
 import { CreateUpdateBatchChangeAlert } from './CreateUpdateBatchChangeAlert'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/preview/CreateUpdateBatchChangeAlert',

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
@@ -27,7 +27,7 @@ const config: Meta = {
 
 export default config
 
-export const Create: Story = args => (
+export const Create: StoryFn = args => (
     <WebStory>
         {props => (
             <CreateUpdateBatchChangeAlert
@@ -41,7 +41,7 @@ export const Create: Story = args => (
     </WebStory>
 )
 
-export const Update: Story = args => (
+export const Update: StoryFn = args => (
     <WebStory>
         {props => (
             <CreateUpdateBatchChangeAlert
@@ -55,7 +55,7 @@ export const Update: Story = args => (
     </WebStory>
 )
 
-export const Disabled: Story = args => (
+export const Disabled: StoryFn = args => (
     <WebStory>
         {props => (
             <MultiSelectContextProvider initialSelected={['id1', 'id2']}>

--- a/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/ChangesetApplyPreviewNode.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import classNames from 'classnames'
 import { of } from 'rxjs'
 
@@ -11,7 +11,7 @@ import styles from './PreviewList.module.scss'
 
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className={classNames(styles.previewListGrid, 'p-3 container')}>{story()}</div>
 )
 
@@ -22,7 +22,7 @@ const config: Meta = {
 
 export default config
 
-export const Overview: Story = () => {
+export const Overview: StoryFn = () => {
     const nodes = [
         ...Object.values(visibleChangesetApplyPreviewNodeStories(false)),
         ...Object.values(hiddenChangesetApplyPreviewStories),

--- a/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, DecoratorFn, Story } from '@storybook/react'
+import type { Meta, Decorator, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 
 import { WebStory } from '../../../../components/WebStory'
@@ -9,7 +9,7 @@ import { hiddenChangesetApplyPreviewStories } from './storyData'
 
 import styles from './PreviewList.module.scss'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className={classNames(styles.previewListGrid, 'p-3 container')}>{story()}</div>
 )
 const config: Meta = {

--- a/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/HiddenChangesetApplyPreviewNode.story.tsx
@@ -19,7 +19,7 @@ const config: Meta = {
 
 export default config
 
-const Template: Story<{ node: HiddenChangesetApplyPreviewFields }> = ({ node }) => (
+const Template: StoryFn<{ node: HiddenChangesetApplyPreviewFields }> = ({ node }) => (
     <WebStory>{props => <HiddenChangesetApplyPreviewNode {...props} node={node} />}</WebStory>
 )
 

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { type Observable, of } from 'rxjs'
 
 import { WebStory } from '../../../../components/WebStory'
@@ -9,7 +9,7 @@ import { filterPublishableIDs } from '../utils'
 import { PreviewList } from './PreviewList'
 import { hiddenChangesetApplyPreviewStories, visibleChangesetApplyPreviewNodeStories } from './storyData'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/preview/PreviewList',

--- a/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewList.story.tsx
@@ -29,7 +29,7 @@ export default config
 
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })
 
-export const DefaultStory: Story = args => {
+export const DefaultStory: StoryFn = args => {
     const publicationStateSet = args.publicationStateSet
 
     const nodes: ChangesetApplyPreviewFields[] = [

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, DecoratorFn, Story } from '@storybook/react'
+import type { Meta, Decorator, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 import { of } from 'rxjs'
 
@@ -10,7 +10,7 @@ import { VisibleChangesetApplyPreviewNode } from './VisibleChangesetApplyPreview
 
 import styles from './PreviewList.module.scss'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className={classNames(styles.previewListGrid, 'p-3 container')}>{story()}</div>
 )
 

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -25,7 +25,7 @@ const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: nul
 
 const stories = visibleChangesetApplyPreviewNodeStories(true)
 
-const Template: Story<{ node: VisibleChangesetApplyPreviewFields }> = ({ node }) => (
+const Template: StoryFn<{ node: VisibleChangesetApplyPreviewFields }> = ({ node }) => (
     <WebStory>
         {props => (
             <VisibleChangesetApplyPreviewNode

--- a/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
+++ b/client/web/src/enterprise/batches/repo/BatchChangeRepoPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { of } from 'rxjs'
 
 import { mockAuthenticatedUser } from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
@@ -89,7 +89,7 @@ const queryEmptyExternalChangesetWithFileDiffs: typeof _queryExternalChangesetWi
         },
     })
 
-const decorator: DecoratorFn = story => <div className="p-3 container web-content">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container web-content">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/repo/BatchChangeRepoPage',
@@ -104,7 +104,7 @@ const config: Meta = {
 
 export default config
 
-export const ListOfBatchChanges: Story = () => (
+export const ListOfBatchChanges: StoryFn = () => (
     <WebStory initialEntries={['/github.com/sourcegraph/awesome/-/batch-changes']}>
         {props => (
             <BatchChangeRepoPage
@@ -122,7 +122,7 @@ export const ListOfBatchChanges: Story = () => (
 
 ListOfBatchChanges.storyName = 'List of batch changes'
 
-export const NoBatchChanges: Story = () => (
+export const NoBatchChanges: StoryFn = () => (
     <WebStory initialEntries={['/github.com/sourcegraph/awesome/-/batch-changes']}>
         {props => (
             <BatchChangeRepoPage

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { noop } from 'lodash'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
@@ -11,7 +11,7 @@ import { ExternalServiceKind } from '../../../graphql-operations'
 import { AddCredentialModal } from './AddCredentialModal'
 import { CREATE_BATCH_CHANGES_CREDENTIAL } from './backend'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/settings/AddCredentialModal',
@@ -107,7 +107,7 @@ RequiresSSHstep2.args = {
 
 RequiresSSHstep2.storyName = 'Requires SSH - step 2'
 
-export const GitHub: Story = () => (
+export const GitHub: StoryFn = () => (
     <WebStory>
         {props => (
             <AddCredentialModal
@@ -126,7 +126,7 @@ export const GitHub: Story = () => (
 
 GitHub.storyName = 'GitHub'
 
-export const GitLab: Story = () => (
+export const GitLab: StoryFn = () => (
     <WebStory>
         {props => (
             <AddCredentialModal
@@ -145,7 +145,7 @@ export const GitLab: Story = () => (
 
 GitLab.storyName = 'GitLab'
 
-export const BitbucketServer: Story = () => (
+export const BitbucketServer: StoryFn = () => (
     <WebStory>
         {props => (
             <AddCredentialModal
@@ -162,7 +162,7 @@ export const BitbucketServer: Story = () => (
     </WebStory>
 )
 
-export const BitbucketCloud: Story = () => (
+export const BitbucketCloud: StoryFn = () => (
     <WebStory>
         {props => (
             <AddCredentialModal

--- a/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -16,7 +16,7 @@ import { noRolloutWindowMockResult, rolloutWindowConfigMockResult } from '../moc
 import { USER_CODE_HOSTS } from './backend'
 import { BatchChangesSettingsArea } from './BatchChangesSettingsArea'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/settings/BatchChangesSettingsArea',
@@ -48,7 +48,7 @@ const sshCredential = (isSiteCredential: boolean): BatchChangesCredentialFields 
         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
 })
 
-export const Overview: Story = () => (
+export const Overview: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
@@ -139,7 +139,7 @@ export const Overview: Story = () => (
     </WebStory>
 )
 
-export const ConfigAdded: Story = () => (
+export const ConfigAdded: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
@@ -222,7 +222,7 @@ export const ConfigAdded: Story = () => (
 
 ConfigAdded.storyName = 'Config added'
 
-export const RolloutWindowsConfigurationStory: Story = () => (
+export const RolloutWindowsConfigurationStory: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsPage.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, type WildcardMockedResponse, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -12,7 +12,7 @@ import { rolloutWindowConfigMockResult } from '../mocks'
 import { GLOBAL_CODE_HOSTS } from './backend'
 import { BatchChangesSiteConfigSettingsPage } from './BatchChangesSiteConfigSettingsPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/settings/BatchChangesSiteConfigSettingsPage',
@@ -51,7 +51,7 @@ const createMock = (...hosts: BatchChangesCodeHostFields[]): WildcardMockedRespo
     nMatches: Number.POSITIVE_INFINITY,
 })
 
-export const Overview: Story = () => (
+export const Overview: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider
@@ -130,7 +130,7 @@ export const Overview: Story = () => (
     </WebStory>
 )
 
-export const NoItems: Story = () => (
+export const NoItems: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink([ROLLOUT_WINDOWS_CONFIGURATION_MOCK, createMock()])}>
@@ -140,7 +140,7 @@ export const NoItems: Story = () => (
     </WebStory>
 )
 
-export const ConfigAdded: Story = () => (
+export const ConfigAdded: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider

--- a/client/web/src/enterprise/batches/settings/CheckButton.story.tsx
+++ b/client/web/src/enterprise/batches/settings/CheckButton.story.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 
@@ -11,7 +11,7 @@ const config: Meta = {
 
 export default config
 
-export const Initial: Story = () => (
+export const Initial: StoryFn = () => (
     <WebStory>
         {props => (
             <CheckButton {...props} label="Checks the state of something" onClick={action('onClick')} loading={false} />
@@ -19,13 +19,13 @@ export const Initial: Story = () => (
     </WebStory>
 )
 
-export const Checking: Story = () => (
+export const Checking: StoryFn = () => (
     <WebStory>
         {props => <CheckButton {...props} label="Checks the state of something" onClick={() => {}} loading={true} />}
     </WebStory>
 )
 
-export const Success: Story = () => (
+export const Success: StoryFn = () => (
     <WebStory>
         {props => (
             <CheckButton
@@ -39,7 +39,7 @@ export const Success: Story = () => (
     </WebStory>
 )
 
-export const Failed: Story = () => (
+export const Failed: StoryFn = () => (
     <WebStory>
         {props => (
             <CheckButton

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.story.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -13,7 +13,7 @@ import {
 import { CHECK_BATCH_CHANGES_CREDENTIAL } from './backend'
 import { CodeHostConnectionNode } from './CodeHostConnectionNode'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/settings/CodeHostConnectionNode',
@@ -35,7 +35,7 @@ const sshCredential = (isSiteCredential: boolean): BatchChangesCredentialFields 
         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
 })
 
-export const Overview: Story = () => (
+export const Overview: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider

--- a/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
@@ -7,7 +7,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { RemoveCredentialModal } from './RemoveCredentialModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/settings/RemoveCredentialModal',
@@ -29,7 +29,7 @@ const credential = {
         'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
 }
 
-export const NoSsh: Story = () => (
+export const NoSsh: StoryFn = () => (
     <WebStory>
         {props => (
             <RemoveCredentialModal
@@ -53,7 +53,7 @@ export const NoSsh: Story = () => (
 
 NoSsh.storyName = 'No ssh'
 
-export const RequiresSsh: Story = () => (
+export const RequiresSsh: StoryFn = () => (
     <WebStory>
         {props => (
             <RemoveCredentialModal

--- a/client/web/src/enterprise/batches/settings/RolloutWindowsConfiguration.story.tsx
+++ b/client/web/src/enterprise/batches/settings/RolloutWindowsConfiguration.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -9,7 +9,7 @@ import { noRolloutWindowMockResult, rolloutWindowConfigMockResult } from '../moc
 
 import { RolloutWindowsConfiguration } from './RolloutWindowsConfiguration'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/settings/RolloutWindowsConfiguration',
@@ -18,7 +18,7 @@ const config: Meta = {
 
 export default config
 
-export const NoRolloutWindowsConfigured: Story = () => (
+export const NoRolloutWindowsConfigured: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider
@@ -37,7 +37,7 @@ export const NoRolloutWindowsConfigured: Story = () => (
     </WebStory>
 )
 
-export const RolloutWindowsConfigured: Story = () => (
+export const RolloutWindowsConfigured: StoryFn = () => (
     <WebStory>
         {props => (
             <MockedTestProvider

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../components/WebStory'
@@ -6,7 +6,7 @@ import { type BatchChangesCredentialFields, ExternalServiceKind } from '../../..
 
 import { ViewCredentialModal } from './ViewCredentialModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/settings/ViewCredentialModal',
@@ -22,7 +22,7 @@ const credential: BatchChangesCredentialFields = {
         'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
 }
 
-export const View: Story = () => (
+export const View: StoryFn = () => (
     <WebStory>
         {props => (
             <ViewCredentialModal

--- a/client/web/src/enterprise/batches/workspaces-list/ListItem.story.tsx
+++ b/client/web/src/enterprise/batches/workspaces-list/ListItem.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 import { mockPreviewWorkspace } from '../batch-spec/batch-spec.mock'
@@ -9,7 +9,7 @@ import { Descriptor } from './Descriptor'
 import { CachedIcon, ExcludeIcon } from './Icons'
 import { ListItem } from './ListItem'
 
-const decorator: DecoratorFn = story => <div className="list-group w-100">{story()}</div>
+const decorator: Decorator = story => <div className="list-group w-100">{story()}</div>
 
 const config: Meta = {
     title: 'web/batches/workspaces-list/ListItem',
@@ -23,7 +23,7 @@ const STATUS_INDICATORS: [key: string, icon: React.FunctionComponent<React.Props
     ['exclude', ExcludeIcon],
 ]
 
-export const Basic: Story = () => (
+export const Basic: StoryFn = () => (
     <WebStory>
         {props => (
             <>
@@ -50,7 +50,7 @@ export const Basic: Story = () => (
     </WebStory>
 )
 
-export const NonRootPath: Story = () => (
+export const NonRootPath: StoryFn = () => (
     <WebStory>
         {props => (
             <>
@@ -71,7 +71,7 @@ export const NonRootPath: Story = () => (
 
 NonRootPath.storyName = 'non-root path'
 
-export const WithStatusIndicator: Story = () => (
+export const WithStatusIndicator: StoryFn = () => (
     <WebStory>
         {props => (
             <>
@@ -87,7 +87,7 @@ export const WithStatusIndicator: Story = () => (
 
 WithStatusIndicator.storyName = 'with status indicator'
 
-export const WithClickHandler: Story = () => (
+export const WithClickHandler: StoryFn = () => (
     <WebStory>
         {props => (
             <>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringLogs.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { parseISO } from 'date-fns'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -10,7 +10,7 @@ import { WebStory } from '../../components/WebStory'
 import { CodeMonitoringLogs, CODE_MONITOR_EVENTS } from './CodeMonitoringLogs'
 import { mockLogs } from './testing/util'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/enterprise/code-monitoring/CodeMonitoringLogs',
@@ -34,7 +34,7 @@ const mockedResponse: MockedResponse[] = [
 
 export default config
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={mockedResponse}>
@@ -44,7 +44,7 @@ export const Default: Story = () => (
     </WebStory>
 )
 
-export const Open: Story = () => (
+export const Open: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={mockedResponse}>
@@ -54,7 +54,7 @@ export const Open: Story = () => (
     </WebStory>
 )
 
-export const Empty: Story = () => {
+export const Empty: StoryFn = () => {
     const emptyMockedResponse: MockedResponse[] = [
         {
             request: {

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 
@@ -86,7 +86,7 @@ const siteAdminProps = {
     authenticatedUser: { ...additionalProps.authenticatedUser, siteAdmin: true },
 }
 
-export const LessThan10Results: Story = () => (
+export const LessThan10Results: StoryFn = () => (
     <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsShortList} />}</WebStory>
 )
 
@@ -98,7 +98,7 @@ LessThan10Results.parameters = {
     },
 }
 
-export const MoreThan10Results: Story = () => (
+export const MoreThan10Results: StoryFn = () => (
     <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsLongList} />}</WebStory>
 )
 
@@ -110,7 +110,7 @@ MoreThan10Results.parameters = {
     },
 }
 
-export const PageLoading: Story = () => (
+export const PageLoading: StoryFn = () => (
     <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsAlwaysLoading} />}</WebStory>
 )
 
@@ -122,7 +122,7 @@ PageLoading.parameters = {
     },
 }
 
-export const ListPageEmptyShowGettingStarted: Story = () => (
+export const ListPageEmptyShowGettingStarted: StoryFn = () => (
     <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsEmptyList} />}</WebStory>
 )
 
@@ -134,7 +134,7 @@ ListPageEmptyShowGettingStarted.parameters = {
     },
 }
 
-export const ListPageUnauthenticatedShowGettingStarted: Story = () => (
+export const ListPageUnauthenticatedShowGettingStarted: StoryFn = () => (
     <WebStory initialEntries={['/code-monitoring']}>
         {props => <CodeMonitoringPage {...props} {...additionalProps} authenticatedUser={null} />}
     </WebStory>
@@ -143,7 +143,7 @@ export const ListPageUnauthenticatedShowGettingStarted: Story = () => (
 ListPageUnauthenticatedShowGettingStarted.storyName =
     'Code monitoring list page - unauthenticated, show getting started'
 
-export const EmptyListPage: Story = () => (
+export const EmptyListPage: StoryFn = () => (
     <WebStory initialEntries={['/code-monitoring/getting-started']}>
         {props => <CodeMonitoringPage {...props} {...additionalPropsEmptyList} testForceTab="list" />}
     </WebStory>
@@ -157,7 +157,7 @@ EmptyListPage.parameters = {
     },
 }
 
-export const EmptyListPageUnauthenticated: Story = () => (
+export const EmptyListPageUnauthenticated: StoryFn = () => (
     <WebStory initialEntries={['/code-monitoring/getting-started']}>
         {props => (
             <CodeMonitoringPage {...props} {...additionalPropsEmptyList} authenticatedUser={null} testForceTab="list" />
@@ -173,7 +173,7 @@ EmptyListPageUnauthenticated.parameters = {
     },
 }
 
-export const SiteAdminUser: Story = () => (
+export const SiteAdminUser: StoryFn = () => (
     <WebStory initialEntries={['/code-monitoring']}>
         {props => <CodeMonitoringPage {...props} {...siteAdminProps} testForceTab="list" />}
     </WebStory>

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import sinon from 'sinon'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -17,7 +17,7 @@ export default config
 
 window.context.emailEnabled = true
 
-export const CreateCodeMonitorPageStory: Story = () => (
+export const CreateCodeMonitorPageStory: StoryFn = () => (
     <WebStory>
         {props => (
             <CreateCodeMonitorPage

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 import { fake } from 'sinon'
 
@@ -15,7 +15,7 @@ export default config
 
 window.context.emailEnabled = true
 
-export const ManageCodeMonitorPageStory: Story = () => (
+export const ManageCodeMonitorPageStory: StoryFn = () => (
     <WebStory>
         {props => (
             <ManageCodeMonitorPage

--- a/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/DeleteMonitorModal.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { NEVER } from 'rxjs'
 import sinon from 'sinon'
 
@@ -17,7 +17,7 @@ const config: Meta = {
 
 export default config
 
-export const DeleteMonitorModalStory: Story = () => (
+export const DeleteMonitorModalStory: StoryFn = () => (
     <WebStory>
         {props => (
             <DeleteMonitorModal

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import sinon from 'sinon'
 
 import { H2 } from '@sourcegraph/wildcard'
@@ -26,7 +26,7 @@ const config: Meta = {
 
 export default config
 
-export const FormTrigerArea: Story = () => (
+export const FormTrigerArea: StoryFn = () => (
     <WebStory>
         {props => (
             <>

--- a/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/EmailAction.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import sinon from 'sinon'
 
 import { H2 } from '@sourcegraph/wildcard'
@@ -35,7 +35,7 @@ const action: ActionProps['action'] = {
 }
 window.context.emailEnabled = true
 
-export const EmailActionStory: Story = () => (
+export const EmailActionStory: StoryFn = () => (
     <WebStory>
         {() => (
             <>

--- a/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/SlackWebhookAction.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import sinon from 'sinon'
 
 import { H2 } from '@sourcegraph/wildcard'
@@ -34,7 +34,7 @@ const action: ActionProps['action'] = {
     includeResults: false,
 }
 
-export const SlackWebhookActionStory: Story = () => (
+export const SlackWebhookActionStory: StoryFn = () => (
     <WebStory>
         {() => (
             <>

--- a/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/actions/WebhookAction.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import sinon from 'sinon'
 
 import { H2 } from '@sourcegraph/wildcard'
@@ -34,7 +34,7 @@ const action: ActionProps['action'] = {
     includeResults: false,
 }
 
-export const WebhookActionStory: Story = () => (
+export const WebhookActionStory: StoryFn = () => (
     <WebStory>
         {() => (
             <>

--- a/client/web/src/enterprise/executors/instances/ExecutorCompatibilityAlert.story.tsx
+++ b/client/web/src/enterprise/executors/instances/ExecutorCompatibilityAlert.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { WebStory } from '../../../components/WebStory'
 import { ExecutorCompatibility } from '../../../graphql-operations'
 
 import { ExecutorCompatibilityAlert } from './ExecutorCompatibilityAlert'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/executors/instances/ExecutorCompatibilityAlert',
@@ -14,7 +14,7 @@ const config: Meta = {
 
 export default config
 
-export const UpToDate: Story = () => (
+export const UpToDate: StoryFn = () => (
     <WebStory>
         {props => (
             <ExecutorCompatibilityAlert
@@ -29,7 +29,7 @@ export const UpToDate: Story = () => (
 // This story is expected to be empty.
 UpToDate.storyName = 'Executor is up to date'
 
-export const Outdated: Story = () => (
+export const Outdated: StoryFn = () => (
     <WebStory>
         {props => (
             <ExecutorCompatibilityAlert
@@ -43,7 +43,7 @@ export const Outdated: Story = () => (
 
 Outdated.storyName = 'Executor is outdated'
 
-export const VersionAhead: Story = () => (
+export const VersionAhead: StoryFn = () => (
     <WebStory>
         {props => (
             <ExecutorCompatibilityAlert

--- a/client/web/src/enterprise/executors/instances/ExecutorsListPage.story.tsx
+++ b/client/web/src/enterprise/executors/instances/ExecutorsListPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { subDays, subHours } from 'date-fns'
 import { type Observable, of } from 'rxjs'
 
@@ -7,7 +7,7 @@ import { ExecutorCompatibility, type ExecutorConnectionFields } from '../../../g
 
 import { ExecutorsListPage } from './ExecutorsListPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/executors/instances/ExecutorsListPage',
@@ -60,7 +60,7 @@ const listExecutorsQuery: () => Observable<ExecutorConnectionFields> = () =>
         ],
     })
 
-export const List: Story = () => (
+export const List: StoryFn = () => (
     <WebStory>{props => <ExecutorsListPage {...props} queryExecutors={listExecutorsQuery} />}</WebStory>
 )
 
@@ -73,7 +73,7 @@ const emptyExecutorsQuery: () => Observable<ExecutorConnectionFields> = () =>
         nodes: [],
     })
 
-export const EmptyList: Story = () => (
+export const EmptyList: StoryFn = () => (
     <WebStory>{props => <ExecutorsListPage {...props} queryExecutors={emptyExecutorsQuery} />}</WebStory>
 )
 

--- a/client/web/src/enterprise/executors/secrets/AddSecretModal.story.tsx
+++ b/client/web/src/enterprise/executors/secrets/AddSecretModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../components/WebStory'
@@ -6,7 +6,7 @@ import { ExecutorSecretScope } from '../../../graphql-operations'
 
 import { AddSecretModal } from './AddSecretModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/executors/secrets/AddSecretModal',
@@ -21,7 +21,7 @@ const config: Meta = {
 
 export default config
 
-export const GitHub: Story = () => (
+export const GitHub: StoryFn = () => (
     <WebStory>
         {props => (
             <AddSecretModal
@@ -37,7 +37,7 @@ export const GitHub: Story = () => (
 
 GitHub.storyName = 'Add secret'
 
-export const DockerAuthConfig: Story = () => (
+export const DockerAuthConfig: StoryFn = () => (
     <WebStory>
         {props => (
             <AddSecretModal

--- a/client/web/src/enterprise/executors/secrets/ExecutorSecretNode.story.tsx
+++ b/client/web/src/enterprise/executors/secrets/ExecutorSecretNode.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subDays, subHours } from 'date-fns'
 
 import { WebStory } from '../../../components/WebStory'
@@ -6,7 +6,7 @@ import { type ExecutorSecretFields, ExecutorSecretScope } from '../../../graphql
 
 import { ExecutorSecretNode } from './ExecutorSecretNode'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/executors/secrets/ExecutorSecretNode',
@@ -34,7 +34,7 @@ const secret: ExecutorSecretFields = {
     updatedAt: subHours(new Date(), 12).toISOString(),
 }
 
-export const Overview: Story = () => (
+export const Overview: StoryFn = () => (
     <WebStory>
         {props => <ExecutorSecretNode {...props} namespaceID={null} node={secret} refetchAll={() => {}} />}
     </WebStory>
@@ -63,7 +63,7 @@ const overwrittenSecret: ExecutorSecretFields = {
     updatedAt: subHours(new Date(), 12).toISOString(),
 }
 
-export const OverwritesGlobal: Story = () => (
+export const OverwritesGlobal: StoryFn = () => (
     <WebStory>
         {props => <ExecutorSecretNode {...props} namespaceID={null} node={overwrittenSecret} refetchAll={() => {}} />}
     </WebStory>

--- a/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.story.tsx
+++ b/client/web/src/enterprise/executors/secrets/ExecutorSecretsListPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -15,7 +15,7 @@ import {
 import { GLOBAL_EXECUTOR_SECRETS, USER_EXECUTOR_SECRETS } from './backend'
 import { GlobalExecutorSecretsListPage, UserExecutorSecretsListPage } from './ExecutorSecretsListPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/executors/secrets/ExecutorSecretsListPage',
@@ -159,7 +159,7 @@ const EXECUTOR_SECRET_LIST_MOCK: MockedResponse<UserExecutorSecretsResult> = {
     },
 }
 
-export const List: Story = () => (
+export const List: StoryFn = () => (
     <WebStory>
         {webProps => (
             <MockedTestProvider mocks={[EXECUTOR_SECRET_LIST_MOCK]}>
@@ -196,7 +196,7 @@ const EMPTY_EXECUTOR_SECRET_LIST_MOCK: MockedResponse<GlobalExecutorSecretsResul
     },
 }
 
-export const EmptyList: Story = () => (
+export const EmptyList: StoryFn = () => (
     <WebStory>
         {webProps => (
             <MockedTestProvider mocks={[EMPTY_EXECUTOR_SECRET_LIST_MOCK]}>

--- a/client/web/src/enterprise/executors/secrets/RemoveSecretModal.story.tsx
+++ b/client/web/src/enterprise/executors/secrets/RemoveSecretModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subDays, subHours } from 'date-fns'
 import { noop } from 'lodash'
 
@@ -9,7 +9,7 @@ import type { ExecutorSecretFields } from '../../../graphql-operations'
 
 import { RemoveSecretModal } from './RemoveSecretModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/executors/secrets/RemoveSecretModal',
@@ -43,7 +43,7 @@ const secret: ExecutorSecretFields = {
     updatedAt: subHours(new Date(), 12).toISOString(),
 }
 
-export const Confirm: Story = () => (
+export const Confirm: StoryFn = () => (
     <WebStory>{props => <RemoveSecretModal {...props} secret={secret} afterDelete={noop} onCancel={noop} />}</WebStory>
 )
 

--- a/client/web/src/enterprise/executors/secrets/SecretAccessLogsModal.story.tsx
+++ b/client/web/src/enterprise/executors/secrets/SecretAccessLogsModal.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { noop } from 'lodash'
 
@@ -12,7 +12,7 @@ import type { ExecutorSecretAccessLogsResult } from '../../../graphql-operations
 import { EXECUTOR_SECRET_ACCESS_LOGS } from './backend'
 import { SecretAccessLogsModal } from './SecretAccessLogsModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/executors/secrets/SecretAccessLogsModal',
@@ -77,7 +77,7 @@ const EXECUTOR_SECRET_LIST_MOCK: MockedResponse<ExecutorSecretAccessLogsResult> 
     },
 }
 
-export const List: Story = () => (
+export const List: StoryFn = () => (
     <WebStory>
         {webProps => (
             <MockedTestProvider mocks={[EXECUTOR_SECRET_LIST_MOCK]}>
@@ -112,7 +112,7 @@ const EMPTY_SECRET_ACCESS_LOGS_LIST_MOCK: MockedResponse<ExecutorSecretAccessLog
     },
 }
 
-export const EmptyList: Story = () => (
+export const EmptyList: StoryFn = () => (
     <WebStory>
         {webProps => (
             <MockedTestProvider mocks={[EMPTY_SECRET_ACCESS_LOGS_LIST_MOCK]}>

--- a/client/web/src/enterprise/executors/secrets/UpdateSecretModal.story.tsx
+++ b/client/web/src/enterprise/executors/secrets/UpdateSecretModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subDays, subHours } from 'date-fns'
 import { noop } from 'lodash'
 
@@ -7,7 +7,7 @@ import { ExecutorSecretScope } from '../../../graphql-operations'
 
 import { UpdateSecretModal } from './UpdateSecretModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/executors/secrets/UpdateSecretModal',
@@ -22,7 +22,7 @@ const config: Meta = {
 
 export default config
 
-export const Update: Story = () => (
+export const Update: StoryFn = () => (
     <WebStory>
         {props => (
             <UpdateSecretModal
@@ -52,7 +52,7 @@ export const Update: Story = () => (
     </WebStory>
 )
 
-export const DockerAuthConfig: Story = () => (
+export const DockerAuthConfig: StoryFn = () => (
     <WebStory>
         {props => (
             <UpdateSecretModal

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -1331,7 +1331,7 @@ const BACKEND_INSIGHT_TERRAFORM_AWS_VERSIONS_MOCK: MockedResponse<GetInsightView
     },
 }
 
-export const BackendInsightDemoCasesShowcase: Story = () => (
+export const BackendInsightDemoCasesShowcase: StoryFn = () => (
     <div>
         <MockedTestProvider mocks={[BACKEND_INSIGHT_COMPONENT_MIGRATION_MOCK]}>
             <BackendInsightView
@@ -1359,7 +1359,7 @@ export const BackendInsightDemoCasesShowcase: Story = () => (
     </div>
 )
 
-export const BackendInsightVitrine: Story = () => (
+export const BackendInsightVitrine: StoryFn = () => (
     <section>
         <article>
             <H2>Card</H2>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/DrillDownFilters.story.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react'
 
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../../../../components/WebStory'
 import { SeriesSortDirection, SeriesSortMode } from '../../../../../../../../graphql-operations'
@@ -14,7 +14,7 @@ const defaultStory: Meta = {
 
 export default defaultStory
 
-export const DrillDownPopover: Story = () => {
+export const DrillDownPopover: StoryFn = () => {
     const exampleReference = useRef(null)
     const initialFiltersValue: InsightFilters = {
         excludeRepoRegexp: 'EXCLUDE',

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/drill-down-filters-panel/drill-down-filters/DrillDownInsightFilters.story.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import type { MockedResponse } from '@apollo/client/testing/core/mocking/mockLink'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -110,7 +110,7 @@ const FILTERS: InsightFilters = {
     },
 }
 
-export const DrillDownFiltersShowcase: Story = () => (
+export const DrillDownFiltersShowcase: StoryFn = () => (
     <MockedTestProvider mocks={[CONTEXTS_GQL_MOCKS]}>
         <DrillDownInsightFilters
             initialValues={FILTERS}
@@ -124,7 +124,7 @@ export const DrillDownFiltersShowcase: Story = () => (
     </MockedTestProvider>
 )
 
-export const DrillDownFiltersHorizontalMode: Story = () => {
+export const DrillDownFiltersHorizontalMode: StoryFn = () => {
     const [mode, setMode] = useState<FilterSectionVisualMode>(FilterSectionVisualMode.HorizontalSections)
 
     return (

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/components/sort-filter-series-panel/SortFilterSeriesPanel.story.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { SeriesSortMode, SeriesSortDirection } from '@sourcegraph/shared/src/graphql-operations'
 
@@ -18,7 +18,7 @@ const defaultStory: Meta = {
 
 export default defaultStory
 
-export const Primary: Story = () => {
+export const Primary: StoryFn = () => {
     const [value, setValue] = useState<DrillDownFiltersFormValues['seriesDisplayOptions']>({
         limit: 20,
         numSamples: null,

--- a/client/web/src/enterprise/insights/components/views/card/InsightCard.story.tsx
+++ b/client/web/src/enterprise/insights/components/views/card/InsightCard.story.tsx
@@ -1,5 +1,5 @@
 import { mdiFilterOutline, mdiDotsVertical } from '@mdi/js'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import {
@@ -28,7 +28,7 @@ export default {
     decorators: [story => <WebStory>{() => story()}</WebStory>],
 } as Meta
 
-export const InsightCardShowcase: Story = () => (
+export const InsightCardShowcase: StoryFn = () => (
     <main style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
         <section>
             <H2>Empty view</H2>

--- a/client/web/src/enterprise/insights/components/views/chart/categorical/CategoricalChart.story.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/categorical/CategoricalChart.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../../../../../components/WebStory'
 
@@ -50,7 +50,7 @@ const getColor = (datum: LanguageUsageDatum) => datum.fill
 const getLink = (datum: LanguageUsageDatum) => datum.linkURL
 const getName = (datum: LanguageUsageDatum) => datum.name
 
-export const CategoricalPieChart: Story = () => (
+export const CategoricalPieChart: StoryFn = () => (
     <CategoricalChart
         type={CategoricalBasedChartTypes.Pie}
         width={400}

--- a/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.story.tsx
+++ b/client/web/src/enterprise/insights/components/views/chart/series/SeriesChart.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { Series } from '@sourcegraph/wildcard'
 
@@ -72,7 +72,7 @@ const SERIES: Series<StandardDatum>[] = [
     },
 ]
 
-export const SeriesLineChart: Story = () => {
+export const SeriesLineChart: StoryFn = () => {
     const seriesToggleState = useSeriesToggle()
 
     return (

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { of } from 'rxjs'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -34,7 +34,7 @@ const codeInsightsBackend: Partial<CodeInsightsGqlBackend> = {
         ]),
 }
 
-export const InsightsDashboardCreationLicensed: Story = () => {
+export const InsightsDashboardCreationLicensed: StoryFn = () => {
     useCodeInsightsLicenseState.setState({ licensed: true, insightsLimit: null })
 
     return (
@@ -44,7 +44,7 @@ export const InsightsDashboardCreationLicensed: Story = () => {
     )
 }
 
-export const InsightsDashboardCreationUnlicensed: Story = () => {
+export const InsightsDashboardCreationUnlicensed: StoryFn = () => {
     useCodeInsightsLicenseState.setState({ licensed: false, insightsLimit: 2 })
 
     return (

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/add-insight-modal/AddInsightModal.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/add-insight-modal/AddInsightModal.story.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import type { MockedResponse } from '@apollo/client/testing/core'
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo/mockedTestProvider'
@@ -16,7 +16,7 @@ import { type CustomInsightDashboard, InsightsDashboardOwnerType, InsightsDashbo
 import { AddInsightModal } from './AddInsightModal'
 import { GET_INSIGHTS_BY_SEARCH_TERM } from './query'
 
-const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => story()}</WebStory>
 
 const config: Meta = {
     title: 'web/insights/AddInsightModal',
@@ -99,7 +99,7 @@ const mockInsights: MockedResponse<FindInsightsBySearchTermResult> = {
     },
 }
 
-export const AddInsightModalStory: Story = () => {
+export const AddInsightModalStory: StoryFn = () => {
     const [open, setOpen] = useState<boolean>(true)
 
     return (

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboard-select/DashboardSelect.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboard-select/DashboardSelect.story.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { WebStory } from '../../../../../../../components/WebStory'
 import { type CustomInsightDashboard, InsightsDashboardOwnerType, InsightsDashboardType } from '../../../../../core'
 
 import { DashboardSelect } from './DashboardSelect'
 
-const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => story()}</WebStory>
 
 const config: Meta = {
     title: 'web/insights/DashboardSelect',
@@ -67,7 +67,7 @@ const DASHBOARDS: CustomInsightDashboard[] = [
     },
 ]
 
-export const DashboardSelectStory: Story = () => {
+export const DashboardSelectStory: StoryFn = () => {
     const [dashboard, setDashboard] = useState<CustomInsightDashboard | undefined>()
 
     return (

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/components/empty-insight-dashboard/EmptyInsightDashboard.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { WebStory } from '../../../../../../../../../components/WebStory'
 import { type InsightDashboard, InsightsDashboardOwnerType, InsightsDashboardType } from '../../../../../../../core'
 
 import { EmptyCustomDashboard } from './EmptyInsightDashboard'
 
-const decorator: DecoratorFn = story => <WebStory>{() => story()}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => story()}</WebStory>
 
 const config: Meta = {
     title: 'web/insights/EmptyInsightDashboard',
@@ -19,7 +19,7 @@ const config: Meta = {
 
 export default config
 
-export const EmptyInsightDashboardStory: Story = () => {
+export const EmptyInsightDashboardStory: StoryFn = () => {
     const dashboard: InsightDashboard = {
         type: InsightsDashboardType.Custom,
         id: '101',

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -19,7 +19,7 @@ export default {
     },
 } as Meta
 
-export const CaptureGroupCreationPage: Story = () => {
+export const CaptureGroupCreationPage: StoryFn = () => {
     useCodeInsightsLicenseState.setState({ licensed: true, insightsLimit: null })
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/ComputeInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/ComputeInsightCreationPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import delay from 'delay'
 import { noop } from 'lodash'
 
@@ -28,7 +28,7 @@ const fakeAPIRequest = async () => {
     throw new Error('Network error')
 }
 
-export const ComputeInsightCreationPage: Story = () => {
+export const ComputeInsightCreationPage: StoryFn = () => {
     useCodeInsightsLicenseState.setState({ licensed: true, insightsLimit: null })
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeLivePreview.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/components/ComputeLivePreview.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { GroupByField, TimeIntervalStepUnit } from '@sourcegraph/shared/src/graphql-operations'
@@ -77,7 +77,7 @@ const MOCK_SERIES: SearchBasedInsightSeries[] = [
     { id: 'series_001', name: 'test series', query: 'test query', stroke: 'var(--blue)' },
 ]
 
-export const ComputeLivePreview: Story = () => (
+export const ComputeLivePreview: StoryFn = () => (
     <MockedTestProvider mocks={[mock]}>
         <div className="m-3 px-4 py-5 bg-white">
             <ComputeLivePreviewComponent

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -23,7 +23,7 @@ export default config
 
 const API = new CodeInsightsGqlBackend({} as any)
 
-export const IntroPageLicensed: Story = () => {
+export const IntroPageLicensed: StoryFn = () => {
     useCodeInsightsLicenseState.setState({ licensed: true, insightsLimit: null })
 
     return (
@@ -33,7 +33,7 @@ export const IntroPageLicensed: Story = () => {
     )
 }
 
-export const IntroPageUnLicensed: Story = () => {
+export const IntroPageUnLicensed: StoryFn = () => {
     useCodeInsightsLicenseState.setState({ licensed: false, insightsLimit: 2 })
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/cards/InsightCards.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { H2 } from '@sourcegraph/wildcard'
 
@@ -17,7 +17,7 @@ export default {
     },
 } as Meta
 
-export const InsightCards: Story = () => (
+export const InsightCards: StoryFn = () => (
     <section className="row">
         <article className="col-sm-4">
             <H2>Search Insight Card</H2>

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import delay from 'delay'
 import { noop } from 'lodash'
 
@@ -53,7 +53,7 @@ const LANG_STATS_MOCK: MockedResponse<LangStatsInsightContentResult> = {
     },
 }
 
-export const LangStatsInsightCreationPage: Story = () => {
+export const LangStatsInsightCreationPage: StoryFn = () => {
     useCodeInsightsLicenseState.setState({ licensed: true, insightsLimit: null })
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import delay from 'delay'
 import { noop } from 'lodash'
 
@@ -28,7 +28,7 @@ const fakeAPIRequest = async () => {
     throw new Error('Network error')
 }
 
-export const SearchInsightCreationPage: Story = () => {
+export const SearchInsightCreationPage: StoryFn = () => {
     useCodeInsightsLicenseState.setState({ licensed: true, insightsLimit: null })
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-404-insight/Standalone404Insight.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { Popover } from '@sourcegraph/wildcard'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -15,4 +15,4 @@ const config: Meta = {
 
 export default config
 
-export const Standalone404InsightExample: Story = () => <Standalone404Insight />
+export const Standalone404InsightExample: StoryFn = () => <Standalone404Insight />

--- a/client/web/src/enterprise/own/RepositoryOwnEditPage.story.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnEditPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -62,7 +62,7 @@ const emptyResponse: MockedResponse<GetIngestedCodeownersResult, GetIngestedCode
     },
 }
 
-export const EmptyNonAdmin: Story = () => (
+export const EmptyNonAdmin: StoryFn = () => (
     <WebStory mocks={[emptyResponse]}>
         {({ useBreadcrumb }) => (
             <RepositoryOwnEditPage repo={repo} authenticatedUser={{ siteAdmin: false }} useBreadcrumb={useBreadcrumb} />
@@ -71,7 +71,7 @@ export const EmptyNonAdmin: Story = () => (
 )
 EmptyNonAdmin.storyName = 'Empty (non-admin)'
 
-export const EmptyAdmin: Story = () => (
+export const EmptyAdmin: StoryFn = () => (
     <WebStory mocks={[emptyResponse]}>
         {({ useBreadcrumb }) => (
             <RepositoryOwnEditPage repo={repo} authenticatedUser={{ siteAdmin: true }} useBreadcrumb={useBreadcrumb} />
@@ -102,7 +102,7 @@ const populatedResponse: MockedResponse<GetIngestedCodeownersResult, GetIngested
     },
 }
 
-export const PopulatedNonAdmin: Story = () => (
+export const PopulatedNonAdmin: StoryFn = () => (
     <WebStory mocks={[populatedResponse]}>
         {({ useBreadcrumb }) => (
             <RepositoryOwnEditPage repo={repo} authenticatedUser={{ siteAdmin: false }} useBreadcrumb={useBreadcrumb} />
@@ -111,7 +111,7 @@ export const PopulatedNonAdmin: Story = () => (
 )
 PopulatedNonAdmin.storyName = 'Populated (non-admin)'
 
-export const PopulatedAdmin: Story = () => (
+export const PopulatedAdmin: StoryFn = () => (
     <WebStory mocks={[populatedResponse]}>
         {({ useBreadcrumb }) => (
             <RepositoryOwnEditPage repo={repo} authenticatedUser={{ siteAdmin: true }} useBreadcrumb={useBreadcrumb} />

--- a/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.story.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 
@@ -42,7 +42,7 @@ const ownAnalyticsDisabled: MockedResponse<GetOwnSignalConfigurationsResult, Get
     },
 }
 
-export const AnalyticsDisabled: Story = () => (
+export const AnalyticsDisabled: StoryFn = () => (
     <WebStory mocks={[ownAnalyticsDisabled]}>{() => <OwnAnalyticsPage />}</WebStory>
 )
 AnalyticsDisabled.storyName = 'AnalyticsDisabled - need to enable own analytics in site admin'
@@ -84,7 +84,7 @@ const presentStats: MockedResponse<GetInstanceOwnStatsResult, GetInstanceOwnStat
     },
 }
 
-export const PresentStats: Story = () => (
+export const PresentStats: StoryFn = () => (
     <WebStory mocks={[ownAnalyticsEnabled, presentStats]}>{() => <OwnAnalyticsPage />}</WebStory>
 )
 PresentStats.storyName = 'PresentStats - statistics available'
@@ -107,7 +107,7 @@ const zeroStats: MockedResponse<GetInstanceOwnStatsResult, GetInstanceOwnStatsVa
     },
 }
 
-export const ZeroStats: Story = () => (
+export const ZeroStats: StoryFn = () => (
     <WebStory mocks={[ownAnalyticsEnabled, zeroStats]}>{() => <OwnAnalyticsPage />}</WebStory>
 )
 ZeroStats.storyName = 'ZeroStats - no statistics computed yet'

--- a/client/web/src/enterprise/rbac/SiteAdminRolesPage.story.tsx
+++ b/client/web/src/enterprise/rbac/SiteAdminRolesPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -11,7 +11,7 @@ import { ALL_PERMISSIONS, ROLES_QUERY, DELETE_ROLE, SET_PERMISSIONS } from './ba
 import { mockPermissions, mockRoles } from './mock'
 import { SiteAdminRolesPage } from './SiteAdminRolesPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/src/site-admin/rbac',
@@ -55,7 +55,7 @@ const mocks = new WildcardMockLink([
     },
 ])
 
-export const RolesPage: Story = () => (
+export const RolesPage: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>

--- a/client/web/src/enterprise/rbac/components/ConfirmDeleteRoleModal.story.tsx
+++ b/client/web/src/enterprise/rbac/components/ConfirmDeleteRoleModal.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -10,7 +10,7 @@ import { mockRoles } from '../mock'
 
 import { ConfirmDeleteRoleModal } from './ConfirmDeleteRoleModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/src/site-admin/rbac',
@@ -24,7 +24,7 @@ const mockOnConfirm = (event: React.FormEvent) => {
 }
 const batchChangeAdminRole = mockRoles.roles.nodes[1]
 
-export const ConfirmDeleteRoleModalStory: Story = () => (
+export const ConfirmDeleteRoleModalStory: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider>

--- a/client/web/src/enterprise/rbac/components/CreateRoleModal.story.tsx
+++ b/client/web/src/enterprise/rbac/components/CreateRoleModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
@@ -11,7 +11,7 @@ import { mockPermissionsMap, mockRoles } from '../mock'
 
 import { CreateRoleModal } from './CreateRoleModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/src/site-admin/rbac',
@@ -33,7 +33,7 @@ const mocks = new WildcardMockLink([
     },
 ])
 
-export const CreateRoleModalStory: Story = () => (
+export const CreateRoleModalStory: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>

--- a/client/web/src/enterprise/rbac/components/Permissions.story.tsx
+++ b/client/web/src/enterprise/rbac/components/Permissions.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -8,7 +8,7 @@ import { mockPermissionsMap, mockRoles } from '../mock'
 
 import { PermissionsList } from './Permissions'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/src/site-admin/rbac/Permissions',
@@ -29,7 +29,7 @@ const isChecked = (role: typeof roleWithAllPermissions): ((value: string) => boo
 
 const roleName = 'TEST-ROLE'
 
-export const NoPermissions: Story = () => (
+export const NoPermissions: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider>
@@ -47,7 +47,7 @@ export const NoPermissions: Story = () => (
 
 NoPermissions.storyName = 'No permissions assigned'
 
-export const OnePermissionAssigned: Story = () => (
+export const OnePermissionAssigned: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider>
@@ -65,7 +65,7 @@ export const OnePermissionAssigned: Story = () => (
 
 OnePermissionAssigned.storyName = 'One permission assigned'
 
-export const AllPermissionsAssigned: Story = () => (
+export const AllPermissionsAssigned: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider>

--- a/client/web/src/enterprise/rbac/components/RoleNode.story.tsx
+++ b/client/web/src/enterprise/rbac/components/RoleNode.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
@@ -11,7 +11,7 @@ import { mockRoles, mockPermissionsMap } from '../mock'
 
 import { RoleNode } from './RoleNode'
 
-const decorator: DecoratorFn = story => <div className="p-3 container list-unstyled">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container list-unstyled">{story()}</div>
 
 const config: Meta = {
     title: 'web/src/site-admin/rbac/RoleNode',
@@ -41,7 +41,7 @@ const mocks = new WildcardMockLink([
 
 const [systemRole, nonSystemRole] = mockRoles.roles.nodes
 
-export const SystemRole: Story = () => (
+export const SystemRole: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>
@@ -53,7 +53,7 @@ export const SystemRole: Story = () => (
 
 SystemRole.storyName = 'System role'
 
-export const NonSystemRole: Story = () => (
+export const NonSystemRole: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.story.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -271,7 +271,7 @@ const USER_PICKER_QUERY_MOCK: MockedResponse<GetUsersListResult, GetUsersListVar
     },
 }
 
-export const SearchJobsListPage: Story = () => (
+export const SearchJobsListPage: StoryFn = () => (
     <MockedTestProvider mocks={[SEARCH_JOBS_MOCK, USER_PICKER_QUERY_MOCK]}>
         <SearchJobsPage isAdmin={false} telemetryService={NOOP_TELEMETRY_SERVICE} />
     </MockedTestProvider>

--- a/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.story.tsx
+++ b/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { NEVER } from 'rxjs'
 import sinon from 'sinon'
 
@@ -14,7 +14,7 @@ const searchContext = {
     id: '1',
 } as SearchContextFields
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/enterprise/searchContexts/DeleteSearchContextModal',
@@ -26,7 +26,7 @@ const config: Meta = {
 
 export default config
 
-export const DeleteSearchContextModalStory: Story = () => (
+export const DeleteSearchContextModalStory: StoryFn = () => (
     <WebStory>
         {webProps => (
             <DeleteSearchContextModal

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { NEVER, type Observable, of } from 'rxjs'
 import sinon from 'sinon'
@@ -12,7 +12,7 @@ import type { OrgAreaOrganizationFields, RepositoryFields } from '../../graphql-
 
 import { SearchContextForm } from './SearchContextForm'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/enterprise/searchContexts/SearchContextForm',
@@ -93,7 +93,7 @@ const authUser: AuthenticatedUser = {
 
 const deleteSearchContext = sinon.fake(() => NEVER)
 
-export const EmptyCreate: Story = () => (
+export const EmptyCreate: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SearchContextForm
@@ -110,7 +110,7 @@ export const EmptyCreate: Story = () => (
 
 EmptyCreate.storyName = 'empty create'
 
-export const EditExisting: Story = () => (
+export const EditExisting: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SearchContextForm

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { NEVER, type Observable, of, throwError } from 'rxjs'
 
@@ -13,7 +13,7 @@ import { WebStory } from '../../components/WebStory'
 
 import { SearchContextPage } from './SearchContextPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/enterprise/searchContexts/SearchContextPage',
@@ -83,7 +83,7 @@ const fetchAutoDefinedContext = (): Observable<SearchContextFields> =>
         name: 'auto-ctx',
     })
 
-export const PublicContext: Story = () => (
+export const PublicContext: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SearchContextPage
@@ -98,7 +98,7 @@ export const PublicContext: Story = () => (
 
 PublicContext.storyName = 'public context'
 
-export const PublicContextUnauthenticated: Story = () => (
+export const PublicContextUnauthenticated: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SearchContextPage
@@ -113,7 +113,7 @@ export const PublicContextUnauthenticated: Story = () => (
 
 PublicContextUnauthenticated.storyName = 'public context, unauthenticated user'
 
-export const AutodefinedContext: Story = () => (
+export const AutodefinedContext: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SearchContextPage
@@ -128,7 +128,7 @@ export const AutodefinedContext: Story = () => (
 
 AutodefinedContext.storyName = 'autodefined context'
 
-export const PrivateContext: Story = () => (
+export const PrivateContext: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SearchContextPage
@@ -143,7 +143,7 @@ export const PrivateContext: Story = () => (
 
 PrivateContext.storyName = 'private context'
 
-export const Loading: Story = () => (
+export const Loading: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SearchContextPage
@@ -158,7 +158,7 @@ export const Loading: Story = () => (
 
 Loading.storyName = 'loading'
 
-export const ErrorStory: Story = () => (
+export const ErrorStory: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SearchContextPage

--- a/client/web/src/enterprise/searchContexts/SearchContextsList.story.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsList.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import {
     mockAuthenticatedUser,
@@ -11,7 +11,7 @@ import { WebStory } from '../../components/WebStory'
 
 import { SearchContextsList, type SearchContextsListProps } from './SearchContextsList'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <div className="p-3 container" style={{ position: 'static' }}>
         {story()}
     </div>
@@ -35,4 +35,4 @@ const defaultProps: SearchContextsListProps = {
     setAlert: () => undefined,
 }
 
-export const Default: Story = () => <WebStory>{() => <SearchContextsList {...defaultProps} />}</WebStory>
+export const Default: StoryFn = () => <WebStory>{() => <SearchContextsList {...defaultProps} />}</WebStory>

--- a/client/web/src/enterprise/site-admin/SiteAdminSidebar.story.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminSidebar.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { Code, Grid } from '@sourcegraph/wildcard'
 
@@ -7,7 +7,7 @@ import { SiteAdminSidebar } from '../../site-admin/SiteAdminSidebar'
 
 import { enterpriseSiteAdminSidebarGroups } from './sidebaritems'
 
-const decorator: DecoratorFn = story => <div style={{ width: '192px' }}>{story()}</div>
+const decorator: Decorator = story => <div style={{ width: '192px' }}>{story()}</div>
 
 const config: Meta = {
     title: 'web/site-admin/AdminSidebar',
@@ -23,7 +23,7 @@ export default config
 
 // Moved story under enterprise folder to avoid failing ci linting
 // due to importing enterprise path in oss folders.
-export const AdminSidebarItems: Story = () => (
+export const AdminSidebarItems: StoryFn = () => (
     <WebStory>
         {webProps => (
             <Grid columnCount={5}>

--- a/client/web/src/enterprise/site-admin/UserManagement/components/RoleAssignmentModal.story.tsx
+++ b/client/web/src/enterprise/site-admin/UserManagement/components/RoleAssignmentModal.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
@@ -12,7 +12,7 @@ import { GET_ALL_ROLES_AND_USER_ROLES, SET_ROLES_FOR_USER } from '../backend'
 
 import { RoleAssignmentModal } from './RoleAssignmentModal'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/src/enterprise/site-admin/rbac',
@@ -84,7 +84,7 @@ const mocks = new WildcardMockLink([
     },
 ])
 
-export const RoleAssignmentModalStory: Story = () => (
+export const RoleAssignmentModalStory: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>

--- a/client/web/src/global/GlobalAlert.story.tsx
+++ b/client/web/src/global/GlobalAlert.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { H1, H2, Code, Text } from '@sourcegraph/wildcard'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -28,7 +28,7 @@ const config: Meta = {
 
 export default config
 
-export const GlobalAlerts: Story = () => (
+export const GlobalAlerts: StoryFn = () => (
     <div>
         <H1>Global Alert</H1>
         <Text>

--- a/client/web/src/marketing/page/SurveyPage.story.tsx
+++ b/client/web/src/marketing/page/SurveyPage.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
 import { SurveyPage } from './SurveyPage'
 import { submitSurveyMock } from './SurveyPage.mocks'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <WebStory mocks={[submitSurveyMock]}>{() => <div className="container mt-3">{story()}</div>}</WebStory>
 )
 
@@ -16,4 +16,4 @@ const config: Meta = {
 
 export default config
 
-export const Page: Story = () => <SurveyPage authenticatedUser={null} forceScore="10" />
+export const Page: StoryFn = () => <SurveyPage authenticatedUser={null} forceScore="10" />

--- a/client/web/src/marketing/toast/SurveyToast.story.tsx
+++ b/client/web/src/marketing/toast/SurveyToast.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
 import { SurveyToast } from '.'
 
-const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
 
 const config: Meta = {
     title: 'web/SurveyToast',
@@ -13,4 +13,4 @@ const config: Meta = {
 
 export default config
 
-export const Toast: Story = () => <SurveyToast forceVisible={true} authenticatedUser={null} />
+export const Toast: StoryFn = () => <SurveyToast forceVisible={true} authenticatedUser={null} />

--- a/client/web/src/nav/GlobalNavbar.story.tsx
+++ b/client/web/src/nav/GlobalNavbar.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { updateJSContextBatchChangesLicense } from '@sourcegraph/shared/src/testing/batches'
@@ -57,7 +57,7 @@ const allAuthenticatedNavItemsProps: Partial<GlobalNavbarProps> = {
     } as AuthenticatedUser,
 }
 
-const decorator: DecoratorFn = Story => {
+const decorator: Decorator = Story => {
     updateJSContextBatchChangesLicense('full')
 
     return (

--- a/client/web/src/nav/GlobalNavbar.story.tsx
+++ b/client/web/src/nav/GlobalNavbar.story.tsx
@@ -87,7 +87,7 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story<GlobalNavbarProps> = props => (
+export const Default: StoryFn<GlobalNavbarProps> = props => (
     <Grid columnCount={1}>
         <div>
             <H3 className="ml-2">Anonymous viewer</H3>

--- a/client/web/src/nav/StatusMessagesNavItem.story.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -7,7 +7,7 @@ import { WebStory } from '../components/WebStory'
 import { StatusMessagesNavItem } from './StatusMessagesNavItem'
 import { allStatusMessages, newStatusMessageMock } from './StatusMessagesNavItem.mocks'
 
-const decorator: DecoratorFn = Story => <Story />
+const decorator: Decorator = Story => <Story />
 
 const config: Meta = {
     title: 'web/nav/StatusMessagesNavItem',
@@ -16,7 +16,7 @@ const config: Meta = {
 
 export default config
 
-export const NoMessages: Story = () => (
+export const NoMessages: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={[newStatusMessageMock([])]}>
@@ -28,7 +28,7 @@ export const NoMessages: Story = () => (
 
 NoMessages.storyName = 'No messages'
 
-export const AllMessageTypes: Story = () => (
+export const AllMessageTypes: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={[newStatusMessageMock(allStatusMessages)]}>
@@ -40,7 +40,7 @@ export const AllMessageTypes: Story = () => (
 
 AllMessageTypes.storyName = 'All message types'
 
-export const IndexingMessage: Story = () => (
+export const IndexingMessage: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider
@@ -62,7 +62,7 @@ export const IndexingMessage: Story = () => (
 
 IndexingMessage.storyName = 'Indexing progress'
 
-export const GitUpdatesDisabled: Story = () => (
+export const GitUpdatesDisabled: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider

--- a/client/web/src/nav/UserNavItem.story.tsx
+++ b/client/web/src/nav/UserNavItem.story.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 
-import { type Args, useMemo } from '@storybook/addons'
-import type { Meta, StoryFn } from '@storybook/react'
+import { useMemo } from '@storybook/addons'
+import type { Meta, StoryFn, Args } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -84,7 +84,7 @@ const OpenByDefaultWrapper: React.FunctionComponent<{
     return children({ menuButtonRef: menuButtonReference })
 }
 
-export const SiteAdmin: Story = args => {
+export const SiteAdmin: StoryFn = args => {
     const props = useMemo(() => commonProps(args), [args])
     return (
         <OpenByDefaultWrapper>
@@ -97,7 +97,7 @@ export const SiteAdmin: Story = args => {
     )
 }
 
-export const WithAvatar: Story = args => {
+export const WithAvatar: StoryFn = args => {
     const props = useMemo(() => commonProps(args), [args])
     return (
         <OpenByDefaultWrapper>

--- a/client/web/src/nav/UserNavItem.story.tsx
+++ b/client/web/src/nav/UserNavItem.story.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 
 import { type Args, useMemo } from '@storybook/addons'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 import { of } from 'rxjs'
 
@@ -9,7 +9,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { NotebookFileBlock } from './NotebookFileBlock'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/search/notebooks/blocks/file/NotebookFileBlock',
@@ -36,7 +36,7 @@ const fileBlockInput: FileBlockInput = {
     lineRange: null,
 }
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {props => (
             <NotebookFileBlock
@@ -54,7 +54,7 @@ export const Default: Story = () => (
     </WebStory>
 )
 
-export const EditMode: Story = () => (
+export const EditMode: StoryFn = () => (
     <WebStory>
         {props => (
             <NotebookFileBlock
@@ -74,7 +74,7 @@ export const EditMode: Story = () => (
 
 EditMode.storyName = 'edit mode'
 
-export const ErrorFetchingFile: Story = () => (
+export const ErrorFetchingFile: StoryFn = () => (
     <WebStory>
         {props => (
             <NotebookFileBlock

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.story.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlockInputs.story.tsx
@@ -1,11 +1,11 @@
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { WebStory } from '../../../components/WebStory'
 
 import { NotebookFileBlockInputs } from './NotebookFileBlockInputs'
 
-const decorator: DecoratorFn = story => <div className="container p-3">{story()}</div>
+const decorator: Decorator = story => <div className="container p-3">{story()}</div>
 
 const config: Meta = {
     title: 'web/search/notebooks/blocks/file/NotebookFileBlockInputs',
@@ -32,6 +32,6 @@ const defaultProps = {
     isSourcegraphDotCom: false,
 }
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>{webProps => <NotebookFileBlockInputs {...webProps} {...defaultProps} />}</WebStory>
 )

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { noop } from 'lodash'
 import { of } from 'rxjs'
 
@@ -15,7 +15,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { NotebookQueryBlock } from './NotebookQueryBlock'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/search/notebooks/blocks/query/NotebookQueryBlock',
@@ -46,7 +46,7 @@ const noopBlockCallbacks = {
     onNewBlock: noop,
 }
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {props => (
             <NotebookQueryBlock
@@ -71,7 +71,7 @@ export const Default: Story = () => (
     </WebStory>
 )
 
-export const Selected: Story = () => (
+export const Selected: StoryFn = () => (
     <WebStory>
         {props => (
             <NotebookQueryBlock
@@ -96,7 +96,7 @@ export const Selected: Story = () => (
     </WebStory>
 )
 
-export const ReadOnlySelected: Story = () => (
+export const ReadOnlySelected: StoryFn = () => (
     <WebStory>
         {props => (
             <NotebookQueryBlock

--- a/client/web/src/notebooks/listPage/NotebooksListPage.story.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Story, Meta } from '@storybook/react'
+import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { subDays } from 'date-fns'
 import { type Observable, of } from 'rxjs'
 
@@ -11,7 +11,7 @@ import { NotebooksListPage } from './NotebooksListPage'
 
 const now = new Date()
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/search/notebooks/listPage/NotebooksListPage',
@@ -64,7 +64,7 @@ const fetchNotebooks = (): Observable<ListNotebooksResult['notebooks']> =>
         pageInfo: { hasNextPage: false, endCursor: null },
     })
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {props => (
             <NotebooksListPage

--- a/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
@@ -10,7 +10,7 @@ import { WebStory } from '../../components/WebStory'
 
 import { NotebookComponent } from './NotebookComponent'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/search/notebooks/notebook/NotebookComponent',
@@ -38,7 +38,7 @@ const blocks: BlockInit[] = [
     },
 ]
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {props => (
             <NotebookComponent
@@ -61,7 +61,7 @@ export const Default: Story = () => (
     </WebStory>
 )
 
-export const DefaultReadOnly: Story = () => (
+export const DefaultReadOnly: StoryFn = () => (
     <WebStory>
         {props => (
             <NotebookComponent

--- a/client/web/src/repo/RepoHeader.story.tsx
+++ b/client/web/src/repo/RepoHeader.story.tsx
@@ -1,5 +1,5 @@
 import { mdiSourceRepository } from '@mdi/js'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { CopyPathAction } from '@sourcegraph/branded'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
@@ -24,7 +24,7 @@ const mockUser = {
     siteAdmin: true,
 } as AuthenticatedUser
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory initialEntries={['/github.com/sourcegraph/sourcegraph/-/tree/']} styles={webStyles}>
         {() => <div className="container mt-3">{story()}</div>}
     </BrandedStory>
@@ -38,7 +38,7 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <>
         <H1>Repo header</H1>
         <H2>Simple</H2>

--- a/client/web/src/repo/actions/GoToCodeHostAction.story.tsx
+++ b/client/web/src/repo/actions/GoToCodeHostAction.story.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react'
 
 import { mdiGithub, mdiGitlab, mdiBitbucket } from '@mdi/js'
-import type { Meta, Story, DecoratorFn } from '@storybook/react'
+import type { Meta, StoryFn, Decorator } from '@storybook/react'
 
 import { PhabricatorIcon } from '@sourcegraph/shared/src/components/icons'
 import { Button, Popover, PopoverTrigger, Icon } from '@sourcegraph/wildcard'
@@ -10,7 +10,7 @@ import { Button, Popover, PopoverTrigger, Icon } from '@sourcegraph/wildcard'
 import { WebStory } from '../../components/WebStory'
 import { ExternalServiceKind } from '../../graphql-operations'
 
-const decorator: DecoratorFn = story => <div className="container mt-3">{story()}</div>
+const decorator: Decorator = story => <div className="container mt-3">{story()}</div>
 
 const config: Meta = {
     title: 'web/repo/actions/InstallBrowserExtensionPopover',
@@ -19,7 +19,7 @@ const config: Meta = {
 
 export default config
 
-export const GitHub: Story = () => (
+export const GitHub: StoryFn = () => (
     <WebStory>
         {() => {
             const serviceKind = ExternalServiceKind.GITHUB
@@ -44,7 +44,7 @@ export const GitHub: Story = () => (
 GitHub.storyName = 'GitHub'
 
 // Disable Chromatic for the non-GitHub popovers since they are mostly the same
-export const GitLab: Story = () => (
+export const GitLab: StoryFn = () => (
     <WebStory>
         {() => {
             const serviceKind = ExternalServiceKind.GITLAB
@@ -71,7 +71,7 @@ GitLab.parameters = {
     },
 }
 
-export const Phabricator: Story = () => (
+export const Phabricator: StoryFn = () => (
     <WebStory>
         {() => {
             const serviceKind = ExternalServiceKind.PHABRICATOR
@@ -97,7 +97,7 @@ Phabricator.parameters = {
     },
 }
 
-export const BitbucketServer: Story = () => (
+export const BitbucketServer: StoryFn = () => (
     <WebStory>
         {() => {
             const serviceKind = ExternalServiceKind.BITBUCKETSERVER

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.story.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -179,7 +179,7 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory mocks={[mockResponse]}>
         {() => (
             <FileOwnershipPanel

--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 
@@ -155,6 +155,6 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory mocks={[mockLoaded]}>{() => <HistoryAndOwnBar enableOwnershipPanel={true} {...variables} />}</WebStory>
 )

--- a/client/web/src/repo/commits/GitCommitNode.story.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { Card } from '@sourcegraph/wildcard'
@@ -8,7 +8,7 @@ import type { GitCommitFields } from '../../graphql-operations'
 
 import { GitCommitNode } from './GitCommitNode'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 window.context.experimentalFeatures = { perforceChangelistMapping: 'enabled' }
 
@@ -118,7 +118,7 @@ FullCustomizable.args = {
 
 FullCustomizable.storyName = 'Full customizable'
 
-export const Compact: Story = () => (
+export const Compact: StoryFn = () => (
     <WebStory>
         {() => (
             <Card>
@@ -134,7 +134,7 @@ export const Compact: Story = () => (
     </WebStory>
 )
 
-export const CommitMessageExpand: Story = () => (
+export const CommitMessageExpand: StoryFn = () => (
     <WebStory>
         {() => (
             <Card>
@@ -152,7 +152,7 @@ export const CommitMessageExpand: Story = () => (
 
 CommitMessageExpand.storyName = 'Commit message expanded'
 
-export const SHAAndParentShown: Story = () => (
+export const SHAAndParentShown: StoryFn = () => (
     <WebStory>
         {() => (
             <Card>
@@ -170,7 +170,7 @@ export const SHAAndParentShown: Story = () => (
 
 SHAAndParentShown.storyName = 'SHA and parent shown'
 
-export const ExpandCommitMessageButtonHidden: Story = () => (
+export const ExpandCommitMessageButtonHidden: StoryFn = () => (
     <WebStory>
         {() => (
             <Card>
@@ -249,7 +249,7 @@ const perforceChangelistNode: GitCommitFields = {
         'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore.',
 }
 
-export const PerforceChangelist: Story = () => (
+export const PerforceChangelist: StoryFn = () => (
     <WebStory>
         {() => (
             <Card>

--- a/client/web/src/repo/commits/RepositoryCommitsPage.story.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -21,7 +21,7 @@ import {
 
 window.context.experimentalFeatures = { perforceChangelistMapping: 'enabled' }
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/RepositoryCommitsPage',

--- a/client/web/src/repo/commits/RepositoryCommitsPage.story.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.story.tsx
@@ -348,7 +348,7 @@ const gitRepo: RepositoryFields = {
     metadata: [],
 }
 
-export const GitCommitsStory: Story<RepositoryCommitsPageProps> = () => (
+export const GitCommitsStory: StoryFn<RepositoryCommitsPageProps> = () => (
     <MockedTestProvider>
         <WebStory
             initialEntries={['/github.com/sourcegraph/sourcegraph/-/commits']}
@@ -361,7 +361,7 @@ export const GitCommitsStory: Story<RepositoryCommitsPageProps> = () => (
 
 GitCommitsStory.storyName = 'Git commits'
 
-export const GitCommitsInPathStory: Story<RepositoryCommitsPageProps> = () => (
+export const GitCommitsInPathStory: StoryFn<RepositoryCommitsPageProps> = () => (
     <MockedTestProvider>
         <WebStory
             initialEntries={['/github.com/sourcegraph/sourcegraph/-/commits/somePath']}
@@ -392,7 +392,7 @@ const perforceRepo: RepositoryFields = {
     metadata: [],
 }
 
-export const PerforceChangelistsStory: Story<RepositoryCommitsPageProps> = () => (
+export const PerforceChangelistsStory: StoryFn<RepositoryCommitsPageProps> = () => (
     <MockedTestProvider>
         <WebStory
             initialEntries={['/perforce.sgdev.org/go/-/changelists']}
@@ -405,7 +405,7 @@ export const PerforceChangelistsStory: Story<RepositoryCommitsPageProps> = () =>
 
 PerforceChangelistsStory.storyName = 'Perforce changelists'
 
-export const PerforceChangelistsInPathStory: Story<RepositoryCommitsPageProps> = () => (
+export const PerforceChangelistsInPathStory: StoryFn<RepositoryCommitsPageProps> = () => (
     <MockedTestProvider>
         <WebStory
             initialEntries={['/perforce.sgdev.org/go/-/changelists/somePath']}

--- a/client/web/src/savedSearches/SavedSearchForm.story.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'
 
@@ -31,7 +31,7 @@ const commonProps: Omit<SavedSearchFormProps, 'isLightTheme'> = {
     },
 }
 
-export const NewSavedSearch: Story = () => (
+export const NewSavedSearch: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SavedSearchForm
@@ -47,7 +47,7 @@ export const NewSavedSearch: Story = () => (
 
 NewSavedSearch.storyName = 'new saved search'
 
-export const NotifcationsDisabled: Story = () => (
+export const NotifcationsDisabled: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SavedSearchForm
@@ -68,7 +68,7 @@ export const NotifcationsDisabled: Story = () => (
 
 NotifcationsDisabled.storyName = 'existing saved search, notifications disabled'
 
-export const NotifcationsEnabled: Story = () => (
+export const NotifcationsEnabled: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SavedSearchForm
@@ -89,7 +89,7 @@ export const NotifcationsEnabled: Story = () => (
 
 NotifcationsEnabled.storyName = 'existing saved search, notifications enabled'
 
-export const NotificationsEnabledWithInvalidQueryWarning: Story = () => (
+export const NotificationsEnabledWithInvalidQueryWarning: StoryFn = () => (
     <WebStory>
         {webProps => (
             <SavedSearchForm

--- a/client/web/src/search/results/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { createBrowserHistory } from 'history'
 import { EMPTY, NEVER, of } from 'rxjs'
 
@@ -57,7 +57,7 @@ const defaultProps: StreamingSearchResultsProps = {
     ownEnabled: true,
 }
 
-const decorator: DecoratorFn = Story => {
+const decorator: Decorator = Story => {
     useNavbarQueryState.setState({ searchQueryFromURL: 'r:golang/oauth2 test f:travis' })
     return <Story />
 }
@@ -72,7 +72,7 @@ const config: Meta = {
 
 export default config
 
-export const StandardRender: Story = () => (
+export const StandardRender: StoryFn = () => (
     <WebStory>
         {() => (
             <SearchQueryStateStoreProvider useSearchQueryState={useNavbarQueryState}>
@@ -84,7 +84,7 @@ export const StandardRender: Story = () => (
 
 StandardRender.storyName = 'standard render'
 
-export const UnauthenticatedUserStandardRender: Story = () => (
+export const UnauthenticatedUserStandardRender: StoryFn = () => (
     <WebStory>
         {() => (
             <SearchQueryStateStoreProvider useSearchQueryState={useNavbarQueryState}>
@@ -96,7 +96,7 @@ export const UnauthenticatedUserStandardRender: Story = () => (
 
 UnauthenticatedUserStandardRender.storyName = 'unauthenticated user standard render'
 
-export const NoResults: Story = () => {
+export const NoResults: StoryFn = () => {
     const result: AggregateStreamingSearchResults = {
         state: 'complete',
         results: [],
@@ -121,7 +121,7 @@ export const NoResults: Story = () => {
 
 NoResults.storyName = 'no results'
 
-export const DidYouMean: Story = () => {
+export const DidYouMean: StoryFn = () => {
     useNavbarQueryState.setState({ searchQueryFromURL: 'javascript test' })
 
     return (
@@ -137,7 +137,7 @@ export const DidYouMean: Story = () => {
 
 DidYouMean.storyName = 'did you mean'
 
-export const ProgressWithWarning: Story = () => {
+export const ProgressWithWarning: StoryFn = () => {
     const result: AggregateStreamingSearchResults = {
         state: 'complete',
         results: MULTIPLE_SEARCH_RESULT.results,
@@ -193,7 +193,7 @@ export const ProgressWithWarning: Story = () => {
 
 ProgressWithWarning.storyName = 'progress with warnings'
 
-export const LoadingWithNoResults: Story = () => (
+export const LoadingWithNoResults: StoryFn = () => (
     <WebStory>
         {() => (
             <SearchQueryStateStoreProvider useSearchQueryState={useNavbarQueryState}>
@@ -205,7 +205,7 @@ export const LoadingWithNoResults: Story = () => (
 
 LoadingWithNoResults.storyName = 'loading with no results'
 
-export const LoadingWithSomeResults: Story = () => {
+export const LoadingWithSomeResults: StoryFn = () => {
     const result: AggregateStreamingSearchResults = {
         state: 'loading',
         results: MULTIPLE_SEARCH_RESULT.results,
@@ -230,7 +230,7 @@ export const LoadingWithSomeResults: Story = () => {
 
 LoadingWithSomeResults.storyName = 'loading with some results'
 
-export const ServerSideAlert: Story = () => {
+export const ServerSideAlert: StoryFn = () => {
     const result: AggregateStreamingSearchResults = {
         state: 'complete',
         results: MULTIPLE_SEARCH_RESULT.results,
@@ -260,7 +260,7 @@ export const ServerSideAlert: Story = () => {
 
 ServerSideAlert.storyName = 'server-side alert'
 
-export const ServerSideAlertNoResults: Story = () => {
+export const ServerSideAlertNoResults: StoryFn = () => {
     const result: AggregateStreamingSearchResults = {
         state: 'complete',
         results: [],
@@ -290,7 +290,7 @@ export const ServerSideAlertNoResults: Story = () => {
 
 ServerSideAlertNoResults.storyName = 'server-side alert with no results'
 
-export const ServerSideAlertUnownedResults: Story = () => {
+export const ServerSideAlertUnownedResults: StoryFn = () => {
     const result: AggregateStreamingSearchResults = {
         state: 'complete',
         results: [],
@@ -322,7 +322,7 @@ export const ServerSideAlertUnownedResults: Story = () => {
 
 ServerSideAlertUnownedResults.storyName = 'server-side alert with unowned results'
 
-export const ErrorWithNoResults: Story = () => {
+export const ErrorWithNoResults: StoryFn = () => {
     const result: AggregateStreamingSearchResults = {
         state: 'error',
         results: [],
@@ -348,7 +348,7 @@ export const ErrorWithNoResults: Story = () => {
 
 ErrorWithNoResults.storyName = 'error with no results'
 
-export const ErrorWithSomeResults: Story = () => {
+export const ErrorWithSomeResults: StoryFn = () => {
     const result: AggregateStreamingSearchResults = {
         state: 'error',
         results: MULTIPLE_SEARCH_RESULT.results,
@@ -374,7 +374,7 @@ export const ErrorWithSomeResults: Story = () => {
 
 ErrorWithSomeResults.storyName = 'error with some results'
 
-export const LimitHitWithSomeResults: Story = () => {
+export const LimitHitWithSomeResults: StoryFn = () => {
     const result: AggregateStreamingSearchResults = {
         state: 'complete',
         results: MULTIPLE_SEARCH_RESULT.results,

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing/core'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -138,7 +138,7 @@ const SEARCH_AGGREGATION_MOCK: MockedResponse<GetSearchAggregationResult> = {
     },
 }
 
-export const SearchAggregationResultDemo: Story = () => (
+export const SearchAggregationResultDemo: StoryFn = () => (
     <BrandedStory>
         {() => (
             <MockedTestProvider mocks={[SEARCH_AGGREGATION_MOCK]}>

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { QuickLink, SearchScope } from '@sourcegraph/shared/src/schema/settings.schema'
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
@@ -127,11 +127,11 @@ const filters: Filter[] = [
     })),
 ]
 
-export const EmptySidebar: Story = () => <WebStory>{() => <SearchFiltersSidebar {...defaultProps} />}</WebStory>
+export const EmptySidebar: StoryFn = () => <WebStory>{() => <SearchFiltersSidebar {...defaultProps} />}</WebStory>
 
 EmptySidebar.storyName = 'empty sidebar'
 
-export const WithEverything: Story = () => (
+export const WithEverything: StoryFn = () => (
     <WebStory>
         {() => (
             <SearchFiltersSidebar

--- a/client/web/src/search/suggestion/SmartSearch.story.tsx
+++ b/client/web/src/search/suggestion/SmartSearch.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
@@ -78,7 +78,7 @@ const twoItemPureAlert: Required<AggregateStreamingSearchResults>['alert'] = {
     ],
 }
 
-export const DefaultStory: Story = () => (
+export const DefaultStory: StoryFn = () => (
     <WebStory>
         {() => (
             <div style={{ padding: '1rem' }}>

--- a/client/web/src/site-admin/SiteAdminGitservers.story.tsx
+++ b/client/web/src/site-admin/SiteAdminGitservers.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -10,7 +10,7 @@ import { WebStory } from '../components/WebStory'
 import { GITSERVERS } from './backend'
 import { SiteAdminGitserversPage } from './SiteAdminGitserversPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/site-admin/Gitservers',
@@ -55,7 +55,7 @@ const mocks = new WildcardMockLink([
     },
 ])
 
-export const GitserversPage: Story = () => (
+export const GitserversPage: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>

--- a/client/web/src/site-admin/SiteAdminMigrationsPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminMigrationsPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { type Observable, of } from 'rxjs'
 
 import { WebStory } from '../components/WebStory'
@@ -6,7 +6,7 @@ import type { OutOfBandMigrationFields } from '../graphql-operations'
 
 import { SiteAdminMigrationsPage } from './SiteAdminMigrationsPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/Site Admin/Migrations',
@@ -21,7 +21,7 @@ const config: Meta = {
 export default config
 
 // invalid, pre-introduction
-export const InvalidPreIntroduction: Story = () => (
+export const InvalidPreIntroduction: StoryFn = () => (
     <WebStory>
         {props => (
             <SiteAdminMigrationsPage
@@ -37,7 +37,7 @@ export const InvalidPreIntroduction: Story = () => (
 InvalidPreIntroduction.storyName = '3.23.2'
 
 // downgrade warning
-export const DowngradeWarning: Story = () => (
+export const DowngradeWarning: StoryFn = () => (
     <WebStory>
         {props => (
             <SiteAdminMigrationsPage
@@ -53,7 +53,7 @@ export const DowngradeWarning: Story = () => (
 DowngradeWarning.storyName = '3.24.2'
 
 // no warnings
-export const NoWarnings: Story = () => (
+export const NoWarnings: StoryFn = () => (
     <WebStory>
         {props => (
             <SiteAdminMigrationsPage
@@ -69,7 +69,7 @@ export const NoWarnings: Story = () => (
 NoWarnings.storyName = '3.25.2'
 
 // upgrade warning
-export const UpgradeWarning: Story = () => (
+export const UpgradeWarning: StoryFn = () => (
     <WebStory>
         {props => (
             <SiteAdminMigrationsPage
@@ -85,7 +85,7 @@ export const UpgradeWarning: Story = () => (
 UpgradeWarning.storyName = '3.26.2'
 
 // invalid, post-deprecation
-export const InvalidPostDeprecation: Story = () => (
+export const InvalidPostDeprecation: StoryFn = () => (
     <WebStory>
         {props => (
             <SiteAdminMigrationsPage

--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -13,7 +13,7 @@ import { WebStory } from '../components/WebStory'
 import { createExternalService } from './fixtures'
 import { SiteAdminWebhookCreatePage } from './SiteAdminWebhookCreatePage'
 
-const decorator: DecoratorFn = Story => <Story />
+const decorator: Decorator = Story => <Story />
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/incoming/SiteAdminWebhookCreatePage',
@@ -22,7 +22,7 @@ const config: Meta = {
 
 export default config
 
-export const WebhookCreatePage: Story = () => {
+export const WebhookCreatePage: StoryFn = () => {
     const mocks = new WildcardMockLink([
         {
             request: {
@@ -65,7 +65,7 @@ export const WebhookCreatePage: Story = () => {
 
 WebhookCreatePage.storyName = 'Create webhook'
 
-export const WebhookCreatePageWithError: Story = () => {
+export const WebhookCreatePageWithError: StoryFn = () => {
     const mockedResponse: MockedResponse[] = [
         {
             request: {

--- a/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { addMinutes, formatRFC3339 } from 'date-fns'
 import { Route, Routes } from 'react-router-dom'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
@@ -17,7 +17,7 @@ import { SiteAdminWebhookPage } from './SiteAdminWebhookPage'
 import { WEBHOOK_BY_ID_LOG_PAGE_HEADER, WEBHOOK_LOGS_BY_ID } from './webhooks/backend'
 import { BODY_JSON, BODY_PLAIN, HEADERS_JSON, HEADERS_PLAIN } from './webhooks/story/fixtures'
 
-const decorator: DecoratorFn = Story => <Story />
+const decorator: Decorator = Story => <Story />
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/incoming/SiteAdminWebhookPage',

--- a/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.story.tsx
@@ -29,7 +29,7 @@ export default config
 const WEBHOOK_MOCK_DATA = buildWebhookLogs()
 const ERRORED_WEBHOOK_MOCK_DATA = WEBHOOK_MOCK_DATA.filter(webhook => webhook.statusCode !== 200)
 
-export const SiteAdminWebhookPageStory: Story = args => {
+export const SiteAdminWebhookPageStory: StoryFn = args => {
     const buildWebhookLogsMock = new WildcardMockLink([
         {
             request: {
@@ -125,7 +125,7 @@ export const SiteAdminWebhookPageStory: Story = args => {
 
 SiteAdminWebhookPageStory.storyName = 'Incoming webhook'
 
-export const SiteAdminWebhookPageWithoutLogsStory: Story = args => {
+export const SiteAdminWebhookPageWithoutLogsStory: StoryFn = args => {
     const buildWebhookLogsMock = new WildcardMockLink([
         {
             request: {

--- a/client/web/src/site-admin/SiteAdminWebhookUpdatePage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookUpdatePage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { Route, Routes } from 'react-router-dom'
 import { WildcardMockLink } from 'wildcard-mock-link'
 
@@ -14,7 +14,7 @@ import { WEBHOOK_BY_ID } from './backend'
 import { createExternalService, createWebhookMock } from './fixtures'
 import { SiteAdminWebhookUpdatePage } from './SiteAdminWebhookUpdatePage'
 
-const decorator: DecoratorFn = Story => <Story />
+const decorator: Decorator = Story => <Story />
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/incoming/SiteAdminWebhookUpdatePage',
@@ -23,7 +23,7 @@ const config: Meta = {
 
 export default config
 
-export const WebhookUpdatePage: Story = () => (
+export const WebhookUpdatePage: StoryFn = () => (
     <WebStory initialEntries={['/site-admin/webhooks/incoming/1']}>
         {() => (
             <MockedTestProvider

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -12,7 +12,7 @@ import type { WebhookFields } from '../graphql-operations'
 import { WEBHOOKS, WEBHOOK_PAGE_HEADER } from './backend'
 import { SiteAdminWebhooksPage } from './SiteAdminWebhooksPage'
 
-const decorator: DecoratorFn = Story => <Story />
+const decorator: Decorator = Story => <Story />
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/incoming/SiteAdminWebhooksPage',
@@ -21,7 +21,7 @@ const config: Meta = {
 
 export default config
 
-export const NoWebhooksFound: Story = () => (
+export const NoWebhooksFound: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider
@@ -73,7 +73,7 @@ export const NoWebhooksFound: Story = () => (
 
 NoWebhooksFound.storyName = 'No webhooks found'
 
-export const FiveWebhooksFound: Story = () => (
+export const FiveWebhooksFound: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider

--- a/client/web/src/site-admin/SiteConfigurationHistoryItem.story.tsx
+++ b/client/web/src/site-admin/SiteConfigurationHistoryItem.story.tsx
@@ -1,4 +1,4 @@
-import type { Story, Meta } from '@storybook/react'
+import type { StoryFn, Meta } from '@storybook/react'
 
 import { WebStory } from '../components/WebStory'
 
@@ -11,7 +11,7 @@ const config: Meta = {
 
 export default config
 
-export const HistoryItemWithNoAuthor: Story = () => (
+export const HistoryItemWithNoAuthor: StoryFn = () => (
     <WebStory>
         {() => (
             <SiteConfigurationHistoryItem
@@ -37,7 +37,7 @@ export const HistoryItemWithNoAuthor: Story = () => (
 
 HistoryItemWithNoAuthor.storyName = 'History item with no author'
 
-export const HistoryItemWithAuthor: Story = () => (
+export const HistoryItemWithAuthor: StoryFn = () => (
     <WebStory>
         {() => (
             <SiteConfigurationHistoryItem
@@ -69,7 +69,7 @@ export const HistoryItemWithAuthor: Story = () => (
 
 HistoryItemWithAuthor.storyName = 'History item with author'
 
-export const HistoryItemWithAuthorButNoDisplayName: Story = () => (
+export const HistoryItemWithAuthorButNoDisplayName: StoryFn = () => (
     <WebStory>
         {() => (
             <SiteConfigurationHistoryItem
@@ -101,7 +101,7 @@ export const HistoryItemWithAuthorButNoDisplayName: Story = () => (
 
 HistoryItemWithAuthorButNoDisplayName.storyName = 'History item with author without display name'
 
-export const HistoryItemWithAuthorWithAvatarURL: Story = () => (
+export const HistoryItemWithAuthorWithAvatarURL: StoryFn = () => (
     <WebStory>
         {() => (
             <SiteConfigurationHistoryItem

--- a/client/web/src/site-admin/UserManagement/components/DateRangeSelect.story.tsx
+++ b/client/web/src/site-admin/UserManagement/components/DateRangeSelect.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { startOfDay, subDays } from 'date-fns'
 
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -7,7 +7,7 @@ import { DateRangeSelect } from './DateRangeSelect'
 
 import webStyles from '../../../SourcegraphWebApp.scss'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory styles={webStyles}>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 
@@ -23,7 +23,7 @@ export default config
 const today = startOfDay(new Date('2022-08-30'))
 const defaultValue: [Date, Date] = [subDays(today, 7), today]
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <div className="d-flex justify-content-around w-50">
         <DateRangeSelect value={defaultValue} defaultIsOpen={true} />
     </div>
@@ -36,7 +36,7 @@ Default.parameters = {
     },
 }
 
-export const WithNegation: Story = () => (
+export const WithNegation: StoryFn = () => (
     <div className="d-flex justify-content-around w-50">
         <DateRangeSelect
             negation={{

--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
@@ -45,7 +45,7 @@ const WebhookInfoLogPageHeaderContainer: React.FunctionComponent<
     return <WebhookInfoLogPageHeader webhookID="1" onlyErrors={onlyErrors} onSetOnlyErrors={setOnlyErrors} />
 }
 
-export const ExternalServicesAndErrors: Story = args => (
+export const ExternalServicesAndErrors: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={buildHeaderMock(args.erroredWebhookCount)}>

--- a/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
+++ b/client/web/src/site-admin/WebhookInfoLogPageHeader.story.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 
 import type { MockedResponse } from '@apollo/client/testing'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -13,7 +13,7 @@ import type { WebhookByIDLogPageHeaderResult } from '../graphql-operations'
 import { WebhookInfoLogPageHeader } from './WebhookInfoLogPageHeader'
 import { type SelectedExternalService, WEBHOOK_BY_ID_LOG_PAGE_HEADER } from './webhooks/backend'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <Container>
         <div className="p-3 container">{story()}</div>
     </Container>

--- a/client/web/src/site-admin/WebhookInformation.story.tsx
+++ b/client/web/src/site-admin/WebhookInformation.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { addMinutes, formatRFC3339 } from 'date-fns'
 
 import { WebStory } from '../components/WebStory'
@@ -6,7 +6,7 @@ import { ExternalServiceKind, type WebhookFields } from '../graphql-operations'
 
 import { WebhookInformation } from './WebhookInformation'
 
-const decorator: DecoratorFn = Story => <Story />
+const decorator: Decorator = Story => <Story />
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/incoming/WebhookInformation',
@@ -17,7 +17,7 @@ export default config
 
 const TIMESTAMP_MOCK = new Date(2021, 10, 8, 16, 40, 30)
 
-export const WebhookDescription: Story = () => (
+export const WebhookDescription: StoryFn = () => (
     <WebStory>{() => <WebhookInformation webhook={createWebhook()} />}</WebStory>
 )
 

--- a/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsUsersPage/AnalyticsUsersPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -10,7 +10,7 @@ import type { UsersStatisticsResult } from '../../../graphql-operations'
 import { AnalyticsUsersPage } from './index'
 import { USERS_STATISTICS } from './queries'
 
-const decorator: DecoratorFn = story => <WebStory>{() => <div className="p-3 container">{story()}</div>}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => <div className="p-3 container">{story()}</div>}</WebStory>
 
 const config: Meta = {
     title: 'web/site-admin/analytics/AnalyticsUsersPage',
@@ -693,7 +693,7 @@ const USER_ANALYTICS_QUERY_MOCK: MockedResponse<UsersStatisticsResult> = {
     },
 }
 
-export const AnalyticsUsersPageExample: Story = () => (
+export const AnalyticsUsersPageExample: StoryFn = () => (
     <MockedTestProvider mocks={[USER_ANALYTICS_QUERY_MOCK]}>
         <AnalyticsUsersPage />
     </MockedTestProvider>

--- a/client/web/src/site-admin/analytics/components/ValueLegendList.story.tsx
+++ b/client/web/src/site-admin/analytics/components/ValueLegendList.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { Container, LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -6,7 +6,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { ValueLegendItem, ValueLegendList, type ValueLegendListProps } from './ValueLegendList'
 
-const decorator: DecoratorFn = Story => <Story />
+const decorator: Decorator = Story => <Story />
 
 const config: Meta = {
     title: 'web/src/site-admin/analytics/components/ValueLegendList',
@@ -15,7 +15,7 @@ const config: Meta = {
 
 export default config
 
-export const SingleValueLegendItem: Story = () => (
+export const SingleValueLegendItem: StoryFn = () => (
     <WebStory>
         {() => (
             <Container>
@@ -27,7 +27,7 @@ export const SingleValueLegendItem: Story = () => (
 
 SingleValueLegendItem.storyName = 'Single value legend item'
 
-export const ValueLegendListStory: Story = () => {
+export const ValueLegendListStory: StoryFn = () => {
     const items: ValueLegendListProps['items'] = [
         {
             value: 12345,

--- a/client/web/src/site-admin/init/SiteInitPage.story.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
@@ -13,7 +13,7 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <WebStory>
         {() => (
             <SiteInitPage
@@ -28,7 +28,7 @@ export const Default: Story = () => (
     </WebStory>
 )
 
-export const Authenticated: Story = () => (
+export const Authenticated: StoryFn = () => (
     <WebStory>
         {() => (
             <SiteInitPage

--- a/client/web/src/site-admin/outbound-webhooks/CreatePage.story.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/CreatePage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -8,7 +8,7 @@ import { WebStory } from '../../components/WebStory'
 import { CreatePage } from './CreatePage'
 import { eventTypesMock } from './mocks'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/outgoing/CreatePage',
@@ -17,7 +17,7 @@ const config: Meta = {
 
 export default config
 
-export const Page: Story = () => (
+export const Page: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={[eventTypesMock]}>

--- a/client/web/src/site-admin/outbound-webhooks/EditPage.story.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/EditPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { WildcardMockLink } from 'wildcard-mock-link'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -9,7 +9,7 @@ import { WebStory } from '../../components/WebStory'
 import { EditPage } from './EditPage'
 import { logConnectionLink, buildOutboundWebhookMock, eventTypesMock } from './mocks'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/outgoing/EditPage',
@@ -18,7 +18,7 @@ const config: Meta = {
 
 export default config
 
-export const Page: Story = () => (
+export const Page: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider

--- a/client/web/src/site-admin/outbound-webhooks/OutboundWebhooksPage.story.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/OutboundWebhooksPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { WildcardMockLink } from 'wildcard-mock-link'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -9,7 +9,7 @@ import { WebStory } from '../../components/WebStory'
 import { buildOutboundWebhooksConnectionLink } from './mocks'
 import { OutboundWebhooksPage } from './OutboundWebhooksPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/outgoing/OutboundWebhooksPage',
@@ -18,7 +18,7 @@ const config: Meta = {
 
 export default config
 
-export const Empty: Story = () => (
+export const Empty: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink([buildOutboundWebhooksConnectionLink(0)])}>
@@ -30,7 +30,7 @@ export const Empty: Story = () => (
 
 Empty.storyName = 'Empty'
 
-export const NotEmpty: Story = () => (
+export const NotEmpty: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={new WildcardMockLink([buildOutboundWebhooksConnectionLink(20)])}>

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { addMinutes, formatRFC3339, subMinutes } from 'date-fns'
 import { WildcardMockLink } from 'wildcard-mock-link'
 
@@ -20,7 +20,7 @@ import type { PermissionsSyncJob } from '../../graphql-operations'
 import { PERMISSIONS_SYNC_JOBS_QUERY, PERMISSIONS_SYNC_JOBS_STATS } from './backend'
 import { PermissionsSyncJobsTable } from './PermissionsSyncJobsTable'
 
-const decorator: DecoratorFn = Story => <Story />
+const decorator: Decorator = Story => <Story />
 
 const config: Meta = {
     title: 'web/src/site-admin/permissions-center/PermissionsSyncJobsTable',
@@ -48,7 +48,7 @@ const FAILED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === Permiss
 const PROCESSING_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.PROCESSING)
 const QUEUED_JOBS_MOCK_DATA = JOBS_MOCK_DATA.filter(job => job.state === PermissionsSyncJobState.QUEUED)
 
-export const SixSyncJobsFound: Story = () => (
+export const SixSyncJobsFound: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncStats.story.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncStats.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
@@ -9,7 +9,7 @@ import { WebStory } from '../../components/WebStory'
 import { PERMISSIONS_SYNC_JOBS_STATS } from './backend'
 import { PermissionsSyncStats } from './PermissionsSyncStats'
 
-const decorator: DecoratorFn = Story => <Story />
+const decorator: Decorator = Story => <Story />
 
 const config: Meta = {
     title: 'web/src/site-admin/permissions-center/PermissionsSyncStats',
@@ -18,7 +18,7 @@ const config: Meta = {
 
 export default config
 
-export const Stats: Story = () => (
+export const Stats: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider

--- a/client/web/src/site-admin/webhooks/MessagePanel.story.tsx
+++ b/client/web/src/site-admin/webhooks/MessagePanel.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
 import { MessagePanel } from './MessagePanel'
 import { BODY_JSON, BODY_PLAIN, HEADERS_JSON, HEADERS_PLAIN } from './story/fixtures'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 const config: Meta = {
     title: 'web/site-admin/webhooks/MessagePanel',
     decorators: [decorator],
@@ -23,7 +23,7 @@ const messagePanelObject = {
     plain: { headers: HEADERS_PLAIN, body: BODY_PLAIN },
 }
 
-export const JSONRequest: Story = () => (
+export const JSONRequest: StoryFn = () => (
     <WebStory>
         {() => (
             <MessagePanel
@@ -67,7 +67,7 @@ JSONResponse.args = {
 
 JSONResponse.storyName = 'JSON response'
 
-export const PlainRequest: Story = () => (
+export const PlainRequest: StoryFn = () => (
     <WebStory>
         {() => (
             <MessagePanel

--- a/client/web/src/site-admin/webhooks/PerformanceGauge.story.tsx
+++ b/client/web/src/site-admin/webhooks/PerformanceGauge.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
 import { PerformanceGauge } from './PerformanceGauge'
 import { StyledPerformanceGauge } from './story/StyledPerformanceGauge'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/PerformanceGauge',
@@ -19,27 +19,27 @@ const config: Meta = {
 
 export default config
 
-export const Loading: Story = () => <WebStory>{() => <PerformanceGauge label="dog" />}</WebStory>
+export const Loading: StoryFn = () => <WebStory>{() => <PerformanceGauge label="dog" />}</WebStory>
 
-export const Zero: Story = () => <WebStory>{() => <PerformanceGauge count={0} label="dog" />}</WebStory>
+export const Zero: StoryFn = () => <WebStory>{() => <PerformanceGauge count={0} label="dog" />}</WebStory>
 
-export const ZeroWithExplicitPlural: Story = () => (
+export const ZeroWithExplicitPlural: StoryFn = () => (
     <WebStory>{() => <PerformanceGauge count={0} label="wolf" plural="wolves" />}</WebStory>
 )
 
 ZeroWithExplicitPlural.storyName = 'zero with explicit plural'
 
-export const One: Story = () => <WebStory>{() => <PerformanceGauge count={1} label="dog" />}</WebStory>
+export const One: StoryFn = () => <WebStory>{() => <PerformanceGauge count={1} label="dog" />}</WebStory>
 
-export const Many: Story = () => <WebStory>{() => <PerformanceGauge count={42} label="dog" />}</WebStory>
+export const Many: StoryFn = () => <WebStory>{() => <PerformanceGauge count={42} label="dog" />}</WebStory>
 
-export const ManyWithExplicitPlural: Story = () => (
+export const ManyWithExplicitPlural: StoryFn = () => (
     <WebStory>{() => <PerformanceGauge count={42} label="wolf" plural="wolves" />}</WebStory>
 )
 
 ManyWithExplicitPlural.storyName = 'many with explicit plural'
 
-export const ClassOverrides: Story = () => (
+export const ClassOverrides: StoryFn = () => (
     <WebStory>{() => <StyledPerformanceGauge count={42} label="dog" />}</WebStory>
 )
 

--- a/client/web/src/site-admin/webhooks/StatusCode.story.tsx
+++ b/client/web/src/site-admin/webhooks/StatusCode.story.tsx
@@ -18,7 +18,7 @@ const config: Meta = {
 
 export default config
 
-export const Success: Story = args => <WebStory>{() => <StatusCode code={args.code} />}</WebStory>
+export const Success: StoryFn = args => <WebStory>{() => <StatusCode code={args.code} />}</WebStory>
 Success.argTypes = {
     code: {
         control: { type: 'number', min: 100, max: 399 },
@@ -28,7 +28,7 @@ Success.args = {
     code: 204,
 }
 
-export const Failure: Story = args => <WebStory>{() => <StatusCode code={args.code} />}</WebStory>
+export const Failure: StoryFn = args => <WebStory>{() => <StatusCode code={args.code} />}</WebStory>
 Failure.argTypes = {
     code: {
         control: { type: 'number', min: 400, max: 599 },

--- a/client/web/src/site-admin/webhooks/StatusCode.story.tsx
+++ b/client/web/src/site-admin/webhooks/StatusCode.story.tsx
@@ -1,10 +1,10 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 
 import { StatusCode } from './StatusCode'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/StatusCode',

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 
 import { Container } from '@sourcegraph/wildcard'
@@ -17,7 +17,7 @@ import { WebhookLogNode } from './WebhookLogNode'
 
 import gridStyles from './WebhookLogPage.module.scss'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <Container>
         <div className={classNames('p-3', 'container', gridStyles.logs)}>{story()}</div>
     </Container>

--- a/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogNode.story.tsx
@@ -59,7 +59,7 @@ export default config
 
 type StoryArguments = Pick<WebhookLogFields, 'receivedAt' | 'statusCode'>
 
-export const Collapsed: Story<StoryArguments> = args => (
+export const Collapsed: StoryFn<StoryArguments> = args => (
     <WebStory>
         {() => (
             <>
@@ -93,7 +93,7 @@ export const Collapsed: Story<StoryArguments> = args => (
     </WebStory>
 )
 
-export const ExpandedRequest: Story<StoryArguments> = args => (
+export const ExpandedRequest: StoryFn<StoryArguments> = args => (
     <WebStory>
         {() => (
             <>
@@ -117,7 +117,7 @@ export const ExpandedRequest: Story<StoryArguments> = args => (
 
 ExpandedRequest.storyName = 'expanded request'
 
-export const ExpandedResponse: Story<StoryArguments> = args => (
+export const ExpandedResponse: StoryFn<StoryArguments> = args => (
     <WebStory>
         {() => (
             <>

--- a/client/web/src/site-admin/webhooks/WebhookLogPage.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPage.story.tsx
@@ -120,7 +120,7 @@ const buildWebhookLogs = (count: number, externalServiceCount: number): WebhookL
     return logs
 }
 
-export const NoLogs: Story = args => (
+export const NoLogs: StoryFn = args => (
     <WebStory>
         {props => (
             <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
@@ -132,7 +132,7 @@ export const NoLogs: Story = args => (
 
 NoLogs.storyName = 'no logs'
 
-export const OnePageOfLogs: Story = args => (
+export const OnePageOfLogs: StoryFn = args => (
     <WebStory>
         {props => (
             <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
@@ -144,7 +144,7 @@ export const OnePageOfLogs: Story = args => (
 
 OnePageOfLogs.storyName = 'one page of logs'
 
-export const TwoPagesOfLogs: Story = args => (
+export const TwoPagesOfLogs: StoryFn = args => (
     <WebStory>
         {props => (
             <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>

--- a/client/web/src/site-admin/webhooks/WebhookLogPage.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { addMinutes, formatRFC3339 } from 'date-fns'
 import { of } from 'rxjs'
 
@@ -11,7 +11,7 @@ import type { queryWebhookLogs, SelectedExternalService } from './backend'
 import { BODY_JSON, BODY_PLAIN, buildHeaderMock, HEADERS_JSON, HEADERS_PLAIN } from './story/fixtures'
 import { WebhookLogPage } from './WebhookLogPage'
 
-const decorator: DecoratorFn = story => <div className="p-3 container">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container">{story()}</div>
 
 const config: Meta = {
     title: 'web/site-admin/webhooks/WebhookLogPage',

--- a/client/web/src/site-admin/webhooks/WebhookLogPageHeader.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPageHeader.story.tsx
@@ -60,7 +60,7 @@ const WebhookLogPageHeaderContainer: React.FunctionComponent<
     )
 }
 
-export const AllZeroes: Story = args => (
+export const AllZeroes: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
@@ -80,7 +80,7 @@ AllZeroes.args = {
 
 AllZeroes.storyName = 'all zeroes'
 
-export const ExternalServices: Story = args => (
+export const ExternalServices: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
@@ -101,7 +101,7 @@ ExternalServices.args = {
 
 ExternalServices.storyName = 'external services'
 
-export const ExternalServicesAndErrors: Story = args => (
+export const ExternalServicesAndErrors: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
@@ -122,7 +122,7 @@ ExternalServicesAndErrors.args = {
 
 ExternalServicesAndErrors.storyName = 'external services and errors'
 
-export const OnlyErrorsTurnedOn: Story = args => (
+export const OnlyErrorsTurnedOn: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
@@ -142,7 +142,7 @@ OnlyErrorsTurnedOn.args = {
 
 OnlyErrorsTurnedOn.storyName = 'only errors turned on'
 
-export const SpecificExternalServiceSelected: Story = args => (
+export const SpecificExternalServiceSelected: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>
@@ -166,7 +166,7 @@ SpecificExternalServiceSelected.args = {
 
 SpecificExternalServiceSelected.storyName = 'specific external service selected'
 
-export const UnmatchedExternalServiceSelected: Story = args => (
+export const UnmatchedExternalServiceSelected: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={buildHeaderMock(args.externalServiceCount, args.erroredWebhookCount)}>

--- a/client/web/src/site-admin/webhooks/WebhookLogPageHeader.story.tsx
+++ b/client/web/src/site-admin/webhooks/WebhookLogPageHeader.story.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { Container } from '@sourcegraph/wildcard'
@@ -11,7 +11,7 @@ import type { SelectedExternalService } from './backend'
 import { buildHeaderMock } from './story/fixtures'
 import { WebhookLogPageHeader } from './WebhookLogPageHeader'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <Container>
         <div className="p-3 container">{story()}</div>
     </Container>

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.story.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 
@@ -21,7 +21,7 @@ const config: Meta = {
 
 export default config
 
-export const CloudAuthedHome: Story = () => (
+export const CloudAuthedHome: StoryFn = () => (
     <WebStory
         legacyLayoutContext={{ isSourcegraphDotCom: true, authenticatedUser: { id: 'userID' } as AuthenticatedUser }}
     >
@@ -31,7 +31,7 @@ export const CloudAuthedHome: Story = () => (
 
 CloudAuthedHome.storyName = 'Cloud authenticated home'
 
-export const ServerHome: Story = () => (
+export const ServerHome: StoryFn = () => (
     <WebStory>{() => <SearchPageContent shouldShowAddCodeHostWidget={false} />}</WebStory>
 )
 

--- a/client/web/src/team/area/TeamChildTeamsPage.story.tsx
+++ b/client/web/src/team/area/TeamChildTeamsPage.story.tsx
@@ -81,7 +81,7 @@ const mockResponse: MockedResponse<ListTeamsOfParentResult> = {
     },
 }
 
-export const Default: Story = function Default() {
+export const Default: StoryFn = function Default() {
     return (
         <WebStory mocks={[mockResponse]} initialEntries={['/teams/team-1/child-teams']}>
             {() => <TeamChildTeamsPage {...testContext} />}

--- a/client/web/src/team/area/TeamChildTeamsPage.story.tsx
+++ b/client/web/src/team/area/TeamChildTeamsPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 

--- a/client/web/src/team/area/TeamMembersPage.story.tsx
+++ b/client/web/src/team/area/TeamMembersPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 

--- a/client/web/src/team/area/TeamMembersPage.story.tsx
+++ b/client/web/src/team/area/TeamMembersPage.story.tsx
@@ -60,7 +60,7 @@ const mockResponse: MockedResponse<ListTeamMembersResult> = {
     },
 }
 
-export const Default: Story = function Default() {
+export const Default: StoryFn = function Default() {
     return (
         <WebStory initialEntries={['/teams/team-1/members']} mocks={[mockResponse]}>
             {() => <TeamMembersPage {...testContext} />}

--- a/client/web/src/team/area/TeamProfilePage.story.tsx
+++ b/client/web/src/team/area/TeamProfilePage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 

--- a/client/web/src/team/area/TeamProfilePage.story.tsx
+++ b/client/web/src/team/area/TeamProfilePage.story.tsx
@@ -13,6 +13,6 @@ const config: Meta = {
 }
 export default config
 
-export const Default: Story = function Default() {
+export const Default: StoryFn = function Default() {
     return <WebStory initialEntries={['/teams/team-1']}>{() => <TeamProfilePage {...testContext} />}</WebStory>
 }

--- a/client/web/src/team/list/TeamListPage.story.tsx
+++ b/client/web/src/team/list/TeamListPage.story.tsx
@@ -1,5 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 

--- a/client/web/src/team/list/TeamListPage.story.tsx
+++ b/client/web/src/team/list/TeamListPage.story.tsx
@@ -17,7 +17,7 @@ const config: Meta = {
 }
 export default config
 
-export const EmptyList: Story = function EmptyList() {
+export const EmptyList: StoryFn = function EmptyList() {
     const mockResponse: MockedResponse<ListTeamsResult> = {
         request: {
             query: getDocumentNode(LIST_TEAMS),
@@ -42,7 +42,7 @@ export const EmptyList: Story = function EmptyList() {
     return <WebStory mocks={[mockResponse]}>{() => <TeamListPage />}</WebStory>
 }
 
-export const ListWithItems: Story = function ListWithItems() {
+export const ListWithItems: StoryFn = function ListWithItems() {
     const mockResponse: MockedResponse<ListTeamsResult> = {
         request: {
             query: getDocumentNode(LIST_TEAMS),

--- a/client/web/src/team/new/NewTeamPage.story.tsx
+++ b/client/web/src/team/new/NewTeamPage.story.tsx
@@ -12,6 +12,6 @@ const config: Meta = {
 }
 export default config
 
-export const Default: Story = function Default() {
+export const Default: StoryFn = function Default() {
     return <WebStory>{() => <NewTeamPage />}</WebStory>
 }

--- a/client/web/src/team/new/NewTeamPage.story.tsx
+++ b/client/web/src/team/new/NewTeamPage.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 

--- a/client/web/src/tour/components/Tour/Tour.story.tsx
+++ b/client/web/src/tour/components/Tour/Tour.story.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import type { Meta, DecoratorFn } from '@storybook/react'
+import type { Meta, Decorator } from '@storybook/react'
 
 import { MockTemporarySettings } from '@sourcegraph/shared/src/settings/temporary/testUtils'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -10,7 +10,7 @@ import { authenticatedTasks } from '../../data'
 
 import { Tour } from './Tour'
 
-const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
 
 const config: Meta = {
     title: 'web/GettingStartedTour/Tour',

--- a/client/web/src/user/profile/UserProfile.story.tsx
+++ b/client/web/src/user/profile/UserProfile.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { WebStory } from '../../components/WebStory'
 import type { UserAreaUserFields } from '../../graphql-operations'
 
 import { UserProfile } from './UserProfile'
 
-const decorator: DecoratorFn = story => <div className="p-3 container list-unstyled">{story()}</div>
+const decorator: Decorator = story => <div className="p-3 container list-unstyled">{story()}</div>
 
 const config: Meta = {
     title: 'web/src/user/profile',
@@ -46,4 +46,4 @@ const mockUser: UserAreaUserFields = {
     },
 }
 
-export const Profile: Story = () => <WebStory>{() => <UserProfile user={mockUser} />}</WebStory>
+export const Profile: StoryFn = () => <WebStory>{() => <UserProfile user={mockUser} />}</WebStory>

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.story.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta } from '@storybook/react'
+import type { Decorator, Meta } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
@@ -6,7 +6,7 @@ import { WebStory } from '../../../components/WebStory'
 
 import { AboutOrganizationPage } from './AboutOrganizationPage'
 
-const decorator: DecoratorFn = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
+const decorator: Decorator = story => <WebStory>{() => <div className="container mt-3">{story()}</div>}</WebStory>
 
 const config: Meta = {
     title: 'web/Organizations/AboutOrganizationPage',

--- a/client/wildcard/src/components/Alert/Alert.story.tsx
+++ b/client/wildcard/src/components/Alert/Alert.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { action } from '@storybook/addon-actions'
-import type { Story, Meta } from '@storybook/react'
+import type { StoryFn, Meta } from '@storybook/react'
 import classNames from 'classnames'
 import { flow } from 'lodash'
 
@@ -45,7 +45,7 @@ const config: Meta = {
 
 export default config
 
-export const Alerts: Story = () => (
+export const Alerts: StoryFn = () => (
     <>
         <H1>Alerts</H1>
         <Text>

--- a/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
+++ b/client/wildcard/src/components/Breadcrumbs/Breadcrumbs.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { ResizableBox } from 'react-resizable'
 
 import { BrandedStory } from '../../stories'
@@ -12,7 +12,7 @@ const config: Meta = {
 
 export default config
 
-export const BreadcrumbsGallery: Story = () => (
+export const BreadcrumbsGallery: StoryFn = () => (
     <ResizableBox width={500} height={30} axis="x" minConstraints={[100, 0]}>
         <Breadcrumbs
             filename="sourcegraph/client/web/src/enteprise/insights/components/insight-view/components/InsighBackend.tsx"

--- a/client/wildcard/src/components/Button/story/Button.story.tsx
+++ b/client/wildcard/src/components/Button/story/Button.story.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 import SearchIcon from 'mdi-react/SearchIcon'
 
@@ -67,7 +67,7 @@ Simple.args = {
     outline: false,
 }
 
-export const AllButtons: Story = () => (
+export const AllButtons: StoryFn = () => (
     <div className="pb-3">
         <H1>Buttons</H1>
         <H2>Variants</H2>
@@ -126,7 +126,7 @@ AllButtons.parameters = {
 
 type ButtonSizesType = typeof BUTTON_SIZES[number] | undefined
 
-export const Group: Story = () => {
+export const Group: StoryFn = () => {
     const [active, setActive] = useState<'Left' | 'Middle' | 'Right'>('Left')
     const buttonSizes: ButtonSizesType[] = ['lg', undefined, 'sm']
 

--- a/client/wildcard/src/components/ButtonLink/ButtonLink.story.tsx
+++ b/client/wildcard/src/components/ButtonLink/ButtonLink.story.tsx
@@ -1,5 +1,5 @@
 import { mdiMagnify } from '@mdi/js'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { startCase } from 'lodash'
 
 import { ButtonLink, H1, H2, Text } from '..'
@@ -36,7 +36,7 @@ const Config: Meta = {
 
 export default Config
 
-export const Overview: Story = () => (
+export const Overview: StoryFn = () => (
     <>
         <H1>ButtonLink</H1>
         <H2>Variants</H2>

--- a/client/wildcard/src/components/Card/Card.story.tsx
+++ b/client/wildcard/src/components/Card/Card.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { H1, H2, H3, Text } from '..'
 import { BrandedStory } from '../../stories/BrandedStory'
@@ -36,7 +36,7 @@ const config: Meta = {
 
 export default config
 
-export const Simple: Story = () => (
+export const Simple: StoryFn = () => (
     <>
         <H1>Cards</H1>
         <Text>

--- a/client/wildcard/src/components/Charts/components/bar-chart/BarChart.story.tsx
+++ b/client/wildcard/src/components/Charts/components/bar-chart/BarChart.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { ParentSize } from '@visx/responsive'
 import { ResizableBox } from 'react-resizable'
 
@@ -59,7 +59,7 @@ const getLink = (datum: LanguageUsageDatum) => datum.linkURL
 const getName = (datum: LanguageUsageDatum) => datum.name
 const getGroup = (datum: LanguageUsageDatum) => datum.group
 
-export const BarChartDemo: Story = () => (
+export const BarChartDemo: StoryFn = () => (
     <main
         style={{
             display: 'flex',

--- a/client/wildcard/src/components/Charts/components/line-chart/components/tooltip/TooltipContent.story.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/components/tooltip/TooltipContent.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '../../../../../../stories/BrandedStory'
 import { H2 } from '../../../../../Typography'
@@ -89,7 +89,7 @@ const ACTIVE_POINT: MinimumPointInfo = {
     xValue: new Date('2020-05-07T19:21:40.286Z'),
 }
 
-export const TooltipLayoutDemo: Story = () => (
+export const TooltipLayoutDemo: StoryFn = () => (
     <div className="d-flex flex-column" style={{ gap: 20 }}>
         <div>
             <H2>Regular tooltip</H2>

--- a/client/wildcard/src/components/Charts/components/line-chart/story/LineChart.story.tsx
+++ b/client/wildcard/src/components/Charts/components/line-chart/story/LineChart.story.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { ParentSize } from '@visx/responsive'
 import { ResizableBox } from 'react-resizable'
 
@@ -30,7 +30,7 @@ const StoryConfig: Meta = {
 
 export default StoryConfig
 
-export const LineChartsDemo: Story = () => (
+export const LineChartsDemo: StoryFn = () => (
     <main
         style={{
             display: 'flex',

--- a/client/wildcard/src/components/Charts/components/pie-chart/PieChart.story.tsx
+++ b/client/wildcard/src/components/Charts/components/pie-chart/PieChart.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '../../../../stories/BrandedStory'
 import { H2, Text } from '../../../Typography'
@@ -27,7 +27,7 @@ const getColor = (datum: LanguageUsageDatum) => datum.fill
 const getLink = (datum: LanguageUsageDatum) => datum.linkURL
 const getName = (datum: LanguageUsageDatum) => datum.name
 
-export const PieChartDemo: Story = () => (
+export const PieChartDemo: StoryFn = () => (
     <main
         style={{
             display: 'flex',

--- a/client/wildcard/src/components/Charts/components/stacked-meter/StackedMeter.story.tsx
+++ b/client/wildcard/src/components/Charts/components/stacked-meter/StackedMeter.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import ParentSize from '@visx/responsive/lib/components/ParentSizeModern'
 
 import { BrandedStory } from '../../../../stories'
@@ -14,7 +14,7 @@ const StoryConfig: Meta = {
 }
 export default StoryConfig
 
-export const StackedMeterDemo: Story = () => {
+export const StackedMeterDemo: StoryFn = () => {
     const data = [
         {
             language: 'JavaScript',

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.story.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.story.tsx
@@ -34,7 +34,7 @@ interface TemplateProps {
     color?: string
 }
 
-const SimpleChartTemplate: Story<TemplateProps> = args => (
+const SimpleChartTemplate: StoryFn<TemplateProps> = args => (
     <ParentSize style={{ width: 400, height: 400 }} debounceTime={0} className="flex-shrink-0">
         {parent => (
             <SvgRoot width={parent.width} height={parent.height} xScale={args.xScale} yScale={args.yScale}>
@@ -49,7 +49,7 @@ const SimpleChartTemplate: Story<TemplateProps> = args => (
     </ParentSize>
 )
 
-export const SmartAxisDemo: Story = args => (
+export const SmartAxisDemo: StoryFn = args => (
     <section style={{ display: 'flex', flexWrap: 'wrap', gap: 20 }}>
         <SimpleChartTemplate
             xScale={scaleTime<number>({

--- a/client/wildcard/src/components/Charts/core/components/SvgRoot.story.tsx
+++ b/client/wildcard/src/components/Charts/core/components/SvgRoot.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import type { AxisScale } from '@visx/axis/lib/types'
 import { ParentSize } from '@visx/responsive'
 import { scaleBand, scaleLinear, scaleTime } from '@visx/scale'

--- a/client/wildcard/src/components/Collapse/Collapse.story.tsx
+++ b/client/wildcard/src/components/Collapse/Collapse.story.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 
 import { mdiChevronDown, mdiChevronLeft } from '@mdi/js'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { H2 } from '..'
 import { BrandedStory } from '../../stories/BrandedStory'
@@ -11,7 +11,7 @@ import { Icon } from '../Icon'
 
 import { Collapse, CollapseHeader, CollapsePanel } from './Collapse'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 
@@ -24,7 +24,7 @@ const config: Meta = {
 
 export default config
 
-export const Simple: Story = () => {
+export const Simple: StoryFn = () => {
     const [isOpened, setIsOpened] = useState(false)
 
     const handleOpenChange = useCallback((next: boolean) => {

--- a/client/wildcard/src/components/Combobox/Combobox.story.tsx
+++ b/client/wildcard/src/components/Combobox/Combobox.story.tsx
@@ -1,7 +1,7 @@
 import { type ChangeEvent, useEffect, useState } from 'react'
 
 import { mdiSourceRepository } from '@mdi/js'
-import type { DecoratorFn, Meta } from '@storybook/react'
+import type { Decorator, Meta } from '@storybook/react'
 
 import { BrandedStory } from '../../stories/BrandedStory'
 import { Button } from '../Button'
@@ -20,7 +20,7 @@ import {
     ComboboxOptionGroup,
 } from './Combobox'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 

--- a/client/wildcard/src/components/Combobox/MultiCombobox.story.tsx
+++ b/client/wildcard/src/components/Combobox/MultiCombobox.story.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { mdiSourceRepository } from '@mdi/js'
-import type { DecoratorFn, Meta } from '@storybook/react'
+import type { Decorator, Meta } from '@storybook/react'
 
 import { BrandedStory } from '../../stories'
 import { Grid } from '../Grid'
@@ -19,7 +19,7 @@ import {
 
 import styles from './MultiComboboxStory.module.scss'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 

--- a/client/wildcard/src/components/Container/Container.story.tsx
+++ b/client/wildcard/src/components/Container/Container.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { H1, H2, H3, Text, Input } from '..'
 import { BrandedStory } from '../../stories/BrandedStory'
@@ -7,7 +7,7 @@ import { Button } from '../Button'
 
 import { Container } from './Container'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 
@@ -19,7 +19,7 @@ const config: Meta = {
 
 export default config
 
-export const Overview: Story = () => (
+export const Overview: StoryFn = () => (
     <>
         <Alert variant="info">
             <Text>

--- a/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.story.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackBadge/FeedbackBadge.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '../../../stories/BrandedStory'
 import { PRODUCT_STATUSES } from '../../Badge'
@@ -34,7 +34,7 @@ const config: Meta = {
 
 export default config
 
-export const FeedbackBadgeExample: Story = () => (
+export const FeedbackBadgeExample: StoryFn = () => (
     <>
         <H1>FeedbackBadges</H1>
         <Text>Our badges come in different status.</Text>

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.story.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.story.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
-import type { Args } from '@storybook/addons'
-import type { Meta, StoryFn } from '@storybook/react'
+import type { Meta, StoryFn, Args } from '@storybook/react'
 
 import { PopoverTrigger, H1 } from '../..'
 import { BrandedStory } from '../../../stories/BrandedStory'
@@ -68,7 +67,7 @@ const commonProps = (
     productResearchEnabled: props.productResearchEnabled,
 })
 
-export const FeedbackPromptWithSuccessResponse: Story = args => (
+export const FeedbackPromptWithSuccessResponse: StoryFn = args => (
     <>
         <H1>This is a feedbackPrompt with success response</H1>
         <FeedbackPrompt onSubmit={handleSuccessSubmit} {...commonProps(args)}>
@@ -86,7 +85,7 @@ export const FeedbackPromptWithSuccessResponse: Story = args => (
     </>
 )
 
-export const FeedbackPromptWithErrorResponse: Story = args => (
+export const FeedbackPromptWithErrorResponse: StoryFn = args => (
     <>
         <H1>This is a feedbackPrompt with error response</H1>
         <FeedbackPrompt onSubmit={handleErrorSubmit} {...commonProps(args)}>
@@ -104,7 +103,7 @@ export const FeedbackPromptWithErrorResponse: Story = args => (
     </>
 )
 
-export const FeedbackPromptWithInModal: Story = args => (
+export const FeedbackPromptWithInModal: StoryFn = args => (
     <>
         <H1>This is a feedbackPrompt in modal</H1>
         <FeedbackPrompt onSubmit={handleSuccessSubmit} modal={true} {...commonProps(args)}>

--- a/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.story.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackPrompt/FeedbackPrompt.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import type { Args } from '@storybook/addons'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { PopoverTrigger, H1 } from '../..'
 import { BrandedStory } from '../../../stories/BrandedStory'

--- a/client/wildcard/src/components/Feedback/FeedbackText/FeedbackText.story.tsx
+++ b/client/wildcard/src/components/Feedback/FeedbackText/FeedbackText.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { H1, Text } from '../..'
 import { BrandedStory } from '../../../stories/BrandedStory'
@@ -20,7 +20,7 @@ const config: Meta = {
 
 export default config
 
-export const FeedbackTextExample: Story = () => (
+export const FeedbackTextExample: StoryFn = () => (
     <>
         <H1>FeedbackText</H1>
         <Text>This is an example of a feedback with a header</Text>

--- a/client/wildcard/src/components/Form/Checkbox/Checkbox.story.tsx
+++ b/client/wildcard/src/components/Form/Checkbox/Checkbox.story.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { H1, H2 } from '../..'
 import { BrandedStory } from '../../../stories/BrandedStory'
@@ -46,7 +46,7 @@ const BaseCheckbox = ({ name, ...props }: { name: string } & Pick<CheckboxProps,
     )
 }
 
-export const CheckboxExamples: Story = () => (
+export const CheckboxExamples: StoryFn = () => (
     <>
         <H1>Checkbox</H1>
         <Grid columnCount={4}>

--- a/client/wildcard/src/components/Form/RadioButton/RadioButton.story.tsx
+++ b/client/wildcard/src/components/Form/RadioButton/RadioButton.story.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { H1, H2 } from '../..'
 import { BrandedStory } from '../../../stories/BrandedStory'
@@ -68,7 +68,7 @@ const BaseRadio = ({ name, ...props }: Pick<RadioButtonProps, 'name' | 'isValid'
     )
 }
 
-export const RadioExamples: Story = () => (
+export const RadioExamples: StoryFn = () => (
     <>
         <H1>Radio</H1>
         <Grid columnCount={4}>

--- a/client/wildcard/src/components/Form/Select/Select.story.tsx
+++ b/client/wildcard/src/components/Form/Select/Select.story.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { H1, H2 } from '../..'
 import { BrandedStory } from '../../../stories/BrandedStory'
@@ -73,7 +73,7 @@ const SelectVariants = ({ isCustomStyle }: Pick<SelectProps, 'isCustomStyle'>) =
     )
 }
 
-export const SelectExamples: Story = () => (
+export const SelectExamples: StoryFn = () => (
     <>
         <H1>Select</H1>
         <H2>Native</H2>

--- a/client/wildcard/src/components/Grid/Grid.story.tsx
+++ b/client/wildcard/src/components/Grid/Grid.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { Grid, type GridProps } from './Grid'
 

--- a/client/wildcard/src/components/Grid/Grid.story.tsx
+++ b/client/wildcard/src/components/Grid/Grid.story.tsx
@@ -12,7 +12,7 @@ const config: Meta = {
 
 export default config
 
-export const GridExamples: Story<GridProps> = ({ columnCount = 5, spacing }) => (
+export const GridExamples: StoryFn<GridProps> = ({ columnCount = 5, spacing }) => (
     <Grid columnCount={columnCount} spacing={spacing}>
         {/* Fill the grid with 20 items to showcase different setups */}
         {new Array(20).fill(0).map((_value, index) => (

--- a/client/wildcard/src/components/Icon/Icon.story.tsx
+++ b/client/wildcard/src/components/Icon/Icon.story.tsx
@@ -1,5 +1,5 @@
 import { mdiClose } from '@mdi/js'
-import type { Story, Meta } from '@storybook/react'
+import type { StoryFn, Meta } from '@storybook/react'
 import CloseIcon from 'mdi-react/CloseIcon'
 
 import { Icon } from '..'
@@ -28,7 +28,7 @@ const config: Meta = {
 }
 export default config
 
-export const Simple: Story = () => (
+export const Simple: StoryFn = () => (
     <>
         <H3>Small Icon</H3>
         <Icon as={SourcegraphIcon} size="sm" aria-label="Sourcegraph logo" />

--- a/client/wildcard/src/components/Link/Link/Link.story.tsx
+++ b/client/wildcard/src/components/Link/Link/Link.story.tsx
@@ -1,11 +1,11 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { Text } from '../..'
 import { BrandedStory } from '../../../stories/BrandedStory'
 
 import { Link } from './Link'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 
@@ -26,7 +26,7 @@ const config: Meta = {
 
 export default config
 
-export const Simple: Story = () => (
+export const Simple: StoryFn = () => (
     <Text>
         Text can contain links, which <Link to="/">trigger a navigation to a different page</Link>.
     </Text>

--- a/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.story.tsx
+++ b/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '../../stories/BrandedStory'
 

--- a/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.story.tsx
+++ b/client/wildcard/src/components/LoadingSpinner/LoadingSpinner.story.tsx
@@ -29,4 +29,4 @@ const config: Meta = {
 
 export default config
 
-export const Simple: Story = (args = {}) => <LoadingSpinner inline={args.inline} />
+export const Simple: StoryFn = (args = {}) => <LoadingSpinner inline={args.inline} />

--- a/client/wildcard/src/components/Menu/Menu.story.tsx
+++ b/client/wildcard/src/components/Menu/Menu.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { BrandedStory } from '../../stories/BrandedStory'
@@ -22,7 +22,7 @@ const config: Meta = {
 
 export default config
 
-export const MenuExample: Story = () => (
+export const MenuExample: StoryFn = () => (
     <Menu>
         <MenuButton variant="primary" outline={true}>
             Actions <span aria-hidden={true}>▾</span>

--- a/client/wildcard/src/components/Modal/Modal.story.tsx
+++ b/client/wildcard/src/components/Modal/Modal.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { H1 } from '..'
 import { BrandedStory } from '../../stories/BrandedStory'
@@ -14,7 +14,7 @@ const config: Meta = {
 
 export default config
 
-export const Default: Story = () => (
+export const Default: StoryFn = () => (
     <Modal aria-label="Welcome message">
         <H1>Hello world!</H1>
     </Modal>
@@ -39,13 +39,13 @@ Default.parameters = {
     ],
 }
 
-export const PositionCentered: Story = () => (
+export const PositionCentered: StoryFn = () => (
     <Modal position="center" aria-label="Welcome message">
         <H1>Hello world!</H1>
     </Modal>
 )
 
-export const PositionFull: Story = () => (
+export const PositionFull: StoryFn = () => (
     <Modal position="full" aria-label="Welcome message">
         <H1>Hello world!</H1>
     </Modal>

--- a/client/wildcard/src/components/NavMenu/NavMenu.story.tsx
+++ b/client/wildcard/src/components/NavMenu/NavMenu.story.tsx
@@ -1,5 +1,5 @@
 import { mdiPoll, mdiAntenna, mdiMenu, mdiMenuUp, mdiMenuDown } from '@mdi/js'
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 import FileTreeOutlineIcon from 'mdi-react/FileTreeOutlineIcon'
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
@@ -142,7 +142,7 @@ const navItems: NavMenuSectionProps[] = [
     },
 ]
 
-export const UserNav: Story = () => (
+export const UserNav: StoryFn = () => (
     <NavMenu
         navTrigger={{
             variant: 'icon',
@@ -183,7 +183,7 @@ const singleSectionNavItems: NavMenuSectionProps[] = [
     },
 ]
 
-export const SingleSectionNavMenuExample: Story = () => (
+export const SingleSectionNavMenuExample: StoryFn = () => (
     <NavMenu
         navTrigger={{
             variant: 'secondary',

--- a/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
@@ -1,5 +1,5 @@
 import { mdiMagnify, mdiPlus, mdiPuzzleOutline } from '@mdi/js'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '../../stories/BrandedStory'
 import { Button } from '../Button'
@@ -10,7 +10,7 @@ import { H1, H2 } from '../Typography'
 
 import { PageHeader } from './PageHeader'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 
@@ -22,7 +22,7 @@ const config: Meta = {
 
 export default config
 
-export const BasicHeader: Story = () => (
+export const BasicHeader: StoryFn = () => (
     <>
         <H1>Page Header</H1>
         <H2>Basic</H2>
@@ -60,7 +60,7 @@ BasicHeader.parameters = {
     },
 }
 
-export const ComplexHeader: Story = () => (
+export const ComplexHeader: StoryFn = () => (
     <PageHeader
         annotation={<FeedbackBadge status="experimental" feedback={{ mailto: 'support@sourcegraph.com' }} />}
         byline={

--- a/client/wildcard/src/components/PageSelector/PageSelector.story.tsx
+++ b/client/wildcard/src/components/PageSelector/PageSelector.story.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { H1, H2 } from '..'
 import { BrandedStory } from '../../stories/BrandedStory'
 
 import { PageSelector } from './PageSelector'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 
@@ -33,7 +33,7 @@ Simple.args = {
     totalPages: 5,
 }
 
-export const AllPageSelectors: Story = () => (
+export const AllPageSelectors: StoryFn = () => (
     <>
         <H1>Page Selector</H1>
         <H2>Short</H2>

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '../../stories/BrandedStory'
 import { Text } from '../Typography/Text/Text'
 
 import { PageSwitcher } from './PageSwitcher'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 

--- a/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
+++ b/client/wildcard/src/components/PageSwitcher/PageSwitcher.story.tsx
@@ -29,7 +29,7 @@ const config: Meta = {
 
 export default config
 
-export const Simple: Story = (args = {}) => {
+export const Simple: StoryFn = (args = {}) => {
     const totalPages = args.totalCount
 
     const [page, setPage] = useState(1)

--- a/client/wildcard/src/components/Panel/story/Panel.story.tsx
+++ b/client/wildcard/src/components/Panel/story/Panel.story.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { mdiClose } from '@mdi/js'
 import { useState } from '@storybook/addons'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 import { upperFirst } from 'lodash'
 
@@ -19,7 +19,7 @@ import { panels } from './TabbedPanelContent.fixtures'
 
 import styles from './Story.module.scss'
 
-const decorator: DecoratorFn = story => <BrandedStory>{() => <div>{story()}</div>}</BrandedStory>
+const decorator: Decorator = story => <BrandedStory>{() => <div>{story()}</div>}</BrandedStory>
 
 const config: Meta = {
     title: 'wildcard/Panel',
@@ -64,7 +64,7 @@ const PanelBodyContent: React.FunctionComponent<
     </div>
 )
 
-export const Simple: Story = () => {
+export const Simple: StoryFn = () => {
     const [position, setPosition] = useState<typeof PANEL_POSITIONS[number]>('left')
 
     const showPanelWithPosition = (postiion: typeof PANEL_POSITIONS[number]) => {

--- a/client/wildcard/src/components/Popover/story/Popover.story.tsx
+++ b/client/wildcard/src/components/Popover/story/Popover.story.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 import { noop } from 'rxjs'
 
@@ -33,7 +33,7 @@ const config: Meta = {
 
 export default config
 
-export const PositionSettingsGallery: Story = () => {
+export const PositionSettingsGallery: StoryFn = () => {
     const [position, setPosition] = useState(Position.top)
 
     return (
@@ -163,7 +163,7 @@ PositionSettingsGallery.parameters = {
     },
 }
 
-export const StandardExample: Story = () => (
+export const StandardExample: StoryFn = () => (
     <ScrollCenterBox title="Root scroll block" className={styles.container}>
         <div className={styles.content}>
             <Popover>
@@ -217,7 +217,7 @@ export const TargetPaddingExample: Story = () => (
     </ScrollCenterBox>
 )
 
-export const AbsoluteStrategyExample: Story = () => (
+export const AbsoluteStrategyExample: StoryFn = () => (
     <ScrollCenterBox title="Root scroll block" className={styles.container}>
         <div className={styles.content}>
             <Popover>
@@ -301,7 +301,7 @@ const FSM_TRANSITIONS: Record<FSM_STATES, Partial<Record<FSM_ACTIONS, FSM_STATES
     },
 }
 
-export const ShowOnFocus: Story = () => {
+export const ShowOnFocus: StoryFn = () => {
     const [state, setState] = useState<FSM_STATES>(FSM_STATES.Initial)
 
     const handleOpenChange = (event: PopoverOpenEvent): void => {

--- a/client/wildcard/src/components/Tabs/Tabs.story.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.story.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react'
+import type { Meta, StoryFn } from '@storybook/react'
 
 import { H1, H2 } from '..'
 import { BrandedStory } from '../../stories/BrandedStory'

--- a/client/wildcard/src/components/Tabs/Tabs.story.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.story.tsx
@@ -5,7 +5,7 @@ import { BrandedStory } from '../../stories/BrandedStory'
 
 import { Tabs, Tab, TabList, TabPanel, TabPanels, type TabsProps } from '.'
 
-export const TabsStory: Story<TabsProps & { actions: boolean }> = args => (
+export const TabsStory: StoryFn<TabsProps & { actions: boolean }> = args => (
     <>
         <H1>Tabs</H1>
         <Container title="Standard">
@@ -64,7 +64,7 @@ const config: Meta = {
     },
 }
 
-const TabsVariant: Story<TabsProps & { actions: boolean }> = args => {
+const TabsVariant: StoryFn<TabsProps & { actions: boolean }> = args => {
     const { actions, lazy, behavior, size, ...props } = args
     return (
         <Tabs lazy={lazy} behavior={behavior} size={size} {...props}>

--- a/client/wildcard/src/components/Tooltip/Tooltip.story.tsx
+++ b/client/wildcard/src/components/Tooltip/Tooltip.story.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { Button, Grid, Code, Text, Input } from '..'
 import { BrandedStory } from '../../stories/BrandedStory'
 
 import { Tooltip } from '.'
 
-const decorator: DecoratorFn = story => <BrandedStory>{() => <div className="p-5">{story()}</div>}</BrandedStory>
+const decorator: Decorator = story => <BrandedStory>{() => <div className="p-5">{story()}</div>}</BrandedStory>
 
 const config: Meta = {
     title: 'wildcard/Tooltip',
@@ -33,7 +33,7 @@ const config: Meta = {
 
 export default config
 
-export const Basic: Story = () => (
+export const Basic: StoryFn = () => (
     <Text>
         You can{' '}
         <Tooltip content="Tooltip 1">
@@ -47,7 +47,7 @@ export const Basic: Story = () => (
     </Text>
 )
 
-export const Conditional: Story = () => {
+export const Conditional: StoryFn = () => {
     const [clicked, setClicked] = useState<boolean>(false)
 
     function onClick() {
@@ -73,7 +73,7 @@ export const Conditional: Story = () => {
     )
 }
 
-export const DefaultOpen: Story = () => (
+export const DefaultOpen: StoryFn = () => (
     <Grid columnCount={1}>
         <div>
             <Tooltip content="Click me!" defaultOpen={true}>
@@ -102,7 +102,7 @@ DefaultOpen.parameters = {
     },
 }
 
-export const DisabledTrigger: Story = () => (
+export const DisabledTrigger: StoryFn = () => (
     <Grid columnCount={1}>
         <div>
             <Tooltip content="Tooltip still works properly" placement="right">
@@ -125,7 +125,7 @@ export const DisabledTrigger: Story = () => (
     </Grid>
 )
 
-export const LongContent: Story = () => (
+export const LongContent: StoryFn = () => (
     <Grid columnCount={1}>
         <div>
             <Tooltip
@@ -142,7 +142,7 @@ export const LongContent: Story = () => (
     </Grid>
 )
 
-export const PlacementOptions: Story = () => (
+export const PlacementOptions: StoryFn = () => (
     <>
         <Grid columnCount={5}>
             <div>
@@ -183,7 +183,7 @@ export const PlacementOptions: Story = () => (
     </>
 )
 
-export const UpdateContent: Story = () => {
+export const UpdateContent: StoryFn = () => {
     const [clicked, setClicked] = useState<boolean>(false)
 
     function onClick() {

--- a/client/wildcard/src/components/Tree/Tree.story.tsx
+++ b/client/wildcard/src/components/Tree/Tree.story.tsx
@@ -1,5 +1,5 @@
 import { mdiFileDocumentOutline, mdiFolderOpenOutline, mdiFolderOutline } from '@mdi/js'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import classNames from 'classnames'
 
 import { BrandedStory } from '../../stories/BrandedStory'
@@ -10,7 +10,7 @@ import { Tree, type TreeNode } from '.'
 
 import styles from './Tree.story.module.scss'
 
-const decorator: DecoratorFn = story => <BrandedStory>{() => <div className="p-5">{story()}</div>}</BrandedStory>
+const decorator: Decorator = story => <BrandedStory>{() => <div className="p-5">{story()}</div>}</BrandedStory>
 
 const config: Meta = {
     title: 'wildcard/Tree',
@@ -43,7 +43,7 @@ const folder = [
     { id: 11, name: 'webpack.config.js', children: [], parent: 0 },
 ] satisfies TreeNode[]
 
-export const Basic: Story = () => (
+export const Basic: StoryFn = () => (
     <Tree
         data={folder}
         defaultExpandedIds={[0, 1, 4, 5, 7]}

--- a/client/wildcard/src/components/Typography/Typography.story.tsx
+++ b/client/wildcard/src/components/Typography/Typography.story.tsx
@@ -1,4 +1,4 @@
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { BrandedStory } from '../../stories'
 import { Link } from '../Link'
@@ -7,7 +7,7 @@ import { Code, Label, H1, H2, H3, H4, H5, H6, Text } from '.'
 import { TYPOGRAPHY_ALIGNMENTS, TYPOGRAPHY_MODES } from './constants'
 import { Heading } from './Heading'
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="container mt-3">{story()}</div>}</BrandedStory>
 )
 
@@ -258,7 +258,7 @@ Simple.args = {
     alignment: 'left',
 }
 
-export const CrossingStyles: Story = () => (
+export const CrossingStyles: StoryFn = () => (
     <>
         <H1>Crossing Header Styles</H1>
         <Text>
@@ -302,7 +302,7 @@ export const CrossingStyles: Story = () => (
 )
 
 const SEMANTIC_COLORS = ['primary', 'success', 'danger', 'warning', 'info', 'merged'] as const
-export const Prose: Story = () => (
+export const Prose: StoryFn = () => (
     <>
         <H2>Prose</H2>
         <Text>Text uses system fonts. The fonts should never be overridden.</Text>

--- a/client/wildcard/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
+++ b/client/wildcard/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
@@ -3,7 +3,7 @@
 // documentation for that. Its primary purpose is to show what Bootstrap's components look like with our styling
 // customizations.
 import { action } from '@storybook/addon-actions'
-import type { DecoratorFn, Meta, Story } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import '@storybook/addon-designs'
 
@@ -18,7 +18,7 @@ import { preventDefault } from './utils'
 
 registerHighlightContributions()
 
-const decorator: DecoratorFn = story => (
+const decorator: Decorator = story => (
     <BrandedStory>{() => <div className="p-3 container">{story()}</div>}</BrandedStory>
 )
 const config: Meta = {
@@ -33,7 +33,7 @@ const config: Meta = {
 
 export default config
 
-export const CodeTypography: Story = () => (
+export const CodeTypography: StoryFn = () => (
     <>
         <H1>Code</H1>
 
@@ -95,7 +95,7 @@ export const CodeTypography: Story = () => (
     </>
 )
 
-export const Colors: Story = () => (
+export const Colors: StoryFn = () => (
     <>
         <H1>Colors</H1>
 
@@ -113,7 +113,7 @@ Colors.parameters = {
     },
 }
 
-export const Layout: Story = () => (
+export const Layout: StoryFn = () => (
     <>
         <H1>Layout</H1>
 
@@ -208,7 +208,7 @@ export const Layout: Story = () => (
     </>
 )
 
-export const InputGroups: Story = () => (
+export const InputGroups: StoryFn = () => (
     <>
         <H1>Input groups</H1>
 
@@ -234,7 +234,7 @@ export const InputGroups: Story = () => (
 
 InputGroups.storyName = 'Input groups'
 
-export const Forms: Story = () => (
+export const Forms: StoryFn = () => (
     <>
         <H1>Forms</H1>
         <Text>
@@ -341,7 +341,7 @@ Forms.parameters = {
     },
 }
 
-export const ListGroups: Story = () => (
+export const ListGroups: StoryFn = () => (
     <>
         <H1>List groups</H1>
         <Text>


### PR DESCRIPTION
The types `Story` and `DecoratorFn` have been deprecated in storybook v7. This batch change ensures we are using the correct types.

[Storybook Migration guide](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#renamed-decoratorfn-to-decorator)

### Test Plan

Ensured storybooks are loading fine.

[_Created by Sourcegraph batch change `bolaji.olajide/update-storybook-type`._](https://sourcegraph.sourcegraph.com/users/bolaji.olajide/batch-changes/update-storybook-type)