### PR TITLE
local: handle exceptions for token checking pre-commit hook

### DIFF
--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -255,13 +255,49 @@ Ensure that the `sourcegraph/syntax-highlighter:insiders` image is already avail
 docker pull -q sourcegraph/syntax-highlighter:insiders
 ```
 
-## `sg` and pre-commits 
+## `sg` and pre-commit hooks
 
-When `sg setup` is run, it will automatically install pre-commit hooks (using [pre-commit.com](https://pre-commit.com)), with a [provided configuration](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/.pre-commit-config.yaml) that will perform a series of fast checks before each commit you create locally. 
+When `sg setup` is run, it will automatically install pre-commit hooks (using [pre-commit.com](https://pre-commit.com)), with a [provided configuration](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/.pre-commit-config.yaml) that will perform a series of fast checks before each commit you create locally.
 
-Amongst that list of checks, is a [script](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/check-tokens.sh) that tries to detect the presence of tokens that would have been accidentally committed. While it's implementation is rather simple and won't catch all tokens (this is covered by automated scans in CI), it's enough to catch common mistakes and save you from having to rotate secrets, as they never left your computer. Due to the importance of such a measure, it's an opt-out process instead of opt-in. 
+Amongst that list of checks, is a [script](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/check-tokens.sh) that tries to detect the presence of tokens that would have been accidentally committed. While it's implementation is rather simple and won't catch all tokens (this is covered by automated scans in CI), it's enough to catch common mistakes and save you from having to rotate secrets, as they never left your computer. Due to the importance of such a measure, it's an opt-out process instead of opt-in.
 
-Therefore, it's strongly recommended to keep the pre-commit git hook. In the eventuality of the pre-commit detecting a false positive, you can disable it through `sg setup disable-pre-commit` and prevent `sg setup` from installing it by passing a flag `sg setup --skip-pre-commit`. 
+Therefore, it's strongly recommended to keep the pre-commit git hook. In the eventuality of the pre-commit detecting a false positive, you can disable it through `sg setup disable-pre-commit` and prevent `sg setup` from installing it by passing a flag `sg setup --skip-pre-commit`.
+
+### Exceptions
+
+There are legitimate cases where code contains what appears to be a Sourcegraph token but isn't usable on any existing deployments.
+Testing code for generating tokens is good example.
+
+You can tell pre-commit to simply skip these files by adding a `// pre-commit:ignore_sourcegraph_token` top-level comment, as
+shown in the example below:
+
+```
+package accesstoken
+
+// pre-commit:ignore_sourcegraph_token
+
+import (
+	"testing"
+)
+
+func TestGenerateDotcomUserGatewayAccessToken(t *testing.T) {
+	type args struct {
+		apiToken string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid token 1",
+			args:    args{apiToken: "0123456789abcdef0123456789abcdef01234567"},
+			want:    "LOOKS_LIKE_A_REAL_TOKEN",
+			wantErr: false,
+		},
+  // (...)
+```
 
 ## Contributing to `sg`
 
@@ -291,7 +327,7 @@ Have questions or need help? Feel free to [open a discussion](https://github.com
 A `sourcegraph/sg` Docker image is available:
 
 ```dockerfile
-# ... 
+# ...
 COPY --from us.gcr.io/sourcegraph-dev/sg:insiders /usr/local/bin/sg ./sg
 # ...
 ```

--- a/internal/accesstoken/cody_access_token_test.go
+++ b/internal/accesstoken/cody_access_token_test.go
@@ -4,6 +4,11 @@ import (
 	"testing"
 )
 
+// This file contains tests for token generation code, so it legitimately contains what
+// appears to be valid tokens. This is fine because those are test tokens. The comment
+// just below tells the pre-commit hook to simply skip this file.
+// pre-commit:ignore_sourcegraph_token
+
 func TestGenerateDotcomUserGatewayAccessToken(t *testing.T) {
 	type args struct {
 		apiToken string


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/devx-support/issues/338 

This PR introduces a mechanism to tell pre-commit to simply skip a file if it legitimately contains what looks like a token but shouldn't raise an error. 

It also fixes a very dumb bug, previously the list of files returned by `git diff` included files that got deleted, which made the script fail because `grep` obviously couldn't read them.

Typically, this happens when doing a large rebase/merge where one of those legitimate files gets added to the diff. 


## Test plan

For the exception bit: 

- Changed a file containing false positives 
- Staged the changes
- Tried to commit
- Observed the failure because a token is detected 
- Added the comment to signal the exception
- Staged the changes again
- Tried to commit 
- Observed that it got ignored as expected. 

For the deleted files, I simply re-used the branch that was provided in the support ticket and observed that it now works with the patch in this PR.  

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@jh/handle-pre-commit-exceptions)