### PR TITLE
graphql: only allow CreatePassword from session cookie

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -415,6 +415,10 @@ func (r *schemaResolver) CreatePassword(ctx context.Context, args *struct {
 },
 ) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only the authenticated user can create their password.
+	if !actor.FromContext(ctx).FromSessionCookie {
+		return nil, errors.New("only allowed from user session")
+	}
+
 	user, err := r.db.Users().GetByCurrentAuthUser(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This makes sure we can only call `CreatePassword` from an actual user session. Now we prevent it from being set using an access token.

Closes https://github.com/sourcegraph/security-issues/issues/353.

## Test plan
- Added unittests
- Confirmed in GraphQL console it works with session cookie
- Use `curl` command below to verify

```
curl \     
  -H 'Authorization: token [your_test_token]' \
  -d '{"query":"mutation { createPassword(newPassword:\"foobazbar123!\") { alwaysNil } }"}' \
  https://sourcegraph.test:3443/.api/graphql
{"errors":[{"message":"only allowed from user session","path":["createPassword"]}],"data":{"createPassword":null}
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
