### PR TITLE
all: use universal-ctags v6.0.0

### DIFF
--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -5,7 +5,7 @@
 # Commit hash of github.com/universal-ctags/ctags.
 # Last bumped 2022-04-04.
 # When bumping please remember to also update Zoekt: https://github.com/sourcegraph/zoekt/blob/d3a8fbd8385f0201dd54ab24114ebd588dfcf0d8/install-ctags-alpine.sh
-CTAGS_VERSION=f95bb3497f53748c2b6afc7f298cff218103ab90
+CTAGS_VERSION=v6.0.0
 
 cleanup() {
   apk --no-cache --purge del ctags-build-deps || true

--- a/dev/nix/ctags.nix
+++ b/dev/nix/ctags.nix
@@ -20,13 +20,13 @@ in
 # yoinked from github.com/nixos/nixpkgs
 unNixifyDylibs { inherit pkgs; } (stdenv.mkDerivation rec {
   pname = "universal-ctags";
-  version = "5.9.20220403.0";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "universal-ctags";
     repo = "ctags";
-    rev = "p${version}";
-    sha256 = "sha256-pd89KERQj6K11Nue3YFNO+NLOJGqcMnHkeqtWvMFk38=";
+    rev = "v${version}";
+    sha256 = "sha256-XlqBndo8g011SDGp3zM7S+AQ0aCp6rpQlqJF6e5Dd6w=";
   };
 
   depsBuildBuild = [

--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 DOCSITE_VERSION = "1.9.4"
 SRC_CLI_VERSION = "5.1.0"
-CTAGS_VERSION = "5.9.20220403.0"
+CTAGS_VERSION = "6.0.0"
 
 SRC_CLI_BUILDFILE = """
 filegroup(
@@ -57,24 +57,24 @@ def tool_deps():
         url = "https://github.com/sourcegraph/src-cli/releases/download/{0}/src-cli_{0}_darwin_arm64.tar.gz".format(SRC_CLI_VERSION),
     )
 
-    # universal-ctags #
+    # universal-ctags # TODO document how this is built and uploaded
     http_file(
         name = "universal-ctags-darwin-amd64",
-        sha256 = "b69501d497b62021e8438e840e0bea62fdbe91d60cf8375c388f2736cd58a1bf",
+        sha256 = "TODO",
         url = "https://storage.googleapis.com/universal_ctags/x86_64-darwin/bin/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )
 
     http_file(
         name = "universal-ctags-darwin-arm64",
-        sha256 = "6631f0bbd65cdedc155fcd9e17c8c31102aeffc78e2438799d4fb43297c5d473",
+        sha256 = "TODO",
         url = "https://storage.googleapis.com/universal_ctags/aarch64-darwin/bin/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )
 
     http_file(
         name = "universal-ctags-linux-amd64",
-        sha256 = "1d349d15736a30c9cc18c1fd9efbfc6081fb59125d799b84cef6b34c735fa28a",
+        sha256 = "TODO",
         url = "https://storage.googleapis.com/universal_ctags/x86_64-linux/bin/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )

--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 DOCSITE_VERSION = "1.9.4"
 SRC_CLI_VERSION = "5.1.0"
-CTAGS_VERSION = "6.0.0"
+CTAGS_VERSION = "5.9.20220403.0"
 
 SRC_CLI_BUILDFILE = """
 filegroup(
@@ -57,24 +57,24 @@ def tool_deps():
         url = "https://github.com/sourcegraph/src-cli/releases/download/{0}/src-cli_{0}_darwin_arm64.tar.gz".format(SRC_CLI_VERSION),
     )
 
-    # universal-ctags # TODO document how this is built and uploaded
+    # universal-ctags #
     http_file(
         name = "universal-ctags-darwin-amd64",
-        sha256 = "TODO",
+        sha256 = "b69501d497b62021e8438e840e0bea62fdbe91d60cf8375c388f2736cd58a1bf",
         url = "https://storage.googleapis.com/universal_ctags/x86_64-darwin/bin/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )
 
     http_file(
         name = "universal-ctags-darwin-arm64",
-        sha256 = "TODO",
+        sha256 = "6631f0bbd65cdedc155fcd9e17c8c31102aeffc78e2438799d4fb43297c5d473",
         url = "https://storage.googleapis.com/universal_ctags/aarch64-darwin/bin/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )
 
     http_file(
         name = "universal-ctags-linux-amd64",
-        sha256 = "TODO",
+        sha256 = "1d349d15736a30c9cc18c1fd9efbfc6081fb59125d799b84cef6b34c735fa28a",
         url = "https://storage.googleapis.com/universal_ctags/x86_64-linux/bin/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )

--- a/wolfi-packages/ctags.yaml
+++ b/wolfi-packages/ctags.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: ctags
-  version: 5.9.20220403.0
+  version: 6.0.0
   epoch: 2
   description: "A maintained ctags implementation"
   target-architecture:
@@ -34,8 +34,8 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://github.com/universal-ctags/ctags/archive/refs/tags/p${{package.version}}.tar.gz
-      expected-sha256: df966f73ae6082acb9f4f7fe4e27f53a593782380f28ccf65f0ac38aaf697888
+      uri: https://github.com/universal-ctags/ctags/archive/refs/tags/v${{package.version}}.tar.gz
+      expected-sha256: 71229a73f25529c9e3dabb2cb7310c55405d31caee8e8a9ab5c71b2406d4005a
   - name: Autogen
     runs: |
       ./autogen.sh


### PR DESCRIPTION
This is the latest release from December 2022. I see important bug fixes between our tagged version and this release.

Test Plan: CI