### PR TITLE
Search: hacky flexible keyword search prototype

### DIFF
--- a/client/branded/src/search-ui/input/toggles/FlexibleSearchToggle.tsx
+++ b/client/branded/src/search-ui/input/toggles/FlexibleSearchToggle.tsx
@@ -1,0 +1,160 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { mdiClose, mdiGoogle, mdiHeart, mdiRadioboxBlank, mdiRadioboxMarked } from '@mdi/js'
+import classNames from 'classnames'
+
+import {
+    Button,
+    Icon,
+    Input,
+    Label,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    Tooltip,
+    Position,
+    H4,
+    H2,
+} from '@sourcegraph/wildcard'
+
+import type { ToggleProps } from './QueryInputToggle'
+
+import smartStyles from './SmartSearchToggle.module.scss'
+import styles from './Toggles.module.scss'
+
+interface FlexibleSearchToggleProps extends Omit<ToggleProps, 'title' | 'iconSvgPath' | 'onToggle'> {
+    onSelect: (enabled: boolean) => void
+}
+
+/**
+ * A toggle displayed in the QueryInput.
+ */
+export const FlexibleSearchToggle: React.FunctionComponent<FlexibleSearchToggleProps> = ({
+    onSelect,
+    interactive = true,
+    isActive,
+    className,
+    disableOn,
+}) => {
+    const disabledRule = useMemo(() => disableOn?.find(({ condition }) => condition), [disableOn])
+    const tooltipValue = useMemo(
+        () => (disabledRule?.reason ?? isActive ? 'Flexible Search enabled' : 'Flexible Search disabled'),
+        [disabledRule?.reason, isActive]
+    )
+
+    const interactiveProps = interactive ? {} : { tabIndex: -1, 'aria-hidden': true }
+
+    const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+
+    return (
+        <Popover isOpen={isPopoverOpen} onOpenChange={event => setIsPopoverOpen(event.isOpen)}>
+            <Tooltip content={tooltipValue} placement="bottom">
+                <PopoverTrigger
+                    as={Button}
+                    className={classNames(
+                        'a11y-ignore',
+                        styles.toggle,
+                        smartStyles.button,
+                        className,
+                        !!disabledRule && styles.disabled,
+                        isActive && styles.toggleActive,
+                        !interactive && styles.toggleNonInteractive
+                    )}
+                    variant="icon"
+                    aria-checked={isActive}
+                    {...interactiveProps}
+                >
+                    <Icon aria-label={tooltipValue} svgPath={mdiHeart} />
+                </PopoverTrigger>
+            </Tooltip>
+
+            <FlexibleSearchToggleMenu
+                onSelect={onSelect}
+                isActive={isActive}
+                closeMenu={() => setIsPopoverOpen(false)}
+            />
+        </Popover>
+    )
+}
+
+const FlexibleSearchToggleMenu: React.FunctionComponent<
+    Pick<FlexibleSearchToggleProps, 'onSelect' | 'isActive'> & { closeMenu: () => void }
+> = ({ onSelect, isActive, closeMenu }) => {
+    const [visibleIsEnabled, setVisibleIsEnabled] = useState(isActive)
+    useEffect(() => {
+        setVisibleIsEnabled(isActive)
+    }, [isActive])
+
+    const onChange = useCallback(
+        (value: boolean) => {
+            setVisibleIsEnabled(value)
+            // Wait a tiny bit for user to see the selection change before closing the popover
+            setTimeout(() => {
+                onSelect(value)
+                closeMenu()
+            }, 100)
+        },
+        [onSelect, closeMenu]
+    )
+
+    return (
+        <PopoverContent
+            aria-labelledby="flexible-search-popover-header"
+            position={Position.bottomEnd}
+            className={smartStyles.popoverWindow}
+        >
+            <div className="d-flex align-items-center px-3 py-2">
+                <H4 as={H2} id="flexible-search-popover-header" className="m-0 flex-1">
+                    Flexible Search
+                </H4>
+                <Button onClick={() => closeMenu()} variant="icon" aria-label="Close">
+                    <Icon aria-hidden={true} svgPath={mdiClose} />
+                </Button>
+            </div>
+            <RadioItem
+                value={true}
+                header="Enable"
+                description="Suggest variations of your query to find more results that may relate."
+                isChecked={visibleIsEnabled}
+                onSelect={onChange}
+            />
+            <RadioItem
+                value={false}
+                header="Disable"
+                description="Only show results that precisely match your query."
+                isChecked={!visibleIsEnabled}
+                onSelect={onChange}
+            />
+        </PopoverContent>
+    )
+}
+
+const RadioItem: React.FunctionComponent<{
+    value: boolean
+    isChecked: boolean
+    onSelect: (value: boolean) => void
+    header: string
+    description: string
+}> = ({ value, isChecked, onSelect, header, description }) => (
+    <Label className={smartStyles.label}>
+        <Input
+            className="sr-only"
+            type="radio"
+            name="flexibleSearch"
+            value={value.toString()}
+            checked={isChecked}
+            onChange={() => onSelect(value)}
+        />
+        <Icon
+            svgPath={isChecked ? mdiRadioboxMarked : mdiRadioboxBlank}
+            aria-hidden={true}
+            className={classNames(smartStyles.radioIcon, isChecked && smartStyles.radioIconActive)}
+            inline={false}
+        />
+
+        <span className="d-flex flex-column">
+            <span className={smartStyles.radioHeader}>{header}</span>
+            <span className={smartStyles.radioDescription}>{description}</span>
+        </span>
+    </Label>
+)

