### PR TITLE
[Wildcard]: Fix MultiCombobox Input UI

### DIFF
--- a/client/wildcard/src/components/Card/Card.module.scss
+++ b/client/wildcard/src/components/Card/Card.module.scss
@@ -1,5 +1,5 @@
 // :where() is used to fix the CSS ordering issue with the Toast component
-// See https: //github.com/sourcegraph/sourcegraph/issues/42217
+// See https://github.com/sourcegraph/sourcegraph/issues/42217
 :where(.card) {
     --card-bg: var(--color-bg-1);
     --card-border-color: var(--border-color-2);

--- a/client/wildcard/src/components/Combobox/MultiCombobox.module.scss
+++ b/client/wildcard/src/components/Combobox/MultiCombobox.module.scss
@@ -57,12 +57,19 @@
     }
 }
 
-.input {
+// :root selector is needed here in order to override .form-control
+// global CSS class, since we don't have any control over CSS order files
+// we can't ensure wildcard styles prevalence over global css styles.
+// Therefore we have to increase cascade speciality synthetically.
+:root .input {
     border: none;
     outline: none;
     padding: 0 0 0 0.5rem;
-    box-shadow: none !important;
     height: 1.75rem;
+
+    &:focus-visible {
+        box-shadow: none;
+    }
 }
 
 .pill {

--- a/client/wildcard/src/components/Combobox/MultiCombobox.story.tsx
+++ b/client/wildcard/src/components/Combobox/MultiCombobox.story.tsx
@@ -26,6 +26,12 @@ const decorator: Decorator = story => (
 const config: Meta = {
     title: 'wildcard/MultiCombobox',
     decorators: [decorator],
+    parameters: {
+        chromatic: {
+            enableDarkMode: true,
+            disableSnapshot: false,
+        },
+    },
 }
 
 export default config


### PR DESCRIPTION
Similar to the infamous https://github.com/sourcegraph/sourcegraph/issues/42217 CSS order problem in webpack. 

Recent migration to esbuild by default caused/revealed the old problem with CSS order over global and module styles. In this particular case CSS global class `.form-control` overrided some local MultiCombox input styles. This PR simply increases cascade speciality but I think general solution here would be wrap global styles with CSS `@layers` and this would give us more control over CSS cascade order (meaning we don't need to control order of files and operate order of cascade instead) 

| Before | After |
| -------- | -------- |
| <img width="1149" alt="Screenshot 2023-10-25 at 16 10 22" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/2aa40df3-4581-4aaa-995f-1f844e93576e"> | <img width="1149" alt="Screenshot 2023-10-25 at 16 18 20" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/b46447c0-a205-453d-a2f4-0f9afaf4f959"> |
| <img width="1149" alt="Screenshot 2023-10-25 at 16 10 52" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/ea9272d4-f7b3-4561-85ca-8776375eed4f"> | <img width="1149" alt="Screenshot 2023-10-25 at 16 18 26" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/43047537-2ce0-4622-95be-780b1a9b8af3"> |

## Test plan
- Check MultiCombobox UI in the app, make sure that combobox input seems ok


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
