### PR TITLE
Bump Zoekt for ctags ranking fix

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5963,8 +5963,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:XD5z5uzWE69KufP8U/KDJwVBYy9h6bvmg8gO7nO1dzE=",
-        version = "v0.0.0-20231026112024-b5a5fdc86e83",
+        sum = "h1:EtLwnFgwJm1Rmwndvnp1mNKAhnCXaD2poC9qpY5sZhU=",
+        version = "v0.0.0-20231027153707-c23ed05237bc",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -548,7 +548,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20231018142932-e00da332dac5
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20231026112024-b5a5fdc86e83
+	github.com/sourcegraph/zoekt v0.0.0-20231027153707-c23ed05237bc
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1599,8 +1599,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20231026112024-b5a5fdc86e83 h1:XD5z5uzWE69KufP8U/KDJwVBYy9h6bvmg8gO7nO1dzE=
-github.com/sourcegraph/zoekt v0.0.0-20231026112024-b5a5fdc86e83/go.mod h1:WVDDy51tFgeKy8zXtujTSbqzgyJrqhrLC9sjWiEfAII=
+github.com/sourcegraph/zoekt v0.0.0-20231027153707-c23ed05237bc h1:EtLwnFgwJm1Rmwndvnp1mNKAhnCXaD2poC9qpY5sZhU=
+github.com/sourcegraph/zoekt v0.0.0-20231027153707-c23ed05237bc/go.mod h1:WVDDy51tFgeKy8zXtujTSbqzgyJrqhrLC9sjWiEfAII=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This version contains a fix for a ranking regression we experienced using SCIP
ctags:
* https://github.com/sourcegraph/zoekt/pull/674

It replaces our earlier workaround (https://github.com/sourcegraph/zoekt/pull/655) with a more robust fix.

Relates to sourcegraph/sourcegraph#57659

## Test plan

Sourcegraph and Zoekt CI