### PR TITLE
Code Navigation: optimize repo link picker

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1979,6 +1979,7 @@ ts_project(
         "src/repo/linkifiy/get-links.test.ts",
         "src/repo/releases/RepositoryReleasesTagsPage.test.tsx",
         "src/repo/tree/TreePage.test.tsx",
+        "src/repo/utils.test.ts",
         "src/search/Notepad.test.tsx",
         "src/search/helpers.test.tsx",
         "src/search/index.test.ts",

--- a/client/web/src/repo/RepoLinkPicker.tsx
+++ b/client/web/src/repo/RepoLinkPicker.tsx
@@ -88,14 +88,12 @@ export const RepoLinkPicker: FC<RepoLinkPickerProps> = props => {
         variables: {
             query: searchTerm.length === 0 ? getInitialSearchTerm(repositoryName) : debouncedSearchTerm,
         },
-        fetchPolicy: 'cache-and-network',
+        fetchPolicy: 'cache-first',
     })
 
     const handleSelect = (selectedValue: string): void => {
         navigate(`/${selectedValue}`)
         setSuggestionOpen(false)
-        // set search term back to an empty string, but replace
-        // new initial value for the gql request
         setSearchTerm('')
     }
 

--- a/client/web/src/repo/RepoLinkPicker.tsx
+++ b/client/web/src/repo/RepoLinkPicker.tsx
@@ -38,6 +38,8 @@ import {
     type RepositoriesSuggestionsVariables,
 } from '../graphql-operations'
 
+import { getInitialSearchTerm } from './utils'
+
 import styles from './RepoLinkPicker.module.scss'
 
 const REPOSITORIES_QUERY = gql`
@@ -195,9 +197,4 @@ export const getCodeHostIconPath = (codeHostType?: ExternalServiceKind): string 
             return mdiSourceRepository
         }
     }
-}
-
-const getInitialSearchTerm = (repo: string) => {
-    const r = repo.split('/')
-    return r[r.length - 1]
 }

--- a/client/web/src/repo/RepoLinkPicker.tsx
+++ b/client/web/src/repo/RepoLinkPicker.tsx
@@ -85,13 +85,18 @@ export const RepoLinkPicker: FC<RepoLinkPickerProps> = props => {
         loading,
     } = useQuery<RepositoriesSuggestionsResult, RepositoriesSuggestionsVariables>(REPOSITORIES_QUERY, {
         skip: !isSuggestionOpen,
-        variables: { query: debouncedSearchTerm },
+        variables: {
+            query: searchTerm.length === 0 ? getInitialSearchTerm(repositoryName) : debouncedSearchTerm,
+        },
         fetchPolicy: 'cache-and-network',
     })
 
     const handleSelect = (selectedValue: string): void => {
         navigate(`/${selectedValue}`)
         setSuggestionOpen(false)
+        // set search term back to an empty string, but replace
+        // new initial value for the gql request
+        setSearchTerm('')
     }
 
     const data = currentData ?? previousData
@@ -192,4 +197,9 @@ export const getCodeHostIconPath = (codeHostType?: ExternalServiceKind): string 
             return mdiSourceRepository
         }
     }
+}
+
+const getInitialSearchTerm = (repo: string) => {
+    const r = repo.split('/')
+    return r[r.length - 1]
 }

--- a/client/web/src/repo/RepoLinkPicker.tsx
+++ b/client/web/src/repo/RepoLinkPicker.tsx
@@ -32,13 +32,10 @@ import {
     useDebounce,
 } from '@sourcegraph/wildcard'
 
-import {
-    ExternalServiceKind,
-    type RepositoriesSuggestionsResult,
-    type RepositoriesSuggestionsVariables,
-} from '../graphql-operations'
+import { type RepositoriesSuggestionsResult, type RepositoriesSuggestionsVariables } from '../graphql-operations'
 
-import { getInitialSearchTerm } from './utils'
+import { CodeHostTypes } from './constants'
+import { getInitialRepoResults } from './utils'
 
 import styles from './RepoLinkPicker.module.scss'
 
@@ -49,11 +46,9 @@ const REPOSITORIES_QUERY = gql`
                 id
                 name
                 url
