### PR TITLE
[Backport 5.2] completions: add backend events on clients and handlers (#57775)

### DIFF
--- a/cmd/frontend/internal/completions/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/completions/resolvers/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//internal/conf",
         "//internal/database",
         "//internal/redispool",
+        "//internal/telemetry/telemetryrecorder",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
     ],

--- a/cmd/frontend/internal/completions/resolvers/resolver.go
+++ b/cmd/frontend/internal/completions/resolvers/resolver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetryrecorder"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -58,6 +59,8 @@ func (c *completionsResolver) Completions(ctx context.Context, args graphqlbacke
 	defer done()
 
 	client, err := client.Get(
+		c.logger,
+		telemetryrecorder.New(c.db),
 		completionsConfig.Endpoint,
 		completionsConfig.Provider,
 		completionsConfig.AccessToken,

--- a/internal/completions/client/BUILD.bazel
+++ b/internal/completions/client/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//internal/httpcli",
         "//internal/metrics",
         "//internal/observation",
+        "//internal/telemetry",
         "//lib/errors",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sourcegraph_log//:log",

--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/anthropic"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/awsbedrock"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/azureopenai"
@@ -10,15 +12,22 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func Get(endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {
+func Get(
+	logger log.Logger,
+	events *telemetry.EventRecorder,
+	endpoint string,
+	provider conftypes.CompletionsProviderName,
+	accessToken string,
+) (types.CompletionsClient, error) {
 	client, err := getBasic(endpoint, provider, accessToken)
 	if err != nil {
 		return nil, err
 	}
-	return newObservedClient(client), nil
+	return newObservedClient(logger, events, client), nil
 }
 
 func getBasic(endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {

--- a/internal/completions/client/observe.go
+++ b/internal/completions/client/observe.go
@@ -10,20 +10,23 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 )
 
 func newObservedClient(inner types.CompletionsClient) *observedClient {
 	observationCtx := observation.NewContext(log.Scoped("completions", "completions client"))
 	ops := newOperations(observationCtx)
 	return &observedClient{
-		inner: inner,
-		ops:   ops,
+		inner:  inner,
+		ops:    ops,
+		events: telemetry.NewBestEffortEventRecorder(logger.Scoped("events"), events),
 	}
 }
 
 type observedClient struct {
-	inner types.CompletionsClient
-	ops   *operations
+	inner  types.CompletionsClient
+	ops    *operations
+	events *telemetry.BestEffortEventRecorder
 }
 
 var _ types.CompletionsClient = (*observedClient)(nil)
@@ -38,9 +41,19 @@ func (o *observedClient) Stream(ctx context.Context, feature types.CompletionsFe
 	tracedSend := func(event types.CompletionResponse) error {
 		if event.StopReason != "" {
 			tr.AddEvent("stopped", attribute.String("reason", event.StopReason))
+
+			o.events.Record(ctx, "cody.completions", "stream", &telemetry.EventParameters{
+				Metadata: telemetry.EventMetadata{
+					"feature": int64(feature.ID()),
+				},
+				PrivateMetadata: map[string]any{
+					"stop_reason": event.StopReason,
+				},
+			})
 		} else {
 			tr.AddEvent("completion", attribute.Int("len", len(event.Completion)))
 		}
+
 		return send(event)
 	}
 
@@ -53,6 +66,12 @@ func (o *observedClient) Complete(ctx context.Context, feature types.Completions
 		MetricLabelValues: []string{params.Model},
 	})
 	defer endObservation(1, observation.Args{})
+
+	defer o.events.Record(ctx, "cody.completions", "complete", &telemetry.EventParameters{
+		Metadata: telemetry.EventMetadata{
+			"feature": int64(feature.ID()),
+		},
+	})
 
 	return o.inner.Complete(ctx, feature, params)
 }

--- a/internal/completions/client/observe.go
+++ b/internal/completions/client/observe.go
@@ -13,13 +13,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 )
 
-func newObservedClient(inner types.CompletionsClient) *observedClient {
-	observationCtx := observation.NewContext(log.Scoped("completions", "completions client"))
+func newObservedClient(logger log.Logger, events *telemetry.EventRecorder, inner types.CompletionsClient) *observedClient {
+	observationCtx := observation.NewContext(logger.Scoped("completions", "completions client"))
 	ops := newOperations(observationCtx)
 	return &observedClient{
 		inner:  inner,
 		ops:    ops,
-		events: telemetry.NewBestEffortEventRecorder(logger.Scoped("events"), events),
+		events: telemetry.NewBestEffortEventRecorder(logger.Scoped("events", "telemetry events"), events),
 	}
 }
 

--- a/internal/completions/httpapi/BUILD.bazel
+++ b/internal/completions/httpapi/BUILD.bazel
@@ -25,6 +25,8 @@ go_library(
         "//internal/redispool",
         "//internal/requestclient",
         "//internal/search/streaming/http",
+        "//internal/telemetry",
+        "//internal/telemetry/telemetryrecorder",
         "//internal/trace",
         "//lib/errors",
         "@com_github_gomodule_redigo//redis",

--- a/internal/completions/httpapi/chat.go
+++ b/internal/completions/httpapi/chat.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetryrecorder"
 )
 
 // NewChatCompletionsStreamHandler is an http handler which streams back completions results.
@@ -18,6 +19,7 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 
 	return newCompletionsHandler(
 		logger,
+		telemetryrecorder.New(db),
 		types.CompletionsFeatureChat,
 		rl,
 		"chat",

--- a/internal/completions/httpapi/codecompletion.go
+++ b/internal/completions/httpapi/codecompletion.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
+	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetryrecorder"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -19,6 +20,7 @@ func NewCodeCompletionsHandler(logger log.Logger, db database.DB) http.Handler {
 	rl := NewRateLimiter(db, redispool.Store, types.CompletionsFeatureCode)
 	return newCompletionsHandler(
 		logger,
+		telemetryrecorder.New(db),
 		types.CompletionsFeatureCode,
 		rl,
 		"code",

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
+	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -25,6 +26,7 @@ const maxRequestDuration = time.Minute
 
 func newCompletionsHandler(
 	logger log.Logger,
+	events *telemetry.EventRecorder,
 	feature types.CompletionsFeature,
 	rl RateLimiter,
 	traceFamily string,
@@ -72,6 +74,8 @@ func newCompletionsHandler(
 		defer done()
 
 		completionClient, err := client.Get(
+			logger,
+			events,
 			completionsConfig.Endpoint,
 			completionsConfig.Provider,
 			completionsConfig.AccessToken,

--- a/internal/completions/types/types.go
+++ b/internal/completions/types/types.go
@@ -120,6 +120,18 @@ func (b CompletionsFeature) IsValid() bool {
 	return false
 }
 
+// ID returns a numeric ID representing the feature for analytics purposes.
+func (b CompletionsFeature) ID() int {
+	switch b {
+	case CompletionsFeatureChat:
+		return 1
+	case CompletionsFeatureCode:
+		return 2
+	default:
+		return -1
+	}
+}
+
 type CompletionsClient interface {
 	// Stream executions a completions request, streaming results to the callback.
 	// Callers should check for ErrStatusNotOK and handle the error appropriately.


### PR DESCRIPTION
This change adds backend telemetry events, using the new telemetry system, on completions clients. In conjunction with https://github.com/sourcegraph/sourcegraph/pull/57774 and Telemetry Export rollout in 5.2.1, this can get us some initial events to start tying completions events to individual interactions as discussed in [Gateway to eventlogger mapping](https://docs.google.com/document/d/1V5MK_SI7OnvzVSi1AnhuX5RzvIZTNIZ3MdHACTBz0tE/edit).

(cherry picked from commit 1a7b408c4317b8839481fbdd3a0f1d58767d61e3 from https://github.com/sourcegraph/sourcegraph/pull/57775)



## Test plan

CI