### PR TITLE
Add troubleshooting for localStorage in Cody Web

### DIFF
--- a/doc/cody/troubleshooting.md
+++ b/doc/cody/troubleshooting.md
@@ -41,7 +41,7 @@ For more information, see [Generate Index to Enable Codebase-Aware Answers](core
 
 If you are automatically signed out of Cody upon every VS Code restart due to keychain authentication issues, please follow the suggested steps detailed in the official VS Code docs on [troubleshooting keychain issues](https://code.visualstudio.com/docs/editor/settings-sync#_troubleshooting-keychain-issues) to resolve this.
 
-### Autocomplete Rate limits
+### Autocomplete rate limits
 
 Cody supports 1,000 suggested autocompletions per day, per user. For Sourcegraph Enterprise instances, this rate limit is pooled across all users.
 
@@ -56,3 +56,14 @@ To resolve this via a workaround:
 1. Quit VS Code.
 2. Run `echo "export NODE_TLS_REJECT_UNAUTHORIZED=0" >> ~/.bashrc` in terminal.
 3. Restart VS Code and sign in again.
+
+### Error exceeding `localStorage` quota
+
+When using Cody chat, you may come across this error:
+
+```
+Failed to execute 'setItem' on 'Storage': Setting the value of 'user-history:$user_id' exceeded the quota.
+```
+
+Experiencing this error means that the size of the chat history exceeded what the local storage in your browser can store. Cody saves all context data along with each chat message and this is what primarily causes this.
+To fix this, navigate to https://sourcegraph.example.com/cody/chat and click on `Clear Chat History` if your instance is on v5.2.3+. If on an older version, please clear your browsing data/browser history.


### PR DESCRIPTION
This doc update adds the step to take when a user hits a local storage exceed error on their Sourcegaph instance when using Cody chat



## Test plan
Doc update previewed locally. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@doc/add-localstorage-troubleshooting-section)