### PR TITLE
nix: upgrade node and pnpm

### DIFF
--- a/dev/nix/nodejs.nix
+++ b/dev/nix/nodejs.nix
@@ -17,5 +17,5 @@ pkgs.nodejs_20.overrideAttrs (oldAttrs: {
     # refuses to build without. We can generate this lock file with `npm install --package-lock-only` but at the time I didn't
     # want to vendor the file. Fortunately, nixpkgs-unstable has typescript at 5.2.2
     typescript = pkgs.nodePackages.typescript; # 5.2.2
-    };
+  };
 })

--- a/dev/nix/nodejs.nix
+++ b/dev/nix/nodejs.nix
@@ -1,5 +1,5 @@
 { pkgs, fetchurl }:
-pkgs.nodejs-18_x.overrideAttrs (oldAttrs: {
+pkgs.nodejs_20.overrideAttrs (oldAttrs: {
   # don't override version here, as it won't be in binary cache
   # and building is super expensive
   # version = "16.19.0";
@@ -7,18 +7,15 @@ pkgs.nodejs-18_x.overrideAttrs (oldAttrs: {
   passthru.pkgs = oldAttrs.passthru.pkgs // {
     pnpm = oldAttrs.passthru.pkgs.pnpm.override rec {
       # PLEASE UPDATE THE SHA512 BELOW OR NOTIFY ONE OF THE NIX USERS BEFORE MERGING A CHANGE TO THESE FILES
-      version = "8.3.0";
+      version = "8.9.2";
       src = fetchurl {
         url = "https://registry.npmjs.org/pnpm/-/pnpm-${version}.tgz";
-        sha512 = "sha512-wRS8ap/SPxBqbUMzcUNkoA0suLqk9BqMlvi8dM2FRuhwUDgqVGYLc5jQ6Ww3uqVc+84zJvN2GYmTWCubaoWPtQ==";
+        sha512 = "sha512-udNf6RsqWFTa3EMDSj57LmdfpLVuIOjgnvB4+lU8GPiu1EBR57Nui43UNfl+sMRMT/O0T8fG+n0h4frBe75mHg==";
       };
     };
-    typescript = oldAttrs.passthru.pkgs.typescript.overrideAttrs (oldAttrs: rec {
-      version = "5.2.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-${version}.tgz";
-        sha512 = "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==";
-      };
-    });
-  };
+    # fetching typescript 5.2.2 from npm registry results in an archive with a missing package-lock.json, which nix
+    # refuses to build without. We can generate this lock file with `npm install --package-lock-only` but at the time I didn't
+    # want to vendor the file. Fortunately, nixpkgs-unstable has typescript at 5.2.2
+    typescript = pkgs.nodePackages.typescript; # 5.2.2
+    };
 })

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696419054,
-        "narHash": "sha256-EdR+dIKCfqL3voZUDYwcvgRDOektQB9KbhBVcE0/3Mo=",
+        "lastModified": 1698553279,
+        "narHash": "sha256-T/9P8yBSLcqo/v+FTOBK+0rjzjPMctVymZydbvR/Fak=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7131f3c223a2d799568e4b278380cd9dac2b8579",
+        "rev": "90e85bc7c1a6fc0760a94ace129d3a1c61c3d035",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     flake-utils.lib.eachDefaultSystem
       (system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
+          pkgs = import nixpkgs { inherit system; overlays = [self.overlays.nodejs-20_x]; };
           pkgsBins = nixpkgs-stable.legacyPackages.${system};
           pkgs' = import nixpkgs { inherit system; overlays = builtins.attrValues self.overlays; };
           pkgsX = xcompileTargets.${system} or null;
@@ -34,7 +34,7 @@
               p4-fusion = p.callPackage ./dev/nix/p4-fusion.nix { };
             }) // {
             # doesnt need the same stability as those above
-            nodejs-18_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
+            nodejs-20_x = pkgs.callPackage ./dev/nix/nodejs.nix { };
           };
 
           # We use pkgs (not pkgs') intentionally to avoid doing extra work of
@@ -47,7 +47,7 @@
       overlays = {
         ctags = final: prev: { universal-ctags = self.packages.${prev.system}.ctags; };
         comby = final: prev: { comby = self.packages.${prev.system}.comby; };
-        nodejs-18_x = final: prev: { nodejs-16_x = self.packages.${prev.system}.nodejs-18_x; };
+        nodejs-20_x = final: prev: { nodejs-20_x = self.packages.${prev.system}.nodejs-20_x; };
         p4-fusion = final: prev: { p4-fusion = self.packages.${prev.system}.p4-fusion; };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
     flake-utils.lib.eachDefaultSystem
       (system:
         let
-          pkgs = import nixpkgs { inherit system; overlays = [self.overlays.nodejs-20_x]; };
+          pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.nodejs-20_x ]; };
           pkgsBins = nixpkgs-stable.legacyPackages.${system};
           pkgs' = import nixpkgs { inherit system; overlays = builtins.attrValues self.overlays; };
           pkgsX = xcompileTargets.${system} or null;

--- a/shell.nix
+++ b/shell.nix
@@ -97,9 +97,9 @@ mkShell {
     shellcheck
 
     # Web tools.
-    nodejs-18_x
-    nodejs-18_x.pkgs.pnpm
-    nodejs-18_x.pkgs.typescript
+    nodejs-20_x
+    nodejs-20_x.pkgs.pnpm
+    nodejs-20_x.pkgs.typescript
 
     # Rust utils for syntax-highlighter service, currently not pinned to the same versions.
     cargo


### PR DESCRIPTION
Upgrade nodejs and pnpm to match what the rest of the repo is using.

We don't fetch typescript from npm registry since 5.2.2 has a missing `package-lock.json`. Fortunately `nixpkgs-unstable` has 5.2.2.
## Test plan
Tested locally
```
bash-5.2$ pnpm --version
8.9.2
bash-5.2$ node --version
v20.8.0
bash-5.2$ tsc --version
Version 5.2.2
bash-5.2$ exit

```
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
