### PR TITLE
dev/msp: 'generate -all' to generate all services and all envs

### DIFF
--- a/dev/managedservicesplatform/BUILD.bazel
+++ b/dev/managedservicesplatform/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//dev/managedservicesplatform/terraformcloud",
         "//lib/errors",
         "//lib/pointers",
+        "@com_github_aws_jsii_runtime_go//:jsii-runtime-go",
         "@com_github_hashicorp_terraform_cdk_go_cdktf//:cdktf",
         "@com_github_sourcegraph_conc//panics",
     ],

--- a/dev/managedservicesplatform/cdktf.go
+++ b/dev/managedservicesplatform/cdktf.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	jsiiruntime "github.com/aws/jsii-runtime-go"
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
 	"github.com/sourcegraph/conc/panics"
 
@@ -29,6 +30,10 @@ func (c CDKTF) OutputDir() string {
 // Synthesize all resources to the output directory that was originally
 // configured.
 func (c CDKTF) Synthesize() error {
+	// Forcibly shut down the JSII runtime post-Synth to make sure that we don't
+	// get bizarre side-effects from multiple apps being rendered.
+	defer jsiiruntime.Close()
+
 	// CDKTF is prone to panics for no good reason, so make a best-effort
 	// attempt to capture them.
 	var catcher panics.Catcher

--- a/dev/sg/msp/repo/repo.go
+++ b/dev/sg/msp/repo/repo.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -26,6 +27,30 @@ func UseManagedServicesRepo(c *cli.Context) error {
 		return os.Chdir(repoRoot)
 	}
 	return nil
+}
+
+func ListServices() ([]string, error) {
+	var services []string
+	return services, filepath.Walk("services", func(path string, info fs.FileInfo, err error) error {
+		if info.Name() == "services" {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		if _, err := os.Stat(ServiceYAMLPath(info.Name())); err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+
+		services = append(services, info.Name())
+		return nil
+	})
 }
 
 func ServiceYAMLPath(serviceID string) string {

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -189,7 +189,15 @@ func init() {
 			Name:        "generate",
 			ArgsUsage:   "<service ID> <environment ID>",
 			Description: "Generate Terraform assets for a Managed Services Platform service spec.",
-			Before:      msprepo.UseManagedServicesRepo,
+			UsageText: `
+# generate single env for a single service
+sg msp generate <service> <env>
+# generate all envs across all services
+sg msp generate -all
+# generate all envs for a single service
+sg msp generate -all <service>
+			`,
+			Before: msprepo.UseManagedServicesRepo,
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
 					Name:  "all",


### PR DESCRIPTION
```sh
sg msp generate -all # generate all envs across all services
sg msp generate -all <service> # generate all envs for a single service
sg msp generate # error, needs service
sg msp generate <service> # error, needs env
sg msp generate <service> <env> # same as before
```
## Test plan

https://github.com/sourcegraph/managed-services/pull/48