### PR TITLE
Cody: Update Bedrock endpoint to match documentation

### DIFF
--- a/internal/completions/client/awsbedrock/bedrock.go
+++ b/internal/completions/client/awsbedrock/bedrock.go
@@ -194,7 +194,7 @@ func (c *awsBedrockAnthropicCompletionStreamClient) makeRequest(ctx context.Cont
 
 	apiURL := url.URL{
 		Scheme: "https",
-		Host:   fmt.Sprintf("bedrock.%s.amazonaws.com", defaultConfig.Region),
+		Host:   fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", defaultConfig.Region),
 	}
 
 	if stream {


### PR DESCRIPTION
GA documentation for AWS Bedrock lists [a different endpoint](https://docs.aws.amazon.com/general/latest/gr/bedrock.html) for InvokeModel & InvokeModelWithResponseStream this updates the endpoint building logic to match the documentation.

## Test plan
Manually tested Autocomplete & chat against internal Bedrock instance
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
