### PR TITLE
Update broken link in usage_statistics.md

### DIFF
--- a/doc/admin/usage_statistics.md
+++ b/doc/admin/usage_statistics.md
@@ -2,7 +2,7 @@
 
 > NOTE: With 3.42 we introduced an all new analytics experience for admins. More information can be found [here](./analytics.md).
 
-Sourcegraph records basic per-user usage statistics. To view analytics, visit the **Site admin > Usage stats** page. (The URL is `https://sourcegraph.example.com/site-admin/usage-statistics`.) This information is available via the GraphQL API to all viewers (not just site admins).
+Sourcegraph records basic per-user usage statistics. To view analytics, visit the **Site admin > Analytics > Users** page. (The URL is `https://sourcegraph.example.com/site-admin/analytics/users`.) This information is available via the GraphQL API to all viewers (not just site admins).
 
 Here you can see charts with counts of unique users by day, week, or months.
 


### PR DESCRIPTION
Updated a broken link (previously displayed a 404) for usage stats. 

Note the rest of this page might need an update as the first sentence regarding charts is true, but I cannot see user-level activity from that page.



## Test plan
Previewed locally