### PR TITLE
feat: add custom chat model selection

### DIFF
--- a/internal/completions/httpapi/chat.go
+++ b/internal/completions/httpapi/chat.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -24,6 +25,9 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 		rl,
 		"chat",
 		func(requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
+			if isAllowedCustomChatModel(requestParams.Model) {
+				return requestParams.Model, nil
+			}
 			// No user defined models for now.
 			if requestParams.Fast {
 				return c.FastChatModel, nil
@@ -31,4 +35,24 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 			return c.ChatModel, nil
 		},
 	)
+}
+
+// We only allow dotcom clients to select a custom chat model and maintain an allowlist for which
+// custom values we support
+func isAllowedCustomChatModel(model string) bool {
+	if !(envvar.SourcegraphDotComMode()) {
+		return false
+	}
+
+	switch model {
+	case "anthropic/claude-2",
+		"anthropic/claude-v1",
+		"anthropic/claude-instant-1",
+		"openai/gpt-4",
+		"openai/gpt-3.5-turbo",
+		"openai/gpt-4-1106-preview":
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
feat: add custom chat model selection

Allow dotcom clients to specify a custom chat model. Maintain an allowlist of supported models, and only allow custom models for dotcom clients.

Models can be specified in the request parameters, and will be returned directly if allowed. Otherwise default to the configured chat model.


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

Set the model field in [CompletionParameters](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/lib/shared/src/sourcegraph-api/completions/types.ts?L26%3A1-35%3A2) to a value that's not on the allowed list will always fallback to using the default model. 

When an allowed model is configured, it should use the correct model accordingly.