### PR TITLE
Add follow-up feedback to Core Concepts

### DIFF
--- a/doc/code_navigation/explanations/uploads.md
+++ b/doc/code_navigation/explanations/uploads.md
@@ -1,6 +1,6 @@
 # Code Graph Data uploads
 
-<p class="subtitle">How data uploads to Code Graph and becomes useful to gather Cody context.</p>
+<p class="subtitle">How Code Graph data is uploaded and used.</p>
 
 <style>
 img.screenshot {
@@ -17,7 +17,7 @@ img.terminal-screenshot {
 }
 </style>
 
-[Code graph indexers](../references/indexers.md) analyze source code and generate an index file, which is subsequently [uploaded to a Sourcegraph instance](../how-to/index_other_languages.md#4-upload-lsif-data) using the [Sourcegraph CLI](../../cli/index.md) for processing. Once processed, this data becomes available for [precise code navigation queries](precise_code_navigation.md).
+[Code graph indexers](../references/indexers.md) analyze source code and generate an index file, which is subsequently [uploaded to a Sourcegraph instance](../how-to/index_other_languages.md#4-upload-lsif-data) using [Sourcegraph CLI](../../cli/index.md) for processing. Once processed, this data becomes available for [precise code navigation queries](precise_code_navigation.md).
 
 ## Lifecycle of an upload
 

--- a/doc/cody/core-concepts/context/context-selection.md
+++ b/doc/cody/core-concepts/context/context-selection.md
@@ -49,9 +49,7 @@ Code Graph involves analyzing the structure of the code rather than treating it 
 
 ## Embeddings
 
-Cody employs numerical vector representations of both your input and pre-calculated representations of your entire codebase. These embeddings are processed by an LLM that understands the semantic relationships between these vectors.
-
-By comparing the user's input vector with the vectors representing various documents in the codebase, Cody can identify documents that are considered relevant. This method relies on machine learning and semantic understanding to find the context that is not apparent through simple keyword or structural analysis.
+Cody employs embeddings to find pieces of your codebase that are semantically related to your query. An LLM is used to pre-calculate the embeddings for your codebase so Cody can quickly find relevant chunks of code.
 
 <div class="getting-started">
   <a class="demo text-center" target="_blank" href="https://docs.sourcegraph.com/cody/core-concepts/embeddings">Learn more →</a>

--- a/doc/cody/core-concepts/context/usage-and-limits.md
+++ b/doc/cody/core-concepts/context/usage-and-limits.md
@@ -6,10 +6,12 @@ Cody's usage and limits policies help optimize its performance and ensure cost-e
 
 ## Cody context window size
 
-Cody's context window represents the amount of contextual information provided to assist in generating code or responses. Currently, the context window size for both chat and commands is set to **7000**.
+Cody's context window represents the amount of contextual information provided to assist in generating code or responses. Currently, the context window size for both chat and commands is set to **7000 tokens per interaction**.
 
-While Cody aims to provide maximum context for each prompt, there are limits to ensure efficiency. Cody shares all relevant context for chat but limits it to **12 code results** and **3 text results** (i.e., 15 tokens) to maintain performance.
+While Cody aims to provide maximum context for each prompt, there are limits to ensure efficiency. Cody shares all relevant context for chat but limits it to **12 code results** and **3 text results** to maintain performance. Each result comprises approximately **250 tokens**.
 
 ## Manage context window size
 
-Site administrators can update the maximum context window size to meet their specific requirements. In that case, default commands do not require the maximum 15 file limit for context, contributing to cost savings and improving response quality.
+Site administrators can update the maximum context window size to meet their specific requirements. While using fewer tokens is a cost-saving solution, it can also cause errors. For example, using the `/edit` command with few tokens might get you errors like `You've selected too much code`.
+
+Using more tokens usually produces high-quality responses. It's recommended not to modify the token limit. However, if needed, you can set the value to a limit that does not comprise quality and generates errors.

--- a/doc/cody/core-concepts/embeddings/configure-embeddings.md
+++ b/doc/cody/core-concepts/embeddings/configure-embeddings.md
@@ -9,7 +9,7 @@ Embeddings will not be configured for any repository unless an admin takes an ac
 
 ## Policies
 
-The recommended way to configure embeddings is by using policies. Embeddings policies define which repositories are automatically scheduled for embedding. These policies are configured through your admin dashboard and will be automatically updated based on the update interval(*link*).
+The recommended way to configure embeddings is by using policies. Embeddings policies define which repositories are automatically scheduled for embedding. These policies are configured through your admin dashboard and will be automatically updated based on the update interval.
 
 ### Create an embeddings policy
 

--- a/doc/cody/core-concepts/embeddings/embedding-index.md
+++ b/doc/cody/core-concepts/embeddings/embedding-index.md
@@ -38,7 +38,7 @@ Cody tries to connect to the correct codebase using Git at start-up, so the manu
 
 To enable Cody to set the codebase config using `git remote get-url origin`, ensure that the `Cody: Codebase` (`cody.codebase`) configuration field is unset in your VS Code User and Workspace settings, and remote workspace and folder-level settings if applicable.
 
-If this attempt fails and you see `NOT INDEXED` below your Cody chatbox, you can manually specify the correct codebase for Cody using the `Cody: Codebase` (`cody.codebase`) configuration option.
+If this attempt fails and you see `Embeddings Not Found` below your Cody chatbox, you can manually specify the correct codebase for Cody using the `Cody: Codebase` (`cody.codebase`) configuration option.
 
 ### Manual Configuration
 

--- a/doc/cody/core-concepts/embeddings/index.md
+++ b/doc/cody/core-concepts/embeddings/index.md
@@ -6,8 +6,6 @@
 
 Embeddings are a semantic representation of text that allow you to create a search index over your codebase. Cody splits your codebase into searchable chunks and sends them to an external service specified in your site's configuration for embedding. The resulting embedding index is stored in a managed object storage service.
 
->NOTE: Embeddings for relevant code files must be enabled for each repository that you want Cody to have context on.
-
 ## Enable embeddings
 
 By default, no embeddings are created. Embeddings are automatically enabled and configured when Cody is enabled. Admins must choose which code is sent to the third-party language model (LLM) for embedding (currently OpenAI). Once Sourcegraph provides first-party embeddings, they will be enabled for all repositories by default.

--- a/doc/cody/core-concepts/keyword-search.md
+++ b/doc/cody/core-concepts/keyword-search.md
@@ -6,24 +6,14 @@ Keyword search is the traditional approach to text search. It splits content int
 
 Both Cody chat and completions use Keyword Search. It comes out of the box without any additional setup. While powerful, this method can be used as a fallback solution when a codebase lacks embeddings with enhanced context quality and decreased latency over time.
 
-An example of a Keyword Search would look like this:
-
-![keyword-search-example](https://storage.googleapis.com/sourcegraph-assets/Docs/keyword-search-example.png)
-
-Here, the query “Auth” would match both “OAuth” and “Author”. It would not match the related statements SAML, OpenID, and Connect, which are common authentication methods.
-
 ## Keyword Search vs Embeddings
 
-### Quality
+Embeddings search over your entire repo set. While Cody with Keyword Search only searches your local VS Code workspace.
 
-In terms of quality, Embeddings searches over your entire repo set. While Cody with Keyword Search only searches your local VS Code workspace. Beyond this ability to search through an extensive codebase, when using embeddings vs. keyword search, it shows that embeddings lead to almost `2x` the acceptance rate (58% vs 31% from recent metrics).
+While setting things up, Keyword Search as the default experience is a cost-effective and time-saving solution. Embeddings need to be produced and managed. It's a time-consuming process.
 
-### Setup
+The codebase is divided into 20-30 line chunks, each run through an embedding service. The results must then be stored on an accessible machine for local Cody clients.
 
-Considering setting things up, Keyword Search as the default experience is a cost-effective and time-saving solution. Embeddings need to be produced and managed. It's a time-consuming process.
-
-The entire codebase is divided into 20-30 line chunks, each run through an embedding service. The results must then be stored on an accessible machine for local Cody clients.
-
-For an enterprise admin who has set up Cody with a Code Search instance, developers on their local machines can seamlessly access it. However, indexing a codebase to produce embeddings can take minutes or even hours for users who have Cody solely on their local machine.
+For an enterprise admin who has set up Cody with a Code Search instance, developers on their local machines can seamlessly access it. However, indexing a codebase to produce embeddings can take minutes or even hours for users with Cody solely on their local machine.
 
 Cody employs keyword-based context to ensure a good user experience until embeddings become available. When they are accessible, Cody will use them, thereby enhancing the quality of responses.


### PR DESCRIPTION
There was some post-follow-up feedback on the original [Core Concepts PR](https://github.com/sourcegraph/sourcegraph/pull/57592/) we shipped yesterday. This PR adds the suggested changes.

## Test plan

Docs added
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@imp-core-concepts)