### PR TITLE
[Repository Pages]: Fix Cody chat sidebar layout

### DIFF
--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -2,6 +2,7 @@ import React, {
     createContext,
     type FC,
     PropsWithChildren,
+    RefObject,
     Suspense,
     useContext,
     useEffect,
@@ -285,21 +286,22 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
 }
 
 interface RepoContainerRootContextData {
-    rootElement: HTMLDivElement | null
+    rootElement: RefObject<HTMLElement>
 }
 
 const RepoContainerRootContext = createContext<RepoContainerRootContextData>({
-    rootElement: null,
+    rootElement: { current: null },
 })
 
 const RepoContainerRoot: FC<PropsWithChildren<{}>> = props => {
     const { children } = props
     const rootElementRef = useRef<HTMLDivElement>(null)
 
-    const context = useMemo(() => ({ rootElement: rootElementRef.current }), [rootElementRef.current])
     return (
         <div ref={rootElementRef} className={classNames('w-100 d-flex flex-row')}>
-            <RepoContainerRootContext.Provider value={context}>{children}</RepoContainerRootContext.Provider>
+            <RepoContainerRootContext.Provider value={{ rootElement: rootElementRef }}>
+                {children}
+            </RepoContainerRootContext.Provider>
         </div>
     )
 }
@@ -308,11 +310,11 @@ const RepoContainerRootPortal: FC<PropsWithChildren<{}>> = props => {
     const { children } = props
     const { rootElement } = useContext(RepoContainerRootContext)
 
-    if (!rootElement) {
+    if (!rootElement.current) {
         return null
     }
 
-    return createPortal(children, rootElement)
+    return createPortal(children, rootElement.current)
 }
 
 interface RepoUserContainerProps extends RepoContainerProps {


### PR DESCRIPTION
Fixes layout regression from https://github.com/sourcegraph/sourcegraph/pull/57609

https://github.com/sourcegraph/sourcegraph/pull/57609 changed the routes and the layout structure around the root repo page wrapper, it caused that Cody chat UI was rendered inside the nested block with flex-column layout and therefore it grew to 100% height and shrink the blob UI block with content. 

This PR doesn't revert changes from https://github.com/sourcegraph/sourcegraph/pull/57609 but adds repo container render point that we could render something on the top level from nested react routes component. 

| Broken layout | Fixed layout |
| ------ | ------ |
| <img width="1149" alt="Screenshot 2023-10-20 at 14 35 39" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/96824d08-8b8c-4b2d-b41d-3726e7717300"> | <img width="1149" alt="Screenshot 2023-10-20 at 14 36 07" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/f65082ee-588b-40a8-bea0-2e931242c12f"> |

## Test plan
- Check that Cody chat sidebar UI works as it worked before (not layout problems)
- Check repository setting pages (should be no problem with layouts there)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
