### PR TITLE
squirrel: Do a lowercase check only if the case-sensitive check fails

### DIFF
--- a/cmd/symbols/squirrel/BUILD.bazel
+++ b/cmd/symbols/squirrel/BUILD.bazel
@@ -48,7 +48,16 @@ go_test(
         "local_code_intel_test.go",
         "service_test.go",
     ],
-    data = glob(["test_repos/**"]),
+    data = glob(["test_repos/**"]) + [
+        # We have to explicitly list those files as the test_repos/starlark folder
+        # is ignored in the .bazelignore file, to avoid picking up the BUILD.bazel
+        # which are test data and not related to the Sourcegraph codebase.
+        "test_repos/starlark/BUILD",
+        "test_repos/starlark/BUILD.bazel",
+        "test_repos/starlark/WORKSPACE",
+        "test_repos/starlark/bzl_library.bzl",
+        "test_repos/starlark/sample.bzl",
+    ],
     embed = [":squirrel"],
     deps = [
         "//internal/search",


### PR DESCRIPTION
One of the bugs in https://github.com/sourcegraph/sourcegraph/pull/58069

## Test plan

Run `go test ./cmd/symbols/squirrel/...`. It wasn't caught by CI: https://sourcegraph.slack.com/archives/C04MYFW01NV/p1699334502046179