### PR TITLE
SCIP ctags: explain the 'kind' naming

### DIFF
--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/ts_scip.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/ts_scip.rs
@@ -60,8 +60,11 @@ pub fn captures_to_kind(kind: &Option<&String>) -> symbol_information::Kind {
 // Universal-ctags uses inconsistent kind names for the same concept (for example typealias for
 // Kotlin vs. talias for Go). For simplicity, we don't try to match the universal-ctags output, we
 // just pass through the SCIP kinds and rely on clients like Zoekt to handle the different naming
-// conventions. When adding a new entry here, be sure to check if Zoekt search ranking needs to be
-// updated to recognize the new kind.
+// conventions.
+//
+// When adding a new entry here, be sure to check if Zoekt search ranking needs to be
+// updated to recognize the new kind. Eventually we plan to consume SCIP directly in clients, making
+// this process less fragile.
 pub fn symbol_kind_to_ctags_kind(kind: &symbol_information::Kind) -> Option<&'static str> {
     use symbol_information::Kind::*;
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/ts_scip.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/ts_scip.rs
@@ -60,7 +60,8 @@ pub fn captures_to_kind(kind: &Option<&String>) -> symbol_information::Kind {
 // Universal-ctags uses inconsistent kind names for the same concept (for example typealias for
 // Kotlin vs. talias for Go). For simplicity, we don't try to match the universal-ctags output, we
 // just pass through the SCIP kinds and rely on clients like Zoekt to handle the different naming
-// conventions.
+// conventions. When adding a new entry here, be sure to check if Zoekt search ranking needs to be
+// updated to recognize the new kind.
 pub fn symbol_kind_to_ctags_kind(kind: &symbol_information::Kind) -> Option<&'static str> {
     use symbol_information::Kind::*;
 

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/ts_scip.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/ts_scip.rs
@@ -54,6 +54,13 @@ pub fn captures_to_kind(kind: &Option<&String>) -> symbol_information::Kind {
     })
 }
 
+
+// Converts a SCIP symbol kind to the ctags format.
+//
+// Universal-ctags uses inconsistent kind names for the same concept (for example typealias for
+// Kotlin vs. talias for Go). For simplicity, we don't try to match the universal-ctags output, we
+// just pass through the SCIP kinds and rely on clients like Zoekt to handle the different naming
+// conventions.
 pub fn symbol_kind_to_ctags_kind(kind: &symbol_information::Kind) -> Option<&'static str> {
     use symbol_information::Kind::*;
 


### PR DESCRIPTION
This change adds a comment explaining how the 'kind' names don't always match
the universal-ctags output exactly.

## Test plan

Comment-only change