### PR TITLE
bzl: add missing test data for squirrel test 

### DIFF
--- a/cmd/symbols/squirrel/BUILD.bazel
+++ b/cmd/symbols/squirrel/BUILD.bazel
@@ -48,7 +48,16 @@ go_test(
         "local_code_intel_test.go",
         "service_test.go",
     ],
-    data = glob(["test_repos/**"]),
+    data = glob(["test_repos/**"]) + [
+        # We have to explicitly list those files as the test_repos/starlark folder
+        # is ignored in the .bazelignore file, to avoid picking up the BUILD.bazel
+        # which are test data and not related to the Sourcegraph codebase.
+        "test_repos/starlark/BUILD",
+        "test_repos/starlark/BUILD.bazel",
+        "test_repos/starlark/WORKSPACE",
+        "test_repos/starlark/bzl_library.bzl",
+        "test_repos/starlark/sample.bzl",
+    ],
     embed = [":squirrel"],
     deps = [
         "//internal/search",


### PR DESCRIPTION
@varungandhi-src's [PR](https://github.com/sourcegraph/sourcegraph/pull/58143) fixes the `go test` part of the issues with Starlark test data, and this PR makes it so Bazel properly sees those files.

The problem was happening exactly as diagnosed by @burmudar over [slack](https://sourcegraph.slack.com/archives/C04MYFW01NV/p1699344515274959?thread_ts=1699334502.046179&cid=C04MYFW01NV). 

## Test plan

```
//cmd/symbols/squirrel:squirrel_test                                     PASSED in 3.5s
```

```
~/work/other S jh/fix-squirrel-build $ bazel cquery '//cmd/symbols/squirrel:*' --output=files
INFO: Analyzed 28 targets (1 packages loaded, 29 targets configured).
INFO: Found 28 targets...
# ....
cmd/symbols/squirrel/test_repos/starlark/BUILD
cmd/symbols/squirrel/test_repos/starlark/BUILD.bazel
cmd/symbols/squirrel/test_repos/starlark/WORKSPACE
cmd/symbols/squirrel/test_repos/starlark/bzl_library.bzl
cmd/symbols/squirrel/test_repos/starlark/sample.bzl
# ... ☝️ are the files that were missing
cmd/symbols/squirrel/util.go
INFO: Elapsed time: 0.343s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
~/work/other  jh/fix-squirrel-build $ 
```


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
