### PR TITLE
use time-safe comparison for gitlab webhook secret

### DIFF
--- a/cmd/frontend/webhooks/gitlab_webhooks.go
+++ b/cmd/frontend/webhooks/gitlab_webhooks.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -62,7 +63,7 @@ func (wr *Router) HandleGitLabWebhook(ctx context.Context, logger log.Logger, w 
 
 func gitlabValidatePayload(r *http.Request, secret string) ([]byte, error) {
 	glSecret := r.Header.Get("X-Gitlab-Token")
-	if glSecret != secret {
+	if subtle.ConstantTimeCompare([]byte(glSecret), []byte(secret)) == 1 {
 		return nil, errors.New("secrets don't match!")
 	}
 

--- a/cmd/frontend/webhooks/gitlab_webhooks.go
+++ b/cmd/frontend/webhooks/gitlab_webhooks.go
@@ -63,7 +63,7 @@ func (wr *Router) HandleGitLabWebhook(ctx context.Context, logger log.Logger, w 
 
 func gitlabValidatePayload(r *http.Request, secret string) ([]byte, error) {
 	glSecret := r.Header.Get("X-Gitlab-Token")
-	if subtle.ConstantTimeCompare([]byte(glSecret), []byte(secret)) == 1 {
+	if subtle.ConstantTimeCompare([]byte(glSecret), []byte(secret)) != 1 {
 		return nil, errors.New("secrets don't match!")
 	}
 


### PR DESCRIPTION
This PR resolves an issue where a timing attack would be possible to retrieve webhook secrets. 
By using a constant-time comparison, regardless of whether the client-provided secret (in the form of a request header `X-Gitlab-Token` is correct or not, the comparison takes the same amount of time.

## Test plan

* Confirm webhooks work as normal.
* CI tests
