### PR TITLE
Add gpt-4-turbo and new Fireworks model support

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/ModelBadges.tsx
@@ -43,12 +43,15 @@ function modelBadgeVariant(model: string, mode: 'completions' | 'embeddings'): '
             // allow list the models on the Cody Gateway side.
             case 'openai/gpt-4':
             case 'openai/gpt-3.5-turbo':
+            case 'openai/gpt-4-1106-preview':
             // Bespoken models hosted for us by Fireworks. These are also allowed on the Cody
             // Gateway side
             case 'fireworks/accounts/fireworks/models/starcoder-16b-w8a16':
             case 'fireworks/accounts/fireworks/models/starcoder-7b-w8a16':
             case 'fireworks/accounts/fireworks/models/starcoder-3b-w8a16':
             case 'fireworks/accounts/fireworks/models/starcoder-1b-w8a16':
+            case 'fireworks/accounts/sourcegraph/models/starcoder-7b':
+            case 'fireworks/accounts/sourcegraph/models/starcoder-16b':
             case 'fireworks/accounts/fireworks/models/llama-v2-7b-code':
             case 'fireworks/accounts/fireworks/models/llama-v2-13b-code':
             case 'fireworks/accounts/fireworks/models/llama-v2-13b-code-instruct':

--- a/cmd/cody-gateway/shared/config.go
+++ b/cmd/cody-gateway/shared/config.go
@@ -120,7 +120,7 @@ func (c *Config) Load() {
 	c.OpenAI.AccessToken = c.GetOptional("CODY_GATEWAY_OPENAI_ACCESS_TOKEN", "The OpenAI access token to be used.")
 	c.OpenAI.OrgID = c.GetOptional("CODY_GATEWAY_OPENAI_ORG_ID", "The OpenAI organization to count billing towards. Setting this ensures we always use the correct negotiated terms.")
 	c.OpenAI.AllowedModels = splitMaybe(c.Get("CODY_GATEWAY_OPENAI_ALLOWED_MODELS",
-		strings.Join([]string{"gpt-4", "gpt-3.5-turbo"}, ","),
+		strings.Join([]string{"gpt-4", "gpt-3.5-turbo", "gpt-4-1106-preview"}, ","),
 		"OpenAI models that can to be used."),
 	)
 	if c.OpenAI.AccessToken != "" && len(c.OpenAI.AllowedModels) == 0 {
@@ -134,6 +134,8 @@ func (c *Config) Load() {
 			"accounts/fireworks/models/starcoder-7b-w8a16",
 			"accounts/fireworks/models/starcoder-3b-w8a16",
 			"accounts/fireworks/models/starcoder-1b-w8a16",
+			"accounts/sourcegraph/models/starcoder-7b",
+			"accounts/sourcegraph/models/starcoder-16b",
 			"accounts/fireworks/models/llama-v2-7b-code",
 			"accounts/fireworks/models/llama-v2-13b-code",
 			"accounts/fireworks/models/llama-v2-13b-code-instruct",

--- a/internal/completions/httpapi/codecompletion.go
+++ b/internal/completions/httpapi/codecompletion.go
@@ -48,6 +48,8 @@ func isAllowedCustomModel(model string) bool {
 		"fireworks/accounts/fireworks/models/starcoder-7b-w8a16",
 		"fireworks/accounts/fireworks/models/starcoder-3b-w8a16",
 		"fireworks/accounts/fireworks/models/starcoder-1b-w8a16",
+		"fireworks/accounts/sourcegraph/models/starcoder-7b",
+		"fireworks/accounts/sourcegraph/models/starcoder-16b",
 		"fireworks/accounts/fireworks/models/llama-v2-7b-code",
 		"fireworks/accounts/fireworks/models/llama-v2-13b-code",
 		"fireworks/accounts/fireworks/models/llama-v2-13b-code-instruct",

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -1121,7 +1121,7 @@ func openaiDefaultMaxPromptTokens(model string) int {
 		return 8_000
 	case "gpt-4-32k":
 		return 32_000
-	case "gpt-3.5-turbo", "gpt-3.5-turbo-instruct":
+	case "gpt-3.5-turbo", "gpt-3.5-turbo-instruct", "gpt-4-1106-preview":
 		return 4_000
 	case "gpt-3.5-turbo-16k":
 		return 16_000

--- a/internal/licensing/codygateway_test.go
+++ b/internal/licensing/codygateway_test.go
@@ -80,7 +80,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			userCount:   pointers.Ptr(50),
 			licenseTags: []string{GPTLLMAccessTag},
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "openai/gpt-3.5-turbo", "openai/gpt-4-1106-preview"},
+				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "openai/gpt-3.5-turbo"},
 				Limit:           50000,
 				IntervalSeconds: 60 * 60 * 24,
 			},

--- a/internal/licensing/codygateway_test.go
+++ b/internal/licensing/codygateway_test.go
@@ -80,7 +80,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			userCount:   pointers.Ptr(50),
 			licenseTags: []string{GPTLLMAccessTag},
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "openai/gpt-3.5-turbo"},
+				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "openai/gpt-3.5-turbo", "openai/gpt-4-1106-preview"},
 				Limit:           50000,
 				IntervalSeconds: 60 * 60 * 24,
 			},


### PR DESCRIPTION
Adds supports for new model identifiers:

- `gpt-4-1106-preview` as the preview for gpt-4-turbo
- `accounts/sourcegraph/models/starcoder-7b` and `accounts/sourcegraph/models/starcoder-16b` as new StarCoder deployments

## Test plan

- Tests green on CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
