### PR TITLE
[Backport 5.2] fix: Check for known Squirrel errors inside GraphQL responses (#58030)

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -1,6 +1,8 @@
 import { once } from 'lodash'
 import gql from 'tagged-template-noop'
 
+import { isErrorLike } from '@sourcegraph/common'
+
 import { searchContext } from '../../searchContext'
 import type * as sourcegraph from '../api'
 import { cache } from '../util'
@@ -54,6 +56,14 @@ export interface RepoMeta {
     name: string
     isFork: boolean
     isArchived: boolean
+}
+
+function isKnownSquirrelErrorLike(value: unknown): boolean {
+    return (
+        isErrorLike(value) &&
+        'message' in value &&
+        (value.message.includes('unrecognized file extension') || value.message.includes('unsupported language'))
+    )
 }
 
 export class API {
@@ -227,7 +237,16 @@ export class API {
     public fetchLocalCodeIntelPayload = cache(
         async ({ repo, commit, path }: RepoCommitPath): Promise<LocalCodeIntelPayload | undefined> => {
             const vars = { repository: repo, commit, path }
-            const response = await queryGraphQL<LocalCodeIntelResponse>(localCodeIntelQuery, vars)
+            const response = await (async (): Promise<LocalCodeIntelResponse> => {
+                try {
+                    return await queryGraphQL<LocalCodeIntelResponse>(localCodeIntelQuery, vars)
+                } catch (error) {
+                    if (isKnownSquirrelErrorLike(error)) {
+                        return { repository: null }
+                    }
+                    throw error
+                }
+            })()
 
             const payloadString = response?.repository?.commit?.blob?.localCodeIntel
             if (!payloadString) {
@@ -284,7 +303,16 @@ export class API {
         const { repo, commit, path } = parseGitURI(new URL(document.uri))
 
         const vars = { repository: repo, commit, path, line: position.line, character: position.character }
-        const response = await queryGraphQL<SymbolInfoResponse>(query, vars)
+        const response = await (async (): Promise<SymbolInfoResponse> => {
+            try {
+                return await queryGraphQL<SymbolInfoResponse>(query, vars)
+            } catch (error) {
+                if (isKnownSquirrelErrorLike(error)) {
+                    return { repository: null }
+                }
+                throw error
+            }
+        })()
 
         const symbolInfoFlexible = response?.repository?.commit?.blob?.symbolInfo ?? undefined
         if (!symbolInfoFlexible) {

--- a/cmd/symbols/squirrel/http_handlers.go
+++ b/cmd/symbols/squirrel/http_handlers.go
@@ -56,7 +56,7 @@ func LocalCodeIntelHandler(readFile readFileFunc) func(w http.ResponseWriter, r 
 			_ = json.NewEncoder(w).Encode(nil)
 
 			// Log the error if it's not an unrecognized file extension or unsupported language error.
-			if !errors.Is(err, unrecognizedFileExtensionError) && !errors.Is(err, UnsupportedLanguageError) {
+			if !errors.Is(err, UnrecognizedFileExtensionError) && !errors.Is(err, UnsupportedLanguageError) {
 				log15.Error("failed to generate local code intel payload", "err", err)
 			}
 

--- a/cmd/symbols/squirrel/util.go
+++ b/cmd/symbols/squirrel/util.go
@@ -236,7 +236,9 @@ func swapNodePtr(other Node, newNode *sitter.Node) *Node {
 	return &ret
 }
 
-var unrecognizedFileExtensionError = errors.New("unrecognized file extension")
+// CAUTION: These error messages are checked by client-side code,
+// so make sure to update clients if changing them.
+var UnrecognizedFileExtensionError = errors.New("unrecognized file extension")
 var UnsupportedLanguageError = errors.New("unsupported language")
 
 // Parses a file and returns info about it.
@@ -251,7 +253,7 @@ func (s *SquirrelService) parse(ctx context.Context, repoCommitPath types.RepoCo
 	// case-insensitive filesystems.
 	langName, ok := extToLang[strings.ToLower(ext)]
 	if !ok {
-		return nil, unrecognizedFileExtensionError
+		return nil, UnrecognizedFileExtensionError
 	}
 
 	langSpec, ok := langToLangSpec[langName]
@@ -412,7 +414,7 @@ func (s *SquirrelService) symbolSearchOne(ctx context.Context, repo string, comm
 		Commit: commit,
 		Path:   symbol.Path,
 	})
-	if errors.Is(err, UnsupportedLanguageError) || errors.Is(err, unrecognizedFileExtensionError) {
+	if errors.Is(err, UnsupportedLanguageError) || errors.Is(err, UnrecognizedFileExtensionError) {
 		return nil, nil
 	}
 	if err != nil {


### PR DESCRIPTION
Cherry-pick #58030 to release branch.

Fixes https://github.com/sourcegraph/sourcegraph/issues/57974

## Test plan

Same as #58030