### PR TITLE
faster graphql-operations codegen step

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -56,3 +56,4 @@ dev/backcompat/flakes.json
 client/browser/src/types/webextension-polyfill/index.d.ts
 
 dev/release/release-config.jsonc
+graphql-operations.ts

--- a/client/shared/dev/BUILD.bazel
+++ b/client/shared/dev/BUILD.bazel
@@ -44,6 +44,8 @@ ts_binary(
         "//:node_modules/@graphql-codegen/typescript",
         "//:node_modules/@graphql-codegen/typescript-apollo-client-helpers",
         "//:node_modules/@graphql-codegen/typescript-operations",
+        "//:node_modules/glob",
+        "//:node_modules/graphql",
         "//:node_modules/prettier",
         "//cmd/frontend/graphqlbackend:graphql_schema",
     ],

--- a/client/shared/dev/generateGraphQlOperations.ts
+++ b/client/shared/dev/generateGraphQlOperations.ts
@@ -1,6 +1,9 @@
+import { readFileSync } from 'fs'
 import path from 'path'
 
 import { CodegenConfig, generate } from '@graphql-codegen/cli'
+import { glob } from 'glob'
+import { GraphQLError } from 'graphql'
 
 const ROOT_FOLDER = path.resolve(__dirname, '../../../')
 
@@ -82,10 +85,23 @@ export const ALL_INPUTS: Input[] = [
     },
 ]
 
+/**
+ * Resolve the globs to files and filter to only files containing "gql`" (which indicates that they
+ * contain a GraphQL operation). The @graphql-codegen/typescript plugin does more advanced filtering
+ * using an AST parse tree, but this simple string check skips AST parsing and saves a lot of time.
+ */
+function resolveAndFilterGlobs(globs: string[]): string[] {
+    const files = globs.flatMap(p =>
+        p.startsWith('!') ? p : glob.sync(p).filter(file => readFileSync(file, 'utf-8').includes('gql`'))
+    )
+    return files
+}
+
 export function createCodegenConfig(operations: Input[]): CodegenConfig {
-    const generates = operations.reduce<CodegenConfig['generates']>((generates, operation) => {
+    const generates: CodegenConfig['generates'] = {}
+    for (const operation of operations) {
         generates[operation.outputPath] = {
-            documents: GLOBS[operation.interfaceNameForOperations],
+            documents: resolveAndFilterGlobs(GLOBS[operation.interfaceNameForOperations]),
             config: {
                 onlyOperationTypes: true,
                 noExport: false,
@@ -97,8 +113,7 @@ export function createCodegenConfig(operations: Input[]): CodegenConfig {
             },
             plugins: [...SHARED_PLUGINS, ...(EXTRA_PLUGINS[operation.interfaceNameForOperations] || [])],
         }
-        return generates
-    }, {})
+    }
 
     return {
         schema: SCHEMA_PATH,
@@ -149,6 +164,13 @@ if (require.main === module) {
     }
     main(process.argv.slice(2)).catch(error => {
         console.error(error)
+        if (error instanceof AggregateError) {
+            for (const e of error.errors) {
+                if (e instanceof GraphQLError) {
+                    console.error(e.source, e.locations)
+                }
+            }
+        }
         process.exit(1)
     })
 }

--- a/client/shared/dev/generateGraphQlOperations.ts
+++ b/client/shared/dev/generateGraphQlOperations.ts
@@ -50,9 +50,6 @@ const SHARED_PLUGINS = [
     'typescript',
     'typescript-operations',
 ]
-
-const PRETTIER = path.join(path.dirname(require.resolve('prettier')), 'bin-prettier.js')
-
 interface Input {
     interfaceNameForOperations: string
     outputPath: string
@@ -105,10 +102,8 @@ export function createCodegenConfig(operations: Input[]): CodegenConfig {
 
     return {
         schema: SCHEMA_PATH,
-        hooks: {
-            afterOneFileWrite: `${PRETTIER} --write`,
-        },
         errorsOnly: true,
+        silent: true,
         config: {
             // https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-operations#config-api-reference
             arrayInputCoercion: false,

--- a/client/web/src/enterprise/insights/admin-ui/components/job-actions/CodeInsightsJobsActions.tsx
+++ b/client/web/src/enterprise/insights/admin-ui/components/job-actions/CodeInsightsJobsActions.tsx
@@ -114,7 +114,8 @@ function getMultipleRetryMutation(jobIds: string[]): string {
     return gql`
         ${CodeInsightsJobFragment}
         mutation RetryCodeInsightsJobs {
-         ${mutations}
+            __typename
+            ${mutations}
         }
     `
 }
@@ -139,7 +140,8 @@ function getMultipleMovetoFrontMutation(jobIds: string[]): string {
     return gql`
         ${CodeInsightsJobFragment}
         mutation MoveToFrontCodeInsightsJobs {
-         ${mutations}
+            __typename
+            ${mutations}
         }
     `
 }
@@ -164,7 +166,8 @@ function getMultipleMovetoBackMutation(jobIds: string[]): string {
     return gql`
         ${CodeInsightsJobFragment}
         mutation MoveToBackCodeInsighsJobs {
-         ${mutations}
+            __typename
+            ${mutations}
         }
     `
 }


### PR DESCRIPTION
Overall, this cuts the time to generate `graphql-operations.ts` files by 50% (from ~4.6s to ~2.3s).

- skip graphql-codegen step for files that lack "gql`": Also fixes an issue in a tsx file that started to throw an error with this filtering step.
- do not run prettier for graphql-operations.ts files: It is not needed because they are not checked in and they can be prettierignored, which can save a lot of time when rebuilding these graphql-operations.ts files.

## Test plan

CI, and manually confirmed that the graphql-operations.ts files that are emitted do not differ after these changes (except for the file mentioned in the bugfix above)