### PR TITLE
searcher: wrap all errors returned in hybrid search path

### DIFF
--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -238,16 +238,11 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 
 		unsearched, ok, err := s.hybrid(ctx, logger, p, sender)
 		if err != nil {
-			logger.Error("hybrid search failed",
-				log.String("repo", string(p.Repo)),
-				log.String("commit", string(p.Commit)),
-				log.Error(err))
+			logger.Error("hybrid search failed", log.Error(err))
 			return errors.Wrap(err, "hybrid search failed")
 		}
 		if !ok {
-			logger.Debug("hybrid search is falling back to normal unindexed search",
-				log.String("repo", string(p.Repo)),
-				log.String("commit", string(p.Commit)))
+			logger.Debug("hybrid search is falling back to normal unindexed search")
 		} else {
 			// now we only need to search unsearched
 			if len(unsearched) == 0 {


### PR DESCRIPTION
Some of the calls done by this code returns very obtuse errors, so lets mix in some more context. Additionally we add in an extra error/debug log at the end of execution which includes the finalState, which will likely be very helpful when debugging errors.

Test Plan: CI