### PR TITLE
Backport 5.2: Update Wolfi base images to latest (#57689)

### DIFF
--- a/cmd/gitserver/image_test.yaml
+++ b/cmd/gitserver/image_test.yaml
@@ -39,6 +39,9 @@ commandTests:
     command: "coursier"
   - name: "p4-fusion is runnable"
     command: "p4-fusion-binary"
+    args:
+    expectedOutput: ["--noBaseCommit"]
+    exitCode: 1
 
   - name: "not running as root"
     command: "/usr/bin/id"

--- a/cmd/server/image_test.yaml
+++ b/cmd/server/image_test.yaml
@@ -30,6 +30,13 @@ commandTests:
     expectedOutput: ["valid commands: submit"]
     exitCode: 2
 
+  # P4-fusion
+  - name: "p4-fusion is runnable"
+    command: "p4-fusion-binary"
+    args:
+    expectedOutput: [ "--noBaseCommit" ]
+    exitCode: 1
+
   # Zoekt binaries
   - name: "zoket binaries are runnable"
     command: "/opt/image_tests/test_zoekt.sh"

--- a/cmd/server/image_tests/test_packages.sh
+++ b/cmd/server/image_tests/test_packages.sh
@@ -12,8 +12,6 @@ bash --version
 
 p4 -h
 
-p4-fusion-binary
-
 coursier
 
 redis-server --version

--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -34,31 +34,31 @@ load("@rules_oci//oci:pull.bzl", "oci_pull")
 def oci_deps():
     oci_pull(
         name = "wolfi_base",
-        digest = "sha256:c922bda016dfc3fb799b2f66c5bf8317bd049e91495bd5e9d39721ee2111136b",
+        digest = "sha256:6ed590d3adebe3bb5a655f672fa8a599ee7b432e18f0831227eb46fa3cd29dae",
         image = "index.docker.io/sourcegraph/wolfi-sourcegraph-base",
     )
 
     oci_pull(
         name = "wolfi_cadvisor_base",
-        digest = "sha256:109cc77a5331f4bd6df22317fb6571f5f0fd557c4c5432c3f382c71c87db8281",
+        digest = "sha256:442a0eb9bc61c809b7e26f21d214bf0c5923c89803485d4ab123db28ba77b537",
         image = "index.docker.io/sourcegraph/wolfi-cadvisor-base",
     )
 
     oci_pull(
         name = "wolfi_symbols_base",
-        digest = "sha256:bf1a98dd0af0e30aaa3ccdc9a4d3db5aca5c18d8215efafe98f6f9813c9043d8",
+        digest = "sha256:6c5ff11cbe30fa87220573f95d13cf12f4ea432c33a89a8a31f4487fd0006a22",
         image = "index.docker.io/sourcegraph/wolfi-symbols-base",
     )
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:82356d311139b890957258777b7dba1e350e22746c727c8ffe36714093b60835",
+        digest = "sha256:a1147fd551868ec84dafce9ef1d2f9c6a64a685bf55e0f4034d4a6f3ed6ac388",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:9eeb0b161868cc535d88b8fa69363c277ff6135cd8bc1a9f7134914395c703cf",
+        digest = "sha256:938ef779926a88c15a9dde2fdf77a18085af8ea3fbabb12746798f10bd0627e3",
         image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
     )
 
@@ -70,133 +70,133 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_postgres_exporter_base",
-        digest = "sha256:9060a15af1c3ba3a224b4136e217293c6cba5873c341cbecac852ebbd469d0e0",
+        digest = "sha256:2f04939a502f98bdc239d914f98d8e308cbdf0ebde05daa5b3c78791f8e92d28",
         image = "index.docker.io/sourcegraph/wolfi-postgres-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_all_in_one_base",
