### PR TITLE
sec: Define GraphQL cost limits

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -633,6 +633,7 @@ func NewSchema(
 	opts := []graphql.SchemaOpt{
 		graphql.Tracer(newRequestTracer(log.Scoped("GraphQL"), db)),
 		graphql.UseStringDescriptions(),
+		graphql.MaxDepth(maxDepth),
 	}
 	opts = append(opts, graphqlOpts...)
 	return graphql.ParseSchema(

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -22,9 +22,14 @@ import (
 // the algorithm
 const costEstimateVersion = 2
 
+const MaxAliasCount = 500        // SECURITY: prevent too many aliased queries
+const MaxFieldCount = 500 * 1000 // SECURITY: prevent deeply nested or overly broad queries
+const maxDepth = 30              // SECURITY: prevent deep queries that consume too many resources
+
 type QueryCost struct {
 	FieldCount int
 	MaxDepth   int
+	AliasCount int
 	Version    int
 }
 
@@ -126,6 +131,7 @@ func EstimateQueryCost(query string, variables map[string]any) (totalCost *Query
 			return nil, errors.Wrap(err, "calculating operation cost")
 		}
 		totalCost.FieldCount += cost.FieldCount
+		totalCost.AliasCount += cost.AliasCount
 		if totalCost.MaxDepth < cost.MaxDepth {
 			totalCost.MaxDepth = cost.MaxDepth
 		}
@@ -158,6 +164,7 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 	limitStack := make([]int, 0)
 	currentLimit := 1
 
+	aliasCount := 0
 	fieldCount := 0
 	depth := 0
 	maxDepth := 0
@@ -191,6 +198,9 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 				}
 				pushLimit()
 			case *ast.Field:
+				if node.Alias != nil {
+					aliasCount++
+				}
 				switch node.Name.Value {
 				// Values that won't appear in the result
 				case "nodes", "__typename":
@@ -306,6 +316,7 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 	return &QueryCost{
 		FieldCount: fieldCount + maxInlineFragmentCost,
 		MaxDepth:   maxDepth,
+		AliasCount: aliasCount,
 	}, visitErr
 }
 

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -121,7 +121,8 @@ func TestSearch(t *testing.T) {
 
 			sr := newSchemaResolver(db, gsClient)
 			gqlSchema, err := graphql.ParseSchema(mainSchema, sr,
-				graphql.Tracer(newRequestTracer(logtest.Scoped(t), db)))
+				graphql.Tracer(newRequestTracer(logtest.Scoped(t), db)),
+				graphql.MaxDepth(maxDepth))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -31,6 +31,7 @@ func mustParseGraphQLSchemaWithClient(t *testing.T, db database.DB, gitserverCli
 		gitserverClient,
 		[]OptionalResolver{},
 		graphql.PanicHandler(printStackTrace{&gqlerrors.DefaultPanicHandler{}}),
+		graphql.MaxDepth(maxDepth),
 	)
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -91,6 +91,14 @@ func serveGraphQL(logger log.Logger, schema *graphql.Schema, rlw graphqlbackend.
 			traceData.costError = costErr
 			traceData.cost = cost
 
+			if !isInternal && (cost.AliasCount > graphqlbackend.MaxAliasCount) {
+				return errors.New("query exceeds maximum alias count")
+			}
+
+			if !isInternal && (cost.FieldCount > graphqlbackend.MaxFieldCount) {
+				return errors.New("query exceeds maximum query cost")
+			}
+
 			if rl, enabled := rlw.Get(); enabled && cost != nil {
 				limited, result, err := rl.RateLimit(r.Context(), uid, cost.FieldCount, graphqlbackend.LimiterArgs{
 					IsIP:          isIP,


### PR DESCRIPTION
This sets a maximum GraphQL query depth of 20 and sets a maximum number of aliases. This helps prevent queries that consume too many resources and lead to a Denial-of-Service.

For more information, or discussion on the change please refer to: 
- https://github.com/sourcegraph/security-issues/issues/359 for the the maxdepth definition;
- https://github.com/sourcegraph/security-issues/issues/358 for the max field count check;

## Test plan
- Tested on local instance
- CI tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
