### PR TITLE
[fix] User email deletion when sub-repo permissions are enabled

### DIFF
--- a/cmd/frontend/backend/user_emails.go
+++ b/cmd/frontend/backend/user_emails.go
@@ -436,11 +436,9 @@ func deleteStalePerforceExternalAccounts(ctx context.Context, db database.DB, us
 		return errors.Wrap(err, "deleting stale external account")
 	}
 
-	// Since we deleted an external account for the user we can no longer trust user
-	// based permissions, so we clear them out.
-	// This also removes the user's sub-repo permissions.
-	if err := db.Authz().RevokeUserPermissions(ctx, &database.RevokeUserPermissionsArgs{UserID: userID}); err != nil {
-		return errors.Wrapf(err, "revoking user permissions for user with ID %d", userID)
+	// Delete all sub-repo permissions for the user.
+	if err := db.SubRepoPerms().DeleteByUser(ctx, userID); err != nil {
+		return errors.Wrap(err, "deleting sub-repo permissions")
 	}
 
 	return nil

--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -256,6 +256,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 			db.UserEmailsFunc.SetDefaultReturn(userEmails)
 			db.AuthzFunc.SetDefaultReturn(authz)
 			db.UserExternalAccountsFunc.SetDefaultReturn(userExternalAccounts)
+			db.SubRepoPermsFunc.SetDefaultReturn(dbmocks.NewMockSubRepoPermsStore())
 
 			RunTests(t, test.gqlTests(db))
 

--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -110,6 +110,7 @@ func TestSetUserEmailVerified(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 		userEmails := dbmocks.NewMockUserEmailsStore()
 		db.UserEmailsFunc.SetDefaultReturn(userEmails)
+		db.SubRepoPermsFunc.SetDefaultReturn(dbmocks.NewMockSubRepoPermsStore())
 
 		tests := []struct {
 			name    string

--- a/internal/database/authz.go
+++ b/internal/database/authz.go
@@ -76,12 +76,15 @@ type noopAuthzStore struct{}
 func (*noopAuthzStore) GrantPendingPermissions(_ context.Context, _ *GrantPendingPermissionsArgs) error {
 	return nil
 }
+
 func (*noopAuthzStore) AuthorizedRepos(_ context.Context, _ *AuthorizedReposArgs) ([]*types.Repo, error) {
 	return []*types.Repo{}, nil
 }
+
 func (*noopAuthzStore) RevokeUserPermissions(_ context.Context, _ *RevokeUserPermissionsArgs) error {
 	return nil
 }
+
 func (*noopAuthzStore) RevokeUserPermissionsList(_ context.Context, _ []*RevokeUserPermissionsArgs) error {
 	return nil
 }


### PR DESCRIPTION
Closes #57582 

Fixes an issue where a user's email address could not be deleted while sub-repo permissions are enabled.

## Test plan

Same unit test still asserts that the account was deleted.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
