### PR TITLE
Auto-update Wolfi base images to latest

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -41,31 +41,31 @@ def oci_deps():
     """
     oci_pull(
         name = "wolfi_base",
-        digest = "sha256:818eb895261404efd4952f11faa70e8530079f7b9ff9225aca74b343f49e3918",
+        digest = "sha256:ddac091c8c7aa8672c3ad097fc0df016f5cf86a2e5e5e915a5e6f0327b2cc48e",
         image = "index.docker.io/sourcegraph/wolfi-sourcegraph-base",
     )
 
     oci_pull(
         name = "wolfi_cadvisor_base",
-        digest = "sha256:930e29cf754a780e9948b9da793de99ec9ae94513ea80d917c6a67ac979fc855",
+        digest = "sha256:d20378947f0b7df72ee6166a70ccf3839c7547dfe918a02f920ee5d4cb031f62",
         image = "index.docker.io/sourcegraph/wolfi-cadvisor-base",
     )
 
     oci_pull(
         name = "wolfi_symbols_base",
-        digest = "sha256:d82045bda06fc745f3a0bcc20507912f530f5d48fbb16f23d88cdfebcd7b324d",
+        digest = "sha256:d699c86891e976b68a7e4611951a90400805db552e222750e04cf3f846e09a2a",
         image = "index.docker.io/sourcegraph/wolfi-symbols-base",
     )
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:269ddcfff8b268af2a348c25f4bf15d07951281fabff347a7c92bf3bb09cf65f",
+        digest = "sha256:c842da00bc3a7056c49902406f9996e4ef874066f80f06c502beb4dc716792cf",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:b5dd7bfde3df1bc8b4f5a9134bf509f4facc172d721fd3d24ced22e28ada956d",
+        digest = "sha256:a16a784a3147b768042b5496a08da429b01a5c81442d2f744216e6ee63c0a6e5",
         image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
     )
 
@@ -77,133 +77,133 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_postgres_exporter_base",
-        digest = "sha256:c5b1536f1dbb378b9f1da1f0b03ba3cff784965372c21943c902276f0b67dcb7",
+        digest = "sha256:109a393c6bc3e5db15413ddb913890fdd26f0531a225ff12aedf5021f57c5bd0",
         image = "index.docker.io/sourcegraph/wolfi-postgres-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_all_in_one_base",
-        digest = "sha256:c5546f349b20c02ebd7428a11e2a6e7a9ae6f89564327a64e1544a0dfbe8915c",
+        digest = "sha256:0be08d4aa088c945f1cbdf6d69a618d3b803786e21d540d24d0ca6a2f7a9a044",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-all-in-one-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_agent_base",
-        digest = "sha256:d2e7110fb2deef97562bc472e6eab126e885f0229ad8162d7a96b2e05b74ca1d",
+        digest = "sha256:7486c7418c6905f84cc95b2bb58ab3fa0779033d5da3045217ecf96c211bed7d",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-agent-base",
     )
 
     oci_pull(
         name = "wolfi_redis_base",
-        digest = "sha256:c2ff8b3e0f21b5698c2a693741a5bdccaf0198908093eba348c9e21edbe1f630",
+        digest = "sha256:8ecedf267d9d017f7defe0ce9de7596b6e0f8d3dc434e4e54069d07a7f1d6f2f",
         image = "index.docker.io/sourcegraph/wolfi-redis-base",
     )
 
     oci_pull(
         name = "wolfi_redis_exporter_base",
-        digest = "sha256:5abd3fd25651b5af3c30d25f33215a7e7d2c4108b6e28b0e6380879d831df68f",
+        digest = "sha256:b60ee6c59823598a4bf6ff9e97a887947cb7b1a925d67f30e0448adcd540743b",
         image = "index.docker.io/sourcegraph/wolfi-redis-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_syntax_highlighter_base",
-        digest = "sha256:f9cc9923f84989639b3d03ef3f8120deb9c2d3cc6d1e8bfc703fa9a5327b4612",
+        digest = "sha256:874544e9e2ac04ac3e7004437b55882b96e4f9b444f81d359afb89361c01c8a9",
         image = "index.docker.io/sourcegraph/wolfi-syntax-highlighter-base",
     )
 
     oci_pull(
         name = "wolfi_search_indexer_base",
-        digest = "sha256:782e33b097b9f68ade8e613c21cc1531a8fc01208c021fe307b05cbdf6dca761",
+        digest = "sha256:26c41915424166a79b4e622d2b804ef28409df9d10123b05722467911e15550b",
         image = "index.docker.io/sourcegraph/wolfi-search-indexer-base",
     )
 
     oci_pull(
         name = "wolfi_repo_updater_base",
-        digest = "sha256:5596447f4c22b5b305016f0fb095e3fc28700d364a660a635f03b14feeda5c03",
+        digest = "sha256:69890df98e79031d3cb8bdb1b91d25eec585d987d9c3a77b7b2034f5f233107b",
         image = "index.docker.io/sourcegraph/wolfi-repo-updater-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:8ae66efec501aca7d6bc66a2b3a19775e2cd2b8db0e4e8c077bca9c764d55673",
+        digest = "sha256:b4a4b8a0afe40c514b62ab7e9f0e4b499f193e0ea7d22dc3b702b34ad2781799",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_executor_base",
-        digest = "sha256:8f6728cadb10d37df4f8da1eecf59b93625977c974ff3d6e4747763eaa734cd5",
+        digest = "sha256:82b3d39633915ddff0ba45a9c04eb627e10d0b2e698ede36386240faa91c5a29",
         image = "index.docker.io/sourcegraph/wolfi-executor-base",
     )
 
     # ???
     oci_pull(
         name = "wolfi_bundled_executor_base",
-        digest = "sha256:aa2816aedaf4964ed9263960bcbe62f5ce6c626e626d351d2073c281c61c4bad",
+        digest = "sha256:414df1099deb034bd46aa10432a2571fa342b129a3e59fde20c2bd63e84c4ca2",
         image = "index.docker.io/sourcegraph/wolfi-bundled-executor-base",
     )
 
     oci_pull(
         name = "wolfi_executor_kubernetes_base",
-        digest = "sha256:183442440539edc342eb7a136b4be35cb43ff819eb1b88e21e7db4ac5a6b373e",
+        digest = "sha256:ceb89c7b756b0134a8d512be72276e7d536921fb2619117059970c5d252389fd",
         image = "index.docker.io/sourcegraph/wolfi-executor-kubernetes-base",
     )
 
     oci_pull(
         name = "wolfi_batcheshelper_base",
-        digest = "sha256:a290fbe16018386fa96666f828cc983533cf6760030104e698a254fff5430519",
+        digest = "sha256:bc26a76ce432e2d2263024d7e285ef9a28801fba0e23f2c1f71d56d6a30bc2a6",
         image = "index.docker.io/sourcegraph/wolfi-batcheshelper-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_base",
-        digest = "sha256:845a876fcbe7609cfa999517996bd7c1974c403f4cad81ff6e1e0c2a8cf2263c",
+        digest = "sha256:75ea7711988255d037e6d6239d915d1d2594452fc343b0b98bfec014c6b6fa9a",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_gcp_base",
-        digest = "sha256:9e02d2c560539ae860bf08ec18748559cb78e11c71ba7342cf4c8816ce1604d8",
+        digest = "sha256:be32b3432ab03a153461bee8c604b23413cf28c978556c30a483f8630f491b82",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-gcp-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12_base",
-        digest = "sha256:24dc2c4153f12aea87d6abc085fd32c83c864ce04c95553b0cb402811e0ef517",
+        digest = "sha256:94cc57d7d62443784dc113ca6fdf072f4b3e58ec3636779b59dc9f96e238d56a",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12-codeinsights_base",
-        digest = "sha256:81007215d3808d69658e4bf2305599c27fdffc5df9df1d0e3091f4ca062a2abb",
+        digest = "sha256:4915ea39e5ab816f935f85cb7e2ace2824d4aade17525f8d9d2863f27f8f27e7",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-codeinsights-base",
     )
 
     oci_pull(
         name = "wolfi_node_exporter_base",
-        digest = "sha256:15d2aa75d3c0d27de62109ea6245f1a7a0a9abf9bf0a97b19ed545b3ab911624",
+        digest = "sha256:a0615019fe6961519c994cfe0de2b595571f9b79a3e60a58b9d452279bcee79a",
         image = "index.docker.io/sourcegraph/wolfi-node-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_opentelemetry_collector_base",
-        digest = "sha256:fb77c37fe80a7e23796a5f0b54478dd075fb7ebf82a58a145d48aad0b03c2618",
+        digest = "sha256:d23cae6f2fe2db4c229c3db5dcbee25dac95de8b6d8c857d409fbc7c797f660d",
         image = "index.docker.io/sourcegraph/wolfi-opentelemetry-collector-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:8ae66efec501aca7d6bc66a2b3a19775e2cd2b8db0e4e8c077bca9c764d55673",
+        digest = "sha256:b4a4b8a0afe40c514b62ab7e9f0e4b499f193e0ea7d22dc3b702b34ad2781799",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_s3proxy_base",
-        digest = "sha256:41fe629da39e876f54902b072470ee379fcf5c3bf7340fc3ae6d294959f0b5bf",
+        digest = "sha256:afec08789b60252c51163227e416a40deec5f34bce7b5db43b3f0647f7691ba5",
         image = "index.docker.io/sourcegraph/wolfi-blobstore-base",
     )
 
     oci_pull(
         name = "wolfi_qdrant_base",
-        digest = "sha256:c6d5509a1bfee07ae27d45347ff36a4cb0c14b23c7d597e161385c34b9742490",
+        digest = "sha256:1d9cb0e1eef19467bc7b42ef36f40571eb37abb5f6eeb04742717cc837050ae0",
         image = "index.docker.io/sourcegraph/wolfi-qdrant-base",
     )


### PR DESCRIPTION
Automatically generated PR to update Wolfi base images to the latest hashes.

Built from Buildkite run [#250770](https://buildkite.com/sourcegraph/sourcegraph/builds/250770).
## Test Plan
- CI build verifies image functionality
- [ ] Confirm PR should be backported to release branch