### PR TITLE
bzl: re-enable sandbox for browser tests

### DIFF
--- a/client/browser/BUILD.bazel
+++ b/client/browser/BUILD.bazel
@@ -354,9 +354,8 @@ jest_test(
     data = [
         ":browser_tests",
     ],
-    patch_node_fs = False,
+    patch_node_fs = True,
     shard_count = 6,
-    tags = ["no-sandbox"],
 )
 
 filegroup(


### PR DESCRIPTION
While working on https://github.com/sourcegraph/devx-support/issues/351 which relates to https://github.com/sourcegraph/sourcegraph/pull/57886 we ended up with @burmudar finding out the following: 

- `bazel test //client/browser:test` is not sandboxed and doesn't have the `patch_node_fs` set to True, on both @sqs's branch and on `main`. 
- Because how NodeJS ecosystem works, the [rules behind this](https://docs.aspect.build/rulesets/aspect_rules_js/docs/js_binary/#copy_data_to_bin-1) are copying files in the output tree to account for peculiarities with the load mechanism that NodeJS uses. 
- Bazel output tree is not cleaned across builds, which is normal, that's where you store the outputs, rules are not supposed to read from here. 
- Because both the new and old implementations of the `//client/browser:test` were not sandboxed nor had the node_fs patch applied, and because of the peculiarities of the NodeJS ecosystem, they end up reusing the same folder on in the output tree. 
- Because we are driving the test runners with globs, both on `main` and on `sqs/vitest` branches, the runner picks up all of what's in that folder, hence the original failure that @burmudar picked up with his usual agency when looking at failures. 

The original issue can be reproduced by simply running `bazel test //client/browser:test` first in `sqs/vitest` branch, then switching branches to `main` and running the same test. 

We tried fixing the `sqs/vitest` branch, but ended up with other issues, and at a fundamental level, the behaviour exposed above is problematic, regardless of using vitest. 

Therefore, the sanest fix at this point is to re-enable the sandbox for the `//client/browser:test` and to apply the node fs patches. 

This results in a build that is 15sec slower, but it's appropriately hermetic now. 

At the root of all of this is https://github.com/sourcegraph/sourcegraph/pull/49897 where we empirically increased the speed of the `//client/web:test` and then ported those in https://github.com/sourcegraph/sourcegraph/commit/29783bf2aa2777a76e85903fe5817456ae6a4a02 to `//client/browser:test` without understanding the risk we were taking wasn't worth the speed increase (only 15s out of 75s). 

## Test plan

1. Reproduced the bug locally. 
2. Iterated on a non vitest branch until we could get the test to pass without encountering the bug. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
