### PR TITLE
symbols: use correct directory in ctags-install-alpine.sh

### DIFF
--- a/cmd/symbols/ctags-install-alpine.sh
+++ b/cmd/symbols/ctags-install-alpine.sh
@@ -6,6 +6,9 @@
 # Last bumped 2022-04-04.
 # When bumping please remember to also update Zoekt: https://github.com/sourcegraph/zoekt/blob/d3a8fbd8385f0201dd54ab24114ebd588dfcf0d8/install-ctags-alpine.sh
 CTAGS_VERSION=v6.0.0
+CTAGS_ARCHIVE_TOP_LEVEL_DIR=ctags-6.0.0
+# When using commits you can rely on
+# CTAGS_ARCHIVE_TOP_LEVEL_DIR=ctags-$CTAGS_VERSION
 
 cleanup() {
   apk --no-cache --purge del ctags-build-deps || true
@@ -36,7 +39,7 @@ NUMCPUS=$(grep -c '^processor' /proc/cpuinfo)
 
 # Installation
 curl --retry 5 "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
-cd /tmp/ctags-$CTAGS_VERSION
+cd /tmp/$CTAGS_ARCHIVE_TOP_LEVEL_DIR
 ./autogen.sh
 ./configure --program-prefix=universal- --enable-json
 make -j"$NUMCPUS" --load-average="$NUMCPUS"


### PR DESCRIPTION
The format of the archive is slightly different for tags vs commits.

Fix for https://github.com/sourcegraph/sourcegraph/pull/57725

Test Plan: used this version of the script in the docker build for the zoekt repo.
