### PR TITLE
Code Navigation: Commit expand clean up

### DIFF
--- a/client/web/src/repo/commits/GitCommitNode.module.scss
+++ b/client/web/src/repo/commits/GitCommitNode.module.scss
@@ -74,6 +74,17 @@
         font-size: 1.5rem;
     }
 }
+.commit-message {
+    display: flex;
+    flex: column wrap;
+    align-items: left;
+    word-wrap: break-word;
+}
+
+.spacer {
+    width: 6.25rem;
+    justify-self: end;
+}
 
 .message {
     display: flex;
@@ -119,13 +130,14 @@
     }
 
     &-body {
+        font-size: 0.75rem;
+        color: var(--text-muted);
         margin-top: 0.5rem;
         margin-bottom: 1.5rem;
-        font-size: 0.75rem;
         overflow: visible;
-        max-width: 100%;
-        word-wrap: break-word;
+        max-width: 85%;
         white-space: pre-wrap;
+        padding-left: 0.34375rem;
     }
 }
 
@@ -186,7 +198,6 @@
     align-items: center;
     justify-content: space-between;
     flex-wrap: nowrap;
-
     color: var(--list-group-color);
     text-decoration: var(--list-group-text-decoration);
     background-color: var(--list-group-bg);

--- a/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeTableRow.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react'
 
-import { mdiDotsHorizontal } from '@mdi/js'
+import { mdiChevronUp, mdiChevronDown } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
@@ -57,7 +57,7 @@ export const GitCommitNodeTableRow: React.FC<
                     size="sm"
                     aria-label={showCommitMessageBody ? 'Hide commit message body' : 'Show commit message body'}
                 >
-                    <Icon aria-hidden={true} svgPath={mdiDotsHorizontal} />
+                    <Icon aria-hidden={true} svgPath={showCommitMessageBody ? mdiChevronUp : mdiChevronDown} />
                 </Button>
             )}
 
@@ -69,12 +69,14 @@ export const GitCommitNodeTableRow: React.FC<
 
     const commitMessageBody =
         expandCommitMessageBody || showCommitMessageBody ? (
-            <tr className={classNames(styles.tableRow, className)}>
-                <td colSpan={3}>
-                    <pre className={styles.messageBody}>
+            <tr className={classNames(styles.commitMessage, className)}>
+                <td className={classNames(styles.colByline)} />
+                <td>
+                    <div className={`${styles.messageBody} flex-1`}>
                         {node.body && <Linkified input={node.body} externalURLs={node.externalURLs} />}
-                    </pre>
+                    </div>
                 </td>
+                <td className={classNames(styles.spacer)} />
             </tr>
         ) : undefined
 


### PR DESCRIPTION
This improves the UI when expanding commit messages by replacing the expand button with a toggleable caret icon. It cleans up the expanded view by adding padding and other styles.

Before: 
https://github.com/sourcegraph/sourcegraph/assets/62355966/00635e6a-66fe-4f2b-973a-5f51fb090163

After: 
https://github.com/sourcegraph/sourcegraph/assets/62355966/12c65d05-bf63-421c-8378-ababc11c97b3

## Test plan
Manual testing on small, medium and large instances