### PR TITLE
DB: small fixes from sqlf.Join precedence audit

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -120,7 +120,7 @@ func (o dbSubscriptionsListOptions) sqlConditions() []*sqlf.Query {
 		conds = append(conds, sqlf.Sprintf("product_subscriptions.archived_at IS NULL"))
 	}
 	if o.Query != "" {
-		conds = append(conds, sqlf.Sprintf("(users.username LIKE %s) OR (primary_emails.primary_email LIKE %s)", "%"+o.Query+"%", "%"+o.Query+"%"))
+		conds = append(conds, sqlf.Sprintf("(users.username LIKE %s OR primary_emails.primary_email LIKE %s)", "%"+o.Query+"%", "%"+o.Query+"%"))
 	}
 	return conds
 }

--- a/cmd/symbols/internal/database/store/search.go
+++ b/cmd/symbols/internal/database/store/search.go
@@ -174,7 +174,7 @@ func negate(query *sqlf.Query) *sqlf.Query {
 		return nil
 	}
 
-	return sqlf.Sprintf("NOT %s", query)
+	return sqlf.Sprintf("NOT (%s)", query)
 }
 
 func globEscape(str string) string {


### PR DESCRIPTION
I learned today that sqlf.Join does not paranthesize its resulting statement, which means operator precedence can cause your resulting SQL query to have different semantics than were likely intended. I did a quick audit of uses of sqlf.Join in our codebase, and only found one definite issue.

More info in [Slack](https://sourcegraph.slack.com/archives/C07KZF47K/p1697661844135659)

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
