### PR TITLE
Diff view: fix line wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Drilling down into an insights query no longer mangles `content:` fields in your query. [#57679](https://github.com/sourcegraph/sourcegraph/pull/57679)
 - The blame column now shows correct blame information when a hunk starts in a folded code section. [#58042](https://github.com/sourcegraph/sourcegraph/pull/58042)
 - The blame column no longer ignores whitespace-only changes by default. [#58134](https://github.com/sourcegraph/sourcegraph/pull/58134)
+- Long lines now wrap correctly in the diff view. [#58138](https://github.com/sourcegraph/sourcegraph/pull/58138)
 
 ### Removed
 

--- a/client/web/src/components/diff/DiffHunk.module.scss
+++ b/client/web/src/components/diff/DiffHunk.module.scss
@@ -30,10 +30,6 @@
     white-space: pre-wrap;
     font-size: 0.75rem;
     background-color: var(--code-bg);
-    &::before {
-        padding-right: 0.5rem;
-        content: attr(data-diff-marker);
-    }
     &--empty {
         background-color: var(--body-bg);
 
@@ -41,6 +37,10 @@
         opacity: 0.5;
     }
     div {
+        &::before {
+            padding-right: 0.5rem;
+            content: attr(data-diff-marker);
+        }
         display: inline;
     }
 }

--- a/client/web/src/components/diff/DiffHunk.tsx
+++ b/client/web/src/components/diff/DiffHunk.tsx
@@ -73,7 +73,7 @@ export const DiffHunk: React.FunctionComponent<React.PropsWithChildren<DiffHunkP
                             line.kind === DiffHunkLineType.ADDED && styles.lineAddition,
                             ((line.kind !== DiffHunkLineType.ADDED && location.hash === '#' + oldAnchor) ||
                                 (line.kind !== DiffHunkLineType.DELETED && location.hash === '#' + newAnchor)) &&
-                                styles.lineActive
+                            styles.lineActive
                         )}
                     >
                         {lineNumbers && (
@@ -115,9 +115,13 @@ export const DiffHunk: React.FunctionComponent<React.PropsWithChildren<DiffHunkP
                                 )}
                             </>
                         )}
-                        <td className={styles.content} data-diff-marker={diffHunkTypeIndicators[line.kind]}>
+                        <td className={styles.content}>
                             <VisuallyHidden>{diffHunkTypeDescriptions[line.kind]}</VisuallyHidden>
-                            <div className="d-inline-block" dangerouslySetInnerHTML={{ __html: line.html }} />
+                            <div
+                                className="d-inline-block"
+                                data-diff-marker={diffHunkTypeIndicators[line.kind]}
+                                dangerouslySetInnerHTML={{ __html: line.html }}
+                            />
                         </td>
                     </tr>
                 )

--- a/client/web/src/components/diff/DiffHunk.tsx
+++ b/client/web/src/components/diff/DiffHunk.tsx
@@ -73,7 +73,7 @@ export const DiffHunk: React.FunctionComponent<React.PropsWithChildren<DiffHunkP
                             line.kind === DiffHunkLineType.ADDED && styles.lineAddition,
                             ((line.kind !== DiffHunkLineType.ADDED && location.hash === '#' + oldAnchor) ||
                                 (line.kind !== DiffHunkLineType.DELETED && location.hash === '#' + newAnchor)) &&
-                            styles.lineActive
+                                styles.lineActive
                         )}
                     >
                         {lineNumbers && (

--- a/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
@@ -56,7 +56,6 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
         </td>
         <td
           class="content"
-          data-diff-marker=" "
         >
           <span
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -65,6 +64,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           </span>
           <div
             class="d-inline-block"
+            data-diff-marker=" "
           >
                     const subscriptions = new Subscription()
           </div>
@@ -104,7 +104,6 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
         </td>
         <td
           class="content"
-          data-diff-marker=" "
         >
           <span
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -113,6 +112,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           </span>
           <div
             class="d-inline-block"
+            data-diff-marker=" "
           >
                     const foo = sourcegraph.app.foo()
           </div>
@@ -152,7 +152,6 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
         </td>
         <td
           class="content"
-          data-diff-marker=" "
         >
           <span
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -161,6 +160,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           </span>
           <div
             class="d-inline-block"
+            data-diff-marker=" "
           >
                     const connection = await createConnection()
           </div>
@@ -189,7 +189,6 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
         />
         <td
           class="content"
-          data-diff-marker="-"
         >
           <span
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -198,6 +197,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           </span>
           <div
             class="d-inline-block"
+            data-diff-marker="-"
           >
                     logger.log(\`WebSocket connection to TypeScript backend opened\`)
           </div>
@@ -226,7 +226,6 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
         </td>
         <td
           class="content"
-          data-diff-marker="+"
         >
           <span
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -235,6 +234,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           </span>
           <div
             class="d-inline-block"
+            data-diff-marker="+"
           >
                     logger.log(\`WebSocket connection to language server opened\`)
           </div>
@@ -274,7 +274,6 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
         </td>
         <td
           class="content"
-          data-diff-marker=" "
         >
           <span
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -283,6 +282,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           </span>
           <div
             class="d-inline-block"
+            data-diff-marker=" "
           >
                     subscriptions.add(
           </div>
@@ -322,7 +322,6 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
         </td>
         <td
           class="content"
-          data-diff-marker=" "
         >
           <span
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -331,6 +330,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           </span>
           <div
             class="d-inline-block"
+            data-diff-marker=" "
           >
                             connection.observeNotification(LogMessageNotification.type).subscribe(({ type, message }) =&gt;
              {
@@ -371,7 +371,6 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
         </td>
         <td
           class="content"
-          data-diff-marker=" "
         >
           <span
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
@@ -380,6 +379,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           </span>
           <div
             class="d-inline-block"
+            data-diff-marker=" "
           >
                                 const method = LSP_TO_LOG_LEVEL[type]
           </div>


### PR DESCRIPTION
This fixes line wrapping behavior in diff view. Previously, if a line didn't fit in the view, it would jump to a new line before properly wrapping. This made it look like the diff added a newline.

The problem was that we're adding a diff marker (the plus/minus) in the gutter, but outside the div with `inline-block`, so the whole div was being pushed to the next line. Instead, if we move the `::before` selector to target the div with the content, the issue goes away. Because we cannot use a data attribute from a parent element in CSS, I also had to move `data-diff-marker` to the div that's being targeted.

Fixes https://github.com/sourcegraph/sourcegraph/issues/57834

## Test plan

See the before in the [issue report](https://github.com/sourcegraph/sourcegraph/issues/57834). Here's the after:

https://github.com/sourcegraph/sourcegraph/assets/12631702/af6e521c-82ed-4f4d-a8d0-6c01d8e96c9c



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
