### PR TITLE
Clean up querying of repository topics

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1190,27 +1190,13 @@ func (s *repoStore) listSQL(ctx context.Context, tr trace.Trace, opt ReposListOp
 		var ands []*sqlf.Query
 		for _, filter := range opt.TopicFilters {
 			filter := filter
-			// This condition checks that the requested topics are contained in
-			// the repo's metadata. This is designed to work with the
-			// idx_repo_github_topics and idx_repo_gitlab_topics index
-			//
-			// We use the unusual `jsonb_build_array` and `jsonb_build_object`
-			// syntax instead of JSONB literals so that we can use SQL
-			// variables for the user-provided topic names (don't want SQL
-			// injections here).
-			githubCond := sqlf.Sprintf(`external_service_type = 'github' AND metadata->'RepositoryTopics'->'Nodes' @> jsonb_build_array(jsonb_build_object('Topic', jsonb_build_object('Name', %s::text)))`, filter.Topic)
-			gitlabCond := sqlf.Sprintf(`external_service_type = 'gitlab' AND metadata->'topics' @> jsonb_build_array(%s::text)`, filter.Topic)
 
+			// This is designed to work with the idx_repo_topics
+			cond := sqlf.Sprintf("%s = ANY(topics)", filter.Topic)
 			if filter.Negated {
-				// Use Coalesce in case the JSON access evaluates to NULL.
-				// Since negating a NULL evaluates to NULL, we want to
-				// explicitly treat NULLs as false first
-				cond := sqlf.Sprintf(`NOT (COALESCE(%s, false) OR COALESCE(%s, false))`, githubCond, gitlabCond)
-				ands = append(ands, cond)
-			} else {
-				cond := sqlf.Sprintf("(%s)", sqlf.Join([]*sqlf.Query{githubCond, gitlabCond}, "OR"))
-				ands = append(ands, cond)
+				cond = sqlf.Sprintf("NOT (%s)", cond)
 			}
+			ands = append(ands, cond)
 		}
 		where = append(where, sqlf.Join(ands, "AND"))
 	}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1192,7 +1192,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr trace.Trace, opt ReposListOp
 			filter := filter
 
 			// This is designed to work with the idx_repo_topics
