### PR TITLE
sg: disable docsite from default start target

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1091,7 +1091,7 @@ commandsets:
       - syntax-highlighter
     commands:
       - web
-      - docsite
+      # - docsite # we're hitting port issues with this, see https://github.com/sourcegraph/devx-support/issues/245
       - zoekt-index-0
       - zoekt-index-1
       - zoekt-web-0
@@ -1115,7 +1115,7 @@ commandsets:
       - searcher
       - caddy
       - symbols
-      - docsite
+      # - docsite # we're hitting port issues with this, see https://github.com/sourcegraph/devx-support/issues/245
       - syntax-highlighter
       - zoekt-index-0
       - zoekt-index-1


### PR DESCRIPTION
Quick follow-up on an issue with docsite being a bit too slow to shut down and causing issues. 

See https://github.com/sourcegraph/devx-support/issues/245 

## Test plan

CI + locally tested. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
