### PR TITLE
Search: clarify wording for indexing job progress

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -190,31 +190,32 @@ const TextSearchIndexedReference: React.FunctionComponent<
             />
             <LinkOrSpan to={indexedRef.ref.url}>
                 <Code weight="bold">{indexedRef.ref.displayName}</Code>
-            </LinkOrSpan>{' '}
+            </LinkOrSpan>
+            &nbsp;&mdash;&nbsp;
             {indexedRef.indexed ? (
                 <span>
-                    &nbsp;&mdash; indexed at{' '}
+                    {indexedRef.current ? 'up to date.' : 'index update in progress.'}
+                    {' Last indexing job ran at '}
                     <Code>
                         <LinkOrSpan
                             to={indexedRef.indexedCommit?.commit ? indexedRef.indexedCommit.commit.url : repo.url}
                         >
                             {indexedRef.indexedCommit!.abbreviatedOID}
                         </LinkOrSpan>
-                    </Code>{' '}
-                    {indexedRef.current ? '(up to date)' : '(index update in progress)'}
+                    </Code>
                     {indexedRef.skippedIndexed && Number(indexedRef.skippedIndexed.count) > 0 ? (
                         <span>
-                            .&nbsp;
+                            {', with '}
                             <Link to={'/search?q=' + encodeURIComponent(indexedRef.skippedIndexed.query)}>
-                                {indexedRef.skippedIndexed.count}{' '}
-                                {pluralize('file', Number(indexedRef.skippedIndexed.count))} skipped during indexing
+                                {indexedRef.skippedIndexed.count} skipped{' '}
+                                {pluralize('file', Number(indexedRef.skippedIndexed.count))}
                             </Link>
                             .
                         </span>
                     ) : null}
                 </span>
             ) : (
-                <span>&nbsp;&mdash; initial indexing in progress</span>
+                <span>initial indexing in progress.</span>
             )}
         </li>
     )


### PR DESCRIPTION
During a recent support issue, some engineers were confused by the wording, and thought the commit SHA and skipped files related to the in-progress indexing job. In reality, they are describing the last successful job run. This change tries to clarify the wording a bit.

## Test plan

Visual inspection.

Before (screenshot from customer instance):

![Screenshot 2023-10-25 at 3 44 38 PM](https://github.com/sourcegraph/sourcegraph/assets/7461306/210bfe58-cf2c-4ff6-b13f-2f39a4c1e8b6)

After (from local testing):

![Screenshot 2023-10-25 at 3 39 11 PM](https://github.com/sourcegraph/sourcegraph/assets/7461306/d662a003-167f-482d-bac6-b74bb5ad4b29)

If an index job is running it will say "indexing in progress" instead of "up to date".
