### PR TITLE
bzl: bump src-cli to 5.2.0

### DIFF
--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -1,7 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 DOCSITE_VERSION = "1.9.4"
-SRC_CLI_VERSION = "5.1.0"
+SRC_CLI_VERSION = "5.2.0"
 CTAGS_VERSION = "6.0.0.2783f009"
 
 SRC_CLI_BUILDFILE = """
@@ -39,21 +39,21 @@ def tool_deps():
     http_archive(
         name = "src-cli-linux-amd64",
         build_file_content = SRC_CLI_BUILDFILE.format("linux-amd64"),
-        sha256 = "270ddad7748c1b76f082b637e336b5c7a58af76d207168469f4b7bef957953e3",
+        sha256 = "40fdb8179c4d6e4d150811dd66610f212b5f4fe6aee4c22ece53665c070b0ac3",
         url = "https://github.com/sourcegraph/src-cli/releases/download/{0}/src-cli_{0}_linux_amd64.tar.gz".format(SRC_CLI_VERSION),
     )
 
     http_archive(
         name = "src-cli-darwin-amd64",
         build_file_content = SRC_CLI_BUILDFILE.format("darwin-amd64"),
-        sha256 = "f14414e3ff4759cd1fbed0107138214f87d9a69cdb55ed1c4522704069420d9b",
+        sha256 = "d65914b94af09400dfa41aa2a83f956f8a11ec2957fdf09fe845b6e3cdb777f8",
         url = "https://github.com/sourcegraph/src-cli/releases/download/{0}/src-cli_{0}_darwin_amd64.tar.gz".format(SRC_CLI_VERSION),
     )
 
     http_archive(
         name = "src-cli-darwin-arm64",
         build_file_content = SRC_CLI_BUILDFILE.format("darwin-arm64"),
-        sha256 = "93dc6c8522792ea16e3c8c81c8cf655a908118e867fda43c048c9b51f4c70e88",
+        sha256 = "866758720a1bb077d21b96fe48841d32d9bf11511cd79d9b1e84ccab3dcdde64",
         url = "https://github.com/sourcegraph/src-cli/releases/download/{0}/src-cli_{0}_darwin_arm64.tar.gz".format(SRC_CLI_VERSION),
     )
 

--- a/doc/cli/references/code-intel/upload.md
+++ b/doc/cli/references/code-intel/upload.md
@@ -15,6 +15,7 @@
 | `-indexerVersion` | The version of the indexer that generated the dump. This will override the 'toolInfo.version' field in the metadata vertex of the LSIF dump file. This must be supplied if the indexer does not set this field (in which case the upload will fail with an explicit message). |  |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-json` | Output relevant state in JSON on success. | `false` |
+| `-max-concurrency` | The maximum number of concurrent uploads. Only relevant for multipart uploads. Defaults to all parts concurrently. | `-1` |
 | `-max-payload-size` | The maximum upload size (in megabytes). Indexes exceeding this limit will be uploaded over multiple HTTP requests. | `100` |
 | `-no-progress` | Do not display progress updates. | `false` |
 | `-open` | Open the LSIF upload page in your browser. | `false` |
@@ -49,6 +50,8 @@ Usage of 'src code-intel upload':
     	Skip validation of TLS certificates against trusted chains
   -json
     	Output relevant state in JSON on success.
+  -max-concurrency int
+    	The maximum number of concurrent uploads. Only relevant for multipart uploads. Defaults to all parts concurrently. (default -1)
   -max-payload-size int
     	The maximum upload size (in megabytes). Indexes exceeding this limit will be uploaded over multiple HTTP requests. (default 100)
   -no-progress
@@ -67,23 +70,28 @@ Usage of 'src code-intel upload':
     	The path of the upload route. For internal use only. (default "/.api/lsif/upload")
 
 Examples:
+  Before running any of these, first use src auth to authenticate.
+  Alternately, use the SRC_ACCESS_TOKEN environment variable for
+  individual src-cli invocations. 
 
-  Upload a SCIP index with explicit repo, commit, and upload files:
+  If run from within the project itself, src-cli will infer various
+  flags based on git metadata.
 
-    	$ src code-intel upload -repo=FOO -commit=BAR -file=index.scip
+        $ src code-intel upload # uploads ./index.scip
+
+  If src-cli is invoked outside the project root, or if you're using
+  a version control system other than git, specify flags explicitly:
+
+    	$ src code-intel upload -root='' -repo=FOO -commit=BAR -file=index.scip
 
   Upload a SCIP index for a subproject:
 
     	$ src code-intel upload -root=cmd/
 
-  Upload a SCIP index when lsifEnforceAuth is enabled:
+  Upload a SCIP index when lsif.enforceAuth is enabled in site settings:
 
     	$ src code-intel upload -github-token=BAZ, or
     	$ src code-intel upload -gitlab-token=BAZ
-
-  Upload an LSIF index when the LSIF indexer does not not declare a tool name.
-
-    	$ src code-intel upload -indexer=lsif-elixir
 
   For any of these commands, an LSIF index (default name: dump.lsif) can be
   used instead of a SCIP index (default name: index.scip).


### PR DESCRIPTION
We bumped src-cli in `internal/src-cli/consts.go` but not in the Bazel defs. This PR corrects it.

## Test plan

Locally tested. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
