### PR TITLE
goroutine: Don't silently stop after panic

### DIFF
--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -2,7 +2,6 @@ package goroutine
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -390,7 +389,7 @@ func runAndConvertPanicToError(ctx context.Context, f func(ctx context.Context) 
 			if e, ok := r.(error); ok {
 				err = errors.Wrap(e, "panic occurred")
 			} else {
-				err = fmt.Errorf("panic occurred: %v", r)
+				err = errors.Newf("panic occurred: %v", r)
 			}
 		}
 	}()

--- a/internal/goroutine/periodic.go
+++ b/internal/goroutine/periodic.go
@@ -2,6 +2,7 @@ package goroutine
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -366,11 +367,11 @@ func (r *PeriodicGoroutine) withOperation(ctx context.Context, f func(ctx contex
 
 func (r *PeriodicGoroutine) withRecorder(ctx context.Context, f func(ctx context.Context) error) error {
 	if r.recorder == nil {
-		return f(ctx)
+		return runAndConvertPanicToError(ctx, f)
 	}
 
 	start := time.Now()
-	err := f(ctx)
+	err := runAndConvertPanicToError(ctx, f)
 	duration := time.Since(start)
 
 	go func() {
@@ -379,6 +380,21 @@ func (r *PeriodicGoroutine) withRecorder(ctx context.Context, f func(ctx context
 	}()
 
 	return err
+}
+
+// runAndConvertPanicToError invokes f with the given ctx and recovers any panics
+// by turning them into an error instead.
+func runAndConvertPanicToError(ctx context.Context, f func(ctx context.Context) error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if e, ok := r.(error); ok {
+				err = errors.Wrap(e, "panic occurred")
+			} else {
+				err = fmt.Errorf("panic occurred: %v", r)
+			}
+		}
+	}()
+	return f(ctx)
 }
 
 func typeFromOperations(operation *observation.Operation) recorder.RoutineType {


### PR DESCRIPTION
If the handler function of a periodic goroutine panics, the handler silently dies. I don't see a panic error log, and it is never invoked again.

After discussing this on Slack, we concluded that periodic routines are most often part of a background job and that they shouldn't take down entire services when a single component misbehaves. Instead we treat them as an error in that component, which will surface in logs and the background jobs UI.

See https://sourcegraph.slack.com/archives/C02UC4WUX1Q/p1696960510011339 for the discussion to go with this behavior.

Closes https://github.com/sourcegraph/sourcegraph/issues/56427

## Test plan

Added a test to verify the behavior. 