### PR TITLE
deps: update grafana base image

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -71,7 +71,7 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_grafana_base",
-        digest = "sha256:4644fa597db008b020f8cbc620ed365854dcfd464832b24bc033b2ce067545ec",
+        digest = "sha256:1334165966d67b676d0765fb59a732e8ba3f5b03365cd6026a6b42c133de48c6",
         image = "us.gcr.io/sourcegraph-dev/wolfi-grafana",
     )
 


### PR DESCRIPTION
This resolves a number of issues due to CVE-2023-4911.

## Test plan
Ran `trivy` on the new image:

```
$ trivy image us.gcr.io/sourcegraph-dev/wolfi-grafana@sha256:1334165966d67b676d0765fb59a732e8ba3f5b03365cd6026a6b42c133de48c6
2023-10-18T14:28:36.722+0200	INFO	Vulnerability scanning is enabled
2023-10-18T14:28:36.722+0200	INFO	Secret scanning is enabled
2023-10-18T14:28:36.722+0200	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-10-18T14:28:36.722+0200	INFO	Please see also https://aquasecurity.github.io/trivy/v0.46/docs/scanner/secret/#recommendation for faster secret detection
2023-10-18T14:28:38.635+0200	INFO	Detected OS: chainguard
2023-10-18T14:28:38.635+0200	INFO	Detecting Chainguard vulnerabilities...
2023-10-18T14:28:38.636+0200	INFO	Number of language-specific files: 0

us.gcr.io/sourcegraph-dev/wolfi-grafana@sha256:1334165966d67b676d0765fb59a732e8ba3f5b03365cd6026a6b42c133de48c6 (chainguard 20230214)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

No vulnerabilities detected.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
