### PR TITLE
blob: Fix missing blame decoration

### DIFF
--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -176,7 +176,7 @@ class BlameDecorationViewPlugin implements PluginValue {
         const builder = new RangeSetBuilder<Decoration>()
 
         // Keeps track of the last found hunk. We don't want to show an additional blame
-        // decoration when a range inside a single hunk is shown.
+        // decoration when a range inside a single hunk is folded.
         let previousHunk: BlameHunk | undefined
 
         for (const { from, to } of view.visibleRanges) {
@@ -188,7 +188,7 @@ class BlameDecorationViewPlugin implements PluginValue {
             const endLine = view.state.doc.lineAt(to).number
             while (line.number <= endLine) {
                 const matchingHunk = lines[line.number]
-                if (matchingHunk && matchingHunk.rev !== previousHunk?.rev) {
+                if (matchingHunk && matchingHunk !== previousHunk) {
                     if (line.number !== 1) {
                         builder.add(line.from, line.from, startOfHunkDecoration)
                     }


### PR DESCRIPTION
The hunks should be compared by identity, not revision. I think I was exploring comparing by revision in order to avoid showing the same decoration for consecutive hunks, but that had other UI issues.



## Test plan

Manual testing.
