### PR TITLE
database/telemetryexport: fixup for metric and trace attribute

### DIFF
--- a/internal/database/telemetry_export_store.go
+++ b/internal/database/telemetry_export_store.go
@@ -103,7 +103,7 @@ func (s *telemetryEventsExportQueueStore) QueueForExport(ctx context.Context, ev
 	var tr trace.Trace
 	tr, ctx = trace.New(ctx, "telemetryevents.QueueForExport",
 		// actually queued events may be different - final attribute is added later
-		attribute.Int("submitted_events", len(events)))
+		attribute.Int("submitted-events", len(events)))
 	defer tr.EndWithErr(&err)
 
 	logger := trace.Logger(ctx, s.logger)
@@ -171,11 +171,11 @@ func (s *telemetryEventsExportQueueStore) QueueForExport(ctx context.Context, ev
 		insertTelemetryEventsChannel(logger, events))
 
 	// Record results
-	if err != nil {
-		counterQueuedEvents.
-			WithLabelValues(strconv.FormatBool(err != nil)).
-			Add(float64(len(events)))
-		tr.SetAttributes(attribute.Int("queued_events", len(events)))
+	counterQueuedEvents.
+		WithLabelValues(strconv.FormatBool(err != nil)).
+		Add(float64(len(events)))
+	if err == nil {
+		tr.SetAttributes(attribute.Int("queued-events", len(events)))
 	}
 
 	return err


### PR DESCRIPTION
Mistake I caught while testing #57681 (backport of https://github.com/sourcegraph/sourcegraph/pull/57605) - I've updated the backport with the same fix.

## Test plan

Ran various cases locally with `?trace=1` and found the trace attributes