### PR TITLE
bzl: add manual tags to a `go_cross_binary` rules that are used with local e2e testing

### DIFF
--- a/dev/codeintel-qa/cmd/clear/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/clear/BUILD.bazel
@@ -23,6 +23,7 @@ go_binary(
 go_cross_binary(
     name = "clear-darwin-arm64",
     platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
+    tags = ["manual"],
     target = ":clear",
     visibility = ["//testing:__pkg__"],
 )

--- a/dev/codeintel-qa/cmd/clone-and-index/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/clone-and-index/BUILD.bazel
@@ -23,6 +23,7 @@ go_binary(
 go_cross_binary(
     name = "clone-and-index-darwin-arm64",
     platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
+    tags = ["manual"],
     target = ":clone-and-index",
     visibility = ["//testing:__pkg__"],
 )

--- a/dev/codeintel-qa/cmd/download/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/download/BUILD.bazel
@@ -24,6 +24,7 @@ go_binary(
 go_cross_binary(
     name = "download-darwin-arm64",
     platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
+    tags = ["manual"],
     target = ":download",
     visibility = ["//testing:__pkg__"],
 )

--- a/dev/codeintel-qa/cmd/query/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/query/BUILD.bazel
@@ -30,6 +30,7 @@ go_binary(
 go_cross_binary(
     name = "query-darwin-arm64",
     platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
+    tags = ["manual"],
     target = ":query",
     visibility = ["//testing:__pkg__"],
 )

--- a/dev/codeintel-qa/cmd/upload-gcs/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/upload-gcs/BUILD.bazel
@@ -23,6 +23,7 @@ go_binary(
 go_cross_binary(
     name = "upload-gcs-darwin-arm64",
     platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
+    tags = ["manual"],
     target = ":upload-gcs",
     visibility = ["//testing:__pkg__"],
 )

--- a/dev/codeintel-qa/cmd/upload/BUILD.bazel
+++ b/dev/codeintel-qa/cmd/upload/BUILD.bazel
@@ -24,6 +24,7 @@ go_binary(
 go_cross_binary(
     name = "upload-darwin-arm64",
     platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
+    tags = ["manual"],
     target = ":upload",
     visibility = ["//testing:__pkg__"],
 )

--- a/internal/cmd/init-sg/BUILD.bazel
+++ b/internal/cmd/init-sg/BUILD.bazel
@@ -20,6 +20,7 @@ go_binary(
 go_cross_binary(
     name = "init-sg-darwin-arm64",
     platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
+    tags = ["manual"],
     target = ":init-sg",
     visibility = ["//testing:__pkg__"],
 )


### PR DESCRIPTION
I was unhappy with https://github.com/sourcegraph/sourcegraph/pull/58151 and wondered if the targets weren't pulled in because nothing actually tells Bazel to not build them when using `...`. Turned out that's right, that's how they got picked up. 

So tagging them with `manual` doesn't affect the original case, which is when you want to run e2e tests locally, because in that case you are explictly calling those targets (transitively). 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
