### PR TITLE
docs: update instructions for rerunning wolfi buildkite pipeline

### DIFF
--- a/doc/dev/how-to/wolfi/add_update_images.md
+++ b/doc/dev/how-to/wolfi/add_update_images.md
@@ -27,7 +27,7 @@ This process is automated by Buildkite, which runs a daily scheduled build to:
 - Update the base image hashes in `dev/oci_deps.bzl`.
 - Open, or update the already open pull request updating the hashes.
 
-To rerun the automation (perhaps to pick up a just-released package version), click the Buildkite run link in the [auto-update pull request](https://github.com/sourcegraph/sourcegraph/pulls?q=is:pr+head:wolfi-autoupdate/main+is:open) and hit "Rebuild". Alternatively, look for the latest "Nightly Rebuild of Wolfi Base Images" run [on Buildkite](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=main).
+To rerun the automation manually (perhaps to pick up a just-released package version or a change you made), open [Buildkite for sourcegraph/sourcegraph](https://buildkite.com/sourcegraph/sourcegraph) and choose New Build > Options > set Environment Variables to `WOLFI_BASE_REBUILD=true` and Create Build.
 
 #### Manual image updates
 


### PR DESCRIPTION
Turns out the previous instructions didn't work, as buildkite will rebuild the original commit. "Rebuild this branch" exists but there seems to be a bug and it doesn't pick up the custom envars.

## Test plan

- Docs - check preview

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
