### PR TITLE
graphqlbackend/telemetry: fix privateMetadata type

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -450,6 +450,7 @@ go_test(
         "slow_requests_tracer_test.go",
         "status_messages_test.go",
         "teams_test.go",
+        "telemetry_test.go",
         "temporary_settings_test.go",
         "testutil_test.go",
         "user_emails_test.go",

--- a/cmd/frontend/graphqlbackend/telemetry.go
+++ b/cmd/frontend/graphqlbackend/telemetry.go
@@ -2,7 +2,6 @@ package graphqlbackend
 
 import (
 	"context"
-	"encoding/json"
 )
 
 // TelemetryRootResolver provides TelemetryResolver via field 'telemetry' as
@@ -35,7 +34,7 @@ type TelemetryEventSourceInput struct {
 type TelemetryEventParametersInput struct {
 	Version         int32                               `json:"version"`
 	Metadata        *[]TelemetryEventMetadataInput      `json:"metadata,omitempty"`
-	PrivateMetadata *json.RawMessage                    `json:"privateMetadata,omitempty"`
+	PrivateMetadata *JSONValue                          `json:"privateMetadata,omitempty"`
 	BillingMetadata *TelemetryEventBillingMetadataInput `json:"billingMetadata,omitempty"`
 }
 

--- a/cmd/frontend/graphqlbackend/telemetry_test.go
+++ b/cmd/frontend/graphqlbackend/telemetry_test.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -82,4 +83,11 @@ func TestTelemetryRecordEvents(t *testing.T) {
 		}`,
 	})
 
+	// Check PrivateMetadata
+	require.Len(t, mockResolver.events, 1)
+	data, err := mockResolver.events[0].Parameters.PrivateMetadata.MarshalJSON()
+	require.NoError(t, err)
+	v := map[string]any{}
+	require.NoError(t, json.Unmarshal(data, &v))
+	require.Equal(t, v["key"], "value")
 }

--- a/cmd/frontend/graphqlbackend/telemetry_test.go
+++ b/cmd/frontend/graphqlbackend/telemetry_test.go
@@ -1,0 +1,85 @@
+package graphqlbackend
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/graph-gophers/graphql-go"
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+)
+
+type mockTelemetryResolver struct {
+	events []TelemetryEventInput
+}
+
+func (m *mockTelemetryResolver) RecordEvents(_ context.Context, args *RecordEventsArgs) (*EmptyResponse, error) {
+	m.events = append(m.events, args.Events...)
+	return &EmptyResponse{}, nil
+}
+
+func TestTelemetryRecordEvents(t *testing.T) {
+	mockResolver := &mockTelemetryResolver{}
+	parsedSchema, err := NewSchema(
+		dbmocks.NewMockDB(),
+		gitserver.NewClient(),
+		[]OptionalResolver{{
+			TelemetryRootResolver: &TelemetryRootResolver{Resolver: mockResolver},
+		}},
+		graphql.PanicHandler(printStackTrace{&gqlerrors.DefaultPanicHandler{}}),
+	)
+	require.NoError(t, err)
+
+	// Write a raw GraphQL event because we want to test providing the raw input
+	// value, as if from a client, which the Variables field in RunTest doesn't
+	// seem to accept right (it wants the final type, which defeats the point)
+	gqlEventInput := `
+	{
+		feature: "cody.fixup"
+		action: "applied"
+		source: {
+		  client: "VSCode.Cody",
+		  clientVersion: "0.14.1"
+		}
+		parameters: {
+		  version: 0
+		  metadata: [
+			{
+			  key: "contextSelection",
+			  value: 1
+			},
+			{
+			  key: "chatPredictions",
+			  value: 0
+			},
+		  ]
+		  privateMetadata: {key:"value"}
+		}
+	  }
+	`
+
+	// Check all fields accepted in GraphQL resolver.
+	RunTest(t, &Test{
+		Schema:  parsedSchema,
+		Context: context.Background(),
+		Query: fmt.Sprintf(`mutation RecordTelemetryEvents() {
+			telemetry {
+				recordEvents(events: [%s]) {
+					alwaysNil
+				}
+			}
+		}`, gqlEventInput),
+		ExpectedResult: `{
+			"telemetry": {
+				"recordEvents": {
+					"alwaysNil": null
+				}
+			}
+		}`,
+	})
+
+}

--- a/cmd/frontend/internal/telemetry/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/telemetry/resolvers/BUILD.bazel
@@ -28,7 +28,6 @@ go_test(
     deps = [
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
-        "//lib/pointers",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
@@ -28,7 +28,7 @@ func newTelemetryGatewayEvents(
 
 		// Parse private metadata
 		var privateMetadata *structpb.Struct
-		if e.Parameters.PrivateMetadata != nil && len(*e.Parameters.PrivateMetadata) > 0 {
+		if e.Parameters.PrivateMetadata != nil {
 			data, err := e.Parameters.PrivateMetadata.MarshalJSON()
 			if err != nil {
 				return nil, errors.Wrapf(err, "error marshaling privateMetadata for event %d", i)

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func TestNewTelemetryGatewayEvents(t *testing.T) {
@@ -108,7 +107,9 @@ func TestNewTelemetryGatewayEvents(t *testing.T) {
 							Value: 123,
 						},
 					},
-					PrivateMetadata: pointers.Ptr(json.RawMessage(`{"private": "super-sensitive"}`)),
+					PrivateMetadata: &graphqlbackend.JSONValue{
+						Value: map[string]any{"private": "super-sensitive"},
+					},
 					BillingMetadata: &graphqlbackend.TelemetryEventBillingMetadataInput{
 						Product:  "Product",
 						Category: "Category",


### PR DESCRIPTION
The `privateMetadata` field, which accepts arbitrary values, was using the wrong JSON type in the backend - it should be `JSONValue`, not `json.RawMessage`, which is another thing entirely. This causes the field to currently be unusable, as the backend type does not match with the GraphQL schema.

This bug does not affect any existing features - the new telemetry export is enabled, but no clients currently use the GraphQL mutation yet (WIP: https://github.com/sourcegraph/cody/pull/1192 - developing this is what caught this). However, it's important that this bug be fixed so that we can start using the new mutation in clients. In the meantime, we can do a clientside check to filter out this broken field (which is optional) until 5.2.2

## Test plan

- [x] New unit test in graphqlbackend layer
- [x] Existing test outputs unchanged by the change in type
- [x] Manual testing (`sg start` and submit GraphQL requests) 
![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/61984b5d-e9e2-4b49-af67-d2c7a0384441)
