### PR TITLE
un-hardcode $DISPLAY for e2e tests to support non-headless local e2e test running

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -32,6 +32,7 @@ build --test_env=BUILDKITE
 # the mocha tests target is the build target and it's tested with `build_test`.
 build --define=E2E_HEADLESS=false
 build --define=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080"
+build --define=DISPLAY=:99
 
 # Provides git commit, branch information to build targets like Percy via status file.
 # https://bazel.build/docs/user-manual#workspace-status

--- a/dev/mocha.bzl
+++ b/dev/mocha.bzl
@@ -91,7 +91,7 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
         "INTEGRATION_TESTS": "true",
 
         # Puppeteer config
-        "DISPLAY": ":99",
+        "DISPLAY": "$(DISPLAY)",
     })
 
     if is_percy_enabled:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1576,12 +1576,12 @@ tests:
       export SOURCEGRAPH_LICENSE_KEY=$(gcloud secrets versions access latest --secret=SOURCEGRAPH_LICENSE_KEY --quiet --project=sourcegraph-ci)
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(gcloud secrets versions access latest --secret=SOURCEGRAPH_LICENSE_GENERATION_KEY --quiet --project=sourcegraph-ci)
 
-      if [ "$(uname)" == "Darwin" ]; then
-        bazel test //testing:e2e_test --config darwin-docker --define=E2E_HEADLESS=false --define=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --define=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --define=GH_TOKEN=$GH_TOKEN
+      if [[ $(uname) == "Darwin" ]]; then
+        BAZEL_FLAGS="--config darwin-docker"
       else
-        bazel test //testing:e2e_test --define=E2E_HEADLESS=false --define=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --define=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --define=GH_TOKEN=$GH_TOKEN
+        BAZEL_FLAGS=""
       fi
-
+      bazel test //testing:e2e_test $BAZEL_FLAGS --define=E2E_HEADLESS=false --define=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --define=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --define=GH_TOKEN=$GH_TOKEN
 
   backend-integration:
     cmd: cd dev/gqltest && go test -long -base-url $BASE_URL -email $EMAIL -username $USERNAME -password $PASSWORD ./gqltest

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1581,7 +1581,7 @@ tests:
       else
         BAZEL_FLAGS=""
       fi
-      bazel test //testing:e2e_test $BAZEL_FLAGS --define=E2E_HEADLESS=false --define=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --define=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --define=GH_TOKEN=$GH_TOKEN
+      bazel test //testing:e2e_test $BAZEL_FLAGS --define=E2E_HEADLESS=false --define=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --define=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --define=GH_TOKEN=$GH_TOKEN --define=DISPLAY=$DISPLAY
 
   backend-integration:
     cmd: cd dev/gqltest && go test -long -base-url $BASE_URL -email $EMAIL -username $USERNAME -password $PASSWORD ./gqltest


### PR DESCRIPTION
This makes it possible to run e2e tests locally on Linux and use the current $DISPLAY for the non-headless browser.

## Test plan

CI