### PR TITLE
squirrel: Re-enable code nav for .pcc/.pc files

### DIFF
--- a/cmd/symbols/squirrel/BUILD.bazel
+++ b/cmd/symbols/squirrel/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//cmd/symbols/types",
         "//internal/api",
+        "//internal/jsonc",
         "//internal/search",
         "//internal/search/result",
         "//internal/types",

--- a/cmd/symbols/squirrel/language-file-extensions.json
+++ b/cmd/symbols/squirrel/language-file-extensions.json
@@ -51,7 +51,12 @@
     "h++",
     "hh",
     "h",
-    "hpp"
+    "hpp",
+    // For Pro*C/C++ which was requested by a customer
+    // See: https://github.com/sourcegraph/customer/issues/124
+    // And https://web.archive.org/web/20231107051418/https://otl.sourceforge.net/otl3_ex59.htm
+    "pc",
+    "pcc"
   ],
   "csharp": [
     "cs",

--- a/cmd/symbols/squirrel/languages.go
+++ b/cmd/symbols/squirrel/languages.go
@@ -2,7 +2,6 @@ package squirrel
 
 import (
 	_ "embed"
-	"encoding/json"
 	"fmt"
 
 	"github.com/grafana/regexp"
@@ -15,6 +14,8 @@ import (
 	"github.com/smacker/go-tree-sitter/python"
 	"github.com/smacker/go-tree-sitter/ruby"
 	"github.com/smacker/go-tree-sitter/typescript/tsx"
+
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 )
 
 //go:embed language-file-extensions.json
@@ -23,7 +24,7 @@ var languageFileExtensionsJson string
 // Mapping from langauge name to file extensions.
 var langToExts = func() map[string][]string {
 	var m map[string][]string
-	err := json.Unmarshal([]byte(languageFileExtensionsJson), &m)
+	err := jsonc.Unmarshal(languageFileExtensionsJson, &m)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes one of the bugs in https://github.com/sourcegraph/sourcegraph/pull/58069

## Test plan

n/a