### PR TITLE
[Backport 5.2] Cody: Experimental OpenAI autocomplete support (#57872)

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -649,7 +649,7 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 	} else if completionsConfig.Provider == string(conftypes.CompletionsProviderNameOpenAI) {
 		// If no endpoint is configured, use a default value.
 		if completionsConfig.Endpoint == "" {
-			completionsConfig.Endpoint = "https://api.openai.com/v1/chat/completions"
+			completionsConfig.Endpoint = "https://api.openai.com"
 		}
 
 		// If not access token is set, we cannot talk to OpenAI. Bail.
@@ -669,7 +669,7 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 
 		// Set a default completions model.
 		if completionsConfig.CompletionModel == "" {
-			completionsConfig.CompletionModel = "gpt-3.5-turbo"
+			completionsConfig.CompletionModel = "gpt-3.5-turbo-instruct"
 		}
 	} else if completionsConfig.Provider == string(conftypes.CompletionsProviderNameAnthropic) {
 		// If no endpoint is configured, use a default value.
@@ -1142,7 +1142,7 @@ func openaiDefaultMaxPromptTokens(model string) int {
 		return 8_000
 	case "gpt-4-32k":
 		return 32_000
-	case "gpt-3.5-turbo":
+	case "gpt-3.5-turbo", "gpt-3.5-turbo-instruct":
 		return 4_000
 	case "gpt-3.5-turbo-16k":
 		return 16_000

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -468,11 +468,11 @@ func TestGetCompletionsConfig(t *testing.T) {
 				ChatModelMaxTokens:       8000,
 				FastChatModel:            "gpt-3.5-turbo",
 				FastChatModelMaxTokens:   4000,
-				CompletionModel:          "gpt-3.5-turbo",
+				CompletionModel:          "gpt-3.5-turbo-instruct",
 				CompletionModelMaxTokens: 4000,
 				AccessToken:              "asdf",
 				Provider:                 "openai",
-				Endpoint:                 "https://api.openai.com/v1/chat/completions",
+				Endpoint:                 "https://api.openai.com",
 			},
 		},
 		{


### PR DESCRIPTION
Adds experimental OpenAI autocomplete support **_only for BYOK configurations_**.  This brings the changes from the Azure OpenAI provider to OpenAI provider.  Additional it updates the default autocomplete model for OpenAI to be `gpt-3.5-turbo-instruct`  as this model continues to support the non-chat based completions api.  

part of https://github.com/sourcegraph/sourcegraph/issues/57724
## Test plan
Verified Chat & autocomplete work in VS Code
Verified Cody web works
Ran client completions and benchmark tooling. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
