### PR TITLE
bazel: add entry about `--macos_sdk_version`

### DIFF
--- a/doc/dev/background-information/bazel/faq.md
+++ b/doc/dev/background-information/bazel/faq.md
@@ -107,6 +107,12 @@ To fix this, you need to install Rosetta 2. There are various ways of doing that
 
 __Tested on Darwin 22.3.0 Darwin Kernel Version 22.3.0__
 
+### On MacOS, your build fails with `xcrun failed with code 1. This most likely indicates that SDK version [10.10] for platform [MacOSX] is unsupported for the target version of xcode.`
+
+Bazel uses `xcrun` to locate the SDK and toolchain for iOS/Mac compilation and xcrun is fails to produce a version or it cannot find the correct directory. This might happen even if `xcrun --show-sdk-path` shows a valid path and `xcrun --show-sdk-version` shows a valid version. At the time of this entry we haven't found the exact cause of this issue and various other bazel projects have encountered the same issue.
+
+Nonetheless, there is a workaround! Pass the following CLI flag when you try to build a target `--macos_sdk_version=13.3`. With the flag bazel should be able to find the MacOS SDK and you should not get the error anymore. It's recommended to add `build --macos_sdk_version=13.3` to your `.bazelrc` file so that you don't have to add the CLI flag every time you invoke a build.
+
 ## Queries
 
 Bazel queries (`bazel query`, `bazel cquery` and `bazel aqueries`) are powerful tools that can assist you to visualize dependencies and understand how targets are being built or tested.
@@ -192,18 +198,18 @@ In the case where your testdata lives in `../**`, Gazelle cannot see those on it
 
 ### My go tests are timing out in CI but there is no output telling me where exactly it failed
 
-By defaults, Go tests are run without the `-v` flag, which means that Go will only print a summary when the testing is complete or has failed. But in the case of Bazel timeouts, i.e. when the test target 
-has a time out on the Bazel side (`short` by default, so 60 seconds) Bazel will kill the Go test binary before it had the chance to flush out its outputs. As a result, you'll see empty logs, which is 
-very incovenient for debugging. 
+By defaults, Go tests are run without the `-v` flag, which means that Go will only print a summary when the testing is complete or has failed. But in the case of Bazel timeouts, i.e. when the test target
+has a time out on the Bazel side (`short` by default, so 60 seconds) Bazel will kill the Go test binary before it had the chance to flush out its outputs. As a result, you'll see empty logs, which is
+very incovenient for debugging.
 
-Solution: run `bazel test --config go-verbose-test` to force Bazel to run the tests with the verbose flag on for any `go_test` rule it encounters. If this only happens in CI, you can combine this solution with the _bazel-do_ feature of `sg` 
-which enables to fire a build running a single, specific test that you provide: 
+Solution: run `bazel test --config go-verbose-test` to force Bazel to run the tests with the verbose flag on for any `go_test` rule it encounters. If this only happens in CI, you can combine this solution with the _bazel-do_ feature of `sg`
+which enables to fire a build running a single, specific test that you provide:
 
 ```
-sg ci bazel test --config go-verbose-test //my/timing-out:target 
+sg ci bazel test --config go-verbose-test //my/timing-out:target
 ```
 
-This will print out the URL of the newly created build and the logs will show you exactly where the tests were when they timed out. 
+This will print out the URL of the newly created build and the logs will show you exactly where the tests were when they timed out.
 
 ### Manually adding a `go_repository`
 


### PR DESCRIPTION
Follow up to https://github.com/sourcegraph/devx-support/issues/339
## Test plan
None - this is a doc change


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@wb/bazel/faq-entry)