### PR TITLE
syntax-highlighter: update scip to version 0.3.2

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "288db33db039b863e97c43a6dc03bbb6fe334ab97e11d52e00b63dd3e6c17487",
+  "checksum": "e8670a8d1bf3edf6c13fc81ee2c1695bbae724f4187e852b2c1feb848b4d13e3",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -10125,13 +10125,13 @@
       },
       "license": "Unlicense/MIT"
     },
-    "scip 0.3.1": {
+    "scip 0.3.2": {
       "name": "scip",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/scip/0.3.1/download",
-          "sha256": "3e84d21062a3ba08d58870c8c36b0c005b2b2261c6ad1bf7042585427c781883"
+          "url": "https://crates.io/api/v1/crates/scip/0.3.2/download",
+          "sha256": "05ba59776110d1ff814521aaf9c688f82361292c830f208aa3476d5b1e248713"
         }
       },
       "targets": [
@@ -10160,7 +10160,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.1"
+        "version": "0.3.2"
       },
       "license": "Apache-2.0"
     },
@@ -10261,7 +10261,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "scip 0.3.1",
+              "id": "scip 0.3.2",
               "target": "scip"
             },
             {
@@ -10319,7 +10319,7 @@
               "target": "protobuf"
             },
             {
-              "id": "scip 0.3.1",
+              "id": "scip 0.3.2",
               "target": "scip"
             },
             {
@@ -10379,7 +10379,7 @@
               "target": "protobuf"
             },
             {
-              "id": "scip 0.3.1",
+              "id": "scip 0.3.2",
               "target": "scip"
             }
           ],
@@ -10426,7 +10426,7 @@
               "target": "lazy_static"
             },
             {
-              "id": "scip 0.3.1",
+              "id": "scip 0.3.2",
               "target": "scip"
             },
             {
@@ -10904,7 +10904,7 @@
               "target": "rocket"
             },
             {
-              "id": "scip 0.3.1",
+              "id": "scip 0.3.2",
               "target": "scip"
             },
             {
@@ -11771,7 +11771,7 @@
               "target": "rustyline"
             },
             {
-              "id": "scip 0.3.1",
+              "id": "scip 0.3.2",
               "target": "scip"
             },
             {

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -1837,9 +1837,9 @@ dependencies = [
 
 [[package]]
 name = "scip"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e84d21062a3ba08d58870c8c36b0c005b2b2261c6ad1bf7042585427c781883"
+checksum = "05ba59776110d1ff814521aaf9c688f82361292c830f208aa3476d5b1e248713"
 dependencies = [
  "protobuf",
 ]

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -63,8 +63,7 @@ syntect = { git = "https://github.com/sourcegraph/syntect", rev = "7e02c5b4085e6
 tree-sitter = "0.20.9"
 tree-sitter-highlight = "0.20.1"
 
-# Since there is no version tag, we pin the dependency to a specific revision
-scip = "0.3.1"
+scip = "0.3.2"
 protobuf = "3"
 
 


### PR DESCRIPTION
This pulls in https://github.com/sourcegraph/scip/pull/217 which I need for https://github.com/sourcegraph/sourcegraph/pull/58082 but I wanted to keep that one focused on the change.


## Test plan

- N/A
