### PR TITLE
gitserver: include stderr in output error message

### DIFF
--- a/internal/gitserver/git_command.go
+++ b/internal/gitserver/git_command.go
@@ -205,10 +205,20 @@ func (c *RemoteGitCommand) DividedOutput(ctx context.Context) ([]byte, []byte, e
 	return stdout, nil, nil
 }
 
-// Output runs the command and returns its standard output.
+// Output runs the command and returns its standard output. If the command
+// fails it usually returns CommandStatusError.
 func (c *RemoteGitCommand) Output(ctx context.Context) ([]byte, error) {
-	stdout, _, err := c.DividedOutput(ctx)
-	return stdout, err
+	// Note: we do not use DividedOutput because we don't want its behaviour
+	// where it throws away stderr in the error message. Stderr in error is
+	// useful to us because the client is not asking for it.
+
+	rc, err := c.sendExec(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	return io.ReadAll(rc)
 }
 
 // CombinedOutput runs the command and returns its combined standard output and standard error.


### PR DESCRIPTION
A long time ago in a galaxy far, far away we included stderr in the error messages returned from git. From reading our codepaths nearly everything goes via DividedOutput which throws the message away since CommandStatusError.Message is always set to a message like "exit status 128". This makes it really hard to understand why something isn't working.

A risk here is we intentionally got rid of stderr output due to security concerns? However, I think the more likely reason was accidental from when the whole RemoteGitCommand vs LocalGitCommand abstraction was introduced.

I noticed this when trying to debug why hybrid search was failing.

Test Plan: CI
