### PR TITLE
dev/msp: add explicit outputs to stack workspaces

### DIFF
--- a/dev/managedservicesplatform/internal/stack/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack",
     visibility = ["//dev/managedservicesplatform:__subpackages__"],
     deps = [
+        "//dev/managedservicesplatform/internal/resourceid",
         "//lib/pointers",
         "@com_github_hashicorp_terraform_cdk_go_cdktf//:cdktf",
     ],

--- a/dev/managedservicesplatform/internal/stack/README.md
+++ b/dev/managedservicesplatform/internal/stack/README.md
@@ -8,15 +8,23 @@ Each stack package must declare the following interface:
 ```go
 import (
   "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack"
+  "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack/options/googleprovider"
 )
 
-type Output struct {}
+// CrossStackOutput allows programatic access to stack outputs across stacks.
+// For human reference outputs, use (stack.ExplicitStackOutputs).Add(...)
+type CrossStackOutput struct {}
 
 type Variables struct {}
 
 const StackName = "..."
 
-func NewStack(stacks *stack.Set, vars Variables) (*Output, error) {
+func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
+  stack, outputs := stacks.New(StackName,
+    googleprovider.With(vars.ProjectID),
+    // ... other stack-wide options
+  )
+
   // ...
 }
 ```

--- a/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
@@ -35,15 +35,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
-type CrossStackOutput struct {
-	// CloudRunServiceAccountEmail is the email associated with the Cloud Run
-	// service's workload service account. If access to additional resources are
-	// needed, this account can be granted access to allow the new service to
-	// access additional resources.
-	CloudRunServiceAccountEmail string
-	// ResolvedImageTag is the final image tag that was configured for deployment.
-	ResolvedImageTag string
-}
+type CrossStackOutput struct{}
 
 type Variables struct {
 	ProjectID             string
@@ -296,10 +288,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	// Collect outputs
 	outputs.Add("cloud_run_service_account", cloudRunBuildVars.ServiceAccount.Email)
 	outputs.Add("resolved_image_tag", resolvedImageTag)
-	return &CrossStackOutput{
-		CloudRunServiceAccountEmail: cloudRunBuildVars.ServiceAccount.Email,
-		ResolvedImageTag:            resolvedImageTag,
-	}, nil
+	return &CrossStackOutput{}, nil
 }
 
 var matchNonAlphaNumericRegex = regexp.MustCompile("[^a-zA-Z0-9]+")

--- a/dev/managedservicesplatform/internal/stack/cloudrun/internal/builder/builder.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/internal/builder/builder.go
@@ -11,9 +11,12 @@ import (
 
 type Variables struct {
 	Service     spec.ServiceSpec
-	Image       string
 	Environment spec.EnvironmentSpec
 
+	// Image and ResolvedImageTag are used to declare the full image reference
+	// to deploy.
+	Image            string
+	ResolvedImageTag string
 	// GCPProjectID for all resources.
 	GCPProjectID string
 	// GCPRegion for all resources.

--- a/dev/managedservicesplatform/internal/stack/cloudrun/internal/builder/job/job.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/internal/builder/job/job.go
@@ -70,11 +70,6 @@ func (b *jobBuilder) AddSecretVolume(name, mountPath string, secret builder.Secr
 }
 
 func (b *jobBuilder) Build(stack cdktf.TerraformStack, vars builder.Variables) (builder.Resource, error) {
-	serviceImageTag, err := vars.Environment.Deploy.ResolveTag(vars.Image)
-	if err != nil {
-		return nil, err
-	}
-
 	var vpcAccess *cloudrunv2job.CloudRunV2JobTemplateTemplateVpcAccess
 	if vars.PrivateNetwork != nil {
 		vpcAccess = &cloudrunv2job.CloudRunV2JobTemplateTemplateVpcAccess{
@@ -120,7 +115,7 @@ func (b *jobBuilder) Build(stack cdktf.TerraformStack, vars builder.Variables) (
 				// Configuration for the single service container.
 				Containers: []*cloudrunv2job.CloudRunV2JobTemplateTemplateContainers{{
 					Name:  pointers.Ptr(vars.Service.ID),
-					Image: pointers.Ptr(fmt.Sprintf("%s:%s", vars.Image, serviceImageTag)),
+					Image: pointers.Ptr(fmt.Sprintf("%s:%s", vars.Image, vars.ResolvedImageTag)),
 
 					Resources: &cloudrunv2job.CloudRunV2JobTemplateTemplateContainersResources{
 						Limits: &vars.ResourceLimits,

--- a/dev/managedservicesplatform/internal/stack/cloudrun/internal/builder/service/service.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/internal/builder/service/service.go
@@ -76,11 +76,6 @@ func (b *serviceBuilder) AddSecretVolume(name, mountPath string, secret builder.
 }
 
 func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variables) (builder.Resource, error) {
-	serviceImageTag, err := vars.Environment.Deploy.ResolveTag(vars.Image)
-	if err != nil {
-		return nil, err
-	}
-
 	var vpcAccess *cloudrunv2service.CloudRunV2ServiceTemplateVpcAccess
 	if vars.PrivateNetwork != nil {
 		vpcAccess = &cloudrunv2service.CloudRunV2ServiceTemplateVpcAccess{
@@ -140,7 +135,7 @@ func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variable
 			// Configuration for the single service container.
 			Containers: []*cloudrunv2service.CloudRunV2ServiceTemplateContainers{{
 				Name:  pointers.Ptr(vars.Service.ID),
-				Image: pointers.Ptr(fmt.Sprintf("%s:%s", vars.Image, serviceImageTag)),
+				Image: pointers.Ptr(fmt.Sprintf("%s:%s", vars.Image, vars.ResolvedImageTag)),
 
 				Resources: &cloudrunv2service.CloudRunV2ServiceTemplateContainersResources{
 					Limits: &vars.ResourceLimits,

--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -59,7 +59,7 @@ var EnvironmentCategoryFolders = map[spec.EnvironmentCategory]string{
 	spec.EnvironmentCategory(""):     DefaultProjectFolderID,
 }
 
-type Output struct {
+type CrossStackOutput struct {
 	// Project is created with a generated project ID.
 	Project project.Project
 
@@ -104,8 +104,8 @@ const (
 )
 
 // NewStack creates a stack that provisions a GCP project.
-func NewStack(stacks *stack.Set, vars Variables) (*Output, error) {
-	stack := stacks.New(StackName,
+func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
+	stack, outputs := stacks.New(StackName,
 		randomprovider.With(),
 		// ID is not known ahead of time, we can omit it
 		googleprovider.With(""))
@@ -163,7 +163,9 @@ func NewStack(stacks *stack.Set, vars Variables) (*Output, error) {
 			})
 	}
 
-	return &Output{
+	// Collect outputs
+	outputs.Add("project_id", project.ProjectId())
+	return &CrossStackOutput{
 		Project: project,
 		CloudRunIdentity: googleprojectserviceidentity.NewGoogleProjectServiceIdentity(stack,
 			id.ResourceID("cloudrun-identity"),


### PR DESCRIPTION
This change allows Stacks to add outputs explicitly, rather than requiring them to be referenced by another stack. We mark everything as non-sensitive as the only values exposed here are for human reference.

## Test plan

https://github.com/sourcegraph/managed-services/pull/48