### PR TITLE
Search blitz: increase poll interval to 5m

### DIFF
--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -54,7 +54,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, env string) {
 
 	loopSearch := func(ctx context.Context, c genericClient, qc *QueryConfig) {
 		if qc.Interval == 0 {
-			qc.Interval = time.Minute
+			qc.Interval = 5 * time.Minute
 		}
 
 		log := log15.New("name", qc.Name, "query", qc.Query, "type", c.clientType())


### PR DESCRIPTION
This increases the poll interval of Search Blitz from 1m to 5m. We are currently running about 80 queries per minute, which is a non-insignificant amount of load on sourcegraph.com. This should cut down the load significantly while keeping a decent granularity for our charts.

[Slack thread](https://sourcegraph.slack.com/archives/C05EA9KQUTA/p1698962313071229)

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
