### PR TITLE
Git blame: make ignoring whitespace configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Site configuration edit history no longer breaks when the user that made the edit is deleted. [#57656](https://github.com/sourcegraph/sourcegraph/pull/57656)
 - Drilling down into an insights query no longer mangles `content:` fields in your query. [#57679](https://github.com/sourcegraph/sourcegraph/pull/57679)
 - The blame column now shows correct blame information when a hunk starts in a folded code section. [#58042](https://github.com/sourcegraph/sourcegraph/pull/58042)
+- The blame column no longer ignores whitespace-only changes by default. [#58134](https://github.com/sourcegraph/sourcegraph/pull/58134)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/git_blob.go
+++ b/cmd/frontend/graphqlbackend/git_blob.go
@@ -5,30 +5,33 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func (r *GitTreeEntryResolver) Blame(ctx context.Context,
 	args *struct {
-		StartLine int32
-		EndLine   int32
+		StartLine        int32
+		EndLine          int32
+		IgnoreWhitespace *bool
 	}) ([]*hunkResolver, error) {
 	hunks, err := r.gitserverClient.BlameFile(ctx, r.commit.repoResolver.RepoName(), r.Path(), &gitserver.BlameOptions{
-		NewestCommit: api.CommitID(r.commit.OID()),
-		StartLine:    int(args.StartLine),
-		EndLine:      int(args.EndLine),
+		NewestCommit:     api.CommitID(r.commit.OID()),
+		StartLine:        int(args.StartLine),
+		EndLine:          int(args.EndLine),
+		IgnoreWhitespace: pointers.Deref(args.IgnoreWhitespace, false),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	var hunksResolver []*hunkResolver
+	hunkResolvers := make([]*hunkResolver, 0, len(hunks))
 	for _, hunk := range hunks {
-		hunksResolver = append(hunksResolver, &hunkResolver{
+		hunkResolvers = append(hunkResolvers, &hunkResolver{
 			db:   r.db,
 			repo: r.commit.repoResolver,
 			hunk: hunk,
 		})
 	}
 
-	return hunksResolver, nil
+	return hunkResolvers, nil
 }

--- a/cmd/frontend/graphqlbackend/git_blob.go
+++ b/cmd/frontend/graphqlbackend/git_blob.go
@@ -5,20 +5,19 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func (r *GitTreeEntryResolver) Blame(ctx context.Context,
 	args *struct {
 		StartLine        int32
 		EndLine          int32
-		IgnoreWhitespace *bool
+		IgnoreWhitespace bool
 	}) ([]*hunkResolver, error) {
 	hunks, err := r.gitserverClient.BlameFile(ctx, r.commit.repoResolver.RepoName(), r.Path(), &gitserver.BlameOptions{
 		NewestCommit:     api.CommitID(r.commit.OID()),
 		StartLine:        int(args.StartLine),
 		EndLine:          int(args.EndLine),
-		IgnoreWhitespace: pointers.Deref(args.IgnoreWhitespace, false),
+		IgnoreWhitespace: args.IgnoreWhitespace,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6029,9 +6029,9 @@ type GitBlob implements TreeEntry & File2 {
     """
     externalURLs: [ExternalLink!]!
     """
-    Blame the blob. If unset, ignoreWhitespace defaults to false.
+    Blame the blob.
     """
-    blame(startLine: Int!, endLine: Int!, ignoreWhitespace: Boolean): [Hunk!]!
+    blame(startLine: Int!, endLine: Int!, ignoreWhitespace: Boolean = false): [Hunk!]!
     """
     Highlight the blob contents.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6029,9 +6029,9 @@ type GitBlob implements TreeEntry & File2 {
     """
     externalURLs: [ExternalLink!]!
     """
-    Blame the blob.
+    Blame the blob. If unset, ignoreWhitespace defaults to false.
     """
-    blame(startLine: Int!, endLine: Int!): [Hunk!]!
+    blame(startLine: Int!, endLine: Int!, ignoreWhitespace: Boolean): [Hunk!]!
     """
     Highlight the blob contents.
     """

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -791,10 +791,10 @@ func (c *clientImplementor) LogReverseEach(ctx context.Context, repo string, com
 
 // BlameOptions configures a blame.
 type BlameOptions struct {
-	NewestCommit api.CommitID `json:",omitempty" url:",omitempty"`
-
-	StartLine int `json:",omitempty" url:",omitempty"` // 1-indexed start line (or 0 for beginning of file)
-	EndLine   int `json:",omitempty" url:",omitempty"` // 1-indexed end line (or 0 for end of file)
+	NewestCommit     api.CommitID `json:",omitempty" url:",omitempty"`
+	IgnoreWhitespace bool         `json:",omitempty" url:",omitempty"`
+	StartLine        int          `json:",omitempty" url:",omitempty"` // 1-indexed start line (or 0 for beginning of file)
+	EndLine          int          `json:",omitempty" url:",omitempty"` // 1-indexed end line (or 0 for end of file)
 }
 
 func (o *BlameOptions) Attrs() []attribute.KeyValue {
@@ -802,6 +802,7 @@ func (o *BlameOptions) Attrs() []attribute.KeyValue {
 		attribute.String("newestCommit", string(o.NewestCommit)),
 		attribute.Int("startLine", o.StartLine),
 		attribute.Int("endLine", o.EndLine),
+		attribute.Bool("ignoreWhitespace", o.IgnoreWhitespace),
 	}
 }
 
@@ -859,7 +860,10 @@ func streamBlameFileCmd(ctx context.Context, checker authz.SubRepoPermissionChec
 		return nil, err
 	}
 
-	args := []string{"blame", "-w", "--porcelain", "--incremental"}
+	args := []string{"blame", "--porcelain", "--incremental"}
+	if opt.IgnoreWhitespace {
+		args = append(args, "-w")
+	}
 	if opt.StartLine != 0 || opt.EndLine != 0 {
 		args = append(args, fmt.Sprintf("-L%d,%d", opt.StartLine, opt.EndLine))
 	}
@@ -899,7 +903,10 @@ func blameFileCmd(ctx context.Context, checker authz.SubRepoPermissionChecker, c
 		return nil, err
 	}
 
-	args := []string{"blame", "-w", "--porcelain"}
+	args := []string{"blame", "--porcelain"}
+	if opt.IgnoreWhitespace {
+		args = append(args, "-w")
+	}
 	if opt.StartLine != 0 || opt.EndLine != 0 {
 		args = append(args, fmt.Sprintf("-L%d,%d", opt.StartLine, opt.EndLine))
 	}


### PR DESCRIPTION
Currently, our `git blame` API endpoint adds the `-w` flag to `git blame`, which causes whitespace-only changes to be ignored when blaming a line. This is different than GitHub's behavior, and a confusing default.

This makes the ignoring whitespace configurable in the GraphQL enpdoint, and disables it by default.

## Test plan

Git blame for [this file](https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/cody/search/CodySearchPage.tsx?L122-129&trace=1) now matches what GitHub shows. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
