### PR TITLE
Append GPT instead of overriding

### DIFF
--- a/internal/licensing/codygateway.go
+++ b/internal/licensing/codygateway.go
@@ -26,7 +26,7 @@ func NewCodyGatewayChatRateLimit(plan Plan, userCount *int, licenseTags []string
 	// Switch on GPT models by default if the customer license has the GPT tag.
 	models := []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-instant-v1", "anthropic/claude-instant-1"}
 	if slices.Contains(licenseTags, GPTLLMAccessTag) {
-		models = []string{"openai/gpt-4", "openai/gpt-3.5-turbo"}
+		models = append(models, "openai/gpt-4", "openai/gpt-3.5-turbo")
 	}
 	switch plan {
 	// TODO: This is just an example for now.
@@ -60,7 +60,7 @@ func NewCodyGatewayCodeRateLimit(plan Plan, userCount *int, licenseTags []string
 	// Switch on GPT models by default if the customer license has the GPT tag.
 	models := []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1"}
 	if slices.Contains(licenseTags, GPTLLMAccessTag) {
-		models = []string{"openai/gpt-3.5-turbo"}
+		models = append(models, "openai/gpt-3.5-turbo")
 	}
 	switch plan {
 	// TODO: This is just an example for now.

--- a/internal/licensing/codygateway_test.go
+++ b/internal/licensing/codygateway_test.go
@@ -22,7 +22,7 @@ func TestNewCodyGatewayChatRateLimit(t *testing.T) {
 			userCount:   pointers.Ptr(50),
 			licenseTags: []string{GPTLLMAccessTag},
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"openai/gpt-4", "openai/gpt-3.5-turbo"},
+				AllowedModels:   []string{"anthropic/claude-v1", "anthropic/claude-2", "anthropic/claude-instant-v1", "anthropic/claude-instant-1", "openai/gpt-4", "openai/gpt-3.5-turbo"},
 				Limit:           2500,
 				IntervalSeconds: 60 * 60 * 24,
 			},
@@ -80,7 +80,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			userCount:   pointers.Ptr(50),
 			licenseTags: []string{GPTLLMAccessTag},
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"openai/gpt-3.5-turbo"},
+				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "openai/gpt-3.5-turbo"},
 				Limit:           50000,
 				IntervalSeconds: 60 * 60 * 24,
 			},


### PR DESCRIPTION
When GPT tag is added, append GPT models to the list of allowed models instead of removing Anthropic ones.


## Test plan

- unit tests updated
- local testing
