### PR TITLE
Bump p4-fusion to version of our fork

### DIFF
--- a/wolfi-images/gitserver.yaml
+++ b/wolfi-images/gitserver.yaml
@@ -16,7 +16,7 @@ contents:
 
     - coursier@sourcegraph
     - p4cli@sourcegraph
-    - p4-fusion=1.13.1-sg-r0@sourcegraph
+    - p4-fusion=1.12-r6@sourcegraph
 
 paths:
   - path: /data/repos

--- a/wolfi-images/gitserver.yaml
+++ b/wolfi-images/gitserver.yaml
@@ -16,7 +16,7 @@ contents:
 
     - coursier@sourcegraph
     - p4cli@sourcegraph
-    - p4-fusion=1.12-r6@sourcegraph
+    - p4-fusion=1.13.1-sg-r0@sourcegraph
 
 paths:
   - path: /data/repos

--- a/wolfi-packages/p4-fusion.yaml
+++ b/wolfi-packages/p4-fusion.yaml
@@ -35,12 +35,12 @@ pipeline:
   # Download p4-fusion
   - uses: fetch
     with:
-      uri: https://github.com/sourcegraph/p4-fusion/archive/52446032942d31baf6b36b09e72928415400a037.tar.gz
-      expected-sha256: 4edfb8b3f3ded5f7de70a7604272fe489604330a0699c93cb9f4c62633530d68
+      uri: https://github.com/sourcegraph/p4-fusion/archive/1927d60872e88244d9421865a1ebcfa89d4d893f.tar.gz
+      expected-sha256: 16cc228293590c294c08d8bd53d228393ca72f4d998b6f38d78dc108969f5003
       extract: false
   - runs: |
       mkdir p4-fusion-src
-      tar -C p4-fusion-src -xzf 52446032942d31baf6b36b09e72928415400a037.tar.gz --strip 1
+      tar -C p4-fusion-src -xzf 1927d60872e88244d9421865a1ebcfa89d4d893f.tar.gz --strip 1
 
   # Download OpenSSL
   - uses: fetch

--- a/wolfi-packages/p4-fusion.yaml
+++ b/wolfi-packages/p4-fusion.yaml
@@ -2,8 +2,8 @@
 
 package:
   name: p4-fusion
-  version: 1.12
-  epoch: 6
+  version: 1.13.1-sg
+  epoch: 0
   description: "A fast Perforce to Git conversion tool"
   target-architecture:
     - x86_64
@@ -35,12 +35,12 @@ pipeline:
   # Download p4-fusion
   - uses: fetch
     with:
-      uri: https://github.com/salesforce/p4-fusion/archive/refs/tags/v${{package.version}}.tar.gz
-      expected-sha256: f5cbca35880aad2e6fac05c669dab6c13c3389aa62cbc5d5ee2ce73e77bcfe78
+      uri: https://github.com/sourcegraph/p4-fusion/archive/52446032942d31baf6b36b09e72928415400a037.tar.gz
+      expected-sha256: 4edfb8b3f3ded5f7de70a7604272fe489604330a0699c93cb9f4c62633530d68
       extract: false
   - runs: |
       mkdir p4-fusion-src
-      tar -C p4-fusion-src -xzf v${{package.version}}.tar.gz --strip 1
+      tar -C p4-fusion-src -xzf 52446032942d31baf6b36b09e72928415400a037.tar.gz --strip 1
 
   # Download OpenSSL
   - uses: fetch


### PR DESCRIPTION
We've forked the tool and are now ready to try some of the fixes out in a more production enviroment, so bundling this temporarily from a specific commit from the fork repo.

Next up, I'll open a PR to use the newly generated base image in bazel and add the new `--noBaseCommit` flag to the perforce syncer.

## Test plan

Ran `sg wolfi package p4-fusion locally and it passed`.