### PR TITLE
Add Neovim extension link to main Cody overview page

### DIFF
--- a/doc/cody/overview/index.md
+++ b/doc/cody/overview/index.md
@@ -129,7 +129,7 @@ To start using Cody, pick one of the following:
   </li>
   <li>
     <a class="card text-left" target="_blank" href="https://plugins.jetbrains.com/plugin/9682-cody-ai-by-sourcegraph">
-      <h3><img alt="JetBrains" src="https://storage.googleapis.com/sourcegraph-assets/docs/images/cody/jb_beam.svg" />JetBrains Extension (experimental)</h3>
+      <h3><img alt="JetBrains" src="https://storage.googleapis.com/sourcegraph-assets/docs/images/cody/jb_beam.svg" />JetBrains Extension (beta)</h3>
       <p>Install Cody's free and open source extension for JetBrains.</p>
     </a>
   </li>

--- a/doc/cody/overview/index.md
+++ b/doc/cody/overview/index.md
@@ -133,6 +133,12 @@ To start using Cody, pick one of the following:
       <p>Install Cody's free and open source extension for JetBrains.</p>
     </a>
   </li>
+    <li>
+    <a class="card text-left" target="_blank" href="https://github.com/sourcegraph/sg.nvim">
+      <h3><img alt="Neovim" src="https://storage.googleapis.com/sourcegraph-assets/Docs/neovim-logo.png" />Neovim Extension (experimental)</h3>
+      <p>Install Cody's free and open source extension for Neovim.</p>
+    </a>
+  </li>
   <li>
      <a class="card text-left" target="_blank" href="https://sourcegraph.com/get-cody">
       <h3><img alt="Cody App" src="https://storage.googleapis.com/sourcegraph-assets/docs/images/cody/cody-logomark-default.svg"/>Cody App</h3>


### PR DESCRIPTION
Add the Neovim extension link to the main Cody overview page. 

![CleanShot 2023-10-16 at 12 57 34@2x](https://github.com/sourcegraph/sourcegraph/assets/12712988/20afe5ce-2828-4f6f-b830-77baece86046)


## Test plan

Docs Added

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@add-neovim)