### PR TITLE
dev/msp: fix redis configuration drift

### DIFF
--- a/dev/managedservicesplatform/internal/resource/redis/redis.go
+++ b/dev/managedservicesplatform/internal/resource/redis/redis.go
@@ -42,7 +42,8 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 			AuthEnabled:           true,
 			TransitEncryptionMode: pointers.Ptr("SERVER_AUTHENTICATION"),
 			PersistenceConfig: &redisinstance.RedisInstancePersistenceConfig{
-				PersistenceMode: pointers.Ptr("RDB"),
+				PersistenceMode:   pointers.Ptr("RDB"),
+				RdbSnapshotPeriod: pointers.Ptr("TWENTY_FOUR_HOURS"),
 			},
 
 			AuthorizedNetwork: config.Network.SelfLink(),


### PR DESCRIPTION
We need to declare this explicitly to avoid infinite drift in Terraform:

```
  # google_redis_instance.redis-instance will be updated in-place
  ~ resource "google_redis_instance" "redis-instance" {
        id                       = "projects/cloud-ops-dashboard-prod-245f/locations/us-central1/instances/redis"
        name                     = "redis"
        # (25 unchanged attributes hidden)

      ~ persistence_config {
          - rdb_snapshot_period     = "TWENTY_FOUR_HOURS" -> null
            # (2 unchanged attributes hidden)
        }
    }
```

## Test plan

n/a