### PR TITLE
cody-gateway: fix embeddings rate-limiting to be consumption-based

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
@@ -164,7 +164,18 @@ func NewHandler(
 				resolvedStatusCode = 200
 			}
 			_, _ = w.Write(data)
-		}))
+		}),
+		func(responseHeaders http.Header) (int, error) {
+			uh := responseHeaders.Get(usageHeaderName)
+			if uh == "" {
+				return 0, errors.New("no usage header set on response")
+			}
+			usage, err := strconv.Atoi(uh)
+			if err != nil {
+				return 0, errors.Wrap(err, "failed to parse usage header as number")
+			}
+			return usage, nil
+		})
 }
 
 func isAllowedModel(allowedModels []string, model string) bool {

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -33,7 +33,8 @@ func GetFeature(ctx context.Context) codygateway.Feature {
 }
 
 // Handle extracts features from codygateway.FeatureHeaderName and uses it to
-// determine the appropriate per-feature rate limits applied for an actor.
+// determine the appropriate per-feature rate limits applied for an actor. It
+// only limits per-request.
 func Handle(
 	baseLogger log.Logger,
 	eventLogger events.Logger,
@@ -48,7 +49,7 @@ func Handle(
 			return
 		}
 
-		HandleFeature(baseLogger, eventLogger, cache, rateLimitNotifier, feature, next).
+		HandleFeature(baseLogger, eventLogger, cache, rateLimitNotifier, feature, next, nil).
 			ServeHTTP(w, r)
 	})
 }
@@ -75,6 +76,10 @@ func HandleFeature(
 	rateLimitNotifier notify.RateLimitNotifier,
 	feature codygateway.Feature,
 	next http.Handler,
+
+	// extractUsage is optional - if a callback isn't provided, a consumption
+	// of 1 is always used. Usage is only evaluated on successful requests.
+	extractUsage func(responseHeaders http.Header) (int, error),
 ) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		act := actor.FromContext(r.Context())
@@ -136,7 +141,14 @@ func HandleFeature(
 
 		// If response is healthy, consume the rate limit
 		if responseRecorder.StatusCode >= 200 && responseRecorder.StatusCode < 300 {
-			if err := commit(r.Context(), 1); err != nil {
+			var usage = 1 // default to 1 for per-request limiting
+			if extractUsage != nil {
+				usage, err = extractUsage(w.Header())
+				if err != nil {
+					logger.Error("failed to extract usage", log.Error(err))
+				}
+			}
+			if err := commit(r.Context(), usage); err != nil {
 				logger.Error("failed to commit rate limit consumption", log.Error(err))
 			}
 		}


### PR DESCRIPTION
This fixes a regression from https://github.com/sourcegraph/sourcegraph/pull/53346, where the original consumption calculation for embeddings usage was as follows:

```go
		// If response is healthy, consume the rate limit
		if responseRecorder.StatusCode >= 200 && responseRecorder.StatusCode < 300 {
			uh := w.Header().Get(usageHeaderName)
			if uh == "" {
				logger.Error("no usage header set on response")
			}
			usage, err := strconv.Atoi(uh)
			if err != nil {
				logger.Error("failed to parse usage header as number", log.Error(err))
			}
			if err := commit(usage); err != nil {
				logger.Error("failed to commit rate limit consumption", log.Error(err))
			}
		}
```

The equivalent of the above is now implemented in a callback provided to the `HandleFeature` constructor which handles usage-based-rate-limiting.

## Test plan

The `usedTokens` variable, which is used to populate the usage header `usageHeaderName`, is also used for event logging, where the value is correctly set, so this should all work as-is.