### PR TITLE
References pane: fix typing on symbols return type

### DIFF
--- a/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
@@ -400,7 +400,7 @@ const findSymbol = async (
         return
     }
 
-    for (const symbol of payload.symbols || []) {
+    for (const symbol of payload.symbols ?? []) {
         if (isInRange(repositoryCommitPathPosition, symbol.def)) {
             return symbol
         }
@@ -455,7 +455,7 @@ const fetchLocalCodeIntelPayload = cache(
             return undefined
         }
 
-        for (const symbol of payload.symbols || []) {
+        for (const symbol of payload.symbols ?? []) {
             if (symbol.refs) {
                 symbol.refs = sortBy(symbol.refs, reference => reference.row)
             }

--- a/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
@@ -400,7 +400,7 @@ const findSymbol = async (
         return
     }
 
-    for (const symbol of payload.symbols) {
+    for (const symbol of payload.symbols || []) {
         if (isInRange(repositoryCommitPathPosition, symbol.def)) {
             return symbol
         }
@@ -455,7 +455,7 @@ const fetchLocalCodeIntelPayload = cache(
             return undefined
         }
 
-        for (const symbol of payload.symbols) {
+        for (const symbol of payload.symbols || []) {
             if (symbol.refs) {
                 symbol.refs = sortBy(symbol.refs, reference => reference.row)
             }
@@ -475,7 +475,7 @@ interface RepositoryCommitPath {
 type RepositoryCommitPathPosition = RepositoryCommitPath & Position
 
 type LocalCodeIntelPayload = {
-    symbols: LocalSymbol[]
+    symbols: LocalSymbol[] | null
 } | null
 
 interface LocalSymbol {


### PR DESCRIPTION
When go marshals a `nil` slice to JSON, it marshals as `null`. However, unlike in go, null is not treated as an empty slice in javascript. This was causing type errors that showed up in the UI.

Rather than fixing this on the backend side of things (which would be fragile, since it's very conventional to use a nil slice to mean empty slice in go), this makes the field nullable in the typescript type.

Fixes #57902 

## Test plan

No longer seeing the type error in the UI. New tests feel unnecessary since this is just making a type match what the backend actually returns.