### PR TITLE
Update ctags epoch

### DIFF
--- a/doc/dev/how-to/wolfi/add_update_packages.md
+++ b/doc/dev/how-to/wolfi/add_update_packages.md
@@ -37,6 +37,7 @@ It's common to need to update a package to the most recent release in order to p
 
 - Depending on the package, this step may download a binary or source code. Projects release code in different ways, so the pipeline may check out a Git repository on a specific branch or download a `.tar.gz` file containing source code.
 - You should also reset the `package.epoch` field to 0 when updating the version.
+  - The `version` is the version of the dependency being packaged, but the `epoch` is like the version of the _package itself_. It should be incremented whenever making changes, and reset to 0 when the dependency version increases.
 
 3. Optionally, build the package locally with `sg wolfi package <package-name>`.
 

--- a/wolfi-packages/ctags.yaml
+++ b/wolfi-packages/ctags.yaml
@@ -4,7 +4,7 @@
 package:
   name: ctags
   version: 6.0.0
-  epoch: 0
+  epoch: 3
   description: "A maintained ctags implementation"
   target-architecture:
     - x86_64


### PR DESCRIPTION
- Fix epoch for ctags package
- Improve docs for epochs

## Test plan

- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@will/ctags-epoch-update)