### PR TITLE
web: Fix syncing feature flag overrides from URL

### DIFF
--- a/client/web/src/featureFlags/FeatureFlagsProvider.tsx
+++ b/client/web/src/featureFlags/FeatureFlagsProvider.tsx
@@ -9,7 +9,6 @@ import { parseUrlOverrideFeatureFlags } from './lib/parseUrlOverrideFeatureFlags
 
 /**
  * Overrides feature flag based on initial URL query parameters
- *
  * @description
  * Enable: "/?feat=my-feature"
  * Disable: "/?feat=-my-feature"
@@ -20,11 +19,11 @@ export const FeatureFlagsLocalOverrideAgent: FC<PropsWithChildren<{}>> = ({ chil
     useEffect(() => {
         try {
             const overrideFeatureFlags = parseUrlOverrideFeatureFlags(location.search)
-            for (const [flagName, value] of Object.entries(overrideFeatureFlags)) {
-                if (!value) {
-                    removeFeatureFlagOverride(flagName)
-                } else {
+            for (const [flagName, value] of overrideFeatureFlags) {
+                if (value !== null) {
                     setFeatureFlagOverride(flagName, value)
+                } else {
+                    removeFeatureFlagOverride(flagName)
                 }
             }
             // Update override counter to notify/update the developer settings


### PR DESCRIPTION
I've changed this code a couple of times between returning an object and a map and it seems I left it in a bad state (`overrideFeatureFlags` returns a map).

## Test plan

Performing a search that includes `feat=search-debug` shows debug information.
