### PR TITLE
search jobs: fix query highlighting

### DIFF
--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -511,7 +511,7 @@ const scanStandard = (query: string): ScanResult<Token[]> => {
     return scan(query, 0)
 }
 
-function detectPatternType(query: string): SearchPatternType | undefined {
+export function detectPatternType(query: string): SearchPatternType | undefined {
     const result = scanStandard(query)
     const tokens =
         result.type === 'success'

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -315,17 +315,15 @@ interface SearchJobProps extends TelemetryProps {
 const SyntaxHighlightedSearchQueryCodeMirror: FC<{ query: string; patternType?: SearchPatternType }> = ({
     query,
     patternType,
-}) => {
-    return (
-        <BaseCodeMirrorQueryInput
-            value={query}
-            readOnly={true}
-            multiLine={true}
-            interpretComments={false}
-            patternType={patternType || SearchPatternType.standard}
-        />
-    )
-}
+}) => (
+    <BaseCodeMirrorQueryInput
+        value={query}
+        readOnly={true}
+        multiLine={true}
+        interpretComments={false}
+        patternType={patternType || SearchPatternType.standard}
+    />
+)
 
 const SearchJob: FC<SearchJobProps> = props => {
     const { job, withCreatorColumn, telemetryService, onRerun, onCancel, onDelete } = props

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -6,10 +6,11 @@ import { timeFormat } from 'd3-time-format'
 import { upperFirst } from 'lodash'
 import LayersSearchOutlineIcon from 'mdi-react/LayersSearchOutlineIcon'
 
-import { SyntaxHighlightedSearchQuery } from '@sourcegraph/branded'
+import { BaseCodeMirrorQueryInput } from '@sourcegraph/branded/src/search-ui/input/BaseCodeMirrorQueryInput'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
-import { SearchJobsOrderBy, SearchJobState } from '@sourcegraph/shared/src/graphql-operations'
+import { SearchJobsOrderBy, SearchJobState, SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { detectPatternType } from '@sourcegraph/shared/src/search/query/scanner'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -311,6 +312,21 @@ interface SearchJobProps extends TelemetryProps {
     onDelete: (job: SearchJobNode) => void
 }
 
+const SyntaxHighlightedSearchQueryCodeMirror: FC<{ query: string; patternType?: SearchPatternType }> = ({
+    query,
+    patternType,
+}) => {
+    return (
+        <BaseCodeMirrorQueryInput
+            value={query}
+            readOnly={true}
+            multiLine={true}
+            interpretComments={false}
+            patternType={patternType || SearchPatternType.standard}
+        />
+    )
+}
+
 const SearchJob: FC<SearchJobProps> = props => {
     const { job, withCreatorColumn, telemetryService, onRerun, onCancel, onDelete } = props
     const { repoStats } = job
@@ -334,7 +350,7 @@ const SearchJob: FC<SearchJobProps> = props => {
                     </Text>
                 )}
 
-                <SyntaxHighlightedSearchQuery query={job.query} />
+                <SyntaxHighlightedSearchQueryCodeMirror query={job.query} patternType={detectPatternType(job.query)} />
             </span>
 
             {withCreatorColumn && (


### PR DESCRIPTION
`SyntaxHighlightedSearchQuery` does not render regexp ranges, such as `[a-z]`, correctly. 

input query: `context:global ghp_[A-Za-z0-9]{36} r:.* rev:*refs/heads/* patterntype:regexp`

Search jobs page:

![image](https://github.com/sourcegraph/sourcegraph/assets/26413131/bfdc4654-f10c-419b-a9a9-ffbb4177ec40)

I couldn't find a simple fix so I decided to replace it with a read-only CodeMirror editor.

I want to get this into the upcoming patch. However, we use `SyntaxHighlightedSearchQuery` in a lot of places and it seems risky to replace the component without baking it a bit on s2. Hence I only fix this bug for Search Jobs.

## Test plan
- This is how it looks locally after the fix:
![image](https://github.com/sourcegraph/sourcegraph/assets/26413131/a18e3342-7972-4a51-b4be-0da0f0b3d8db)
