### PR TITLE
msp: support templating in service env var

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -22,6 +22,11 @@ type EnvironmentSpec struct {
 	// LivenessProbe is only provisioned if this field is set.
 	LivenessProbe *EnvironmentLivenessProbeSpec `json:"livenessProbe,omitempty"`
 
+	// Env is key-value pairs of environment variables to set on the service.
+	//
+	// Values can be subsituted with supported runtime values with gotemplate, e.g., "{{ .ProjectID }}"
+	// 	- ProjectID: The project ID of the service.
+	//	- ServiceDnsName: The DNS name of the service.
 	Env       map[string]string `json:"env,omitempty"`
 	SecretEnv map[string]string `json:"secretEnv,omitempty"`
 }


### PR DESCRIPTION
Support variable substitution from terraform runtime information, see test plan for use cases.

## Test plan

> I know we already have `GOOGLE_CLOUD_PROJECT`, but this can unlock more use cases

spec

```
  env:
    CAPI_PROJECT: "{{ .ProjectID }}"
    CAPI_DASHBOARD_EXTERNAL_URL: "https://{{ .ServiceDnsName }}"
```

`terraform plan`

```
Terraform will perform the following actions:

  # google_cloud_run_v2_service.cloudrun will be updated in-place
  ~ resource "google_cloud_run_v2_service" "cloudrun" {
        id                      = "projects/cloud-ops-dashboard-prod-245f/locations/us-central1/services/cloud-ops-dashboard"
        name                    = "cloud-ops-dashboard"
        # (17 unchanged attributes hidden)

      ~ template {
            # (6 unchanged attributes hidden)

          ~ containers {
                name    = "cloud-ops-dashboard"
                # (3 unchanged attributes hidden)

              ~ env {
                    name  = "CAPI_PROJECT"
                  ~ value = "cloud-ops-dashboard-prod-245f" -> "ABC_cloud-ops-dashboard-prod-245f"
                }

                # (15 unchanged blocks hidden)
            }

            # (1 unchanged block hidden)
        }

        # (1 unchanged block hidden)
    }
```
