### PR TITLE
fix passing multiple args to jest --testPathIgnorePatterns

### DIFF
--- a/client/browser/package.json
+++ b/client/browser/package.json
@@ -23,7 +23,7 @@
     "lint:js": "eslint --cache '**/*.[jt]s?(x)'",
     "lint:css": "stylelint 'src/**/*.scss'",
     "clean": "rm -rf build/ dist/ *.zip *.xpi .checksum",
-    "test": "jest --testPathIgnorePatterns end-to-end integration",
+    "test": "jest --testPathIgnorePatterns end-to-end --testPathIgnorePatterns integration",
     "test-e2e": "TS_NODE_PROJECT=src/end-to-end/tsconfig.json mocha './src/end-to-end/**/*.test.ts'",
     "run-integration": "TS_NODE_PROJECT=src/integration/tsconfig.json SOURCEGRAPH_BASE_URL=https://sourcegraph.com mocha --parallel=${CI:-\"false\"} --retries=2 ./src/integration/**/*.test.ts",
     "test-integration": "node scripts/test-integration",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -5,7 +5,7 @@
   "description": "The Sourcegraph web app",
   "scripts": {
     "build-ts": "tsc --build tsconfig.json --emitDeclarationOnly",
-    "test": "jest --testPathIgnorePatterns end-to-end --testPathIgnorePatterns regression integration",
+    "test": "jest --testPathIgnorePatterns end-to-end --testPathIgnorePatterns regression --testPathIgnorePatterns integration",
     "task:mocha": "cross-env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' mocha",
     "test:regression": "pnpm run task:mocha './src/regression/**/*.test.ts' --exit",
     "test:regression:codeintel": "pnpm task:mocha ./src/regression/codeintel.test.ts",

--- a/dev/ci/internal/ci/operations.go
+++ b/dev/ci/internal/ci/operations.go
@@ -325,7 +325,7 @@ func frontendTests(pipeline *bk.Pipeline) {
 	// Shared tests
 	pipeline.AddStep(":jest: Test (all)",
 		withPnpmCache(),
-		bk.AnnotatedCmd("dev/ci/pnpm-test.sh --testPathIgnorePatterns client/web client/browser", bk.AnnotatedCmdOpts{
+		bk.AnnotatedCmd("dev/ci/pnpm-test.sh --testPathIgnorePatterns client/web --testPathIgnorePatterns client/browser", bk.AnnotatedCmdOpts{
 			TestReports: &bk.TestReportOpts{
 				TestSuiteKeyVariableName: "BUILDKITE_ANALYTICS_FRONTEND_UNIT_TEST_SUITE_API_KEY",
 			},

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch-web": "pnpm --filter @sourcegraph/web run watch",
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
-    "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook \"/out/.*test.js\" \"/out/.*test.d.ts\"",
+    "test": "jest --testPathIgnorePatterns end-to-end --testPathIgnorePatterns regression --testPathIgnorePatterns integration --testPathIgnorePatterns storybook \"/out/.*test.js\" \"/out/.*test.d.ts\"",
     "_test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json mocha --parallel=${CI:-\"false\"} --retries=1 --jobs=2",
     "test-integration": "pnpm _test-integration \"./client/web/src/integration/**/*.test.ts\"",
     "test-integration:debug": "BROWSER=chrome KEEP_BROWSER=true DEVTOOLS=true DISABLE_APP_ASSETS_MOCKING=true WINDOW_WIDTH=1920 WINDOW_HEIGHT=1080 pnpm _test-integration --retries=0 --jobs=1",

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1607,7 +1607,7 @@ tests:
       SOURCEGRAPH_BASE_URL: https://sourcegraph.com
 
   client:
-    cmd: pnpm jest --testPathIgnorePatterns end-to-end regression integration storybook
+    cmd: pnpm jest --testPathIgnorePatterns end-to-end --testPathIgnorePatterns regression --testPathIgnorePatterns integration --testPathIgnorePatterns storybook
 
   docsite:
     cmd: .bin/docsite_${DOCSITE_VERSION} check ./doc


### PR DESCRIPTION
To pass multiple ignore patterns to Jest, you need to use `--testPathIgnorePatterns pattern1 --testPathIgnorePatterns pattern2 ...`. Otherwise, `--testPathIgnorePatterns pattern1 pattern2` treats `pattern2` as a test pattern to run, not to ignore.

The consequence of this is that some npm scripts and CI steps were running tests that they didn't need to run.




## Test plan

CI