### PR TITLE
Make lookAhead optional in Perforce connection config

### DIFF
--- a/cmd/gitserver/internal/vcssyncer/perforce.go
+++ b/cmd/gitserver/internal/vcssyncer/perforce.go
@@ -250,6 +250,9 @@ func configureFusionClient(conn *schema.PerforceConnection) FusionConfig {
 	fc.Enabled = conn.FusionClient.Enabled
 
 	// Optional
+	if conn.FusionClient.LookAhead > 0 {
+		fc.LookAhead = conn.FusionClient.LookAhead
+	}
 	if conn.FusionClient.NetworkThreads > 0 {
 		fc.NetworkThreads = conn.FusionClient.NetworkThreads
 	}

--- a/cmd/gitserver/internal/vcssyncer/perforce.go
+++ b/cmd/gitserver/internal/vcssyncer/perforce.go
@@ -248,7 +248,6 @@ func configureFusionClient(conn *schema.PerforceConnection) FusionConfig {
 
 	// Required
 	fc.Enabled = conn.FusionClient.Enabled
-	fc.LookAhead = conn.FusionClient.LookAhead
 
 	// Optional
 	if conn.FusionClient.NetworkThreads > 0 {

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -90,7 +90,7 @@
       "type": "object",
       "description": "Configuration for the experimental p4-fusion client",
       "additionalProperties": false,
-      "required": ["enabled", "lookAhead"],
+      "required": ["enabled"],
       "properties": {
         "enabled": {
           "description": "Enable the p4-fusion client for cloning and fetching repos",
@@ -128,7 +128,7 @@
           "minimum": 1
         },
         "lookAhead": {
-          "description": "How many CLs in the future, at most, shall we keep downloaded by the time it is to commit them",
+          "description": "DEPRECATED: this setting is ignored.",
           "type": "integer",
           "default": 2000,
           "minimum": 1

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -128,7 +128,7 @@
           "minimum": 1
         },
         "lookAhead": {
-          "description": "DEPRECATED: this setting is ignored.",
+          "description": "How many CLs in the future, at most, shall we keep downloaded by the time it is to commit them",
           "type": "integer",
           "default": 2000,
           "minimum": 1

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1008,7 +1008,7 @@ type FusionClient struct {
 	FsyncEnable bool `json:"fsyncEnable,omitempty"`
 	// IncludeBinaries description: Whether to include binary files
 	IncludeBinaries bool `json:"includeBinaries,omitempty"`
-	// LookAhead description: DEPRECATED: this setting is ignored.
+	// LookAhead description: How many CLs in the future, at most, shall we keep downloaded by the time it is to commit them
 	LookAhead int `json:"lookAhead,omitempty"`
 	// MaxChanges description: How many changes to fetch during initial clone. The default of -1 will fetch all known changes
 	MaxChanges int `json:"maxChanges,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1008,8 +1008,8 @@ type FusionClient struct {
 	FsyncEnable bool `json:"fsyncEnable,omitempty"`
 	// IncludeBinaries description: Whether to include binary files
 	IncludeBinaries bool `json:"includeBinaries,omitempty"`
-	// LookAhead description: How many CLs in the future, at most, shall we keep downloaded by the time it is to commit them
-	LookAhead int `json:"lookAhead"`
+	// LookAhead description: DEPRECATED: this setting is ignored.
+	LookAhead int `json:"lookAhead,omitempty"`
 	// MaxChanges description: How many changes to fetch during initial clone. The default of -1 will fetch all known changes
 	MaxChanges int `json:"maxChanges,omitempty"`
 	// NetworkThreads description: The number of threads in the threadpool for running network calls. Defaults to the number of logical CPUs.


### PR DESCRIPTION
Closes #57638 

Makes `lookAhead` optional in the Perforce config and default to 2000 if unset.

## Test plan

No real changes here, tests should still pass and such.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