-			cond := sqlf.Sprintf("%s = ANY(topics)", filter.Topic)
+			cond := sqlf.Sprintf("topics @> '{%s}", filter.Topic)
 			if filter.Negated {
 				cond = sqlf.Sprintf("NOT (%s)", cond)
 			}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1192,7 +1192,7 @@ func (s *repoStore) listSQL(ctx context.Context, tr trace.Trace, opt ReposListOp
 			filter := filter
 
 			// This is designed to work with the idx_repo_topics
-			cond := sqlf.Sprintf("topics @> '{%s}", filter.Topic)
+			cond := sqlf.Sprintf("topics @> ARRAY[%s]::text[]", filter.Topic)
 			if filter.Negated {
 				cond = sqlf.Sprintf("NOT (%s)", cond)
 			}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -136,7 +136,7 @@
     },
     {
       "Name": "get_topics",
-      "Definition": "CREATE OR REPLACE FUNCTION public.get_topics(external_service_type text, metadata jsonb)\n RETURNS text[]\n LANGUAGE sql\n IMMUTABLE\nRETURN CASE external_service_type WHEN 'github'::text THEN ARRAY(SELECT jsonb_array_elements_text.value FROM jsonb_array_elements_text(jsonb_path_query_array(get_topics.metadata, '$.\"RepositoryTopics\".\"Nodes\"[*].\"Topic\".\"Name\"'::jsonpath)) jsonb_array_elements_text(value)) WHEN 'gitlab'::text THEN ARRAY(SELECT jsonb_array_elements_text.value FROM jsonb_array_elements_text((get_topics.metadata -\u003e 'topics'::text)) jsonb_array_elements_text(value)) ELSE '{}'::text[] END\n"
+      "Definition": "CREATE OR REPLACE FUNCTION public.get_topics(external_service_type text, metadata jsonb)\n RETURNS text[]\n LANGUAGE sql\n IMMUTABLE\nAS $function$\n    SELECT CASE external_service_type\n    WHEN 'github' THEN\n        ARRAY(SELECT * FROM jsonb_array_elements_text(jsonb_path_query_array(metadata, '$.RepositoryTopics.Nodes[*].Topic.Name')))\n    WHEN 'gitlab' THEN\n        ARRAY(SELECT * FROM jsonb_array_elements_text(metadata-\u003e'topics'))\n    ELSE\n        '{}'::text[]\n    END;\n$function$\n"
     },
     {
       "Name": "invalidate_session_for_userid_on_password_change",

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -83,6 +83,10 @@
       "Definition": "CREATE OR REPLACE FUNCTION public.delete_user_repo_permissions_on_user_soft_delete()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$ BEGIN\n    IF NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL THEN\n    \tDELETE FROM user_repo_permissions WHERE user_id = OLD.id;\n    END IF;\n    RETURN NULL;\n  END\n$function$\n"
     },
     {
+      "Name": "extract_topics_from_metadata",
+      "Definition": "CREATE OR REPLACE FUNCTION public.extract_topics_from_metadata(external_service_type text, metadata jsonb)\n RETURNS text[]\n LANGUAGE plpgsql\n IMMUTABLE\nAS $function$\nBEGIN\n    RETURN CASE external_service_type\n    WHEN 'github' THEN\n        ARRAY(SELECT * FROM jsonb_array_elements_text(jsonb_path_query_array(metadata, '$.RepositoryTopics.Nodes[*].Topic.Name')))\n    WHEN 'gitlab' THEN\n        ARRAY(SELECT * FROM jsonb_array_elements_text(metadata-\u003e'topics'))\n    ELSE\n        '{}'::text[]\n    END;\nEXCEPTION WHEN others THEN\n    -- Catch exceptions in the case that metadata is not shaped like we expect\n    RETURN '{}'::text[];\nEND;\n$function$\n"
+    },
+    {
       "Name": "func_configuration_policies_delete",
       "Definition": "CREATE OR REPLACE FUNCTION public.func_configuration_policies_delete()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        UPDATE configuration_policies_audit_logs\n        SET record_deleted_at = NOW()\n        WHERE policy_id IN (\n            SELECT id FROM OLD\n        );\n\n        RETURN NULL;\n    END;\n$function$\n"
     },
