### PR TITLE
Skip more perforce tests that regularly time out

### DIFF
--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -86,6 +86,8 @@ func TestSubRepoPermissionsPerforce(t *testing.T) {
 }
 
 func TestSubRepoPermissionsSymbols(t *testing.T) {
+	t.Skip("Flaky, need to fix")
+
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
 	cleanup := createPerforceExternalService(t, testPermsDepot, false)
@@ -123,6 +125,8 @@ func TestSubRepoPermissionsSymbols(t *testing.T) {
 }
 
 func TestSubRepoPermissionsSearch(t *testing.T) {
+	t.Skip("Flaky, need to fix")
+
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
 	cleanup := createPerforceExternalService(t, testPermsDepot, false)


### PR DESCRIPTION
Those add a lot of additional run time to CI, so disabling them temporarily.

```
2023/10/23 21:31:41 Site admin has been created: gqltest-admin
2023/10/23 21:31:41 License key added and verified
--- FAIL: TestSubRepoPermissionsSymbols (32.90s)
    sub_repo_permissions_test.go:93: Creating Alice
    sub_repo_permissions_test.go:93: Waiting for user permissions to be synced: Retry timed out in 30s
FAIL
^^^ +++
```

cc @pjlast

## Test plan

CI.