### PR TITLE
tweak wording and remove obtrusive CTA from cody chat messages

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -168,7 +168,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                     <div className="d-flex">
                         <CodyCTAIcon className="flex-shrink-0" />
                         <div className="ml-3">
-                            <H3>Cody is more powerful in your IDE</H3>
+                            <H3>Cody is more powerful in your editor</H3>
                             <Text>
                                 Cody adds powerful AI assistant functionality like inline completions and assist, and
                                 powerful recipes to help you understand codebases and generate and fix code more
@@ -198,12 +198,12 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                 }
                 description={
                     <>
-                        Cody answers code questions and writes code for you by leveraging your entire codebase and the
-                        code graph.
+                        Cody answers code questions and writes code for you using your entire codebase and the code
+                        graph.
                         {!isSourcegraphDotCom && !isCodyApp && isCTADismissed && (
                             <>
                                 {' '}
-                                <Link to="/help/cody#get-cody">Cody is more powerful in the IDE</Link>.
+                                <Link to="/help/cody#get-cody">Get Cody in your editor.</Link>
                             </>
                         )}
                     </>

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -114,7 +114,6 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
         deleteHistoryItem,
         logTranscriptEvent,
     } = codyChatStore
-    const [showVSCodeCTA] = useState<boolean>(Math.random() < 0.5 || true)
     const [isCTADismissed = true, setIsCTADismissed] = useTemporarySetting('cody.chatPageCta.dismissed', false)
     const onCTADismiss = (): void => setIsCTADismissed(true)
 
@@ -269,85 +268,45 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                             deleteHistoryItem={deleteHistoryItem}
                         />
                     </div>
-                    {isSourcegraphDotCom &&
-                        !isCTADismissed &&
-                        (showVSCodeCTA ? (
-                            <MarketingBlock
-                                wrapperClassName="d-flex"
-                                contentClassName={classNames(
-                                    'flex-grow-1 d-flex flex-column justify-content-between',
-                                    styles.ctaWrapper
-                                )}
-                            >
-                                <H3 className="d-flex align-items-center mb-4">Try the VS Code Extension</H3>
-                                <Text>
-                                    This extension combines an LLM with the context of your code to help you generate
-                                    and fix code.
-                                </Text>
-                                <div className="mb-2">
-                                    <Link
-                                        to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai"
-                                        className={classNames(
-                                            'd-inline-flex align-items-center text-merged',
-                                            styles.ctaLink
-                                        )}
-                                        onClick={() => logTranscriptEvent(EventName.CODY_CHAT_DOWNLOAD_VSCODE)}
-                                    >
-                                        Download the VS Code Extension
-                                        <Icon svgPath={mdiChevronRight} aria-hidden={true} />
-                                    </Link>
-                                </div>
-                                <img
-                                    src="https://storage.googleapis.com/sourcegraph-assets/TryCodyVSCodeExtension.png"
-                                    alt="Try Cody VS Code Extension"
-                                    width={666}
-                                />
-                                <Icon
-                                    svgPath={mdiClose}
-                                    aria-label="Close try Cody widget"
-                                    className={classNames(styles.closeButton, 'position-absolute m-0')}
-                                    onClick={onCTADismiss}
-                                />
-                            </MarketingBlock>
-                        ) : (
-                            <MarketingBlock
-                                wrapperClassName="d-flex"
-                                contentClassName={classNames(
-                                    'flex-grow-1 d-flex flex-column justify-content-between',
-                                    styles.ctaWrapper
-                                )}
-                            >
-                                <H3 className="d-flex align-items-center mb-4">Try Cody on Public Code</H3>
-                                <Text>
-                                    Cody explains, generates, and translates code within specific files and
-                                    repositories.
-                                </Text>
-                                <div className="mb-2">
-                                    <Link
-                                        to="https://sourcegraph.com/github.com/openai/openai-cookbook/-/blob/apps/file-q-and-a/nextjs-with-flask-server/server/answer_question.py"
-                                        className={classNames(
-                                            'd-inline-flex align-items-center text-merged',
-                                            styles.ctaLink
-                                        )}
-                                        onClick={() => logTranscriptEvent(EventName.CODY_CHAT_TRY_ON_PUBLIC_CODE)}
-                                    >
-                                        Try on a file, or repository
-                                        <Icon svgPath={mdiChevronRight} aria-hidden={true} />
-                                    </Link>
-                                </div>
-                                <img
-                                    src="https://storage.googleapis.com/sourcegraph-assets/TryCodyOnPublicCode.png"
-                                    alt="Try Cody on Public Code"
-                                    width={666}
-                                />
-                                <Icon
-                                    svgPath={mdiClose}
-                                    aria-label="Close try Cody widget"
-                                    className={classNames(styles.closeButton, 'position-absolute m-0')}
-                                    onClick={onCTADismiss}
-                                />
-                            </MarketingBlock>
-                        ))}
+                    {isSourcegraphDotCom && !isCTADismissed && (
+                        <MarketingBlock
+                            wrapperClassName="d-flex"
+                            contentClassName={classNames(
+                                'flex-grow-1 d-flex flex-column justify-content-between',
+                                styles.ctaWrapper
+                            )}
+                        >
+                            <H3 className="d-flex align-items-center mb-4">Use Cody in your editor</H3>
+                            <Text>
+                                Autocomplete, test generation, refactors, code Q&A, and more&mdash;with the context of
+                                your code.
+                            </Text>
+                            <div className="mb-2">
+                                <Link
+                                    to="/get-cody"
+                                    className={classNames(
+                                        'd-inline-flex align-items-center text-merged',
+                                        styles.ctaLink
+                                    )}
+                                    onClick={() => logTranscriptEvent(EventName.CODY_CHAT_GET_EDITOR_EXTENSION)}
+                                >
+                                    Get Cody in your editor
+                                    <Icon svgPath={mdiChevronRight} aria-hidden={true} />
+                                </Link>
+                            </div>
+                            <img
+                                src="https://storage.googleapis.com/sourcegraph-assets/TryCodyVSCodeExtension.png"
+                                alt="Try Cody VS Code Extension"
+                                width={666}
+                            />
+                            <Icon
+                                svgPath={mdiClose}
+                                aria-label="Close try Cody widget"
+                                className={classNames(styles.closeButton, 'position-absolute m-0')}
+                                onClick={onCTADismiss}
+                            />
+                        </MarketingBlock>
+                    )}
                 </div>
 
                 {isCodyApp ? (

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -26,7 +26,6 @@ import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { Button, Icon, TextArea, Link, Tooltip, Alert, Text, H2 } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../../tracking/eventLogger'
-import { EventName, EventLocation } from '../../../util/constants'
 import { CodyPageIcon } from '../../chat/CodyPageIcon'
 import { isCodyEnabled, isEmailVerificationNeededForCody, isSignInRequiredForCody } from '../../isCodyEnabled'
 import { useCodySidebar } from '../../sidebar/Provider'
@@ -276,13 +275,6 @@ const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = React.mem
                     </Button>
                 </div>
             )}
