### PR TITLE
Tree view: speed up contributors query

### DIFF
--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -36,13 +36,13 @@ import type {
     DiffSinceResult,
     DiffSinceVariables,
     GitCommitFields,
-    RepositoryContributorNodeFields,
     Scalars,
     TreeCommitsResult,
     TreeCommitsVariables,
     TreePageOwnershipNodeFields,
     TreePageOwnershipResult,
     TreePageOwnershipVariables,
+    TreePageRepositoryContributorNodeFields,
     TreePageRepositoryContributorsResult,
     TreePageRepositoryContributorsVariables,
     TreePageRepositoryFields,
@@ -653,7 +653,7 @@ interface QuerySpec {
 }
 
 interface RepositoryContributorNodeProps extends QuerySpec {
-    node: RepositoryContributorNodeFields
+    node: TreePageRepositoryContributorNodeFields
     repoName: string
     sourceType: string
 }

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -402,17 +402,6 @@ const CONTRIBUTORS_QUERY = gql`
             }
         }
         count
-        commits(first: 1) {
-            nodes {
-                oid
-                abbreviatedOID
-                url
-                subject
-                author {
-                    date
-                }
-            }
-        }
     }
 `
 


### PR DESCRIPTION
Loading the contributors for a repo can take quite a bit of time. Turns out, most of this time was spent fetching the first commit for each contributor. We don't actually use that data, so this removes that from the GraphQL query, which cuts the example I was looking at from 900ms to 300ms. 

Fixes [#57826](https://github.com/sourcegraph/sourcegraph/issues/57826)

## Test plan

It builds without that info. And it speeds it up. Manually checked that there is no visible change. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
