### PR TITLE
Add scip-ctags kinds for js, ts, and rust

### DIFF
--- a/docker-images/syntax-highlighter/crates/scip-syntax/queries/javascript/scip-tags.scm
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/queries/javascript/scip-tags.scm
@@ -1,15 +1,16 @@
-(namespace_import (identifier) @descriptor.term)
+(namespace_import (identifier) @descriptor.term @kind.variable)
 (named_imports
- [(import_specifier alias: (_) @descriptor.term)
-  (import_specifier name: (_) @descriptor.term !alias)])
+  (import_specifier alias: (_) @descriptor.term @kind.variable))
+(named_imports
+  (import_specifier name: (_) @descriptor.term @kind.variable !alias))
 
 ;; Function / Generator declaration.
 ;;   Don't think there is any reason to expose anything from within the body of the functions
-(function_declaration (identifier) @descriptor.method body: (_) @local)
-(generator_function_declaration  (identifier) @descriptor.method body: (_) @local)
+(function_declaration (identifier) @descriptor.method @kind.function body: (_) @local)
+(generator_function_declaration  (identifier) @descriptor.method @kind.function body: (_) @local)
 
-(lexical_declaration (variable_declarator name: (identifier) @descriptor.term)) @scope
-(variable_declaration (variable_declarator name: (identifier) @descriptor.term)) @scope
+(lexical_declaration (variable_declarator name: (identifier) @descriptor.term @kind.variable)) @scope
+(variable_declaration (variable_declarator name: (identifier) @descriptor.term @kind.variable)) @scope
 
 ;; {{{ Handle multiple scenarios of literal objects at top level
 ;; var X = { key: value }
@@ -21,25 +22,31 @@
 ;;
 (object
   (pair
-    key: (property_identifier) @descriptor.method
+    key: (property_identifier) @descriptor.method @kind.function
     value: [(function) (arrow_function)]))
 
 ((object
    (pair
-     key: (property_identifier) @descriptor.term
+     key: (property_identifier) @descriptor.term @kind.property
      value: (_) @_value_type))
  (#filter! @_value_type "function" "arrow_function"))
 ;; }}}
 
 ;; class X { ... }
 (class_declaration
-  name: (_) @descriptor.type
+  name: (_) @descriptor.type @kind.class
   body: (_) @scope)
 
 (class_declaration
  (class_body
   [(method_definition
-     name: (_) @descriptor.method
+     name: (_) @descriptor.method @kind.method (#not-eq? @descriptor.method "constructor")
+     body: (_) @local)]))
+
+(class_declaration
+ (class_body
+  [(method_definition
+     name: (_) @descriptor.method @kind.constructor (#eq? @descriptor.method "constructor")
      body: (_) @local)]))
 
 [(if_statement) (while_statement) (for_statement) (do_statement) (call_expression)] @local

--- a/docker-images/syntax-highlighter/crates/scip-syntax/queries/rust/scip-tags.scm
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/queries/rust/scip-tags.scm
@@ -1,30 +1,40 @@
 ;; TODO: Could do @scope.ignore to ignore this as a definition
 
 (mod_item
- name: (_) @descriptor.namespace) @scope
+  name: (_) @descriptor.namespace @kind.namespace) @scope
 
 (trait_item
- name: (_) @descriptor.type) @scope
+  name: (_) @descriptor.type @kind.trait) @scope
 
 (impl_item
- trait: [(generic_type type: (type_identifier) @descriptor.type)
-         (type_identifier) @descriptor.type]?
+  trait: (generic_type type: (type_identifier) @descriptor.type @kind.trait)) @scope
 
- type: [(generic_type type: (type_identifier) @descriptor.type)
-        (type_identifier) @descriptor.type]) @scope
+(impl_item
+  trait: (type_identifier) @descriptor.type @kind.trait) @scope
+
+(impl_item
+  type: (generic_type type: (type_identifier) @descriptor.type @kind.struct)
+  body: (_) @scope)
+
+(impl_item
+  type: (type_identifier) @descriptor.type @kind.struct
+  body: (_) @scope)
 
 ;; TODO: @local to stop traversal
 (function_signature_item
- name: (identifier) @descriptor.method)
+  name: (identifier) @descriptor.method @kind.function)
 
 (function_item
- name: (identifier) @descriptor.method body: (_) @local)
+  name: (identifier) @descriptor.method @kind.function body: (_) @local)
 
 (struct_item
- name: (type_identifier) @descriptor.type) @scope
+  name: (type_identifier) @descriptor.type @kind.struct) @scope
 
 (field_declaration
-  name: (_) @descriptor.term) @enclosing
+  name: (_) @descriptor.term @kind.field) @enclosing
 
