### PR TITLE
Make sub-repo permissions integration test functional

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -16,7 +16,7 @@ import (
 const (
 	perforceRepoName = "perforce/test-perms"
 	testPermsDepot   = "test-perms"
-	aliceEmail       = "alice@perforce-tests.sgdev.org"
+	aliceEmail       = "alice@perforce.sgdev.org"
 	aliceUsername    = "alice"
 )
 
@@ -27,7 +27,7 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 	t.Cleanup(cleanup)
 	userClient, repoName, err := createTestUserAndWaitForRepo(t)
 	if err != nil {
-		t.Skip("Repo failed to clone in 45 seconds, skipping test")
+		t.Fatalf("Failed to create user and wait for repo: %v", err)
 	}
 
 	// Test cases
@@ -90,7 +90,7 @@ func TestSubRepoPermissionsSymbols(t *testing.T) {
 	t.Cleanup(cleanup)
 	userClient, repoName, err := createTestUserAndWaitForRepo(t)
 	if err != nil {
-		t.Skip("Repo failed to clone in 45 seconds, skipping test")
+		t.Fatalf("Failed to create user and wait for repo: %v", err)
 	}
 
 	err = client.WaitForReposToBeIndexed(perforceRepoName)
@@ -127,14 +127,17 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 	t.Cleanup(cleanup)
 	userClient, _, err := createTestUserAndWaitForRepo(t)
 	if err != nil {
-		t.Skip("Repo failed to clone in 45 seconds, skipping test")
+		t.Fatalf("Failed to create user and wait for repo: %v", err)
 	}
 
-	err = client.WaitForReposToBeIndexed(perforceRepoName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// TODO(pjlast): Waiting for repos to be indexed here seems to be very inconsistent
+	// err = client.WaitForReposToBeIndexed(perforceRepoName)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
 
+	// TODO(pjlast): Removing all the dependencies on indexed searches until
+	// they can be run reliably
 	tests := []struct {
 		name          string
 		query         string
@@ -142,45 +145,46 @@ func TestSubRepoPermissionsSearch(t *testing.T) {
 		minMatchCount int64
 	}{
 		{
-			name:          "indexed search, nonzero result",
-			query:         `index:only This depot is used to test`,
+			name:          "search, nonzero result",     // "indexed search, nonzero result",
+			query:         `This depot is used to test`, // `index:only This depot is used to test`,
 			minMatchCount: 1,
 		},
+		// {
+		// 	name:          "unindexed multiline search, nonzero result",
+		// 	query:         `index:no This depot is used to test`,
+		// 	minMatchCount: 1,
+		// },
 		{
-			name:          "unindexed multiline search, nonzero result",
-			query:         `index:no This depot is used to test`,
-			minMatchCount: 1,
-		},
-		{
-			name:       "indexed search of restricted content",
-			query:      `index:only uploading your secrets`,
+			name:       "search of restricted content", // "indexed search of restricted content",
+			query:      `uploading your secrets`,       // `index:only uploading your secrets`,
 			zeroResult: true,
 		},
-		{
-			name:       "unindexed search of restricted content",
-			query:      `index:no uploading your secrets`,
-			zeroResult: true,
-		},
-		{
-			name:       "structural, indexed search of restricted content",
-			query:      `repo:^perforce/test-perms$ echo "..." index:only patterntype:structural`,
-			zeroResult: true,
-		},
-		{
-			name:       "structural, unindexed search of restricted content",
-			query:      `repo:^perforce/test-perms$ echo "..." index:no patterntype:structural`,
-			zeroResult: true,
-		},
-		{
-			name:          "structural, indexed search, nonzero result",
-			query:         `println(...) index:only patterntype:structural`,
-			minMatchCount: 1,
-		},
-		{
-			name:          "structural, unindexed search, nonzero result",
-			query:         `println(...) index:no patterntype:structural`,
-			minMatchCount: 1,
-		},
+		// {
+		// 	name:       "unindexed search of restricted content",
+		// 	query:      `index:no uploading your secrets`,
+		// 	zeroResult: true,
+		// },
+		// TODO(pjlast): Removing all structural searches since they don't seem to work without indexing?
+		// {
+		// 	name:       "structural, indexed search of restricted content",
+		// 	query:      `repo:^perforce/test-perms$ echo "..." index:only patterntype:structural`,
+		// 	zeroResult: true,
+		// },
+		// {
+		// 	name:       "structural, unindexed search of restricted content",
+		// 	query:      `repo:^perforce/test-perms$ echo "..." index:no patterntype:structural`,
+		// 	zeroResult: true,
+		// },
+		// {
+		// 	name:          "structural, indexed search, nonzero result",
+		// 	query:         `println(...) index:only patterntype:structural`,
+		// 	minMatchCount: 1,
+		// },
+		// {
+		// 	name:          "structural, unindexed search, nonzero result",
+		// 	query:         `println(...) index:no patterntype:structural`,
+		// 	minMatchCount: 1,
+		// },
 		{
 			name:          "filename search, nonzero result",
 			query:         `repo:^perforce/test-perms$ type:path app`,
@@ -348,7 +352,7 @@ func createTestUserAndWaitForRepo(t *testing.T) (*gqltestutil.Client, string, er
 		t.Fatal(err)
 	}
 
-	err = userClient.WaitForReposToBeClonedWithin(5*time.Second, perforceRepoName)
+	err = userClient.WaitForReposToBeClonedWithin(120*time.Second, perforceRepoName)
 	if err != nil {
 		return nil, "", err
 	}
@@ -371,7 +375,7 @@ func syncUserPerms(t *testing.T, userID, userName string) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if userPermsInfo != nil && !userPermsInfo.SyncedAt.IsZero() {
+		if userPermsInfo != nil && !userPermsInfo.UpdatedAt.IsZero() {
 			return nil
 		}
 		return gqltestutil.ErrContinueRetry

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -80,7 +80,7 @@ mutation {
 	return errors.Wrap(err, "deleting repo from disk")
 }
 
-// WaitForReposToBeIndexed waits (up to 30 seconds) for all repositories
+// WaitForReposToBeIndexed waits (up to 180 seconds) for all repositories
 // in the list to be indexed.
 //
 // This method requires the authenticated user to be a site admin.

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -90,6 +90,7 @@ func (c *Client) WaitForReposToBeIndexed(repos ...string) error {
 	defer cancel()
 
 	var missing collections.Set[string]
+	var err error
 	for {
 		select {
 		case <-ctx.Done():
@@ -97,6 +98,7 @@ func (c *Client) WaitForReposToBeIndexed(repos ...string) error {
 		default:
 		}
 
+		// Only fetched indexed repositories
 		const query = `
 query Repositories {
 	repositories(first: 1000, notIndexed: false, notCloned: false) {
@@ -106,7 +108,7 @@ query Repositories {
 	}
 }
 `
-		var err error
+		// Compare list of repos returned by query to expected list of indexed repos
 		missing, err = c.waitForReposByQuery(query, repos...)
 		if err != nil {
 			return errors.Wrap(err, "wait for repos to be indexed")
@@ -120,6 +122,10 @@ query Repositories {
 	return nil
 }
 
+// waitForReposByQuery executes the GraphQL query and compares the repo list returned
+// with the list of repos passed in.
+//
+// Any repos in the list that are not returned by the GraphQL are returned as "missing".
 func (c *Client) waitForReposByQuery(query string, repos ...string) (collections.Set[string], error) {
 	var resp struct {
 		Data struct {

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -43,6 +43,7 @@ server_integration_test(
 
 server_integration_test(
     name = "backend_integration_test",
+    timeout = "long",
     args = [
         "$(location //dev/gqltest:gqltest_test)",  # actual test
         "$(location //dev/authtest:authtest_test)",  # actual test


### PR DESCRIPTION
This PR makes the sub-repo permissions tests actually functional. This test basically had no chance of ever passing.

Firstly, the user email was completely wrong.

These tests would always auto-skip since the actual time it waits for repos to clone is 5 seconds, not 45 seconds.

Then, the tests themselves are extremely flaky while waiting for a repo to be indexed. I simplified that part and took out the dependence on waiting for a repo to be indexed.

I don't think permissions should depend on whether a repo is indexed or not anyways. But I left that part commented out for now and we can revisit it.

## Test plan

CI actually runs the test and passes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
