### PR TITLE
env var DEV_WEB_BUILDER_NO_SPLITTING to disable code splitting

### DIFF
--- a/client/web/dev/esbuild/config.ts
+++ b/client/web/dev/esbuild/config.ts
@@ -36,7 +36,7 @@ export function esbuildBuildOptions(ENVIRONMENT_CONFIG: EnvironmentConfig): esbu
         logLevel: 'error',
         jsx: 'automatic',
         jsxDev: ENVIRONMENT_CONFIG.NODE_ENV === 'development',
-        splitting: true,
+        splitting: !ENVIRONMENT_CONFIG.DEV_WEB_BUILDER_NO_SPLITTING,
         chunkNames: 'chunks/chunk-[name]-[hash]',
         entryNames: '[name]-[hash]',
         outdir: STATIC_ASSETS_PATH,

--- a/client/web/dev/utils/environment-config.ts
+++ b/client/web/dev/utils/environment-config.ts
@@ -53,6 +53,9 @@ export const ENVIRONMENT_CONFIG = {
      */
     DEV_WEB_BUILDER_OMIT_SLOW_DEPS: Boolean(process.env.DEV_WEB_BUILDER_OMIT_SLOW_DEPS),
 
+    /** Disable code splitting for faster dev builds and dev page navigation. */
+    DEV_WEB_BUILDER_NO_SPLITTING: Boolean(process.env.DEV_WEB_BUILDER_NO_SPLITTING),
+
     /**
      * ----------------------------------------
      * Application features configuration.


### PR DESCRIPTION
For local dev, you can set the env var `DEV_WEB_BUILDER_NO_SPLITTING` to disable code splitting in the esbuild web build. This produces a large single bundle, but it is ~25% faster to produce and means that page navigations need not fetch additional chunks (which incurs an esbuild full rebuild). The downside is that the bundle is quite large (~20MB), but parsing does not seem to be noticeably slow on my machine. So, this is an overall speedup for local dev.




## Test plan

CI