### PR TITLE
Sent custom CodyInstall event to HubSpot

### DIFF
--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -175,10 +175,14 @@ func (r *schemaResolver) LogEvents(ctx context.Context, args *EventBatch) (*Empt
 				DatabaseID: userID,
 			})
 
-			hubspotutil.SyncUserWithEventParams(userPrimaryEmail, hubspotutil.NewCodyClientInstalledEventID, &hubspot.ContactProperties{
-				DatabaseID:                   userID,
-				VSCodyInstalledEmailsEnabled: emailsEnabled,
-			}, map[string]string{"ide": ide, "emailsEnabled": strconv.FormatBool(emailsEnabled)})
+			hubspotutil.SyncUserWithV3Event(userPrimaryEmail, hubspotutil.CodyClientInstalledV3EventID,
+				&hubspot.ContactProperties{
+					DatabaseID: userID,
+				},
+				&hubspot.CodyInstallV3EventProperties{
+					Ide:           ide,
+					EmailsEnabled: strconv.FormatBool(emailsEnabled),
+				})
 		}
 
 		// On Sourcegraph.com only, log a HubSpot event indicating when the user clicks button to downloads Cody App.

--- a/cmd/frontend/hubspot/events.go
+++ b/cmd/frontend/hubspot/events.go
@@ -27,3 +27,39 @@ func (c *Client) baseEventURL() *url.URL {
 		Path:   "/v1/event",
 	}
 }
+
+// LogV3Event logs a user action or event. The response will have a status code of
+// 204 with no data in the body
+//
+// https://developers.hubspot.com/docs/api/analytics/events
+func (c *Client) LogV3Event(email, eventName string, properties any) error {
+	params := V3EventParams{
+		Email:      email,
+		EventName:  eventName,
+		Properties: properties}
+
+	err := c.postJSON("LogV3Event", c.baseV3EventURL(), params, &struct{}{})
+	if err != nil && err.Error() != "EOF" {
+		return err
+	}
+	return nil
+}
+
+type V3EventParams struct {
+	Email      string `json:"email"`
+	EventName  string `json:"eventName"`
+	Properties any    `json:"properties"`
+}
+
+type CodyInstallV3EventProperties struct {
+	Ide           string `json:"ide"`
+	EmailsEnabled string `json:"emails_enabled"`
+}
+
+func (c *Client) baseV3EventURL() *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   "api.hubspot.com",
+		Path:   "/events/v3/send",
+	}
+}

