### PR TITLE
GraphQL: add history to TreeEntry

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -82,6 +82,7 @@ go_library(
         "git_revision.go",
         "git_tree.go",
         "git_tree_entry.go",
+        "git_tree_history.go",
         "git_tree_submodule.go",
         "githubapps.go",
         "gitserver.go",

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -223,9 +223,11 @@ func (r *GitCommitResolver) ExternalURLs(ctx context.Context) ([]*externallink.R
 	return externallink.Commit(ctx, r.db, repo, api.CommitID(r.oid))
 }
 
-func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {
+type TreeArgs struct {
 	Path string
-}) (*GitTreeEntryResolver, error) {
+}
+
+func (r *GitCommitResolver) Tree(ctx context.Context, args *TreeArgs) (*GitTreeEntryResolver, error) {
 	treeEntry, err := r.path(ctx, args.Path, func(stat fs.FileInfo) error {
 		if !stat.Mode().IsDir() {
 			return errors.Errorf("not a directory: %q", args.Path)

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -360,7 +360,7 @@ type AncestorsArgs struct {
 	Before      *string
 }
 
-func (r *GitCommitResolver) Ancestors(ctx context.Context, args *AncestorsArgs) (*gitCommitConnectionResolver, error) {
+func (r *GitCommitResolver) Ancestors(ctx context.Context, args *AncestorsArgs) *gitCommitConnectionResolver {
 	return &gitCommitConnectionResolver{
 		db:              r.db,
 		gitserverClient: r.gitserverClient,
@@ -373,7 +373,7 @@ func (r *GitCommitResolver) Ancestors(ctx context.Context, args *AncestorsArgs) 
 		afterCursor:     args.AfterCursor,
 		before:          args.Before,
 		repo:            r.repoResolver,
-	}, nil
+	}
 }
 
 func (r *GitCommitResolver) Diff(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/git_tree_history.go
+++ b/cmd/frontend/graphqlbackend/git_tree_history.go
@@ -16,8 +16,8 @@ type HistoryArgs struct {
 	// a way to get an updated filename for commits that traverse renames.
 }
 
-func (r *GitTreeEntryResolver) History(ctx context.Context, args HistoryArgs) *fileHistoryConnection {
-	return &fileHistoryConnection{
+func (r *GitTreeEntryResolver) History(ctx context.Context, args HistoryArgs) *treeEntryHistoryConnection {
+	return &treeEntryHistoryConnection{
 		stat: r.stat,
 		commits: r.commit.Ancestors(ctx, &AncestorsArgs{
 			ConnectionArgs: args.ConnectionArgs,
@@ -27,12 +27,12 @@ func (r *GitTreeEntryResolver) History(ctx context.Context, args HistoryArgs) *f
 	}
 }
 
-type fileHistoryConnection struct {
+type treeEntryHistoryConnection struct {
 	stat    fs.FileInfo
 	commits *gitCommitConnectionResolver
 }
 
-func (r *fileHistoryConnection) Nodes(ctx context.Context) ([]*GitTreeEntryResolver, error) {
+func (r *treeEntryHistoryConnection) Nodes(ctx context.Context) ([]*GitTreeEntryResolver, error) {
 	commits, err := r.commits.Nodes(ctx)
 	if err != nil {
 		return nil, err
@@ -48,10 +48,10 @@ func (r *fileHistoryConnection) Nodes(ctx context.Context) ([]*GitTreeEntryResol
 	return treeEntries, nil
 }
 
-func (r *fileHistoryConnection) TotalCount(ctx context.Context) (*int32, error) {
+func (r *treeEntryHistoryConnection) TotalCount(ctx context.Context) (*int32, error) {
 	return r.commits.TotalCount(ctx)
 }
 
-func (r *fileHistoryConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+func (r *treeEntryHistoryConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
 	return r.commits.PageInfo(ctx)
 }

--- a/cmd/frontend/graphqlbackend/git_tree_history.go
+++ b/cmd/frontend/graphqlbackend/git_tree_history.go
@@ -1,0 +1,57 @@
+package graphqlbackend
+
+import (
+	"context"
+	"io/fs"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+type HistoryArgs struct {
+	graphqlutil.ConnectionArgs
+	After *string
+
+	// TODO(@camdencheek): implement follow. Right now, we wouldn't have
+	// a way to get an updated filename for commits that traverse renames.
+}
+
+func (r *GitTreeEntryResolver) History(ctx context.Context, args HistoryArgs) *fileHistoryConnection {
+	return &fileHistoryConnection{
+		stat: r.stat,
+		commits: r.commit.Ancestors(ctx, &AncestorsArgs{
+			ConnectionArgs: args.ConnectionArgs,
+			AfterCursor:    args.After,
+			Path:           pointers.Ptr(r.Path()),
+		}),
+	}
+}
+
+type fileHistoryConnection struct {
+	stat    fs.FileInfo
+	commits *gitCommitConnectionResolver
+}
+
+func (r *fileHistoryConnection) Nodes(ctx context.Context) ([]*GitTreeEntryResolver, error) {
+	commits, err := r.commits.Nodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	treeEntries := make([]*GitTreeEntryResolver, len(commits))
+	for i, commit := range commits {
+		treeEntries[i] = NewGitTreeEntryResolver(commit.db, commit.gitserverClient, GitTreeEntryResolverOpts{
+			Commit: commit,
+			Stat:   r.stat,
+		})
+	}
+	return treeEntries, nil
+}
+
+func (r *fileHistoryConnection) TotalCount(ctx context.Context) (*int32, error) {
+	return r.commits.TotalCount(ctx)
+}
+
+func (r *fileHistoryConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	return r.commits.PageInfo(ctx)
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5528,7 +5528,30 @@ interface TreeEntry {
     """
     The revision history for this file or directory.
     """
-    history(first: Int, after: String): [TreeEntry!]!
+    history(first: Int, after: String): TreeEntryConnection!
+    """
+    The Git commit containing this tree entry.
+    """
+    commit: GitCommit!
+}
+
+"""
+A list of TreeEntry
+"""
+type TreeEntryConnection {
+    """
+    A list of TreeEntry.
+    """
+    nodes: [TreeEntry!]!
+    """
+    The total count of TreeEntry in the connection. This total count may be larger
+    than the number of nodes in this object when the result is paginated.
+    """
+    totalCount: Int
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
 }
 
 """
@@ -5654,6 +5677,10 @@ type GitTree implements TreeEntry {
     Whether this tree entry is a single child
     """
     isSingleChild: Boolean!
+    """
+    The revision history for this file or directory.
+    """
+    history(first: Int, after: String): TreeEntryConnection!
 }
 
 """
@@ -6065,6 +6092,10 @@ type GitBlob implements TreeEntry & File2 {
     LFS is set if the GitBlob is a pointer to a file stored in LFS.
     """
     lfs: LFS
+    """
+    The revision history for this file
+    """
+    history(first: Int, after: String): TreeEntryConnection!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5530,7 +5530,8 @@ interface TreeEntry {
     """
     history(first: Int, after: String): TreeEntryConnection!
     """
-    The Git commit containing this tree entry.
+    The Git commit containing this tree entry was reached through.
+    Note that a tree entry can exist in multiple commits.
     """
     commit: GitCommit!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5525,6 +5525,10 @@ interface TreeEntry {
     Whether this tree entry is a single child
     """
     isSingleChild: Boolean!
+    """
+    The revision history for this file or directory.
+    """
+    history(first: Int, after: String): [TreeEntry!]!
 }
 
 """

--- a/cmd/gitserver/internal/integration_tests/archivereader_test.go
+++ b/cmd/gitserver/internal/integration_tests/archivereader_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestClient_ArchiveReader(t *testing.T) {
-	root := gitserver.CreateRepoDir(t)
+	root := t.TempDir()
 
 	type test struct {
 		name string

--- a/cmd/gitserver/internal/integration_tests/archivereader_test.go
+++ b/cmd/gitserver/internal/integration_tests/archivereader_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestClient_ArchiveReader(t *testing.T) {
-	root := t.TempDir()
+	root := gitserver.CreateRepoDir(t)
 
 	type test struct {
 		name string


### PR DESCRIPTION
This adds a new `history` method to the `TreeEntry` GraphQL object. It returns the history of that entry as a set of `TreeEntry` nodes. This is to suport #57827. Previously, fetching the history would take a separate GraphQL request entry.

A sticky design choice was whether to make `history` return a connection of `TreeEntry` or `Commit` objects. I think that the choice to return `TreeEntry` is slightly more correct even though it requires another layer of querying to get to the underlying commit for two reasons:
1) If we just return the commits that modified the tree, if we wanted to fetch the content at the historical revision (say, to fetch a diff), we'd have to make a followup query for the path at the returned commit instead of just adding a field to the first query.
2) It makes it theoretically possible to follow renames. We don't do that right now because it wouldn't be super easy to implement, but if we returned commits that modified the path and followed renames, when we did a followup query to fetch the content at one of the historical commits, it might fail because the path doesn't exist (it was renamed). The returned tree entry naturally contains the path name, so we could return the changed path name along with the history entry.

Example query:

```graphql
query GetTreeHistory {
  repository(name: "github.com/sourcegraph/sourcegraph") {
    id
    name
    commit(rev: "HEAD") {
      tree {
        entries {
          history(first: 1) {
            nodes {
              commit {
                message
                author{
                  date
                }
              }
            }
          }
        }
      }
    }
  }
}
```

## Test plan

Add a functional test for the resolver. Manually checked the output of the GraphQL query. 
