### PR TITLE
PRETEND RELEASE WIP: release_patch: build 

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -9,27 +9,43 @@ requirements:
   - name: "Bazel"
     cmd: bazel version
     fixInstructions: Run `sg setup` and try again.
-  - name: "buildozer"
-    cmd: buildozer -version
-    fixInstructions: Run `go install github.com/bazelbuild/buildtools/buildozer@latest` and try again.
   - name: "Github CLI"
     cmd: gh version
     fixInstructions: brew install gh
 
-create:
-  steps:
-    patch:
-      - name: "generate"
-        cmd: |
-          bazel run //dev:write_all_generated
-      # we don't use this for patch releases
-      # - name: "migration"
-      #   cmd: |
-      #     comby -in-place \
-      #       'const maxVersionString = ":[1]"' \
-      #       'const maxVersionString = "{{version}}"' \
-      #       internal/database/migration/shared/data/cmd/generator/consts.go
+internal:
+  create:
+    steps:
+      patch:
+        # we don't use this for patch releases
+        # - name: "migration"
+        #   cmd: |
+        #     comby -in-place \
+        #       'const maxVersionString = ":[1]"' \
+        #       'const maxVersionString = "{{version}}"' \
+        #       internal/database/migration/shared/data/cmd/generator/consts.go
 
-      - name: "bazel"
+        - name: "db.schemas"
+          cmd: |
+            bazel run //tools/release:generate_schemas_archive -- {{version}} inject-current-schemas $PWD
+        - name: "git"
+          cmd: |
+            branch="wip_{{version}}"
+            git checkout -b $branch
+            git add tools/release/schema_deps.bzl
+
+            # Careful with the quoting for the config, using double quotes will lead
+            # to the shell dropping out all quotes from the json, leading to failed
+            # parsing.
+            git commit -m "release_patch: {{version}}" -m '{{config}}'
+            git push origin $branch
+        - name: "github"
+          cmd: |
+            gh pr create -f -t "PRETEND RELEASE WIP: release_patch: build ${NEW_VERSION}"
+
+  finalize:
+    steps:
+      - name: "db.schemas"
         cmd: |
-          bazel run //tools/release:create_patch --run_under="cd $PWD &&" -- {{version}}
+          echo "TODO"
+          # run //tools/release:upload_current_schemas -- {{version}}

--- a/tools/release/BUILD.bazel
+++ b/tools/release/BUILD.bazel
@@ -1,13 +1,3 @@
-load(":release.bzl", "release_patch")
-
-# exports_files(srcs = [
-#     "finalize_release_patch.sh",
-#     "release_patch.sh.tpl",
-# ])
-release_patch(
-    name = "create_patch",
-)
-
 sh_binary(
     name = "finalize_patch",
     srcs = [":finalize_release_patch.sh"],

--- a/tools/release/schema_deps.bzl
+++ b/tools/release/schema_deps.bzl
@@ -8,6 +8,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def schema_deps():
     http_file(
         name = "schemas_archive",
-        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.2.1.tar.gz"],
-        sha256 = "3ec54f2d132ba5fc4f084f3bc76650f1c759ab32b5b73aba2ac9df91098ffeaf",
+        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.2.123456.tar.gz"],
+        sha256 = "a18114d5df31fd0f22c77b572601c834039353f66c8107c9364139f6a2d24571",
     )


### PR DESCRIPTION
- Add a wig_git_versions list
- tmp
- fixup
- tmp
- Prevent wrong versions
- fixup
- fixup
- fixup
- fixup
- fixup
- fixpu
- Add new Runtype for wip releases
- do not accidentally push images on public registry
- Rework the rule, takes version as an argument
- sg: draft sg ci build-release
- run bazel cmd in bash -c so that bash-esque vars gets picked up
- Add comment
- Add a final step + release finalize thigny
- move release_patch to tools/release
- add initial impl of approve pr
- POC
- Fix merge things
- wip wip
- ififfi
- Write migrations to source tree
- Save wip instructions
- wfipewfp
- fiuxp
- fix finalize_release
- remove outdated command
- fix
- doc
- fix diff test
- Update step
- fixup
- fixup
- wip
- fixup
- Remove outdated doc file
- fixup
- Publish images internally tagged with wip_vX.Y.Z
- fixup
- fixup
- Create a runner abstraction
- Parse config from commits if asked to
- Rework manifest
- fixup
- Add promote commands
- release_patch: v5.2.123456


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@wip_v5.2.123456)