### PR TITLE
codeintel: Fix path-matching query fragment for diagnostics in GraphQL

### DIFF
--- a/internal/codeintel/codenav/internal/lsifstore/metadata_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/metadata_by_position.go
@@ -266,6 +266,6 @@ FROM codeintel_scip_document_lookup sid
 JOIN codeintel_scip_documents sd ON sd.id = sid.document_id
 WHERE
 	sid.upload_id = %s AND
-	sid.document_path = %s
+	sid.document_path LIKE %s
 LIMIT 1
 `

--- a/internal/codeintel/codenav/internal/lsifstore/metadata_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/metadata_by_position_test.go
@@ -64,6 +64,10 @@ func TestDatabaseHover(t *testing.T) {
 }
 
 func TestGetDiagnostics(t *testing.T) {
-	// NOTE: No SCIP indexer currently emit diagnostics
+	// FIXME(issue: https://github.com/sourcegraph/sourcegraph/issues/57621)
+	// We should add a test case here, but that requires creating a SCIP index
+	// with a diagnostic field, and uploading that to the database, whereas
+	// the current testing infrastructure doesn't support that,
+	// and adding a non-reproducibly generated SQL file for testing is not a good idea.
 	t.Skip()
 }


### PR DESCRIPTION
Fixes #56904 

We should use `LIKE` instead of `=` because the query fragment passed in
has the form `path + "%"` for [pattern matching](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE).

That said, it seems a bit weird that the path used here is used as a pattern, not as a literal path. When requesting other subfields like hovers, the path is treated literally. 😕 Keeping that as-is for backwards compatibility, and since nobody around has strong opinions on this.

## Test plan

Manually tested this against a fake index generated from scip-go modified
to emit diagnostics. I don't think it's a good idea to create more tech debt
by adding a large SQL file with a bunch of binary strings without clear
reproduction steps, which is what one of the other tests does for hovers.

<img width="908" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/93103176/373bf44d-b4c6-4706-90ba-d37e3847a051">
