### PR TITLE
[Backport 5.2] gomod: update zoekt for ranking regression fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a bug where gitserver statistics would not be properly decoded / reported when using REST (i.e. `experimentalFeatures.enableGRPC = false` in site configuration). [#57318](https://github.com/sourcegraph/sourcegraph/pull/57318)
 - Updated the `curl` and `libcurl` dependencies to `8.4.0-r0` to fix [CVE-2023-38545](https://curl.se/docs/CVE-2023-38545.html). [#57533](https://github.com/sourcegraph/sourcegraph/pull/57533)
 - Fixed a bug where commit signing failed when creating a changeset if `batchChanges.enforceFork` is set to true. [#57520](https://github.com/sourcegraph/sourcegraph/pull/57520)
+- Fixed a regression in ranking of Go struct and interface in search results. [zoekt#655](https://github.com/sourcegraph/zoekt/pull/655)
 
 ### Removed
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -6413,8 +6413,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:5zlXkgLiskj4oBm+WlyGXbDK7JrHKfBDti2gaHPPVzo=",
-        version = "v0.0.0-20230929125214-1065c6646489",
+        sum = "h1:1Xa7GWtMdnatmIqzOsAhLigU+SttgXPvygKn0eMJZzc=",
+        version = "v0.0.0-20231017111049-f17ff0bac96a",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -552,7 +552,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20230929125214-1065c6646489
+	github.com/sourcegraph/zoekt v0.0.0-20231017111049-f17ff0bac96a
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2052,8 +2052,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20230929125214-1065c6646489 h1:5zlXkgLiskj4oBm+WlyGXbDK7JrHKfBDti2gaHPPVzo=
-github.com/sourcegraph/zoekt v0.0.0-20230929125214-1065c6646489/go.mod h1:gHfSe997J5w8zX5MGHFei/darZmml75Xvpoykwtknlo=
+github.com/sourcegraph/zoekt v0.0.0-20231017111049-f17ff0bac96a h1:1Xa7GWtMdnatmIqzOsAhLigU+SttgXPvygKn0eMJZzc=
+github.com/sourcegraph/zoekt v0.0.0-20231017111049-f17ff0bac96a/go.mod h1:gHfSe997J5w8zX5MGHFei/darZmml75Xvpoykwtknlo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This updates zoekt to include a fix in ranking.

- 8c5bd7de94 Use Go 1.21.2
- 659eac980e all: remove deprecated RepoList.Minimal
- f17ff0bac9 scoring: handle scip-ctags kinds

Test Plan: CI

Cherry-picked from #57665