### PR TITLE
blob: Simplify/cleanup some extension usage

### DIFF
--- a/client/shared/src/components/CodeMirrorEditor.tsx
+++ b/client/shared/src/components/CodeMirrorEditor.tsx
@@ -164,15 +164,20 @@ export function replaceValue(view: EditorView, newValue: string): ChangeSpec | u
 /**
  * Helper hook for extensions that depend on on some input props.
  * With this hook the extension is isolated in a compartment so it can be
- * updated without reconfiguring the whole editor.
+ * updated without reconfiguring the whole editor. The return value is
+ * stable and should be included in the initial set of extensions.
+ * On rerender the hook will update the extension if it changed by
+ * dispatching an effect to editorRef.
  *
  * Use `useMemo` to compute the extension from some input:
  *
  * const extension = useCompartment(
- * editorRef,
- * useMemo(() => EditorView.darkTheme(isLightTheme === false), [isLightTheme])
+ *   editorRef,
+ *   useMemo(() => EditorView.darkTheme(isLightTheme === false), [isLightTheme])
  * )
  * const editor = useCodeMirror(..., ..., extension)
+ *
+ *
  * @param editorRef - Ref object to the editor instance
  * @param extension - the dynamic extension(s) to add to the editor
  * @returns a compartmentalized extension

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1305,6 +1305,7 @@ ts_project(
         "src/repo/blob/codemirror/blame-decorations.tsx",
         "src/repo/blob/codemirror/code-folding.tsx",
         "src/repo/blob/codemirror/document-highlights.ts",
+        "src/repo/blob/codemirror/eof.ts",
         "src/repo/blob/codemirror/highlight.ts",
         "src/repo/blob/codemirror/hovercard.tsx",
         "src/repo/blob/codemirror/index.ts",

--- a/client/web/src/repo/blob/codemirror/eof.ts
+++ b/client/web/src/repo/blob/codemirror/eof.ts
@@ -48,5 +48,5 @@ export const hideEmptyLastLine: Extension = [
             fontStyle: 'italic',
             marginTop: '.2rem',
         },
-    })
+    }),
 ]

--- a/client/web/src/repo/blob/codemirror/eof.ts
+++ b/client/web/src/repo/blob/codemirror/eof.ts
@@ -1,0 +1,52 @@
+import type { Extension } from '@codemirror/state'
+import { Decoration, EditorView, WidgetType } from '@codemirror/view'
+
+class NoLineBreakWidget extends WidgetType {
+    constructor(private noLineBreakComment: string) {
+        super()
+    }
+
+    public eq(other: NoLineBreakWidget): boolean {
+        return this.noLineBreakComment === other.noLineBreakComment
+    }
+
+    public toDOM(): HTMLElement {
+        const div = document.createElement('div')
+        div.className = 'no-line-break-msg'
+        div.textContent = this.noLineBreakComment
+        return div
+    }
+}
+
+// This decoration will replace/remove the last line break which
+// causes the last line to be hidden.
+const removeLastLineDeco = Decoration.replace({})
+const eofNoteDeco = Decoration.replace({
+    widget: new NoLineBreakWidget('(No new line at end of file)'),
+    block: true,
+})
+
+/**
+ * An extensions that hides the last (empty) line if the file ends with
+ * a line break, or shows a message that the line doesn't end with a line
+ * break.
+ */
+export const hideEmptyLastLine: Extension = [
+    EditorView.decorations.compute(['doc'], state => {
+        const lastLine = state.doc.line(state.doc.lines)
+        return Decoration.set(
+            lastLine.length === 0
+                ? // Subtract 1 to exclude newline character at end of line
+                  // when setting decoration range
+                  removeLastLineDeco.range(lastLine.from - 1, lastLine.to)
+                : eofNoteDeco.range(lastLine.to)
+        )
+    }),
+    EditorView.theme({
+        '.no-line-break-msg': {
+            color: 'var(--text-muted)',
+            fontStyle: 'italic',
+            marginTop: '.2rem',
+        },
+    })
+]

--- a/client/web/src/repo/blob/codemirror/links.ts
+++ b/client/web/src/repo/blob/codemirror/links.ts
@@ -1,4 +1,4 @@
-import { Facet, RangeSetBuilder } from '@codemirror/state'
+import { RangeSetBuilder } from '@codemirror/state'
 import {
     Decoration,
     type DecorationSet,
@@ -13,7 +13,6 @@ import { logger } from '@sourcegraph/common'
 import { SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
 
 import { getLinksFromString } from '../../linkifiy/get-links'
-import type { BlobInfo } from '../CodeMirrorBlob'
 
 import { syntaxHighlight } from './highlight'
 
@@ -145,8 +144,4 @@ class LinkBuilder implements PluginValue {
 /**
  * Transforms URLs within code comments and string literals into links.
  */
-export const buildLinks = Facet.define<BlobInfo>({
-    static: true,
-    compareInput: (blobInfoA, blobInfoB) => blobInfoA.lsif === blobInfoB.lsif,
-    enables: ViewPlugin.fromClass(LinkBuilder, { decorations: plugin => plugin.decorations }),
-})
+export const linkify = ViewPlugin.fromClass(LinkBuilder, { decorations: plugin => plugin.decorations })


### PR DESCRIPTION
- Move the end-of-file decoration extension into its own module
- Remove blobInfo dependency of `buildLinks` extension (renamed to `linkify`)
- Use `useCompartment` for blobProps and wrap settings to simplify component structure.
- Remove theme extension. We are using our own CSS rules for dark/light theme styling.



## Test plan

Manual testing:

- Last line is hidden when empty
- Links are clickable