### PR TITLE
remove duplicate option in streams API example

### DIFF
--- a/doc/api/stream_api/index.md
+++ b/doc/api/stream_api/index.md
@@ -24,7 +24,7 @@ curl --header "Accept: text/event-stream" \
      --get \
      --url "<Sourcegraph URL>/.api/search/stream" \
      --data-urlencode "q=<query>" \
-     [--data-urlencode "display=<display-limit>"]
+     ["display=<display-limit>"]
 ```
 
 | parameter | description |


### PR DESCRIPTION
`--data-urlencode` was listed twice in example.

## Test plan

Docs: see change in page


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@peterguy/docs-fix-stream-api-example)