-(enum_item name: (_) @descriptor.type) @scope
-(enum_variant name: (_) @descriptor.term)
+(enum_item name: (_) @descriptor.type @kind.enum) @scope
+(enum_variant name: (_) @descriptor.term @kind.enummember)
+
+(const_item name: (_) @descriptor.term @kind.constant)
+(static_item name: (_) @descriptor.term @kind.variable)

--- a/docker-images/syntax-highlighter/crates/scip-syntax/queries/typescript/scip-tags.scm
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/queries/typescript/scip-tags.scm
@@ -1,20 +1,20 @@
 ;;include javascript
 
-(module name: (string (string_fragment) @descriptor.namespace) body: (_) @scope)
+(module name: (string (string_fragment) @descriptor.namespace @kind.module) body: (_) @scope)
 
-(interface_declaration name: (_) @descriptor.type body: (_) @scope)
+(interface_declaration name: (_) @descriptor.type @kind.interface body: (_) @scope)
 (interface_declaration
     (object_type
         [
-            (method_signature (property_identifier) @descriptor.method)
-            (property_signature (property_identifier) @descriptor.term)]))
+            (method_signature (property_identifier) @descriptor.method @kind.method)
+            (property_signature (property_identifier) @descriptor.term @kind.property)]))
 
 (class_declaration
     (class_body
-        [(public_field_definition name: (_) @descriptor.term)]))
+        [(public_field_definition name: (_) @descriptor.term @kind.property)]))
 
 
-(enum_declaration name: (_) @descriptor.type body: (_) @scope)
+(enum_declaration name: (_) @descriptor.type @kind.enum body: (_) @scope)
 (enum_declaration
     (enum_body
-        (property_identifier) @descriptor.term))
+        (property_identifier) @descriptor.term @kind.property))

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__ctags__test__ctags_runner_basic.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__ctags__test__ctags_runner_basic.snap
@@ -3,8 +3,8 @@ source: crates/scip-syntax/src/ctags.rs
 expression: output
 ---
 {"_type":"program","name":"SCIP Ctags","version":"5.9.0"}
-{"_type":"tag","name":"other","path":"main.rs","language":"rust","line":6,"kind":"method","scope":null}
-{"_type":"tag","name":"something","path":"main.rs","language":"rust","line":5,"kind":"method","scope":null}
-{"_type":"tag","name":"main","path":"main.rs","language":"rust","line":1,"kind":"method","scope":null}
+{"_type":"tag","name":"other","path":"main.rs","language":"rust","line":6,"kind":"function","scope":null}
+{"_type":"tag","name":"something","path":"main.rs","language":"rust","line":5,"kind":"function","scope":null}
+{"_type":"tag","name":"main","path":"main.rs","language":"rust","line":1,"kind":"function","scope":null}
 {"_type":"completed","command":"generate-tags"}
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_ctags-empty-scope.rs.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_ctags-empty-scope.rs.snap
@@ -9,35 +9,56 @@ expression: dumped
   use scip_treesitter_languages::parsers::BundledParser;
   use walkdir::WalkDir;
   
