### PR TITLE
Svelte: remove `extends` directive for a file that doesn't exist

### DIFF
--- a/client/web-sveltekit/tsconfig.json
+++ b/client/web-sveltekit/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
The svelte `tsconfig.json` file references another `tsconfig` that doesn't exist. This causes my editor to complain. I don't think this is specific to my environment because there is no `.gitignore` entry that would cause that file to be ignored. 

## Test plan

My editor no longer complains. 
