### PR TITLE
github test: make the sorting more stable in test

### DIFF
--- a/internal/authz/providers/github/BUILD.bazel
+++ b/internal/authz/providers/github/BUILD.bazel
@@ -59,6 +59,5 @@ go_test(
         "@com_github_gregjones_httpcache//:httpcache",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/internal/authz/providers/github/BUILD.bazel
+++ b/internal/authz/providers/github/BUILD.bazel
@@ -59,5 +59,6 @@ go_test(
         "@com_github_gregjones_httpcache//:httpcache",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//slices",
     ],
 )

--- a/internal/authz/providers/github/github_test.go
+++ b/internal/authz/providers/github/github_test.go
@@ -41,10 +41,6 @@ func mockClientFunc(mockClient client) func() (client, error) {
 	}
 }
 
-func stableSortRepoID(v []extsvc.RepoID) {
-	slices.SortStableFunc(v, stdcmp.Less[extsvc.RepoID])
-}
-
 // newMockClientWithTokenMock is used to keep the behaviour of WithToken function mocking
 // which is lost during moving the client interface to mockgen usage
 func newMockClientWithTokenMock() *MockClient {
@@ -211,8 +207,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
 		}
 
-		stableSortRepoID(wantRepoIDs)
-		stableSortRepoID(repoIDs.Exacts)
+		slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
+		slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
 		if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 			t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 		}
@@ -261,8 +257,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
 			}
-			stableSortRepoID(wantRepoIDs)
-			stableSortRepoID(repoIDs.Exacts)
+			slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
+			slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
 			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 			}
@@ -297,8 +293,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=",
 			}
-			stableSortRepoID(wantRepoIDs)
-			stableSortRepoID(repoIDs.Exacts)
+			slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
+			slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
 			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 			}
@@ -370,8 +366,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				"MDEwOlJlcG9zaXRvcnkyNDQ1nsteam1=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2nsteam2=",
 			}
-			stableSortRepoID(wantRepoIDs)
-			stableSortRepoID(repoIDs.Exacts)
+			slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
+			slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
 			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 			}
@@ -424,8 +420,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 					"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=", // from ListOrgRepositories
 					"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=", // from ListOrgRepositories
 				}
-				stableSortRepoID(wantRepoIDs)
-				stableSortRepoID(repoIDs.Exacts)
+				slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
+				slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
 				if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 					t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 				}
@@ -479,7 +475,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				"MDEwOlJlcG9zaXRvcnkyNDI2nsteam1=",
 			}
 
-			stableSortRepoID(wantRepoIDs)
+			slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
 			// first call
 			t.Run("first call", func(t *testing.T) {
 				repoIDs, err := p.FetchUserPerms(context.Background(),
@@ -493,7 +489,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 					t.Fatalf("expected repos to be listed: callsToListOrgRepos=%d, callsToListTeamRepos=%d",
 						callsToListOrgRepos, callsToListTeamRepos)
 				}
-				stableSortRepoID(repoIDs.Exacts)
+				slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
 				if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 					t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 				}
@@ -514,7 +510,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 					t.Fatalf("expected repos not to be listed: callsToListOrgRepos=%d, callsToListTeamRepos=%d",
 						callsToListOrgRepos, callsToListTeamRepos)
 				}
-				stableSortRepoID(repoIDs.Exacts)
+				slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
 				if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 					t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 				}
@@ -535,7 +531,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 					t.Fatalf("expected repos to be listed: callsToListOrgRepos=%d, callsToListTeamRepos=%d",
 						callsToListOrgRepos, callsToListTeamRepos)
 				}
-				stableSortRepoID(repoIDs.Exacts)
+				slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
 				if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 					t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 				}

--- a/internal/authz/providers/github/github_test.go
+++ b/internal/authz/providers/github/github_test.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	"golang.org/x/exp/slices"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gregjones/httpcache"
 

--- a/internal/authz/providers/github/github_test.go
+++ b/internal/authz/providers/github/github_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/exp/slices"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gregjones/httpcache"
+	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"

--- a/internal/authz/providers/github/github_test.go
+++ b/internal/authz/providers/github/github_test.go
@@ -41,7 +41,7 @@ func mockClientFunc(mockClient client) func() (client, error) {
 }
 
 func stableSortRepoID(v []extsvc.RepoID) {
-	slices.SortStableFunc(v, func(a, b extsvc.RepoID) bool { return strings.Compare(string(a), string(b)) <= 1 })
+	slices.SortStableFunc(v, func(a, b extsvc.RepoID) bool { return strings.Compare(string(a), string(b)) < 1 })
 }
 
 // newMockClientWithTokenMock is used to keep the behaviour of WithToken function mocking