+  static LANGUAGE: &str = "Rust";
+//       ^^^^^^^^ definition scip-ctags LANGUAGE.
+  const THRESHOLD: i32 = 10;
+//      ^^^^^^^^^ definition(Constant) scip-ctags THRESHOLD.
+  
+  trait Yay {}
+//      ^^^ definition(Trait) scip-ctags Yay#
+  
   #[derive(Parser)]
   #[command(author, version, about, long_about = None)]
   struct Arguments {
-//       ^^^^^^^^^ definition scip-ctags Arguments#
+//       ^^^^^^^^^ definition(Struct) scip-ctags Arguments#
       /// Root directory to run local navigation over
       root_dir: String,
-//    ^^^^^^^^ definition scip-ctags Arguments#root_dir.
+//    ^^^^^^^^ definition(Field) scip-ctags Arguments#root_dir.
+  }
+  
+  impl Arguments {
+//     ^^^^^^^^^ definition(Struct) scip-ctags Arguments#
+      fn parse() {}
+//       ^^^^^ definition(Function) scip-ctags Arguments#parse().
+  }
+  
+  impl Yay for Arguments {
+//     ^^^ definition(Trait) scip-ctags Yay#
+//             ^^^^^^^^^ definition(Struct) scip-ctags Yay#Arguments#
+      fn pog() {}
+//       ^^^ definition(Function) scip-ctags Yay#Arguments#pog().
   }
   
   struct ParseTiming {
-//       ^^^^^^^^^^^ definition scip-ctags ParseTiming#
+//       ^^^^^^^^^^^ definition(Struct) scip-ctags ParseTiming#
       pub filepath: String,
-//        ^^^^^^^^ definition scip-ctags ParseTiming#filepath.
+//        ^^^^^^^^ definition(Field) scip-ctags ParseTiming#filepath.
       pub duration: std::time::Duration,
-//        ^^^^^^^^ definition scip-ctags ParseTiming#duration.
+//        ^^^^^^^^ definition(Field) scip-ctags ParseTiming#duration.
   }
   
   fn parse_files(dir: &Path) -> Vec<ParseTiming> {
-//   ^^^^^^^^^^^ definition scip-ctags parse_files().
+//   ^^^^^^^^^^^ definition(Function) scip-ctags parse_files().
       // TODO
   }
   
   fn measure_parsing() {
-//   ^^^^^^^^^^^^^^^ definition scip-ctags measure_parsing().
+//   ^^^^^^^^^^^^^^^ definition(Function) scip-ctags measure_parsing().
       // TODO
   }
   
   fn main() {
-//   ^^^^ definition scip-ctags main().
+//   ^^^^ definition(Function) scip-ctags main().
       // TODO
   }
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.js.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.js.snap
@@ -16,7 +16,7 @@ expression: dumped
   
   // Function declaration
   function functionDeclaration() {
-//         ^^^^^^^^^^^^^^^^^^^ definition scip-ctags functionDeclaration().
+//         ^^^^^^^^^^^^^^^^^^^ definition(Function) scip-ctags functionDeclaration().
     return "Hello, I'm a function declaration";
   }
   
@@ -34,9 +34,9 @@ expression: dumped
   
   // ES6 class declaration
   class ClassDeclaration {
-//      ^^^^^^^^^^^^^^^^ definition scip-ctags ClassDeclaration#
+//      ^^^^^^^^^^^^^^^^ definition(Class) scip-ctags ClassDeclaration#
     constructor() {
-//  ^^^^^^^^^^^ definition scip-ctags ClassDeclaration#constructor().
+//  ^^^^^^^^^^^ definition(Constructor) scip-ctags ClassDeclaration#constructor().
       this.message = "Hello, I'm a class declaration";
     }
   }
@@ -45,12 +45,12 @@ expression: dumped
   var objectDeclaration = {
 //    ^^^^^^^^^^^^^^^^^ definition scip-ctags objectDeclaration.
     message: "Hello, I'm an object declaration"
-//  ^^^^^^^ definition scip-ctags objectDeclaration.message.
+//  ^^^^^^^ definition(Property) scip-ctags objectDeclaration.message.
   };
   
   // Object constructor declaration
   function ObjectConstructor() {
-//         ^^^^^^^^^^^^^^^^^ definition scip-ctags ObjectConstructor().
+//         ^^^^^^^^^^^^^^^^^ definition(Function) scip-ctags ObjectConstructor().
     this.message = "Hello, I'm an object constructor";
   }
   var objectConstructed = new ObjectConstructor();
@@ -66,13 +66,13 @@ expression: dumped
   
   // ES6 Generator Function declaration
   function* generatorFunction(){
-//          ^^^^^^^^^^^^^^^^^ definition scip-ctags generatorFunction().
+//          ^^^^^^^^^^^^^^^^^ definition(Function) scip-ctags generatorFunction().
     yield "Hello, I'm a generator function";
   }
   
   // ES6 Async Function declaration
   async function asyncFunction() {
-//               ^^^^^^^^^^^^^ definition scip-ctags asyncFunction().
+//               ^^^^^^^^^^^^^ definition(Function) scip-ctags asyncFunction().
     return "Hello, I'm an async function";
   }
   
