### PR TITLE
Require approval to run Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,31 +4,12 @@
   "semanticCommits": "disabled",
   "rebaseWhen": "never",
   "prBodyNotes": ["Test plan: CI should pass with updated dependencies."],
+  "dependencyDashboardApproval": true,
   "packageRules": [
     {
       "matchDepTypes": ["engines"],
       "matchPackageNames": ["node"],
       "rangeStrategy": "bump"
-    },
-    {
-      "packageNames": ["@octokit/rest", "@slack/web-api", "googleapis"],
-      "reviewers": ["beyang"]
-    },
-    {
-      "packagePatterns": ["^@visx/"],
-      "reviewers": ["team:code-insights-frontend"]
-    },
-    {
-      "packageNames": ["react-grid-layout"],
-      "reviewers": ["team:code-insights-frontend"]
-    },
-    {
-      "groupName": "Upstream Alpine 3.12 Docker image",
-      "matchDatasources": ["docker"],
-      "packagePatterns": ["^alpine:3.12"],
-      "fileMatch": ["^Dockerfile$"],
-      "paths": ["docker-images/**"],
-      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
We don't seem to regularly address any of these PRs that are currently open, but Renovate force pushes to the PRs it currently has open. For some of the current branches, we ran what looks like >2500 builds so far. That seems quite wasteful to me.

This makes the workflow explicit: You go to the dashboard, check the checkbox, and get the PR you want to merge in a moment. No more crazy amount of CI jobs generated from pretty much stale PRs.

Also, most of the package specific rules felt outdated so removed them.

Once this is merged, I will close the current stale PRs (can be reopened using the dashboard) and we should ideally see less CI jobs.

## Test plan

Verify that Renovate still works after this PR.