### PR TITLE
bazel: spelling error in codeintel e2e local target

### DIFF
--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -251,6 +251,6 @@ server_integration_test(
     runner_src = ":codeintel_integration_test.sh",
     tags = [
         "manual",
-        "no-sanbdox",
+        "no-sandbox",
     ],
 )


### PR DESCRIPTION

## Test plan
Tested locally - the target runs but fail due to unrelated reasons to this PR, which I'm addressing seperately

