### PR TITLE
Code Navigation: align EOF message with code mirror content

### DIFF
--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -154,6 +154,10 @@ const blameDecorationTheme = EditorView.theme({
         // override default .cm-gutters z-index 200
         zIndex: 201,
     },
+    '.no-line-break-msg': {
+        marginLeft: 'calc(var(--blame-decoration-width))',
+        zIndex: 201,
+    },
 })
 
 class BlameDecorationViewPlugin implements PluginValue {

--- a/client/web/src/repo/blob/codemirror/blame-decorations.tsx
+++ b/client/web/src/repo/blob/codemirror/blame-decorations.tsx
@@ -155,8 +155,7 @@ const blameDecorationTheme = EditorView.theme({
         zIndex: 201,
     },
     '.no-line-break-msg': {
-        marginLeft: 'calc(var(--blame-decoration-width))',
-        zIndex: 201,
+        marginLeft: 'var(--blame-decoration-width)',
     },
 })
 


### PR DESCRIPTION
Fixes a layout bug that was causing EOF message in the blob view to align with git blame decorations instead of with code mirror content. Before and After video: 


https://github.com/sourcegraph/sourcegraph/assets/62355966/79dd6673-6f05-448d-a24c-7d08ce779fe0


## Test plan
Manual testing on files with and without the EOF decoration
