### PR TITLE
Add back 'ui/assets/' to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,7 @@ internal/database/migration/shared/data/**/*.json
 cmd/xlang-python/python-langserver/
 package-lock.json
 package.json
+ui/assets/
 src-tauri/assets/
 src-tauri/target/
 vendor/


### PR DESCRIPTION
This line was removed in #57365 but it seems it causes `sg lint --fix format` to format all the generated JS and JSON files inside ui/assets/ and is thus rather slow. I believe this folder can be safely ignored.



## Test plan

👀 
