### PR TITLE
httpapi: put router for external API in same place as handler

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -54,8 +54,7 @@ func newExternalHTTPHandler(
 	authMiddlewares := auth.AuthMiddleware()
 
 	// HTTP API handler, the call order of middleware is LIFO.
-	r := router.New(mux.NewRouter().PathPrefix("/.api/").Subrouter())
-	apiHandler, err := httpapi.NewHandler(db, r, schema, rateLimitWatcher, handlers)
+	apiHandler, err := httpapi.NewHandler(db, schema, rateLimitWatcher, handlers)
 	if err != nil {
 		return nil, errors.Errorf("create external HTTP API handler: %v", err)
 	}

--- a/cmd/frontend/internal/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//cmd/frontend/internal/httpapi/webhookhandlers",
         "//cmd/frontend/internal/routevar",
         "//cmd/frontend/internal/search",
-        "//cmd/frontend/registry/api",
         "//cmd/frontend/webhooks",
         "//internal/actor",
         "//internal/api",

--- a/cmd/frontend/internal/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//cmd/frontend/internal/httpapi/webhookhandlers",
         "//cmd/frontend/internal/routevar",
         "//cmd/frontend/internal/search",
+        "//cmd/frontend/registry/api",
         "//cmd/frontend/webhooks",
         "//internal/actor",
         "//internal/api",

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -3,7 +3,6 @@ package httpapi
 import (
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 	"github.com/throttled/throttled/v2/store/memstore"
 
@@ -11,7 +10,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
@@ -30,7 +28,6 @@ func newTest(t *testing.T) *httptestutil.Client {
 	db := dbmocks.NewMockDB()
 
 	handler, err := NewHandler(db,
-		router.New(mux.NewRouter()),
 		nil,
 		rateLimiter,
 		&Handlers{

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/webhookhandlers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 	frontendsearch "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search"
+	frontendregistry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry/api"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	confProto "github.com/sourcegraph/sourcegraph/internal/api/internalapi/v1"
@@ -109,7 +110,7 @@ func NewHandler(
 		WriteErrBody: env.InsecureDev,
 	})
 
-	m.PathPrefix("/registry").Methods("GET").Name(apirouter.Registry).Handler(trace.Route(jsonHandler(registry.HandleRegistry)))
+	m.PathPrefix("/registry").Methods("GET").Name(apirouter.Registry).Handler(trace.Route(jsonHandler(frontendregistry.HandleRegistry)))
 	m.PathPrefix("/scim/v2").Methods("GET", "POST", "PUT", "PATCH", "DELETE").Name(apirouter.SCIM).Handler(trace.Route(handlers.SCIMHandler))
 	m.Path("/graphql").Methods("POST").Name(apirouter.GraphQL).Handler(trace.Route(jsonHandler(serveGraphQL(logger, schema, rateLimiter, false))))
 

--- a/cmd/frontend/internal/httpapi/repo_shield_test.go
+++ b/cmd/frontend/internal/httpapi/repo_shield_test.go
@@ -59,7 +59,7 @@ func TestRepoShield(t *testing.T) {
 	}
 
 	var resp map[string]any
-	if err := c.GetJSON("/repos/github.com/gorilla/mux/-/shield", &resp); err != nil {
+	if err := c.GetJSON("/.api/repos/github.com/gorilla/mux/-/shield", &resp); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(resp, wantResp) {

--- a/cmd/frontend/internal/httpapi/router/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/router/BUILD.bazel
@@ -5,8 +5,5 @@ go_library(
     srcs = ["router.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router",
     visibility = ["//cmd/frontend:__subpackages__"],
-    deps = [
-        "//cmd/frontend/internal/routevar",
-        "@com_github_gorilla_mux//:mux",
-    ],
+    deps = ["@com_github_gorilla_mux//:mux"],
 )

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -3,8 +3,6 @@ package router
 
 import (
 	"github.com/gorilla/mux"
-
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/routevar"
 )
 
 const (
@@ -14,34 +12,11 @@ const (
 	SCIPUpload       = "scip.upload"
 	SCIPUploadExists = "scip.upload.exists"
 
-	SearchStream          = "search.stream"
-	SearchJobResults      = "search.job.results"
-	SearchJobLogs         = "search.job.logs"
-	ComputeStream         = "compute.stream"
-	GitBlameStream        = "git.blame.stream"
-	ChatCompletionsStream = "completions.stream"
-	CodeCompletions       = "completions.code"
-
-	SrcCli             = "src-cli"
-	SrcCliVersionCache = "src-cli.version-cache"
+	ComputeStream = "compute.stream"
 
 	Registry = "registry"
 
-	RepoShield = "repo.shield"
-
-	Webhooks                = "webhooks"
-	GitHubWebhooks          = "github.webhooks"
-	GitLabWebhooks          = "gitlab.webhooks"
-	BitbucketServerWebhooks = "bitbucketServer.webhooks"
-	BitbucketCloudWebhooks  = "bitbucketCloud.webhooks"
-
 	SCIM = "scim"
-
-	BatchesFileGet    = "batches.file.get"
-	BatchesFileExists = "batches.file.exists"
-	BatchesFileUpload = "batches.file.upload"
-
-	CodeInsightsDataExport = "insights.data.export"
 
 	GitInfoRefs         = "internal.git.info-refs"
 	GitUploadPack       = "internal.git.upload-pack"
@@ -53,51 +28,6 @@ const (
 	DocumentRanks       = "internal.document-ranks"
 	UpdateIndexStatus   = "internal.update-index-status"
 )
-
-// New creates a new API router with route URL pattern definitions but
-// no handlers attached to the routes.
-func New(base *mux.Router) *mux.Router {
-	if base == nil {
-		panic("base == nil")
-	}
-
-	base.StrictSlash(true)
-
-	addRegistryRoute(base)
-	addSCIMRoute(base)
-	addGraphQLRoute(base)
-	base.Path("/webhooks/{webhook_uuid}").Methods("POST").Name(Webhooks)
-	base.Path("/github-webhooks").Methods("POST").Name(GitHubWebhooks)
-	base.Path("/gitlab-webhooks").Methods("POST").Name(GitLabWebhooks)
-	base.Path("/bitbucket-server-webhooks").Methods("POST").Name(BitbucketServerWebhooks)
-	base.Path("/bitbucket-cloud-webhooks").Methods("POST").Name(BitbucketCloudWebhooks)
-	base.Path("/files/batch-changes/{spec}/{file}").Methods("GET").Name(BatchesFileGet)
-	base.Path("/files/batch-changes/{spec}/{file}").Methods("HEAD").Name(BatchesFileExists)
-	base.Path("/files/batch-changes/{spec}").Methods("POST").Name(BatchesFileUpload)
-	base.Path("/lsif/upload").Methods("POST").Name(LSIFUpload)
-	base.Path("/scip/upload").Methods("POST").Name(SCIPUpload)
-	base.Path("/scip/upload").Methods("HEAD").Name(SCIPUploadExists)
-	base.Path("/search/stream").Methods("GET").Name(SearchStream)
-	base.Path("/search/export/{id}.csv").Methods("GET").Name(SearchJobResults)
-	base.Path("/search/export/{id}.log").Methods("GET").Name(SearchJobLogs)
-	base.Path("/compute/stream").Methods("GET", "POST").Name(ComputeStream)
-	base.Path("/blame/" + routevar.Repo + routevar.RepoRevSuffix + "/stream/{Path:.*}").Methods("GET").Name(GitBlameStream)
-	base.Path("/src-cli/versions/{rest:.*}").Methods("GET", "POST").Name(SrcCliVersionCache)
-	base.Path("/src-cli/{rest:.*}").Methods("GET").Name(SrcCli)
-	base.Path("/insights/export/{id}").Methods("GET").Name(CodeInsightsDataExport)
-	base.Path("/completions/stream").Methods("POST").Name(ChatCompletionsStream)
-	base.Path("/completions/code").Methods("POST").Name(CodeCompletions)
-
-	// repo contains routes that are NOT specific to a revision. In these routes, the URL may not contain a revspec after the repo (that is, no "github.com/foo/bar@myrevspec").
-	repoPath := `/repos/` + routevar.Repo
-
-	// Additional paths added will be treated as a repo. To add a new path that should not be treated as a repo
-	// add above repo paths.
-	repo := base.PathPrefix(repoPath + "/" + routevar.RepoPathDelim + "/").Subrouter()
-	repo.Path("/shield").Methods("GET").Name(RepoShield)
-
-	return base
-}
 
 // NewInternal creates a new API router for internal endpoints.
 func NewInternal(base *mux.Router) *mux.Router {


### PR DESCRIPTION
This does the same thing that I did for the UI router:

1. Move the route definitions to the place where the handlers are defined.
2. Keep the naming of some endpoints around when they're referenced.

Once I also do this for the internal handler, I can clean up more routes.


## Test plan

- Tested locally by booting up `sg start` and clicking around and using API
- Kicked-off `sg ci main-dry-run`: https://buildkite.com/sourcegraph/sourcegraph/builds/249248