@@ -133,10 +137,6 @@
     {
       "Name": "func_row_to_lsif_uploads_transition_columns",
       "Definition": "CREATE OR REPLACE FUNCTION public.func_row_to_lsif_uploads_transition_columns(rec record)\n RETURNS lsif_uploads_transition_columns\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        RETURN (rec.state, rec.expired, rec.num_resets, rec.num_failures, rec.worker_hostname, rec.committed_at);\n    END;\n$function$\n"
-    },
-    {
-      "Name": "get_topics",
-      "Definition": "CREATE OR REPLACE FUNCTION public.get_topics(external_service_type text, metadata jsonb)\n RETURNS text[]\n LANGUAGE sql\n IMMUTABLE\nAS $function$\n    SELECT CASE external_service_type\n    WHEN 'github' THEN\n        ARRAY(SELECT * FROM jsonb_array_elements_text(jsonb_path_query_array(metadata, '$.RepositoryTopics.Nodes[*].Topic.Name')))\n    WHEN 'gitlab' THEN\n        ARRAY(SELECT * FROM jsonb_array_elements_text(metadata-\u003e'topics'))\n    ELSE\n        '{}'::text[]\n    END;\n$function$\n"
     },
     {
       "Name": "invalidate_session_for_userid_on_password_change",
@@ -23696,7 +23696,7 @@
           "IsIdentity": false,
           "IdentityGeneration": "",
           "IsGenerated": "ALWAYS",
-          "GenerationExpression": "get_topics(external_service_type, metadata)",
+          "GenerationExpression": "extract_topics_from_metadata(external_service_type, metadata)",
           "Comment": ""
         },
         {

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -135,6 +135,10 @@
       "Definition": "CREATE OR REPLACE FUNCTION public.func_row_to_lsif_uploads_transition_columns(rec record)\n RETURNS lsif_uploads_transition_columns\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        RETURN (rec.state, rec.expired, rec.num_resets, rec.num_failures, rec.worker_hostname, rec.committed_at);\n    END;\n$function$\n"
     },
     {
+      "Name": "get_topics",
+      "Definition": "CREATE OR REPLACE FUNCTION public.get_topics(external_service_type text, metadata jsonb)\n RETURNS text[]\n LANGUAGE sql\n IMMUTABLE\nRETURN CASE external_service_type WHEN 'github'::text THEN ARRAY(SELECT jsonb_array_elements_text.value FROM jsonb_array_elements_text(jsonb_path_query_array(get_topics.metadata, '$.\"RepositoryTopics\".\"Nodes\"[*].\"Topic\".\"Name\"'::jsonpath)) jsonb_array_elements_text(value)) WHEN 'gitlab'::text THEN ARRAY(SELECT jsonb_array_elements_text.value FROM jsonb_array_elements_text((get_topics.metadata -\u003e 'topics'::text)) jsonb_array_elements_text(value)) ELSE '{}'::text[] END\n"
+    },
+    {
       "Name": "invalidate_session_for_userid_on_password_change",
       "Definition": "CREATE OR REPLACE FUNCTION public.invalidate_session_for_userid_on_password_change()\n RETURNS trigger\n LANGUAGE plpgsql\nAS $function$\n    BEGIN\n        IF OLD.passwd != NEW.passwd THEN\n            NEW.invalidated_sessions_at = now() + (1 * interval '1 second');\n            RETURN NEW;\n        END IF;\n    RETURN NEW;\n    END;\n$function$\n"
     },
