### PR TITLE
Commit view: speed up repository comparison

### DIFF
--- a/cmd/frontend/graphqlbackend/preview_repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/preview_repository_comparison.go
@@ -126,7 +126,7 @@ func fileDiffConnectionCompute(patch []byte) func(ctx context.Context, args *Fil
 	}
 }
 
-func previewNewFile(db database.DB, r *FileDiffResolver) FileResolver {
+func previewNewFile(db database.DB, r *fileDiffResolver) FileResolver {
 	fileStat := CreateFileInfo(r.FileDiff.NewName, false)
 	return NewVirtualFileResolver(fileStat, fileDiffVirtualFileContent(r), VirtualFileResolverOptions{
 		// TODO: Add view in webapp to render full preview files.
@@ -134,7 +134,7 @@ func previewNewFile(db database.DB, r *FileDiffResolver) FileResolver {
 	})
 }
 
-func fileDiffVirtualFileContent(r *FileDiffResolver) FileContentFunc {
+func fileDiffVirtualFileContent(r *fileDiffResolver) FileContentFunc {
 	var (
 		once       sync.Once
 		newContent string

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gosyntect"
 	"github.com/sourcegraph/sourcegraph/internal/highlight"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 type RepositoryComparisonInput struct {
@@ -63,17 +64,8 @@ type FileDiff interface {
 }
 
 func NewRepositoryComparison(ctx context.Context, db database.DB, client gitserver.Client, r *RepositoryResolver, args *RepositoryComparisonInput) (*RepositoryComparisonResolver, error) {
-	var baseRevspec, headRevspec string
-	if args.Base == nil {
-		baseRevspec = "HEAD"
-	} else {
-		baseRevspec = *args.Base
-	}
-	if args.Head == nil {
-		headRevspec = "HEAD"
-	} else {
-		headRevspec = *args.Head
-	}
+	baseRevspec := pointers.Deref(args.Base, "HEAD")
+	headRevspec := pointers.Deref(args.Head, "HEAD")
 
 	getCommit := func(ctx context.Context, repo api.RepoName, revspec string) (*GitCommitResolver, error) {
 		if revspec == gitserver.DevNullSHA {


### PR DESCRIPTION
This is a small perf improvement for a commit's diff view. There is more we should do here, but this improved the speed of the example I was looking at. 

Contributes to fixing https://github.com/sourcegraph/sourcegraph/issues/57833

## Test plan

Existing tests and manual test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
