### PR TITLE
change string to correct doc link

### DIFF
--- a/internal/database/migration/multiversion/drift.go
+++ b/internal/database/migration/multiversion/drift.go
@@ -83,7 +83,7 @@ func CheckDrift(ctx context.Context, r *runner.Runner, version string, out *outp
 		""+
 			"Before continuing with this operation, run the migrator's drift command and follow instructions to repair the schema to the expected current state."+
 			" "+
-			"See https://docs.sourcegraph.com/admin/how-to/manual_database_migrations#drift for additional instructions."+
+			"See https://docs.sourcegraph.com/admin/updates/migrator/schema-drift for additional instructions."+
 			"\n",
 	))
 


### PR DESCRIPTION
Quick fix to correct the doc string in the drift output

> 3)Doc link  for resolving schema diffs output to the logs is incorrect i.e https://docs.sourcegraph.com/admin/how-to/manual_database_migrations#drift
  The correct link is https://docs.sourcegraph.com/admin/updates/migrator/schema-drift

## Test plan

Minor change CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
