### PR TITLE
Fixup GitTree behavior after adding test suite

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -60,6 +60,7 @@ func TestGitTree_Entries(t *testing.T) {
 		case "folder/", "folder":
 			if recursive {
 				return []fs.FileInfo{
+					CreateFileInfo("folder/", true),
 					CreateFileInfo("folder/nestedfile", false),
 					CreateFileInfo("folder/subfolder/", true),
 					CreateFileInfo("folder/subfolder/deeplynestedfile", false),
@@ -76,6 +77,7 @@ func TestGitTree_Entries(t *testing.T) {
 		case ".aspect/", ".aspect":
 			if recursive {
 				return []fs.FileInfo{
+					CreateFileInfo(".aspect/", true),
 					CreateFileInfo(".aspect/rules/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
@@ -91,6 +93,8 @@ func TestGitTree_Entries(t *testing.T) {
 		case ".aspect/rules/", ".aspect/rules":
 			if recursive {
 				return []fs.FileInfo{
+					CreateFileInfo(".aspect/", true),
+					CreateFileInfo(".aspect/rules/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
 					CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
 				}, nil
@@ -99,24 +103,61 @@ func TestGitTree_Entries(t *testing.T) {
 				CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
 			}, nil
 		case ".aspect/rules/external_repository_action_cache/", ".aspect/rules/external_repository_action_cache":
+			if recursive {
+				return []fs.FileInfo{
+					CreateFileInfo(".aspect/", true),
+					CreateFileInfo(".aspect/rules/", true),
+					CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
+					CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
+				}, nil
+			}
 			return []fs.FileInfo{
 				CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
 			}, nil
 		case ".aspect/cli/", ".aspect/cli":
+			if recursive {
+				return []fs.FileInfo{
+					CreateFileInfo(".aspect/", true),
+					CreateFileInfo(".aspect/cli/", true),
+					CreateFileInfo(".aspect/cli/file1", false),
+					CreateFileInfo(".aspect/cli/file2", false),
+				}, nil
+			}
 			return []fs.FileInfo{
 				CreateFileInfo(".aspect/cli/file1", false),
 				CreateFileInfo(".aspect/cli/file2", false),
 			}, nil
 		case "folder/subfolder/", "folder/subfolder":
+			if recursive {
+				return []fs.FileInfo{
+					CreateFileInfo("folder/", true),
+					CreateFileInfo("folder/subfolder/", true),
+					CreateFileInfo("folder/subfolder/deeplynestedfile", false),
+				}, nil
+			}
 			return []fs.FileInfo{
 				CreateFileInfo("folder/subfolder/deeplynestedfile", false),
 			}, nil
 		case "folder/subfolder2/", "folder/subfolder2":
+			if recursive {
+				return []fs.FileInfo{
+					CreateFileInfo("folder/", true),
+					CreateFileInfo("folder/subfolder2/", true),
+					CreateFileInfo("folder/subfolder2/file", false),
+					CreateFileInfo("folder/subfolder2/file2", false),
+				}, nil
+			}
 			return []fs.FileInfo{
 				CreateFileInfo("folder/subfolder2/file", false),
 				CreateFileInfo("folder/subfolder2/file2", false),
 			}, nil
 		case "folder2/", "folder2":
+			if recursive {
+				return []fs.FileInfo{
+					CreateFileInfo("folder2/", true),
+					CreateFileInfo("folder2/file", false),
+				}, nil
+			}
 			return []fs.FileInfo{
 				CreateFileInfo("folder2/file", false),
 			}, nil
@@ -281,6 +322,19 @@ func TestGitTree_Entries(t *testing.T) {
 		assertEntries(t, []fs.FileInfo{
 			CreateFileInfo(".aspect/cli/", true),
 			CreateFileInfo(".aspect/rules/", true),
+		}, entries)
+
+		opts = GitTreeEntryResolverOpts{
+			Commit: &GitCommitResolver{
+				repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
+			},
+			Stat: CreateFileInfo(".aspect/rules/", true),
+		}
+		gitTree = NewGitTreeEntryResolver(db, gitserverClient, opts)
+
+		entries, err = gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{RecursiveSingleChild: true})
+		require.NoError(t, err)
+		assertEntries(t, []fs.FileInfo{
 			CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
 			CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
 		}, entries)
@@ -300,7 +354,6 @@ func TestGitTree_Entries(t *testing.T) {
 			CreateFileInfo("folder/", true),
 			CreateFileInfo("folder2/", true),
 			CreateFileInfo("file", false),
-			CreateFileInfo("folder2/file", false),
 		}, entries)
 	})
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5615,9 +5615,15 @@ type GitTree implements TreeEntry {
         """
         recursive: Boolean = false
         """
-        Recurse into sub-trees of single-child directories. If true, we return a flat list of
-        every directory that is a single child, and any directories or files that are
-        nested in a single child.
+        If recurseSingleChild is true, and the requested path only has a single child
+        that is a directory, recurse into that directory.
+        Only respected when recursive is false.
+        Example:
+        FS structure:
+        /folder/subfolder/file
+        Request for entries of /folder:
+        Instead of returning just /folder/subfolder, this API also travserse into subfolder
+        until it hits something with more than 1 child that's not a dir.
         """
         recursiveSingleChild: Boolean = false
         """


### PR DESCRIPTION
There were two issues with that PR that introduced the test suite:
- When switching recursive on, we accidentally added more entries than expected, because git would also output parents of the requested subtree to list.
- I misunderstood what recursiveSingleChild is supposed to do. As a result, the code is a bunch simpler.

Closes https://github.com/sourcegraph/sourcegraph/issues/57999 Closes https://github.com/sourcegraph/sourcegraph/issues/57936

## Test plan

Added tests for both of these cases.