### PR TITLE
bazel: fix depgard regexp typo

### DIFF
--- a/dev/ci/internal/ci/BUILD.bazel
+++ b/dev/ci/internal/ci/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//internal/lazyregexp",
         "//internal/oobmigration",
         "//lib/errors",
+        "@com_github_grafana_regexp//:regexp",
         "@com_github_masterminds_semver//:semver",
         "@com_github_sourcegraph_log//:log",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/grafana/regexp"
 	"github.com/sourcegraph/sourcegraph/dev/ci/images"
 	bk "github.com/sourcegraph/sourcegraph/dev/ci/internal/buildkite"
 	"github.com/sourcegraph/sourcegraph/dev/ci/internal/ci/operations"

--- a/dev/linters/depguard/depguard.go
+++ b/dev/linters/depguard/depguard.go
@@ -19,7 +19,7 @@ var Deny map[string]string = map[string]string{
 	"errors$":                             "Use github.com/sourcegraph/sourcegraph/lib/errors instead",
 	"github.com/cockroachdb/errors$":      "Use github.com/sourcegraph/sourcegraph/lib/errors instead",
 	"github.com/hashicorp/go-multierror$": "Use github.com/sourcegraph/sourcegraph/lib/errors instead",
-	"rexexp$":                             "Use github.com/grafana/regexp instead",
+	"regexp$":                             "Use github.com/grafana/regexp instead",
 	"github.com/hexops/autogold$":         "Use github.com/hexops/autogold/v2 instead",
 	"github.com/google/go-github/github$": "Use github.com/google/go-github/v55/github instead. To convert between v48 and v55, use the internal/extsvc/github/githubconvert package",
 }

--- a/dev/sg/ci/BUILD.bazel
+++ b/dev/sg/ci/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "@com_github_buildkite_go_buildkite_v3//buildkite",
         "@com_github_gen2brain_beeep//:beeep",
         "@com_github_google_uuid//:uuid",
+        "@com_github_grafana_regexp//:regexp",
         "@com_github_sourcegraph_run//:run",
         "@com_github_urfave_cli_v2//:cli",
     ],

--- a/dev/sg/ci/subcommands.go
+++ b/dev/sg/ci/subcommands.go
@@ -6,13 +6,13 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"github.com/google/uuid"
+	"github.com/grafana/regexp"
 	sgrun "github.com/sourcegraph/run"
 	"github.com/urfave/cli/v2"
 

--- a/dev/sg/internal/wolfi/BUILD.bazel
+++ b/dev/sg/internal/wolfi/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//dev/sg/root",
         "//lib/errors",
         "//lib/output",
+        "@com_github_grafana_regexp//:regexp",
         "@com_github_urfave_cli_v2//:cli",
     ],
 )

--- a/dev/sg/internal/wolfi/update_hashes.go
+++ b/dev/sg/internal/wolfi/update_hashes.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
+	"github.com/grafana/regexp"
 	"github.com/urfave/cli/v2"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"

--- a/dev/sg/sg_app.go
+++ b/dev/sg/sg_app.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -17,6 +16,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/google/go-github/v55/github"
+	"github.com/grafana/regexp"
 	"github.com/urfave/cli/v2"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"

--- a/internal/codycontext/BUILD.bazel
+++ b/internal/codycontext/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//internal/search/streaming",
         "//internal/types",
         "//lib/errors",
+        "@com_github_grafana_regexp//:regexp",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",

--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 
+	"github.com/grafana/regexp"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel/attribute"

--- a/internal/database/migration/drift/BUILD.bazel
+++ b/internal/database/migration/drift/BUILD.bazel
@@ -25,5 +25,6 @@ go_library(
         "//lib/errors",
         "//lib/output",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_grafana_regexp//:regexp",
     ],
 )

--- a/internal/database/migration/drift/util_search.go
+++ b/internal/database/migration/drift/util_search.go
@@ -2,8 +2,8 @@ package drift
 
 import (
 	"fmt"
+	"github.com/grafana/regexp"
 	"net/url"
-	"regexp"
 	"strings"
 )
 


### PR DESCRIPTION
I was randomly browsing this file and saw this mistake

## Test plan
CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
