### PR TITLE
Add tests to cover GitTree resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -224,8 +224,7 @@ func (r *GitCommitResolver) ExternalURLs(ctx context.Context) ([]*externallink.R
 }
 
 func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
-	Path      string
-	Recursive bool
+	Path string
 }) (*GitTreeEntryResolver, error) {
 	treeEntry, err := r.path(ctx, args.Path, func(stat fs.FileInfo) error {
 		if !stat.Mode().IsDir() {
@@ -238,10 +237,6 @@ func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	// Note: args.Recursive is deprecated
-	if treeEntry != nil {
-		treeEntry.isRecursive = args.Recursive
-	}
 	return treeEntry, nil
 }
 

--- a/cmd/frontend/graphqlbackend/git_ref.go
+++ b/cmd/frontend/graphqlbackend/git_ref.go
@@ -106,21 +106,20 @@ func unmarshalGitRefID(id graphql.ID) (repoID graphql.ID, rev string, err error)
 	return spec.Repository, spec.Rev, err
 }
 
+type GitTarget interface {
+	OID(context.Context) (GitObjectID, error)
+	AbbreviatedOID(context.Context) (string, error)
+	Commit(context.Context) (*GitCommitResolver, error)
+	Type(context.Context) (GitObjectType, error)
+}
+
 func (r *GitRefResolver) ID() graphql.ID      { return marshalGitRefID(r.repo.ID(), r.name) }
 func (r *GitRefResolver) Name() string        { return r.name }
 func (r *GitRefResolver) AbbrevName() string  { return strings.TrimPrefix(r.name, gitRefPrefix(r.name)) }
 func (r *GitRefResolver) DisplayName() string { return gitRefDisplayName(r.name) }
 func (r *GitRefResolver) Prefix() string      { return gitRefPrefix(r.name) }
 func (r *GitRefResolver) Type() string        { return gitRefType(r.name) }
-func (r *GitRefResolver) Target() interface {
-	OID(context.Context) (GitObjectID, error)
-	//lint:ignore U1000 is used by graphql via reflection
-	AbbreviatedOID(context.Context) (string, error)
-	//lint:ignore U1000 is used by graphql via reflection
-	Commit(context.Context) (*GitCommitResolver, error)
-	//lint:ignore U1000 is used by graphql via reflection
-	Type(context.Context) (GitObjectType, error)
-} {
+func (r *GitRefResolver) Target() GitTarget {
 	if r.target != "" {
 		return &gitObject{repo: r.repo, oid: r.target, typ: GitObjectTypeCommit}
 	}

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"io/fs"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func (r *GitTreeEntryResolver) IsRoot() bool {
@@ -22,6 +24,7 @@ type gitTreeEntryConnectionArgs struct {
 	Recursive bool
 	// If recurseSingleChild is true, we will return a flat list of every
 	// directory and file in a single-child nest.
+	// Only respected when Recursive is false.
 	RecursiveSingleChild bool
 	// If Ancestors is true and the tree is loaded from a subdirectory, we will
 	// return a flat list of all entries in all parent directories.
@@ -44,7 +47,19 @@ func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 	tr, ctx := trace.New(ctx, "GitTreeEntryResolver.entries")
 	defer tr.EndWithErr(&err)
 
-	entries, err := r.gitserverClient.ReadDir(ctx, r.commit.repoResolver.RepoName(), api.CommitID(r.commit.OID()), r.Path(), r.isRecursive || args.Recursive)
+	if args.First != nil && *args.First < 0 {
+		return nil, errors.Newf("invalid argument for first, must be non-negative")
+	}
+
+	if args.Recursive && args.RecursiveSingleChild {
+		// No extra work needed, recursive includes all these.
+		args.RecursiveSingleChild = false
+	}
+
+	// If RecursiveSingleChild is true, we also get all files recursively. Otherwise, we would
+	// have to do a readdir for every single directory to see if it has only one child (and nested)
+	// dirs, too.
+	entries, err := r.gitserverClient.ReadDir(ctx, r.commit.repoResolver.RepoName(), api.CommitID(r.commit.OID()), r.Path(), args.Recursive || args.RecursiveSingleChild)
 	if err != nil {
 		if strings.Contains(err.Error(), "file does not exist") { // TODO proper error value
 			// empty tree is not an error
@@ -53,57 +68,88 @@ func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryCo
 		}
 	}
 
-	sort.Sort(byDirectory(entries))
-
-	if args.First != nil && len(entries) > int(*args.First) {
-		entries = entries[:int(*args.First)]
+	// If RecursiveSingleChild is true, we need to filter out non-single-childs
+	// again.
+	filteredEntries := entries
+	if args.RecursiveSingleChild {
+		// Reset filteredEntries.
+		filteredEntries = filteredEntries[:0]
+		// Convert the entries into a tree fs.
+		fs := entriesToFsTree(r.stat, entries)
+		// Keep all files in the current directory.
+		for _, entry := range entries {
+			if normalizePath(filepath.Dir(normalizePath(entry.Name()))) == normalizePath(r.Path()) {
+				filteredEntries = append(filteredEntries, entry)
+			}
+		}
+		// And now traverse all the children and check if there's at most 1 item
+		// in it.
+		var traverseFs func(*fsNode, int)
+		traverseFs = func(fs *fsNode, l int) {
+			if fs.IsDir() && len(fs.children) == 1 {
+				if l != 0 {
+					filteredEntries = append(filteredEntries, fs.node)
+				}
+				traverseFs(fs.children[0], l+1)
+				return
+			} else {
+				if !fs.IsDir() {
+					if l != 0 {
+						filteredEntries = append(filteredEntries, fs.node)
+					}
+				}
+			}
+		}
+		for _, c := range fs.children {
+			traverseFs(c, 0)
+		}
 	}
 
-	l := make([]*GitTreeEntryResolver, 0, len(entries))
-	for _, entry := range entries {
-		// Apply any additional filtering
+	maxResolvers := len(filteredEntries)
+	if args.First != nil && int(*args.First) < maxResolvers {
+		maxResolvers = int(*args.First)
+	}
 
+	sort.Sort(byDirectory(filteredEntries))
+
+	resolvers := make([]*GitTreeEntryResolver, 0, maxResolvers)
+	seen := 0
+	for _, entry := range filteredEntries {
+		if seen == maxResolvers {
+			break
+		}
+
+		// Apply any additional filtering
 		if filter == nil || filter(entry) {
+			seen++
 			opts := GitTreeEntryResolverOpts{
 				Commit: r.Commit(),
 				Stat:   entry,
 			}
-			l = append(l, NewGitTreeEntryResolver(r.db, r.gitserverClient, opts))
+			resolvers = append(resolvers, NewGitTreeEntryResolver(r.db, r.gitserverClient, opts))
 		}
-	}
-
-	// Update endLine filtering
-	hasSingleChild := len(l) == 1
-	for i := range l {
-		l[i].isSingleChild = &hasSingleChild
-	}
-
-	if !args.Recursive && args.RecursiveSingleChild && len(l) == 1 {
-		subEntries, err := l[0].entries(ctx, args, filter)
-		if err != nil {
-			return nil, err
-		}
-		l = append(l, subEntries...)
 	}
 
 	if args.Ancestors && !r.IsRoot() {
-		var parent *GitTreeEntryResolver
-		parent, err = r.parent(ctx)
+		p := r.Path()
+		p = strings.Trim(p, "/")
+		parent := NewGitTreeEntryResolver(r.db, r.gitserverClient, GitTreeEntryResolverOpts{
+			Commit: r.commit,
+			Stat:   CreateFileInfo(filepath.Dir(p), true),
+		})
+		parentEntries, err := parent.entries(ctx, &gitTreeEntryConnectionArgs{
+			Ancestors: true,
+		}, nil)
 		if err != nil {
 			return nil, err
 		}
-		if parent != nil {
-			parentEntries, err := parent.Entries(ctx, args)
-			if err != nil {
-				return nil, err
-			}
-			l = append(parentEntries, l...)
-		}
+		resolvers = append(parentEntries, resolvers...)
 	}
 
-	return l, nil
+	return resolvers, nil
 }
 
+// byDirectory implements sort.Sortable and orders directories before files.
 type byDirectory []fs.FileInfo
 
 func (s byDirectory) Len() int {
@@ -124,4 +170,53 @@ func (s byDirectory) Less(i, j int) bool {
 	}
 
 	return s[i].Name() < s[j].Name()
+}
+
+type fsNode struct {
+	name     string
+	node     fs.FileInfo
+	children []*fsNode
+}
+
+func (n *fsNode) IsDir() bool {
+	return n.node.IsDir()
+}
+
+// entriesToFsTree takes a slice of fs.FileInfo entries and converts them into a
+// tree structure like a file system. This makes it easy to traverse the tree
+// for what would otherwise be a simple slice of strings basically.
+func entriesToFsTree(root fs.FileInfo, entries []fs.FileInfo) *fsNode {
+	// Make sure we order by length, this means that dirs are always inserted before files.
+	sort.Slice(entries, func(i, j int) bool {
+		return len(entries[i].Name()) < len(entries[j].Name())
+	})
+	normRoot := normalizePath(root.Name())
+	tree := &fsNode{name: normRoot, node: root}
+	for _, entry := range entries {
+		path := normalizePath(entry.Name())
+		path = strings.TrimPrefix(path, normRoot)
+		segments := strings.Split(path, "/")
+		curTree := tree
+		for i, s := range segments {
+			if i == len(segments)-1 {
+				node := &fsNode{name: s, node: entry}
+				curTree.children = append(curTree.children, node)
+			} else {
+				for _, c := range curTree.children {
+					if c.name == s {
+						curTree = c
+						break
+					}
+				}
+			}
+		}
+	}
+	return tree
+}
+
+func normalizePath(path string) string {
+	if path == "." || path == "/" {
+		path = ""
+	}
+	return strings.Trim(path, "/")
 }

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -1,6 +1,7 @@
 package graphqlbackend
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io/fs"
@@ -44,9 +45,7 @@ type GitTreeEntryResolver struct {
 	contentErr       error
 	// stat is this tree entry's file info. Its Name method must return the full path relative to
 	// the root, not the basename.
-	stat          fs.FileInfo
-	isRecursive   bool  // whether entries is populated recursively (otherwise just current level of hierarchy)
-	isSingleChild *bool // whether this is the single entry in its parent. Only set by the (&GitTreeEntryResolver) entries.
+	stat fs.FileInfo
 }
 
 type GitTreeEntryResolverOpts struct {
@@ -86,12 +85,13 @@ func (r *GitTreeEntryResolver) TotalLines(ctx context.Context) (int32, error) {
 		return 0, err
 	}
 
-	// We only care about the full content length here, so we just need content to be set.
-	content, err := r.Content(ctx, &GitTreeContentPageArgs{})
+	// Call content so that r.fullContentBytes is populated.
+	_, err = r.Content(ctx, &GitTreeContentPageArgs{})
 	if err != nil {
 		return 0, err
 	}
-	return int32(len(strings.Split(content, "\n"))), nil
+
+	return int32(lineCount(r.fullContentBytes)), nil
 }
 
 func (r *GitTreeEntryResolver) ByteSize(ctx context.Context) (int32, error) {
@@ -100,6 +100,7 @@ func (r *GitTreeEntryResolver) ByteSize(ctx context.Context) (int32, error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return int32(len(r.fullContentBytes)), nil
 }
 
@@ -113,40 +114,96 @@ func (r *GitTreeEntryResolver) Content(ctx context.Context, args *GitTreeContent
 		)
 	})
 
-	return pageContent(strings.Split(string(r.fullContentBytes), "\n"), args.StartLine, args.EndLine), r.contentErr
+	return string(pageContent(r.fullContentBytes, int32ToIntPtr(args.StartLine), int32ToIntPtr(args.EndLine))), r.contentErr
 }
 
-func pageContent(content []string, startLine, endLine *int32) string {
-	totalContentLength := len(content)
-	startCursor := 0
-	endCursor := totalContentLength
-
-	// Any nil or illegal value for startLine or endLine gets set to either the start or
-	// end of the file respectively.
-
-	// If startLine is set and is a legit value, set the cursor to point to it.
-	if startLine != nil && *startLine > 0 {
-		// The left index is inclusive, so we have to shift it back by 1
-		startCursor = int(*startLine) - 1
+func int32ToIntPtr(p *int32) *int {
+	if p == nil {
+		return nil
 	}
-	if startCursor >= totalContentLength {
-		startCursor = totalContentLength
-	}
+	val := int(*p)
+	return &val
+}
 
-	// If endLine is set and is a legit value, set the cursor to point to it.
-	if endLine != nil && *endLine >= 0 {
-		endCursor = int(*endLine)
-	}
-	if endCursor > totalContentLength {
-		endCursor = totalContentLength
+// pageContent returns a subslice of content for the range of startLine:endLine.
+// If startLine is unset, it is set to 1 (start of file).
+// If endLine is unset, it is set to the end of the file.
+// endLine must not be before startLine, otherwise the whole content is returned.
+// startLine and endLine are 1-indexed!
+func pageContent(content []byte, startLine, endLine *int) []byte {
+	// Trivial case: No pagination.
+	if startLine == nil && endLine == nil {
+		return content
 	}
 
-	// Final failsafe in case someone is really messing around with this API.
+	totalLineCount := lineCount(content)
+
+	var (
+		startCursor int
+		endCursor   int = totalLineCount
+	)
+
+	if startLine != nil {
+		if *startLine < 1 {
+			startCursor = 0
+		} else if *startLine > totalLineCount {
+			startCursor = totalLineCount
+		} else {
+			startCursor = *startLine - 1
+		}
+	}
+
+	if endLine != nil {
+		if *endLine > 0 {
+			endCursor = *endLine
+		}
+	}
+
 	if endCursor < startCursor {
-		return strings.Join(content[0:totalContentLength], "\n")
+		return content
 	}
 
-	return strings.Join(content[startCursor:endCursor], "\n")
+	start := nthIndex(content, '\n', startCursor)
+	if start == -1 {
+		start = 0
+	}
+	end := nthIndex(content, '\n', endCursor)
+	if end == -1 {
+		end = len(content)
+	}
+	if end < start {
+		return content
+	}
+
+	return content[start:end]
+}
+
+func lineCount(in []byte) int {
+	c := bytes.Count(in, []byte("\n"))
+	// Final newline doesn't mark a new line.
+	if in[len(in)-1] != '\n' {
+		return c + 1
+	}
+	return c
+}
+
+func nthIndex(in []byte, sep byte, n int) (idx int) {
+	if n < 0 {
+		return -1
+	}
+	if len(in) < 1 {
+		return -1
+	}
+
+	start := 0
+	for i := 0; i < n; i++ {
+		idx := bytes.IndexByte(in[start:], sep)
+		if idx == -1 {
+			return idx
+		}
+		start = start + idx + 1
+	}
+	return start
 }
 
 func (r *GitTreeEntryResolver) RichHTML(ctx context.Context, args *GitTreeContentPageArgs) (string, error) {
@@ -154,6 +211,7 @@ func (r *GitTreeEntryResolver) RichHTML(ctx context.Context, args *GitTreeConten
 	if err != nil {
 		return "", err
 	}
+
 	return richHTML(content, path.Ext(r.Path()))
 }
 
@@ -163,6 +221,7 @@ func (r *GitTreeEntryResolver) Binary(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+
 	return binary.IsBinary(r.fullContentBytes), nil
 }
 
@@ -188,30 +247,28 @@ func (r *GitTreeEntryResolver) Commit() *GitCommitResolver { return r.commit }
 
 func (r *GitTreeEntryResolver) Repository() *RepositoryResolver { return r.commit.repoResolver }
 
-func (r *GitTreeEntryResolver) IsRecursive() bool { return r.isRecursive }
-
 func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 	return r.url(ctx).String(), nil
 }
 
 func (r *GitTreeEntryResolver) url(ctx context.Context) *url.URL {
-	tr, ctx := trace.New(ctx, "GitTreeEntryResolver.url")
-	defer tr.End()
-
-	if submodule := r.Submodule(); submodule != nil {
-		tr.SetAttributes(attribute.Bool("submodule", true))
-		submoduleURL := submodule.URL()
-		if strings.HasPrefix(submoduleURL, "../") {
-			submoduleURL = path.Join(r.Repository().Name(), submoduleURL)
-		}
-		repoName, err := cloneURLToRepoName(ctx, r.db, submoduleURL)
-		if err != nil {
-			log15.Error("Failed to resolve submodule repository name from clone URL", "cloneURL", submodule.URL(), "err", err)
-			return &url.URL{}
-		}
-		return &url.URL{Path: "/" + repoName + "@" + submodule.Commit()}
+	submodule := r.Submodule()
+	if submodule == nil {
+		return r.urlPath(r.commit.repoRevURL())
 	}
-	return r.urlPath(r.commit.repoRevURL())
+
+	tr, ctx := trace.New(ctx, "GitTreeEntryResolver.url", attribute.Bool("submodule", true))
+	defer tr.End()
+	submoduleURL := submodule.URL()
+	if strings.HasPrefix(submoduleURL, "../") {
+		submoduleURL = path.Join(r.Repository().Name(), submoduleURL)
+	}
+	repoName, err := cloneURLToRepoName(ctx, r.db, submoduleURL)
+	if err != nil {
+		log15.Error("Failed to resolve submodule repository name from clone URL", "cloneURL", submodule.URL(), "err", err)
+		return &url.URL{}
+	}
+	return &url.URL{Path: "/" + repoName + "@" + submodule.Commit()}
 }
 
 func (r *GitTreeEntryResolver) CanonicalURL() string {
@@ -309,17 +366,16 @@ func CreateFileInfo(path string, isDir bool) fs.FileInfo {
 	return fileInfo{path: path, isDir: isDir}
 }
 
-func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeEntryConnectionArgs) (bool, error) {
+func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context) (bool, error) {
 	if !r.IsDirectory() {
 		return false, nil
 	}
-	if r.isSingleChild != nil {
-		return *r.isSingleChild, nil
-	}
+
 	entries, err := r.gitserverClient.ReadDir(ctx, r.commit.repoResolver.RepoName(), api.CommitID(r.commit.OID()), path.Dir(r.Path()), false)
 	if err != nil {
 		return false, err
 	}
+
 	return len(entries) == 1, nil
 }
 
@@ -401,7 +457,6 @@ func (r *GitTreeEntryResolver) SymbolInfo(ctx context.Context, args *symbolInfoA
 }
 
 func (r *GitTreeEntryResolver) LFS(ctx context.Context) (*lfsResolver, error) {
-	// We only care about the full content length here, so we just need content to be set.
 	content, err := r.Content(ctx, &GitTreeContentPageArgs{})
 	if err != nil {
 		return nil, err
@@ -428,20 +483,6 @@ func (r *GitTreeEntryResolver) OwnershipStats(ctx context.Context) (OwnershipSta
 		return nil, nil
 	}
 	return EnterpriseResolvers.ownResolver.GitTreeOwnershipStats(ctx, r)
-}
-
-func (r *GitTreeEntryResolver) parent(ctx context.Context) (*GitTreeEntryResolver, error) {
-	if r.IsRoot() {
-		return nil, nil
-	}
-
-	parentPath := path.Dir(r.Path())
-	return r.commit.path(ctx, parentPath, func(stat fs.FileInfo) error {
-		if !stat.Mode().IsDir() {
-			return errors.Errorf("not a directory: %q", parentPath)
-		}
-		return nil
-	})
 }
 
 type symbolInfoArgs struct {

--- a/cmd/frontend/graphqlbackend/git_tree_entry_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry_test.go
@@ -2,15 +2,16 @@ package graphqlbackend
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func TestGitTreeEntry_RawZipArchiveURL(t *testing.T) {
@@ -71,12 +72,6 @@ func TestGitTreeEntry_Content(t *testing.T) {
 
 func TestGitTreeEntry_ContentPagination(t *testing.T) {
 	wantPath := "foobar.md"
-	fullContent := `1
-2
-3
-4
-5
-6`
 
 	db := dbmocks.NewMockDB()
 	gitserverClient := gitserver.NewMockClient()
@@ -85,7 +80,7 @@ func TestGitTreeEntry_ContentPagination(t *testing.T) {
 		if name != wantPath {
 			t.Fatalf("wrong name in ReadFile call. want=%q, have=%q", wantPath, name)
 		}
-		return []byte(fullContent), nil
+		return testContent, nil
 	})
 
 	tests := []struct {
@@ -96,27 +91,27 @@ func TestGitTreeEntry_ContentPagination(t *testing.T) {
 		{
 			startLine:   2,
 			endLine:     6,
-			wantContent: "2\n3\n4\n5\n6",
+			wantContent: "2\n3\n4\n5\n6\n",
 		},
 		{
 			startLine:   0,
 			endLine:     2,
-			wantContent: "1\n2",
+			wantContent: "1\n2\n",
 		},
 		{
 			startLine:   0,
 			endLine:     0,
-			wantContent: "",
+			wantContent: string(testContent),
 		},
 		{
 			startLine:   6,
 			endLine:     6,
-			wantContent: "6",
+			wantContent: "6\n",
 		},
 		{
 			startLine:   -1,
 			endLine:     -1,
-			wantContent: fullContent,
+			wantContent: string(testContent),
 		},
 		{
 			startLine:   7,
@@ -126,11 +121,11 @@ func TestGitTreeEntry_ContentPagination(t *testing.T) {
 		{
 			startLine:   5,
 			endLine:     2,
-			wantContent: fullContent,
+			wantContent: string(testContent),
 		},
 	}
 
-	for _, tc := range tests {
+	for i, tc := range tests {
 		opts := GitTreeEntryResolverOpts{
 			Commit: &GitCommitResolver{
 				repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
@@ -147,7 +142,7 @@ func TestGitTreeEntry_ContentPagination(t *testing.T) {
 			t.Fatal(err)
 		}
 		if diff := cmp.Diff(newFileContent, tc.wantContent); diff != "" {
-			t.Fatalf("wrong newFileContent: %s", diff)
+			t.Fatalf("wrong newFileContent %d: %s", i, diff)
 		}
 
 		newByteSize, err := gitTree.ByteSize(context.Background())
@@ -155,7 +150,7 @@ func TestGitTreeEntry_ContentPagination(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if have, want := newByteSize, int32(len([]byte(fullContent))); have != want {
+		if have, want := newByteSize, int32(len(testContent)); have != want {
 			t.Fatalf("wrong file size, want=%d have=%d", want, have)
 		}
 
@@ -164,7 +159,7 @@ func TestGitTreeEntry_ContentPagination(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if have, want := newTotalLines, int32(len(strings.Split(fullContent, "\n"))); have != want {
+		if have, want := newTotalLines, int32(lineCount(testContent)); have != want {
 			t.Fatalf("wrong file size, want=%d have=%d", want, have)
 		}
 	}
@@ -182,7 +177,7 @@ func TestGitTreeEntry_ContentPagination(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(newFileContent, fullContent); diff != "" {
+	if diff := cmp.Diff(newFileContent, string(testContent)); diff != "" {
 		t.Fatalf("wrong newFileContent: %s", diff)
 	}
 
@@ -191,7 +186,112 @@ func TestGitTreeEntry_ContentPagination(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if have, want := newByteSize, int32(len([]byte(fullContent))); have != want {
+	if have, want := newByteSize, int32(len(testContent)); have != want {
 		t.Fatalf("wrong file size, want=%d have=%d", want, have)
 	}
+}
+
+var testContent = []byte(`1
+2
+3
+4
+5
+6
+`)
+
+var testContentNoNewline = []byte(`1
+2
+3`)
+
+func TestPageContent(t *testing.T) {
+	t.Run("No pagination", func(t *testing.T) {
+		have := pageContent(testContent, nil, nil)
+		assert.Equal(t, string(testContent), string(have))
+		have = pageContent(testContentNoNewline, nil, nil)
+		assert.Equal(t, string(testContentNoNewline), string(have))
+	})
+	t.Run("Single line", func(t *testing.T) {
+		// At beginning.
+		have := pageContent(testContent, pointers.Ptr(1), pointers.Ptr(1))
+		assert.Equal(t, "1\n", string(have))
+		// In the middle.
+		have = pageContent(testContent, pointers.Ptr(3), pointers.Ptr(3))
+		assert.Equal(t, "3\n", string(have))
+		// At the end.
+		have = pageContent(testContent, pointers.Ptr(6), pointers.Ptr(6))
+		assert.Equal(t, "6\n", string(have))
+		// At the end without newline.
+		have = pageContent(testContentNoNewline, pointers.Ptr(3), pointers.Ptr(3))
+		assert.Equal(t, "3", string(have))
+	})
+	t.Run("Multi line", func(t *testing.T) {
+		// At beginning.
+		have := pageContent(testContent, pointers.Ptr(1), pointers.Ptr(2))
+		assert.Equal(t, "1\n2\n", string(have))
+		// In the middle.
+		have = pageContent(testContent, pointers.Ptr(3), pointers.Ptr(4))
+		assert.Equal(t, "3\n4\n", string(have))
+		// At the end.
+		have = pageContent(testContent, pointers.Ptr(5), pointers.Ptr(6))
+		assert.Equal(t, "5\n6\n", string(have))
+		// At the end without newline.
+		have = pageContent(testContentNoNewline, pointers.Ptr(2), pointers.Ptr(3))
+		assert.Equal(t, "2\n3", string(have))
+	})
+	t.Run("No startLine", func(t *testing.T) {
+		// Whole file.
+		have := pageContent(testContent, nil, pointers.Ptr(6))
+		assert.Equal(t, string(testContent), string(have))
+		// Subsection of the file.
+		have = pageContent(testContent, nil, pointers.Ptr(3))
+		assert.Equal(t, "1\n2\n3\n", string(have))
+		// First line only.
+		have = pageContent(testContent, nil, pointers.Ptr(1))
+		assert.Equal(t, "1\n", string(have))
+		// No final newline.
+		have = pageContent(testContentNoNewline, nil, pointers.Ptr(3))
+		assert.Equal(t, "1\n2\n3", string(have))
+		// Invalid input.
+		have = pageContent(testContent, nil, pointers.Ptr(0))
+		assert.Equal(t, string(testContent), string(have))
+		have = pageContent(testContent, nil, pointers.Ptr(10000))
+		assert.Equal(t, string(testContent), string(have))
+		have = pageContent(testContent, nil, pointers.Ptr(-1))
+		assert.Equal(t, string(testContent), string(have))
+	})
+	t.Run("No endLine", func(t *testing.T) {
+		// Whole file.
+		have := pageContent(testContent, pointers.Ptr(1), nil)
+		assert.Equal(t, string(testContent), string(have))
+		// Subsection of the file.
+		have = pageContent(testContent, pointers.Ptr(4), nil)
+		assert.Equal(t, "4\n5\n6\n", string(have))
+		// Last line only.
+		have = pageContent(testContent, pointers.Ptr(6), nil)
+		assert.Equal(t, "6\n", string(have))
+		// No final newline.
+		have = pageContent(testContentNoNewline, pointers.Ptr(1), nil)
+		assert.Equal(t, "1\n2\n3", string(have))
+		// Invalid input.
+		have = pageContent(testContent, pointers.Ptr(0), nil)
+		assert.Equal(t, string(testContent), string(have))
+		have = pageContent(testContent, pointers.Ptr(10000), nil)
+		assert.Equal(t, "", string(have))
+		have = pageContent(testContent, pointers.Ptr(-1), nil)
+		assert.Equal(t, string(testContent), string(have))
+	})
+	t.Run("Invalid range", func(t *testing.T) {
+		// Out of bounds.
+		have := pageContent(testContent, pointers.Ptr(1), pointers.Ptr(1000))
+		assert.Equal(t, string(testContent), string(have))
+		// Negative start.
+		have = pageContent(testContent, pointers.Ptr(-1), pointers.Ptr(4))
+		assert.Equal(t, "1\n2\n3\n4\n", string(have))
+		// Negative end.
+		have = pageContent(testContent, pointers.Ptr(1), pointers.Ptr(-4))
+		assert.Equal(t, string(testContent), string(have))
+		// End < start.
+		have = pageContent(testContent, pointers.Ptr(4), pointers.Ptr(1))
+		assert.Equal(t, string(testContent), string(have))
+	})
 }

--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -7,15 +7,340 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/fileutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
+
+func TestGitTree_Entries(t *testing.T) {
+	db := dbmocks.NewMockDB()
+	gitserverClient := gitserver.NewMockClient()
+
+	wantPath := ""
+
+	gitserverClient.ReadDirFunc.SetDefaultHook(func(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, recursive bool) ([]fs.FileInfo, error) {
+		switch path {
+		case "", ".", "/":
+			if recursive {
+				return []fs.FileInfo{
+					CreateFileInfo(".aspect/", true),
+					CreateFileInfo(".aspect/rules/", true),
+					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
+					CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
+					CreateFileInfo(".aspect/cli/", true),
+					CreateFileInfo(".aspect/cli/file1", false),
+					CreateFileInfo(".aspect/cli/file2", false),
+					CreateFileInfo("folder/", true),
+					CreateFileInfo("folder/nestedfile", false),
+					CreateFileInfo("folder/subfolder/", true),
+					CreateFileInfo("folder/subfolder/deeplynestedfile", false),
+					CreateFileInfo("folder/subfolder2/", true),
+					CreateFileInfo("folder/subfolder2/file", false),
+					CreateFileInfo("folder/subfolder2/file2", false),
+					CreateFileInfo("folder2/", true),
+					CreateFileInfo("folder2/file", false),
+					CreateFileInfo("file", false),
+				}, nil
+			}
+			return []fs.FileInfo{
+				CreateFileInfo(".aspect/", true),
+				CreateFileInfo("folder/", true),
+				CreateFileInfo("folder2/", true),
+				CreateFileInfo("file", false),
+			}, nil
+		case "folder/", "folder":
+			if recursive {
+				return []fs.FileInfo{
+					CreateFileInfo("folder/nestedfile", false),
+					CreateFileInfo("folder/subfolder/", true),
+					CreateFileInfo("folder/subfolder/deeplynestedfile", false),
+					CreateFileInfo("folder/subfolder2/", true),
+					CreateFileInfo("folder/subfolder2/file", false),
+					CreateFileInfo("folder/subfolder2/file2", false),
+				}, nil
+			}
+			return []fs.FileInfo{
+				CreateFileInfo("folder/nestedfile", false),
+				CreateFileInfo("folder/subfolder/", true),
+				CreateFileInfo("folder/subfolder2/", true),
+			}, nil
+		case ".aspect/", ".aspect":
+			if recursive {
+				return []fs.FileInfo{
+					CreateFileInfo(".aspect/rules/", true),
+					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
+					CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
+					CreateFileInfo(".aspect/cli/", true),
+					CreateFileInfo(".aspect/cli/file1", false),
+					CreateFileInfo(".aspect/cli/file2", false),
+				}, nil
+			}
+			return []fs.FileInfo{
+				CreateFileInfo(".aspect/rules/", true),
+				CreateFileInfo(".aspect/cli/", true),
+			}, nil
+		case ".aspect/rules/", ".aspect/rules":
+			if recursive {
+				return []fs.FileInfo{
+					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
+					CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
+				}, nil
+			}
+			return []fs.FileInfo{
+				CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
+			}, nil
+		case ".aspect/rules/external_repository_action_cache/", ".aspect/rules/external_repository_action_cache":
+			return []fs.FileInfo{
+				CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
+			}, nil
+		case ".aspect/cli/", ".aspect/cli":
+			return []fs.FileInfo{
+				CreateFileInfo(".aspect/cli/file1", false),
+				CreateFileInfo(".aspect/cli/file2", false),
+			}, nil
+		case "folder/subfolder/", "folder/subfolder":
+			return []fs.FileInfo{
+				CreateFileInfo("folder/subfolder/deeplynestedfile", false),
+			}, nil
+		case "folder/subfolder2/", "folder/subfolder2":
+			return []fs.FileInfo{
+				CreateFileInfo("folder/subfolder2/file", false),
+				CreateFileInfo("folder/subfolder2/file2", false),
+			}, nil
+		case "folder2/", "folder2":
+			return []fs.FileInfo{
+				CreateFileInfo("folder2/file", false),
+			}, nil
+		default:
+			return nil, errors.Newf("bad argument %q", path)
+		}
+	})
+
+	opts := GitTreeEntryResolverOpts{
+		Commit: &GitCommitResolver{
+			repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
+		},
+		Stat: CreateFileInfo(wantPath, true),
+	}
+	gitTree := NewGitTreeEntryResolver(db, gitserverClient, opts)
+
+	// Plain list all root entries.
+	t.Run("root", func(t *testing.T) {
+		entries, err := gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/", true),
+			CreateFileInfo("folder/", true),
+			CreateFileInfo("folder2/", true),
+			CreateFileInfo("file", false),
+		}, entries)
+		entries, err = gitTree.Files(context.Background(), &gitTreeEntryConnectionArgs{})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo("file", false),
+		}, entries)
+		entries, err = gitTree.Directories(context.Background(), &gitTreeEntryConnectionArgs{})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/", true),
+			CreateFileInfo("folder/", true),
+			CreateFileInfo("folder2/", true),
+		}, entries)
+	})
+
+	t.Run("Subfolder", func(t *testing.T) {
+		opts := GitTreeEntryResolverOpts{
+			Commit: &GitCommitResolver{
+				repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
+			},
+			Stat: CreateFileInfo("folder/", true),
+		}
+		gitTree := NewGitTreeEntryResolver(db, gitserverClient, opts)
+
+		entries, err := gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo("folder/subfolder/", true),
+			CreateFileInfo("folder/subfolder2/", true),
+			CreateFileInfo("folder/nestedfile", false),
+		}, entries)
+		entries, err = gitTree.Files(context.Background(), &gitTreeEntryConnectionArgs{})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo("folder/nestedfile", false),
+		}, entries)
+		entries, err = gitTree.Directories(context.Background(), &gitTreeEntryConnectionArgs{})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo("folder/subfolder/", true),
+			CreateFileInfo("folder/subfolder2/", true),
+		}, entries)
+	})
+
+	t.Run("Pagination", func(t *testing.T) {
+		entries, err := gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{ConnectionArgs: graphqlutil.ConnectionArgs{First: pointers.Ptr(int32(1))}})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/", true),
+		}, entries)
+		entries, err = gitTree.Files(context.Background(), &gitTreeEntryConnectionArgs{ConnectionArgs: graphqlutil.ConnectionArgs{First: pointers.Ptr(int32(1))}})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo("file", false),
+		}, entries)
+		entries, err = gitTree.Directories(context.Background(), &gitTreeEntryConnectionArgs{ConnectionArgs: graphqlutil.ConnectionArgs{First: pointers.Ptr(int32(1))}})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/", true),
+		}, entries)
+
+		// Invalid first.
+		_, err = gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{ConnectionArgs: graphqlutil.ConnectionArgs{First: pointers.Ptr(int32(-1))}})
+		require.Error(t, err)
+
+		// First is bigger than the number of entries.
+		entries, err = gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{ConnectionArgs: graphqlutil.ConnectionArgs{First: pointers.Ptr(int32(100))}})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/", true),
+			CreateFileInfo("folder/", true),
+			CreateFileInfo("folder2/", true),
+			CreateFileInfo("file", false),
+		}, entries)
+	})
+
+	t.Run("Recursive", func(t *testing.T) {
+		entries, err := gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{Recursive: true})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/", true),
+			CreateFileInfo(".aspect/cli/", true),
+			CreateFileInfo(".aspect/rules/", true),
+			CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
+			CreateFileInfo("folder/", true),
+			CreateFileInfo("folder/subfolder/", true),
+			CreateFileInfo("folder/subfolder2/", true),
+			CreateFileInfo("folder2/", true),
+			CreateFileInfo(".aspect/cli/file1", false),
+			CreateFileInfo(".aspect/cli/file2", false),
+			CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
+			CreateFileInfo("file", false),
+			CreateFileInfo("folder/nestedfile", false),
+			CreateFileInfo("folder/subfolder/deeplynestedfile", false),
+			CreateFileInfo("folder/subfolder2/file", false),
+			CreateFileInfo("folder/subfolder2/file2", false),
+			CreateFileInfo("folder2/file", false),
+		}, entries)
+		entries, err = gitTree.Files(context.Background(), &gitTreeEntryConnectionArgs{Recursive: true})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/cli/file1", false),
+			CreateFileInfo(".aspect/cli/file2", false),
+			CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
+			CreateFileInfo("file", false),
+			CreateFileInfo("folder/nestedfile", false),
+			CreateFileInfo("folder/subfolder/deeplynestedfile", false),
+			CreateFileInfo("folder/subfolder2/file", false),
+			CreateFileInfo("folder/subfolder2/file2", false),
+			CreateFileInfo("folder2/file", false),
+		}, entries)
+		entries, err = gitTree.Directories(context.Background(), &gitTreeEntryConnectionArgs{Recursive: true})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/", true),
+			CreateFileInfo(".aspect/cli/", true),
+			CreateFileInfo(".aspect/rules/", true),
+			CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
+			CreateFileInfo("folder/", true),
+			CreateFileInfo("folder/subfolder/", true),
+			CreateFileInfo("folder/subfolder2/", true),
+			CreateFileInfo("folder2/", true),
+		}, entries)
+	})
+
+	t.Run("RecursiveSingleChild", func(t *testing.T) {
+		opts := GitTreeEntryResolverOpts{
+			Commit: &GitCommitResolver{
+				repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
+			},
+			Stat: CreateFileInfo(".aspect/", true),
+		}
+		gitTree := NewGitTreeEntryResolver(db, gitserverClient, opts)
+
+		entries, err := gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{RecursiveSingleChild: true})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/cli/", true),
+			CreateFileInfo(".aspect/rules/", true),
+			CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
+			CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
+		}, entries)
+
+		opts = GitTreeEntryResolverOpts{
+			Commit: &GitCommitResolver{
+				repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
+			},
+			Stat: CreateFileInfo(wantPath, true),
+		}
+		gitTree = NewGitTreeEntryResolver(db, gitserverClient, opts)
+
+		entries, err = gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{RecursiveSingleChild: true})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/", true),
+			CreateFileInfo("folder/", true),
+			CreateFileInfo("folder2/", true),
+			CreateFileInfo("file", false),
+			CreateFileInfo("folder2/file", false),
+		}, entries)
+	})
+
+	t.Run("Ancestors", func(t *testing.T) {
+		opts := GitTreeEntryResolverOpts{
+			Commit: &GitCommitResolver{
+				repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
+			},
+			Stat: CreateFileInfo("folder/subfolder/", true),
+		}
+		gitTree := NewGitTreeEntryResolver(db, gitserverClient, opts)
+
+		entries, err := gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{Ancestors: true})
+		require.NoError(t, err)
+		// TODO: This test is currently correct, but should we really return all
+		// elements in the ancestors, or are we only interested in the parent
+		// tree objects?
+		// Also, the ordering here feels arbitrary(?)
+		assertEntries(t, []fs.FileInfo{
+			CreateFileInfo(".aspect/", true),
+			CreateFileInfo("folder/", true),
+			CreateFileInfo("folder2/", true),
+			CreateFileInfo("file", false),
+			CreateFileInfo("folder/subfolder/", true),
+			CreateFileInfo("folder/subfolder2/", true),
+			CreateFileInfo("folder/nestedfile", false),
+			CreateFileInfo("folder/subfolder/deeplynestedfile", false),
+		}, entries)
+	})
+}
+
+func assertEntries(t *testing.T, expected []fs.FileInfo, entries []*GitTreeEntryResolver) {
+	t.Helper()
+	have := []fs.FileInfo{}
+	for _, e := range entries {
+		have = append(have, CreateFileInfo(e.Path(), e.IsDirectory()))
+	}
+
+	require.Equal(t, expected, have, "entries do not match expected")
+}
 
 func TestGitTree(t *testing.T) {
 	db := dbmocks.NewMockDB()

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5305,12 +5305,6 @@ type GitCommit implements Node {
         The path of the tree.
         """
         path: String = ""
-        """
-        Whether to recurse into sub-trees. If true, it overrides the value of the "recursive" parameter on all of
-        GitTree's fields.
-        DEPRECATED: Use the "recursive" parameter on GitTree's fields instead.
-        """
-        recursive: Boolean = false
     ): GitTree
     """
     A list of file names in this repository.
@@ -5525,20 +5519,7 @@ interface TreeEntry {
     """
     Whether this tree entry is a single child
     """
-    isSingleChild(
-        """
-        Returns the first n files in the tree.
-        """
-        first: Int
-        """
-        Recurse into sub-trees.
-        """
-        recursive: Boolean = false
-        """
-        Recurse into sub-trees of single-child directories
-        """
-        recursiveSingleChild: Boolean = false
-    ): Boolean!
+    isSingleChild: Boolean!
 }
 
 """
@@ -5595,7 +5576,7 @@ type GitTree implements TreeEntry {
     """
     directories(
         """
-        Returns the first n files in the tree.
+        Returns the first n directories in the tree.
         """
         first: Int
         """
@@ -5663,20 +5644,7 @@ type GitTree implements TreeEntry {
     """
     Whether this tree entry is a single child
     """
-    isSingleChild(
-        """
-        Returns the first n files in the tree.
-        """
-        first: Int
-        """
-        Recurse into sub-trees.
-        """
-        recursive: Boolean = false
-        """
-        Recurse into sub-trees of single-child directories
-        """
-        recursiveSingleChild: Boolean = false
-    ): Boolean!
+    isSingleChild: Boolean!
 }
 
 """
@@ -6083,20 +6051,7 @@ type GitBlob implements TreeEntry & File2 {
     """
     Always false, since a blob is a file, not directory.
     """
-    isSingleChild(
-        """
-        Returns the first n files in the tree.
-        """
-        first: Int
-        """
-        Recurse into sub-trees.
-        """
-        recursive: Boolean = false
-        """
-        Recurse into sub-trees of single-child directories
-        """
-        recursiveSingleChild: Boolean = false
-    ): Boolean!
+    isSingleChild: Boolean!
     """
     LFS is set if the GitBlob is a pointer to a file stored in LFS.
     """


### PR DESCRIPTION
I wanted to look into this resolver because it seemed to cause a lot of load on S2 and dotcom. Looking at it, I realize that there are zero tests so I didn't even know what's expected to be returned here. This PR adds a baseline for what should be returned and fixed a bunch of bugs:

- Improper argument validation that could cause panics
- Improperly counted results for `first` argument (still weird with `ancestors: true` but changing that might break things)
- Removed arguments from GraphQL schema that weren't actually respected
- Fix line ending handling in content pagination to return indication if file ended with no newline
- Fix TotalLines for files without a final newline
- Improves performance of line parsing
- Fix ancestors option creating too many results by recursively including all children into the set again (was able to get 90000 entries returned from S2 for a relatively small folder structure)
- Make behavior of recursiveSingleChild match what's documented in GraphQL. Before, we would only recurse if the looked at entry is a single child (or first:1 was set). **Does that make sense?**

Ultimately, the dir traversal we do in here should IMO happen in gitserver directly where we already have it in tree structure, but that will have to be for later. For now, this mostly adds some confidence to these resolvers.

Might help with https://github.com/sourcegraph/sourcegraph/issues/57522, but have to confirm that. We do less recursion now for sure.

## Test plan

Added a test suite for these resolvers!