### PR TITLE
ci: release sg msp build

### DIFF
--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -104,18 +104,21 @@ jobs:
         run: |
           cd dev/sg
           GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          GOARCH=${{ matrix.arch }} go build -o "sg-msp_$(go env GOOS)_${{ matrix.arch }}" -tags=msp -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Build and upload Linux
         if: startsWith(matrix.os, 'ubuntu-') == true
         run: |
           cd dev/sg
           GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          GOARCH=${{ matrix.arch }} go build -o "sg-msp_$(go env GOOS)_${{ matrix.arch }}" -tags=msp -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
       - name: Upload release asset
         run: |
           cd dev/sg
           release_name="${{ needs.create_release.outputs.release_name }}"
           gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_${{ matrix.arch }}"
+          gh release upload -R="${repo}" ${release_name} "sg-msp_$(go env GOOS)_${{ matrix.arch }}"
         env:
           repo: sourcegraph/sg
           GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}


### PR DESCRIPTION
`sg msp` is hidden behind the build tag `msp`.

I would like to start using `sg msp` in CD pipeline. Being able to download the release from the internet would make my life easier.


## Test plan

merged and 👀 

tested commands locally, `/sg-msp_darwin_arm64 msp -h` works