### PR TITLE
disable eslint rule etc/no-deprecated for massive file save speedup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -242,6 +242,7 @@ See https://handbook.sourcegraph.com/community/faq#is-all-of-sourcegraph-open-so
       },
     ],
     'import/order': 'off',
+    'etc/no-deprecated': 'off',
   },
   overrides: [
     {

--- a/client/shared/src/codeintel/legacy-extensions/lsif/definition-hover.test.ts
+++ b/client/shared/src/codeintel/legacy-extensions/lsif/definition-hover.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable etc/no-deprecated */
 import * as assert from 'assert'
 
 import * as sinon from 'sinon'

--- a/client/shared/src/codeintel/legacy-extensions/lsif/providers.test.ts
+++ b/client/shared/src/codeintel/legacy-extensions/lsif/providers.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable etc/no-deprecated */
 import * as assert from 'assert'
 
 import * as sinon from 'sinon'

--- a/client/shared/src/codeintel/legacy-extensions/lsif/references.test.ts
+++ b/client/shared/src/codeintel/legacy-extensions/lsif/references.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable etc/no-deprecated */
 import * as assert from 'assert'
 
 import * as sinon from 'sinon'

--- a/client/shared/src/codeintel/legacy-extensions/search/providers.test.ts
+++ b/client/shared/src/codeintel/legacy-extensions/search/providers.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable etc/no-deprecated */
 import * as assert from 'assert'
 
 import * as sinon from 'sinon'


### PR DESCRIPTION
With this rule enabled, saving a file in VS Code often takes 2-5 seconds or longer. With it disabled, saving a file is usually instant.

This rule can be useful, but it's not worth the massive slowdown it causes.

This rule is identified as the biggest culprit in slow eslint analysis by running `TIMING=1 pnpm exec eslint --fix client/web/dev/server/development.server.ts`.

## Test plan

CI