### PR TITLE
cody-gateway/embeddings: record input_character_count

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
@@ -105,6 +105,12 @@ func NewHandler(
 							"resolved_status_code":                           resolvedStatusCode,
 							codygateway.EmbeddingsTokenUsageMetadataField:    usedTokens,
 							"batch_size": len(body.Input),
+							"input_character_count": func() (characters int) {
+								for _, input := range body.Input {
+									characters += len(input)
+								}
+								return characters
+							}(),
 						},
 					},
 				)


### PR DESCRIPTION
Records the raw character count of embeddings input, similar to how we record raw character counts for the completions handler.

## Test plan

n/a