### PR TITLE
dbworker: include recordID in fetchDebugInformationForJob error

### DIFF
--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -1056,7 +1056,7 @@ func (s *store[T]) fetchDebugInformationForJob(ctx context.Context, recordID int
 		return "", err
 	}
 	if !ok {
-		return "", errors.Newf("fetching debug information for record %d didn't return rows")
+		return "", errors.Newf("fetching debug information for record %d didn't return rows", recordID)
 	}
 	return debug, nil
 }


### PR DESCRIPTION
Not sure why go's format string linter isn't picking this up.

Test Plan: n/a