@@ -86,77 +86,77 @@ expression: dumped
   
   // ES6 class declaration
   class ExampleClass {
-//      ^^^^^^^^^^^^ definition scip-ctags ExampleClass#
+//      ^^^^^^^^^^^^ definition(Class) scip-ctags ExampleClass#
   
     // Private field declaration (ES2020)
     #privateField = "Hello, I'm a private field";
   
     // Private method declaration (ES2020)
     #privateMethod() {
-//  ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#`#privateMethod`().
+//  ^^^^^^^^^^^^^^ definition(Method) scip-ctags ExampleClass#`#privateMethod`().
       return "Hello, I'm a private method";
     }
   
     // Class Constructor
     constructor(publicField, publicMethodParameter) {
-//  ^^^^^^^^^^^ definition scip-ctags ExampleClass#constructor().
+//  ^^^^^^^^^^^ definition(Constructor) scip-ctags ExampleClass#constructor().
       this.publicField = publicField; // Public Field
       this.publicMethodParameter = publicMethodParameter;
     }
   
     // Instance method
     instanceMethod() {
-//  ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#instanceMethod().
+//  ^^^^^^^^^^^^^^ definition(Method) scip-ctags ExampleClass#instanceMethod().
       return "Hello, I'm an instance method";
     }
   
     // Static method
     static staticMethod() {
-//         ^^^^^^^^^^^^ definition scip-ctags ExampleClass#staticMethod().
+//         ^^^^^^^^^^^^ definition(Method) scip-ctags ExampleClass#staticMethod().
       return "Hello, I'm a static method";
     }
   
     // Getter method
     get retrievedField() {
-//      ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#retrievedField().
+//      ^^^^^^^^^^^^^^ definition(Method) scip-ctags ExampleClass#retrievedField().
       return this.publicField;
     }
   
     // Setter method
     set updatedField(value) {
-//      ^^^^^^^^^^^^ definition scip-ctags ExampleClass#updatedField().
+//      ^^^^^^^^^^^^ definition(Method) scip-ctags ExampleClass#updatedField().
       this.publicField = value;
     }
   
     // Public method using private field and private method
     publicMethod() {
-//  ^^^^^^^^^^^^ definition scip-ctags ExampleClass#publicMethod().
+//  ^^^^^^^^^^^^ definition(Method) scip-ctags ExampleClass#publicMethod().
       return this.#privateMethod() + " " + this.#privateField;
     }
   
     // Method using arguments
     methodWithArgs(arg1, arg2) {
-//  ^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#methodWithArgs().
+//  ^^^^^^^^^^^^^^ definition(Method) scip-ctags ExampleClass#methodWithArgs().
       return "Hello, I received " + arg1 + " and " + arg2;
     }
   
     // Method using rest parameters
     methodWithRestArgs(...args) {
-//  ^^^^^^^^^^^^^^^^^^ definition scip-ctags ExampleClass#methodWithRestArgs().
+//  ^^^^^^^^^^^^^^^^^^ definition(Method) scip-ctags ExampleClass#methodWithRestArgs().
       return "Hello, I received " + args.join(", ");
     }
   }
   
   // Prototype methods
   function MyClass() {}
-//         ^^^^^^^ definition scip-ctags MyClass().
+//         ^^^^^^^ definition(Function) scip-ctags MyClass().
   MyClass.prototype.myMethod = function() {};
   
   // Generator function
   function* myGeneratorFunction() {}
-//          ^^^^^^^^^^^^^^^^^^^ definition scip-ctags myGeneratorFunction().
+//          ^^^^^^^^^^^^^^^^^^^ definition(Function) scip-ctags myGeneratorFunction().
   
   // Async function
   async function myAsyncFunction() {}
