### PR TITLE
gopackages: Don't keep zip file in memory

### DIFF
--- a/cmd/gitserver/internal/vcssyncer/go_modules.go
+++ b/cmd/gitserver/internal/vcssyncer/go_modules.go
@@ -1,9 +1,9 @@
 package vcssyncer
 
 import (
-	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path"
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/mod/module"
 	modzip "golang.org/x/mod/zip"
 
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/gitserverfs"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
@@ -26,6 +27,7 @@ func NewGoModulesSyncer(
 	connection *schema.GoModulesConnection,
 	svc *dependencies.Service,
 	client *gomodproxy.Client,
+	reposDir string,
 ) VCSSyncer {
 	placeholder, err := reposource.ParseGoVersionedPackage("sourcegraph.com/placeholder@v0.0.0")
 	if err != nil {
@@ -39,12 +41,14 @@ func NewGoModulesSyncer(
 		placeholder: placeholder,
 		svc:         svc,
 		configDeps:  connection.Dependencies,
-		source:      &goModulesSyncer{client: client},
+		source:      &goModulesSyncer{client: client, reposDir: reposDir},
+		reposDir:    reposDir,
 	}
 }
 
 type goModulesSyncer struct {
-	client *gomodproxy.Client
+	client   *gomodproxy.Client
+	reposDir string
 }
 
 func (s goModulesSyncer) ParseVersionedPackageFromNameAndVersion(name reposource.PackageName, version string) (reposource.VersionedPackage, error) {
@@ -64,13 +68,14 @@ func (goModulesSyncer) ParsePackageFromRepoName(repoName api.RepoName) (reposour
 }
 
 func (s *goModulesSyncer) Download(ctx context.Context, dir string, dep reposource.VersionedPackage) error {
-	zipBytes, err := s.client.GetZip(ctx, dep.PackageSyntax(), dep.PackageVersion())
+	zip, err := s.client.GetZip(ctx, dep.PackageSyntax(), dep.PackageVersion())
 	if err != nil {
 		return errors.Wrap(err, "get zip")
 	}
+	defer zip.Close()
 
 	mod := dep.(*reposource.GoVersionedPackage).Module
-	if err = unzip(mod, zipBytes, dir); err != nil {
+	if err = unzip(mod, zip, s.reposDir, dir); err != nil {
 		return errors.Wrap(err, "failed to unzip go module")
 	}
 
@@ -79,20 +84,28 @@ func (s *goModulesSyncer) Download(ctx context.Context, dir string, dep reposour
 
 // unzip the given go module zip into workDir, skipping any files that aren't
 // valid according to modzip.CheckZip or that are potentially malicious.
-func unzip(mod module.Version, zipBytes []byte, workDir string) error {
-	zipFile := path.Join(workDir, "mod.zip")
-	err := os.WriteFile(zipFile, zipBytes, 0o666)
+func unzip(mod module.Version, zipContent io.Reader, reposDir string, workDir string) (err error) {
+	// We cannot unzip in a streaming fashion, so we write the zip file to
+	// a temporary file. Otherwise, we would need to load the entire zip into
+	// memory, which isn't great for multi-megabyte+ files.
+
+	// Create a tmpdir that gitserver manages.
+	tmpdir, err := gitserverfs.TempDir(reposDir, "gomod-zips")
 	if err != nil {
-		return errors.Wrapf(err, "failed to create go module zip file %q", zipFile)
+		return err
 	}
+	defer os.RemoveAll(tmpdir)
 
-	files, err := modzip.CheckZip(mod, zipFile)
+	// Write the whole package to a temporary file.
+	zip, zipLen, err := writeZipToTemp(tmpdir, zipContent)
+	if err != nil {
+		return err
+	}
+	defer zip.Close()
+
+	files, err := modzip.CheckZip(mod, zip.Name())
 	if err != nil && len(files.Valid) == 0 {
-		return errors.Wrapf(err, "failed to check go module zip %q", zipFile)
-	}
-
-	if err = os.RemoveAll(zipFile); err != nil {
-		return errors.Wrapf(err, "failed to remove module zip file %q", zipFile)
+		return errors.Wrapf(err, "failed to check go module zip %q", zip.Name())
 	}
 
 	if len(files.Valid) == 0 {
@@ -104,8 +117,7 @@ func unzip(mod module.Version, zipBytes []byte, workDir string) error {
 		valid[f] = struct{}{}
 	}
 
-	br := bytes.NewReader(zipBytes)
-	err = unpack.Zip(br, int64(br.Len()), workDir, unpack.Opts{
+	err = unpack.Zip(zip, zipLen, workDir, unpack.Opts{
 		SkipInvalid:    true,
 		SkipDuplicates: true,
 		Filter: func(path string, file fs.FileInfo) bool {

--- a/cmd/gitserver/internal/vcssyncer/go_modules_test.go
+++ b/cmd/gitserver/internal/vcssyncer/go_modules_test.go
@@ -63,7 +63,7 @@ func TestGoModulesSyncer_unzip(t *testing.T) {
 	}
 
 	workDir := t.TempDir()
-	err = unzip(dep.Module, bytes.NewReader(zipBuf.Bytes()), workDir)
+	err = unzip(dep.Module, bytes.NewReader(zipBuf.Bytes()), workDir, workDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gitserver/internal/vcssyncer/go_modules_test.go
+++ b/cmd/gitserver/internal/vcssyncer/go_modules_test.go
@@ -63,7 +63,7 @@ func TestGoModulesSyncer_unzip(t *testing.T) {
 	}
 
 	workDir := t.TempDir()
-	err = unzip(dep.Module, zipBuf.Bytes(), workDir)
+	err = unzip(dep.Module, bytes.NewReader(zipBuf.Bytes()), workDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gitserver/internal/vcssyncer/jvm_packages.go
+++ b/cmd/gitserver/internal/vcssyncer/jvm_packages.go
@@ -36,7 +36,7 @@ const (
 	jvmMajorVersion0 = 44
 )
 
-func NewJVMPackagesSyncer(connection *schema.JVMPackagesConnection, svc *dependencies.Service, cacheDir string) VCSSyncer {
+func NewJVMPackagesSyncer(connection *schema.JVMPackagesConnection, svc *dependencies.Service, cacheDir string, reposDir string) VCSSyncer {
 	placeholder, err := reposource.ParseMavenVersionedPackage("com.sourcegraph:sourcegraph:1.0.0")
 	if err != nil {
 		panic(fmt.Sprintf("expected placeholder package to parse but got %v", err))
@@ -51,6 +51,7 @@ func NewJVMPackagesSyncer(connection *schema.JVMPackagesConnection, svc *depende
 		placeholder: placeholder,
 		svc:         svc,
 		configDeps:  connection.Maven.Dependencies,
+		reposDir:    reposDir,
 		source: &jvmPackagesSyncer{
 			coursier: chandle,
 			config:   connection,

--- a/cmd/gitserver/internal/vcssyncer/jvm_packages_test.go
+++ b/cmd/gitserver/internal/vcssyncer/jvm_packages_test.go
@@ -203,7 +203,7 @@ func TestJVMCloneCommand(t *testing.T) {
 
 	depsSvc := dependencies.TestService(database.NewDB(logger, dbtest.NewDB(t)))
 	cacheDir := filepath.Join(dir, "cache")
-	s := NewJVMPackagesSyncer(&schema.JVMPackagesConnection{Maven: schema.Maven{Dependencies: []string{}}}, depsSvc, cacheDir).(*vcsPackagesSyncer)
+	s := NewJVMPackagesSyncer(&schema.JVMPackagesConnection{Maven: schema.Maven{Dependencies: []string{}}}, depsSvc, cacheDir, dir).(*vcsPackagesSyncer)
 	bareGitDirectory := path.Join(dir, "git")
 
 	s.runCloneCommand(t, examplePackageUrl, bareGitDirectory, []string{exampleVersionedPackage})

--- a/cmd/gitserver/internal/vcssyncer/npm_packages.go
+++ b/cmd/gitserver/internal/vcssyncer/npm_packages.go
@@ -26,6 +26,7 @@ func NewNpmPackagesSyncer(
 	connection schema.NpmPackagesConnection,
 	svc *dependencies.Service,
 	client npm.Client,
+	reposDir string,
 ) VCSSyncer {
 	placeholder, err := reposource.ParseNpmVersionedPackage("@sourcegraph/placeholder@1.0.0")
 	if err != nil {
@@ -39,6 +40,7 @@ func NewNpmPackagesSyncer(
 		placeholder: placeholder,
 		svc:         svc,
 		configDeps:  connection.Dependencies,
+		reposDir:    reposDir,
 		source:      &npmPackagesSyncer{client: client},
 	}
 }

--- a/cmd/gitserver/internal/vcssyncer/npm_packages_test.go
+++ b/cmd/gitserver/internal/vcssyncer/npm_packages_test.go
@@ -110,6 +110,7 @@ func TestNpmCloneCommand(t *testing.T) {
 		schema.NpmPackagesConnection{Dependencies: []string{}},
 		depsSvc,
 		&client,
+		dir,
 	).(*vcsPackagesSyncer)
 
 	bareGitDirectory := path.Join(dir, "git")

--- a/cmd/gitserver/internal/vcssyncer/packages_syncer_test.go
+++ b/cmd/gitserver/internal/vcssyncer/packages_syncer_test.go
@@ -42,6 +42,7 @@ func TestVcsDependenciesSyncer_Fetch(t *testing.T) {
 		placeholder: placeholder,
 		source:      depsSource,
 		svc:         depsService,
+		reposDir:    t.TempDir(),
 	}
 
 	remoteURL := &vcs.URL{URL: url.URL{Path: "fake/foo"}}

--- a/cmd/gitserver/internal/vcssyncer/python_packages.go
+++ b/cmd/gitserver/internal/vcssyncer/python_packages.go
@@ -35,6 +35,7 @@ func NewPythonPackagesSyncer(
 		svc:         svc,
 		configDeps:  connection.Dependencies,
 		source:      &pythonPackagesSyncer{client: client, reposDir: reposDir},
+		reposDir:    reposDir,
 	}
 }
 
@@ -152,22 +153,4 @@ func unpackPythonPackage(pkg io.Reader, packageURL, reposDir, workDir string) er
 	}
 
 	return stripSingleOutermostDirectory(workDir)
-}
-
-func writeZipToTemp(tmpdir string, pkg io.Reader) (*os.File, int64, error) {
-	// Create a temp file.
-	f, err := os.CreateTemp(tmpdir, "pypi-package-")
-	if err != nil {
-		return nil, 0, err
-	}
-
-	// Write contents to file.
-	read, err := io.Copy(f, pkg)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	// Reset read head.
-	_, err = f.Seek(0, 0)
-	return f, read, err
 }

--- a/cmd/gitserver/internal/vcssyncer/python_packages_test.go
+++ b/cmd/gitserver/internal/vcssyncer/python_packages_test.go
@@ -57,7 +57,7 @@ func TestUnpackPythonPackage_TGZ(t *testing.T) {
 	pkg := bytes.NewReader(createTgz(t, files))
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(pkg, "https://some.where/pckg.tar.gz", tmp, tmp); err != nil {
+	if err := unpackPythonPackage(pkg, "https://some.where/pckg.tar.gz", tmp); err != nil {
 		t.Fatal()
 	}
 
@@ -127,7 +127,7 @@ func TestUnpackPythonPackage_ZIP(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(&zipBuf, "https://some.where/pckg.zip", tmp, tmp); err != nil {
+	if err := unpackPythonPackage(&zipBuf, "https://some.where/pckg.zip", tmp); err != nil {
 		t.Fatal()
 	}
 
@@ -171,13 +171,13 @@ func TestUnpackPythonPackage_InvalidZip(t *testing.T) {
 
 	pkg := bytes.NewReader(createTgz(t, files))
 
-	if err := unpackPythonPackage(pkg, "https://some.where/pckg.whl", t.TempDir(), t.TempDir()); err == nil {
+	if err := unpackPythonPackage(pkg, "https://some.where/pckg.whl", t.TempDir()); err == nil {
 		t.Fatal("no error returned from unpack package")
 	}
 }
 
 func TestUnpackPythonPackage_UnsupportedFormat(t *testing.T) {
-	if err := unpackPythonPackage(bytes.NewReader([]byte{}), "https://some.where/pckg.exe", "", ""); err == nil {
+	if err := unpackPythonPackage(bytes.NewReader([]byte{}), "https://some.where/pckg.exe", ""); err == nil {
 		t.Fatal()
 	}
 }
@@ -211,7 +211,7 @@ func TestUnpackPythonPackage_Wheel(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(b, wheelURL, tmp, tmp); err != nil {
+	if err := unpackPythonPackage(b, wheelURL, tmp); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/gitserver/internal/vcssyncer/python_packages_test.go
+++ b/cmd/gitserver/internal/vcssyncer/python_packages_test.go
@@ -57,7 +57,7 @@ func TestUnpackPythonPackage_TGZ(t *testing.T) {
 	pkg := bytes.NewReader(createTgz(t, files))
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(pkg, "https://some.where/pckg.tar.gz", tmp); err != nil {
+	if err := unpackPythonPackage(pkg, "https://some.where/pckg.tar.gz", tmp, tmp); err != nil {
 		t.Fatal()
 	}
 
@@ -127,7 +127,7 @@ func TestUnpackPythonPackage_ZIP(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(&zipBuf, "https://some.where/pckg.zip", tmp); err != nil {
+	if err := unpackPythonPackage(&zipBuf, "https://some.where/pckg.zip", tmp, tmp); err != nil {
 		t.Fatal()
 	}
 
@@ -171,13 +171,13 @@ func TestUnpackPythonPackage_InvalidZip(t *testing.T) {
 
 	pkg := bytes.NewReader(createTgz(t, files))
 
-	if err := unpackPythonPackage(pkg, "https://some.where/pckg.whl", t.TempDir()); err == nil {
+	if err := unpackPythonPackage(pkg, "https://some.where/pckg.whl", t.TempDir(), t.TempDir()); err == nil {
 		t.Fatal("no error returned from unpack package")
 	}
 }
 
 func TestUnpackPythonPackage_UnsupportedFormat(t *testing.T) {
-	if err := unpackPythonPackage(bytes.NewReader([]byte{}), "https://some.where/pckg.exe", ""); err == nil {
+	if err := unpackPythonPackage(bytes.NewReader([]byte{}), "https://some.where/pckg.exe", "", ""); err == nil {
 		t.Fatal()
 	}
 }
@@ -211,7 +211,7 @@ func TestUnpackPythonPackage_Wheel(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	if err := unpackPythonPackage(b, wheelURL, tmp); err != nil {
+	if err := unpackPythonPackage(b, wheelURL, tmp, tmp); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/gitserver/internal/vcssyncer/ruby_packages.go
+++ b/cmd/gitserver/internal/vcssyncer/ruby_packages.go
@@ -24,6 +24,7 @@ func NewRubyPackagesSyncer(
 	connection *schema.RubyPackagesConnection,
 	svc *dependencies.Service,
 	client *rubygems.Client,
+	reposDir string,
 ) VCSSyncer {
 	return &vcsPackagesSyncer{
 		logger:      log.Scoped("RubyPackagesSyncer"),
@@ -32,6 +33,7 @@ func NewRubyPackagesSyncer(
 		placeholder: reposource.NewRubyVersionedPackage("sourcegraph/placeholder", "0.0.0"),
 		svc:         svc,
 		configDeps:  connection.Dependencies,
+		reposDir:    reposDir,
 		source:      &rubyDependencySource{client: client},
 	}
 }

--- a/cmd/gitserver/internal/vcssyncer/rust_packages.go
+++ b/cmd/gitserver/internal/vcssyncer/rust_packages.go
@@ -21,6 +21,7 @@ func NewRustPackagesSyncer(
 	connection *schema.RustPackagesConnection,
 	svc *dependencies.Service,
 	client *crates.Client,
+	reposDir string,
 ) VCSSyncer {
 	return &vcsPackagesSyncer{
 		logger:      log.Scoped("RustPackagesSyncer"),
@@ -29,6 +30,7 @@ func NewRustPackagesSyncer(
 		placeholder: reposource.ParseRustVersionedPackage("sourcegraph.com/placeholder@0.0.0"),
 		svc:         svc,
 		configDeps:  connection.Dependencies,
+		reposDir:    reposDir,
 		source:      &rustDependencySource{client: client},
 	}
 }

--- a/cmd/gitserver/internal/vcssyncer/syncer.go
+++ b/cmd/gitserver/internal/vcssyncer/syncer.go
@@ -107,7 +107,7 @@ func NewVCSSyncer(ctx context.Context, opts *NewVCSSyncerOpts) (VCSSyncer, error
 		if _, err := extractOptions(&c); err != nil {
 			return nil, err
 		}
-		return NewJVMPackagesSyncer(&c, opts.DepsSvc, opts.CoursierCacheDir), nil
+		return NewJVMPackagesSyncer(&c, opts.DepsSvc, opts.CoursierCacheDir, opts.ReposDir), nil
 	case extsvc.TypeNpmPackages:
 		var c schema.NpmPackagesConnection
 		urn, err := extractOptions(&c)
@@ -118,7 +118,7 @@ func NewVCSSyncer(ctx context.Context, opts *NewVCSSyncerOpts) (VCSSyncer, error
 		if err != nil {
 			return nil, err
 		}
-		return NewNpmPackagesSyncer(c, opts.DepsSvc, cli), nil
+		return NewNpmPackagesSyncer(c, opts.DepsSvc, cli, opts.ReposDir), nil
 	case extsvc.TypeGoModules:
 		var c schema.GoModulesConnection
 		urn, err := extractOptions(&c)
@@ -126,7 +126,7 @@ func NewVCSSyncer(ctx context.Context, opts *NewVCSSyncerOpts) (VCSSyncer, error
 			return nil, err
 		}
 		cli := gomodproxy.NewClient(urn, c.Urls, httpcli.ExternalClientFactory)
-		return NewGoModulesSyncer(&c, opts.DepsSvc, cli), nil
+		return NewGoModulesSyncer(&c, opts.DepsSvc, cli, opts.ReposDir), nil
 	case extsvc.TypePythonPackages:
 		var c schema.PythonPackagesConnection
 		urn, err := extractOptions(&c)
@@ -148,7 +148,7 @@ func NewVCSSyncer(ctx context.Context, opts *NewVCSSyncerOpts) (VCSSyncer, error
 		if err != nil {
 			return nil, err
 		}
-		return NewRustPackagesSyncer(&c, opts.DepsSvc, cli), nil
+		return NewRustPackagesSyncer(&c, opts.DepsSvc, cli, opts.ReposDir), nil
 	case extsvc.TypeRubyPackages:
 		var c schema.RubyPackagesConnection
 		urn, err := extractOptions(&c)
@@ -159,7 +159,7 @@ func NewVCSSyncer(ctx context.Context, opts *NewVCSSyncerOpts) (VCSSyncer, error
 		if err != nil {
 			return nil, err
 		}
-		return NewRubyPackagesSyncer(&c, opts.DepsSvc, cli), nil
+		return NewRubyPackagesSyncer(&c, opts.DepsSvc, cli, opts.ReposDir), nil
 	}
 	return NewGitRepoSyncer(opts.RecordingCommandFactory), nil
 }

--- a/internal/extsvc/gomodproxy/client.go
+++ b/internal/extsvc/gomodproxy/client.go
@@ -68,8 +68,7 @@ func (c *Client) GetVersion(ctx context.Context, mod reposource.PackageName, ver
 	return &module.Version{Path: string(mod), Version: v.Version}, nil
 }
 
-// GetZip returns the zip archive bytes of the given module and version.
-func (c *Client) GetZip(ctx context.Context, mod reposource.PackageName, version string) ([]byte, error) {
+func (c *Client) GetZip(ctx context.Context, mod reposource.PackageName, version string) (io.ReadCloser, error) {
 	escapedVersion, err := module.EscapeVersion(version)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to escape version")
@@ -80,13 +79,7 @@ func (c *Client) GetZip(ctx context.Context, mod reposource.PackageName, version
 		return nil, err
 	}
 
-	// TODO: remove and return io.Reader
-	zipBytes, err := io.ReadAll(zip)
-	if err != nil {
-		return nil, err
-	}
-
-	return zipBytes, nil
+	return zip, nil
 }
 
 func (c *Client) get(ctx context.Context, doer httpcli.Doer, mod reposource.PackageName, paths ...string) (respBody io.ReadCloser, err error) {

--- a/internal/extsvc/gomodproxy/client_test.go
+++ b/internal/extsvc/gomodproxy/client_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +79,20 @@ func TestClient_GetZip(t *testing.T) {
 			mod = ps[0]
 		}
 
-		zipBytes, err := cli.GetZip(ctx, reposource.PackageName(mod), version)
+		zipStream, err := cli.GetZip(ctx, reposource.PackageName(mod), version)
+		t.Cleanup(func() {
+			if zipStream != nil {
+				_ = zipStream.Close()
+			}
+		})
+
+		var zipBytes []byte
+		if zipStream != nil {
+			zipBytes, err = io.ReadAll(zipStream)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
 
 		r := result{Error: fmt.Sprint(err)}
 


### PR DESCRIPTION
This aligns what we do for Go with what we do for python, writing a zip file to disk. This should prevent big memory spikes when large go modules are downloaded.

## Test plan

Adjusted tests and checked locally that both python and go modules are still cloned correctly. 