### PR TITLE
Add support for new Fireworks and Anthropic models

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
@@ -37,6 +37,7 @@ function modelBadgeVariant(model: string, mode: 'completions' | 'embeddings'): '
             case 'anthropic/claude-instant-v1.1':
             case 'anthropic/claude-instant-v1.1-100k':
             case 'anthropic/claude-instant-v1.2':
+            case 'anthropic/claude-instant-1.2-cyan':
             // See here: https://platform.openai.com/docs/models/model-endpoint-compatibility
             // for currently available Anthropic models. Note that we also need to
             // allow list the models on the Cody Gateway side.
@@ -51,6 +52,8 @@ function modelBadgeVariant(model: string, mode: 'completions' | 'embeddings'): '
             case 'fireworks/accounts/fireworks/models/llama-v2-7b-code':
             case 'fireworks/accounts/fireworks/models/llama-v2-13b-code':
             case 'fireworks/accounts/fireworks/models/llama-v2-13b-code-instruct':
+            case 'fireworks/accounts/fireworks/models/llama-v2-34b-code-instruct':
+            case 'fireworks/accounts/fireworks/models/mistral-7b-instruct-4k':
             case 'fireworks/accounts/fireworks/models/wizardcoder-15b': {
                 return 'secondary'
             }

--- a/cmd/cody-gateway/shared/config.go
+++ b/cmd/cody-gateway/shared/config.go
@@ -107,6 +107,7 @@ func (c *Config) Load() {
 			"claude-instant-v1.1",
 			"claude-instant-v1.1-100k",
 			"claude-instant-v1.2",
+			"claude-instant-1.2-cyan",
 		}, ","),
 		"Anthropic models that can be used."))
 	if c.Anthropic.AccessToken != "" && len(c.Anthropic.AllowedModels) == 0 {
@@ -136,6 +137,8 @@ func (c *Config) Load() {
 			"accounts/fireworks/models/llama-v2-7b-code",
 			"accounts/fireworks/models/llama-v2-13b-code",
 			"accounts/fireworks/models/llama-v2-13b-code-instruct",
+			"accounts/fireworks/models/llama-v2-34b-code-instruct",
+			"accounts/fireworks/models/mistral-7b-instruct-4k",
 			"accounts/fireworks/models/wizardcoder-15b",
 		}, ","),
 		"Fireworks models that can be used."))

--- a/internal/completions/httpapi/codecompletion.go
+++ b/internal/completions/httpapi/codecompletion.go
@@ -53,7 +53,8 @@ func isAllowedCustomModel(model string) bool {
 		"fireworks/accounts/fireworks/models/llama-v2-13b-code-instruct",
 		"fireworks/accounts/fireworks/models/llama-v2-34b-code-instruct",
 		"fireworks/accounts/fireworks/models/mistral-7b-instruct-4k",
-		"fireworks/accounts/fireworks/models/wizardcoder-15b":
+		"fireworks/accounts/fireworks/models/wizardcoder-15b",
+		"anthropic/claude-instant-1.2-cyan":
 		return true
 	}
 

--- a/internal/completions/httpapi/codecompletion.go
+++ b/internal/completions/httpapi/codecompletion.go
@@ -44,21 +44,16 @@ func isAllowedCustomModel(model string) bool {
 	}
 
 	switch model {
-	case "fireworks/accounts/fireworks/models/starcoder-16b-w8a16":
-		fallthrough
-	case "fireworks/accounts/fireworks/models/starcoder-7b-w8a16":
-		fallthrough
-	case "fireworks/accounts/fireworks/models/starcoder-3b-w8a16":
-		fallthrough
-	case "fireworks/accounts/fireworks/models/starcoder-1b-w8a16":
-		fallthrough
-	case "fireworks/accounts/fireworks/models/llama-v2-7b-code":
-		fallthrough
-	case "fireworks/accounts/fireworks/models/llama-v2-13b-code":
-		fallthrough
-	case "fireworks/accounts/fireworks/models/llama-v2-13b-code-instruct":
-		fallthrough
-	case "fireworks/accounts/fireworks/models/wizardcoder-15b":
+	case "fireworks/accounts/fireworks/models/starcoder-16b-w8a16",
+		"fireworks/accounts/fireworks/models/starcoder-7b-w8a16",
+		"fireworks/accounts/fireworks/models/starcoder-3b-w8a16",
+		"fireworks/accounts/fireworks/models/starcoder-1b-w8a16",
+		"fireworks/accounts/fireworks/models/llama-v2-7b-code",
+		"fireworks/accounts/fireworks/models/llama-v2-13b-code",
+		"fireworks/accounts/fireworks/models/llama-v2-13b-code-instruct",
+		"fireworks/accounts/fireworks/models/llama-v2-34b-code-instruct",
+		"fireworks/accounts/fireworks/models/mistral-7b-instruct-4k",
+		"fireworks/accounts/fireworks/models/wizardcoder-15b":
 		return true
 	}
 


### PR DESCRIPTION
Adds a few new supported model strings:

- `anthropic/claude-instant-1.2-cyan` c.f. https://sourcegraph.slack.com/archives/C04D0GRD1GB/p1698458381224209?thread_ts=1698383238.134869&cid=C04D0GRD1GB
- `fireworks/accounts/fireworks/models/llama-v2-34b-code-instruct` and `fireworks/accounts/fireworks/models/mistral-7b-instruct-4k` c.f. https://app.fireworks.ai/models/fireworks/mistral-7b-instruct-4k and https://app.fireworks.ai/models/fireworks/llama-v2-34b-code-instruct

## Test plan

- Only adding a new code completion model string

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