-//               ^^^^^^^^^^^^^^^ definition scip-ctags myAsyncFunction().
+//               ^^^^^^^^^^^^^^^ definition(Function) scip-ctags myAsyncFunction().
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.ts.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_globals.ts.snap
@@ -3,38 +3,38 @@ source: crates/scip-syntax/src/lib.rs
 expression: dumped
 ---
   class MyClass {
-//      ^^^^^^^ definition scip-ctags MyClass#
+//      ^^^^^^^ definition(Class) scip-ctags MyClass#
       public_field: number
-//    ^^^^^^^^^^^^ definition scip-ctags MyClass#public_field.
+//    ^^^^^^^^^^^^ definition(Property) scip-ctags MyClass#public_field.
       #private_field: number
-//    ^^^^^^^^^^^^^^ definition scip-ctags MyClass#`#private_field`.
+//    ^^^^^^^^^^^^^^ definition(Property) scip-ctags MyClass#`#private_field`.
       private also_private_field: number
-//            ^^^^^^^^^^^^^^^^^^ definition scip-ctags MyClass#also_private_field.
+//            ^^^^^^^^^^^^^^^^^^ definition(Property) scip-ctags MyClass#also_private_field.
   
       public_method() {}
-//    ^^^^^^^^^^^^^ definition scip-ctags MyClass#public_method().
+//    ^^^^^^^^^^^^^ definition(Method) scip-ctags MyClass#public_method().
       #private_method() {}
-//    ^^^^^^^^^^^^^^^ definition scip-ctags MyClass#`#private_method`().
+//    ^^^^^^^^^^^^^^^ definition(Method) scip-ctags MyClass#`#private_method`().
       private also_private_method() {}
-//            ^^^^^^^^^^^^^^^^^^^ definition scip-ctags MyClass#also_private_method().
+//            ^^^^^^^^^^^^^^^^^^^ definition(Method) scip-ctags MyClass#also_private_method().
   }
   
   interface MyInterface {
-//          ^^^^^^^^^^^ definition scip-ctags MyInterface#
+//          ^^^^^^^^^^^ definition(Interface) scip-ctags MyInterface#
       bruh: number,
-//    ^^^^ definition scip-ctags MyInterface#bruh.
+//    ^^^^ definition(Property) scip-ctags MyInterface#bruh.
       sayBruh(): void,
-//    ^^^^^^^ definition scip-ctags MyInterface#sayBruh().
+//    ^^^^^^^ definition(Method) scip-ctags MyInterface#sayBruh().
   }
   
   enum MyEnum {
-//     ^^^^^^ definition scip-ctags MyEnum#
+//     ^^^^^^ definition(Enum) scip-ctags MyEnum#
       zig,
-//    ^^^ definition scip-ctags MyEnum#zig.
+//    ^^^ definition(Property) scip-ctags MyEnum#zig.
       rust,
-//    ^^^^ definition scip-ctags MyEnum#rust.
+//    ^^^^ definition(Property) scip-ctags MyEnum#rust.
       go,
-//    ^^ definition scip-ctags MyEnum#go.
+//    ^^ definition(Property) scip-ctags MyEnum#go.
   }
   
   var global1 = 0;
