### PR TITLE
gomod: update zoekt to 5.2 release branch

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6413,8 +6413,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:1Xa7GWtMdnatmIqzOsAhLigU+SttgXPvygKn0eMJZzc=",
-        version = "v0.0.0-20231017111049-f17ff0bac96a",
+        sum = "h1:zrClxAF4C5g8B3G9Ejs/R0un6uU6c0MHgI0YHwVnvJk=",
+        version = "v0.0.0-20231101131556-379ed5a0bb34",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -552,7 +552,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20231017111049-f17ff0bac96a
+	github.com/sourcegraph/zoekt v0.0.0-20231101131556-379ed5a0bb34
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2052,8 +2052,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20231017111049-f17ff0bac96a h1:1Xa7GWtMdnatmIqzOsAhLigU+SttgXPvygKn0eMJZzc=
-github.com/sourcegraph/zoekt v0.0.0-20231017111049-f17ff0bac96a/go.mod h1:gHfSe997J5w8zX5MGHFei/darZmml75Xvpoykwtknlo=
+github.com/sourcegraph/zoekt v0.0.0-20231101131556-379ed5a0bb34 h1:zrClxAF4C5g8B3G9Ejs/R0un6uU6c0MHgI0YHwVnvJk=
+github.com/sourcegraph/zoekt v0.0.0-20231101131556-379ed5a0bb34/go.mod h1:gHfSe997J5w8zX5MGHFei/darZmml75Xvpoykwtknlo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
We create a new release branch in zoekt called "sourcegraph-5.2". It is based off the version in the sourcegraph 5.2 release branch. We then cherry-picked 3 commits from main into it. This is to avoid the large number of changes we are making, but including the fixes we want.

https://github.com/sourcegraph/zoekt/compare/f17ff0bac96a...379ed5a0bb34

- https://github.com/sourcegraph/zoekt/commit/39e647cabf C-tags: use type def instead of type alias
- https://github.com/sourcegraph/zoekt/commit/ebf3aedaee Ranking: standardize ctags kind names before scoring
- https://github.com/sourcegraph/zoekt/commit/379ed5a0bb Debug: make indexing timeout configurable

This update was done by running "./dev/zoekt/update sourcegraph-5.2"

Note: we can't do a normal backport due to wanting to run a different version in main. This is the closest we get to backporting via cherry-picks in zoekt.

Test Plan: CI already run in zoekt, then this CI.
