### PR TITLE
ci: let runtype.ManuallyTriggered execute the same build as PR

### DIFF
--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -129,7 +129,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		if bzlCmd == "" {
 			return nil, errors.Newf("no bazel command was given")
 		}
-	case runtype.PullRequest:
+	case runtype.ManuallyTriggered, runtype.PullRequest:
 		// First, we set up core test operations that apply both to PRs and to other run
 		// types such as main.
 		ops.Merge(CoreTestOperations(buildOptions, c.Diff, CoreTestOperationsOptions{


### PR DESCRIPTION
If the runtype is `ManuallyTriggered` run the same build as if it is a PR

### QUESTINO
Should it also not do any wolfi stuff? Since that also pushes images 🤔 

## Test plan
* `go build -o pipeline ./dev/ci/gen-pipeline.go`
* `git co _manually_triggered_external/ext_e951611910c8c24c65cabb19c90d25f035f25af9`
```
./pipeline| jq '.steps[] | if has("label") then .label else .steps[] | .label end'
":bazel: Perform bazel prechecks"
":bazel: Tests"
":bazel::snail: Async BackCompat Tests"
":pineapple::lint-roller: Run sg lint"
"Sonarcloud Scan"
```

