### PR TITLE
sg: fix `sg wolfi image` builds

### DIFF
--- a/dev/sg/internal/wolfi/base-image.go
+++ b/dev/sg/internal/wolfi/base-image.go
@@ -50,6 +50,7 @@ func (c PackageRepoConfig) DoBaseImageBuild(name string, buildDir string) error 
 		"-v", fmt.Sprintf("%s:/keys", c.KeyDir),
 		"-v", fmt.Sprintf("%s:/images", c.ImageDir),
 		"-e", fmt.Sprintf("SOURCE_DATE_EPOCH=%d", time.Now().Unix()),
+		"-w", "/work",
 		"cgr.dev/chainguard/apko", "build",
 		"--debug",
 		"--arch", "x86_64",


### PR DESCRIPTION
A recent update to the apko image changed the default workdir, which breaks our `include: ./sourcegraph-base.yaml`. This PR explicitly sets the workdir.


## Test plan

- Tested locally - fixes issue

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
