### PR TITLE
fix client/web jest tests

### DIFF
--- a/client/web/jest.config.js
+++ b/client/web/jest.config.js
@@ -8,11 +8,7 @@ const exportedConfig = {
   ...config,
   displayName: 'web',
   rootDir: __dirname,
-  setupFiles: [
-    ...config.setupFiles,
-    'jest-canvas-mock', // mocking canvas is required for Monaco editor to work in unit tests
-    path.join(__dirname, 'dev/mocks/mockEventLogger.ts'),
-  ],
+  setupFiles: [...config.setupFiles, path.join(__dirname, 'dev/mocks/mockEventLogger.ts')],
 }
 
 module.exports = exportedConfig

--- a/package.json
+++ b/package.json
@@ -229,7 +229,6 @@
     "http-proxy-middleware": "^2.0.6",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
-    "jest-canvas-mock": "^2.3.0",
     "jest-fetch-mock": "^3.0.3",
     "jest-junit": "^13.0.0",
     "jsdom": "^16.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -952,9 +952,6 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.17.15)(ts-node@10.9.1)
-      jest-canvas-mock:
-        specifier: ^2.3.0
-        version: 2.3.0
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3
@@ -15902,10 +15899,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  /cssfontparser@1.2.1:
-    resolution: {integrity: sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==}
-    dev: true
-
   /csso@4.2.0:
     resolution: {integrity: sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==}
     engines: {node: '>=8.0.0'}
@@ -20383,13 +20376,6 @@ packages:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
     dev: true
 
-  /jest-canvas-mock@2.3.0:
-    resolution: {integrity: sha512-3TMyR66VG2MzAW8Negzec03bbcIjVJMfGNvKzrEnbws1CYKqMNkvIJ8LbkoGYfp42tKqDmhIpQq3v+MNLW2A2w==}
-    dependencies:
-      cssfontparser: 1.2.1
-      moo-color: 1.0.2
-    dev: true
-
   /jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -22824,12 +22810,6 @@ packages:
       vscode-languageserver-types: 3.17.2
       yaml-language-server-parser: 0.1.3
     dev: false
-
-  /moo-color@1.0.2:
-    resolution: {integrity: sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==}
-    dependencies:
-      color-name: 1.1.4
-    dev: true
 
   /morgan@1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}


### PR DESCRIPTION
The jest-canvas-mock lib is no longer needed. It was erroring because it assumes that `global.jest` is defined, but we can just remove it.




## Test plan

CI