### PR TITLE
gomod: update zoekt and go-ctags

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5838,8 +5838,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_go_ctags",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/go-ctags",
-        sum = "h1:Okjvl9eO68GDev76KPfJqJOqRGfxOCyXCB2THAT6Bus=",
-        version = "v0.0.0-20230929045819-c736fcb519eb",
+        sum = "h1:7MrEECTEf+UmMdllIIbAHng17Uwqm8WbHEUAyv9LMBk=",
+        version = "v0.0.0-20231024141911-299d0263dc95",
     )
 
     go_repository(
@@ -5950,8 +5950,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:2IPj5DTbBb8cAPF5ZJGIVxO81MTLpuF68YQPyr1KbzQ=",
-        version = "v0.0.0-20231018143538-16e2ff8c98ee",
+        sum = "h1:2c267+erbUpGj7M1WSBNDMlHubeefewYn3oYYuQ1uyo=",
+        version = "v0.0.0-20231024152421-0f21f325cc5d",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ require (
 	github.com/shurcooL/httpgzip v0.0.0-20190720172056-320755c1c1b0
 	github.com/slack-go/slack v0.10.1
 	github.com/smacker/go-tree-sitter v0.0.0-20220209044044-0d3022e933c3
-	github.com/sourcegraph/go-ctags v0.0.0-20230929045819-c736fcb519eb
+	github.com/sourcegraph/go-ctags v0.0.0-20231024141911-299d0263dc95
 	github.com/sourcegraph/go-diff v0.6.2-0.20221123165719-f8cd299c40f3
 	github.com/sourcegraph/go-jsonschema v0.0.0-20221230021921-34aaf28fc4ac
 	github.com/sourcegraph/go-langserver v2.0.1-0.20181108233942-4a51fa2e1238+incompatible
@@ -543,7 +543,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20231018142932-e00da332dac5
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20231018143538-16e2ff8c98ee
+	github.com/sourcegraph/zoekt v0.0.0-20231024152421-0f21f325cc5d
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1553,8 +1553,8 @@ github.com/sourcegraph/conc v0.2.0 h1:96VpOCAtXDCQ8Oycz0ftHqdPyMi8w12ltN4L2noYg7
 github.com/sourcegraph/conc v0.2.0/go.mod h1:8lmPpTLA0hsWqw4lw7wS1e694U2tMjRrc1Asvupb4QM=
 github.com/sourcegraph/embedded-postgres v1.19.1-0.20230624001757-345a8df15ded h1:QcxHhicvH6TFpSmC3vZKWbwLSHmwy72+CESqjjaIsZA=
 github.com/sourcegraph/embedded-postgres v1.19.1-0.20230624001757-345a8df15ded/go.mod h1:0B+3bPsMvcNgR9nN+bdM2x9YaNYDnf3ksUqYp1OAub0=
-github.com/sourcegraph/go-ctags v0.0.0-20230929045819-c736fcb519eb h1:Okjvl9eO68GDev76KPfJqJOqRGfxOCyXCB2THAT6Bus=
-github.com/sourcegraph/go-ctags v0.0.0-20230929045819-c736fcb519eb/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
+github.com/sourcegraph/go-ctags v0.0.0-20231024141911-299d0263dc95 h1:7MrEECTEf+UmMdllIIbAHng17Uwqm8WbHEUAyv9LMBk=
+github.com/sourcegraph/go-ctags v0.0.0-20231024141911-299d0263dc95/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
 github.com/sourcegraph/go-diff v0.6.2-0.20221123165719-f8cd299c40f3 h1:11miag7hlORpW7ici5mL7T9PyiEsmVmf+8PFOvJ/ZrA=
 github.com/sourcegraph/go-diff v0.6.2-0.20221123165719-f8cd299c40f3/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/sourcegraph/go-jsonschema v0.0.0-20221230021921-34aaf28fc4ac h1:Bq9XPdAOBkA9NWeNEh2VeIlGlizg9rL5VkYFZje2S+4=
@@ -1587,8 +1587,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20231018143538-16e2ff8c98ee h1:2IPj5DTbBb8cAPF5ZJGIVxO81MTLpuF68YQPyr1KbzQ=
-github.com/sourcegraph/zoekt v0.0.0-20231018143538-16e2ff8c98ee/go.mod h1:7KKGxC1hEyRVTZB9QEpktVC20ANFmKVwX6IdcWx7yk8=
+github.com/sourcegraph/zoekt v0.0.0-20231024152421-0f21f325cc5d h1:2c267+erbUpGj7M1WSBNDMlHubeefewYn3oYYuQ1uyo=
+github.com/sourcegraph/zoekt v0.0.0-20231024152421-0f21f325cc5d/go.mod h1:WVDDy51tFgeKy8zXtujTSbqzgyJrqhrLC9sjWiEfAII=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This has a bunch of ranking tweaks such as upranking markdown files (hence the go-ctags bump). A side effect of this change is that markdown headings will appear in symbol search results. I have a suspicion this won't be that bad in practice and in fact may be useful (eg the symbol sidebar when viewing a markdown file).

If this is a problem, we will likely revert that change in go-ctags and then work on how to only have that information for search ranking.

https://github.com/sourcegraph/zoekt/compare/16e2ff8c98ee...0f21f325cc5d

- https://github.com/sourcegraph/zoekt/commit/f39e6eb573 zoekt: add debug flag to show DebugScore output
- https://github.com/sourcegraph/zoekt/commit/081cd037fd boost graphql types in results
- https://github.com/sourcegraph/zoekt/commit/70f5dd3fcc score: always upscore symbol matches
- https://github.com/sourcegraph/zoekt/commit/d8bfea1efb score: factors for headers in markdown
- https://github.com/sourcegraph/zoekt/commit/4f214152eb score: clean up debug output
- https://github.com/sourcegraph/zoekt/commit/328fcb7a50 nix: use go 1.21 and universal-ctags 6.0.0
- https://github.com/sourcegraph/zoekt/commit/7cc2872df4 nix: use tag for rev in ctags derivation
- https://github.com/sourcegraph/zoekt/commit/d3fc0dcee8 score: remove repetition-boost
- https://github.com/sourcegraph/zoekt/commit/c869a248a3 scoring: score methods and funcs the same
- https://github.com/sourcegraph/zoekt/commit/ca7ee51ee7 scoring: show atom count in debug score
- https://github.com/sourcegraph/zoekt/commit/5bbf05d436 fix tests
- https://github.com/sourcegraph/zoekt/commit/0a17ccb25a scoring: reduce allocations for addScore
- https://github.com/sourcegraph/zoekt/commit/d4ba942a02 gomod: update go-ctags and ctags in docker
- https://github.com/sourcegraph/zoekt/commit/0f21f325cc C-tags: use type def instead of type alias

Test Plan: CI
