### PR TITLE
msp: add subscription deploy type

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -36,7 +36,7 @@ type EnvironmentSpec struct {
 
 func (s EnvironmentSpec) Validate() []error {
 	var errs []error
-	// TODO: Add validation
+	errs = append(errs, s.Deploy.Validate()...)
 	return errs
 }
 
@@ -53,14 +53,29 @@ const (
 )
 
 type EnvironmentDeploySpec struct {
-	Type   EnvironmentDeployType        `json:"type"`
-	Manual *EnvironmentDeployManualSpec `json:"manual,omitempty"`
+	Type         EnvironmentDeployType                  `json:"type"`
+	Manual       *EnvironmentDeployManualSpec           `json:"manual,omitempty"`
+	Subscription *EnvironmentDeployTypeSubscriptionSpec `json:"subscription,omitempty"`
+}
+
+func (s EnvironmentDeploySpec) Validate() []error {
+	var errs []error
+	if s.Type == EnvironmentDeployTypeSubscription {
+		if s.Subscription == nil {
+			errs = append(errs, errors.New("no subscription specified when deploy type is subscription"))
+		}
+		if s.Subscription.Tag == "" {
+			errs = append(errs, errors.New("no tag in image subscription specified"))
+		}
+	}
+	return errs
 }
 
 type EnvironmentDeployType string
 
 const (
-	EnvironmentDeployTypeManual = "manual"
+	EnvironmentDeployTypeManual       = "manual"
+	EnvironmentDeployTypeSubscription = "subscription"
 )
 
 // ResolveTag uses the deploy spec to resolve an appropriate tag for the environment.
@@ -69,17 +84,17 @@ const (
 func (d EnvironmentDeploySpec) ResolveTag(repo string) (string, error) {
 	switch d.Type {
 	case EnvironmentDeployTypeManual:
-		var tag string
 		if d.Manual == nil {
-			tag = "insiders"
-		} else {
-			tag = d.Manual.Tag
+			return "insiders", nil
 		}
+		return d.Manual.Tag, nil
+	case EnvironmentDeployTypeSubscription:
+		// we already validated in Validate(), hence it's fine to assume this won't panic
 		updater, err := imageupdater.New()
 		if err != nil {
 			return "", errors.Wrapf(err, "create image updater")
 		}
-		tagAndDigest, err := updater.ResolveTagAndDigest(repo, tag)
+		tagAndDigest, err := updater.ResolveTagAndDigest(repo, d.Subscription.Tag)
 		if err != nil {
 			return "", errors.Wrapf(err, "resolve digest for tag %q", "insiders")
 		}
@@ -90,7 +105,14 @@ func (d EnvironmentDeploySpec) ResolveTag(repo string) (string, error) {
 }
 
 type EnvironmentDeployManualSpec struct {
+	// Tag is the tag to deploy. If empty, defaults to "insiders".
 	Tag string `json:"tag,omitempty"`
+}
+
+type EnvironmentDeployTypeSubscriptionSpec struct {
+	// Tag is the tag to subscribe to.
+	Tag string `json:"tag,omitempty"`
+	// TODO: In the future, we may support subscribing by semver constraints.
 }
 
 type EnvironmentDomainSpec struct {


### PR DESCRIPTION
follow up https://github.com/sourcegraph/sourcegraph/pull/57953

introduce a new deployment type `subscription` to subscribe for image tags from container registry

## Test plan

https://github.com/sourcegraph/managed-services/pull/29
