### PR TITLE
Update dotcom footer links

### DIFF
--- a/client/web/src/storm/pages/SearchPage/SearchPageFooter.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageFooter.tsx
@@ -29,12 +29,12 @@ export const SearchPageFooter: FC = () => {
                           href: 'https://about.sourcegraph.com/cody',
                       },
                       {
-                          name: 'App',
-                          href: 'https://about.sourcegraph.com/app',
-                      },
-                      {
                           name: 'Enterprise',
                           href: 'https://about.sourcegraph.com/get-started?t=enterprise',
+                      },
+                      {
+                          name: 'Security',
+                          href: 'https://about.sourcegraph.com/security',
                       },
                       { name: 'Discord', href: 'https://srcgr.ph/discord-server' },
                   ]


### PR DESCRIPTION
Updates the footer for the search homepage specific to Sourcegraph.com:

- Removes the 'App' link, which pointed to the app download page.
- Adds a 'Security' link pointing to our Security page on the marketing site.

## Test plan
All links in footer for the SearchPage component were tested with the storybook live preview.