### PR TITLE
Add p4 binary back to repo-updater image

### DIFF
--- a/cmd/repo-updater/image_test.yaml
+++ b/cmd/repo-updater/image_test.yaml
@@ -9,10 +9,10 @@ commandTests:
   - name: "coursier is runnable"
     command: "coursier"
   # TODO: This test can be removed after the 5.3 release
-  - name: "p4 is runnable"
-    command: "p4"
-    args:
-      - -h
+  # - name: "p4 is runnable"
+  #   command: "p4"
+  #   args:
+  #     - -h
 
   - name: "not running as root"
     command: "/usr/bin/id"

--- a/cmd/repo-updater/image_test.yaml
+++ b/cmd/repo-updater/image_test.yaml
@@ -8,7 +8,7 @@ commandTests:
         value: "true"
   - name: "coursier is runnable"
     command: "coursier"
-  # TODO: Remove after 5.3 release
+  # TODO: This test can be removed after the 5.3 release
   - name: "p4 is runnable"
     command: "p4"
     args:

--- a/cmd/repo-updater/image_test.yaml
+++ b/cmd/repo-updater/image_test.yaml
@@ -8,6 +8,11 @@ commandTests:
         value: "true"
   - name: "coursier is runnable"
     command: "coursier"
+  # TODO: Remove after 5.3 release
+  - name: "p4 is runnable"
+    command: "p4"
+    args:
+      - -h
 
   - name: "not running as root"
     command: "/usr/bin/id"

--- a/wolfi-images/repo-updater.yaml
+++ b/wolfi-images/repo-updater.yaml
@@ -8,6 +8,6 @@ contents:
 
     ## repo-updater packages
     - coursier@sourcegraph
-    - p4cli@sourcegraph # TODO: Remove after 5.3 release
+    - p4cli@sourcegraph # TODO: This package can be removed after the 5.3 release
 
 # MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023

--- a/wolfi-images/repo-updater.yaml
+++ b/wolfi-images/repo-updater.yaml
@@ -8,5 +8,6 @@ contents:
 
     ## repo-updater packages
     - coursier@sourcegraph
+    - p4cli@sourcegraph # TODO: Remove after 5.3 release
 
 # MANUAL REBUILD: Wed Oct 11 09:59:22 BST 2023


### PR DESCRIPTION
Reverts #57120

Update: ah, this needs to be a two-step process, one to revert the image and the next to add the test.

After https://github.com/sourcegraph/sourcegraph/pull/57119 we no longer require the `p4cli` package on `main`. However, we use images built from `main` on the 5.2 release branch rather than building a separate set of images, and the 5.2 branch requires this package to be present.

So far building-from-main has been a simple solution that hasn't caused problems, but does mean that changes which are backwards-incompatible with the release branch break things.

My preferred solution would be to [investigate rules_apko](https://github.com/sourcegraph/security/issues/998) as this will simplify the build process and should solve this problem.
A quicker, but conceptually more complex solution would be to build a separate set of images for 5.2.

## Test plan

- New CI tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