@@ -23683,6 +23687,19 @@
           "Comment": ""
         },
         {
+          "Name": "topics",
+          "Index": 17,
+          "TypeName": "text[]",
+          "IsNullable": true,
+          "Default": "",
+          "CharacterMaximumLength": 0,
+          "IsIdentity": false,
+          "IdentityGeneration": "",
+          "IsGenerated": "ALWAYS",
+          "GenerationExpression": "get_topics(external_service_type, metadata)",
+          "Comment": ""
+        },
+        {
           "Name": "updated_at",
           "Index": 6,
           "TypeName": "timestamp with time zone",
@@ -23741,22 +23758,12 @@
           "ConstraintDefinition": "PRIMARY KEY (id)"
         },
         {
-          "Name": "idx_repo_github_topics",
+          "Name": "idx_repo_topics",
           "IsPrimaryKey": false,
           "IsUnique": false,
           "IsExclusion": false,
           "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX idx_repo_github_topics ON repo USING gin (((metadata -\u003e 'RepositoryTopics'::text) -\u003e 'Nodes'::text)) WHERE external_service_type = 'github'::text",
-          "ConstraintType": "",
-          "ConstraintDefinition": ""
-        },
-        {
-          "Name": "idx_repo_gitlab_topics",
-          "IsPrimaryKey": false,
-          "IsUnique": false,
-          "IsExclusion": false,
-          "IsDeferrable": false,
-          "IndexDefinition": "CREATE INDEX idx_repo_gitlab_topics ON repo USING gin ((metadata -\u003e 'topics'::text)) WHERE external_service_type = 'gitlab'::text",
+          "IndexDefinition": "CREATE INDEX idx_repo_topics ON repo USING gin (topics)",
           "ConstraintType": "",
           "ConstraintDefinition": ""
         },

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3521,8 +3521,8 @@ Referenced by:
 
 # Table "public.repo"
 ```
-        Column         |           Type           | Collation | Nullable |             Default              
------------------------+--------------------------+-----------+----------+----------------------------------
+        Column         |           Type           | Collation | Nullable |                                 Default                                  
+-----------------------+--------------------------+-----------+----------+--------------------------------------------------------------------------
  id                    | integer                  |           | not null | nextval('repo_id_seq'::regclass)
  name                  | citext                   |           | not null | 
  description           | text                     |           |          | 
@@ -3539,12 +3539,12 @@ Referenced by:
  private               | boolean                  |           | not null | false
  stars                 | integer                  |           | not null | 0
  blocked               | jsonb                    |           |          | 
+ topics                | text[]                   |           |          | generated always as (get_topics(external_service_type, metadata)) stored
 Indexes:
     "repo_pkey" PRIMARY KEY, btree (id)
     "repo_external_unique_idx" UNIQUE, btree (external_service_type, external_service_id, external_id)
     "repo_name_unique" UNIQUE CONSTRAINT, btree (name) DEFERRABLE
-    "idx_repo_github_topics" gin (((metadata -> 'RepositoryTopics'::text) -> 'Nodes'::text)) WHERE external_service_type = 'github'::text
-    "idx_repo_gitlab_topics" gin ((metadata -> 'topics'::text)) WHERE external_service_type = 'gitlab'::text
+    "idx_repo_topics" gin (topics)
     "repo_archived" btree (archived)
     "repo_blocked_idx" btree ((blocked IS NOT NULL))
     "repo_created_at" btree (created_at)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -3521,8 +3521,8 @@ Referenced by:
 
 # Table "public.repo"
 ```
-        Column         |           Type           | Collation | Nullable |                                 Default                                  
------------------------+--------------------------+-----------+----------+--------------------------------------------------------------------------
+        Column         |           Type           | Collation | Nullable |                                          Default                                           
+-----------------------+--------------------------+-----------+----------+--------------------------------------------------------------------------------------------
  id                    | integer                  |           | not null | nextval('repo_id_seq'::regclass)
  name                  | citext                   |           | not null | 
  description           | text                     |           |          | 
@@ -3539,7 +3539,7 @@ Referenced by:
  private               | boolean                  |           | not null | false
  stars                 | integer                  |           | not null | 0
  blocked               | jsonb                    |           |          | 
- topics                | text[]                   |           |          | generated always as (get_topics(external_service_type, metadata)) stored
+ topics                | text[]                   |           |          | generated always as (extract_topics_from_metadata(external_service_type, metadata)) stored
 Indexes:
     "repo_pkey" PRIMARY KEY, btree (id)
     "repo_external_unique_idx" UNIQUE, btree (external_service_type, external_service_id, external_id)

--- a/migrations/frontend/1697750425_topic_column/down.sql
+++ b/migrations/frontend/1697750425_topic_column/down.sql
@@ -1,3 +1,4 @@
 -- Undo the changes made in the up migration
 
 ALTER TABLE IF EXISTS repo DROP COLUMN IF EXISTS topics;
+DROP FUNCTION IF EXISTS get_topics;

--- a/migrations/frontend/1697750425_topic_column/down.sql
+++ b/migrations/frontend/1697750425_topic_column/down.sql
@@ -1,0 +1,3 @@
+-- Undo the changes made in the up migration
+
+ALTER TABLE IF EXISTS repo DROP COLUMN IF EXISTS topics;

--- a/migrations/frontend/1697750425_topic_column/down.sql
+++ b/migrations/frontend/1697750425_topic_column/down.sql
@@ -1,4 +1,2 @@
--- Undo the changes made in the up migration
-
 ALTER TABLE IF EXISTS repo DROP COLUMN IF EXISTS topics;
 DROP FUNCTION IF EXISTS get_topics;