-                externalServices(first: 1) {
-                    nodes {
-                        id
-                        kind
-                    }
+                externalRepository {
+                    id
+                    serviceType
                 }
             }
             pageInfo {
@@ -88,7 +83,7 @@ export const RepoLinkPicker: FC<RepoLinkPickerProps> = props => {
     } = useQuery<RepositoriesSuggestionsResult, RepositoriesSuggestionsVariables>(REPOSITORIES_QUERY, {
         skip: !isSuggestionOpen,
         variables: {
-            query: searchTerm.length === 0 ? getInitialSearchTerm(repositoryName) : debouncedSearchTerm,
+            query: searchTerm.length === 0 ? getInitialRepoResults(repositoryName) : debouncedSearchTerm,
         },
         fetchPolicy: 'cache-first',
     })
@@ -151,7 +146,7 @@ export const RepoLinkPicker: FC<RepoLinkPickerProps> = props => {
                                         className={styles.item}
                                     >
                                         <Icon
-                                            svgPath={getCodeHostIconPath(suggestion.externalServices.nodes[0]?.kind)}
+                                            svgPath={getCodeHostIconPath(suggestion.externalRepository.serviceType)}
                                             height="1rem"
                                             width="1rem"
                                             inline={false}
@@ -170,27 +165,27 @@ export const RepoLinkPicker: FC<RepoLinkPickerProps> = props => {
     )
 }
 
-export const getCodeHostIconPath = (codeHostType?: ExternalServiceKind): string => {
+export const getCodeHostIconPath = (codeHostType?: String): string => {
     switch (codeHostType) {
-        case ExternalServiceKind.GITHUB: {
+        case CodeHostTypes.GITHUB: {
             return mdiGithub
         }
-        case ExternalServiceKind.BITBUCKETCLOUD: {
+        case CodeHostTypes.BITBUCKETCLOUD: {
             return mdiBitbucket
         }
-        case ExternalServiceKind.BITBUCKETSERVER: {
+        case CodeHostTypes.BITBUCKETSERVER: {
             return mdiBitbucket
         }
-        case ExternalServiceKind.GITLAB: {
+        case CodeHostTypes.GITLAB: {
             return mdiGitlab
         }
-        case ExternalServiceKind.GITOLITE: {
+        case CodeHostTypes.GITOLITE: {
             return mdiGit
         }
-        case ExternalServiceKind.AWSCODECOMMIT: {
+        case CodeHostTypes.AWSCODECOMMIT: {
             return mdiAws
         }
-        case ExternalServiceKind.AZUREDEVOPS: {
+        case CodeHostTypes.AZUREDEVOPS: {
             return mdiMicrosoftAzure
         }
         default: {

--- a/client/web/src/repo/constants.ts
+++ b/client/web/src/repo/constants.ts
@@ -2,3 +2,13 @@ export const LogsPageTabs = {
     COMMANDS: 0,
     SYNCLOGS: 1,
 } as const
+
+export const CodeHostTypes = {
+    GITHUB: 'github',
+    BITBUCKETCLOUD: 'bitbucketCloud',
+    BITBUCKETSERVER: 'bitbucketServer',
+    GITLAB: 'gitlab',
+    GITOLITE: 'gitolite',
+    AWSCODECOMMIT: 'awsCodeCommit',
+    AZUREDEVOPS: 'azureDevOps',
+}

--- a/client/web/src/repo/constants.ts
+++ b/client/web/src/repo/constants.ts
@@ -3,12 +3,12 @@ export const LogsPageTabs = {
     SYNCLOGS: 1,
 } as const
 
-export const CodeHostTypes = {
-    GITHUB: 'github',
-    BITBUCKETCLOUD: 'bitbucketCloud',
-    BITBUCKETSERVER: 'bitbucketServer',
-    GITLAB: 'gitlab',
-    GITOLITE: 'gitolite',
-    AWSCODECOMMIT: 'awsCodeCommit',
-    AZUREDEVOPS: 'azureDevOps',
+export enum CodeHostTypes {
+    GITHUB = 'github',
+    BITBUCKETCLOUD = 'bitbucketCloud',
+    BITBUCKETSERVER = 'bitbucketServer',
+    GITLAB = 'gitlab',
+    GITOLITE = 'gitolite',
+    AWSCODECOMMIT = 'awsCodeCommit',
+    AZUREDEVOPS = 'azureDevOps',
 }

--- a/client/web/src/repo/constants.ts
+++ b/client/web/src/repo/constants.ts
@@ -3,7 +3,7 @@ export const LogsPageTabs = {
     SYNCLOGS: 1,
 } as const
 
-export enum CodeHostTypes {
+export enum CodeHostType {
     GITHUB = 'github',
     BITBUCKETCLOUD = 'bitbucketCloud',
     BITBUCKETSERVER = 'bitbucketServer',
@@ -11,4 +11,5 @@ export enum CodeHostTypes {
     GITOLITE = 'gitolite',
     AWSCODECOMMIT = 'awsCodeCommit',
     AZUREDEVOPS = 'azureDevOps',
+    OTHER = 'other',
 }

--- a/client/web/src/repo/utils.test.ts
+++ b/client/web/src/repo/utils.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from '@jest/globals'
 
-import { getInitialRepoResults } from './utils'
+import { getInitialSearchTerm } from './utils'
 
 describe('getInitialSearchTerm', () => {
     const tests: {
         name: string
         repo: string
-        expected: String
+        expected: string
     }[] = [
         {
             name: 'works with a github repo url',
@@ -45,10 +45,9 @@ describe('getInitialSearchTerm', () => {
         },
     ]
 
-    for (let i = 0; i < tests.length; i++) {
-        let t = tests[i]
+    for (const t of tests) {
         it(t.name, () => {
-            expect(getInitialRepoResults(t.repo)).toBe(t.expected)
+            expect(getInitialSearchTerm(t.repo)).toBe(t.expected)
         })
     }
 })

--- a/client/web/src/repo/utils.test.ts
+++ b/client/web/src/repo/utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { getInitialSearchTerm } from './utils'
+
+describe('getInitialSearchTerm', () => {
+    const tests: {
+        name: string
+        repo: string
+        expected: String
+    }[] = [
+        {
+            name: 'works with a github repo url',
+            repo: 'github.com/sourcegraph/sourcegraph',
+            expected: 'sourcegraph',
+        },
+        {
+            name: 'works with a gitlab repo url',
+            repo: 'gitlab.com/SourcegraphCody/jsonrpc2',
+            expected: 'jsonrpc2',
+        },
+        {
+            name: 'works with a perforce depot url',
+            repo: 'public.perforce.com/sourcegraph/myp4depot',
+            expected: 'myp4depot',
+        },
+        {
+            name: 'works with a bitbucket repo name',
+            repo: 'bitbucket.org/username/projectname/mybitbucketrepo',
+            expected: 'mybitbucketrepo',
+        },
+        {
+            name: 'works with a gerrit repo name',
+            repo: 'mygerritserver.com/c/mygerritrepo',
+            expected: 'mygerritrepo',
+        },
+        {
+            name: 'works with an Azure DevOps repo name',
+            repo: 'https://dev.azure.com/myADOorgname/myADOproject/_git/myADOrepo',
+            expected: 'myADOrepo',
+        },
+        {
+            name: 'works with a Plastic SCM repo name',
+            repo: 'https://cloud.plasticscm.com/my-plastic-repo',
+            expected: 'my-plastic-repo',
+        },
+    ]
+
+    for (let i = 0; i < tests.length; i++) {
+        let t = tests[i]
+        it(t.name, () => {
+            expect(getInitialSearchTerm(t.repo)).toBe(t.expected)
+        })
+    }
+})

--- a/client/web/src/repo/utils.test.ts
+++ b/client/web/src/repo/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals'
 
-import { getInitialSearchTerm } from './utils'
+import { getInitialRepoResults } from './utils'
 
 describe('getInitialSearchTerm', () => {
     const tests: {
@@ -48,7 +48,7 @@ describe('getInitialSearchTerm', () => {
     for (let i = 0; i < tests.length; i++) {
         let t = tests[i]
         it(t.name, () => {
-            expect(getInitialSearchTerm(t.repo)).toBe(t.expected)
+            expect(getInitialRepoResults(t.repo)).toBe(t.expected)
         })
     }
 })

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -1,4 +1,8 @@
+import { at } from 'lodash'
+
 import { type GitCommitFields, RepositoryType } from '../graphql-operations'
+
+import { CodeHostType } from './constants'
 
 export const isPerforceChangelistMappingEnabled = (): boolean =>
     window.context.experimentalFeatures.perforceChangelistMapping === 'enabled'
@@ -13,7 +17,35 @@ export const getCanonicalURL = (sourceType: RepositoryType | string, node: GitCo
         ? node.perforceChangelist.canonicalURL
         : node.canonicalURL
 
-export const getInitialRepoResults = (repo: string) => {
+export const getInitialSearchTerm = (repo: string): string => {
     const r = repo.split('/')
-    return r[r.length - 1]
+    // This is what the linter required instead of r[r.length - 1].
+    // *shrugs*
+    return at(r, r.length - 1)[0]
+}
+
+export const stringToCodeHostType = (codeHostType: string): CodeHostType => {
+    switch (codeHostType) {
+        case 'github': {
+            return CodeHostType.GITHUB
+        }
+        case 'gitlab': {
+            return CodeHostType.GITLAB
+        }
+        case 'bitbucketCloud': {
+            return CodeHostType.BITBUCKETCLOUD
+        }
+        case 'gitolite': {
+            return CodeHostType.GITOLITE
+        }
+        case 'awsCodeCommit': {
+            return CodeHostType.AWSCODECOMMIT
+        }
+        case 'azureDevOps': {
+            return CodeHostType.AZUREDEVOPS
+        }
+        default: {
+            return CodeHostType.OTHER
+        }
+    }
 }

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -13,7 +13,7 @@ export const getCanonicalURL = (sourceType: RepositoryType | string, node: GitCo
         ? node.perforceChangelist.canonicalURL
         : node.canonicalURL
 
-export const getInitialSearchTerm = (repo: string) => {
+export const getInitialRepoResults = (repo: string) => {
     const r = repo.split('/')
     return r[r.length - 1]
 }

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -12,3 +12,8 @@ export const getCanonicalURL = (sourceType: RepositoryType | string, node: GitCo
     isPerforceChangelistMappingEnabled() && isPerforceDepotSource(sourceType) && node.perforceChangelist
         ? node.perforceChangelist.canonicalURL
         : node.canonicalURL
+
+export const getInitialSearchTerm = (repo: string) => {
+    const r = repo.split('/')
+    return r[r.length - 1]
+}


### PR DESCRIPTION
Before, the RepoLinkPicker was initializing the first set of results by running a query with a value of `""`. While this doesn't affect small instances much, large instances, like dotcom, are affected by very slow initial loading times.  

Now, it's faster. 

This also fixes a bug where users without site-admin privileges were unable to use the feature due to getting a bunch of errors when clicking the dropdown instead of repo names. 
  
## Test plan
- Tested performance on local dev environment - **Negligible/No observable improvement**
- Tested performance on `k8s.sgdev.org` - **Negligible improvement**
- Tested performance on `dotcom` - **Markedly faster than before**
- Add unit test
