### PR TITLE
monitoring/telemetry: un-hide panels, improve docstrings

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -7610,6 +7610,147 @@ Generated query for warning alert: `max((max(src_codeintel_commit_graph_queued_d
 
 <br />
 
+## telemetry: telemetry_gateway_exporter_queue_growth
+
+<p class="subtitle">rate of growth of export queue over 30m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> telemetry: 1+ rate of growth of export queue over 30m for 1h0m0s
+- <span class="badge badge-critical">critical</span> telemetry: 1+ rate of growth of export queue over 30m for 36h0m0s
+
+**Next steps**
+
+- Check the "number of events exported per batch over 30m" dashboard panel to see if export throughput is at saturation.
+- Increase `TELEMETRY_GATEWAY_EXPORTER_EXPORT_BATCH_SIZE` to export more events per batch.
+- Reduce `TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL` to schedule more export jobs.
+- See worker logs in the `worker.telemetrygateway-exporter` log scope for more details to see if any export errors are occuring - if logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph`s Telemetry Gateway service.
+- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#telemetry-telemetry-gateway-exporter-queue-growth).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_telemetry_telemetry_gateway_exporter_queue_growth",
+  "critical_telemetry_telemetry_gateway_exporter_queue_growth"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((max(deriv(src_telemetrygatewayexporter_queue_size[30m]))) > 1)`
+
+Generated query for critical alert: `max((max(deriv(src_telemetrygatewayexporter_queue_size[30m]))) > 1)`
+
+</details>
+
+<br />
+
+## telemetry: telemetrygatewayexporter_exporter_errors_total
+
+<p class="subtitle">events exporter operation errors every 30m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> telemetry: 0+ events exporter operation errors every 30m
+
+**Next steps**
+
+- Failures indicate that exporting of telemetry events from Sourcegraph are failing.
+This may affect the performance of the database as the backlog grows.
+
+See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
+If logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph`s Telemetry Gateway service.
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#telemetry-telemetrygatewayexporter-exporter-errors-total).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_telemetry_telemetrygatewayexporter_exporter_errors_total"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))) > 0)`
+
+</details>
+
+<br />
+
+## telemetry: telemetrygatewayexporter_queue_cleanup_errors_total
+
+<p class="subtitle">export queue cleanup operation errors every 30m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> telemetry: 0+ export queue cleanup operation errors every 30m
+
+**Next steps**
+
+- Failures indicate that pruning of already-exported telemetry events from the database is failing.
+This may affect the performance of the database as the export queue table grows.
+
+See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#telemetry-telemetrygatewayexporter-queue-cleanup-errors-total).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_telemetry_telemetrygatewayexporter_queue_cleanup_errors_total"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))) > 0)`
+
+</details>
+
+<br />
+
+## telemetry: telemetrygatewayexporter_queue_metrics_reporter_errors_total
+
+<p class="subtitle">export backlog metrics reporting operation errors every 30m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> telemetry: 0+ export backlog metrics reporting operation errors every 30m
+
+**Next steps**
+
+- Failures indicate that reporting of telemetry events metrics is failing.
+This may affect the reliability of telemetry events export metrics.
+
+See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
+- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#telemetry-telemetrygatewayexporter-queue-metrics-reporter-errors-total).
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_telemetry_telemetrygatewayexporter_queue_metrics_reporter_errors_total"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Generated query for warning alert: `max((sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))) > 0)`
+
+</details>
+
+<br />
+
 ## telemetry: telemetry_job_error_rate
 
 <p class="subtitle">usage data exporter operation error rate over 5m</p>
