### PR TITLE
Fix experimental badge in Code Search Features docs

### DIFF
--- a/doc/code_search/explanations/features.md
+++ b/doc/code_search/explanations/features.md
@@ -94,9 +94,13 @@ Use the "Searching everywhere" or "Searching in this repo" filter to determine w
 
 <img src="https://storage.googleapis.com/sourcegraph-assets/Fuzzy%20Finder%20-%20Search%20Scope.png" alt="Fuzzy search">
 
-## Multi-branch indexing <span class="badge badge-primary">experimental</span>
+## Multi-branch indexing
 
-> NOTE: This feature is still in active development and must be enabled by a Sourcegraph site admin in site configuration.
+<aside class="experimental">
+<p>
+<span style="margin-right:0.25rem;" class="badge badge-experimental">Experimental</span> Multi-branch indexing is in the experimental stage and must be enabled by a Sourcegraph site admin in site configuration.
+</p>
+</aside>
 
 The most common branch to search is your default branch. To speed up this common operation, Sourcegraph maintains an index of the source code on your default branch. Some organizations have other branches that are regularly searched. To speed up search for those branches, Sourcegraph can be configured to index up to 64 branches per repository.
 


### PR DESCRIPTION
The PR fixes the experimental label badge in the heading. 

## Ref. Thread

- https://sourcegraph.slack.com/archives/C01DXLN3D0T/p1698768999710409

## Test plan

Docs added

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@fix-exp-badge)