-            <Link
-                to="/get-cody"
-                className="d-inline-block w-100 ml-auto text-right font-italic"
-                onClick={() => eventLogger.log(EventName.CODY_CTA, { location: EventLocation.CHAT_RESPONSE })}
-            >
-                Use commands, autocomplete and more in your IDE.
-            </Link>
         </div>
     )
 })

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -57,11 +57,11 @@ const codyPlatformCardItems = (
         },
     },
     {
-        title: 'More powerful in your IDE',
+        title: 'More powerful in your editor',
         description: (
             <>
                 The extensions combine an LLM with the context of your code to help you generate and fix code more
-                accurately. <Link to="/help/cody#get-cody">View supported IDEs</Link>.
+                accurately. <Link to="/help/cody#get-cody">View supported editors.</Link>
             </>
         ),
         icon: <IDEIcon />,

--- a/client/web/src/cody/widgets/CodyRecipesWidget.tsx
+++ b/client/web/src/cody/widgets/CodyRecipesWidget.tsx
@@ -87,7 +87,7 @@ export const CodyRecipesWidget: React.FC<{ editor?: CodeMirrorEditor }> = ({ edi
                     onClick={() => void executeRecipe('find-code-smells', { scope: { editor } })}
                     disabled={isMessageInProgress}
                 />
-                <RecipeAction title="Get Cody for your IDE" to="/get-cody" disabled={isMessageInProgress} />
+                <RecipeAction title="Get Cody in your editor" to="/get-cody" disabled={isMessageInProgress} />
             </Recipe>
         </Recipes>
     )

--- a/client/web/src/get-cody/GetCodyPage.tsx
+++ b/client/web/src/get-cody/GetCodyPage.tsx
@@ -65,7 +65,7 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
                     <div>
                         <Text className={styles.getStartedWithCodyTitle}>Get started with Cody</Text>
                         <Text className={styles.getStartedWithCodyDescription}>
-                            Try Cody free on your local machine with the Cody app and IDE extensions.
+                            Try Cody free on your local machine with the Cody app and editor extensions.
                         </Text>
                     </div>
                     <CodyLetsWorkIcon className={styles.codyLetsWorkImage} />
@@ -119,9 +119,7 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
 
                     {/* Install cody extension section */}
                     <div className={classNames(styles.card, 'get-cody-step')}>
-                        <H2 className={styles.cardTitle}>
-                            Install the Cody extension for your IDE(s) and start using Cody
-                        </H2>
+                        <H2 className={styles.cardTitle}>Install the Cody editor extension and start using Cody</H2>
                         <div className={classNames(styles.downloadBtnWrapper)}>
                             <div>
                                 <Link
@@ -194,9 +192,9 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
                             Optional: Install the Cody desktop app for higher quality responses
                         </H2>
                         <Text className={styles.cardDescription}>
-                            The Cody app, when combined with a Cody IDE extension, enables context fetching for all of
-                            your local repositories. Without the app, Cody only fetches context on the repository
-                            currently open in your IDE.
+                            The Cody app, when combined with a Cody editor extension, enables context fetching for all
+                            of your local repositories. Without the app, Cody only fetches context on the repository
+                            currently open in your editor.
                         </Text>
                         <div className={styles.downloadButtonWrapper}>
                             <div className={classNames('d-flex flex-row flex-wrap', styles.downloadMacWrapper)}>

--- a/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsExtensionsPage/index.tsx
@@ -212,21 +212,21 @@ export const AnalyticsExtensionsPage: React.FunctionComponent = () => {
                             <Text as="li">
                                 {installationStats.vscode}% of users have installed the{' '}
                                 <AnchorLink to="/help/integration/editor" target="_blank">
-                                    VS Code IDE extension
+                                    VS Code extension
                                 </AnchorLink>
                                 . Promote installation to increase the value.
                             </Text>
                             <Text as="li">
                                 {installationStats.jetbrains}% of users have installed the{' '}
                                 <AnchorLink to="/help/integration/editor" target="_blank">
-                                    JetBrains IDE plugin
+                                    JetBrains plugin
                                 </AnchorLink>
                                 . Promote installation to increase the value.
                             </Text>
                             <Text as="li">
                                 {installationStats.browser}% of users have installed the{' '}
                                 <AnchorLink to="/help/integration/browser_extension" target="_blank">
-                                    Browser extension
+                                    browser extension
                                 </AnchorLink>
                                 . Promote installation to increase the value.
                             </Text>

--- a/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsSearchPage/index.tsx
@@ -217,11 +217,11 @@ export const AnalyticsSearchPage: React.FC = () => {
                         <Text as="li">
                             Promote the{' '}
                             <AnchorLink to="/help/integration/editor" target="_blank">
-                                IDE extension
+                                editor extension
                             </AnchorLink>{' '}
                             and{' '}
                             <AnchorLink to="/help/cli" target="_blank">
-                                SRC CLI
+                                src CLI
                             </AnchorLink>{' '}
                             to your users to allow them to search where they work.
                         </Text>

--- a/client/web/src/storm/pages/SearchPage/TryCodyCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/TryCodyCtaSection.tsx
@@ -120,12 +120,9 @@ export const TryCodyCtaSection: React.FC<TryCodyCtaSectionProps> = ({
             >
                 <H3 className="d-flex align-items-center">
                     <CodyInIDEIcon aria-hidden={true} />
-                    Install Cody for your IDE
+                    Get Cody in your editor
                 </H3>
-                <Text>
-                    Cody for your IDE provides the power of LLMs to help you generate and fix code, right where you
-                    commit.
-                </Text>
+                <Text>Cody helps you write, fix, and understand code in your editor.</Text>
                 <div className="mb-2">
                     <ButtonLink
                         to="/help/cody#get-cody"

--- a/client/web/src/util/constants.ts
+++ b/client/web/src/util/constants.ts
@@ -21,6 +21,7 @@ export const enum EventName {
     CODY_SIDEBAR_CHAT_OPENED = 'web:codySidebar:chatOpened',
     CODY_SIGNUP = 'CodySignup',
     CODY_CHAT_DOWNLOAD_VSCODE = 'web:codyChat:downloadVSCodeCTA',
+    CODY_CHAT_GET_EDITOR_EXTENSION = 'web:codyChat:getEditorExtensionCTA',
     CODY_CHAT_TRY_ON_PUBLIC_CODE = 'web:codyChat:tryOnPublicCodeCTA',
     CODY_CTA = 'ClickedOnCodyCTA',
     VIEW_EDITOR_EXTENSIONS = 'CodyClickViewEditorExtensions',


### PR DESCRIPTION
A "get Cody in your editor" CTA was showing in the bottom right of every single chat message. This was obtrusive. There is already a CTA at the top of the page to get Cody in your editor. Here is the CTA that was removed:

![rm-cody-cta](https://github.com/sourcegraph/sourcegraph/assets/1976/4b7b17b5-7b37-4fe7-a69b-3264b2c48912)


Also generally prefers the term "editor" to "IDE" except in the specific context of JetBrains IDEs.




## Test plan

CI