### PR TITLE
code-search: handle changeset fork when creating a batch change via src-cli

### DIFF
--- a/lib/batches/changeset_spec.go
+++ b/lib/batches/changeset_spec.go
@@ -103,6 +103,7 @@ func (c *ChangesetSpec) MarshalJSON() ([]byte, error) {
 		Body           string                 `json:"body,omitempty"`
 		Commits        []GitCommitDescription `json:"commits,omitempty"`
 		Published      *PublishedValue        `json:"published,omitempty"`
+		Fork           *bool                  `json:"fork,omitempty"`
 	}{
 		BaseRepository: c.BaseRepository,
 		ExternalID:     c.ExternalID,
@@ -113,6 +114,7 @@ func (c *ChangesetSpec) MarshalJSON() ([]byte, error) {
 		Title:          c.Title,
 		Body:           c.Body,
 		Commits:        c.Commits,
+		Fork:           c.Fork,
 	}
 	if !c.Published.Nil() {
 		v.Published = &c.Published

--- a/lib/batches/changeset_spec_test.go
+++ b/lib/batches/changeset_spec_test.go
@@ -111,6 +111,26 @@ func TestParseChangesetSpec(t *testing.T) {
 			}`,
 			err: "2 errors occurred:\n\t* Must validate one and only one schema (oneOf)\n\t* commits: Array must have at most 1 items",
 		},
+		{
+			name: "with fork",
+			rawSpec: `{
+				"baseRepository": "graphql-id",
+				"baseRef": "refs/heads/master",
+				"baseRev": "d34db33f",
+				"headRef": "refs/heads/my-branch",
+				"headRepository": "graphql-id",
+				"title": "my title",
+				"body": "my body",
+				"published": false,
+				"commits": [{
+				  "message": "commit message",
+				  "diff": "the diff",
+				  "authorName": "Mary McButtons",
+				  "authorEmail": "mary@example.com"
+				}],
+				"fork": true
+			}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/lib/batches/schema/changeset_spec_stringdata.go
+++ b/lib/batches/schema/changeset_spec_stringdata.go
@@ -60,6 +60,10 @@ const ChangesetSpecJSON = `{
           "description": "The GraphQL ID of the repository that contains the branch with this changeset's changes. Fork repositories and cross-repository changesets are not yet supported. Therefore, headRepository must be equal to baseRepository.",
           "examples": ["UmVwb3NpdG9yeTo5Cg=="]
         },
+        "fork": {
+          "type": "boolean",
+          "description": "Whether to publish the changeset to a fork of the target repository. If omitted, the changeset will be published to a branch directly on the target repository, unless the global ` + "`" + `batches.enforceFork` + "`" + ` setting is enabled. If set, this property will override any global setting."
+        },
         "headRef": {
           "type": "string",
           "description": "The full name of the Git ref that holds the changes proposed by this changeset. This ref will be created or updated with the commits.",

--- a/schema/changeset_spec.schema.json
+++ b/schema/changeset_spec.schema.json
@@ -55,6 +55,10 @@
           "description": "The GraphQL ID of the repository that contains the branch with this changeset's changes. Fork repositories and cross-repository changesets are not yet supported. Therefore, headRepository must be equal to baseRepository.",
           "examples": ["UmVwb3NpdG9yeTo5Cg=="]
         },
+        "fork": {
+          "type": "boolean",
+          "description": "Whether to publish the changeset to a fork of the target repository. If omitted, the changeset will be published to a branch directly on the target repository, unless the global `batches.enforceFork` setting is enabled. If set, this property will override any global setting."
+        },
         "headRef": {
           "type": "string",
           "description": "The full name of the Git ref that holds the changes proposed by this changeset. This ref will be created or updated with the commits.",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -478,6 +478,8 @@ type BranchChangesetSpec struct {
 	Body string `json:"body"`
 	// Commits description: The Git commits with the proposed changes. These commits are pushed to the head ref.
 	Commits []*GitCommitDescription `json:"commits"`
+	// Fork description: Whether to publish the changeset to a fork of the target repository. If omitted, the changeset will be published to a branch directly on the target repository, unless the global `batches.enforceFork` setting is enabled. If set, this property will override any global setting.
+	Fork bool `json:"fork,omitempty"`
 	// HeadRef description: The full name of the Git ref that holds the changes proposed by this changeset. This ref will be created or updated with the commits.
 	HeadRef string `json:"headRef"`
 	// HeadRepository description: The GraphQL ID of the repository that contains the branch with this changeset's changes. Fork repositories and cross-repository changesets are not yet supported. Therefore, headRepository must be equal to baseRepository.


### PR DESCRIPTION
Part 1 of [#58150](https://github.com/sourcegraph/sourcegraph/issues/58150)

#51572 added the `fork` attribute to the changeset template. This allowed per-batch-change control for pushing to a fork of the upstream repository. However, this was only supported by SSBC, and the field was ignored by batch changes created via the `src-cli` tool.

This PR adds the attributes to the `/lib` so that `src-cli` can properly parse the fork attribute whenever it's specified in a batch spec.

## Test plan

* I did a couple of manual tests to ensure this change didn't introduce any regression.
* Added a test for fork support to the `ParseChangesetSpec` function.
* Batch changes created via `src-cli` with the fork attribute now have the proper `fork_namespace` set.

![CleanShot 2023-11-07 at 14 08 42@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/e3a76517-e5d1-448a-a94c-40cf9b80129c)