@@ -43,7 +43,7 @@ expression: dumped
 //    ^^^^^^^ definition scip-ctags global2.
   
   function func() {
-//         ^^^^ definition scip-ctags func().
+//         ^^^^ definition(Function) scip-ctags func().
       var c;
       function inAnotherFunc() {
           var b;
@@ -56,12 +56,12 @@ expression: dumped
   var myObject = {
 //    ^^^^^^^^ definition scip-ctags myObject.
     myProperty: "value",
-//  ^^^^^^^^^^ definition scip-ctags myObject.myProperty.
+//  ^^^^^^^^^^ definition(Property) scip-ctags myObject.myProperty.
   
     myMethod: function() {},
-//  ^^^^^^^^ definition scip-ctags myObject.myMethod().
+//  ^^^^^^^^ definition(Function) scip-ctags myObject.myMethod().
     myArrow: () => {},
-//  ^^^^^^^ definition scip-ctags myObject.myArrow().
+//  ^^^^^^^ definition(Function) scip-ctags myObject.myArrow().
   };
   
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_javascript-object.js.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_javascript-object.js.snap
@@ -5,12 +5,12 @@ expression: dumped
   var myObject = {
 //    ^^^^^^^^ definition scip-ctags myObject.
     myProperty: "value",
-//  ^^^^^^^^^^ definition scip-ctags myObject.myProperty.
+//  ^^^^^^^^^^ definition(Property) scip-ctags myObject.myProperty.
   
     myMethod: function() {},
-//  ^^^^^^^^ definition scip-ctags myObject.myMethod().
+//  ^^^^^^^^ definition(Function) scip-ctags myObject.myMethod().
     myArrow: () => {},
-//  ^^^^^^^ definition scip-ctags myObject.myArrow().
+//  ^^^^^^^ definition(Function) scip-ctags myObject.myArrow().
   };
   
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_scopes.rs.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__scip_snapshot_scopes.rs.snap
@@ -3,46 +3,49 @@ source: crates/scip-syntax/src/lib.rs
 expression: dumped
 ---
   pub trait Tag {
-//          ^^^ definition scip-ctags Tag#
+//          ^^^ definition(Trait) scip-ctags Tag#
       // This is a pretty big thing
       // And some more things here
       fn name(&self) -> &str;
-//       ^^^^ definition scip-ctags Tag#name().
+//       ^^^^ definition(Function) scip-ctags Tag#name().
   }
   
   mod namespace {
-//    ^^^^^^^^^ definition scip-ctags namespace/
+//    ^^^^^^^^^ definition(Namespace) scip-ctags namespace/
       mod nested {
-//        ^^^^^^ definition scip-ctags namespace/nested/
+//        ^^^^^^ definition(Namespace) scip-ctags namespace/nested/
           mod even_more_nested {
-//            ^^^^^^^^^^^^^^^^ definition scip-ctags namespace/nested/even_more_nested/
+//            ^^^^^^^^^^^^^^^^ definition(Namespace) scip-ctags namespace/nested/even_more_nested/
               pub struct CoolStruct {}
-//                       ^^^^^^^^^^ definition scip-ctags namespace/nested/even_more_nested/CoolStruct#
+//                       ^^^^^^^^^^ definition(Struct) scip-ctags namespace/nested/even_more_nested/CoolStruct#
   
               impl Tag for CoolStruct {
-//                         ^^^^^^^^^^ definition scip-ctags namespace/nested/even_more_nested/Tag#CoolStruct#
+//                 ^^^ definition(Trait) scip-ctags namespace/nested/even_more_nested/Tag#
+//                         ^^^^^^^^^^ definition(Struct) scip-ctags namespace/nested/even_more_nested/Tag#CoolStruct#
                   fn name(&self) -> &str {}
-//                   ^^^^ definition scip-ctags namespace/nested/even_more_nested/Tag#CoolStruct#name().
+//                   ^^^^ definition(Function) scip-ctags namespace/nested/even_more_nested/Tag#CoolStruct#name().
               }
           }
       }
   }
   
   fn something() {}
-//   ^^^^^^^^^ definition scip-ctags something().
+//   ^^^^^^^^^ definition(Function) scip-ctags something().
   
   impl X for Y {}
-//           ^ definition scip-ctags X#Y#
+//     ^ definition(Trait) scip-ctags X#
+//           ^ definition(Struct) scip-ctags X#Y#
   impl<T> X<T> for Y<T<X>> {}
-//                 ^ definition scip-ctags X#Y#
+//        ^ definition(Trait) scip-ctags X#
+//                 ^ definition(Struct) scip-ctags X#Y#
   
   enum MyEnum {
-//     ^^^^^^ definition scip-ctags MyEnum#
+//     ^^^^^^ definition(Enum) scip-ctags MyEnum#
       Dog,
-//    ^^^ definition scip-ctags MyEnum#Dog.
+//    ^^^ definition(EnumMember) scip-ctags MyEnum#Dog.
       Cat(u8),
-//    ^^^ definition scip-ctags MyEnum#Cat.
+//    ^^^ definition(EnumMember) scip-ctags MyEnum#Cat.
       Bat(String),
-//    ^^^ definition scip-ctags MyEnum#Bat.
+//    ^^^ definition(EnumMember) scip-ctags MyEnum#Bat.
   }
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__tags_snapshot_ctags-empty-scope.rs.snap
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/snapshots/scip_syntax__test__tags_snapshot_ctags-empty-scope.rs.snap
@@ -2,12 +2,18 @@
 source: crates/scip-syntax/src/lib.rs
 expression: "String::from_utf8_lossy(buf_writer.buffer())"
 ---
-{"_type":"tag","name":"Arguments","path":"ctags-empty-scope.rs","language":"rust","line":10,"kind":"type","scope":null}
-{"_type":"tag","name":"root_dir","path":"ctags-empty-scope.rs","language":"rust","line":12,"kind":"variable","scope":"Arguments"}
-{"_type":"tag","name":"ParseTiming","path":"ctags-empty-scope.rs","language":"rust","line":15,"kind":"type","scope":null}
-{"_type":"tag","name":"duration","path":"ctags-empty-scope.rs","language":"rust","line":17,"kind":"variable","scope":"ParseTiming"}
-{"_type":"tag","name":"filepath","path":"ctags-empty-scope.rs","language":"rust","line":16,"kind":"variable","scope":"ParseTiming"}
-{"_type":"tag","name":"main","path":"ctags-empty-scope.rs","language":"rust","line":28,"kind":"method","scope":null}
-{"_type":"tag","name":"measure_parsing","path":"ctags-empty-scope.rs","language":"rust","line":24,"kind":"method","scope":null}
-{"_type":"tag","name":"parse_files","path":"ctags-empty-scope.rs","language":"rust","line":20,"kind":"method","scope":null}
+{"_type":"tag","name":"Yay","path":"ctags-empty-scope.rs","language":"rust","line":11,"kind":"trait","scope":null}
+{"_type":"tag","name":"Arguments","path":"ctags-empty-scope.rs","language":"rust","line":15,"kind":"struct","scope":null}
+{"_type":"tag","name":"root_dir","path":"ctags-empty-scope.rs","language":"rust","line":17,"kind":"field","scope":"Arguments"}
+{"_type":"tag","name":"parse","path":"ctags-empty-scope.rs","language":"rust","line":21,"kind":"function","scope":"Arguments"}
+{"_type":"tag","name":"Arguments","path":"ctags-empty-scope.rs","language":"rust","line":24,"kind":"struct","scope":"Yay"}
+{"_type":"tag","name":"pog","path":"ctags-empty-scope.rs","language":"rust","line":25,"kind":"function","scope":"Yay.Arguments"}
+{"_type":"tag","name":"ParseTiming","path":"ctags-empty-scope.rs","language":"rust","line":28,"kind":"struct","scope":null}
+{"_type":"tag","name":"duration","path":"ctags-empty-scope.rs","language":"rust","line":30,"kind":"field","scope":"ParseTiming"}
+{"_type":"tag","name":"filepath","path":"ctags-empty-scope.rs","language":"rust","line":29,"kind":"field","scope":"ParseTiming"}
+{"_type":"tag","name":"main","path":"ctags-empty-scope.rs","language":"rust","line":41,"kind":"function","scope":null}
+{"_type":"tag","name":"measure_parsing","path":"ctags-empty-scope.rs","language":"rust","line":37,"kind":"function","scope":null}
+{"_type":"tag","name":"parse_files","path":"ctags-empty-scope.rs","language":"rust","line":33,"kind":"function","scope":null}
+{"_type":"tag","name":"THRESHOLD","path":"ctags-empty-scope.rs","language":"rust","line":9,"kind":"constant","scope":null}
+{"_type":"tag","name":"LANGUAGE","path":"ctags-empty-scope.rs","language":"rust","line":8,"kind":"variable","scope":null}
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/ts_scip.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/ts_scip.rs
@@ -44,6 +44,8 @@ pub fn captures_to_kind(kind: &Option<&String>) -> symbol_information::Kind {
         "kind.singletonmethod" => SingletonMethod,
         "kind.struct" => Struct,
         "kind.typealias" => TypeAlias,
+        "kind.trait" => Trait,
+        // "kind.implementation" => Implementation, TODO
         _ => UnspecifiedKind,
     })
 }
@@ -75,6 +77,8 @@ pub fn symbol_kind_to_ctags_kind(kind: &symbol_information::Kind) -> Option<&'st
         SingletonMethod => Some("singletonMethod"),
         Struct => Some("struct"),
         TypeAlias => Some("typeAlias"),
+        Trait => Some("trait"),
+        // Implementation => Some("implementation"), TODO
         _ => None,
     }
 }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/testdata/ctags-empty-scope.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/testdata/ctags-empty-scope.rs
@@ -5,11 +5,24 @@ use scip_syntax::locals::parse_tree;
 use scip_treesitter_languages::parsers::BundledParser;
 use walkdir::WalkDir;
 
+static LANGUAGE: &str = "Rust";
+const THRESHOLD: i32 = 10;
+
+trait Yay {}
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Arguments {
     /// Root directory to run local navigation over
     root_dir: String,
+}
+
+impl Arguments {
+    fn parse() {}
+}
+
+impl Yay for Arguments {
+    fn pog() {}
 }
 
 struct ParseTiming {


### PR DESCRIPTION
Add scip-ctags kinds for js, ts, and rust; I can improve Zig another time (it would require a lot of new query work).

## Test plan

Snapshot tests.