-        digest = "sha256:842deee42fe6f37ee37d697e4d196af171c61bb6392cacb7e629357b6ee0dd93",
+        digest = "sha256:cad0d67abccce789e8bb53daec5e5b85b392a7ef952454250694dddf005fa1e8",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-all-in-one-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_agent_base",
-        digest = "sha256:42fe051efdb4b9e90b06ea0b1aa4726341b58d6abc08cb959d2ac567d6cdecb7",
+        digest = "sha256:b2992e8a7fdb783da50db91249b1a1115a6f4e667eb8bffd9a71a1f805bef346",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-agent-base",
     )
 
     oci_pull(
         name = "wolfi_redis_base",
-        digest = "sha256:4e09e43afd8c29ed7ef55b838a183041785aae7589ae6253e7a8d8bacea399ff",
+        digest = "sha256:4d6eea2f193d72f8d4ea4f21b5dd7f80aa57204fbadffeffe40e76af36637ac5",
         image = "index.docker.io/sourcegraph/wolfi-redis-base",
     )
 
     oci_pull(
         name = "wolfi_redis_exporter_base",
-        digest = "sha256:74f6418809af3f99aa0e3c1151a34009cfa1d5e5580293ff1b8fb9b736075387",
+        digest = "sha256:479528edc55bab31cd6f98b0f90562fd95600bac227e911abff1cb27bd5ea0d8",
         image = "index.docker.io/sourcegraph/wolfi-redis-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_syntax_highlighter_base",
-        digest = "sha256:04eb69f64c44ea32f8ad55b6312aacf90d3edf6979c96030dfa3520923e672d9",
+        digest = "sha256:d100bb61f21d9217fe2bceca1b60735d2d1859a7306734dc6b628b993a86d2cb",
         image = "index.docker.io/sourcegraph/wolfi-syntax-highlighter-base",
     )
 
     oci_pull(
         name = "wolfi_search_indexer_base",
-        digest = "sha256:09c7239ef9be70a48f67864873b9de6593cfd107d4e8e7ccb178b50a87f6a30c",
+        digest = "sha256:c31bf4cdf7a7b52e9697d941f1a83cbc4d82b792dcaa991896ddd6e842ac106e",
         image = "index.docker.io/sourcegraph/wolfi-search-indexer-base",
     )
 
     oci_pull(
         name = "wolfi_repo_updater_base",
-        digest = "sha256:328fd156e6b73e0880ea4e6bd55ca6650ec4eeb14fe50d313f283e5c78dc993d",
+        digest = "sha256:f3d2dfa1c32d5ccecca29f9595eb062f0ddd815418b6904a35a78b5d34f4d54d",
         image = "index.docker.io/sourcegraph/wolfi-repo-updater-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:a41fa66a13f197a80fb6f5357fa45fb9e529dd23df3ef71b1f2dec86b0c87ffe",
+        digest = "sha256:88cf6039d37ebfa79f3dee6f2862aa8441d3e65a14cdf71214d32d04fc8c5c85",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_executor_base",
-        digest = "sha256:31cd087340f7013959e3e8409f9c01dd880f053cc82fa149a38758cd505806ce",
+        digest = "sha256:c030c215650b39dabb9fc5cb7d438431a936f59dcae559d1751aa1e9f603ce52",
         image = "index.docker.io/sourcegraph/wolfi-executor-base",
     )
 
     # ???
     oci_pull(
         name = "wolfi_bundled_executor_base",
-        digest = "sha256:80029d78387dd73a53846a961a0b4a34e098b91e02d46841ac99b3bd90c4a6dc",
+        digest = "sha256:aa931c25e13971de892b60e0ad3d892cd6eeabdaf2dac6d6473b238eddb85513",
         image = "index.docker.io/sourcegraph/wolfi-bundled-executor-base",
     )
 
     oci_pull(
         name = "wolfi_executor_kubernetes_base",
-        digest = "sha256:bf8e4469233319b69f2e9315542b3d9fdb4007b7471e9aa8908380af70bc804f",
+        digest = "sha256:89e2f5fcf1c69b02254a2ecc4857beda7288351bd52b8fb1e88c1c8f0182995e",
         image = "index.docker.io/sourcegraph/wolfi-executor-kubernetes-base",
     )
 
     oci_pull(
         name = "wolfi_batcheshelper_base",
-        digest = "sha256:3da3fab4c56c0646477ab246cf1faa0bc0cd42c1c6c18ac34df46c7af12d4755",
+        digest = "sha256:72a97d66c9f701aae0dbf3a5ea6330f209fe2240d5a0018c76b8e9b9d2d45dad",
         image = "index.docker.io/sourcegraph/wolfi-batcheshelper-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_base",
-        digest = "sha256:38b9a9d5915a121cfc0d9251d9cf16515a69710429642b6df401cbd1a806dd87",
+        digest = "sha256:c021e04d20af9a79b4ba2eedb7c83bf78e259a99e43d34754c3d5bda4add445c",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_gcp_base",
-        digest = "sha256:278f62f5479ab6ee52f48c380a18e9fa84cba9f248b1a07306699ead994f115e",
+        digest = "sha256:9835899e66e57c24eeb0c6e92b452d46c5fa8287fe85d1718b725c647604fb28",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-gcp-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12_base",
-        digest = "sha256:e8bced812dcde651f0621175483fe87e7ac95ff14726d4d4abfb3aad3bd85d01",
+        digest = "sha256:818933fff05a6f9b6f8ef738fabad7fcc70e57d873ddbc8187e3445a1e815aa5",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12-codeinsights_base",
-        digest = "sha256:7ebce4accc89c37125fcfff3625affc4092ca8b85e175d0d4df762d9c1fad09f",
+        digest = "sha256:d55b9886a1c2321a9f6e215ee3ce8468a28ebc638d9c224c5fafa4b7ade62912",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-codeinsights-base",
     )
 
     oci_pull(
         name = "wolfi_node_exporter_base",
-        digest = "sha256:295ccea8c56a17afaad5f77c737b44d2a49a4c48590f8924de5b7e579a4f96df",
+        digest = "sha256:72ce533b14be7f2ec75e32fe2063e6d65ef41d1202ac3e206b4411f3000b268a",
         image = "index.docker.io/sourcegraph/wolfi-node-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_opentelemetry_collector_base",
-        digest = "sha256:c0d47763f3b38c7e96bc26493e330f25ac9ab20adbf3b3cdc344b49e74a3a7d6",
+        digest = "sha256:41a2fcd6cb01c4d0f7bb33f05fe8a1e3991e5eae38b145af0975c50df3e77677",
         image = "index.docker.io/sourcegraph/wolfi-opentelemetry-collector-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:a41fa66a13f197a80fb6f5357fa45fb9e529dd23df3ef71b1f2dec86b0c87ffe",
+        digest = "sha256:88cf6039d37ebfa79f3dee6f2862aa8441d3e65a14cdf71214d32d04fc8c5c85",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_s3proxy_base",
-        digest = "sha256:91cd81e3fab601af0a1b61b347ff291ef347939918fc7dbbed6117651669c3c7",
+        digest = "sha256:27d983a210084f2ee2dc73686ad874958c33fd78a63c0c9fd12582842016ccdb",
         image = "index.docker.io/sourcegraph/wolfi-blobstore-base",
     )
 
     oci_pull(
         name = "wolfi_qdrant_base",
-        digest = "sha256:66108923575bf094220fbc94368938a567d76dd11ec03d7e6ddc67b9e658c22b",
+        digest = "sha256:046e2ac46f26cffa8f0ff71b293181bc2e3ba53afcd0e4a7cf8ffbd8dfa11eee",
         image = "index.docker.io/sourcegraph/wolfi-qdrant-base",
     )


### PR DESCRIPTION
Auto-update Wolfi base image hashes at 2023-10-24 03:09:35 UTC

This patches CVE-2023-45853 High vulnerability in base image

Co-authored-by: Buildkite <buildkite@sourcegraph.com>
(cherry picked from commit 699aeb563da9ea63b54a36b2dde62bb6c807d6ab)



## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