--- a/client/branded/src/search-ui/input/toggles/Toggles.tsx
+++ b/client/branded/src/search-ui/input/toggles/Toggles.tsx
@@ -19,6 +19,7 @@ import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transf
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 
 import { CopyQueryButton } from './CopyQueryButton'
+import { FlexibleSearchToggle } from './FlexibleSearchToggle'
 import { QueryInputToggle } from './QueryInputToggle'
 import { SmartSearchToggle } from './SmartSearchToggle'
 
@@ -36,6 +37,7 @@ export interface TogglesProps
     className?: string
     showCopyQueryButton?: boolean
     showSmartSearchButton?: boolean
+    showFlexibleSearchButton?: boolean
     /**
      * If set to false makes all buttons non-actionable. The main use case for
      * this prop is showing the toggles in examples. This is different from
@@ -75,6 +77,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
         submitSearch,
         showCopyQueryButton = true,
         showSmartSearchButton = true,
+        showFlexibleSearchButton,
         structuralSearchDisabled,
     } = props
 
@@ -127,6 +130,14 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
         },
         [setSearchMode, submitOnToggle]
     )
+
+    const onSelectFlexibleSearch = useCallback((): void => {
+        const newPatternType: SearchPatternType =
+            patternType !== SearchPatternType.keyword ? SearchPatternType.keyword : SearchPatternType.standard
+
+        setPatternType(newPatternType)
+        submitOnToggle({ newPatternType })
+    }, [patternType, setPatternType, submitOnToggle])
 
     const fullQuery = getFullQuery(navbarSearchQuery, selectedSearchContextSpec || '', caseSensitive, patternType)
 
@@ -197,6 +208,14 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
                         className="test-smart-search-toggle"
                         isActive={searchMode === SearchMode.SmartSearch}
                         onSelect={onSelectSmartSearch}
+                        interactive={props.interactive}
+                    />
+                )}
+                {showFlexibleSearchButton && (
+                    <FlexibleSearchToggle
+                        className="test-flexible-search-toggle"
+                        isActive={patternType == SearchPatternType.keyword}
+                        onSelect={onSelectFlexibleSearch}
                         interactive={props.interactive}
                     />
                 )}

--- a/client/branded/src/search-ui/input/toggles/index.ts
+++ b/client/branded/src/search-ui/input/toggles/index.ts
@@ -1,4 +1,5 @@
 export * from './CopyQueryButton'
 export * from './QueryInputToggle'
 export * from './SmartSearchToggle'
+export * from './FlexibleSearchToggle'
 export * from './Toggles'

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -32,6 +32,7 @@ export const FEATURE_FLAGS = [
     'enable-sveltekit',
     'search-content-based-lang-detection',
     'search-new-keyword',
+    'search-llm-rerank',
     'search-debug',
 ] as const
 

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -111,6 +111,9 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                         settingsCascade={props.settingsCascade}
                         navbarSearchQuery={queryState.query}
                         submitSearch={submitSearchOnChange}
+                        showFlexibleSearchButton={
+                            window.context?.experimentalFeatures?.flexibleKeywordSearch === 'enabled'
+                        }
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
                     />
                 </LazyV2SearchInput>

--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -53,6 +53,7 @@ export function useCachedSearchResults(
     const results = useObservable(
         useMemo(() => {
             // If query and options have not changed, return cached value
+            console.log('equal? ' + isEqual(options, cachedResults.current?.options))
             if (query === cachedResults.current?.query && isEqual(options, cachedResults.current?.options)) {
                 return of(cachedResults.current.results)
             }

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -4,12 +4,13 @@ import { mdiChevronDoubleDown, mdiChevronDoubleUp, mdiThumbUp, mdiThumbDown, mdi
 import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
+import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { CaseSensitivityProps, SearchPatternTypeProps } from '@sourcegraph/shared/src/search'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, Icon, Alert, useSessionStorage, Link, Text } from '@sourcegraph/wildcard'
+import { Button, Icon, Alert, useSessionStorage, Link, Text, Label } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
 import { canWriteBatchChanges, NO_ACCESS_BATCH_CHANGES_WRITE, NO_ACCESS_SOURCEGRAPH_COM } from '../../batches/utils'
@@ -67,6 +68,10 @@ export interface SearchResultsInfoBarProps
     setSidebarCollapsed: (collapsed: boolean) => void
 
     isSourcegraphDotCom: boolean
+
+    showRankingToggle: boolean
+    isRerankingEnabled: boolean
+    setRerankingEnabled: (enabled: boolean) => void
 }
 
 /**
@@ -209,7 +214,17 @@ export const SearchResultsInfoBar: React.FunctionComponent<
                 {props.stats}
 
                 <div className={styles.expander} />
-
+                {props.showRankingToggle && (
+                    <Label className={styles.toggle}>
+                        LLM reranking{' '}
+                        <Toggle
+                            value={props.isRerankingEnabled}
+                            onToggle={() => props.setRerankingEnabled(!props.isRerankingEnabled)}
+                            title="Enable Reranking"
+                            className="mr-2"
+                        />
+                    </Label>
+                )}
                 <ul className="nav align-items-center">
                     <SearchActionsMenu
                         authenticatedUser={props.authenticatedUser}

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -33,6 +33,7 @@ export const useNavbarQueryState = create<NavbarQueryState>((set, get) => ({
     searchCaseSensitivity: false,
     searchPatternType: SearchPatternType.standard,
     searchMode: SearchMode.SmartSearch,
+    llmRerank: false,
     searchQueryFromURL: '',
 
     setQueryState: queryStateUpdate => {

--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -23,14 +23,14 @@ func Get(
 	provider conftypes.CompletionsProviderName,
 	accessToken string,
 ) (types.CompletionsClient, error) {
-	client, err := getBasic(endpoint, provider, accessToken)
+	client, err := GetBasic(endpoint, provider, accessToken)
 	if err != nil {
 		return nil, err
 	}
 	return newObservedClient(logger, events, client), nil
 }
 
-func getBasic(endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {
+func GetBasic(endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {
 	switch provider {
 	case conftypes.CompletionsProviderNameAnthropic:
 		return anthropic.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -53,7 +53,12 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 		endpoints = append(endpoints, endpoint) //nolint:staticcheck
 	}
 
-	flushSender := newFlushCollectSender(opts, endpoints, conf.RankingMaxQueueSizeBytes(), streamer)
+	rerankPattern := ""
+	if unwrapped, ok := q.(ZoektQueryWithPattern); ok {
+		q = unwrapped.Q
+		rerankPattern = unwrapped.Pattern
+	}
+	flushSender := newFlushCollectSender(opts, rerankPattern, endpoints, conf.RankingMaxQueueSizeBytes(), streamer)
 	defer flushSender.Flush()
 
 	// During re-balancing a repository can appear on more than one replica.

--- a/internal/search/backend/rerank.go
+++ b/internal/search/backend/rerank.go
@@ -1,0 +1,110 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sourcegraph/zoekt"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/client"
+	"github.com/sourcegraph/sourcegraph/internal/completions/types"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func rerank(pattern string, result *zoekt.SearchResult) (*zoekt.SearchResult, error) {
+	completionsConfig := conf.GetCompletionsConfig(conf.Get().SiteConfig())
+	if completionsConfig == nil {
+		return result, errors.New("completions are not configured")
+	}
+
+	completionsClient, err := client.GetBasic(
+		completionsConfig.Endpoint,
+		completionsConfig.Provider,
+		completionsConfig.AccessToken,
+	)
+
+	if err != nil {
+		return result, err
+	}
+
+	prompt := fmt.Sprintf("Please rerank these code search results for the following search query: \"%s\"."+
+		" Format the result as XML, like this: <list><item><filename>filename 1</filename>"+
+		"<explanation>this is why I chose this item</explanation></item><item><filename>filename 2</filename>"+
+		"<explanation>why I chose this item</explanation></item></list>"+
+		"\n\n.", pattern)
+
+	for f, file := range result.Files {
+		prompt += file.FileName + "\n"
+
+		for m, match := range file.ChunkMatches {
+			prompt += string(match.Content) + "\n"
+			if m > 10 {
+				break
+			}
+		}
+		prompt += "\n"
+
+		if f > 20 {
+			break
+		}
+	}
+
+	params := types.CompletionRequestParameters{
+		Model: completionsConfig.FastChatModel,
+		Messages: []types.Message{{
+			Speaker: "human",
+			Text:    prompt,
+		}, {
+			Speaker: "assistant",
+		}},
+		MaxTokensToSample: 500,
+		Temperature:       0.2,
+		TopK:              -1,
+		TopP:              -1,
+	}
+
+	resp, err := completionsClient.Complete(context.Background(), types.CompletionsFeatureChat, params)
+	if err != nil {
+		return result, err
+	}
+
+	fmt.Println(resp.Completion)
+
+	rerankedResult := zoekt.SearchResult{
+		Stats:         result.Stats,
+		Progress:      result.Progress,
+		RepoURLs:      result.RepoURLs,
+		LineFragments: result.LineFragments,
+	}
+	fileMatches := make([]zoekt.FileMatch, 0)
+
+	var ranked = map[string]bool{}
+	next := resp.Completion
+	for true {
+		start := strings.Index(next, "<filename>")
+		end := strings.Index(next, "</filename>")
+		if start < 0 || end < 0 {
+			break
+		}
+
+		filename := next[start+len("<filename>") : end]
+		for _, match := range result.Files {
+			if match.FileName == filename {
+				fileMatches = append(fileMatches, match)
+				ranked[filename] = true
+			}
+		}
+		next = next[end+len("</filename>"):]
+	}
+
+	for _, match := range result.Files {
+		if !ranked[match.FileName] {
+			fileMatches = append(fileMatches, match)
+		}
+	}
+
+	rerankedResult.Files = fileMatches
+	return &rerankedResult, nil
+}

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/zoekt"
 	proto "github.com/sourcegraph/zoekt/grpc/protos/zoekt/webserver/v1"
+	zoektquery "github.com/sourcegraph/zoekt/query"
 	"github.com/sourcegraph/zoekt/rpc"
 	zoektstream "github.com/sourcegraph/zoekt/stream"
 	"google.golang.org/grpc"
@@ -125,4 +126,9 @@ func ZoektDialGRPC(endpoint string) zoekt.Streamer {
 		client:   proto.NewWebserverServiceClient(conn),
 		dialErr:  err,
 	})
+}
+
+type ZoektQueryWithPattern struct {
+	zoektquery.Q
+	Pattern string
 }

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -298,6 +298,7 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 	return &search.Features{
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
 		UseZoektParser:          flagSet.GetBoolOr("search-new-keyword", false),
+		RerankResults:           flagSet.GetBoolOr("search-llm-rerank", false),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),
 	}
 }

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -52,9 +52,9 @@ func NewPlanJob(inputs *search.Inputs, plan query.Plan) (job.Job, error) {
 
 		newJobTree, err := keyword.NewKeywordSearchJob(plan, newJob)
 		if err != nil {
+
 			return nil, err
 		}
-
 		jobTree = newJobTree
 	}
 
@@ -812,6 +812,11 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 	includePrivate := b.repoOptions.Visibility == query.Private || b.repoOptions.Visibility == query.Any
 	globalZoektQuery := zoekt.NewGlobalZoektQuery(zoektQuery, defaultScope, includePrivate)
 
+	rerankPattern := ""
+	if b.features.RerankResults && b.patternType == query.SearchTypeKeyword {
+		rerankPattern = b.query.OriginalPattern
+	}
+
 	zoektParams := &search.ZoektParameters{
 		// TODO(rvantonder): the Query value is set when the global zoekt query is
 		// enriched with private repository data in the search job's Run method, and
@@ -823,7 +828,7 @@ func (b *jobBuilder) newZoektGlobalSearch(typ search.IndexedRequestType) (job.Jo
 		FileMatchLimit: b.fileMatchLimit,
 		Select:         b.selector,
 		Features:       *b.features,
-		KeywordScoring: b.patternType == query.SearchTypeKeyword,
+		RerankPattern:  rerankPattern,
 	}
 
 	switch typ {
@@ -850,11 +855,15 @@ func (b *jobBuilder) newZoektSearch(typ search.IndexedRequestType) (job.Job, err
 		return nil, err
 	}
 
+	rerankPattern := ""
+	if b.features.RerankResults && b.patternType == query.SearchTypeKeyword {
+		rerankPattern = b.query.OriginalPattern
+	}
 	zoektParams := &search.ZoektParameters{
 		FileMatchLimit: b.fileMatchLimit,
 		Select:         b.selector,
 		Features:       *b.features,
-		KeywordScoring: b.patternType == query.SearchTypeKeyword,
+		RerankPattern:  rerankPattern,
 	}
 
 	switch typ {

--- a/internal/search/keyword/query_transformer.go
+++ b/internal/search/keyword/query_transformer.go
@@ -137,6 +137,7 @@ func queryStringToKeywordQuery(queryString string) (*keywordQuery, error) {
 		return nil, err
 	}
 
+	newBasic.OriginalPattern = strings.Join(patterns, " ")
 	return &keywordQuery{newBasic, transformedPatterns}, nil
 }
 

--- a/internal/search/keyword/term_utils.go
+++ b/internal/search/keyword/term_utils.go
@@ -12,6 +12,11 @@ func removePunctuation(input string) string {
 }
 
 func stemTerm(input string) string {
+	// Apply common code search stems
+	if stemmed, ok := codeSearchStems[input]; ok {
+		return stemmed
+	}
+
 	// Attempt to stem words, but only use the stem if it's a prefix of the original term. This
 	// avoids cases where the stem is noisy and no longer matches the original term.
 	stemmed, err := snowball.Stem(input, "english", false)
@@ -26,25 +31,32 @@ func isCommonTerm(input string) bool {
 	return commonCodeSearchTerms.Has(input) || stopWords.Has(input)
 }
 
+var codeSearchStems = map[string]string{
+	"repository":     "repo",
+	"configuration":  "config",
+	"authentication": "auth",
+}
+
 var commonCodeSearchTerms = stringSet{
-	"class":       {},
-	"classes":     {},
-	"code":        {},
-	"codebase":    {},
-	"cody":        {},
-	"define":      {},
-	"defines":     {},
-	"defined":     {},
-	"design":      {},
-	"find":        {},
-	"finding":     {},
-	"function":    {},
-	"functions":   {},
-	"implement":   {},
-	"implements":  {},
-	"implemented": {},
-	"method":      {},
-	"methods":     {},
-	"package":     {},
-	"product":     {},
+	"class":          {},
+	"classes":        {},
+	"code":           {},
+	"codebase":       {},
+	"cody":           {},
+	"define":         {},
+	"defines":        {},
+	"defined":        {},
+	"design":         {},
+	"find":           {},
+	"finding":        {},
+	"function":       {},
+	"functions":      {},
+	"implement":      {},
+	"implements":     {},
+	"implemented":    {},
+	"implementation": {},
+	"method":         {},
+	"methods":        {},
+	"package":        {},
+	"product":        {},
 }

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
+	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 )
@@ -215,7 +216,8 @@ func (p Plan) ToQ() Q {
 //	    patterns (e.g., to repos, files, etc.).
 type Basic struct {
 	Parameters
-	Pattern Node
+	Pattern         Node
+	OriginalPattern string
 }
 
 func (b Basic) ToParseTree() Q {
@@ -665,4 +667,10 @@ func (f *Flat) ToBasic() Basic {
 		pattern = *f.Pattern
 	}
 	return Basic{Parameters: f.Parameters, Pattern: pattern}
+}
+
+// ZoektQueryWithPattern is a Zoekt query that retains the original query pattern.
+type ZoektQueryWithPattern struct {
+	zoektquery.Q
+	Pattern string
 }

--- a/internal/search/types_test.go
+++ b/internal/search/types_test.go
@@ -149,8 +149,7 @@ func TestZoektParameters(t *testing.T) {
 				MaxDocDisplayCount:  500,
 				ChunkMatches:        true,
 				UseDocumentRanks:    true,
-				DocumentRanksWeight: 4500,
-				UseKeywordScoring:   true},
+				DocumentRanksWeight: 4500},
 		},
 	}
 	for _, tt := range cases {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -849,6 +849,8 @@ type ExperimentalFeatures struct {
 	EnableStorm bool `json:"enableStorm,omitempty"`
 	// EventLogging description: Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.
 	EventLogging string `json:"eventLogging,omitempty"`
+	// FlexibleKeywordSearch description: Enables flexible keyword search.
+	FlexibleKeywordSearch string `json:"flexibleKeywordSearch,omitempty"`
 	// GitServerPinnedRepos description: List of repositories pinned to specific gitserver instances. The specified repositories will remain at their pinned servers on scaling the cluster. If the specified pinned server differs from the current server that stores the repository, then it must be re-cloned to the specified server.
 	GitServerPinnedRepos map[string]string `json:"gitServerPinnedRepos,omitempty"`
 	// GoPackages description: Allow adding Go package host connections
@@ -937,6 +939,7 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "enablePermissionsWebhooks")
 	delete(m, "enableStorm")
 	delete(m, "eventLogging")
+	delete(m, "flexibleKeywordSearch")
 	delete(m, "gitServerPinnedRepos")
 	delete(m, "goPackages")
 	delete(m, "insightsAlternateLoadingStrategy")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -198,6 +198,12 @@
           "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
+        "flexibleKeywordSearch": {
+          "description": "Enables flexible keyword search.",
+          "type": "string",
+          "enum": ["enabled", "disabled"],
+          "default": "enabled"
+        },
         "perforce": {
           "description": "Allow adding Perforce code host connections",
           "type": "string",


### PR DESCRIPTION
Sharing my hacky prototype of flexible keyword search so internal team members can test it out.

How it works:
* By default, it uses the `keyword` pattern type, which splits tokens on whitespace, applies light stemming, and creates a Zoekt "OR" query
* When LLM reranking is enabled, it uses approximate BM25 scoring and reranks the top 20 results using a fast chat model

To try it out:
* Enable the feature in site settings: `"experimentalFeatures.flexibleKeywordSearch": "enabled"`
* In the search bar, disable Smart Search and enable Flexible Search (the heart icon)
* Try out a keyword query like "connect to Anthropic", using the default ranking
* Adjust the ranking toggle to try out LLM reranking as well

What it looks like when Flexible Search is enabled:

![Screenshot 2023-10-27 at 5 10 58 PM](https://github.com/sourcegraph/sourcegraph/assets/7461306/8e3108c9-e3d3-4517-8075-afb997775b14)

## Test plan

Very hacky, no intention of merging!