### PR TITLE
search: use Zoekt parser in frontend

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -295,6 +295,7 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 
 	return &search.Features{
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
+		Keyword:                 flagSet.GetBoolOr("search-new-keyword", false),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),
 	}
 }

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1470,7 +1470,7 @@ func RunRepoSubsetTextSearch(
 		}
 
 		typ := search.TextRequest
-		zoektQuery, err := zoektutil.QueryToZoektQuery(b, resultTypes, nil, typ)
+		zoektQuery, err := zoektutil.QueryToZoektQuery(b, resultTypes, &search.Features{}, typ)
 		if err != nil {
 			return nil, streaming.Stats{}, err
 		}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -416,6 +416,10 @@ type Features struct {
 	// currently just supported by Zoekt.
 	ContentBasedLangFilters bool `json:"search-content-based-lang-detection"`
 
+	// Keyword when true will use a new way to interpret queries optimized for
+	// keyword search. This is currently just supported by Zoekt.
+	Keyword bool `json:"search-new-keyword"`
+
 	// Debug when true will set the Debug field on FileMatches. This may grow
 	// from here. For now we treat this like a feature flag for convenience.
 	Debug bool `json:"debug"`

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -18,15 +18,28 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 	isCaseSensitive := b.IsCaseSensitive()
 
 	if b.Pattern != nil {
-		q, err = toZoektPattern(
-			b.Pattern,
-			isCaseSensitive,
-			resultTypes.Has(result.TypeFile),
-			resultTypes.Has(result.TypePath),
-			typ,
-		)
-		if err != nil {
-			return nil, err
+		if feat.Keyword {
+			q, err = toZoektPatternNew(
+				b.Pattern,
+				isCaseSensitive,
+				resultTypes.Has(result.TypeFile),
+				resultTypes.Has(result.TypePath),
+				typ,
+			)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			q, err = toZoektPattern(
+				b.Pattern,
+				isCaseSensitive,
+				resultTypes.Has(result.TypeFile),
+				resultTypes.Has(result.TypePath),
+				typ,
+			)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -111,6 +124,53 @@ func QueryForFileContentArgs(opt query.RepoHasFileContentArgs, caseSensitive boo
 	}
 	q = zoekt.Simplify(q)
 	return q
+}
+
+func toZoektPatternNew(expression query.Node, isCaseSensitive, patternMatchesContent, patternMatchesPath bool, typ search.IndexedRequestType) (zoekt.Q, error) {
+	q, err := zoekt.Parse(query.StringHuman([]query.Node{expression}))
+	if err != nil {
+		return nil, err
+	}
+	fileNameOnly := patternMatchesPath && !patternMatchesContent
+	contentOnly := !patternMatchesPath && patternMatchesContent
+
+	// Enforce fileNameOnly and contentOnly
+	q = zoekt.Map(q, func(r zoekt.Q) zoekt.Q {
+		if s, ok := r.(*zoekt.Regexp); ok {
+			s.CaseSensitive = isCaseSensitive
+			s.Content = contentOnly
+			s.FileName = fileNameOnly
+		}
+		if s, ok := r.(*zoekt.Substring); ok {
+			s.CaseSensitive = isCaseSensitive
+			s.Content = contentOnly
+			s.FileName = fileNameOnly
+		}
+		return r
+	})
+
+	// Need to expand the content atoms before applying zoekt.Symbol. This is
+	// so we keep the non-symbol logic of matching filename or symbol.
+	q = zoekt.Map(q, zoekt.ExpandFileContent)
+
+	// If type symbol wrap all content atoms with zoekt.Symbol.
+	if typ == search.SymbolRequest {
+		q = zoekt.Map(q, func(q zoekt.Q) zoekt.Q {
+			switch s := q.(type) {
+			case *zoekt.Substring:
+				if s.Content {
+					return &zoekt.Symbol{Expr: s}
+				}
+			case *zoekt.Regexp:
+				if s.Content {
+					return &zoekt.Symbol{Expr: s}
+				}
+			}
+			return q
+		})
+	}
+
+	return zoekt.Simplify(q), nil
 }
 
 func toZoektPattern(


### PR DESCRIPTION
This change is behind a feature flag.

We use Zoekt's query parser when we send a query to Zoekt, bypassing Sourcegraph's current logic for interpreting patterns. Filters should keep working as expected. The most notable difference is probably that Zoekt interprets "foo bar" with an implicit "AND" while Sourcegraph concatenates the two terms.

The intend is to experiment with different
ways of parsing the user query.

Test plan:
CI