--- a/migrations/frontend/1697750425_topic_column/metadata.yaml
+++ b/migrations/frontend/1697750425_topic_column/metadata.yaml
@@ -1,0 +1,2 @@
+name: topic column
+parents: [1697558292, 1697535944]

--- a/migrations/frontend/1697750425_topic_column/up.sql
+++ b/migrations/frontend/1697750425_topic_column/up.sql
@@ -1,0 +1,23 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+ALTER TABLE IF EXISTS repo
+ADD COLUMN IF NOT EXISTS topics text[] GENERATED ALWAYS AS (
+    CASE
+    WHEN repo.external_service_type = 'github' THEN
+        jsonb_array_elements_text(jsonb_path_query_array(repo.metadata, '$.RepositoryTopics.Nodes[*].Topic.Name'))::text[]
+    WHEN repo.external_service_type = 'gitlab' THEN
+        jsonb_array_elements_text(repo.metadata->'topics')::text[]
+    ELSE
+        '{}'::text[]
+    END
+) STORED;

--- a/migrations/frontend/1697750425_topic_column/up.sql
+++ b/migrations/frontend/1697750425_topic_column/up.sql
@@ -1,15 +1,3 @@
--- Perform migration here.
---
--- See /migrations/README.md. Highlights:
---  * Make migrations idempotent (use IF EXISTS)
---  * Make migrations backwards-compatible (old readers/writers must continue to work)
---  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
---    is defined per file, and that each such statement is NOT wrapped in a transaction.
---    Each such migration must also declare "createIndexConcurrently: true" in their
---    associated metadata.yaml file.
---  * If you are modifying Postgres extensions, you must also declare "privileged: true"
---    in the associated metadata.yaml file.
-
 CREATE OR REPLACE FUNCTION get_topics(external_service_type text, metadata jsonb)
     RETURNS text[]
     LANGUAGE SQL

