### PR TITLE
Add note on visibility options on GHE

### DIFF
--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -298,6 +298,7 @@ If you would like internal repositories to remain private, but you're experienci
   }
 }
 ```
+> NOTE: An explanation on visibility options in GitHub Enterprise. `public`- Only index public GitHub Enterprise repositories visible to all users. This excludes private and internal repos. `private` - Index both public and private GitHub Enterprise repositories. This allows accessing private repos the token has access to. `internal` - Include GitHub Enterprise internal repositories in addition to public/private repos. Internal repos are only visible to org members.
 
 ### Trigger permissions sync from GitHub webhooks
 


### PR DESCRIPTION
This commit adds an expanded explanation on what GitHub Enterprise visibility options represent and what they do.


## Test plan
Doc update. Previewed locally.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@doc/ghe-visibility-explanation)