### PR TITLE
Cody: Experimental OpenAI autocomplete support

### DIFF
--- a/internal/completions/client/openai/openai.go
+++ b/internal/completions/client/openai/openai.go
@@ -312,8 +312,8 @@ type openaiResponse struct {
 }
 
 func getPrompt(messages []types.Message) (string, error) {
-	if len(messages) != 1 {
-		return "", errors.New("Expected to receive exactly one message with the prompt")
+	if l := len(messages); l != 1 {
+		return "", errors.Errof("expected to receive exactly one message with the prompt (got %d)", l)
 	}
 
 	return messages[0].Text, nil

--- a/internal/completions/client/openai/openai.go
+++ b/internal/completions/client/openai/openai.go
@@ -126,6 +126,7 @@ func (c *openAIChatCompletionStreamClient) Stream(
 	return dec.Err()
 }
 
+// makeRequest formats the request and calls the chat/completions endpoint for code_completion requests
 func (c *openAIChatCompletionStreamClient) makeRequest(ctx context.Context, requestParams types.CompletionRequestParameters, stream bool) (*http.Response, error) {
 	if requestParams.TopK < 0 {
 		requestParams.TopK = 0
@@ -197,6 +198,7 @@ func (c *openAIChatCompletionStreamClient) makeRequest(ctx context.Context, requ
 	return resp, nil
 }
 
+// makeCompletionRequest formats the request and calls the completions endpoint for code_completion requests
 func (c *openAIChatCompletionStreamClient) makeCompletionRequest(ctx context.Context, requestParams types.CompletionRequestParameters, stream bool) (*http.Response, error) {
 	if requestParams.TopK < 0 {
 		requestParams.TopK = 0
@@ -251,35 +253,37 @@ func (c *openAIChatCompletionStreamClient) makeCompletionRequest(ctx context.Con
 	return resp, nil
 }
 
+// openAIChatCompletionsRequestParameters request object for openAI chat endpoint https://platform.openai.com/docs/api-reference/chat/create
 type openAIChatCompletionsRequestParameters struct {
-	Model            string             `json:"model"`
-	Messages         []message          `json:"messages"`
-	Temperature      float32            `json:"temperature,omitempty"`
-	TopP             float32            `json:"top_p,omitempty"`
-	N                int                `json:"n,omitempty"`
-	Stream           bool               `json:"stream,omitempty"`
-	Stop             []string           `json:"stop,omitempty"`
-	MaxTokens        int                `json:"max_tokens,omitempty"`
-	PresencePenalty  float32            `json:"presence_penalty,omitempty"`
-	FrequencyPenalty float32            `json:"frequency_penalty,omitempty"`
-	LogitBias        map[string]float32 `json:"logit_bias,omitempty"`
-	User             string             `json:"user,omitempty"`
+	Model            string             `json:"model"`                       // request.Model
+	Messages         []message          `json:"messages"`                    // request.Messages
+	Temperature      float32            `json:"temperature,omitempty"`       // request.Temperature
+	TopP             float32            `json:"top_p,omitempty"`             // request.TopP
+	N                int                `json:"n,omitempty"`                 // always 1
+	Stream           bool               `json:"stream,omitempty"`            // request.Stream
+	Stop             []string           `json:"stop,omitempty"`              // request.StopSequences
+	MaxTokens        int                `json:"max_tokens,omitempty"`        // request.MaxTokensToSample
+	PresencePenalty  float32            `json:"presence_penalty,omitempty"`  // unused
+	FrequencyPenalty float32            `json:"frequency_penalty,omitempty"` // unused
+	LogitBias        map[string]float32 `json:"logit_bias,omitempty"`        // unused
+	User             string             `json:"user,omitempty"`              // unused
 }
 
+// openAICompletionsRequestParameters payload for openAI completions endpoint https://platform.openai.com/docs/api-reference/completions/create
 type openAICompletionsRequestParameters struct {
-	Model            string             `json:"model"`
-	Prompt           string             `json:"prompt"`
-	Temperature      float32            `json:"temperature,omitempty"`
-	TopP             float32            `json:"top_p,omitempty"`
-	N                int                `json:"n,omitempty"`
-	Stream           bool               `json:"stream,omitempty"`
-	Stop             []string           `json:"stop,omitempty"`
-	MaxTokens        int                `json:"max_tokens,omitempty"`
-	PresencePenalty  float32            `json:"presence_penalty,omitempty"`
-	FrequencyPenalty float32            `json:"frequency_penalty,omitempty"`
-	LogitBias        map[string]float32 `json:"logit_bias,omitempty"`
-	Suffix           string             `json:"suffix,omitempty"`
-	User             string             `json:"user,omitempty"`
+	Model            string             `json:"model"`                       // request.Model
+	Prompt           string             `json:"prompt"`                      // request.Messages[0] - formatted prompt expected to be the only message
+	Temperature      float32            `json:"temperature,omitempty"`       // request.Temperature
+	TopP             float32            `json:"top_p,omitempty"`             // request.TopP
+	N                int                `json:"n,omitempty"`                 // always 1
+	Stream           bool               `json:"stream,omitempty"`            // request.Stream
+	Stop             []string           `json:"stop,omitempty"`              // request.StopSequences
+	MaxTokens        int                `json:"max_tokens,omitempty"`        // request.MaxTokensToSample
+	PresencePenalty  float32            `json:"presence_penalty,omitempty"`  // unused
+	FrequencyPenalty float32            `json:"frequency_penalty,omitempty"` // unused
+	LogitBias        map[string]float32 `json:"logit_bias,omitempty"`        // unused
+	Suffix           string             `json:"suffix,omitempty"`            // unused
+	User             string             `json:"user,omitempty"`              // unused
 }
 
 type message struct {
@@ -313,7 +317,7 @@ type openaiResponse struct {
 
 func getPrompt(messages []types.Message) (string, error) {
 	if l := len(messages); l != 1 {
-		return "", errors.Errof("expected to receive exactly one message with the prompt (got %d)", l)
+		return "", errors.Errorf("expected to receive exactly one message with the prompt (got %d)", l)
 	}
 
 	return messages[0].Text, nil

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -624,7 +624,7 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 	} else if completionsConfig.Provider == string(conftypes.CompletionsProviderNameOpenAI) {
 		// If no endpoint is configured, use a default value.
 		if completionsConfig.Endpoint == "" {
-			completionsConfig.Endpoint = "https://api.openai.com/v1/chat/completions"
+			completionsConfig.Endpoint = "https://api.openai.com"
 		}
 
 		// If not access token is set, we cannot talk to OpenAI. Bail.

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -644,7 +644,7 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 
 		// Set a default completions model.
 		if completionsConfig.CompletionModel == "" {
-			completionsConfig.CompletionModel = "gpt-3.5-turbo"
+			completionsConfig.CompletionModel = "gpt-3.5-turbo-instruct"
 		}
 	} else if completionsConfig.Provider == string(conftypes.CompletionsProviderNameAnthropic) {
 		// If no endpoint is configured, use a default value.
@@ -1121,7 +1121,7 @@ func openaiDefaultMaxPromptTokens(model string) int {
 		return 8_000
 	case "gpt-4-32k":
 		return 32_000
-	case "gpt-3.5-turbo":
+	case "gpt-3.5-turbo", "gpt-3.5-turbo-instruct":
 		return 4_000
 	case "gpt-3.5-turbo-16k":
 		return 16_000

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -468,11 +468,11 @@ func TestGetCompletionsConfig(t *testing.T) {
 				ChatModelMaxTokens:       8000,
 				FastChatModel:            "gpt-3.5-turbo",
 				FastChatModelMaxTokens:   4000,
-				CompletionModel:          "gpt-3.5-turbo",
+				CompletionModel:          "gpt-3.5-turbo-instruct",
 				CompletionModelMaxTokens: 4000,
 				AccessToken:              "asdf",
 				Provider:                 "openai",
-				Endpoint:                 "https://api.openai.com/v1/chat/completions",
+				Endpoint:                 "https://api.openai.com",
 			},
 		},
 		{


### PR DESCRIPTION
Adds experimental OpenAI autocomplete support **_only for BYOK configurations_**.  This brings the changes from the Azure OpenAI provider to OpenAI provider.  Additional it updates the default autocomplete model for OpenAI to be `gpt-3.5-turbo-instruct`  as this model continues to support the non-chat based completions api.  

part of https://github.com/sourcegraph/sourcegraph/issues/57724
## Test plan
Verified Chat & autocomplete work in VS Code
Verified Cody web works
Ran client completions and benchmark tooling. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
