### PR TITLE
conf: enable Prometheus to sample the lastUpdateTime metric concurrently with the actual config update process

### DIFF
--- a/internal/conf/BUILD.bazel
+++ b/internal/conf/BUILD.bazel
@@ -44,7 +44,6 @@ go_library(
         "@com_github_grafana_regexp//:regexp",
         "@com_github_hashicorp_cronexpr//:cronexpr",
         "@com_github_prometheus_client_golang//prometheus",
-        "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_jsonx//:jsonx",
         "@com_github_sourcegraph_log//:log",
         "@com_github_xeipuuv_gojsonschema//:gojsonschema",


### PR DESCRIPTION
In the previous iteration of this functionality (#57682), the lastUpdateTime metric only updated:

1. Prior to the update thread sleeping
2. Immediately after it wakes up from sleep
3. In the small window of time immediately between the lastUpdateTime was set to time.Now (after a successful fetch) and the next instruction (to set the new value of the metric).

All of this means that metric was only infrequently updated. It successfully handles the case where site configuration is unavailable for a bit (e.g repeated fetch failures over a long period of time). However, this also meant that in the happy path case, the last update times were consistently too low (e.x. ~500 nanoseconds) since the metric is never updated during the most time consuming part of the process: actually reaching out over the network

This change fixes the above issue by tweaking the Prometheus gauge definition to execute a callback that simply reads the lastUpdateTime struct field whenever Prometheus scrapes the service metrics. This allows the sampling to occur at any point during the client update process (including during the execution of fetchAndUpdate) instead of only at certain points.

## Test plan

CI 

Also I previewed the metric below in my local dev instance. Notice that the fetch times seem more realistic (half a second, 3 seconds, etc.). This indicates that the metric is updated regardless of whether or the updating thread is sleeping, jittering, actually fetching over the network etc. 

<img width="1674" alt="Screenshot 2023-10-19 at 11 49 19 AM" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/d9150578-e9f2-42bc-afb2-7ddaf150b408">


