### PR TITLE
telemetrygateway: support arbitrary privateMetadata types from graphqlbackend

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -553,6 +553,7 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_throttled_throttled_v2//store/memstore",
+        "@org_golang_google_protobuf//types/known/structpb",
     ],
 )
 

--- a/cmd/frontend/graphqlbackend/telemetry_test.go
+++ b/cmd/frontend/graphqlbackend/telemetry_test.go
@@ -2,13 +2,13 @@ package graphqlbackend
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/graph-gophers/graphql-go"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -24,70 +24,172 @@ func (m *mockTelemetryResolver) RecordEvents(_ context.Context, args *RecordEven
 }
 
 func TestTelemetryRecordEvents(t *testing.T) {
-	mockResolver := &mockTelemetryResolver{}
-	parsedSchema, err := NewSchema(
-		dbmocks.NewMockDB(),
-		gitserver.NewClient(),
-		[]OptionalResolver{{
-			TelemetryRootResolver: &TelemetryRootResolver{Resolver: mockResolver},
-		}},
-		graphql.PanicHandler(printStackTrace{&gqlerrors.DefaultPanicHandler{}}),
-	)
-	require.NoError(t, err)
-
-	// Write a raw GraphQL event because we want to test providing the raw input
-	// value, as if from a client, which the Variables field in RunTest doesn't
-	// seem to accept right (it wants the final type, which defeats the point)
-	gqlEventInput := `
-	{
-		feature: "cody.fixup"
-		action: "applied"
-		source: {
-		  client: "VSCode.Cody",
-		  clientVersion: "0.14.1"
-		}
-		parameters: {
-		  version: 0
-		  metadata: [
-			{
-			  key: "contextSelection",
-			  value: 1
-			},
-			{
-			  key: "chatPredictions",
-			  value: 0
-			},
-		  ]
-		  privateMetadata: {key:"value"}
-		}
-	  }
-	`
-
-	// Check all fields accepted in GraphQL resolver.
-	RunTest(t, &Test{
-		Schema:  parsedSchema,
-		Context: context.Background(),
-		Query: fmt.Sprintf(`mutation RecordTelemetryEvents() {
-			telemetry {
-				recordEvents(events: [%s]) {
-					alwaysNil
+	for _, tc := range []struct {
+		name string
+		// Write a raw GraphQL event because we want to test providing the raw input
+		// value, as if from a client, which the Variables field in RunTest doesn't
+		// seem to accept right (it wants the final type, which defeats the point)
+		gqlEventsInput string
+		assert         func(t *testing.T, gotEvents []TelemetryEventInput)
+	}{
+		{
+			name: "object privateMetadata",
+			gqlEventsInput: `
+				{
+					feature: "cody.fixup"
+					action: "applied"
+					source: {
+						client: "VSCode.Cody",
+						clientVersion: "0.14.1"
+					}
+					parameters: {
+						version: 0
+						metadata: [
+							{
+								key: "contextSelection",
+								value: 1
+							},
+							{
+								key: "chatPredictions",
+								value: 0
+							},
+						]
+						privateMetadata: {key:"value"}
+					}
 				}
-			}
-		}`, gqlEventInput),
-		ExpectedResult: `{
-			"telemetry": {
-				"recordEvents": {
-					"alwaysNil": null
-				}
-			}
-		}`,
-	})
+			`,
+			assert: func(t *testing.T, gotEvents []TelemetryEventInput) {
+				// Check PrivateMetadata
+				require.Len(t, gotEvents, 1)
+				value := gotEvents[0].Parameters.PrivateMetadata.Value
+				require.NotNil(t, value)
+				v, ok := value.(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, "value", v["key"])
 
-	// Check PrivateMetadata
-	require.Len(t, mockResolver.events, 1)
-	data, err := mockResolver.events[0].Parameters.PrivateMetadata.MarshalJSON()
-	require.NoError(t, err)
-	v := map[string]any{}
-	require.NoError(t, json.Unmarshal(data, &v))
-	require.Equal(t, v["key"], "value")
+				// Sanity check strucpb marshalling used in cmd/frontend/internal/telemetry/resolvers
+				_, err := structpb.NewStruct(v)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "string privateMetadata",
+			gqlEventsInput: `
+				{
+					feature: "cody.fixup"
+					action: "applied"
+					source: {
+						client: "VSCode.Cody",
+						clientVersion: "0.14.1"
+					}
+					parameters: {
+						version: 0
+						metadata: [
+							{
+								key: "contextSelection",
+								value: 1
+							},
+							{
+								key: "chatPredictions",
+								value: 0
+							},
+						]
+						privateMetadata: "some value"
+					}
+				}
+			`,
+			assert: func(t *testing.T, gotEvents []TelemetryEventInput) {
+				// Check PrivateMetadata
+				require.Len(t, gotEvents, 1)
+				value := gotEvents[0].Parameters.PrivateMetadata.Value
+				require.NotNil(t, value)
+				v, ok := value.(string)
+				require.True(t, ok)
+				require.Equal(t, "some value", v)
+
+				// Sanity check strucpb marshalling used in cmd/frontend/internal/telemetry/resolvers
+				_, err := structpb.NewValue(value)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "numeric privateMetadata",
+			gqlEventsInput: `
+				{
+					feature: "cody.fixup"
+					action: "applied"
+					source: {
+						client: "VSCode.Cody",
+						clientVersion: "0.14.1"
+					}
+					parameters: {
+						version: 0
+						metadata: [
+							{
+								key: "contextSelection",
+								value: 1
+							},
+							{
+								key: "chatPredictions",
+								value: 0
+							},
+						]
+						privateMetadata: 12
+					}
+				}
+			`,
+			assert: func(t *testing.T, gotEvents []TelemetryEventInput) {
+				// Check PrivateMetadata
+				require.Len(t, gotEvents, 1)
+				value := gotEvents[0].Parameters.PrivateMetadata.Value
+				require.NotNil(t, value)
+				v, ok := value.(int32)
+				require.Truef(t, ok, "got %T", value)
+				require.Equal(t, int32(12), v)
+
+				// Sanity check strucpb marshalling used in cmd/frontend/internal/telemetry/resolvers
+				_, err := structpb.NewValue(value)
+				require.NoError(t, err)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+
+			mockResolver := &mockTelemetryResolver{}
+			parsedSchema, err := NewSchema(
+				dbmocks.NewMockDB(),
+				gitserver.NewClient(),
+				[]OptionalResolver{{
+					TelemetryRootResolver: &TelemetryRootResolver{Resolver: mockResolver},
+				}},
+				graphql.PanicHandler(printStackTrace{&gqlerrors.DefaultPanicHandler{}}),
+			)
+			require.NoError(t, err)
+
+			// Check all fields accepted in GraphQL resolver.
+			RunTest(t, &Test{
+				Schema:  parsedSchema,
+				Context: context.Background(),
+				Query: fmt.Sprintf(`mutation RecordTelemetryEvents() {
+					telemetry {
+						recordEvents(events: [%s]) {
+							alwaysNil
+						}
+					}
+				}`, tc.gqlEventsInput),
+				ExpectedResult: `{
+					"telemetry": {
+						"recordEvents": {
+							"alwaysNil": null
+						}
+					}
+				}`,
+			})
+
+			// Run assertions defined by test case
+			tc.assert(t, mockResolver.events)
+		})
+	}
 }

--- a/cmd/frontend/graphqlbackend/telemetry_test.go
+++ b/cmd/frontend/graphqlbackend/telemetry_test.go
@@ -30,7 +30,8 @@ func TestTelemetryRecordEvents(t *testing.T) {
 		// value, as if from a client, which the Variables field in RunTest doesn't
 		// seem to accept right (it wants the final type, which defeats the point)
 		gqlEventsInput string
-		assert         func(t *testing.T, gotEvents []TelemetryEventInput)
+		// Assertions on received events.
+		assert func(t *testing.T, gotEvents []TelemetryEventInput)
 	}{
 		{
 			name: "object privateMetadata",
@@ -154,9 +155,6 @@ func TestTelemetryRecordEvents(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
-			t.Parallel()
-
 			mockResolver := &mockTelemetryResolver{}
 			parsedSchema, err := NewSchema(
 				dbmocks.NewMockDB(),
@@ -167,6 +165,11 @@ func TestTelemetryRecordEvents(t *testing.T) {
 				graphql.PanicHandler(printStackTrace{&gqlerrors.DefaultPanicHandler{}}),
 			)
 			require.NoError(t, err)
+
+			// Parallel must start here, as NewSchema is not concurrency-safe
+			// (it assigns to a global variable).
+			tc := tc
+			t.Parallel()
 
 			// Check all fields accepted in GraphQL resolver.
 			RunTest(t, &Test{

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -29,17 +28,24 @@ func newTelemetryGatewayEvents(
 		// Parse private metadata
 		var privateMetadata *structpb.Struct
 		if e.Parameters.PrivateMetadata != nil {
-			data, err := e.Parameters.PrivateMetadata.MarshalJSON()
-			if err != nil {
-				return nil, errors.Wrapf(err, "error marshaling privateMetadata for event %d", i)
-			}
-			var privateData map[string]any
-			if err := json.Unmarshal(data, &privateData); err != nil {
-				return nil, errors.Wrapf(err, "error unmarshaling privateMetadata for event %d", i)
-			}
-			privateMetadata, err = structpb.NewStruct(privateData)
-			if err != nil {
-				return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf for event %d", i)
+			switch v := e.Parameters.PrivateMetadata.Value.(type) {
+			// If the input is an object, turn it into proto struct as-is
+			case map[string]any:
+				var err error
+				privateMetadata, err = structpb.NewStruct(v)
+				if err != nil {
+					return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf struct for event %d", i)
+				}
+
+			// Otherwise, nest the value within a proto struct
+			default:
+				protoValue, err := structpb.NewValue(v)
+				if err != nil {
+					return nil, errors.Wrapf(err, "error converting privateMetadata to protobuf value for event %d", i)
+				}
+				privateMetadata = &structpb.Struct{
+					Fields: map[string]*structpb.Value{"value": protoValue},
+				}
 			}
 		}
 

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
@@ -141,6 +141,68 @@ func TestNewTelemetryGatewayEvents(t *testing.T) {
   "timestamp": "2023-02-24T14:48:30Z"
 }`),
 		},
+		{
+			name: "with string PrivateMetadata",
+			ctx:  context.Background(),
+			event: graphqlbackend.TelemetryEventInput{
+				Feature: "Feature",
+				Action:  "Example",
+				Parameters: graphqlbackend.TelemetryEventParametersInput{
+					Version: 0,
+					PrivateMetadata: &graphqlbackend.JSONValue{
+						Value: "some metadata",
+					},
+				},
+			},
+			expect: autogold.Expect(`{
+  "action": "Example",
+  "feature": "Feature",
+  "id": "with string PrivateMetadata",
+  "parameters": {
+    "privateMetadata": {
+      "value": "some metadata"
+    }
+  },
+  "source": {
+    "client": {},
+    "server": {
+      "version": "0.0.0+dev"
+    }
+  },
+  "timestamp": "2023-02-24T14:48:30Z"
+}`),
+		},
+		{
+			name: "with numeric PrivateMetadata",
+			ctx:  context.Background(),
+			event: graphqlbackend.TelemetryEventInput{
+				Feature: "Feature",
+				Action:  "Example",
+				Parameters: graphqlbackend.TelemetryEventParametersInput{
+					Version: 0,
+					PrivateMetadata: &graphqlbackend.JSONValue{
+						Value: 1234,
+					},
+				},
+			},
+			expect: autogold.Expect(`{
+  "action": "Example",
+  "feature": "Feature",
+  "id": "with numeric PrivateMetadata",
+  "parameters": {
+    "privateMetadata": {
+      "value": 1234
+    }
+  },
+  "source": {
+    "client": {},
+    "server": {
+      "version": "0.0.0+dev"
+    }
+  },
+  "timestamp": "2023-02-24T14:48:30Z"
+}`),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := newTelemetryGatewayEvents(tc.ctx,


### PR DESCRIPTION
The bug fix in #57719 (backported in #57720) fixed support for the common case, a JSON object `privateMetadata`, but the GraphQL schema describes that any valid JSON should be accepted, and GraphQL validation permits primitives like `string`:

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/657a023c-876a-46dc-a768-eba3af820ef2)

This change improves on #57719 with support for arbitrary types in case they get submitted. Similar to #57719, this is not a customer-affecting bug today as there are no usages, but it is important we land this fix to minimize the impact of this bug as we introduce usages like https://github.com/sourcegraph/cody/pull/1192.

The diff is mostly tests, as the fix is fairly minimal.

## Test plan

- [x] Updated unit tests assert that the GraphQL library we use does indeed accept incoming types as the equivalent Go type in `JSONValue.Value`
- [x] Updated unit tests assert that marshalling of arbitrary types to proto works as expected
- [x] Manual testing with `sg start` demonstrates GraphQL requests with arbitrary `privateMetadata` types are accepted: 
![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/946b9ca2-8afd-479a-833b-85478542454c)
![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/59aea94a-02f5-4ad6-8d1e-633ee091dd37)
![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/fe62e257-1c70-4e46-ab88-4eb445f9009e)
