### PR TITLE
Search: do not interpret `content:` as regex if it is quoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- Drilling down into an insights query no longer mangles `content:` fields in your query. [#57679](https://github.com/sourcegraph/sourcegraph/pull/57679)
 
 ### Removed
 

--- a/internal/insights/query/querybuilder/builder_test.go
+++ b/internal/insights/query/querybuilder/builder_test.go
@@ -879,6 +879,17 @@ func TestPointDiffQuery(t *testing.T) {
 			},
 			autogold.Expect(BasicQuery("repo:repo1|repo2 after:2022-01-01T01:01:00Z before:2022-02-01T01:01:00Z type:diff insights")),
 		},
+		{
+			// Test for #57323. Previously, the content field would get mangled to `content:/"TEST"/`
+			"no mangle content",
+			PointDiffQueryOpts{
+				Before:      before,
+				After:       &after,
+				RepoList:    []string{},
+				SearchQuery: BasicQuery(`content:"TEST" patternType:regexp`),
+			},
+			autogold.Expect(BasicQuery(`after:2022-01-01T01:01:00Z before:2022-02-01T01:01:00Z type:diff patterntype:regexp content:"TEST"`)),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -15,7 +15,7 @@ func SubstituteAliases(searchType SearchType) func(nodes []Node) []Node {
 	mapper := func(nodes []Node) []Node {
 		return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 			if field == "content" {
-				if searchType == SearchTypeRegex {
+				if searchType == SearchTypeRegex && !annotation.Labels.IsSet(Quoted) {
 					annotation.Labels.Set(Regexp)
 				} else {
 					annotation.Labels.Set(Literal)


### PR DESCRIPTION
We have some logic that annotates a `content:` node as regex if `patterntype:regex` is set. This allows us to do things like `content:^a:b`, since escaping colons used to be a significant part of how `content:` was used.

However, another significant way `content:` is used is to just search for string literals that would otherwise be interpreted as search syntax. Like `content:"a and b"`. It's a pretty solid heuristic to not treat a quoted string as regex, especially since we now have `/.../`-delimited regex literals, which makes using `content:` for regex patterns largely unnecessary. 

This was causing an issue where a parsing roundtrip for code insights would mangle a query like `content:"TEST" patterntype:regex` to `content:/"TEST"/`, which is obviously not ideal.

Fixes #57323 

## Test plan

Added a unit test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
