### PR TITLE
squirrel: Do case-insensitive comparison of file extensions

### DIFF
--- a/cmd/symbols/squirrel/language-file-extensions.json
+++ b/cmd/symbols/squirrel/language-file-extensions.json
@@ -51,9 +51,7 @@
     "h++",
     "hh",
     "h",
-    "hpp",
-    "pc",
-    "pcc"
+    "hpp"
   ],
   "csharp": [
     "cs",

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -246,7 +246,10 @@ func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCo
 		ext = strings.TrimPrefix(filepath.Ext(repoCommitPath.Path), ".")
 	}
 
-	langName, ok := extToLang[ext]
+	// It is not uncommon to have files with upper-case extensions
+	// like .C, .H, .CPP etc., especially for code developed on
+	// case-insensitive filesystems.
+	langName, ok := extToLang[strings.ToLower(ext)]
 	if !ok {
 		return nil, unrecognizedFileExtensionError
 	}


### PR DESCRIPTION
While investigating https://github.com/sourcegraph/sourcegraph/issues/57974, I noticed
that the list of file extensions in the Squirrel code for C and C++ is partly wrong
and partly incomplete. So this PR fixes that. Specifically:

There are a bunch of uppercase extensions in use:
- `.C`, `.CC` and so on -- confirmed via Sourcegraph.com using a `count:all` query.
- The `.pc` and `.pcc` files are just wrong. `pc` is most common for pkg-config files,
  and `pcc` is for PCGen files.

~We don't add a general lower-casing step before comparing the extension as it is
not common in other languages to have uppercase file extensions.~

~However, we could do that, since the current list of extensions is all lower-case.~

Ideally, https://github.com/sourcegraph/sourcegraph/issues/56379 would've been
fixed already, and we'd just use that, instead of fixing these stupid issues as one-offs.

## Test plan

n/a