### PR TITLE
Fully disable sub repo perms test

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -21,6 +21,8 @@ const (
 )
 
 func TestSubRepoPermissionsPerforce(t *testing.T) {
+	t.Skip("Flaky, need to fix")
+
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
 	cleanup := createPerforceExternalService(t, testPermsDepot, false)


### PR DESCRIPTION
This still causes delays of up to 45s without adding any value, so let's skip it entirely until we fix it.

## Test plan

CI should tell that it's disabled.