### PR TITLE
doc: remove duplicated paragraph about GH proxy removal

### DIFF
--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -16,13 +16,11 @@ For upgrade procedures or general info about sourcegraph versioning see the link
 
 ## Unreleased
 
-- The GitHub proxy service has been removed in 5.2 and is now removed from kubernetes deployment options. [#55290](https://github.com/sourcegraph/sourcegraph/issues/55290)
+No applicable notes for unreleased versions.
 
 #### Notes for 5.2:
 
 - The GitHub proxy service has been removed and is no longer required. You can safely remove it. [#55290](https://github.com/sourcegraph/sourcegraph/issues/55290)
-
-No applicable notes for unreleased versions.
 
 <!-- Add changes changes to this section before release. -->
 ## v5.1.8 ➔ v5.1.9


### PR DESCRIPTION
While going through some files touched by released tooling, noticed a duplicated entry that is now irrelevant. 

## Test plan

CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@jh/fix-botched-update-in-doc-admin-updates-k8s)