@@ -160,8 +160,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				switch page {
 				case 1:
 					return []*github.Repository{
-						{ID: "MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE="}, // existing repo
 						{ID: "MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234="},
+						{ID: "MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE="}, // existing repo
 					}, true, 1, nil
 				case 2:
 					return []*github.Repository{
@@ -206,8 +206,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 		wantRepoIDs := []extsvc.RepoID{
 			"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
-			"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
 			"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
+			"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
 		}
 
 		stableSortRepoID(wantRepoIDs)
@@ -256,9 +256,9 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			}
 
 			wantRepoIDs := []extsvc.RepoID{
-				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
-				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
+				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
+				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
 			}
 			stableSortRepoID(wantRepoIDs)
 			stableSortRepoID(repoIDs.Exacts)
@@ -289,12 +289,12 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			}
 
 			wantRepoIDs := []extsvc.RepoID{
-				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
-				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
+				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTadmin=",
 				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=",
-				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=",
+				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
+				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
 			}
 			stableSortRepoID(wantRepoIDs)
 			stableSortRepoID(repoIDs.Exacts)
@@ -360,14 +360,14 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			}
 
 			wantRepoIDs := []extsvc.RepoID{
-				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
-				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
+				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTadmin=",
-				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=",
-				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=",
-				"MDEwOlJlcG9zaXRvcnkyNDQ1nsteam1=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2nsteam2=",
+				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=",
+				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
+				"MDEwOlJlcG9zaXRvcnkyNDQ1nsteam1=",
+				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
 			}
 			stableSortRepoID(wantRepoIDs)
 			stableSortRepoID(repoIDs.Exacts)
@@ -416,12 +416,12 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				}
 
 				wantRepoIDs := []extsvc.RepoID{
-					"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=", // from ListAffiliatedRepos
-					"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=", // from ListAffiliatedRepos
+					"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=", // from ListOrgRepositories
 					"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=", // from ListAffiliatedRepos
 					"MDEwOlJlcG9zaXRvcnkyNDI2NTadmin=", // from ListOrgRepositories
 					"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=", // from ListOrgRepositories
-					"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=", // from ListOrgRepositories
+					"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=", // from ListAffiliatedRepos
+					"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=", // from ListAffiliatedRepos
 				}
 				stableSortRepoID(wantRepoIDs)
 				stableSortRepoID(repoIDs.Exacts)
@@ -469,13 +469,13 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			p.groupsCache = memCache
 
 			wantRepoIDs := []extsvc.RepoID{
-				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
-				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
+				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTadmin=",
-				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=",
-				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2nsteam1=",
+				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=",
+				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
+				"MDEwOlJlcG9zaXRvcnkyNTI0MjU2NzE=",
 			}
 
 			stableSortRepoID(wantRepoIDs)

--- a/internal/authz/providers/github/github_test.go
+++ b/internal/authz/providers/github/github_test.go
@@ -42,7 +42,7 @@ func mockClientFunc(mockClient client) func() (client, error) {
 }
 
 func stableSortRepoID(v []extsvc.RepoID) {
-	slices.SortStableFunc(v, func(a, b extsvc.RepoID) int { return stdcmp.Compare(string(a), string(b)) })
+	slices.SortStableFunc(v, stdcmp.Less[extsvc.RepoID])
 }
 
 // newMockClientWithTokenMock is used to keep the behaviour of WithToken function mocking

--- a/internal/authz/providers/github/github_test.go
+++ b/internal/authz/providers/github/github_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	stdcmp "cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -39,6 +38,10 @@ func mockClientFunc(mockClient client) func() (client, error) {
 	return func() (client, error) {
 		return mockClient, nil
 	}
+}
+
+func stableSortRepoID(v []extsvc.RepoID) {
+	slices.SortStableFunc(v, func(a, b extsvc.RepoID) bool { return strings.Compare(string(a), string(b)) <= 1 })
 }
 
 // newMockClientWithTokenMock is used to keep the behaviour of WithToken function mocking
@@ -207,8 +210,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 			"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
 		}
 
-		slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
-		slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
+		stableSortRepoID(wantRepoIDs)
+		stableSortRepoID(repoIDs.Exacts)
 		if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 			t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 		}
@@ -257,8 +260,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
 			}
-			slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
-			slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
+			stableSortRepoID(wantRepoIDs)
+			stableSortRepoID(repoIDs.Exacts)
 			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 			}
@@ -293,8 +296,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=",
 			}
-			slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
-			slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
+			stableSortRepoID(wantRepoIDs)
+			stableSortRepoID(repoIDs.Exacts)
 			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 			}
@@ -366,8 +369,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				"MDEwOlJlcG9zaXRvcnkyNDQ1nsteam1=",
 				"MDEwOlJlcG9zaXRvcnkyNDI2nsteam2=",
 			}
-			slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
-			slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
+			stableSortRepoID(wantRepoIDs)
+			stableSortRepoID(repoIDs.Exacts)
 			if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 				t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 			}
@@ -420,8 +423,8 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 					"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1234=", // from ListOrgRepositories
 					"MDEwOlJlcG9zaXRvcnkyNDI2NTE5678=", // from ListOrgRepositories
 				}
-				slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
-				slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
+				stableSortRepoID(wantRepoIDs)
+				stableSortRepoID(repoIDs.Exacts)
 				if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 					t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 				}