--- a/migrations/frontend/1697750425_topic_column/up.sql
+++ b/migrations/frontend/1697750425_topic_column/up.sql
@@ -2,7 +2,8 @@ CREATE OR REPLACE FUNCTION get_topics(external_service_type text, metadata jsonb
     RETURNS text[]
     LANGUAGE SQL
     IMMUTABLE
-    RETURN CASE external_service_type
+AS $$
+    SELECT CASE external_service_type
     WHEN 'github' THEN
         ARRAY(SELECT * FROM jsonb_array_elements_text(jsonb_path_query_array(metadata, '$.RepositoryTopics.Nodes[*].Topic.Name')))
     WHEN 'gitlab' THEN
@@ -10,6 +11,7 @@ CREATE OR REPLACE FUNCTION get_topics(external_service_type text, metadata jsonb
     ELSE
         '{}'::text[]
     END;
+$$;
 
 
 ALTER TABLE IF EXISTS repo

--- a/migrations/frontend/1697752805_index_topics_column/down.sql
+++ b/migrations/frontend/1697752805_index_topics_column/down.sql
@@ -1,0 +1,3 @@
+-- Undo the changes made in the up migration
+
+DROP INDEX IF EXISTS idx_repo_topics;

--- a/migrations/frontend/1697752805_index_topics_column/down.sql
+++ b/migrations/frontend/1697752805_index_topics_column/down.sql
@@ -1,3 +1,1 @@
--- Undo the changes made in the up migration
-
 DROP INDEX IF EXISTS idx_repo_topics;

--- a/migrations/frontend/1697752805_index_topics_column/metadata.yaml
+++ b/migrations/frontend/1697752805_index_topics_column/metadata.yaml
@@ -1,0 +1,3 @@
+name: index topics column
+parents: [1697750425]
+createIndexConcurrently: true

--- a/migrations/frontend/1697752805_index_topics_column/up.sql
+++ b/migrations/frontend/1697752805_index_topics_column/up.sql
@@ -1,0 +1,14 @@
+-- Perform migration here.
+--
+-- See /migrations/README.md. Highlights:
+--  * Make migrations idempotent (use IF EXISTS)
+--  * Make migrations backwards-compatible (old readers/writers must continue to work)
+--  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
+--    is defined per file, and that each such statement is NOT wrapped in a transaction.
+--    Each such migration must also declare "createIndexConcurrently: true" in their
+--    associated metadata.yaml file.
+--  * If you are modifying Postgres extensions, you must also declare "privileged: true"
+--    in the associated metadata.yaml file.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repo_topics
+ON repo USING GIN(topics);

--- a/migrations/frontend/1697752805_index_topics_column/up.sql
+++ b/migrations/frontend/1697752805_index_topics_column/up.sql
@@ -1,14 +1,2 @@
--- Perform migration here.
---
--- See /migrations/README.md. Highlights:
---  * Make migrations idempotent (use IF EXISTS)
---  * Make migrations backwards-compatible (old readers/writers must continue to work)
---  * If you are using CREATE INDEX CONCURRENTLY, then make sure that only one statement
---    is defined per file, and that each such statement is NOT wrapped in a transaction.
---    Each such migration must also declare "createIndexConcurrently: true" in their
---    associated metadata.yaml file.
---  * If you are modifying Postgres extensions, you must also declare "privileged: true"
---    in the associated metadata.yaml file.
-
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_repo_topics
 ON repo USING GIN(topics);

--- a/migrations/frontend/1697754648_drop_old_repo_topic_indexes/down.sql
+++ b/migrations/frontend/1697754648_drop_old_repo_topic_indexes/down.sql
@@ -1,0 +1,9 @@
+CREATE INDEX IF NOT EXISTS idx_repo_gitlab_topics
+ON repo
+USING GIN((metadata->'topics'))
+WHERE external_service_type = 'gitlab';
+
+CREATE INDEX IF NOT EXISTS idx_repo_github_topics
+ON repo
+USING GIN((metadata->'RepositoryTopics'->'Nodes'))
+WHERE external_service_type = 'github';

--- a/migrations/frontend/1697754648_drop_old_repo_topic_indexes/metadata.yaml
+++ b/migrations/frontend/1697754648_drop_old_repo_topic_indexes/metadata.yaml
@@ -1,0 +1,2 @@
+name: drop old repo topic indexes
+parents: [1697752805]

--- a/migrations/frontend/1697754648_drop_old_repo_topic_indexes/up.sql
+++ b/migrations/frontend/1697754648_drop_old_repo_topic_indexes/up.sql
@@ -1,3 +1,2 @@
 DROP INDEX IF EXISTS idx_repo_github_topics;
 DROP INDEX IF EXISTS idx_repo_gitlab_topics;
-COMMENT ON idx_repo_topics IS 'For efficiently looking up repositories by topic';

--- a/migrations/frontend/1697754648_drop_old_repo_topic_indexes/up.sql
+++ b/migrations/frontend/1697754648_drop_old_repo_topic_indexes/up.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_repo_github_topics;
+DROP INDEX IF EXISTS idx_repo_gitlab_topics;
+COMMENT ON idx_repo_topics IS 'For efficiently looking up repositories by topic';


### PR DESCRIPTION
Previously, querying repos by topic was pretty messy, especially after we added support for gitlab topics. We had to dig down into the metadata, which not particularly nicely structured JSON for github, and we had to do this both for the index and for queries. 

This adds a generated column `topics` which isolates the complexity of extracting the topics from the metadata while maintaining normalization. It replaces the codehost-specific indexes with a single GIN index on that column so that querying for repos with a specific topic is both fast and easy.

## Test plan

@jasonhawkharris updated all the tests for gitlab topics in https://github.com/sourcegraph/sourcegraph/pull/57649, and all the tests pass. 