### PR TITLE
Web client: fix copyability of text

### DIFF
--- a/client/web/src/components/diff/DiffHunk.module.scss
+++ b/client/web/src/components/diff/DiffHunk.module.scss
@@ -46,7 +46,6 @@
 }
 
 .diff-type-description {
-    -webkit-user-select: none;
     user-select: none;
 }
 

--- a/client/web/src/components/diff/DiffHunk.module.scss
+++ b/client/web/src/components/diff/DiffHunk.module.scss
@@ -45,6 +45,11 @@
     }
 }
 
+.diff-type-description {
+    -webkit-user-select: none;
+    user-select: none;
+}
+
 .num {
     background-color: var(--code-bg);
     min-width: 2.5rem;

--- a/client/web/src/components/diff/DiffHunk.tsx
+++ b/client/web/src/components/diff/DiffHunk.tsx
@@ -73,7 +73,7 @@ export const DiffHunk: React.FunctionComponent<React.PropsWithChildren<DiffHunkP
                             line.kind === DiffHunkLineType.ADDED && styles.lineAddition,
                             ((line.kind !== DiffHunkLineType.ADDED && location.hash === '#' + oldAnchor) ||
                                 (line.kind !== DiffHunkLineType.DELETED && location.hash === '#' + newAnchor)) &&
-                                styles.lineActive
+                            styles.lineActive
                         )}
                     >
                         {lineNumbers && (
@@ -116,7 +116,9 @@ export const DiffHunk: React.FunctionComponent<React.PropsWithChildren<DiffHunkP
                             </>
                         )}
                         <td className={styles.content}>
-                            <VisuallyHidden>{diffHunkTypeDescriptions[line.kind]}</VisuallyHidden>
+                            <VisuallyHidden className={styles.diffTypeDescription}>
+                                {diffHunkTypeDescriptions[line.kind]}
+                            </VisuallyHidden>
                             <div
                                 className="d-inline-block"
                                 data-diff-marker={diffHunkTypeIndicators[line.kind]}

--- a/client/web/src/components/diff/DiffHunk.tsx
+++ b/client/web/src/components/diff/DiffHunk.tsx
@@ -73,7 +73,7 @@ export const DiffHunk: React.FunctionComponent<React.PropsWithChildren<DiffHunkP
                             line.kind === DiffHunkLineType.ADDED && styles.lineAddition,
                             ((line.kind !== DiffHunkLineType.ADDED && location.hash === '#' + oldAnchor) ||
                                 (line.kind !== DiffHunkLineType.DELETED && location.hash === '#' + newAnchor)) &&
-                            styles.lineActive
+                                styles.lineActive
                         )}
                     >
                         {lineNumbers && (

--- a/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
+++ b/client/web/src/components/diff/__snapshots__/DiffHunk.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           class="content"
         >
           <span
+            class="diffTypeDescription"
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
           >
             unchanged line
@@ -106,6 +107,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           class="content"
         >
           <span
+            class="diffTypeDescription"
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
           >
             unchanged line
@@ -154,6 +156,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           class="content"
         >
           <span
+            class="diffTypeDescription"
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
           >
             unchanged line
@@ -191,6 +194,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           class="content"
         >
           <span
+            class="diffTypeDescription"
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
           >
             deleted line
@@ -228,6 +232,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           class="content"
         >
           <span
+            class="diffTypeDescription"
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
           >
             added line
@@ -276,6 +281,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           class="content"
         >
           <span
+            class="diffTypeDescription"
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
           >
             unchanged line
@@ -324,6 +330,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           class="content"
         >
           <span
+            class="diffTypeDescription"
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
           >
             unchanged line
@@ -373,6 +380,7 @@ exports[`DiffHunk > renders a unified diff view for the given diff hunk 1`] = `
           class="content"
         >
           <span
+            class="diffTypeDescription"
             style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
           >
             unchanged line

--- a/client/web/src/repo/blob/codemirror/eof.ts
+++ b/client/web/src/repo/blob/codemirror/eof.ts
@@ -22,7 +22,7 @@ class NoLineBreakWidget extends WidgetType {
 // causes the last line to be hidden.
 const removeLastLineDeco = Decoration.replace({})
 const eofNoteDeco = Decoration.replace({
-    widget: new NoLineBreakWidget('(No new line at end of file)'),
+    widget: new NoLineBreakWidget('(No newline at end of file)'),
     block: true,
 })
 
@@ -47,6 +47,7 @@ export const hideEmptyLastLine: Extension = [
             color: 'var(--text-muted)',
             fontStyle: 'italic',
             marginTop: '.2rem',
+            userSelect: 'none',
         },
     }),
 ]

--- a/client/web/src/repo/blob/codemirror/eof.ts
+++ b/client/web/src/repo/blob/codemirror/eof.ts
@@ -48,6 +48,7 @@ export const hideEmptyLastLine: Extension = [
             fontStyle: 'italic',
             marginTop: '.2rem',
             userSelect: 'none',
+            '-webkit-user-select': 'none',
         },
     }),
 ]

--- a/client/web/src/repo/blob/codemirror/eof.ts
+++ b/client/web/src/repo/blob/codemirror/eof.ts
@@ -48,7 +48,7 @@ export const hideEmptyLastLine: Extension = [
             fontStyle: 'italic',
             marginTop: '.2rem',
             userSelect: 'none',
-            '-webkit-user-select': 'none',
+            cursor: 'default',
         },
     }),
 ]


### PR DESCRIPTION
This adds the `user-select: none` attribute to text in two places. The first is the `no newline at end of file` notice. It's really easy to accidentally copy that instead of the code, so this just makes it non-selectable. The second is the hidden text describing the types of diff lines. Previously, this would make text copied from diffs unusable, so this makes that text not show up when copied. 

## Test plan

Ensured that not copying the text succeeds in both firefox and safari. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
