### PR TITLE
dev: update ctags in bazel to 6.0.0

### DIFF
--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 DOCSITE_VERSION = "1.9.4"
 SRC_CLI_VERSION = "5.1.0"
-CTAGS_VERSION = "5.9.20220403.0"
+CTAGS_VERSION = "6.0.0.2783f009"
 
 SRC_CLI_BUILDFILE = """
 filegroup(
@@ -57,24 +57,28 @@ def tool_deps():
         url = "https://github.com/sourcegraph/src-cli/releases/download/{0}/src-cli_{0}_darwin_arm64.tar.gz".format(SRC_CLI_VERSION),
     )
 
-    # universal-ctags #
+    # universal-ctags
+    #
+    # Two step process to update these. First land a commit in main updating
+    # the version in dev/nix/ctags.nix. Then copy the hashes from
+    # https://github.com/sourcegraph/sourcegraph/actions/workflows/universal-ctags.yml
     http_file(
         name = "universal-ctags-darwin-amd64",
-        sha256 = "b69501d497b62021e8438e840e0bea62fdbe91d60cf8375c388f2736cd58a1bf",
-        url = "https://storage.googleapis.com/universal_ctags/x86_64-darwin/bin/universal-ctags-{0}".format(CTAGS_VERSION),
+        sha256 = "7aead221c07d8092a0cbfad6e69ae526292e405bbe2f06d38d346969e23a6f68",
+        url = "https://storage.googleapis.com/universal_ctags/x86_64-darwin/dist/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )
 
     http_file(
         name = "universal-ctags-darwin-arm64",
-        sha256 = "6631f0bbd65cdedc155fcd9e17c8c31102aeffc78e2438799d4fb43297c5d473",
-        url = "https://storage.googleapis.com/universal_ctags/aarch64-darwin/bin/universal-ctags-{0}".format(CTAGS_VERSION),
+        sha256 = "ac4a73b69042c60e68f80f8819d5c6b05e233386042ba867205a252046d6471e",
+        url = "https://storage.googleapis.com/universal_ctags/aarch64-darwin/dist/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )
 
     http_file(
         name = "universal-ctags-linux-amd64",
-        sha256 = "1d349d15736a30c9cc18c1fd9efbfc6081fb59125d799b84cef6b34c735fa28a",
-        url = "https://storage.googleapis.com/universal_ctags/x86_64-linux/bin/universal-ctags-{0}".format(CTAGS_VERSION),
+        sha256 = "e99b942754ce9d55c9445513236c010753d26decbb38ed932780bec098ac0809",
+        url = "https://storage.googleapis.com/universal_ctags/x86_64-linux/dist/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
     )


### PR DESCRIPTION
Landed a PR which updated ctags for everything but bazel, now that CI has built the artifacts this updates it for bazel. Used the output from https://github.com/sourcegraph/sourcegraph/actions/runs/6628151191

Test Plan: copy pasted sha from the CI run above, did not validate other than double check so that may go wrong. Also double checked the artifact name via the listing at https://storage.googleapis.com/universal_ctags
