### PR TITLE
wolfi-packages: set epoch to 0 for ctags

### DIFF
--- a/wolfi-packages/ctags.yaml
+++ b/wolfi-packages/ctags.yaml
@@ -4,7 +4,7 @@
 package:
   name: ctags
   version: 6.0.0
-  epoch: 2
+  epoch: 0
   description: "A maintained ctags implementation"
   target-architecture:
     - x86_64


### PR DESCRIPTION
I recently bumped the version and did not realise I needed to update the epoch back to 0.

Test Plan: CI