### PR TITLE
bext: Fix SG button in file page header

### DIFF
--- a/client/browser/src/end-to-end/github.test.ts
+++ b/client/browser/src/end-to-end/github.test.ts
@@ -13,9 +13,7 @@ import { retry } from '@sourcegraph/shared/src/testing/utils'
 
 import { closeInstallPageTab, testSingleFilePage } from './shared'
 
-// Skip github.com tests because the redesign broke the extension for the file pages,
-// and the pull request tests were already skipped.
-describe.skip('Sourcegraph browser extension on github.com', function () {
+describe('Sourcegraph browser extension on github.com', function () {
     this.slow(8000)
 
     const { browser, sourcegraphBaseUrl, ...restConfig } = getConfig('browser', 'sourcegraphBaseUrl')
@@ -44,7 +42,8 @@ describe.skip('Sourcegraph browser extension on github.com', function () {
         repoName: 'github.com/sourcegraph/jsonrpc2',
         commitID: '6864d8cc6d35a79f50745f8990cb4d594a8036f4',
         sourcegraphBaseUrl,
-        getLineSelector: lineNumber => `#LC${lineNumber}`,
+        // Hovercards are broken on the new GitHub file page
+        // getLineSelector: lineNumber => `#LC${lineNumber}`,
         goToDefinitionURL:
             'https://github.com/sourcegraph/jsonrpc2/blob/6864d8cc6d35a79f50745f8990cb4d594a8036f4/call_opt.go#L5:6',
     })

--- a/client/browser/src/end-to-end/shared.ts
+++ b/client/browser/src/end-to-end/shared.ts
@@ -34,7 +34,7 @@ export function testSingleFilePage({
     commitID: string
 
     /** The CSS selector for a line (with or without line number part) in the code view */
-    getLineSelector: (lineNumber: number) => string
+    getLineSelector?: (lineNumber: number) => string
 
     /** The expected URL for the "Go to Definition" button */
     goToDefinitionURL?: string
@@ -67,39 +67,41 @@ export function testSingleFilePage({
             })
         })
 
-        it('shows hover tooltips when hovering a token', async () => {
-            await getDriver().page.goto(url)
-            await getDriver().page.waitForSelector(
-                '[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]'
-            )
-
-            // Trigger tokenization of the line.
-            const lineNumber = 16
-            const line = await getDriver().page.waitForSelector(getLineSelector(lineNumber), {
-                timeout: 10000,
-            })
-
-            if (!line) {
-                throw new Error(`Found no line with number ${lineNumber}`)
-            }
-
-            // Hover line to give codeintellify time to register listeners for
-            // tokenization (only necessary in CI, not sure why).
-            await line.hover()
-
-            const [token] = await line.$x('.//span[text()="CallOption"]')
-            await token.hover()
-            await getDriver().page.waitForSelector('.test-tooltip-go-to-definition')
-            await getDriver().page.waitForSelector('.test-tooltip-content')
-            await retry(async () => {
-                assert.strictEqual(
-                    await getDriver().page.evaluate(
-                        () => document.querySelector<HTMLAnchorElement>('.test-tooltip-go-to-definition')?.href
-                    ),
-                    goToDefinitionURL || `${sourcegraphBaseUrl}/${repoName}@${commitID}/-/blob/call_opt.go#L5:6`
+        if (getLineSelector) {
+            it('shows hover tooltips when hovering a token', async () => {
+                await getDriver().page.goto(url)
+                await getDriver().page.waitForSelector(
+                    '[data-testid="code-view-toolbar"] [data-testid="open-on-sourcegraph"]'
                 )
+
+                // Trigger tokenization of the line.
+                const lineNumber = 16
+                const line = await getDriver().page.waitForSelector(getLineSelector(lineNumber), {
+                    timeout: 10000,
+                })
+
+                if (!line) {
+                    throw new Error(`Found no line with number ${lineNumber}`)
+                }
+
+                // Hover line to give codeintellify time to register listeners for
+                // tokenization (only necessary in CI, not sure why).
+                await line.hover()
+
+                const [token] = await line.$x('.//span[text()="CallOption"]')
+                await token.hover()
+                await getDriver().page.waitForSelector('.test-tooltip-go-to-definition')
+                await getDriver().page.waitForSelector('.test-tooltip-content')
+                await retry(async () => {
+                    assert.strictEqual(
+                        await getDriver().page.evaluate(
+                            () => document.querySelector<HTMLAnchorElement>('.test-tooltip-go-to-definition')?.href
+                        ),
+                        goToDefinitionURL || `${sourcegraphBaseUrl}/${repoName}@${commitID}/-/blob/call_opt.go#L5:6`
+                    )
+                })
             })
-        })
+        }
     })
 }
 

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -160,8 +160,7 @@ export const createFileLineContainerToolbarMount: NonNullable<CodeView['getToolb
     mountElement.className = className
 
     // new GitHub code view: https://docs.github.com/en/repositories/working-with-files/managing-files/navigating-files-with-the-new-code-view
-    const container =
-        codeViewElement.querySelector('#repos-sticky-header .react-blob-header-edit-and-raw-actions')
+    const container = codeViewElement.querySelector('#repos-sticky-header .react-blob-header-edit-and-raw-actions')
     if (container instanceof HTMLElement) {
         container.prepend(mountElement)
         return mountElement

--- a/client/browser/src/shared/code-hosts/github/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/github/codeHost.tsx
@@ -161,8 +161,7 @@ export const createFileLineContainerToolbarMount: NonNullable<CodeView['getToolb
 
     // new GitHub code view: https://docs.github.com/en/repositories/working-with-files/managing-files/navigating-files-with-the-new-code-view
     const container =
-        codeViewElement.querySelector('#repos-sticky-header')?.childNodes[0]?.childNodes[0]?.childNodes[1]
-            ?.childNodes[2] // we have to use this level of nesting when selecting a target container because #repos-sticky-header children don't have specific classes or ids
+        codeViewElement.querySelector('#repos-sticky-header .react-blob-header-edit-and-raw-actions')
     if (container instanceof HTMLElement) {
         container.prepend(mountElement)
         return mountElement

--- a/dev/ci/internal/ci/changed/diff.go
+++ b/dev/ci/internal/ci/changed/diff.go
@@ -13,6 +13,7 @@ const (
 	None Diff = 0
 
 	Go Diff = 1 << iota
+	ClientBrowserExtensions
 	Client
 	GraphQL
 	DatabaseSchema
@@ -210,6 +211,11 @@ func ParseDiff(files []string) (diff Diff, changedFiles ChangedFiles) {
 		if strings.HasSuffix(p, ".pb.go") {
 			diff |= Protobuf
 		}
+
+		// Affects browser extensions
+		if strings.HasPrefix(p, "client/browser/") {
+			diff |= ClientBrowserExtensions
+		}
 	}
 
 	return
@@ -224,6 +230,8 @@ func (d Diff) String() string {
 		return "Go"
 	case Client:
 		return "Client"
+	case ClientBrowserExtensions:
+		return "ClientBrowserExtensions"
 	case GraphQL:
 		return "GraphQL"
 	case DatabaseSchema:

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -163,7 +163,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			ops.Merge(operations.NewNamedSet("Browser Extensions",
 				addBrowserExtensionUnitTests,
 				addBrowserExtensionIntegrationTests(0), // we pass 0 here as we don't have other pipeline steps to contribute to the resulting Percy build
-				frontendTests,
 			))
 		}
 

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -159,6 +159,14 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 				triggerAsync(buildOptions)))
 		}
 
+		if c.Diff.Has(changed.ClientBrowserExtensions) {
+			ops.Merge(operations.NewNamedSet("Browser Extensions",
+				addBrowserExtensionUnitTests,
+				addBrowserExtensionIntegrationTests(0), // we pass 0 here as we don't have other pipeline steps to contribute to the resulting Percy build
+				frontendTests,
+			))
+		}
+
 	case runtype.ReleaseNightly:
 		ops.Append(triggerReleaseBranchHealthchecks(minimumUpgradeableVersion))
 


### PR DESCRIPTION
For reasons unknown I looked at the browser extension. This seems to fix the issues of showing the "open in sourcegraph" button in the file header.

![2023-10-18_16-01](https://github.com/sourcegraph/sourcegraph/assets/179026/5a488a44-e8b8-4014-8502-0fb0ab69bc6d)

I modified the E2E test to make hovercard testing optional so that we can at least test the toolbar button.

Addendum: I also updated the pipline generate to run browser extension tests when code inside `client/browser/` changes.

## Test plan

Manual testing and reenabling the E2E test for the button specifically.