@@ -7667,137 +7808,6 @@ Generated query for warning alert: `max((sum by (op) (increase(src_telemetry_job
 <summary>Technical details</summary>
 
 Generated query for warning alert: `max((rate(src_telemetry_job_total{op="SendEvents"}[1h]) / on () group_right () src_telemetry_job_max_throughput * 100) > 90)`
-
-</details>
-
-<br />
-
-## telemetry: telemetry_gateway_exporter_queue_growth
-
-<p class="subtitle">rate of growth of export queue over 30m</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> telemetry: 1+ rate of growth of export queue over 30m for 1h0m0s
-- <span class="badge badge-critical">critical</span> telemetry: 1+ rate of growth of export queue over 30m for 36h0m0s
-
-**Next steps**
-
-- Increase `TELEMETRY_GATEWAY_EXPORTER_EXPORT_BATCH_SIZE` to export more events per batch.
-- Reduce `TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL` to schedule more export jobs.
-- See worker logs in the `worker.telemetrygateway-exporter` log scope for more details to see if any export errors are occuring - if logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph`s Telemetry Gateway service.
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#telemetry-telemetry-gateway-exporter-queue-growth).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_telemetry_telemetry_gateway_exporter_queue_growth",
-  "critical_telemetry_telemetry_gateway_exporter_queue_growth"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for warning alert: `max((max(deriv(src_telemetrygatewayexporter_queue_size[30m]))) > 1)`
-
-Generated query for critical alert: `max((max(deriv(src_telemetrygatewayexporter_queue_size[30m]))) > 1)`
-
-</details>
-
-<br />
-
-## telemetry: telemetrygatewayexporter_exporter_errors_total
-
-<p class="subtitle">events exporter operation errors every 30m</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> telemetry: 0+ events exporter operation errors every 30m
-
-**Next steps**
-
-- See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
-If logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph`s Telemetry Gateway service.
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#telemetry-telemetrygatewayexporter-exporter-errors-total).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_telemetry_telemetrygatewayexporter_exporter_errors_total"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for warning alert: `max((sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))) > 0)`
-
-</details>
-
-<br />
-
-## telemetry: telemetrygatewayexporter_queue_cleanup_errors_total
-
-<p class="subtitle">export queue cleanup operation errors every 30m</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> telemetry: 0+ export queue cleanup operation errors every 30m
-
-**Next steps**
-
-- See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#telemetry-telemetrygatewayexporter-queue-cleanup-errors-total).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_telemetry_telemetrygatewayexporter_queue_cleanup_errors_total"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for warning alert: `max((sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))) > 0)`
-
-</details>
-
-<br />
-
-## telemetry: telemetrygatewayexporter_queue_metrics_reporter_errors_total
-
-<p class="subtitle">export backlog metrics reporting operation errors every 30m</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> telemetry: 0+ export backlog metrics reporting operation errors every 30m
-
-**Next steps**
-
-- See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#telemetry-telemetrygatewayexporter-queue-metrics-reporter-errors-total).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_telemetry_telemetrygatewayexporter_queue_metrics_reporter_errors_total"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for warning alert: `max((sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))) > 0)`
 
 </details>
 

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -7658,11 +7658,8 @@ Generated query for critical alert: `max((max(deriv(src_telemetrygatewayexporter
 
 **Next steps**
 
-- Failures indicate that exporting of telemetry events from Sourcegraph are failing.
-This may affect the performance of the database as the backlog grows.
-
-See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
-If logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph`s Telemetry Gateway service.
+- Failures indicate that exporting of telemetry events from Sourcegraph are failing. This may affect the performance of the database as the backlog grows.
+- See worker logs in the `worker.telemetrygateway-exporter` log scope for more details. If logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph`s Telemetry Gateway service.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#telemetry-telemetrygatewayexporter-exporter-errors-total).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -7693,10 +7690,8 @@ Generated query for warning alert: `max((sum(increase(src_telemetrygatewayexport
 
 **Next steps**
 
-- Failures indicate that pruning of already-exported telemetry events from the database is failing.
-This may affect the performance of the database as the export queue table grows.
-
-See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
+- Failures indicate that pruning of already-exported telemetry events from the database is failing. This may affect the performance of the database as the export queue table grows.
+- See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#telemetry-telemetrygatewayexporter-queue-cleanup-errors-total).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -7727,10 +7722,8 @@ Generated query for warning alert: `max((sum(increase(src_telemetrygatewayexport
 
 **Next steps**
 
-- Failures indicate that reporting of telemetry events metrics is failing.
-This may affect the reliability of telemetry events export metrics.
-
-See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
+- Failures indicate that reporting of telemetry events metrics is failing. This may affect the reliability of telemetry events export metrics.
+- See worker logs in the `worker.telemetrygateway-exporter` log scope for more details.
 - Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#telemetry-telemetrygatewayexporter-queue-metrics-reporter-errors-total).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -30778,7 +30778,7 @@ Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_
 
 <br />
 
-### Telemetry: Usage data exporter: Job operations
+### Telemetry: Usage data exporter (legacy): Job operations
 
 #### telemetry: telemetry_job_total
 
@@ -30932,7 +30932,7 @@ Query: `sum by (op)(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m
 
 <br />
 
-### Telemetry: Usage data exporter: Queue size
+### Telemetry: Usage data exporter (legacy): Queue size
 
 #### telemetry: telemetry_job_queue_size_queue_size
 
@@ -30978,7 +30978,7 @@ Query: `sum(increase(src_telemetry_job_queue_size_total{job=~"^worker.*"}[30m]))
 
 <br />
 
-### Telemetry: Usage data exporter: Utilization
+### Telemetry: Usage data exporter (legacy): Utilization
 
 #### telemetry: telemetry_job_utilized_throughput
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -30457,6 +30457,327 @@ Query: `sum by (op)(increase(src_codeintel_uploads_reconciler_scip_data_errors_t
 
 To see this dashboard, visit `/-/debug/grafana/d/telemetry/telemetry` on your Sourcegraph instance.
 
+### Telemetry: Telemetry Gateway Exporter: Export and queue metrics
+
+#### telemetry: telemetry_gateway_exporter_queue_size
+
+<p class="subtitle">Telemetry event payloads pending export</p>
+
+The number of events queued to be exported.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100000` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(src_telemetrygatewayexporter_queue_size)`
+
+</details>
+
+<br />
+
+#### telemetry: telemetry_gateway_exporter_queue_growth
+
+<p class="subtitle">Rate of growth of export queue over 30m</p>
+
+A positive value indicates the queue is growing.
+
+Refer to the [alerts reference](./alerts.md#telemetry-telemetry-gateway-exporter-queue-growth) for 2 alerts related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100001` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `max(deriv(src_telemetrygatewayexporter_queue_size[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: src_telemetrygatewayexporter_exported_events
+
+<p class="subtitle">Events exported from queue per hour</p>
+
+The number of events being exported.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100010` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `max(increase(src_telemetrygatewayexporter_exported_events[1h]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetry_gateway_exporter_batch_size
+
+<p class="subtitle">Number of events exported per batch over 30m</p>
+
+The number of events exported in each batch. The largest bucket is the maximum number of events exported per batch.
+If the distribution trends to the maximum bucket, then events export throughput is at or approaching saturation - try increasing  `TELEMETRY_GATEWAY_EXPORTER_EXPORT_BATCH_SIZE` or decreasing `TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL`.
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100011` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum by (le) (rate(src_telemetrygatewayexporter_batch_size_bucket[30m]))`
+
+</details>
+
+<br />
+
+### Telemetry: Telemetry Gateway Exporter: Export job operations
+
+#### telemetry: telemetrygatewayexporter_exporter_total
+
+<p class="subtitle">Events exporter operations every 30m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100100` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_telemetrygatewayexporter_exporter_total{job=~"^worker.*"}[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetrygatewayexporter_exporter_99th_percentile_duration
+
+<p class="subtitle">Aggregate successful events exporter operation duration distribution over 30m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100101` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum  by (le)(rate(src_telemetrygatewayexporter_exporter_duration_seconds_bucket{job=~"^worker.*"}[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetrygatewayexporter_exporter_errors_total
+
+<p class="subtitle">Events exporter operation errors every 30m</p>
+
+Refer to the [alerts reference](./alerts.md#telemetry-telemetrygatewayexporter-exporter-errors-total) for 1 alert related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100102` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetrygatewayexporter_exporter_error_rate
+
+<p class="subtitle">Events exporter operation error rate over 30m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100103` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_exporter_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))) * 100`
+
+</details>
+
+<br />
+
+### Telemetry: Telemetry Gateway Exporter: Export queue cleanup job operations
+
+#### telemetry: telemetrygatewayexporter_queue_cleanup_total
+
+<p class="subtitle">Export queue cleanup operations every 30m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100200` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_telemetrygatewayexporter_queue_cleanup_total{job=~"^worker.*"}[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetrygatewayexporter_queue_cleanup_99th_percentile_duration
+
+<p class="subtitle">Aggregate successful export queue cleanup operation duration distribution over 30m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100201` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum  by (le)(rate(src_telemetrygatewayexporter_queue_cleanup_duration_seconds_bucket{job=~"^worker.*"}[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetrygatewayexporter_queue_cleanup_errors_total
+
+<p class="subtitle">Export queue cleanup operation errors every 30m</p>
+
+Refer to the [alerts reference](./alerts.md#telemetry-telemetrygatewayexporter-queue-cleanup-errors-total) for 1 alert related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100202` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetrygatewayexporter_queue_cleanup_error_rate
+
+<p class="subtitle">Export queue cleanup operation error rate over 30m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100203` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_queue_cleanup_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))) * 100`
+
+</details>
+
+<br />
+
+### Telemetry: Telemetry Gateway Exporter: Export queue metrics reporting job operations
+
+#### telemetry: telemetrygatewayexporter_queue_metrics_reporter_total
+
+<p class="subtitle">Export backlog metrics reporting operations every 30m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100300` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_total{job=~"^worker.*"}[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetrygatewayexporter_queue_metrics_reporter_99th_percentile_duration
+
+<p class="subtitle">Aggregate successful export backlog metrics reporting operation duration distribution over 30m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100301` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum  by (le)(rate(src_telemetrygatewayexporter_queue_metrics_reporter_duration_seconds_bucket{job=~"^worker.*"}[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetrygatewayexporter_queue_metrics_reporter_errors_total
+
+<p class="subtitle">Export backlog metrics reporting operation errors every 30m</p>
+
+Refer to the [alerts reference](./alerts.md#telemetry-telemetrygatewayexporter-queue-metrics-reporter-errors-total) for 1 alert related to this panel.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100302` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))`
+
+</details>
+
+<br />
+
+#### telemetry: telemetrygatewayexporter_queue_metrics_reporter_error_rate
+
+<p class="subtitle">Export backlog metrics reporting operation error rate over 30m</p>
+
+This panel has no related alerts.
+
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100303` on your Sourcegraph instance.
+
+<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
+
+<details>
+<summary>Technical details</summary>
+
+Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))) * 100`
+
+</details>
+
+<br />
+
 ### Telemetry: Usage data exporter: Job operations
 
 #### telemetry: telemetry_job_total
@@ -30465,7 +30786,7 @@ To see this dashboard, visit `/-/debug/grafana/d/telemetry/telemetry` on your So
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100000` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100400` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
@@ -30484,7 +30805,7 @@ Query: `sum(increase(src_telemetry_job_total{job=~"^worker.*"}[5m]))`
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100001` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100401` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
@@ -30503,7 +30824,7 @@ Query: `sum  by (le)(rate(src_telemetry_job_duration_seconds_bucket{job=~"^worke
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100002` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100402` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
@@ -30522,7 +30843,7 @@ Query: `sum(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m]))`
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100003` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100403` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
@@ -30541,7 +30862,7 @@ Query: `sum(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m])) / (s
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100010` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100410` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
@@ -30560,7 +30881,7 @@ Query: `sum by (op)(increase(src_telemetry_job_total{job=~"^worker.*"}[5m]))`
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100011` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100411` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
@@ -30579,7 +30900,7 @@ Query: `histogram_quantile(0.99, sum  by (le,op)(rate(src_telemetry_job_duration
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100012` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100412` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
@@ -30598,7 +30919,7 @@ Query: `sum by (op)(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m
 
 Refer to the [alerts reference](./alerts.md#telemetry-telemetry-job-error-rate) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100013` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100413` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
 
@@ -30619,7 +30940,7 @@ Query: `sum by (op)(increase(src_telemetry_job_errors_total{job=~"^worker.*"}[5m
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100100` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100500` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
 
@@ -30644,7 +30965,7 @@ This value compares the rate of enqueues against the rate of finished jobs.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100101` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100501` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Code Insights team](https://handbook.sourcegraph.com/departments/engineering/teams/code-insights).*</sub>
 
@@ -30665,269 +30986,6 @@ Query: `sum(increase(src_telemetry_job_queue_size_total{job=~"^worker.*"}[30m]))
 
 Refer to the [alerts reference](./alerts.md#telemetry-telemetry-job-utilized-throughput) for 1 alert related to this panel.
 
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100200` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `rate(src_telemetry_job_total{op="SendEvents"}[1h]) / on() group_right() src_telemetry_job_max_throughput * 100`
-
-</details>
-
-<br />
-
-### Telemetry: Telemetry Gateway Exporter: Export and queue metrics
-
-#### telemetry: telemetry_gateway_exporter_queue_size
-
-<p class="subtitle">Telemetry event payloads pending export</p>
-
-The number of events queued to be exported.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100300` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(src_telemetrygatewayexporter_queue_size)`
-
-</details>
-
-<br />
-
-#### telemetry: telemetry_gateway_exporter_queue_growth
-
-<p class="subtitle">Rate of growth of export queue over 30m</p>
-
-A positive value indicates the queue is growing.
-
-Refer to the [alerts reference](./alerts.md#telemetry-telemetry-gateway-exporter-queue-growth) for 2 alerts related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100301` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `max(deriv(src_telemetrygatewayexporter_queue_size[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: src_telemetrygatewayexporter_exported_events
-
-<p class="subtitle">Events exported from queue per hour</p>
-
-The number of events being exported.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100310` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `max(increase(src_telemetrygatewayexporter_exported_events[1h]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetry_gateway_exporter_batch_size
-
-<p class="subtitle">Number of events exported per batch over 30m</p>
-
-The number of events exported in each batch.
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100311` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum by (le) (rate(src_telemetrygatewayexporter_batch_size_bucket[30m]))`
-
-</details>
-
-<br />
-
-### Telemetry: Telemetry Gateway Exporter: Export job operations
-
-#### telemetry: telemetrygatewayexporter_exporter_total
-
-<p class="subtitle">Events exporter operations every 30m</p>
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100400` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_telemetrygatewayexporter_exporter_total{job=~"^worker.*"}[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetrygatewayexporter_exporter_99th_percentile_duration
-
-<p class="subtitle">Aggregate successful events exporter operation duration distribution over 30m</p>
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100401` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum  by (le)(rate(src_telemetrygatewayexporter_exporter_duration_seconds_bucket{job=~"^worker.*"}[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetrygatewayexporter_exporter_errors_total
-
-<p class="subtitle">Events exporter operation errors every 30m</p>
-
-Refer to the [alerts reference](./alerts.md#telemetry-telemetrygatewayexporter-exporter-errors-total) for 1 alert related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100402` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetrygatewayexporter_exporter_error_rate
-
-<p class="subtitle">Events exporter operation error rate over 30m</p>
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100403` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_exporter_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_exporter_errors_total{job=~"^worker.*"}[30m]))) * 100`
-
-</details>
-
-<br />
-
-### Telemetry: Telemetry Gateway Exporter: Export queue cleanup job operations
-
-#### telemetry: telemetrygatewayexporter_queue_cleanup_total
-
-<p class="subtitle">Export queue cleanup operations every 30m</p>
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100500` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_telemetrygatewayexporter_queue_cleanup_total{job=~"^worker.*"}[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetrygatewayexporter_queue_cleanup_99th_percentile_duration
-
-<p class="subtitle">Aggregate successful export queue cleanup operation duration distribution over 30m</p>
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100501` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum  by (le)(rate(src_telemetrygatewayexporter_queue_cleanup_duration_seconds_bucket{job=~"^worker.*"}[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetrygatewayexporter_queue_cleanup_errors_total
-
-<p class="subtitle">Export queue cleanup operation errors every 30m</p>
-
-Refer to the [alerts reference](./alerts.md#telemetry-telemetrygatewayexporter-queue-cleanup-errors-total) for 1 alert related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100502` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetrygatewayexporter_queue_cleanup_error_rate
-
-<p class="subtitle">Export queue cleanup operation error rate over 30m</p>
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100503` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_queue_cleanup_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_queue_cleanup_errors_total{job=~"^worker.*"}[30m]))) * 100`
-
-</details>
-
-<br />
-
-### Telemetry: Telemetry Gateway Exporter: Export queue metrics reporting job operations
-
-#### telemetry: telemetrygatewayexporter_queue_metrics_reporter_total
-
-<p class="subtitle">Export backlog metrics reporting operations every 30m</p>
-
-This panel has no related alerts.
-
 To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100600` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
@@ -30935,64 +30993,7 @@ To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=10060
 <details>
 <summary>Technical details</summary>
 
-Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_total{job=~"^worker.*"}[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetrygatewayexporter_queue_metrics_reporter_99th_percentile_duration
-
-<p class="subtitle">Aggregate successful export backlog metrics reporting operation duration distribution over 30m</p>
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100601` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum  by (le)(rate(src_telemetrygatewayexporter_queue_metrics_reporter_duration_seconds_bucket{job=~"^worker.*"}[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetrygatewayexporter_queue_metrics_reporter_errors_total
-
-<p class="subtitle">Export backlog metrics reporting operation errors every 30m</p>
-
-Refer to the [alerts reference](./alerts.md#telemetry-telemetrygatewayexporter-queue-metrics-reporter-errors-total) for 1 alert related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100602` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))`
-
-</details>
-
-<br />
-
-#### telemetry: telemetrygatewayexporter_queue_metrics_reporter_error_rate
-
-<p class="subtitle">Export backlog metrics reporting operation error rate over 30m</p>
-
-This panel has no related alerts.
-
-To see this panel, visit `/-/debug/grafana/d/telemetry/telemetry?viewPanel=100603` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Data & Analytics team](https://handbook.sourcegraph.com/departments/engineering/teams/data-analytics).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m])) / (sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_total{job=~"^worker.*"}[30m])) + sum(increase(src_telemetrygatewayexporter_queue_metrics_reporter_errors_total{job=~"^worker.*"}[30m]))) * 100`
+Query: `rate(src_telemetry_job_total{op="SendEvents"}[1h]) / on() group_right() src_telemetry_job_max_throughput * 100`
 
 </details>
 

--- a/monitoring/definitions/shared/usage_data_pipeline.go
+++ b/monitoring/definitions/shared/usage_data_pipeline.go
@@ -11,7 +11,7 @@ var DataAnalytics dataAnalytics
 // codeInsights provides `CodeInsights` implementations.
 type dataAnalytics struct{}
 
-var usageDataExporterNamespace = "Usage data exporter"
+var usageDataExporterNamespace = "Usage data exporter (legacy)"
 
 // src_telemetry_job_queue_size
 func (dataAnalytics) NewTelemetryJobQueueGroup(containerName string) monitoring.Group {
@@ -67,7 +67,7 @@ func (dataAnalytics) NewTelemetryJobOperationsGroup(containerName string) monito
 
 func (dataAnalytics) TelemetryJobThroughputGroup(containerName string) monitoring.Group {
 	return monitoring.Group{
-		Title:  "Usage data exporter: Utilization",
+		Title:  "Usage data exporter (legacy): Utilization",
 		Hidden: true,
 		Rows: []monitoring.Row{
 			{

--- a/monitoring/definitions/telemetry.go
+++ b/monitoring/definitions/telemetry.go
@@ -98,11 +98,8 @@ func Telemetry() *monitoring.Dashboard {
 					Duration:  shared.NoAlertsOption("none"),
 					ErrorRate: shared.NoAlertsOption("none"),
 					Errors: shared.WarningOption(monitoring.Alert().Greater(0), `
-						Failures indicate that exporting of telemetry events from Sourcegraph are failing.
-						This may affect the performance of the database as the backlog grows.
-
-						See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details.
-						If logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph's Telemetry Gateway service.
+						- Failures indicate that exporting of telemetry events from Sourcegraph are failing. This may affect the performance of the database as the backlog grows.
+						- See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details. If logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph's Telemetry Gateway service.
 					`),
 				},
 			}),
@@ -121,10 +118,8 @@ func Telemetry() *monitoring.Dashboard {
 					Duration:  shared.NoAlertsOption("none"),
 					ErrorRate: shared.NoAlertsOption("none"),
 					Errors: shared.WarningOption(monitoring.Alert().Greater(0), `
-						Failures indicate that pruning of already-exported telemetry events from the database is failing.
-						This may affect the performance of the database as the export queue table grows.
-
-						See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details.
+						- Failures indicate that pruning of already-exported telemetry events from the database is failing. This may affect the performance of the database as the export queue table grows.
+						- See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details.
 					`),
 				},
 			}),
@@ -143,10 +138,8 @@ func Telemetry() *monitoring.Dashboard {
 					Duration:  shared.NoAlertsOption("none"),
 					ErrorRate: shared.NoAlertsOption("none"),
 					Errors: shared.WarningOption(monitoring.Alert().Greater(0), `
-						Failures indicate that reporting of telemetry events metrics is failing.
-						This may affect the reliability of telemetry events export metrics.
-
-						See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details.
+						- Failures indicate that reporting of telemetry events metrics is failing. This may affect the reliability of telemetry events export metrics.
+						- See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details.
 					`),
 				},
 			}),

--- a/monitoring/definitions/telemetry.go
+++ b/monitoring/definitions/telemetry.go
@@ -18,15 +18,9 @@ func Telemetry() *monitoring.Dashboard {
 		Title:       "Telemetry",
 		Description: "Monitoring telemetry services in Sourcegraph.",
 		Groups: []monitoring.Group{
-			// Legacy dashboards - TODO(@bobheadxi): remove after 5.2.2
-			shared.DataAnalytics.NewTelemetryJobOperationsGroup(containerName),
-			shared.DataAnalytics.NewTelemetryJobQueueGroup(containerName),
-			shared.DataAnalytics.TelemetryJobThroughputGroup(containerName),
-
 			// The new stuff - https://docs.sourcegraph.com/dev/background-information/telemetry
 			{
-				Title:  "Telemetry Gateway Exporter: Export and queue metrics",
-				Hidden: true, // TODO(@bobheadxi): not yet enabled by default, un-hide in 5.2.1
+				Title: "Telemetry Gateway Exporter: Export and queue metrics",
 				Rows: []monitoring.Row{
 					{
 						{
@@ -50,6 +44,7 @@ func Telemetry() *monitoring.Dashboard {
 							// Critical when it grows without ever reducing
 							Critical: monitoring.Alert().Greater(1).For(36 * time.Hour),
 							NextSteps: `
+								- Check the "number of events exported per batch over 30m" dashboard panel to see if export throughput is at saturation.
 								- Increase 'TELEMETRY_GATEWAY_EXPORTER_EXPORT_BATCH_SIZE' to export more events per batch.
 								- Reduce 'TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL' to schedule more export jobs.
 								- See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details to see if any export errors are occuring - if logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph's Telemetry Gateway service.
@@ -79,8 +74,11 @@ func Telemetry() *monitoring.Dashboard {
 									p.HeatmapPanel.Targets[0].Format = "heatmap"
 									p.HeatmapPanel.Targets[0].LegendFormat = "{{le}}"
 								}),
-							NoAlert:        true,
-							Interpretation: "The number of events exported in each batch.",
+							NoAlert: true,
+							Interpretation: `
+								The number of events exported in each batch. The largest bucket is the maximum number of events exported per batch.
+								If the distribution trends to the maximum bucket, then events export throughput is at or approaching saturation - try increasing  'TELEMETRY_GATEWAY_EXPORTER_EXPORT_BATCH_SIZE' or decreasing 'TELEMETRY_GATEWAY_EXPORTER_EXPORT_INTERVAL'.
+							`,
 						},
 					},
 				},
@@ -94,13 +92,15 @@ func Telemetry() *monitoring.Dashboard {
 					},
 					Namespace:       "Telemetry Gateway Exporter",
 					DescriptionRoot: "Export job operations",
-					Hidden:          true, // TODO(@bobheadxi): not yet enabled by default, un-hide in 5.2.1
 				},
 				SharedObservationGroupOptions: shared.SharedObservationGroupOptions{
 					Total:     shared.NoAlertsOption("none"),
 					Duration:  shared.NoAlertsOption("none"),
 					ErrorRate: shared.NoAlertsOption("none"),
 					Errors: shared.WarningOption(monitoring.Alert().Greater(0), `
+						Failures indicate that exporting of telemetry events from Sourcegraph are failing.
+						This may affect the performance of the database as the backlog grows.
+
 						See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details.
 						If logs only indicate that exports failed, reach out to Sourcegraph with relevant log entries, as this may be an issue in Sourcegraph's Telemetry Gateway service.
 					`),
@@ -115,14 +115,17 @@ func Telemetry() *monitoring.Dashboard {
 					},
 					Namespace:       "Telemetry Gateway Exporter",
 					DescriptionRoot: "Export queue cleanup job operations",
-					Hidden:          true, // TODO(@bobheadxi): not yet enabled by default, un-hide in 5.2.1
 				},
 				SharedObservationGroupOptions: shared.SharedObservationGroupOptions{
 					Total:     shared.NoAlertsOption("none"),
 					Duration:  shared.NoAlertsOption("none"),
 					ErrorRate: shared.NoAlertsOption("none"),
-					Errors: shared.WarningOption(monitoring.Alert().Greater(0),
-						"See worker logs in the `worker.telemetrygateway-exporter` log scope for more details."),
+					Errors: shared.WarningOption(monitoring.Alert().Greater(0), `
+						Failures indicate that pruning of already-exported telemetry events from the database is failing.
+						This may affect the performance of the database as the export queue table grows.
+
+						See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details.
+					`),
 				},
 			}),
 			shared.Observation.NewGroup(containerName, monitoring.ObservableOwnerDataAnalytics, shared.ObservationGroupOptions{
@@ -134,16 +137,24 @@ func Telemetry() *monitoring.Dashboard {
 					},
 					Namespace:       "Telemetry Gateway Exporter",
 					DescriptionRoot: "Export queue metrics reporting job operations",
-					Hidden:          true,
 				},
 				SharedObservationGroupOptions: shared.SharedObservationGroupOptions{
 					Total:     shared.NoAlertsOption("none"),
 					Duration:  shared.NoAlertsOption("none"),
 					ErrorRate: shared.NoAlertsOption("none"),
-					Errors: shared.WarningOption(monitoring.Alert().Greater(0),
-						"See worker logs in the `worker.telemetrygateway-exporter` log scope for more details."),
+					Errors: shared.WarningOption(monitoring.Alert().Greater(0), `
+						Failures indicate that reporting of telemetry events metrics is failing.
+						This may affect the reliability of telemetry events export metrics.
+
+						See worker logs in the 'worker.telemetrygateway-exporter' log scope for more details.
+					`),
 				},
 			}),
+
+			// Legacy dashboards
+			shared.DataAnalytics.NewTelemetryJobOperationsGroup(containerName),
+			shared.DataAnalytics.NewTelemetryJobQueueGroup(containerName),
+			shared.DataAnalytics.TelemetryJobThroughputGroup(containerName),
 		},
 	}
 }


### PR DESCRIPTION
Some gentle doc writing during ship coffee break - this adds a bit more detail to the telemetry panel help text, unhides them as they are now available by default, and puts them above the Cloud-specific exporter.

Not that important so not backporting.

## Test plan

n/a

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@telemetry-monitoring-improvements)