--- a/cmd/frontend/hubspot/hubspot.go
+++ b/cmd/frontend/hubspot/hubspot.go
@@ -100,7 +100,7 @@ func (c *Client) postJSON(methodName string, baseURL *url.URL, reqPayload, respP
 		return wrapError(methodName, err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		buf := new(bytes.Buffer)
 		_, _ = buf.ReadFrom(resp.Body)
 		return wrapError(methodName, errors.Errorf("Code %v: %s", resp.StatusCode, buf.String()))

--- a/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
+++ b/cmd/frontend/hubspot/hubspotutil/hubspotutil.go
@@ -19,6 +19,7 @@ import (
 // - timeline
 // - forms
 // - crm.objects.contacts.read
+// - analytics.behavioral_events.send
 var HubSpotAccessToken = env.Get("HUBSPOT_ACCESS_TOKEN", "", "HubSpot access token for accessing certain HubSpot endpoints.")
 
 // SurveyFormID is the ID for a satisfaction (NPS) survey.
@@ -41,8 +42,8 @@ var SelfHostedSiteInitEventID = "000010399089"
 // CodyClientInstalledEventID is the HubSpot Event ID for when a user reports installing a Cody client.
 var CodyClientInstalledEventID = "000018021981"
 
-// NewCodyClientInstalledEventID is the HubSpot ID for the new event which support custom properties.
-var NewCodyClientInstalledEventID = "pe2762526_codyinstall"
+// CodyClientInstalledV3EventID is the HubSpot ID for the new event which support custom properties.
+var CodyClientInstalledV3EventID = "pe2762526_codyinstall"
 
 // AppDownloadButtonClickedEventID is the HubSpot Event ID for when a user clicks on a button to download Cody App.
 var AppDownloadButtonClickedEventID = "000019179879"
@@ -81,20 +82,21 @@ func SyncUser(email, eventID string, contactParams *hubspot.ContactProperties) {
 
 	// Update or create user contact information in HubSpot, and we want to sync the
 	// contact independent of the request lifecycle.
-	err := syncHubSpotContact(context.Background(), email, eventID, contactParams, map[string]string{})
+	err := syncHubSpotContact(context.Background(), email, eventID, contactParams)
 	if err != nil {
 		log15.Warn("syncHubSpotContact: failed to create or update HubSpot contact", "source", "HubSpot", "error", err)
 	}
 }
 
-// SyncUserWithEventParams handles creating or syncing a user profile in HubSpot, and if provided,
-// logs a user event along with the event params.
-func SyncUserWithEventParams(email, eventID string, contactParams *hubspot.ContactProperties, eventParams map[string]string) {
+// SyncUserWithV3Event handles creating or syncing a user profile in HubSpot, and if provided,
+// logs a V3 custom event along with the event params.
+func SyncUserWithV3Event(email, eventName string, contactParams *hubspot.ContactProperties, eventProperties any) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Printf("panic in tracking.SyncUser: %s", err)
+			log.Printf("panic in tracking.SyncUserWithV3Event: %s", err)
 		}
 	}()
+
 	// If the user no API token present or on-prem environment, don't do any tracking
 	if !HasAPIKey() || !envvar.SourcegraphDotComMode() {
 		return
@@ -102,13 +104,23 @@ func SyncUserWithEventParams(email, eventID string, contactParams *hubspot.Conta
 
 	// Update or create user contact information in HubSpot, and we want to sync the
 	// contact independent of the request lifecycle.
-	err := syncHubSpotContact(context.Background(), email, eventID, contactParams, eventParams)
+	err := syncHubSpotContact(context.Background(), email, "", contactParams)
 	if err != nil {
 		log15.Warn("syncHubSpotContact: failed to create or update HubSpot contact", "source", "HubSpot", "error", err)
 	}
+
+	// Log the V3 event
+	if eventName != "" {
+		c := Client()
+		err = c.LogV3Event(email, eventName, eventProperties)
+		if err != nil {
+			log.Printf("LOGV3Event: failed to event %s", err)
+
+		}
+	}
 }
 
-func syncHubSpotContact(ctx context.Context, email, eventID string, contactParams *hubspot.ContactProperties, eventParams map[string]string) error {
+func syncHubSpotContact(ctx context.Context, email, eventID string, contactParams *hubspot.ContactProperties) error {
 	if email == "" {
 		return errors.New("user must have a valid email address")
 	}
@@ -129,7 +141,7 @@ func syncHubSpotContact(ctx context.Context, email, eventID string, contactParam
 
 	// Log the user event
 	if eventID != "" {
-		err = c.LogEvent(ctx, email, eventID, eventParams)
+		err = c.LogEvent(ctx, email, eventID, map[string]string{})
 		if err != nil {
 			return errors.Wrap(err, "LogEvent")
 		}


### PR DESCRIPTION
Send a custom behavioural CodyInstall event to HubSpot using the V3 API.

The previous attempt tried to send the new event using the same old API which doesn't work.

Tested locally using API Key.

## Test plan

```graphql
mutation {
  logEvents(
    events: [{event: "CodyInstalled", url: "https://sourcegraph.com/cody", source: WEB, userCookieID: "71dc375b-c5bb-408e-b1b9-0e6383b3b2b8", publicArgument: "{\"extensionDetails\": { \"ide\": \"vscode\"}}"}]
  ) {
    alwaysNil
    __typename
  }
}
```