### PR TITLE
JetBrains: Cody: Encoding port in requestFrom param

### DIFF
--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -121,8 +121,20 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
 
     /** Get the requester, port, and destination from the url parameters */
     const urlSearchParams = useMemo(() => new URLSearchParams(location.search), [location.search])
-    const requestFrom = useMemo(() => urlSearchParams.get('requestFrom'), [urlSearchParams])
-    const port = useMemo(() => urlSearchParams.get('port'), [urlSearchParams])
+    let requestFrom = useMemo(() => urlSearchParams.get('requestFrom'), [urlSearchParams])
+    let port = useMemo(() => urlSearchParams.get('port'), [urlSearchParams])
+
+    // Allow a single query parameter `requestFrom=JETBRAIN-PORT_NUMBER`. The motivation for this parameter encoding is that
+    // the separate `port=NUMBER` parameter is lost when we try to log in via GitHub directly from the JetBrains IDE. By encoding the
+    // port number inside requestFrom, we have a single query parameter just like with VS Code.
+    if (requestFrom?.includes('-')) {
+        const [requestFrom1, port1, ...rest] = requestFrom?.split('-')
+        if (requestFrom1 && port1 && rest.length === 0 && port1.match(/^[0-9]/)) {
+            requestFrom = requestFrom1
+            port = port1
+        }
+    }
+
     const destination = useMemo(() => urlSearchParams.get('destination'), [urlSearchParams])
 
     /** The validated requester where the callback request originally comes from. */

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -129,7 +129,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
     // port number inside requestFrom, we have a single query parameter just like with VS Code.
     if (requestFrom?.includes('-')) {
         const [requestFrom1, port1, ...rest] = requestFrom?.split('-')
-        if (requestFrom1 && port1 && rest.length === 0 && port1.match(/^[0-9]/)) {
+        if (requestFrom1 && port1 && rest.length === 0 && port1.match(/^\d/)) {
             requestFrom = requestFrom1
             port = port1
         }


### PR DESCRIPTION
Previously, the JetBrains plugin used two query parameters during onboarding

- `requestFrom=JETBRAINS` to inform the user that they are authenticating for a JetBrains IDE.
- `port=NUMBER`: to indicate which `http://localhost:NUMBER` URL to redirect to after authorization. Without the port number, we don't know how to send the access token to the local IDE.

This PR adds support to encode both parameters together as `requestFrom=JETBRAINS-PORT_NUMBER`. The motivation for this change is to solve https://github.com/sourcegraph/jetbrains/issues/19. We hit on an issue that GitHub SSO was not working when linking directly from the IDE, and we suspect that the root issue is related to the two parameter encoding. If this change does not work as intended, then we plan to revert the diff.

## Test plan

We have not been able to test this fix with a local build because GitHub won't redirect to a local URL. Once this PR goes live on sourcegraph.com, we will confirm that this fix works correctly by doing the following steps

* Open JetBrains IDE with Cody plugin installed
* Try signing in via GitHub
* Check redirection is correct with port query param

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