@@ -475,7 +478,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 				"MDEwOlJlcG9zaXRvcnkyNDI2nsteam1=",
 			}
 
-			slices.SortStableFunc(wantRepoIDs, stdcmp.Less[extsvc.RepoID])
+			stableSortRepoID(wantRepoIDs)
 			// first call
 			t.Run("first call", func(t *testing.T) {
 				repoIDs, err := p.FetchUserPerms(context.Background(),
@@ -489,7 +492,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 					t.Fatalf("expected repos to be listed: callsToListOrgRepos=%d, callsToListTeamRepos=%d",
 						callsToListOrgRepos, callsToListTeamRepos)
 				}
-				slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
+				stableSortRepoID(repoIDs.Exacts)
 				if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 					t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 				}
@@ -510,7 +513,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 					t.Fatalf("expected repos not to be listed: callsToListOrgRepos=%d, callsToListTeamRepos=%d",
 						callsToListOrgRepos, callsToListTeamRepos)
 				}
-				slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
+				stableSortRepoID(repoIDs.Exacts)
 				if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 					t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 				}
@@ -531,7 +534,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 					t.Fatalf("expected repos to be listed: callsToListOrgRepos=%d, callsToListTeamRepos=%d",
 						callsToListOrgRepos, callsToListTeamRepos)
 				}
-				slices.SortStableFunc(repoIDs.Exacts, stdcmp.Less[extsvc.RepoID])
+				stableSortRepoID(repoIDs.Exacts)
 				if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 					t.Fatalf("RepoIDs mismatch (-want +got):\n%s", diff)
 				}


### PR DESCRIPTION
I've observed a few times but ultimately this is diffcult to catch in the act but here is one data point where the sorting order isn't stable like in this [build](https://buildkite.com/sourcegraph/sourcegraph/builds/249376#018b89e8-b855-4663-939a-dc8c39847dfb) for this [test](https://buildkiteartifacts.com/ce5a7366-33fc-414f-aff4-ac5542f2233f/1c544f6a-e12e-42d5-bfff-b3c95f10496d/018b89e6-f28c-44e7-9372-1e5289ef101a/018b89e8-b855-4663-939a-dc8c39847dfb/_bk_artefacts_2974006606/test.log?response-content-type=text%2Fplain&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7L3ZLZ2PFG%2F20231101%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231101T084636Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjENf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIC6ktEz1Ia0hxBZsrZ7jLGrlYMBPK%2Bo%2BUeGiyxDTfBuKAiEAz9ghdspDRGYJOX6azRWFsCkZO1%2FtpRrwAFEOPxE%2FYesq8QMIEBAAGgwwMzIzNzk3MDUzMDMiDCJcvTUSBTPvuy1SXirOA3tptmKUSeQ6ayrHc2ptQUM7zZ2nAZeE11%2FijqRLh7kostnNxCVcHOPaDDRjB%2FYh9hMucbNdYJO00Mg6lPE89N0LFpTEX2LMIFJJDdvpZEpWdKh4REGeB8B8MccrWwlhLEhx31SJPAPzX8pyn7owBA7wIkxl2iQYAcmQKc8Pd%2FF2nevloof038BRXzB9k3qXusifHVud5KIGCJFnI1jpxUI97FUXSt0dinj%2B8Qh1UDipSA%2BrRY%2BfC67wgjKL8%2B0ebdtBier%2B%2BbBtZN2lbtoDnyP1riH60mNXIEak0tK%2Bc0SyU40j%2FlV5%2BzGmkFDd7YmcjeA3YYkmNd80Cl9dkldGbivl9MlaA1FQ8PXrwwWWPCxHiHiaTQoLWWcsAz7rMac7HVWx0%2B%2F22HwYOZJi8KWmff8%2FDTMS4tLQ1KCjNWGTUY3XqSOCl9oyyBbURDXfLE7QQprtHA1ZIsfCdsR%2FdKdfBpteEvQhcbnuWf3etKFZas1aJfYYMpL7B6Jvn0IpFpl1db3NzVOJ88NojRYXwa98Q91J6o6pnTK4w8w8ZsOZXZIxf9S4VaTQZkY7M4EaR4SEWuU4wFGu%2Bk%2F3cEp0bbGia2u3hZN7uvsDN65pJP0ovDCw4YeqBjqlATr%2BQz3TUCFT1UJT4Sb3uL3GHe0SyLpUhMiGzLT1AqGut006p1wdx2PZqZIK5He9PZaTezL8q3on4iILVEKo7ZJqm5XAzUDCThuvNVMz9d0WHsbaGo0QYrBIOhL%2B2yBgcizmjgHbcj05QGUbJaeUjNpjvsV%2BCzV2F%2BVZ60QJ8mpwVZ7R9tTHsb8WXreRLO%2F6srJjzR%2BW4Yl%2Bf59nSp%2FfoZ%2BP2VwuAQ%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=5ba16af223f84dd2317470a97556c7cbc552bf290e1efd078ceaffb1d6b14efa)



## Test plan
CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
