### PR TITLE
Revert "Add temporary logging to dotcom sudo handler (#56429)"

### DIFF
--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -55,7 +55,7 @@ func AccessTokenAuthMiddleware(db database.DB, baseLogger log.Logger, next http.
 		if headerValue := r.Header.Get("Authorization"); headerValue != "" && token == "" {
 			// Handle Authorization header
 			var err error
-			token, sudoUser, err = authz.ParseAuthorizationHeader(logger, r, headerValue)
+			token, sudoUser, err = authz.ParseAuthorizationHeader(headerValue)
 			if err != nil {
 				if !envvar.SourcegraphDotComMode() && authz.IsUnrecognizedScheme(err) {
 					// Ignore Authorization headers that we don't handle.

--- a/internal/authz/BUILD.bazel
+++ b/internal/authz/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//lib/errors",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
-        "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )
@@ -49,7 +48,6 @@ go_test(
         "//lib/errors",
         "@com_github_gobwas_glob//:glob",
         "@com_github_google_go_cmp//cmp",
-        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/internal/authz/header.go
+++ b/internal/authz/header.go
@@ -2,11 +2,7 @@ package authz
 
 import (
 	"bytes"
-	"io"
-	"net/http"
 	"strings"
-
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -39,7 +35,7 @@ func IsUnrecognizedScheme(err error) bool {
 //
 // The returned values are derived directly from user input and have not been validated or
 // authenticated.
-func ParseAuthorizationHeader(logger log.Logger, r *http.Request, headerValue string) (token, sudoUser string, err error) {
+func ParseAuthorizationHeader(headerValue string) (token, sudoUser string, err error) {
 	scheme, token68, params, err := parseHTTPCredentials(headerValue)
 	if err != nil {
 		return "", "", err
@@ -59,9 +55,6 @@ func ParseAuthorizationHeader(logger log.Logger, r *http.Request, headerValue st
 	}
 
 	if envvar.SourcegraphDotComMode() && scheme == SchemeTokenSudo {
-		// Attempt to read the body. This might fail if it was read before.
-		body, readErr := io.ReadAll(r.Body)
-		logger.Warn("saw request with sudo mode", log.String("path", r.URL.Path), log.String("body", string(body)), log.Error(readErr))
 		return "", "", errors.New("use of access tokens with sudo scope is disabled")
 	}
 

--- a/internal/authz/header_test.go
+++ b/internal/authz/header_test.go
@@ -63,11 +63,7 @@ func TestParseAuthorizationHeader(t *testing.T) {
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(false)
 
-		r := &http.Request{
-			URL:  &url.URL{Path: ".api/graphql"},
-			Body: io.NopCloser(strings.NewReader("the body")),
-		}
-		_, _, err := ParseAuthorizationHeader(logtest.Scoped(t), r, `token`)
+		_, _, err := ParseAuthorizationHeader(`token`)
 		got := fmt.Sprintf("%v", err)
 		want := "no token value in the HTTP Authorization request header"
 		if diff := cmp.Diff(want, got); diff != "" {

--- a/internal/authz/header_test.go
+++ b/internal/authz/header_test.go
@@ -2,17 +2,11 @@ package authz
 
 import (
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-
-	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 )
@@ -37,7 +31,7 @@ func TestParseAuthorizationHeader(t *testing.T) {
 	}
 	for input, test := range tests {
 		t.Run(input, func(t *testing.T) {
-			token, sudoUser, err := ParseAuthorizationHeader(logtest.Scoped(t), nil, input)
+			token, sudoUser, err := ParseAuthorizationHeader(input)
 			if (err != nil) != test.err {
 				t.Errorf("got error %v, want error? %v", err, test.err)
 			}
@@ -57,24 +51,12 @@ func TestParseAuthorizationHeader(t *testing.T) {
 		envvar.MockSourcegraphDotComMode(true)
 		defer envvar.MockSourcegraphDotComMode(false)
 
-		r := &http.Request{
-			URL:  &url.URL{Path: ".api/graphql"},
-			Body: io.NopCloser(strings.NewReader("the body")),
-		}
-		logger, captured := logtest.Captured(t)
-		_, _, err := ParseAuthorizationHeader(logger, r, `token-sudo token="tok==", user="alice"`)
+		_, _, err := ParseAuthorizationHeader(`token-sudo token="tok==", user="alice"`)
 		got := fmt.Sprintf("%v", err)
 		want := "use of access tokens with sudo scope is disabled"
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatalf("Mismatch (-want +got):\n%s", diff)
 		}
-		logs := captured()
-		require.Equal(t, []string{"saw request with sudo mode"}, logs.Messages())
-		require.Equal(t, map[string]any{
-			"body":  "the body",
-			"error": "<nil>",
-			"path":  ".api/graphql",
-		}, logs[0].Fields)
 	})
 
 	t.Run("empty token does not raise sudo error on dotcom", func(t *testing.T) {


### PR DESCRIPTION
This reverts commit aa8c53f43b19eb381d5301f0a06104a06d6a0118.

No longer needed.

## Test plan

CI.