### PR TITLE
[Search UI]: Add new experimental search UI navigation

### DIFF
--- a/client/branded/src/search-ui/input/SearchBox.story.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.story.tsx
@@ -24,10 +24,6 @@ export default config
 
 const defaultProps: SearchBoxProps = {
     telemetryService: NOOP_TELEMETRY_SERVICE,
-    settingsCascade: {
-        final: null,
-        subjects: null,
-    },
     queryState: { query: 'hello repo:test' },
     isSourcegraphDotCom: false,
     patternType: SearchPatternType.standard,

--- a/client/branded/src/search-ui/input/SearchBox.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.tsx
@@ -192,7 +192,6 @@ export const SearchBox: FC<SearchBoxProps> = props => {
                         setCaseSensitivity={props.setCaseSensitivity}
                         searchMode={props.searchMode}
                         setSearchMode={props.setSearchMode}
-                        settingsCascade={props.settingsCascade}
                         submitSearch={props.submitSearchOnToggle}
                         navbarSearchQuery={queryState.query}
                         className={styles.searchBoxToggles}

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -1,5 +1,10 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
+:root {
+    --search-box-color: var(--input-bg);
+    --search-box-border: 1px solid var(--border-color-2);
+}
+
 .container {
     width: 100%;
     position: relative;
@@ -29,8 +34,8 @@
     min-height: 32px;
     padding: 0 0.25rem;
     border-radius: 4px;
-    border: 1px solid var(--border-color-2);
-    background-color: var(--input-bg);
+    border: var(--search-box-border);
+    background-color: var(--search-box-color);
     position: relative;
 
     &:focus-within {

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -111,7 +111,8 @@ const staticExtensions: Extension = [
     EditorView.theme({
         '&': {
             flex: 1,
-            backgroundColor: 'var(--input-bg)',
+            // To change code mirror input area color via CSS property
+            backgroundColor: 'var(--search-box-color)',
             borderRadius: 'var(--border-radius)',
             borderColor: 'var(--border-color)',
             // To ensure that the input doesn't overflow the parent
@@ -147,8 +148,6 @@ export enum QueryInputVisualMode {
 
 export interface CodeMirrorQueryInputWrapperProps {
     queryState: QueryState
-    onChange: (queryState: QueryState) => void
-    onSubmit: () => void
     interpretComments: boolean
     patternType: SearchPatternType
     placeholder: string
@@ -156,14 +155,16 @@ export interface CodeMirrorQueryInputWrapperProps {
     extensions?: Extension
     visualMode?: QueryInputVisualMode | `${QueryInputVisualMode}`
     className?: string
+    onChange: (queryState: QueryState) => void
+    onSubmit: () => void
+    onFocus?: (editor: EditorView) => void
+    onBlur?: (editor: EditorView) => void
 }
 
 export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<CodeMirrorQueryInputWrapperProps>>(
     (
         {
             queryState,
-            onChange,
-            onSubmit,
             interpretComments,
             patternType,
             placeholder,
@@ -172,6 +173,10 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
             visualMode = QueryInputVisualMode.Standard,
             className,
             children,
+            onChange,
+            onSubmit,
+            onFocus,
+            onBlur,
         },
         ref
     ) => {
@@ -305,6 +310,8 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
                         onEnter={onSubmitHandler}
                         onChange={onChangeHandler}
                         multiLine={false}
+                        onFocus={onFocus}
+                        onBlur={onBlur}
                     />
                     {!mode && children}
                 </div>

--- a/client/branded/src/search-ui/input/toggles/Toggles.test.tsx
+++ b/client/branded/src/search-ui/input/toggles/Toggles.test.tsx
@@ -19,7 +19,6 @@ describe('Toggles', () => {
                     setCaseSensitivity={() => undefined}
                     searchMode={SearchMode.Precise}
                     setSearchMode={() => undefined}
-                    settingsCascade={{ subjects: null, final: {} }}
                 />
             )
 
@@ -36,7 +35,6 @@ describe('Toggles', () => {
                     setCaseSensitivity={() => undefined}
                     searchMode={SearchMode.Precise}
                     setSearchMode={() => undefined}
-                    settingsCascade={{ subjects: null, final: {} }}
                 />
             )
             expect(screen.getAllByRole('checkbox', { name: 'Case sensitivity toggle' })).toMatchSnapshot()
@@ -52,7 +50,6 @@ describe('Toggles', () => {
                     setCaseSensitivity={() => undefined}
                     searchMode={SearchMode.Precise}
                     setSearchMode={() => undefined}
-                    settingsCascade={{ subjects: null, final: {} }}
                 />
             )
             expect(screen.getAllByRole('checkbox', { name: 'Regular expression toggle' })).toMatchSnapshot()

--- a/client/branded/src/search-ui/input/toggles/Toggles.tsx
+++ b/client/branded/src/search-ui/input/toggles/Toggles.tsx
@@ -13,7 +13,6 @@ import {
     type SearchModeProps,
 } from '@sourcegraph/shared/src/search'
 import { findFilter, FilterKind } from '@sourcegraph/shared/src/search/query/query'
-import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 
 import { QueryInputToggle } from './QueryInputToggle'
 import { SmartSearchToggle } from './SmartSearchToggle'
@@ -25,7 +24,6 @@ export interface TogglesProps
         SearchPatternTypeMutationProps,
         CaseSensitivityProps,
         SearchModeProps,
-        SettingsCascadeProps,
         Partial<Pick<SubmitSearchProps, 'submitSearch'>> {
     navbarSearchQuery: string
     className?: string

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1159,6 +1159,7 @@ ts_project(
         "src/nav/StatusMessagesNavItemQueries.ts",
         "src/nav/UserNavItem.tsx",
         "src/nav/index.ts",
+        "src/nav/new-global-navigation/NewGlobalNavigationBar.tsx",
         "src/notebooks/GlobalNotebooksArea.tsx",
         "src/notebooks/backend.ts",
         "src/notebooks/blocks/NotebookBlock.tsx",

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -222,6 +222,15 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
         return <Navigate to={PageRoutes.PostSignUp} replace={true} />
     }
 
+    const showNavigationSearchBox =
+        isSearchRelatedPage &&
+        !isSearchHomepage &&
+        !isCommunitySearchContextPage &&
+        !isSearchConsolePage &&
+        !isSearchNotebooksPage &&
+        !isCodySearchPage &&
+        !isSearchJobsPage
+
     return (
         <div
             className={classNames(
@@ -261,15 +270,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                 <>
                     {newSearchNavigation ? (
                         <NewGlobalNavigationBar
-                            showSearchBox={
-                                isSearchRelatedPage &&
-                                !isSearchHomepage &&
-                                !isCommunitySearchContextPage &&
-                                !isSearchConsolePage &&
-                                !isSearchNotebooksPage &&
-                                !isCodySearchPage &&
-                                !isSearchJobsPage
-                            }
+                            showSearchBox={showNavigationSearchBox}
                             authenticatedUser={props.authenticatedUser}
                             isSourcegraphDotCom={props.isSourcegraphDotCom}
                             ownEnabled={props.ownEnabled}
@@ -284,15 +285,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                     ) : (
                         <GlobalNavbar
                             {...props}
-                            showSearchBox={
-                                isSearchRelatedPage &&
-                                !isSearchHomepage &&
-                                !isCommunitySearchContextPage &&
-                                !isSearchConsolePage &&
-                                !isSearchNotebooksPage &&
-                                !isCodySearchPage &&
-                                !isSearchJobsPage
-                            }
+                            showSearchBox={showNavigationSearchBox}
                             setFuzzyFinderIsVisible={setFuzzyFinderVisible}
                             isRepositoryRelatedPage={isRepositoryRelatedPage}
                             showKeyboardShortcutsHelp={showKeyboardShortcutsHelp}

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -25,6 +25,7 @@ import { useHandleSubmitFeedback } from './hooks'
 import type { LegacyLayoutRouteContext } from './LegacyRouteContext'
 import { SurveyToast } from './marketing/toast'
 import { GlobalNavbar } from './nav/GlobalNavbar'
+import { NewGlobalNavigationBar } from './nav/new-global-navigation/NewGlobalNavigationBar'
 import { EnterprisePageRoutes, PageRoutes } from './routes.constants'
 import { parseSearchURLQuery } from './search'
 import { NotepadContainer } from './search/Notepad'
@@ -114,6 +115,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
     const isGetCodyPage = location.pathname === PageRoutes.GetCody
     const isPostSignUpPage = location.pathname === PageRoutes.PostSignUp
 
+    const newSearchNavigation = useExperimentalFeatures<boolean>(features => features.newSearchNavigationUI ?? false)
     const [enableContrastCompliantSyntaxHighlighting] = useFeatureFlag('contrast-compliant-syntax-highlighting')
 
     const { theme } = useTheme()
@@ -256,22 +258,51 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                 !disableFeedbackSurvey &&
                 !props.isCodyApp && <SurveyToast authenticatedUser={props.authenticatedUser} />}
             {!isSiteInit && !isSignInOrUp && !isGetCodyPage && !isPostSignUpPage && (
-                <GlobalNavbar
-                    {...props}
-                    showSearchBox={
-                        isSearchRelatedPage &&
-                        !isSearchHomepage &&
-                        !isCommunitySearchContextPage &&
-                        !isSearchConsolePage &&
-                        !isSearchNotebooksPage &&
-                        !isCodySearchPage &&
-                        !isSearchJobsPage
-                    }
-                    setFuzzyFinderIsVisible={setFuzzyFinderVisible}
-                    isRepositoryRelatedPage={isRepositoryRelatedPage}
-                    showKeyboardShortcutsHelp={showKeyboardShortcutsHelp}
-                    showFeedbackModal={showFeedbackModal}
-                />
+                <>
+                    {newSearchNavigation ? (
+                        <NewGlobalNavigationBar
+                            showSearchBox={
+                                isSearchRelatedPage &&
+                                !isSearchHomepage &&
+                                !isCommunitySearchContextPage &&
+                                !isSearchConsolePage &&
+                                !isSearchNotebooksPage &&
+                                !isCodySearchPage &&
+                                !isSearchJobsPage
+                            }
+                            authenticatedUser={props.authenticatedUser}
+                            isSourcegraphDotCom={props.isSourcegraphDotCom}
+                            ownEnabled={props.ownEnabled}
+                            notebooksEnabled={props.notebooksEnabled}
+                            searchContextsEnabled={props.searchContextsEnabled}
+                            codeMonitoringEnabled={props.codeMonitoringEnabled}
+                            batchChangesEnabled={props.batchChangesEnabled}
+                            codeInsightsEnabled={props.codeInsightsEnabled ?? false}
+                            selectedSearchContextSpec={props.selectedSearchContextSpec}
+                            fetchSearchContexts={props.fetchSearchContexts}
+                            getUserSearchContextNamespaces={props.getUserSearchContextNamespaces}
+                            telemetryService={props.telemetryService}
+                            platformContext={props.platformContext}
+                        />
+                    ) : (
+                        <GlobalNavbar
+                            {...props}
+                            showSearchBox={
+                                isSearchRelatedPage &&
+                                !isSearchHomepage &&
+                                !isCommunitySearchContextPage &&
+                                !isSearchConsolePage &&
+                                !isSearchNotebooksPage &&
+                                !isCodySearchPage &&
+                                !isSearchJobsPage
+                            }
+                            setFuzzyFinderIsVisible={setFuzzyFinderVisible}
+                            isRepositoryRelatedPage={isRepositoryRelatedPage}
+                            showKeyboardShortcutsHelp={showKeyboardShortcutsHelp}
+                            showFeedbackModal={showFeedbackModal}
+                        />
+                    )}
+                </>
             )}
             {props.isCodyApp && <StartupUpdateChecker />}
             {needsSiteInit && !isSiteInit && <Navigate replace={true} to="/site-admin/init" />}

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -279,10 +279,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                             batchChangesEnabled={props.batchChangesEnabled}
                             codeInsightsEnabled={props.codeInsightsEnabled ?? false}
                             selectedSearchContextSpec={props.selectedSearchContextSpec}
-                            fetchSearchContexts={props.fetchSearchContexts}
-                            getUserSearchContextNamespaces={props.getUserSearchContextNamespaces}
                             telemetryService={props.telemetryService}
-                            platformContext={props.platformContext}
                         />
                     ) : (
                         <GlobalNavbar

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
@@ -46,6 +46,7 @@ const externalService = {
     lastSyncError: null,
     repoCount: 0,
     lastSyncAt: null,
+    unrestricted: false,
     nextSyncAt: null,
     updatedAt: '2021-03-15T19:39:11Z',
     createdAt: '2021-03-15T19:39:11Z',

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -42,6 +42,7 @@ const externalService = {
     lastSyncError: null,
     repoCount: 1337,
     lastSyncAt: null,
+    unrestricted: false,
     nextSyncAt: null,
     updatedAt: '2021-03-15T19:39:11Z',
     createdAt: '2021-03-15T19:39:11Z',

--- a/client/web/src/devsettings/DeveloperSettingsGlobalNavItem.tsx
+++ b/client/web/src/devsettings/DeveloperSettingsGlobalNavItem.tsx
@@ -14,7 +14,6 @@ import {
     parseUrlOverrideFeatureFlags,
 } from '../featureFlags/lib/parseUrlOverrideFeatureFlags'
 import { useFeatureFlagOverrides } from '../featureFlags/useFeatureFlagOverrides'
-import { NavAction } from '../nav'
 import { toggleDevSettingsDialog, useOverrideCounter } from '../stores'
 
 /**
@@ -31,45 +30,39 @@ function getReloadURL(): string {
     return url.toString()
 }
 
-export const DeveloperSettingsGlobalNavItem: FC<{}> = () => {
+export const DeveloperSettingsGlobalNavItem: FC<{ className?: string }> = ({ className }) => {
     const counter = useOverrideCounter()
     const hasOverrides = counter.featureFlags + counter.temporarySettings > 0
     const showReloadButton = useMighNeedReload()
 
     return (
-        <NavAction>
-            <span className="d-flex">
-                <Button
-                    className={classNames(showReloadButton && 'pr-1')}
-                    variant="link"
-                    onClick={() => toggleDevSettingsDialog(true)}
-                >
-                    Developer Settings
-                    {hasOverrides && (
-                        <Tooltip
-                            content={`You have ${counter.featureFlags} local feature flag and ${counter.temporarySettings} temporary settings overrides.`}
-                        >
-                            <Icon
-                                className="ml-1"
-                                style={{ color: 'var(--orange)' }}
-                                svgPath={mdiAlertOctagon}
-                                aria-hidden={true}
-                            />
-                        </Tooltip>
-                    )}
-                </Button>
-                {showReloadButton && (
-                    <>
-                        <ReloadButton variant="icon" />
-                        <Shortcut
-                            held={['Mod']}
-                            ordered={['r']}
-                            onMatch={() => (window.location.href = getReloadURL())}
+        <span className={classNames(className, 'd-flex')}>
+            <Button
+                variant="link"
+                className={classNames(showReloadButton && 'pr-1')}
+                onClick={() => toggleDevSettingsDialog(true)}
+            >
+                Developer Settings
+                {hasOverrides && (
+                    <Tooltip
+                        content={`You have ${counter.featureFlags} local feature flag and ${counter.temporarySettings} temporary settings overrides.`}
+                    >
+                        <Icon
+                            className="ml-1"
+                            style={{ color: 'var(--orange)' }}
+                            svgPath={mdiAlertOctagon}
+                            aria-hidden={true}
                         />
-                    </>
+                    </Tooltip>
                 )}
-            </span>
-        </NavAction>
+            </Button>
+            {showReloadButton && (
+                <>
+                    <ReloadButton variant="icon" />
+                    <Shortcut held={['Mod']} ordered={['r']} onMatch={() => (window.location.href = getReloadURL())} />
+                </>
+            )}
+        </span>
     )
 }
 

--- a/client/web/src/nav/GlobalNavbar.module.scss
+++ b/client/web/src/nav/GlobalNavbar.module.scss
@@ -35,3 +35,8 @@
     padding: 0.75rem 1rem;
     border-bottom: 1px solid var(--border-color);
 }
+
+.list {
+    width: 100%;
+    overflow: hidden;
+}

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -316,8 +316,6 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
     const navbarReference = useRef<HTMLDivElement | null>(null)
     const navLinkVariant = useCalculatedNavLinkVariant(navbarReference)
 
-    console.log({ navLinkVariant })
-
     const searchNavBarItems = useMemo(() => {
         const items: (NavDropdownItem | false)[] = [
             showSearchContext && { path: EnterprisePageRoutes.Contexts, content: 'Contexts' },

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -1,4 +1,4 @@
-import React, { type SetStateAction, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { FC, MutableRefObject, type SetStateAction, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 import BarChartIcon from 'mdi-react/BarChartIcon'
@@ -6,6 +6,7 @@ import BookOutlineIcon from 'mdi-react/BookOutlineIcon'
 import CommentQuoteOutline from 'mdi-react/CommentQuoteOutlineIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import { type RouteObject, useLocation } from 'react-router-dom'
+import useResizeObserver from 'use-resize-observer'
 
 import { isMacPlatform } from '@sourcegraph/common'
 import { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
@@ -15,7 +16,7 @@ import type { SearchContextInputProps } from '@sourcegraph/shared/src/search'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-import { Button, ButtonLink, Link, ProductStatusBadge, useWindowSize } from '@sourcegraph/wildcard'
+import { Button, ButtonLink, Link, ProductStatusBadge } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../auth'
 import type { BatchChangesProps } from '../batches'
@@ -77,12 +78,10 @@ export interface GlobalNavbarProps
  * Calculates NavLink variant based whether current content fits into container or not.
  * @param containerReference a reference to navbar container
  */
-function useCalculatedNavLinkVariant(
-    containerReference: React.MutableRefObject<HTMLDivElement | null>,
-    authenticatedUser: GlobalNavbarProps['authenticatedUser']
-): 'compact' | undefined {
+function useCalculatedNavLinkVariant(containerReference: MutableRefObject<HTMLElement | null>): 'compact' | undefined {
+    const { width = 0 } = useResizeObserver({ ref: containerReference })
+
     const [navLinkVariant, setNavLinkVariant] = useState<'compact'>()
-    const { width } = useWindowSize()
     const [savedWindowWidth, setSavedWindowWidth] = useState<number>()
 
     useLayoutEffect(() => {
@@ -90,15 +89,14 @@ function useCalculatedNavLinkVariant(
         if (!container) {
             return
         }
+
         if (container.offsetWidth < container.scrollWidth) {
             setNavLinkVariant('compact')
             setSavedWindowWidth(width)
         } else if (savedWindowWidth && width > savedWindowWidth) {
             setNavLinkVariant(undefined)
         }
-        // Listen for change in `authenticatedUser` to re-calculate with new dimensions,
-        // based on change in navbar's content.
-    }, [containerReference, savedWindowWidth, width, authenticatedUser])
+    }, [containerReference, savedWindowWidth, width])
 
     return navLinkVariant
 }
@@ -159,35 +157,8 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
         }
     }, [showSearchBox, onNavbarQueryChange])
 
-    const navbarReference = useRef<HTMLDivElement | null>(null)
-    const navLinkVariant = useCalculatedNavLinkVariant(navbarReference, props.authenticatedUser)
-
     // CodeInsightsEnabled props controls insights appearance over OSS and Enterprise version
-    const codeInsights = codeInsightsEnabled && !isCodyApp && !isSourcegraphDotCom
-
-    const searchNavBarItems = useMemo(() => {
-        const items: (NavDropdownItem | false)[] = [
-            !!showSearchContext && { path: EnterprisePageRoutes.Contexts, content: 'Contexts' },
-            ownEnabled && { path: EnterprisePageRoutes.Own, content: 'Code ownership' },
-            codySearchEnabled && {
-                path: EnterprisePageRoutes.CodySearch,
-                content: (
-                    <>
-                        Natural language search <ProductStatusBadge status="experimental" />
-                    </>
-                ),
-            },
-            !!isSearchJobsEnabled() && {
-                path: EnterprisePageRoutes.SearchJobs,
-                content: (
-                    <>
-                        Search Jobs <ProductStatusBadge className="ml-2" status="experimental" />
-                    </>
-                ),
-            },
-        ]
-        return items.filter<NavDropdownItem>((item): item is NavDropdownItem => !!item)
-    }, [ownEnabled, showSearchContext, codySearchEnabled])
+    const codeInsights = (codeInsightsEnabled && !isCodyApp && !isSourcegraphDotCom) ?? false
 
     const { fuzzyFinderNavbar } = useFuzzyFinderFeatureFlags()
 
@@ -198,7 +169,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
     return (
         <>
             <NavBar
-                ref={navbarReference}
                 logo={
                     !isCodyApp && (
                         <BrandLogo
@@ -210,95 +180,30 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                     )
                 }
             >
-                <NavGroup>
-                    {!isCodyApp &&
-                        (searchNavBarItems.length > 0 ? (
-                            <NavDropdown
-                                toggleItem={{
-                                    path: PageRoutes.Search,
-                                    altPath: PageRoutes.RepoContainer,
-                                    icon: MagnifyIcon,
-                                    content: 'Code Search',
-                                    variant: navLinkVariant,
-                                }}
-                                routeMatch={routeMatch}
-                                homeItem={{ content: 'Search home' }}
-                                items={searchNavBarItems}
-                                name="search"
-                            />
-                        ) : (
-                            <NavItem icon={MagnifyIcon}>
-                                <NavLink variant={navLinkVariant} to={PageRoutes.Search}>
-                                    Code Search
-                                </NavLink>
-                            </NavItem>
-                        ))}
-                    <NavItem icon={CodyLogo}>
-                        <NavLink variant={navLinkVariant} to={EnterprisePageRoutes.Cody}>
-                            Cody
-                        </NavLink>
-                    </NavItem>
-                    {showSearchNotebook && (
-                        <NavItem icon={BookOutlineIcon}>
-                            <NavLink variant={navLinkVariant} to={EnterprisePageRoutes.Notebooks}>
-                                Notebooks
-                            </NavLink>
-                        </NavItem>
-                    )}
-                    {showCodeMonitoring && (
-                        <NavItem icon={CodeMonitoringLogo}>
-                            <NavLink variant={navLinkVariant} to="/code-monitoring">
-                                Monitoring
-                            </NavLink>
-                        </NavItem>
-                    )}
-                    {/* This is the only circumstance where we show something
-                         batch-changes-related even if the instance does not have batch
-                         changes enabled, for marketing purposes on sourcegraph.com */}
-                    {showBatchChanges && <BatchChangesNavItem variant={navLinkVariant} />}
-                    {codeInsights && (
-                        <NavItem icon={BarChartIcon}>
-                            <NavLink variant={navLinkVariant} to="/insights">
-                                Insights
-                            </NavLink>
-                        </NavItem>
-                    )}
-                    {isCodyApp && (
-                        <NavDropdown
-                            routeMatch="something-that-never-matches"
-                            toggleItem={{
-                                path: '#',
-                                icon: CommentQuoteOutline,
-                                content: 'Feedback',
-                                variant: navLinkVariant,
-                            }}
-                            items={[
-                                {
-                                    content: 'Join our Discord',
-                                    path: 'https://discord.com/servers/sourcegraph-969688426372825169',
-                                    target: '_blank',
-                                },
-                                {
-                                    content: 'File an issue',
-                                    path: 'https://github.com/sourcegraph/app',
-                                    target: '_blank',
-                                },
-                            ]}
-                            name="feedback"
-                        />
-                    )}
-                    {isSourcegraphDotCom && (
-                        <NavItem>
-                            <NavLink variant={navLinkVariant} to="https://about.sourcegraph.com" external={true}>
-                                About Sourcegraph
-                            </NavLink>
-                        </NavItem>
-                    )}
-                </NavGroup>
+                <InlineNavigationPanel
+                    isCodyApp={isCodyApp}
+                    showSearchContext={showSearchContext}
+                    showOwn={ownEnabled}
+                    showCodySearch={codySearchEnabled}
+                    showSearchJobs={isSearchJobsEnabled()}
+                    showSearchNotebook={showSearchNotebook}
+                    showCodeMonitoring={showCodeMonitoring}
+                    showBatchChanges={showBatchChanges}
+                    showCodeInsights={codeInsights}
+                    routeMatch={routeMatch}
+                    isSourcegraphDotCom={isSourcegraphDotCom}
+                />
+
                 <NavActions>
-                    {developerMode && <DeveloperSettingsGlobalNavItem />}
+                    {process.env.NODE_ENV === 'development' && (
+                        <NavAction>
+                            <DeveloperSettingsGlobalNavItem />
+                        </NavAction>
+                    )}
                     {isCodyApp && <UpdateGlobalNav />}
-                    {props.authenticatedUser?.siteAdmin && <AccessRequestsGlobalNavItem />}
+                    {props.authenticatedUser?.siteAdmin && (
+                        <AccessRequestsGlobalNavItem className="d-flex align-items-center py-1" />
+                    )}
                     {isSourcegraphDotCom && (
                         <NavAction>
                             <Link
@@ -372,5 +277,156 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                 </div>
             )}
         </>
+    )
+}
+
+export interface InlineNavigationPanelProps {
+    isCodyApp: boolean
+    showSearchContext: boolean
+    showOwn: boolean
+    showCodySearch: boolean
+    showSearchJobs: boolean
+    showSearchNotebook: boolean
+    showCodeMonitoring: boolean
+    showBatchChanges: boolean
+    showCodeInsights: boolean
+    isSourcegraphDotCom: boolean
+
+    /** A current react router route match */
+    routeMatch?: string
+    className?: string
+}
+
+export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
+    const {
+        isCodyApp,
+        showSearchContext,
+        showOwn,
+        showCodySearch,
+        showSearchJobs,
+        showSearchNotebook,
+        showBatchChanges,
+        showCodeInsights,
+        showCodeMonitoring,
+        isSourcegraphDotCom,
+        routeMatch,
+        className,
+    } = props
+
+    const navbarReference = useRef<HTMLDivElement | null>(null)
+    const navLinkVariant = useCalculatedNavLinkVariant(navbarReference)
+
+    console.log({ navLinkVariant })
+
+    const searchNavBarItems = useMemo(() => {
+        const items: (NavDropdownItem | false)[] = [
+            showSearchContext && { path: EnterprisePageRoutes.Contexts, content: 'Contexts' },
+            showOwn && { path: EnterprisePageRoutes.Own, content: 'Code ownership' },
+            showCodySearch && {
+                path: EnterprisePageRoutes.CodySearch,
+                content: (
+                    <>
+                        Natural language search <ProductStatusBadge status="experimental" />
+                    </>
+                ),
+            },
+            showSearchJobs && {
+                path: EnterprisePageRoutes.SearchJobs,
+                content: (
+                    <>
+                        Search Jobs <ProductStatusBadge className="ml-2" status="experimental" />
+                    </>
+                ),
+            },
+        ]
+        return items.filter<NavDropdownItem>((item): item is NavDropdownItem => !!item)
+    }, [showOwn, showSearchContext, showCodySearch, showSearchJobs])
+
+    return (
+        <NavGroup ref={navbarReference} className={classNames(className, styles.list)}>
+            {!isCodyApp &&
+                (searchNavBarItems.length > 0 ? (
+                    <NavDropdown
+                        toggleItem={{
+                            path: PageRoutes.Search,
+                            altPath: PageRoutes.RepoContainer,
+                            icon: MagnifyIcon,
+                            content: 'Code Search',
+                            variant: navLinkVariant,
+                        }}
+                        routeMatch={routeMatch}
+                        homeItem={{ content: 'Search home' }}
+                        items={searchNavBarItems}
+                        name="search"
+                    />
+                ) : (
+                    <NavItem icon={MagnifyIcon}>
+                        <NavLink variant={navLinkVariant} to={PageRoutes.Search}>
+                            Code Search
+                        </NavLink>
+                    </NavItem>
+                ))}
+            <NavItem icon={CodyLogo}>
+                <NavLink variant={navLinkVariant} to={EnterprisePageRoutes.Cody}>
+                    Cody
+                </NavLink>
+            </NavItem>
+            {showSearchNotebook && (
+                <NavItem icon={BookOutlineIcon}>
+                    <NavLink variant={navLinkVariant} to={EnterprisePageRoutes.Notebooks}>
+                        Notebooks
+                    </NavLink>
+                </NavItem>
+            )}
+            {showCodeMonitoring && (
+                <NavItem icon={CodeMonitoringLogo}>
+                    <NavLink variant={navLinkVariant} to="/code-monitoring">
+                        Monitoring
+                    </NavLink>
+                </NavItem>
+            )}
+            {/* This is the only circumstance where we show something
+                batch-changes-related even if the instance does not have batch
+                changes enabled, for marketing purposes on sourcegraph.com */}
+            {showBatchChanges && <BatchChangesNavItem variant={navLinkVariant} />}
+            {showCodeInsights && (
+                <NavItem icon={BarChartIcon}>
+                    <NavLink variant={navLinkVariant} to="/insights">
+                        Insights
+                    </NavLink>
+                </NavItem>
+            )}
+            {isCodyApp && (
+                <NavDropdown
+                    routeMatch="something-that-never-matches"
+                    toggleItem={{
+                        path: '#',
+                        icon: CommentQuoteOutline,
+                        content: 'Feedback',
+                        variant: navLinkVariant,
+                    }}
+                    items={[
+                        {
+                            content: 'Join our Discord',
+                            path: 'https://discord.com/servers/sourcegraph-969688426372825169',
+                            target: '_blank',
+                        },
+                        {
+                            content: 'File an issue',
+                            path: 'https://github.com/sourcegraph/app',
+                            target: '_blank',
+                        },
+                    ]}
+                    name="feedback"
+                />
+            )}
+            {isSourcegraphDotCom && (
+                <NavItem>
+                    <NavLink variant={navLinkVariant} to="https://about.sourcegraph.com" external={true}>
+                        About Sourcegraph
+                    </NavLink>
+                </NavItem>
+            )}
+        </NavGroup>
     )
 }

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -195,7 +195,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                 />
 
                 <NavActions>
-                    {process.env.NODE_ENV === 'development' && (
+                    {developerMode && (
                         <NavAction>
                             <DeveloperSettingsGlobalNavItem />
                         </NavAction>

--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -30,6 +30,7 @@ interface NavBarProps {
 
 interface NavGroupProps {
     children: React.ReactNode
+    className?: string
 }
 
 interface NavItemProps {
@@ -69,26 +70,26 @@ export const NavBar = forwardRef(function NavBar({ children, logo }, reference):
 
 export const MobileNavGroupContext = React.createContext(false)
 
-export const NavGroup = ({ children }: NavGroupProps): JSX.Element => {
+export const NavGroup = forwardRef<HTMLDivElement, NavGroupProps>(({ children, className }: NavGroupProps, ref) => {
     const isMobileSize = useMatchMedia(`(max-width: ${VIEWPORT_SM}px)`)
 
     return (
         <MobileNavGroupContext.Provider value={isMobileSize}>
             {isMobileSize ? (
-                <Menu>
+                <Menu ref={ref} className={className}>
                     <MenuButton aria-label="Sections Navigation">
                         <Icon aria-hidden={true} svgPath={mdiMenu} />
                     </MenuButton>
                     <MenuList>{children}</MenuList>
                 </Menu>
             ) : (
-                <div className={navBarStyles.menu}>
+                <div ref={ref} className={classNames(navBarStyles.menu, className)}>
                     <ul className={navBarStyles.list}>{children}</ul>
                 </div>
             )}
         </MobileNavGroupContext.Provider>
     )
-}
+})
 
 export const NavActions: React.FunctionComponent<React.PropsWithChildren<NavActionsProps>> = ({ children }) => (
     <ul className={navActionStyles.actions}>{children}</ul>

--- a/client/web/src/nav/NavBar/NavItem.module.scss
+++ b/client/web/src/nav/NavBar/NavItem.module.scss
@@ -3,12 +3,15 @@
 .item {
     display: flex;
     align-items: stretch;
+
     &:first-child {
         margin-left: 0;
     }
+
     &:last-child {
         margin-right: 0;
     }
+
     @media (--xs-breakpoint-down) {
         margin: 0;
     }
@@ -26,12 +29,18 @@
                 padding: 0.125rem;
                 margin: -0.125rem;
             }
+
             @media (--xs-breakpoint-down) {
                 margin: 0;
                 border: 0;
             }
         }
     }
+}
+
+.item-focusable-content {
+    display: flex;
+    align-items: center;
 }
 
 .link {
@@ -60,6 +69,7 @@
             margin: 0;
             border: 0;
             background-color: var(--link-color);
+
             .link-content {
                 margin-bottom: 0;
             }
@@ -69,10 +79,12 @@
             }
         }
     }
+
     .link-content {
         display: inline-flex;
         align-items: center;
     }
+
     @media (--xs-breakpoint-down) {
         padding: 0.75rem 0.625rem;
         flex: 1;
@@ -83,6 +95,7 @@
 
 .active {
     border-bottom: 2px solid var(--brand-secondary);
+
     &:focus-visible {
         margin-top: 0.125rem;
         @media (--xs-breakpoint-down) {
@@ -106,27 +119,23 @@
 .icon {
     color: var(--header-icon-color);
     border-radius: 3px;
+
     @media (--md-breakpoint-down) {
         color: var(--icon-color);
     }
+
     @media (--xs-breakpoint-down) {
         color: var(--body-color);
     }
 }
 
 .icon-included {
-    margin-left: 0.25rem;
     display: inline-flex;
+    margin-left: 0.25rem;
+    white-space: nowrap;
+
     &.is-compact {
-        @media (--md-breakpoint-up) {
-            display: none;
-        }
-    }
-    @media (--md-breakpoint-down) {
         display: none;
-    }
-    @media (--xs-breakpoint-down) {
-        display: inline-flex;
     }
 }
 

--- a/client/web/src/nav/UserNavItem.story.tsx
+++ b/client/web/src/nav/UserNavItem.story.tsx
@@ -41,6 +41,7 @@ const authenticatedUser: UserNavItemProps['authenticatedUser'] = {
     session: { canSignOut: true },
     settingsURL: '#',
     siteAdmin: true,
+    emails: [],
     organizations: {
         nodes: [
             {

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -48,6 +48,7 @@ export interface UserNavItemProps extends TelemetryProps {
     menuButtonRef?: React.Ref<HTMLButtonElement>
     showFeedbackModal: () => void
     showKeyboardShortcutsHelp: () => void
+    className?: string
 }
 
 /**
@@ -63,6 +64,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
         showFeedbackModal,
         showKeyboardShortcutsHelp,
         telemetryService,
+        className,
     } = props
 
     const { themeSetting, setThemeSetting } = useTheme()
@@ -111,7 +113,11 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             ref={menuButtonRef}
                             variant="link"
                             data-testid="user-nav-item-toggle"
-                            className={classNames('d-flex align-items-center text-decoration-none', styles.menuButton)}
+                            className={classNames(
+                                'd-flex align-items-center text-decoration-none',
+                                styles.menuButton,
+                                className
+                            )}
                             aria-label={`${isExpanded ? 'Close' : 'Open'} user profile menu`}
                         >
                             <div className="position-relative">

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`GlobalNavbar > default 1`] = `
       class="divider"
     />
     <div
-      class="menu"
+      class="menu list"
     >
       <ul
         class="list"

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.module.scss
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.module.scss
@@ -1,0 +1,222 @@
+.nav {
+    display: flex;
+    width: 100%;
+    // Reserve vertical space in order to avoid global navigation
+    // jumping when we switch no search box / with search box modes
+    // Formula: 2rem from Search box UI + 1rem paddings + 1 border height
+    min-height: 3.0625rem;
+    gap: 0.5rem;
+    align-items: center;
+    position: relative;
+    padding: 0.5rem;
+    background: var(--color-bg-1);
+    border-bottom: 1px solid var(--border-color-2);
+
+    // TODO: Move to the top level of this component consumer
+    flex-shrink: 0;
+}
+
+.menu-button {
+    border: none;
+    padding: 0.25rem;
+
+    :global(.theme-dark) & {
+        &:hover {
+            background-color: var(--oc-gray-8) !important;
+        }
+    }
+
+    :global(.theme-light) & {
+        &:hover {
+            background-color: var(--oc-gray-2) !important;
+        }
+    }
+}
+
+.logo {
+    width: 1.5rem;
+    height: 1.5rem;
+
+    &:hover {
+        @keyframes spin {
+            50% {
+                transform: rotate(180deg) scale(1.2);
+            }
+            100% {
+                transform: rotate(180deg) scale(1);
+            }
+        }
+
+        @media (prefers-reduced-motion: no-preference) {
+            animation: spin 0.5s ease-in-out 1;
+        }
+    }
+}
+
+.search-bar {
+    flex-grow: 1;
+    border: none;
+    position: relative;
+    z-index: 2;
+    min-width: 0;
+    --search-box-border: none;
+
+    :global(.theme-dark) & {
+        --search-box-color: var(--input-bg);
+
+        &--focused {
+            --search-box-color: unset;
+        }
+    }
+
+    :global(.theme-light) & {
+        --search-box-color: var(--oc-gray-2);
+
+        &--focused {
+            --search-box-color: unset;
+        }
+    }
+}
+
+.inline-navigation-list {
+    margin: -0.5rem 1rem;
+}
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background-color: rgba(172, 182, 192, 0.2);
+    z-index: 1;
+    animation: fadeIn 0.1s ease-in;
+}
+
+@keyframes fadeIn {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}
+
+.sidebar-navigation {
+    position: fixed;
+    top: 0;
+    left: 0;
+    display: flex;
+    flex-direction: column;
+    width: 300px;
+    height: 100%;
+    transform: unset;
+    border: none;
+    padding: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+
+    &-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.625rem 0.5rem 0.5rem 0.5rem;
+    }
+
+    &-logo-link {
+        flex-grow: 1;
+        display: flex;
+        align-items: center;
+    }
+
+    &-logo {
+        width: 140px;
+    }
+
+    &-nav {
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+        flex-grow: 1;
+        overflow: auto;
+    }
+
+    &-list {
+        padding: 0;
+        margin: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        flex-grow: 1;
+
+        &--nested {
+            .nav-link {
+                padding-left: 2.25rem;
+            }
+        }
+    }
+}
+
+.nav-item {
+    display: flex;
+    width: 100%;
+    flex-grow: 1;
+
+    &-nested {
+        flex-direction: column;
+    }
+}
+
+.nav-link {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    align-items: center;
+    gap: 0.25rem;
+    font-weight: normal;
+    font-size: 1rem;
+    border: none;
+    border-radius: 0;
+
+    :global(.theme-dark) & {
+        &:hover {
+            background-color: var(--oc-gray-8) !important;
+        }
+    }
+
+    :global(.theme-light) & {
+        &:hover {
+            background-color: var(--oc-gray-2) !important;
+        }
+    }
+}
+
+.icon {
+    display: inline-flex;
+    width: 1.25rem !important;
+    height: 1.25rem !important;
+    align-items: center;
+    vertical-align: text-bottom;
+    fill: currentColor;
+    color: var(--header-icon-color);
+}
+
+.footer {
+    padding: 0.5rem 0.75rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.developer-link {
+    margin-left: -0.75rem;
+}
+
+.version {
+    color: var(--text-muted);
+    margin: 0;
+}
+
+.sign-in-buttons {
+    display: flex;
+    flex-shrink: 0;
+}

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.module.scss
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.module.scss
@@ -59,6 +59,7 @@
     position: relative;
     z-index: 2;
     min-width: 0;
+
     --search-box-border: none;
 
     :global(.theme-dark) & {
@@ -108,7 +109,7 @@
     left: 0;
     display: flex;
     flex-direction: column;
-    width: 300px;
+    width: 18.75rem;
     height: 100%;
     transform: unset;
     border: none;
@@ -130,7 +131,7 @@
     }
 
     &-logo {
-        width: 140px;
+        width: 8.75rem;
     }
 
     &-nav {

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
@@ -29,6 +29,13 @@ export default config
 export const NewGlobalNavigationBarDemo: StoryFn = () => (
     <NewGlobalNavigationBar
         isSourcegraphDotCom={true}
+        ownEnabled={true}
+        notebooksEnabled={true}
+        searchContextsEnabled={true}
+        codeMonitoringEnabled={true}
+        showSearchBox={true}
+        codeInsightsEnabled={true}
+        batchChangesEnabled={true}
         authenticatedUser={
             {
                 username: 'alice',
@@ -47,7 +54,6 @@ export const NewGlobalNavigationBarDemo: StoryFn = () => (
                 siteAdmin: true,
             } as AuthenticatedUser
         }
-        // authenticatedUser={null}
         selectedSearchContextSpec=""
         fetchSearchContexts={mockFetchSearchContexts}
         getUserSearchContextNamespaces={mockGetUserSearchContextNamespaces}

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
@@ -2,10 +2,6 @@ import { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { updateJSContextBatchChangesLicense } from '@sourcegraph/shared/src/testing/batches'
-import {
-    mockFetchSearchContexts,
-    mockGetUserSearchContextNamespaces,
-} from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
 
 import { AuthenticatedUser } from '../../auth'
 import { WebStory } from '../../components/WebStory'
@@ -55,9 +51,6 @@ export const NewGlobalNavigationBarDemo: StoryFn = () => (
             } as AuthenticatedUser
         }
         selectedSearchContextSpec=""
-        fetchSearchContexts={mockFetchSearchContexts}
-        getUserSearchContextNamespaces={mockGetUserSearchContextNamespaces}
         telemetryService={NOOP_TELEMETRY_SERVICE}
-        platformContext={{} as any}
     />
 )

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
@@ -1,0 +1,57 @@
+import { Decorator, Meta, StoryFn } from '@storybook/react'
+
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { updateJSContextBatchChangesLicense } from '@sourcegraph/shared/src/testing/batches'
+import {
+    mockFetchSearchContexts,
+    mockGetUserSearchContextNamespaces,
+} from '@sourcegraph/shared/src/testing/searchContexts/testHelpers'
+
+import { AuthenticatedUser } from '../../auth'
+import { WebStory } from '../../components/WebStory'
+import { GlobalNavbar, GlobalNavbarProps } from '../GlobalNavbar'
+
+import { NewGlobalNavigationBar } from './NewGlobalNavigationBar'
+
+const decorator: Decorator<GlobalNavbarProps> = Story => {
+    updateJSContextBatchChangesLicense('full')
+
+    return <WebStory>{() => <Story />}</WebStory>
+}
+
+const config: Meta<typeof GlobalNavbar> = {
+    title: 'web/nav/GlobalNav',
+    decorators: [decorator],
+}
+
+export default config
+
+export const NewGlobalNavigationBarDemo: StoryFn = () => (
+    <NewGlobalNavigationBar
+        isSourcegraphDotCom={true}
+        authenticatedUser={
+            {
+                username: 'alice',
+                organizations: {
+                    nodes: [
+                        {
+                            __typename: 'Org',
+                            id: 'acme',
+                            name: 'acme',
+                            displayName: 'Acme',
+                            url: 'https://example.com',
+                            settingsURL: null,
+                        },
+                    ],
+                },
+                siteAdmin: true,
+            } as AuthenticatedUser
+        }
+        // authenticatedUser={null}
+        selectedSearchContextSpec=""
+        fetchSearchContexts={mockFetchSearchContexts}
+        getUserSearchContextNamespaces={mockGetUserSearchContextNamespaces}
+        telemetryService={NOOP_TELEMETRY_SERVICE}
+        platformContext={{} as any}
+    />
+)

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -126,7 +126,7 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
                         telemetryService={telemetryService}
                     />
                 ) : (
-                    <SighInUpButtons isSourcegraphDotCom={isSourcegraphDotCom} />
+                    <SignInUpButtons isSourcegraphDotCom={isSourcegraphDotCom} />
                 )}
             </nav>
 
@@ -247,11 +247,11 @@ const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
     )
 }
 
-interface SighInUpButtonsProps {
+interface SignInUpButtonsProps {
     isSourcegraphDotCom: boolean
 }
 
-const SighInUpButtons: FC<SighInUpButtonsProps> = props => {
+const SignInUpButtons: FC<SignInUpButtonsProps> = props => {
     const { isSourcegraphDotCom } = props
     const location = useLocation()
 

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -9,13 +9,7 @@ import { NavLink, useLocation, useNavigate } from 'react-router-dom'
 import shallow from 'zustand/shallow'
 
 import { Toggles } from '@sourcegraph/branded/src'
-import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
-import {
-    SearchQueryState,
-    fetchSearchContexts,
-    getUserSearchContextNamespaces,
-    SubmitSearchParameters,
-} from '@sourcegraph/shared/src/search'
+import { SearchQueryState, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Text, Icon, Button, Modal, Link, ProductStatusBadge, ButtonLink } from '@sourcegraph/wildcard'
@@ -36,7 +30,7 @@ import { UserNavItem } from '../UserNavItem'
 
 import styles from './NewGlobalNavigationBar.module.scss'
 
-interface NewGlobalNavigationBar extends TelemetryProps, PlatformContextProps<'requestGraphQL'> {
+interface NewGlobalNavigationBar extends TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
     ownEnabled: boolean
@@ -47,8 +41,6 @@ interface NewGlobalNavigationBar extends TelemetryProps, PlatformContextProps<'r
     codeInsightsEnabled: boolean
     showSearchBox: boolean
     selectedSearchContextSpec?: string
-    fetchSearchContexts: typeof fetchSearchContexts
-    getUserSearchContextNamespaces: typeof getUserSearchContextNamespaces
 }
 
 /**
@@ -67,9 +59,6 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
         authenticatedUser,
         selectedSearchContextSpec,
         showSearchBox,
-        fetchSearchContexts,
-        getUserSearchContextNamespaces,
-        platformContext,
         telemetryService,
     } = props
 
@@ -108,9 +97,6 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         authenticatedUser={authenticatedUser}
                         selectedSearchContextSpec={selectedSearchContextSpec}
-                        fetchSearchContexts={fetchSearchContexts}
-                        getUserSearchContextNamespaces={getUserSearchContextNamespaces}
-                        platformContext={platformContext}
                         telemetryService={telemetryService}
                     />
                 ) : (
@@ -181,12 +167,10 @@ const selectQueryState = (state: SearchQueryState): NavigationSearchBoxState => 
     searchMode: state.searchMode,
 })
 
-interface NavigationSearchBoxProps extends TelemetryProps, PlatformContextProps<'requestGraphQL'> {
+interface NavigationSearchBoxProps extends TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
     selectedSearchContextSpec?: string
-    fetchSearchContexts: typeof fetchSearchContexts
-    getUserSearchContextNamespaces: typeof getUserSearchContextNamespaces
 }
 
 /**
@@ -194,15 +178,7 @@ interface NavigationSearchBoxProps extends TelemetryProps, PlatformContextProps<
  * search box gets focus.
  */
 const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
-    const {
-        authenticatedUser,
-        isSourcegraphDotCom,
-        selectedSearchContextSpec,
-        fetchSearchContexts,
-        getUserSearchContextNamespaces,
-        platformContext,
-        telemetryService,
-    } = props
+    const { authenticatedUser, isSourcegraphDotCom, selectedSearchContextSpec, telemetryService } = props
 
     const navigate = useNavigate()
     const location = useLocation()
@@ -242,13 +218,10 @@ const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
                 patternType={searchPatternType}
                 interpretComments={false}
                 queryState={queryState}
-                platformContext={platformContext}
                 submitSearch={submitSearchOnChange}
                 isSourcegraphDotCom={isSourcegraphDotCom}
                 authenticatedUser={authenticatedUser}
                 selectedSearchContextSpec={selectedSearchContextSpec}
-                getUserSearchContextNamespaces={getUserSearchContextNamespaces}
-                fetchSearchContexts={fetchSearchContexts}
                 telemetryService={telemetryService}
                 className={classNames(styles.searchBar, { [styles.searchBarFocused]: isFocused })}
                 onFocus={handleFocus}

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -1,0 +1,462 @@
+import { FC, useCallback, useState, ComponentType, PropsWithChildren } from 'react'
+
+import { mdiClose, mdiMenu } from '@mdi/js'
+import classNames from 'classnames'
+import BarChartIcon from 'mdi-react/BarChartIcon'
+import BookOutlineIcon from 'mdi-react/BookOutlineIcon'
+import MagnifyIcon from 'mdi-react/MagnifyIcon'
+import { NavLink, useLocation, useNavigate } from 'react-router-dom'
+import shallow from 'zustand/shallow'
+
+import { Toggles } from '@sourcegraph/branded/src'
+import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import {
+    SearchQueryState,
+    fetchSearchContexts,
+    getUserSearchContextNamespaces,
+    SubmitSearchParameters,
+} from '@sourcegraph/shared/src/search'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
+import { Text, Icon, Button, Modal, Link, ProductStatusBadge, ButtonLink } from '@sourcegraph/wildcard'
+
+import { AuthenticatedUser } from '../../auth'
+import { BatchChangesIconNav } from '../../batches/icons'
+import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
+import { CodyLogo } from '../../cody/components/CodyLogo'
+import { BrandLogo } from '../../components/branding/BrandLogo'
+import { DeveloperSettingsGlobalNavItem } from '../../devsettings/DeveloperSettingsGlobalNavItem'
+import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
+import { EnterprisePageRoutes, PageRoutes } from '../../routes.constants'
+import { isSearchJobsEnabled } from '../../search-jobs/utility'
+import { LazyV2SearchInput } from '../../search/input/LazyV2SearchInput'
+import { setSearchCaseSensitivity, setSearchMode, setSearchPatternType, useNavbarQueryState } from '../../stores'
+import { InlineNavigationPanel } from '../GlobalNavbar'
+import { UserNavItem } from '../UserNavItem'
+
+import styles from './NewGlobalNavigationBar.module.scss'
+
+interface NewGlobalNavigationBar extends TelemetryProps, PlatformContextProps<'requestGraphQL'> {
+    authenticatedUser: AuthenticatedUser | null
+    isSourcegraphDotCom: boolean
+    ownEnabled: boolean
+    notebooksEnabled: boolean
+    searchContextsEnabled: boolean
+    codeMonitoringEnabled: boolean
+    batchChangesEnabled: boolean
+    codeInsightsEnabled: boolean
+    showSearchBox: boolean
+    selectedSearchContextSpec?: string
+    fetchSearchContexts: typeof fetchSearchContexts
+    getUserSearchContextNamespaces: typeof getUserSearchContextNamespaces
+}
+
+/**
+ * New experimental global navigation bar with inline search bar and
+ * dynamic navigation items.
+ */
+export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
+    const {
+        isSourcegraphDotCom,
+        ownEnabled,
+        notebooksEnabled,
+        searchContextsEnabled,
+        codeMonitoringEnabled,
+        batchChangesEnabled,
+        codeInsightsEnabled,
+        authenticatedUser,
+        selectedSearchContextSpec,
+        showSearchBox,
+        fetchSearchContexts,
+        getUserSearchContextNamespaces,
+        platformContext,
+        telemetryService,
+    } = props
+
+    const isLightTheme = useIsLightTheme()
+    const [isSideMenuOpen, setSideMenuOpen] = useState(false)
+
+    // Features enablement flags and conditions
+    const isLicensed = !!window.context?.licenseInfo
+    const showOwn = ownEnabled
+    const showSearchContext = searchContextsEnabled && !isSourcegraphDotCom
+    const [showCodySearch] = useFeatureFlag('cody-web-search')
+    const showSearchJobs = isSearchJobsEnabled()
+    const showSearchNotebook = notebooksEnabled && !isSourcegraphDotCom
+    const showCodeMonitoring = codeMonitoringEnabled && !isSourcegraphDotCom
+    const showBatchChanges = batchChangesEnabled && isLicensed && !isSourcegraphDotCom
+    const showCodeInsights = codeInsightsEnabled && !isSourcegraphDotCom
+
+    return (
+        <>
+            <nav aria-label="Main" className={styles.nav}>
+                <Button
+                    variant="secondary"
+                    outline={true}
+                    className={styles.menuButton}
+                    onClick={() => setSideMenuOpen(true)}
+                >
+                    <Icon svgPath={mdiMenu} aria-label="Navigation menu" />
+                </Button>
+
+                <NavLink to={PageRoutes.Search}>
+                    <BrandLogo variant="symbol" isLightTheme={isLightTheme} className={styles.logo} />
+                </NavLink>
+
+                {showSearchBox ? (
+                    <NavigationSearchBox
+                        isSourcegraphDotCom={isSourcegraphDotCom}
+                        authenticatedUser={authenticatedUser}
+                        selectedSearchContextSpec={selectedSearchContextSpec}
+                        fetchSearchContexts={fetchSearchContexts}
+                        getUserSearchContextNamespaces={getUserSearchContextNamespaces}
+                        platformContext={platformContext}
+                        telemetryService={telemetryService}
+                    />
+                ) : (
+                    <InlineNavigationPanel
+                        isCodyApp={false}
+                        showSearchContext={showSearchContext}
+                        showOwn={showOwn}
+                        showCodySearch={showCodySearch}
+                        showSearchJobs={showSearchJobs}
+                        showSearchNotebook={showSearchNotebook}
+                        showCodeMonitoring={showCodeMonitoring}
+                        showBatchChanges={showBatchChanges}
+                        showCodeInsights={showCodeInsights}
+                        isSourcegraphDotCom={isSourcegraphDotCom}
+                        className={styles.inlineNavigationList}
+                    />
+                )}
+
+                {authenticatedUser ? (
+                    <UserNavItem
+                        isCodyApp={false}
+                        isSourcegraphDotCom={isSourcegraphDotCom}
+                        authenticatedUser={authenticatedUser}
+                        showFeedbackModal={() => {}}
+                        className="ml-auto"
+                        showKeyboardShortcutsHelp={() => {}}
+                        telemetryService={telemetryService}
+                    />
+                ) : (
+                    <SighInUpButtons isSourcegraphDotCom={isSourcegraphDotCom} />
+                )}
+            </nav>
+
+            {isSideMenuOpen && (
+                <SidebarNavigation
+                    showSearchContext={showSearchContext}
+                    showOwn={showOwn}
+                    showCodySearch={showCodySearch}
+                    showSearchJobs={showSearchJobs}
+                    showSearchNotebook={showSearchNotebook}
+                    showCodeMonitoring={showCodeMonitoring}
+                    showBatchChanges={showBatchChanges}
+                    showCodeInsights={showCodeInsights}
+                    isSourcegraphDotCom={isSourcegraphDotCom}
+                    onClose={() => setSideMenuOpen(false)}
+                />
+            )}
+        </>
+    )
+}
+
+type NavigationSearchBoxState = Pick<
+    SearchQueryState,
+    'queryState' | 'setQueryState' | 'submitSearch' | 'searchCaseSensitivity' | 'searchPatternType' | 'searchMode'
+>
+
+/**
+ * Search query state selector to filter out only needed state fields from
+ * global search query state store. (Re-render nav search box only whenever one
+ * of these fields has been changed)
+ */
+const selectQueryState = (state: SearchQueryState): NavigationSearchBoxState => ({
+    queryState: state.queryState,
+    setQueryState: state.setQueryState,
+    submitSearch: state.submitSearch,
+    searchCaseSensitivity: state.searchCaseSensitivity,
+    searchPatternType: state.searchPatternType,
+    searchMode: state.searchMode,
+})
+
+interface NavigationSearchBoxProps extends TelemetryProps, PlatformContextProps<'requestGraphQL'> {
+    authenticatedUser: AuthenticatedUser | null
+    isSourcegraphDotCom: boolean
+    selectedSearchContextSpec?: string
+    fetchSearchContexts: typeof fetchSearchContexts
+    getUserSearchContextNamespaces: typeof getUserSearchContextNamespaces
+}
+
+/**
+ * Compact version of search box UI, shows expanded version when the
+ * search box gets focus.
+ */
+const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
+    const {
+        authenticatedUser,
+        isSourcegraphDotCom,
+        selectedSearchContextSpec,
+        fetchSearchContexts,
+        getUserSearchContextNamespaces,
+        platformContext,
+        telemetryService,
+    } = props
+
+    const navigate = useNavigate()
+    const location = useLocation()
+
+    const [isFocused, setFocused] = useState(false)
+    const { searchMode, queryState, searchPatternType, searchCaseSensitivity, setQueryState, submitSearch } =
+        useNavbarQueryState(selectQueryState, shallow)
+
+    const submitSearchOnChange = useCallback(
+        (parameters: Partial<SubmitSearchParameters> = {}) => {
+            submitSearch({
+                location,
+                source: 'nav',
+                historyOrNavigate: navigate,
+                selectedSearchContextSpec,
+                ...parameters,
+            })
+        },
+        [submitSearch, navigate, location, selectedSearchContextSpec]
+    )
+
+    const handleFocus = useCallback(() => {
+        setFocused(true)
+    }, [])
+
+    const handleBlur = useCallback(() => {
+        setFocused(false)
+    }, [])
+
+    // TODO: Move this check outside of navigation component and share it via context
+    const structuralSearchDisabled = window.context?.experimentalFeatures?.structuralSearch === 'disabled'
+
+    return (
+        <>
+            <LazyV2SearchInput
+                visualMode="compact"
+                patternType={searchPatternType}
+                interpretComments={false}
+                queryState={queryState}
+                platformContext={platformContext}
+                submitSearch={submitSearchOnChange}
+                isSourcegraphDotCom={isSourcegraphDotCom}
+                authenticatedUser={authenticatedUser}
+                selectedSearchContextSpec={selectedSearchContextSpec}
+                getUserSearchContextNamespaces={getUserSearchContextNamespaces}
+                fetchSearchContexts={fetchSearchContexts}
+                telemetryService={telemetryService}
+                className={classNames(styles.searchBar, { [styles.searchBarFocused]: isFocused })}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                onChange={setQueryState}
+                onSubmit={submitSearchOnChange}
+            >
+                <Toggles
+                    searchMode={searchMode}
+                    patternType={searchPatternType}
+                    caseSensitive={searchCaseSensitivity}
+                    navbarSearchQuery={queryState.query}
+                    structuralSearchDisabled={structuralSearchDisabled}
+                    setPatternType={setSearchPatternType}
+                    setCaseSensitivity={setSearchCaseSensitivity}
+                    setSearchMode={setSearchMode}
+                    submitSearch={submitSearchOnChange}
+                />
+            </LazyV2SearchInput>
+
+            {isFocused && <div className={styles.overlay} />}
+        </>
+    )
+}
+
+interface SighInUpButtonsProps {
+    isSourcegraphDotCom: boolean
+}
+
+const SighInUpButtons: FC<SighInUpButtonsProps> = props => {
+    const { isSourcegraphDotCom } = props
+    const location = useLocation()
+
+    return (
+        <div className={styles.signInButtons}>
+            <Button
+                as={Link}
+                to={'/sign-in?returnTo=' + encodeURI(location.pathname + location.search + location.hash)}
+                size="sm"
+                variant="secondary"
+                outline={true}
+                className="mr-1"
+            >
+                Sign in
+            </Button>
+            {!isSourcegraphDotCom && window.context?.allowSignup && (
+                <ButtonLink to="/sign-up" variant="primary" size="sm">
+                    Sign up
+                </ButtonLink>
+            )}
+        </div>
+    )
+}
+
+interface SidebarNavigationProps {
+    isSourcegraphDotCom: boolean
+    showSearchContext: boolean
+    showOwn: boolean
+    showCodySearch: boolean
+    showSearchJobs: boolean
+    showSearchNotebook: boolean
+    showCodeMonitoring: boolean
+    showBatchChanges: boolean
+    showCodeInsights: boolean
+    onClose: () => void
+}
+
+const SidebarNavigation: FC<SidebarNavigationProps> = props => {
+    const {
+        showSearchContext,
+        showOwn,
+        showCodySearch,
+        showSearchJobs,
+        showSearchNotebook,
+        showCodeMonitoring,
+        showBatchChanges,
+        showCodeInsights,
+        isSourcegraphDotCom,
+        onClose,
+    } = props
+
+    const isLightTheme = useIsLightTheme()
+
+    const handleNavigationClick = (): void => {
+        // Close the navigation modal/sidebar on any navigation transition
+        // But leave it open in case of any other click (like developer link open event)
+        onClose()
+    }
+
+    return (
+        <Modal aria-label="Sidebar navigation" className={styles.sidebarNavigation} onDismiss={onClose}>
+            <header className={styles.sidebarNavigationHeader}>
+                <Button variant="secondary" outline={true} className={styles.menuButton} onClick={onClose}>
+                    <Icon svgPath={mdiClose} aria-label="Close sidebar navigation" />
+                </Button>
+                <NavLink to={PageRoutes.Search} className={styles.sidebarNavigationLogoLink}>
+                    <BrandLogo variant="logo" isLightTheme={isLightTheme} className={styles.sidebarNavigationLogo} />
+                </NavLink>
+            </header>
+
+            <nav className={styles.sidebarNavigationNav}>
+                <ul className={styles.sidebarNavigationList}>
+                    <li className={classNames(styles.navItem, styles.navItemNested)}>
+                        <Button
+                            as={Link}
+                            to={PageRoutes.Search}
+                            className={styles.navLink}
+                            onClick={handleNavigationClick}
+                        >
+                            <Icon as={MagnifyIcon} className={styles.icon} aria-hidden={true} /> Code Search
+                        </Button>
+
+                        <ul className={classNames(styles.sidebarNavigationList, styles.sidebarNavigationListNested)}>
+                            {showSearchContext && (
+                                <NavItemLink url={EnterprisePageRoutes.Contexts} onClick={handleNavigationClick}>
+                                    Context
+                                </NavItemLink>
+                            )}
+                            {showOwn && <NavItemLink url={EnterprisePageRoutes.Own}>Code ownership</NavItemLink>}
+                            {showCodySearch && (
+                                <NavItemLink url={EnterprisePageRoutes.CodySearch} onClick={handleNavigationClick}>
+                                    Natural language search <ProductStatusBadge status="experimental" />
+                                </NavItemLink>
+                            )}
+                            {showSearchJobs && (
+                                <NavItemLink url={EnterprisePageRoutes.SearchJobs} onClick={handleNavigationClick}>
+                                    Search Jobs <ProductStatusBadge className="ml-2" status="experimental" />
+                                </NavItemLink>
+                            )}
+                        </ul>
+                    </li>
+
+                    <NavItemLink url={EnterprisePageRoutes.Cody} icon={CodyLogo} onClick={handleNavigationClick}>
+                        Cody
+                    </NavItemLink>
+
+                    {showSearchNotebook && (
+                        <NavItemLink
+                            url={EnterprisePageRoutes.Notebooks}
+                            icon={BookOutlineIcon}
+                            onClick={handleNavigationClick}
+                        >
+                            Notebooks
+                        </NavItemLink>
+                    )}
+
+                    {showCodeMonitoring && (
+                        <NavItemLink url="/code-monitoring" icon={CodeMonitoringLogo} onClick={handleNavigationClick}>
+                            Code Monitoring
+                        </NavItemLink>
+                    )}
+
+                    {showBatchChanges && (
+                        <NavItemLink url="/batch-changes" icon={BatchChangesIconNav} onClick={handleNavigationClick}>
+                            Batch Changes
+                        </NavItemLink>
+                    )}
+
+                    {showCodeInsights && (
+                        <NavItemLink url="/insights" icon={BarChartIcon} onClick={handleNavigationClick}>
+                            Insights
+                        </NavItemLink>
+                    )}
+
+                    {isSourcegraphDotCom && (
+                        <NavItemLink
+                            url="https://about.sourcegraph.com"
+                            external={true}
+                            onClick={handleNavigationClick}
+                        >
+                            About Sourcegraph
+                        </NavItemLink>
+                    )}
+                </ul>
+            </nav>
+
+            <footer className={styles.footer}>
+                {process.env.NODE_ENV === 'development' && (
+                    <DeveloperSettingsGlobalNavItem className={styles.developerLink} />
+                )}
+                <Text className={styles.version}>Sourcegraph version: {window.context.version ?? 'unknown'}</Text>
+            </footer>
+        </Modal>
+    )
+}
+
+interface NavItemLinkProps {
+    url: string
+    external?: boolean
+    icon?: ComponentType<{ className?: string }>
+    onClick?: () => void
+}
+
+const NavItemLink: FC<PropsWithChildren<NavItemLinkProps>> = props => {
+    const { url, external, icon: IconComponent, children, onClick } = props
+
+    return (
+        <li className={styles.navItem}>
+            <Button
+                as={Link}
+                to={url}
+                rel={external ? 'noreferrer noopener' : undefined}
+                target={external ? '_blank' : undefined}
+                className={styles.navLink}
+                onClick={onClick}
+            >
+                {IconComponent && <Icon as={IconComponent} className={styles.icon} aria-hidden={true} />} {children}
+            </Button>
+        </li>
+    )
+}

--- a/client/web/src/search/input/LazyV2SearchInput.module.scss
+++ b/client/web/src/search/input/LazyV2SearchInput.module.scss
@@ -1,0 +1,20 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
+// Match query input styling for the intermediate input displayed while
+// lazy-loading the query input component, to avoid unstable UI.
+.intermediate-input {
+    height: 100%;
+    font-size: var(--code-font-size);
+    border: none;
+    padding-left: 0;
+    padding-right: 0;
+
+    &:focus {
+        box-shadow: none;
+    }
+
+    @media (--xs-breakpoint-down) {
+        height: auto;
+        padding: 0;
+    }
+}

--- a/client/web/src/search/input/LazyV2SearchInput.tsx
+++ b/client/web/src/search/input/LazyV2SearchInput.tsx
@@ -1,13 +1,45 @@
-import { Suspense, type PropsWithChildren, type FC } from 'react'
+import { Suspense, type PropsWithChildren, type FC, useCallback, ChangeEvent } from 'react'
+
+import classNames from 'classnames'
 
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
+import { Input } from '@sourcegraph/wildcard'
 
 import type { V2SearchInputProps } from './V2SearchInput'
+
+import styles from './LazyV2SearchInput.module.scss'
 
 const V2SearchInput = lazyComponent(() => import('./V2SearchInput'), 'V2SearchInput')
 
 export const LazyV2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = props => (
-    <Suspense fallback={null}>
+    <Suspense fallback={<PlainQueryInput {...props} />}>
         <V2SearchInput {...props} />
     </Suspense>
 )
+
+/**
+ * A plain query input displayed during lazy-loading of the LazyQueryInput. It has no suggestions
+ * but still allows typing and submitting queries.
+ */
+const PlainQueryInput: FC<PropsWithChildren<Pick<V2SearchInputProps, 'queryState' | 'onChange' | 'className'>>> = ({
+    queryState,
+    onChange,
+    className,
+}) => {
+    const onInputChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement>) => {
+            onChange({ query: event.target.value })
+        },
+        [onChange]
+    )
+    return (
+        <Input
+            value={queryState.query}
+            spellCheck={false}
+            placeholder="Search for code or files..."
+            className="w-100"
+            inputClassName={classNames('text-code', styles.intermediateInput, className)}
+            onChange={onInputChange}
+        />
+    )
+}

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -105,7 +105,6 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                         setCaseSensitivity={setSearchCaseSensitivity}
                         searchMode={searchMode}
                         setSearchMode={setSearchMode}
-                        settingsCascade={props.settingsCascade}
                         navbarSearchQuery={queryState.query}
                         submitSearch={submitSearchOnChange}
                         structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}

--- a/client/web/src/search/input/V2SearchInput.tsx
+++ b/client/web/src/search/input/V2SearchInput.tsx
@@ -109,6 +109,8 @@ export const V2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = ({
     submitSearch,
     selectedSearchContextSpec,
     visualMode,
+    onFocus,
+    onBlur,
     ...inputProps
 }) => {
     const { recentSearches } = useRecentSearches()
@@ -183,16 +185,18 @@ export const V2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = ({
 
     return (
         <CodeMirrorQueryInputWrapper
-            patternType={inputProps.patternType}
             interpretComments={false}
-            queryState={inputProps.queryState}
-            onChange={inputProps.onChange}
-            onSubmit={inputProps.onSubmit}
             placeholder="Search for code or files..."
+            patternType={inputProps.patternType}
+            queryState={inputProps.queryState}
             suggestionSource={suggestionSource}
             extensions={extensions}
             visualMode={visualMode}
             className={inputProps.className}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            onChange={inputProps.onChange}
+            onSubmit={inputProps.onSubmit}
         >
             {children}
         </CodeMirrorQueryInputWrapper>

--- a/client/web/src/site-admin/AccessRequestsPage/AccessRequestsGlobalNavItem.tsx
+++ b/client/web/src/site-admin/AccessRequestsPage/AccessRequestsGlobalNavItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { FC } from 'react'
 
 import { mdiAccountPlus } from '@mdi/js'
 
@@ -11,11 +11,16 @@ import { checkRequestAccessAllowed } from '../../util/checkRequestAccessAllowed'
 
 import { ACCESS_REQUESTS_COUNT } from './queries'
 
+interface AccessRequestsGlobalNavItemProps {
+    className?: string
+}
+
 /**
  * A link to the access requests page that the number of pending requests.
  * Does not render anything if request access is not allowed or there are no pending requests.
  */
-export const AccessRequestsGlobalNavItem: React.FunctionComponent = () => {
+export const AccessRequestsGlobalNavItem: FC<AccessRequestsGlobalNavItemProps> = props => {
+    const { className } = props
     const isRequestAccessAllowed = checkRequestAccessAllowed(window.context)
 
     const { data } = useQuery<AccessRequestsCountResult, AccessRequestsCountVariables>(ACCESS_REQUESTS_COUNT, {
@@ -28,12 +33,7 @@ export const AccessRequestsGlobalNavItem: React.FunctionComponent = () => {
     }
 
     return (
-        <ButtonLink
-            variant="success"
-            size="sm"
-            to="/site-admin/account-requests"
-            className="d-flex align-items-center py-1"
-        >
+        <ButtonLink variant="success" size="sm" to="/site-admin/account-requests" className={className}>
             <Icon svgPath={mdiAccountPlus} size="md" aria-label="Account requests icons" color="var(--success-2)" />
             <Text className="mx-1" weight="bold" as="span">
                 {data?.accessRequests.totalCount}

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -60,7 +60,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
         telemetryService,
         platformContext,
         searchContextsEnabled,
-        settingsCascade,
         selectedSearchContextSpec: dynamicSearchContextSpec,
         fetchSearchContexts,
         setSelectedSearchContextSpec,
@@ -149,7 +148,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
                 setCaseSensitivity={setSearchCaseSensitivity}
                 searchMode={searchMode}
                 setSearchMode={setSearchMode}
-                settingsCascade={settingsCascade}
                 navbarSearchQuery={queryState.query}
                 showSmartSearchButton={false}
                 structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch === 'disabled'}
@@ -165,7 +163,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
             telemetryService={telemetryService}
             authenticatedUser={authenticatedUser}
             isSourcegraphDotCom={isSourcegraphDotCom}
-            settingsCascade={settingsCascade}
             searchContextsEnabled={searchContextsEnabled}
             showSearchContext={searchContextsEnabled}
             showSearchContextManagement={true}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2380,6 +2380,8 @@ type SettingsExperimentalFeatures struct {
 	FuzzyFinderSymbols *bool `json:"fuzzyFinderSymbols,omitempty"`
 	// GoCodeCheckerTemplates description: Shows a panel with code insights templates for go code checker results.
 	GoCodeCheckerTemplates *bool `json:"goCodeCheckerTemplates,omitempty"`
+	// NewSearchNavigationUI description: Enables new experimental search UI navigation
+	NewSearchNavigationUI *bool `json:"newSearchNavigationUI,omitempty"`
 	// ProactiveSearchResultsAggregations description: Search results aggregations are triggered automatically with a search.
 	ProactiveSearchResultsAggregations *bool `json:"proactiveSearchResultsAggregations,omitempty"`
 	// SearchContextsQuery description: DEPRECATED: This feature is now permanently enabled. Enables query based search contexts
@@ -2444,6 +2446,7 @@ func (v *SettingsExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "fuzzyFinderRepositories")
 	delete(m, "fuzzyFinderSymbols")
 	delete(m, "goCodeCheckerTemplates")
+	delete(m, "newSearchNavigationUI")
 	delete(m, "proactiveSearchResultsAggregations")
 	delete(m, "searchContextsQuery")
 	delete(m, "searchQueryInput")

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -13,6 +13,14 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "newSearchNavigationUI": {
+          "description": "Enables new experimental search UI navigation",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
+        },
         "codeInsightsRepoUI": {
           "description": "Specifies which (code insight repo) editor to use for repo query UI",
           "type": "string",


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/54794

## Problem 
The problem this PR is trying to solve is optimising/freeing vertical space (free it for actual content that matters but still manage our global navigation in a way that this is still visible and accessible). Vertical space becomes a bigger problem in places where we have a lot of sticky content on top (like blob UI page or even search result page), users who don't use big external monitors can't use Sourcegraph efficiently. 

## Solution
The solution is to merge search box UI and global navigation UI, similar how our code search product have it (see Google Code Search and Github navigation). 

<img width="300" alt="Screenshot 2023-11-07 at 13 51 05" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/5c2633ff-c8fe-4160-aecc-40dfec9bbbda"> <img width="300" alt="Screenshot 2023-11-07 at 13 51 07" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/86c926ca-a8e4-48c8-be62-054949df75a1"> 

<img width="300" alt="Screenshot 2023-11-07 at 13 51 18" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/5f1708e1-2343-408a-bb95-1315a47b65e4"> <img width="300" alt="Screenshot 2023-11-07 at 13 51 20" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/bdba124e-0a21-497b-874e-d526d6e2203b">

Note: that we still not sure about some decisions about this navigation, this might affect our feature visibility in unexpected way, so on pages where search isn't related directly (like code insights, batch changes we still show old global navigation UI) 

## Availability 
New navigation UI is under experimental feature flag `newSearchNavigationUI`.

## Other improvements 
- Fixed compact/full navigation transition breakpoint (now navigation switches only and only when there is no enough space for navigation items, previously it was static break point which didn't work properly for generic content)
- Search UI box now has plain query input fallback UI to show when we load search box UI component (it should help with UI thrashing) 

## Further steps 
It's in experimental stage, so implementation may lack some things in layout like Mobile layout might be weird, we will improve it in a follow up PR if this UI will work out.  

## Test plan
- First of all check old navigation, it should be no regression on mobile and desktop versions
- Turn on experimental navigation with experimentalFeatures: `newSearchNavigationUI`
- Check that you can go through search core flow with new navigation. 
