### PR TITLE
Blob view: remove duplicate show history

### DIFF
--- a/client/web/src/repo/blob/own/HistoryAndOwnBar.tsx
+++ b/client/web/src/repo/blob/own/HistoryAndOwnBar.tsx
@@ -30,10 +30,6 @@ export const HistoryAndOwnBar: React.FunctionComponent<{
         navigate({ hash: '#tab=ownership' })
     }, [navigate])
 
-    const openHistoryPanel = useCallback(() => {
-        navigate({ hash: '#tab=history' })
-    }, [navigate])
-
     const { data, error, loading } = useQuery<FetchOwnersAndHistoryResult, FetchOwnersAndHistoryVariables>(
         FETCH_OWNERS_AND_HISTORY,
         {
@@ -92,15 +88,6 @@ export const HistoryAndOwnBar: React.FunctionComponent<{
                         hideExpandCommitMessageBody={true}
                         className={styles.history}
                     />
-                    <Button
-                        variant="link"
-                        size="sm"
-                        display="inline"
-                        className="pt-0 pb-0 border-0"
-                        onClick={openHistoryPanel}
-                    >
-                        Show history
-                    </Button>
                 </div>
             )}
             {ownership && (


### PR DESCRIPTION
This removes the `Show history` link on the latest commit line, which is a duplicate of the toggle button in the actions bar. https://github.com/sourcegraph/sourcegraph/issues/57702 will make it easier to find the history toggle, but I don't think we need to block on that PR to merge this change.

![CleanShot 2023-10-27 at 16 48 00@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/afe30a20-e1d4-4533-a9a0-fcf24fa5151c)

Fixes https://github.com/sourcegraph/sourcegraph/issues/57568

# Test plan

See screenshot.