### PR TITLE
build: fixup typo in BUILD file no-sandbox tag

### DIFF
--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -251,6 +251,6 @@ server_integration_test(
     runner_src = ":codeintel_integration_test.sh",
     tags = [
         "manual",
-        "no-sanbdox",
+        "no-sandbox",
     ],
 )


### PR DESCRIPTION
In the `//testing:codeintel_integration_test_local` target.

## Test plan

Run test target locally as this target is not meant to be run on CI
