### PR TITLE
licensing: export events in dotcom mode

### DIFF
--- a/internal/licensing/BUILD.bazel
+++ b/internal/licensing/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/licensing",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//cmd/frontend/envvar",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/env",

--- a/internal/licensing/telemetryexport.go
+++ b/internal/licensing/telemetryexport.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/exp/slices"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/license"
 )
@@ -67,6 +68,10 @@ var (
 func newTelemetryEventsExportMode(licenseKey string, pk ssh.PublicKey) TelemetryEventsExportMode {
 	if licenseKey == "" {
 		return TelemetryEventsExportAll // without licensing
+	}
+
+	if envvar.SourcegraphDotComMode() {
+		return TelemetryEventsExportAll // dotcom mode
 	}
 
 	// Use parametrized pk for testing


### PR DESCRIPTION
#57605 disables the new telemetry export in dotcom because it has an older license and does not fulfill any of the other conditions for default enablement. This adds a hardcoded env check on good old `envvar.SourcegraphDotComMode()`, since we already use this to e.g. determine if we can export sensitive metadata.

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/865336f2-0a88-4386-a9a7-d82a7c5075a3)

## Test plan

n/a