### PR TITLE
fix extra args handling in `sg`

### DIFF
--- a/dev/sg/internal/sgconf/config.go
+++ b/dev/sg/internal/sgconf/config.go
@@ -3,6 +3,7 @@ package sgconf
 import (
 	"io"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 
@@ -38,6 +39,7 @@ func parseConfig(data []byte) (*Config, error) {
 
 	for name, cmd := range conf.Commands {
 		cmd.Name = name
+		normalizeCmd(&cmd)
 		conf.Commands[name] = cmd
 	}
 
@@ -48,10 +50,17 @@ func parseConfig(data []byte) (*Config, error) {
 
 	for name, cmd := range conf.Tests {
 		cmd.Name = name
+		normalizeCmd(&cmd)
 		conf.Tests[name] = cmd
 	}
 
 	return &conf, nil
+}
+
+func normalizeCmd(cmd *run.Command) {
+	// Trim trailing whitespace so extra args apply to last command (instead of being interpreted as
+	// a new shell command on a separate line).
+	cmd.Cmd = strings.TrimSpace(cmd.Cmd)
 }
 
 type Commandset struct {


### PR DESCRIPTION
When running `sg test <target> extra-arg1 extra-arg2 ...`, the extra args are generally appended to the `<target>` command on a new line, which means the extra args are interpreted by the shell as their own command. The user's intent is for them to be appended to the last command in the `<target>` command string, which this commit achieves by trimming trailing whitespace.




## Test plan

n/a