### PR TITLE
[Cody Web] temp redirect to new path

### DIFF
--- a/client/web/src/enterprise/routes.tsx
+++ b/client/web/src/enterprise/routes.tsx
@@ -1,4 +1,6 @@
-import { Navigate, type RouteObject } from 'react-router-dom'
+import { useEffect } from 'react'
+
+import { Navigate, type RouteObject, useNavigate } from 'react-router-dom'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -114,6 +116,25 @@ export const enterpriseRoutes: RouteObject[] = [
     {
         path: EnterprisePageRoutes.CodySearch,
         element: <LegacyRoute render={props => <CodySearchPage {...props} />} />,
+    },
+    // TODO: [TEMPORARY] remove this redirect route when the marketing page is added.
+    {
+        path: '/cody/*',
+        element: (
+            <LegacyRoute
+                render={() => {
+                    const chatID = window.location.pathname.split('/').pop()
+                    const navigate = useNavigate()
+
+                    useEffect(() => {
+                        navigate(`/cody/chat/${chatID}`)
+                    }, [navigate, chatID])
+
+                    return <div />
+                }}
+                condition={() => !window.location.pathname.startsWith('/cody/chat')}
+            />
+        ),
     },
     {
         path: EnterprisePageRoutes.Cody + '/*',

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -143,6 +143,10 @@ func InitRouter(db database.DB) {
 		{path: "/app/auth/callback", name: "app-auth-callback", title: "Auth callback", index: false},
 		{path: "/cody/chat", name: "cody", title: "Cody", index: false},
 		{path: "/cody/chat/{chatID}", name: "cody-chat", title: "Cody", index: false},
+		// TODO: [TEMPORARY] remove this redirect route when the marketing page is added.
+		{path: "/cody", name: "cody", title: "Cody", index: false},
+		// TODO: [TEMPORARY] remove this redirect route when the marketing page is added.
+		{path: "/cody/{chatID}", name: "cody-chat", title: "Cody", index: false},
 		{path: "/get-cody", name: "get-cody", title: "Cody", index: false},
 		{path: "/post-sign-up", name: "post-sign-up", title: "Cody", index: false},
 		{path: "/unlock-account/{token}", name: uirouter.RouteUnlockAccount, title: "Unlock Your Account", index: false},


### PR DESCRIPTION
Marketing is going to take over `/cody`. In the previous PR I moved Cody Web from `/cody` to `/cody/chat`.

In this PR I am adding a temp redirect from `/cody` to `/cody/chat` until marketing adds their landing page.


## Test plan
- visit `/cody` should redirect to `/cody/chat`
- visit `/cody/abc` should redirect to `/cody/chat/abc`
- visit `/cody/chat` should be rendered correctly