### PR TITLE
search: use 10x defaults if using Zoekt parser

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -295,7 +295,7 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 
 	return &search.Features{
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
-		Keyword:                 flagSet.GetBoolOr("search-new-keyword", false),
+		UseZoektParser:          flagSet.GetBoolOr("search-new-keyword", false),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),
 	}
 }

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -215,7 +215,11 @@ func (o *ZoektParameters) ToSearchOptions(ctx context.Context) *zoekt.SearchOpti
 	// replica respectively.
 	searchOpts.ShardMaxMatchCount = 10_000
 	searchOpts.TotalMaxMatchCount = 100_000
-	if o.KeywordScoring {
+	// KeywordScoring and Features.UseZoektParser represent different approaches we
+	// are evaluating to deliver a better keyword-based search experience. For now
+	// these are separate, but we might combine them in the future. Both profit from
+	// higher defaults.
+	if o.KeywordScoring || o.Features.UseZoektParser {
 		// Keyword searches tends to match much more broadly than code searches, so we need to
 		// consider more candidates to ensure we don't miss highly-ranked documents
 		searchOpts.ShardMaxMatchCount *= 10
@@ -416,9 +420,9 @@ type Features struct {
 	// currently just supported by Zoekt.
 	ContentBasedLangFilters bool `json:"search-content-based-lang-detection"`
 
-	// Keyword when true will use a new way to interpret queries optimized for
+	// UseZoektParser when true will use a new way to interpret queries optimized for
 	// keyword search. This is currently just supported by Zoekt.
-	Keyword bool `json:"search-new-keyword"`
+	UseZoektParser bool `json:"search-new-keyword"`
 
 	// Debug when true will set the Debug field on FileMatches. This may grow
 	// from here. For now we treat this like a feature flag for convenience.

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -18,7 +18,7 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 	isCaseSensitive := b.IsCaseSensitive()
 
 	if b.Pattern != nil {
-		if feat.Keyword {
+		if feat.UseZoektParser {
 			q, err = toZoektPatternNew(
 				b.Pattern,
 				isCaseSensitive,


### PR DESCRIPTION
This change is behind a feature flag.

Our experiments showed that often we miss the top results especially if the keywords are very common. Increasing the limits for `ShardMaxMatchCount` and `TotalMaxMatchCount` improves the results. We use the same limits as we do for "keyword scoring",  which are also identical to Zoekt's default limits. 

I also renamed the internal feature flag from `Keyword` to `UseZoektParser` to avoid confusion with `KeywordScoring`. 

Test plan:
- local testing: ran a couple of searches with `feat=search-new-keyword` and confirmed results are looking promising

<img width="920" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/d18f5e23-8abd-46aa-977c-05e69afe2e69">


<img width="950" alt="Screenshot 2023-10-18 at 11 28 18" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/c72ce22e-b19a-4bb9-a2e9-da92ad441f59">

- the new limits are identical to [Zoekt's default limits](https://github.com/sourcegraph/zoekt/blob/f17ff0bac96acb444f554e9cf13e04e92bbf1b67/eval.go#L140-L149) and we already use the same limits for keyword scoring.
- CI

