### PR TITLE
web: add all search feature flags to client side

### DIFF
--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -30,6 +30,9 @@ export const FEATURE_FLAGS = [
     'end-user-onboarding',
     'admin-onboarding',
     'enable-sveltekit',
+    'search-content-based-lang-detection',
+    'search-new-keyword',
+    'search-debug',
 ] as const
 
 export type FeatureFlagName = typeof FEATURE_FLAGS[number]

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -293,6 +293,8 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 		logger.Warn("search feature flags are not available")
 	}
 
+	// When adding a new feature flag remember to add it to the list in
+	// client/web/src/featureFlags/featureFlags.ts to allow overriding.
 	return &search.Features{
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
 		UseZoektParser:          flagSet.GetBoolOr("search-new-keyword", false),


### PR DESCRIPTION
With the recent changes in how feature flags work in the web app we now need the flags listed in the allow list for per request (via feat=) overrides.

Test Plan: CI