### PR TITLE
release: 5.2.2 config and CHANGELOG for 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,25 @@ All notable changes to Sourcegraph are documented in this file.
 - The following experimental settings in site-configuration are now deprecated and will not be read anymore: `maxReorderQueueSize`, `maxQueueMatchCount`, `maxReorderDurationMS`. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
 - The feature-flag `search-ranking`, which allowed to disable the improved ranking introduced in 5.1, is now deprecated and will not be read anymore. [#57468](https://github.com/sourcegraph/sourcegraph/pull/57468)
 
-## Unreleased 5.2.1
+## Unreleased 5.2.2
+
+### Added
+
+-
+
+### Changed
+
+-
+
+### Fixed
+
+-
+
+### Removed
+
+-
+
+## 5.2.1
 
 ### Added
 

--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -23,13 +23,13 @@
       "captainGitHubUsername": "unknwon",
       "captainSlackUsername": "joe"
     },
-    "5.2.1": {
-      "codeFreezeDate": "2023-10-11T10:00:00.000+02:00",
-      "securityApprovalDate": "2023-10-11T10:00:00.000+02:00",
-      "releaseDate": "2023-10-18T10:00:00.000+02:00",
-      "current": "5.2.1",
-      "captainGitHubUsername": "keegancsmith",
-      "captainSlackUsername": "keegan"
+    "5.2.2": {
+      "codeFreezeDate": "2023-10-25T10:00:00.000-07:00",
+      "securityApprovalDate": "2023-10-25T10:00:00.000-07:00",
+      "releaseDate": "2023-11-01T10:00:00.000-07:00",
+      "current": "5.2.2",
+      "captainGitHubUsername": "camdencheek",
+      "captainSlackUsername": "camden"
     }
   },
   "dryRun": {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/57319

Test Plan: n/a