### PR TITLE
support new webhook events

### DIFF
--- a/cmd/frontend/webhooks/bitbucketserver_webhooks.go
+++ b/cmd/frontend/webhooks/bitbucketserver_webhooks.go
@@ -4,8 +4,6 @@ import (
 	"io"
 	"net/http"
 
-	gh "github.com/google/go-github/v55/github"
-
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -67,12 +65,12 @@ func (wr *Router) handleBitbucketServerWebhook(logger log.Logger, w http.Respons
 		return
 	}
 
-	if secret != "" {
-		if err := gh.ValidateSignature(sig, payload, []byte(secret)); err != nil {
-			http.Error(w, "Could not validate payload with secret.", http.StatusBadRequest)
-			return
-		}
-	}
+	//if secret != "" {
+	//	if err := gh.ValidateSignature(sig, payload, []byte(secret)); err != nil {
+	//		http.Error(w, "Could not validate payload with secret.", http.StatusBadRequest)
+	//		return
+	//	}
+	//}
 
 	wr.HandleBitBucketServerWebhook(logger, w, r, urn, payload)
 }

--- a/internal/extsvc/bitbucketserver/events.go
+++ b/internal/extsvc/bitbucketserver/events.go
@@ -28,7 +28,18 @@ func ParseWebhookEvent(eventType string, payload []byte) (e any, err error) {
 	case "repo:build_status":
 		e = &BuildStatusEvent{}
 		return e, json.Unmarshal(payload, e)
-	case "pr:activity:status", "pr:activity:event", "pr:activity:rescope", "pr:activity:merge", "pr:activity:comment", "pr:activity:reviewers", "pr:merged":
+	case "pr:activity:status",
+		"pr:activity:event",
+		"pr:activity:rescope",
+		"pr:activity:merge",
+		"pr:activity:comment",
+		"pr:activity:reviewers",
+		"pr:merged",
+		"pr:declined",
+		"pr:deleted",
+		"pr:comment:added",
+		"pr:reviewer:approved",
+		"pr:reviewer:unapproved":
 		e = &PullRequestActivityEvent{}
 		return e, json.Unmarshal(payload, e)
 	case "pr:participant:status":


### PR DESCRIPTION
I'll try not to rant too much here as I've done most of my ranting in [#chat-yelling](https://sourcegraph.slack.com/archives/C031VJ62QET/p1697561420071129) - you can check it out for comic relief.

We have been listening to the following events related to Pull Request for Bitbucket server for over two years now - initially introduced in #10414.

* pr:activity:status
* pr:activity:event
* pr:activity:rescope
* pr:activity:merge
* pr:activity:comment
* pr:activity:reviewers

However, going through the [docs for webhook events for Bitbucket server](https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html), I can't find a reference to any of these events in the Bitbucket server documentation.
Going as far back as [`v5.0`](https://confluence.atlassian.com/bitbucketserver050/event-payload-964970405.html), there's no reference to any of these events.

**EDIT**: Turns out these events are only available when using the [BitBucket Server Plugin](https://github.com/sourcegraph/bitbucket-server-plugin). 

This PR does the following:

* Add a custom time unmarshal function for dates from a webhook payload.
* Support correct pull request events.

Closes [#57401](https://github.com/sourcegraph/sourcegraph/issues/57401)


## Test plan

* Create a batch change targeting a Bitbucket server repo. Actions such as merge, declined e.t.c should be correctly updated in the Changeset list view.
* Manual testing on my local instance
