### PR TITLE
prettier: add package to prettier ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 .bin/
 *.bundle.*
+package/
 bazel-*
 client/phabricator/scripts/loader.js
 client/browser/build


### PR DESCRIPTION
Found prettier was linting files from `package/` which contains node_modules like js files
## Test plan
Local and CI

