### PR TITLE
[Cody GA Docs] Add DatGrip to list of supported JetBrains IDEs

### DIFF
--- a/doc/cody/overview/install-jetbrains.md
+++ b/doc/cody/overview/install-jetbrains.md
@@ -128,6 +128,7 @@ The Cody extension by Sourcegraph enhances your coding experience in your IDE by
   - [Android Studio](https://developer.android.com/studio)
   - [AppCode](https://www.jetbrains.com/objc/)
   - [CLion](https://www.jetbrains.com/clion/)
+  - [DataGrip](https://www.jetbrains.com/datagrip/)
   - [GoLand](https://www.jetbrains.com/go/)
   - [IntelliJ IDEA](https://www.jetbrains.com/idea/) (Community and Ultimate editions)
   - [PhpStorm](https://www.jetbrains.com/phpstorm/)


### PR DESCRIPTION
The PR adds DataGrip as the supported IDE in JetBrains docs.

## Test plan

Docs Added

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@add-datagrip)