### PR TITLE
access tokens: Improve identification of dev instances

### DIFF
--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -180,7 +180,7 @@ func (s *accessTokenStore) createToken(ctx context.Context, subjectUserID int32,
 	if err != nil || licenseInfo == nil {
 		isDevInstance = true
 	} else {
-		isDevInstance = (licenseInfo.HasTag("dev") && licenseInfo.UserCount == 0)
+		isDevInstance = licensing.IsLicensePublicKeyOverridden()
 	}
 
 	token, b, err := accesstoken.GeneratePersonalAccessToken(includeInstanceIdentifier, config.LicenseKey, isDevInstance)

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -180,7 +180,7 @@ func (s *accessTokenStore) createToken(ctx context.Context, subjectUserID int32,
 	if err != nil || licenseInfo == nil {
 		isDevInstance = true
 	} else {
-		isDevInstance = licenseInfo.HasTag("dev")
+		isDevInstance = (licenseInfo.HasTag("dev") && licenseInfo.UserCount == 0)
 	}
 
 	token, b, err := accesstoken.GeneratePersonalAccessToken(includeInstanceIdentifier, config.LicenseKey, isDevInstance)

--- a/internal/licensing/licensing.go
+++ b/internal/licensing/licensing.go
@@ -46,9 +46,7 @@ var publicKey = func() ssh.PublicKey {
 
 // IsLicensePublicKeyOverridden checks if the hardcoded license public key has been overridden
 func IsLicensePublicKeyOverridden() bool {
-	configuredPublicKey := string(bytes.TrimSpace(ssh.MarshalAuthorizedKey(publicKey)))
-
-	return publicKeyData != configuredPublicKey
+	return publicKeyData != string(bytes.TrimSpace(ssh.MarshalAuthorizedKey(publicKey)))
 }
 
 // toInfo converts from the return type of license.ParseSignedKey to the return type of this

--- a/internal/licensing/licensing.go
+++ b/internal/licensing/licensing.go
@@ -20,6 +20,7 @@ type Info struct {
 	license.Info
 }
 
+// publicKeyData is the public key used to verify Sourcegraph license keys
 const publicKeyData = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUUd9r83fGmYVLzcqQp5InyAoJB5lLxlM7s41SUUtxfnG6JpmvjNd+WuEptJGk0C/Zpyp/cCjCV4DljDs8Z7xjRbvJYW+vklFFxXrMTBs/+HjpIBKlYTmG8SqTyXyu1s4485Kh1fEC5SK6z2IbFaHuSHUXgDi/IepSOg1QudW4n8J91gPtT2E30/bPCBRq8oz/RVwJSDMvYYjYVb//LhV0Mx3O6hg4xzUNuwiCtNjCJ9t4YU2sV87+eJwWtQNbSQ8TelQa8WjG++XSnXUHw12bPDe7wGL/7/EJb7knggKSAMnpYpCyV35dyi4DsVc46c+b6P0gbVSosh3Uc3BJHSWF`
 
 // publicKey is the public key used to verify product license keys.

--- a/internal/licensing/licensing.go
+++ b/internal/licensing/licensing.go
@@ -1,6 +1,7 @@
 package licensing
 
 import (
+	"bytes"
 	"log"
 	"sync"
 	"time"
@@ -19,6 +20,8 @@ type Info struct {
 	license.Info
 }
 
+const publicKeyData = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUUd9r83fGmYVLzcqQp5InyAoJB5lLxlM7s41SUUtxfnG6JpmvjNd+WuEptJGk0C/Zpyp/cCjCV4DljDs8Z7xjRbvJYW+vklFFxXrMTBs/+HjpIBKlYTmG8SqTyXyu1s4485Kh1fEC5SK6z2IbFaHuSHUXgDi/IepSOg1QudW4n8J91gPtT2E30/bPCBRq8oz/RVwJSDMvYYjYVb//LhV0Mx3O6hg4xzUNuwiCtNjCJ9t4YU2sV87+eJwWtQNbSQ8TelQa8WjG++XSnXUHw12bPDe7wGL/7/EJb7knggKSAMnpYpCyV35dyi4DsVc46c+b6P0gbVSosh3Uc3BJHSWF`
+
 // publicKey is the public key used to verify product license keys.
 var publicKey = func() ssh.PublicKey {
 	// If a key is set from SOURCEGRAPH_LICENSE_GENERATION_KEY, use that key to verify licenses instead.
@@ -32,7 +35,6 @@ var publicKey = func() ssh.PublicKey {
 	//
 	// To convert PKCS#8 format (which `openssl rsa -in key.pem -pubout` produces) to the format
 	// that ssh.ParseAuthorizedKey reads here, use `ssh-keygen -i -mPKCS8 -f key.pub`.
-	const publicKeyData = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUUd9r83fGmYVLzcqQp5InyAoJB5lLxlM7s41SUUtxfnG6JpmvjNd+WuEptJGk0C/Zpyp/cCjCV4DljDs8Z7xjRbvJYW+vklFFxXrMTBs/+HjpIBKlYTmG8SqTyXyu1s4485Kh1fEC5SK6z2IbFaHuSHUXgDi/IepSOg1QudW4n8J91gPtT2E30/bPCBRq8oz/RVwJSDMvYYjYVb//LhV0Mx3O6hg4xzUNuwiCtNjCJ9t4YU2sV87+eJwWtQNbSQ8TelQa8WjG++XSnXUHw12bPDe7wGL/7/EJb7knggKSAMnpYpCyV35dyi4DsVc46c+b6P0gbVSosh3Uc3BJHSWF`
 	var err error
 	publicKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(publicKeyData))
 	if err != nil {
@@ -40,6 +42,13 @@ var publicKey = func() ssh.PublicKey {
 	}
 	return publicKey
 }()
+
+// IsLicensePublicKeyOverridden checks if the hardcoded license public key has been overridden
+func IsLicensePublicKeyOverridden() bool {
+	configuredPublicKey := string(bytes.TrimSpace(ssh.MarshalAuthorizedKey(publicKey)))
+
+	return publicKeyData != configuredPublicKey
+}
 
 // toInfo converts from the return type of license.ParseSignedKey to the return type of this
 // package's methods (which use the Info wrapper type).

--- a/internal/licensing/licensing.go
+++ b/internal/licensing/licensing.go
@@ -44,7 +44,7 @@ var publicKey = func() ssh.PublicKey {
 	return publicKey
 }()
 
-// IsLicensePublicKeyOverridden checks if the hardcoded license public key has been overridden
+// IsLicensePublicKeyOverridden checks if the hardcoded license public key has been overridden with a *different* key
 func IsLicensePublicKeyOverridden() bool {
 	return publicKeyData != string(bytes.TrimSpace(ssh.MarshalAuthorizedKey(publicKey)))
 }


### PR DESCRIPTION
Some instances such as S2 sets the `dev` tag, so it's not a good signal for identifying whether an instance is a local dev instance.

Instead, check whether the license signing private key has been overridden via the env `SOURCEGRAPH_LICENSE_GENERATION_KEY`. If the associated public key matches the hardcoded license signing public key, we can determine that the instance is a real, correctly-licensed instance. If not, it's a dev instance.

## Test plan

- CI
- Manual testing locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
