### PR TITLE
codehost tests: improve error description

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/codeHost.test.ts
@@ -185,7 +185,7 @@ describe('isPrivateRepository', () => {
         })
 
         it('returns [private=true] on unsuccessful request', async () => {
-            fetch.mockRejectOnce(new Error('Error happened'))
+            fetch.mockRejectOnce(new Error('fake error happened for unsuccessful request'))
 
             expect(await isPrivateRepository('test-org/test-repo', fetchCache)).toBeTruthy()
             expect(fetch).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Giving a little more context where this test fails with a fake error. Instead of
![Screenshot 2023-11-06 at 11 27 01](https://github.com/sourcegraph/sourcegraph/assets/1001709/bcfe53e0-04f0-4474-9af7-c37236238554)

## Test plan
CI

