### PR TITLE
Bump p4-fusion package to latest in gitserver image

### DIFF
--- a/wolfi-images/gitserver.yaml
+++ b/wolfi-images/gitserver.yaml
@@ -16,7 +16,7 @@ contents:
 
     - coursier@sourcegraph
     - p4cli@sourcegraph
-    - p4-fusion=1.12-r6@sourcegraph
+    - p4-fusion=1.13.1-sg-r0@sourcegraph
 
 paths:
   - path: /data/repos


### PR DESCRIPTION
After #57751 added this new package, this PR is here to add it to a new gitserver base image.

In the past PR of this series, we will then update the base image tags and start using this binary.

## Test plan

CI.