### PR TITLE
client: Centralize ref panel logic for Location grouping & uniquing

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.mocks.ts
+++ b/client/web/src/codeintel/ReferencesPanel.mocks.ts
@@ -19,7 +19,7 @@ import {
     type ResolveRepoAndRevisionVariables,
 } from '../graphql-operations'
 
-import { buildPreciseLocation } from './location'
+import { buildPreciseLocation, LocationsGroup } from './location'
 import type { ReferencesPanelProps } from './ReferencesPanel'
 import {
     USE_PRECISE_CODE_INTEL_FOR_POSITION_QUERY,
@@ -701,10 +701,10 @@ export const defaultProps: ReferencesPanelProps = {
     useCodeIntel: ({ variables }: UseCodeIntelParameters): UseCodeIntelResult => {
         const [result, setResult] = useState<UseCodeIntelResult>({
             data: {
-                implementations: { endCursor: '', nodes: [] },
-                prototypes: { endCursor: '', nodes: [] },
-                references: { endCursor: '', nodes: [] },
-                definitions: { endCursor: '', nodes: [] },
+                implementations: { endCursor: '', nodes: LocationsGroup.empty },
+                prototypes: { endCursor: '', nodes: LocationsGroup.empty },
+                references: { endCursor: '', nodes: LocationsGroup.empty },
+                definitions: { endCursor: '', nodes: LocationsGroup.empty },
             },
             loading: true,
             referencesHasNextPage: false,
@@ -737,20 +737,20 @@ export const defaultProps: ReferencesPanelProps = {
                     data: {
                         implementations: {
                             endCursor: lsif.implementations.pageInfo.endCursor,
-                            nodes: lsif.implementations.nodes.map(buildPreciseLocation),
+                            nodes: new LocationsGroup(lsif.implementations.nodes.map(buildPreciseLocation)),
                         },
                         prototypes: {
                             endCursor: lsif.prototypes.pageInfo.endCursor,
-                            nodes: lsif.prototypes.nodes.map(buildPreciseLocation),
+                            nodes: new LocationsGroup(lsif.prototypes.nodes.map(buildPreciseLocation)),
                         },
 
                         references: {
                             endCursor: lsif.references.pageInfo.endCursor,
-                            nodes: lsif.references.nodes.map(buildPreciseLocation),
+                            nodes: new LocationsGroup(lsif.references.nodes.map(buildPreciseLocation)),
                         },
                         definitions: {
                             endCursor: lsif.definitions.pageInfo.endCursor,
-                            nodes: lsif.definitions.nodes.map(buildPreciseLocation),
+                            nodes: new LocationsGroup(lsif.definitions.nodes.map(buildPreciseLocation)),
                         },
                     },
                 }))

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -620,18 +620,24 @@ const CollapsibleLocationList: React.FunctionComponent<
 
                 <CollapsePanel id={props.name} data-testid={props.name}>
                     {locationsCount > 0 ? (
-                        <LocationsList
-                            searchToken={props.searchToken}
-                            locationsGroup={props.locationsGroup}
-                            isActiveLocation={props.isActiveLocation}
-                            setActiveLocation={props.setActiveLocation}
-                            filter={props.filter}
-                            activeURL={props.activeURL}
-                            navigateToUrl={props.navigateToUrl}
-                            handleOpenChange={(id, isOpen) => props.handleOpenChange(props.name + id, isOpen)}
-                            isOpen={id => props.isOpen(props.name + id)}
-                            fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
-                        />
+                        <>
+                            {props.locationsGroup.map((locations, index) => (
+                                <CollapsibleRepoLocationGroup
+                                    key={locations.repoName}
+                                    activeURL={props.activeURL}
+                                    searchToken={props.searchToken}
+                                    locations={locations}
+                                    openByDefault={index === 0}
+                                    isActiveLocation={props.isActiveLocation}
+                                    setActiveLocation={props.setActiveLocation}
+                                    filter={props.filter}
+                                    navigateToUrl={props.navigateToUrl}
+                                    handleOpenChange={(id, isOpen) => props.handleOpenChange(props.name + id, isOpen)}
+                                    isOpen={id => props.isOpen(props.name + id)}
+                                    fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
+                                />
+                            ))}
+                        </>
                     ) : (
                         <Text className="text-muted pl-4 pb-0">
                             {props.filter ? (
@@ -766,52 +772,6 @@ const SideBlob: React.FunctionComponent<React.PropsWithChildren<SideBlobProps>> 
         />
     )
 }
-
-interface LocationsListProps
-    extends ActiveLocationProps,
-        CollapseProps,
-        SearchTokenProps,
-        HighlightedFileLineRangesProps {
-    locationsGroup: LocationsGroup
-    filter: string | undefined
-    navigateToUrl: (url: string) => void
-    activeURL: string
-}
-
-/** Component to display one single section (defs/refs/impls) in the ref
- * panel, handling multiple repos.
- */
-const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsListProps>> = ({
-    locationsGroup,
-    isActiveLocation,
-    setActiveLocation,
-    filter,
-    navigateToUrl,
-    handleOpenChange,
-    isOpen,
-    searchToken,
-    fetchHighlightedFileLineRanges,
-    activeURL,
-}) => (
-    <>
-        {locationsGroup.map((group, index) => (
-            <CollapsibleRepoLocationGroup
-                key={group.repoName}
-                activeURL={activeURL}
-                searchToken={searchToken}
-                locations={group}
-                openByDefault={index === 0}
-                isActiveLocation={isActiveLocation}
-                setActiveLocation={setActiveLocation}
-                filter={filter}
-                navigateToUrl={navigateToUrl}
-                handleOpenChange={handleOpenChange}
-                isOpen={isOpen}
-                fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-            />
-        ))}
-    </>
-)
 
 /** Component to display the Locations for a single repo */
 const CollapsibleRepoLocationGroup: React.FunctionComponent<

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -591,7 +591,7 @@ const CollapsibleLocationList: React.FunctionComponent<
     const isOpen = props.isOpen(props.name) ?? true
 
     const repoCount = props.locationsGroup.repoCount
-    const locationsCount = props.locationsGroup.locationsCount
+    const locationsCount = props.locationsGroup.getLocationsCount
     const quantityLabel = `(${locationsCount} ${pluralize('item', locationsCount)}${
         repoCount > 1 ? ` from ${repoCount} repositories` : ''
     } displayed${props.hasMore ? ', more available' : ''})`
@@ -923,14 +923,14 @@ const CollapsibleLocationGroup: React.FunctionComponent<
         highlighted = group.path.split(filter)
     }
 
-    const { repo, commitID, file } = group.locations[0]
+    const { repo, commitID, file } = group.getLocations[0]
     const ranges = useMemo(
         () =>
-            group.locations.map(location => ({
+            group.getLocations.map(location => ({
                 startLine: location.range?.start.line ?? 0,
                 endLine: (location.range?.end.line ?? 0) + 1,
             })),
-        [group.locations]
+        [group.getLocations]
     )
 
     const fetchHighlightedFileRangeLines = useCallback(
@@ -1001,8 +1001,8 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                 )}{' '}
                             </span>
                             <span className={classNames('ml-2 text-muted', styles.cardHeaderSmallText)}>
-                                ({group.locations.length}{' '}
-                                {pluralize('occurrence', group.locations.length, 'occurrences')})
+                                ({group.getLocations.length}{' '}
+                                {pluralize('occurrence', group.getLocations.length, 'occurrences')})
                             </span>
                         </span>
                         <Badge small={true} variant="secondary" className="ml-4">
@@ -1014,10 +1014,10 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                 <CollapsePanel id={repoName + group.path} className="ml-0">
                     <div className={styles.locationContainer}>
                         <ul className="list-unstyled mb-0">
-                            {group.locations.map((reference, index) => {
+                            {group.getLocations.map((reference, index) => {
                                 const isActive = isActiveLocation(reference)
                                 const isFirstInActive =
-                                    isActive && !(index > 0 && isActiveLocation(group.locations[index - 1]))
+                                    isActive && !(index > 0 && isActiveLocation(group.getLocations[index - 1]))
                                 const locationActive = isActive ? styles.locationActive : ''
                                 const clickReference = (event: MouseEvent<HTMLElement>): void => {
                                     // If anything other than a normal primary click is detected,

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -591,7 +591,7 @@ const CollapsibleLocationList: React.FunctionComponent<
     const isOpen = props.isOpen(props.name) ?? true
 
     const repoCount = props.locationsGroup.repoCount
-    const locationsCount = props.locationsGroup.getLocationsCount
+    const locationsCount = props.locationsGroup.getLocationsCount()
     const quantityLabel = `(${locationsCount} ${pluralize('item', locationsCount)}${
         repoCount > 1 ? ` from ${repoCount} repositories` : ''
     } displayed${props.hasMore ? ', more available' : ''})`
@@ -883,14 +883,14 @@ const CollapsibleLocationGroup: React.FunctionComponent<
         highlighted = group.path.split(filter)
     }
 
-    const { repo, commitID, file } = group.getLocations[0]
+    const { repo, commitID, file } = group.getLocations()[0]
     const ranges = useMemo(
         () =>
-            group.getLocations.map(location => ({
+            group.getLocations().map(location => ({
                 startLine: location.range?.start.line ?? 0,
                 endLine: (location.range?.end.line ?? 0) + 1,
             })),
-        [group.getLocations]
+        [group.getLocations()]
     )
 
     const fetchHighlightedFileRangeLines = useCallback(
@@ -961,8 +961,8 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                 )}{' '}
                             </span>
                             <span className={classNames('ml-2 text-muted', styles.cardHeaderSmallText)}>
-                                ({group.getLocations.length}{' '}
-                                {pluralize('occurrence', group.getLocations.length, 'occurrences')})
+                                ({group.getLocations().length}{' '}
+                                {pluralize('occurrence', group.getLocations().length, 'occurrences')})
                             </span>
                         </span>
                         <Badge small={true} variant="secondary" className="ml-4">
@@ -974,10 +974,10 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                 <CollapsePanel id={repoName + group.path} className="ml-0">
                     <div className={styles.locationContainer}>
                         <ul className="list-unstyled mb-0">
-                            {group.getLocations.map((reference, index) => {
+                            {group.getLocations().map((reference, index) => {
                                 const isActive = isActiveLocation(reference)
                                 const isFirstInActive =
-                                    isActive && !(index > 0 && isActiveLocation(group.getLocations[index - 1]))
+                                    isActive && !(index > 0 && isActiveLocation(group.getLocations()[index - 1]))
                                 const locationActive = isActive ? styles.locationActive : ''
                                 const clickReference = (event: MouseEvent<HTMLElement>): void => {
                                     // If anything other than a normal primary click is detected,

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -592,11 +592,9 @@ const CollapsibleLocationList: React.FunctionComponent<
 
     const repoCount = props.locationsGroup.repoCount
     const locationsCount = props.locationsGroup.locationsCount
-    const quantityLabel = useMemo(() => {
-        return `(${locationsCount} ${pluralize('item', locationsCount)}${
-            repoCount > 1 ? ` from ${repoCount} repositories` : ''
-        } displayed${props.hasMore ? ', more available' : ''})`
-    }, [repoCount, locationsCount, props.hasMore])
+    const quantityLabel = `(${locationsCount} ${pluralize('item', locationsCount)}${
+        repoCount > 1 ? ` from ${repoCount} repositories` : ''
+    } displayed${props.hasMore ? ', more available' : ''})`
 
     return (
         <Collapse isOpen={isOpen} onOpenChange={isOpen => props.handleOpenChange(props.name, isOpen)}>
@@ -794,28 +792,26 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
     searchToken,
     fetchHighlightedFileLineRanges,
     activeURL,
-}) => {
-    return (
-        <>
-            {locationsGroup.map((group, index) => (
-                <CollapsibleRepoLocationGroup
-                    key={group.repoName}
-                    activeURL={activeURL}
-                    searchToken={searchToken}
-                    locations={group}
-                    openByDefault={index === 0}
-                    isActiveLocation={isActiveLocation}
-                    setActiveLocation={setActiveLocation}
-                    filter={filter}
-                    navigateToUrl={navigateToUrl}
-                    handleOpenChange={handleOpenChange}
-                    isOpen={isOpen}
-                    fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-                />
-            ))}
-        </>
-    )
-}
+}) => (
+    <>
+        {locationsGroup.map((group, index) => (
+            <CollapsibleRepoLocationGroup
+                key={group.repoName}
+                activeURL={activeURL}
+                searchToken={searchToken}
+                locations={group}
+                openByDefault={index === 0}
+                isActiveLocation={isActiveLocation}
+                setActiveLocation={setActiveLocation}
+                filter={filter}
+                navigateToUrl={navigateToUrl}
+                handleOpenChange={handleOpenChange}
+                isOpen={isOpen}
+                fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+            />
+        ))}
+    </>
+)
 
 /** Component to display the Locations for a single repo */
 const CollapsibleRepoLocationGroup: React.FunctionComponent<

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -591,7 +591,7 @@ const CollapsibleLocationList: React.FunctionComponent<
     const isOpen = props.isOpen(props.name) ?? true
 
     const repoCount = props.locationsGroup.repoCount
-    const locationsCount = props.locationsGroup.getLocationsCount()
+    const locationsCount = props.locationsGroup.locationsCount
     const quantityLabel = `(${locationsCount} ${pluralize('item', locationsCount)}${
         repoCount > 1 ? ` from ${repoCount} repositories` : ''
     } displayed${props.hasMore ? ', more available' : ''})`
@@ -883,15 +883,14 @@ const CollapsibleLocationGroup: React.FunctionComponent<
         highlighted = group.path.split(filter)
     }
 
-    const locations = group.getLocations()
-    const { repo, commitID, file } = locations[0]
+    const { repo, commitID, file } = group.locations[0]
     const ranges = useMemo(
         () =>
-            locations.map(location => ({
+            group.locations.map(location => ({
                 startLine: location.range?.start.line ?? 0,
                 endLine: (location.range?.end.line ?? 0) + 1,
             })),
-        [locations]
+        [group.locations]
     )
 
     const fetchHighlightedFileRangeLines = useCallback(
@@ -962,8 +961,8 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                                 )}{' '}
                             </span>
                             <span className={classNames('ml-2 text-muted', styles.cardHeaderSmallText)}>
-                                ({group.getLocations().length}{' '}
-                                {pluralize('occurrence', group.getLocations().length, 'occurrences')})
+                                ({group.locations.length}{' '}
+                                {pluralize('occurrence', group.locations.length, 'occurrences')})
                             </span>
                         </span>
                         <Badge small={true} variant="secondary" className="ml-4">
@@ -975,10 +974,10 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                 <CollapsePanel id={repoName + group.path} className="ml-0">
                     <div className={styles.locationContainer}>
                         <ul className="list-unstyled mb-0">
-                            {group.getLocations().map((reference, index) => {
+                            {group.locations.map((reference, index) => {
                                 const isActive = isActiveLocation(reference)
                                 const isFirstInActive =
-                                    isActive && !(index > 0 && isActiveLocation(group.getLocations()[index - 1]))
+                                    isActive && !(index > 0 && isActiveLocation(group.locations[index - 1]))
                                 const locationActive = isActive ? styles.locationActive : ''
                                 const clickReference = (event: MouseEvent<HTMLElement>): void => {
                                     // If anything other than a normal primary click is detected,

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -593,7 +593,6 @@ const CollapsibleLocationList: React.FunctionComponent<
     const repoCount = props.locationsGroup.repoCount
     const locationsCount = props.locationsGroup.locationsCount
     const quantityLabel = useMemo(() => {
-        // const repoNumber = uniqBy(props.locations, 'repo').length
         return `(${locationsCount} ${pluralize('item', locationsCount)}${
             repoCount > 1 ? ` from ${repoCount} repositories` : ''
         } displayed${props.hasMore ? ', more available' : ''})`

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -3,7 +3,7 @@ import React, { type MouseEvent, useCallback, useEffect, useLayoutEffect, useMem
 import { mdiArrowCollapseRight, mdiChevronDown, mdiChevronRight, mdiFilterOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 import type * as H from 'history'
-import { capitalize, uniqBy } from 'lodash'
+import { capitalize } from 'lodash'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { type Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
@@ -60,13 +60,7 @@ import type { HoverThresholdProps } from '../repo/RepoContainer'
 import { parseBrowserRepoURL } from '../util/url'
 
 import type { CodeIntelligenceProps } from '.'
-import {
-    type Location,
-    type LocationGroup,
-    locationGroupQuality,
-    buildRepoLocationGroups,
-    type RepoLocationGroup,
-} from './location'
+import { type Location, LocationsGroup, LocationsGroupedByRepo, LocationsGroupedByFile } from './location'
 import { FETCH_HIGHLIGHTED_BLOB } from './ReferencesPanelQueries'
 import { newSettingsGetter } from './settings'
 import { findSearchToken } from './token'
@@ -281,8 +275,6 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
 
 const SHOW_SPINNER_DELAY_MS = 100
 
-const empty: any[] = []
-
 const ReferencesList: React.FunctionComponent<
     React.PropsWithChildren<
         ReferencesPanelPropsWithToken & {
@@ -352,10 +344,10 @@ const ReferencesList: React.FunctionComponent<
         // Make sure this effect only runs once
     }, [loading])
 
-    const references = data?.references.nodes ?? empty
-    const definitions = data?.definitions.nodes ?? empty
-    const implementations = data?.implementations.nodes ?? empty
-    const prototypes = data?.prototypes.nodes ?? empty
+    const references = data?.references.nodes ?? LocationsGroup.empty
+    const definitions = data?.definitions.nodes ?? LocationsGroup.empty
+    const implementations = data?.implementations.nodes ?? LocationsGroup.empty
+    const prototypes = data?.prototypes.nodes ?? LocationsGroup.empty
 
     // The "active URL" is the URL of the highlighted line number in SideBlob,
     // which also influences which item gets highlighted inside
@@ -396,10 +388,13 @@ const ReferencesList: React.FunctionComponent<
     // definitions) we select the first definition. We set it as activeLocation
     // and push it to the blobMemoryHistory so the code blob is open.
     useEffect(() => {
-        if (props.jumpToFirst && definitions.length > 0) {
-            setActiveLocation(definitions[0])
+        if (props.jumpToFirst) {
+            const firstDef = definitions.first
+            if (firstDef) {
+                setActiveLocation(firstDef)
+            }
         }
-    }, [setActiveLocation, props.jumpToFirst, definitions, setActiveURL])
+    }, [setActiveLocation, props.jumpToFirst, definitions.first, setActiveURL])
 
     const onBlobNav = (url: string): void => {
         // Store the URL that the user promoted even if no definition/reference
@@ -462,7 +457,7 @@ const ReferencesList: React.FunctionComponent<
                     <CollapsibleLocationList
                         {...props}
                         name="definitions"
-                        locations={definitions}
+                        locationsGroup={definitions}
                         hasMore={false}
                         loadingMore={false}
                         filter={debouncedFilter}
@@ -476,7 +471,7 @@ const ReferencesList: React.FunctionComponent<
                     <CollapsibleLocationList
                         {...props}
                         name="references"
-                        locations={references}
+                        locationsGroup={references}
                         hasMore={referencesHasNextPage}
                         fetchMore={fetchMoreReferences}
                         loadingMore={fetchMoreReferencesLoading}
@@ -491,7 +486,7 @@ const ReferencesList: React.FunctionComponent<
                     <CollapsibleLocationList
                         {...props}
                         name="implementations"
-                        locations={implementations}
+                        locationsGroup={implementations}
                         hasMore={implementationsHasNextPage}
                         fetchMore={fetchMoreImplementations}
                         loadingMore={fetchMoreImplementationsLoading}
@@ -506,7 +501,7 @@ const ReferencesList: React.FunctionComponent<
                     <CollapsibleLocationList
                         {...props}
                         name="prototypes"
-                        locations={prototypes}
+                        locationsGroup={prototypes}
                         hasMore={prototypesHasNextPage}
                         fetchMore={fetchMorePrototypes}
                         loadingMore={fetchMorePrototypesLoading}
@@ -581,7 +576,7 @@ interface CollapsibleLocationListProps
         SearchTokenProps,
         HighlightedFileLineRangesProps {
     name: string
-    locations: Location[]
+    locationsGroup: LocationsGroup
     filter: string | undefined
     hasMore: boolean
     fetchMore?: () => void
@@ -594,12 +589,15 @@ const CollapsibleLocationList: React.FunctionComponent<
     React.PropsWithChildren<CollapsibleLocationListProps>
 > = props => {
     const isOpen = props.isOpen(props.name) ?? true
+
+    const repoCount = props.locationsGroup.repoCount
+    const locationsCount = props.locationsGroup.locationsCount
     const quantityLabel = useMemo(() => {
-        const repoNumber = uniqBy(props.locations, 'repo').length
-        return `(${props.locations.length} ${pluralize('item', props.locations.length)}${
-            repoNumber > 1 ? ` from ${repoNumber} repositories` : ''
+        // const repoNumber = uniqBy(props.locations, 'repo').length
+        return `(${locationsCount} ${pluralize('item', locationsCount)}${
+            repoCount > 1 ? ` from ${repoCount} repositories` : ''
         } displayed${props.hasMore ? ', more available' : ''})`
-    }, [props.locations, props.hasMore])
+    }, [repoCount, locationsCount, props.hasMore])
 
     return (
         <Collapse isOpen={isOpen} onOpenChange={isOpen => props.handleOpenChange(props.name, isOpen)}>
@@ -624,10 +622,10 @@ const CollapsibleLocationList: React.FunctionComponent<
                 </CardHeader>
 
                 <CollapsePanel id={props.name} data-testid={props.name}>
-                    {props.locations.length > 0 ? (
+                    {locationsCount > 0 ? (
                         <LocationsList
                             searchToken={props.searchToken}
-                            locations={props.locations}
+                            locationsGroup={props.locationsGroup}
                             isActiveLocation={props.isActiveLocation}
                             setActiveLocation={props.setActiveLocation}
                             filter={props.filter}
@@ -777,14 +775,17 @@ interface LocationsListProps
         CollapseProps,
         SearchTokenProps,
         HighlightedFileLineRangesProps {
-    locations: Location[]
+    locationsGroup: LocationsGroup
     filter: string | undefined
     navigateToUrl: (url: string) => void
     activeURL: string
 }
 
+/** Component to display one single section (defs/refs/impls) in the ref
+ * panel, handling multiple repos.
+ */
 const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsListProps>> = ({
-    locations,
+    locationsGroup,
     isActiveLocation,
     setActiveLocation,
     filter,
@@ -795,16 +796,14 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
     fetchHighlightedFileLineRanges,
     activeURL,
 }) => {
-    const repoLocationGroups = useMemo(() => buildRepoLocationGroups(locations), [locations])
-
     return (
         <>
-            {repoLocationGroups.map((group, index) => (
+            {locationsGroup.map((group, index) => (
                 <CollapsibleRepoLocationGroup
                     key={group.repoName}
                     activeURL={activeURL}
                     searchToken={searchToken}
-                    repoLocationGroup={group}
+                    locations={group}
                     openByDefault={index === 0}
                     isActiveLocation={isActiveLocation}
                     setActiveLocation={setActiveLocation}
@@ -819,6 +818,7 @@ const LocationsList: React.FunctionComponent<React.PropsWithChildren<LocationsLi
     )
 }
 
+/** Component to display the Locations for a single repo */
 const CollapsibleRepoLocationGroup: React.FunctionComponent<
     React.PropsWithChildren<
         ActiveLocationProps &
@@ -827,13 +827,13 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
             HighlightedFileLineRangesProps & {
                 filter: string | undefined
                 navigateToUrl: (url: string) => void
-                repoLocationGroup: RepoLocationGroup
+                locations: LocationsGroupedByRepo
                 openByDefault: boolean
                 activeURL: string
             }
     >
 > = ({
-    repoLocationGroup,
+    locations,
     isActiveLocation,
     setActiveLocation,
     navigateToUrl,
@@ -845,38 +845,40 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     fetchHighlightedFileLineRanges,
     activeURL,
 }) => {
-    const open = isOpen(repoLocationGroup.repoName) ?? openByDefault
+    const repoName = locations.repoName
+    const open = isOpen(repoName) ?? openByDefault
 
     return (
-        <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(repoLocationGroup.repoName, isOpen)}>
+        <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(repoName, isOpen)}>
             <div className={styles.repoLocationGroup}>
                 <CollapseHeader
                     as={Button}
                     aria-expanded={open}
-                    aria-label={`Repository ${repoLocationGroup.repoName}`}
+                    aria-label={`Repository ${repoName}`}
                     type="button"
                     className={classNames('d-flex justify-content-start w-100', styles.repoLocationGroupHeader)}
                 >
                     <Icon aria-hidden="true" svgPath={open ? mdiChevronDown : mdiChevronRight} />
                     <small>
                         <span className={classNames('text-small', styles.repoLocationGroupHeaderRepoName)}>
-                            {displayRepoName(repoLocationGroup.repoName)}
+                            {displayRepoName(repoName)}
                         </span>
                     </small>
                 </CollapseHeader>
 
-                <CollapsePanel id={repoLocationGroup.repoName}>
-                    {repoLocationGroup.referenceGroups.map(group => (
+                <CollapsePanel id={repoName}>
+                    {locations.perFileGroups.map(group => (
                         <CollapsibleLocationGroup
-                            key={group.path + group.repoName}
+                            key={group.path + repoName}
                             activeURL={activeURL}
                             searchToken={searchToken}
+                            repoName={repoName}
                             group={group}
                             isActiveLocation={isActiveLocation}
                             setActiveLocation={setActiveLocation}
                             filter={filter}
-                            handleOpenChange={(id, isOpen) => handleOpenChange(repoLocationGroup.repoName + id, isOpen)}
-                            isOpen={id => isOpen(repoLocationGroup.repoName + id)}
+                            handleOpenChange={(id, isOpen) => handleOpenChange(repoName + id, isOpen)}
+                            isOpen={id => isOpen(repoName + id)}
                             navigateToUrl={navigateToUrl}
                             fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                         />
@@ -893,13 +895,15 @@ const CollapsibleLocationGroup: React.FunctionComponent<
             CollapseProps &
             SearchTokenProps &
             HighlightedFileLineRangesProps & {
-                group: LocationGroup
+                repoName: string
+                group: LocationsGroupedByFile
                 filter: string | undefined
                 navigateToUrl: (url: string) => void
                 activeURL: string
             }
     >
 > = ({
+    repoName,
     group,
     setActiveLocation,
     isActiveLocation,
@@ -1007,12 +1011,12 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                             </span>
                         </span>
                         <Badge small={true} variant="secondary" className="ml-4">
-                            {locationGroupQuality(group)}
+                            {group.quality}
                         </Badge>
                     </small>
                 </CollapseHeader>
 
-                <CollapsePanel id={group.repoName + group.path} className="ml-0">
+                <CollapsePanel id={repoName + group.path} className="ml-0">
                     <div className={styles.locationContainer}>
                         <ul className="list-unstyled mb-0">
                             {group.locations.map((reference, index) => {

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -60,7 +60,7 @@ import type { HoverThresholdProps } from '../repo/RepoContainer'
 import { parseBrowserRepoURL } from '../util/url'
 
 import type { CodeIntelligenceProps } from '.'
-import { type Location, LocationsGroup, LocationsGroupedByRepo, LocationsGroupedByFile } from './location'
+import { type Location, LocationsGroup, type LocationsGroupedByRepo, type LocationsGroupedByFile } from './location'
 import { FETCH_HIGHLIGHTED_BLOB } from './ReferencesPanelQueries'
 import { newSettingsGetter } from './settings'
 import { findSearchToken } from './token'
@@ -883,14 +883,15 @@ const CollapsibleLocationGroup: React.FunctionComponent<
         highlighted = group.path.split(filter)
     }
 
-    const { repo, commitID, file } = group.getLocations()[0]
+    const locations = group.getLocations()
+    const { repo, commitID, file } = locations[0]
     const ranges = useMemo(
         () =>
-            group.getLocations().map(location => ({
+            locations.map(location => ({
                 startLine: location.range?.start.line ?? 0,
                 endLine: (location.range?.end.line ?? 0) + 1,
             })),
-        [group.getLocations()]
+        [locations]
     )
 
     const fetchHighlightedFileRangeLines = useCallback(

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -91,7 +91,7 @@ export class LocationsGroupedByFile {
  * This type is specialized for use in the reference panel code.
  * So if a given (repo, file) pair contains both search-based Locations
  * and precise Locations, the search-based Locations are discarded.
-  */
+ */
 export class LocationsGroup {
     /** Invariant: `locationsCount` is the sum of sizes of Location arrays in `groups` */
     private locationsCount: number

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -74,7 +74,7 @@ export class LocationsGroupedByFile {
     }
 
     /** Do not modify the returned Array. */
-    public get getLocations(): Location[] {
+    public getLocations(): Location[] {
         return this.locations
     }
 
@@ -129,10 +129,10 @@ export class LocationsGroup {
                     )
                 }
                 const g = new LocationsGroupedByFile(locations)
-                if (g.getLocations.length > locations.length) {
+                if (g.getLocations().length > locations.length) {
                     throw new Error('materialized new locations out of thin air')
                 }
-                this.locationsCount += g.getLocations.length
+                this.locationsCount += g.getLocations().length
                 perFileLocations.push(g)
             }
             this.groups.push({ repoName, perFileGroups: perFileLocations })
@@ -145,13 +145,13 @@ export class LocationsGroup {
      * in case there are mixed search-based and precise Locations,
      * or if there are duplicates.
      */
-    public get getLocationsCount(): number {
+    public getLocationsCount(): number {
         return this.locationsCount
     }
 
     public get first(): Location | undefined {
         if (this.locationsCount > 0) {
-            return this.groups[0].perFileGroups[0].getLocations[0]
+            return this.groups[0].perFileGroups[0].getLocations()[0]
         }
         return undefined
     }
@@ -181,7 +181,7 @@ export class LocationsGroup {
         const out: Location[] = []
         for (const group of this.groups) {
             for (const locs of group.perFileGroups) {
-                out.push(...locs.getLocations)
+                out.push(...locs.getLocations())
             }
         }
         return out

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -15,27 +15,170 @@ export interface Location {
     precise: boolean
 }
 
-export interface RepoLocationGroup {
+export type LocationsGroupedByRepo = {
+    /** Invariant: `repoName` matches the 'repo' key in all Locations in `perFileGroups` */
     repoName: string
-    referenceGroups: LocationGroup[]
-}
-
-export interface LocationGroup {
-    repoName: string
-    path: string
-    locations: Location[]
+    /** Invariant: This array is non-empty */
+    perFileGroups: LocationsGroupedByFile[]
 }
 
 export type LocationGroupQuality = 'PRECISE' | 'SEARCH-BASED'
 
-export const locationGroupQuality = (group: LocationGroup): LocationGroupQuality => {
-    if (group.locations.length === 0) {
-        throw new Error(`No locations in ${group.path}`)
+export class LocationsGroupedByFile {
+    /** Invariant: `path` matches the 'file' key in all Locations in `_locations` */
+    public path: string
+    /** Invariant: `precise` matches the 'precise' key in all Locations in `_locations` */
+    private _precise: boolean
+    /** Invariant: This array is non-empty */
+    private _locations: Location[]
+
+    /** Pre-condition: `locations` should be non-empty, and every entry
+     * should have the same value for 'file'.
+     */
+    constructor(locations: Location[]) {
+        console.assert(locations.length > 0, 'pre-condition failure')
+        this.path = locations[0].file
+        this._precise = locations[0].precise
+        this._locations = [locations[0]]
+        for (const [i, loc] of locations.entries()) {
+            if (i === 0) {
+                continue
+            }
+            this.tryAdd(loc)
+        }
     }
 
-    // Since we don't mix precise & search-based in a single file, we know that in a
-    // single group all locations are either search-based or precise.
-    return group.locations[0].precise ? 'PRECISE' : 'SEARCH-BASED'
+    /** Attempt to add the Location to this group without mixing
+     * search-based and precise Locations.
+     *
+     * If one attempts to mix them, precise locations will be preferred.
+     */
+    private tryAdd(location: Location) {
+        if (this._precise && !location.precise) {
+            return
+        }
+        if (!this._precise && location.precise) {
+            this._precise = true
+            this._locations = [location]
+            return
+        }
+        console.assert(location.file == this.path, 'pre-condition failure')
+        console.assert(location.precise == this._precise)
+        this._locations.push(location)
+    }
+
+    public get locations(): Location[] {
+        return this._locations
+    }
+
+    public get quality(): LocationGroupQuality {
+        return this._precise ? 'PRECISE' : 'SEARCH-BASED'
+    }
+}
+
+/** Type to store locations grouped by (repo, file) pairs.
+ *
+ * This type is specialized for use in the reference panel code.
+ * So if a given (repo, file) pair contains both search-based Locations
+ * and precise Locations, the search-based Locations are discarded.
+ * */
+export class LocationsGroup {
+    /** Invariant: `_totalCount` is the sum of sizes of Location arrays in `_groups` */
+    private _locationsCount: number
+    private _groups: LocationsGroupedByRepo[]
+
+    public constructor(locations: Location[]) {
+        this._locationsCount = 0
+        this._groups = []
+        this.resetLocations(locations)
+    }
+
+    /** Returns the total number of locations combined across all groups.
+     *
+     * This may be less than the number of Locations passed to the constructor,
+     * in case there are mixed search-based and precise Locations,
+     * or if there are duplicates.
+     */
+    public get locationsCount(): number {
+        return this._locationsCount
+    }
+
+    public get first(): Location | undefined {
+        if (this._locationsCount > 0) {
+            return this._groups[0].perFileGroups[0].locations[0]
+        }
+        return undefined
+    }
+
+    public get repoCount(): number {
+        return this._groups.length
+    }
+
+    public map<T>(callback: (arg0: LocationsGroupedByRepo, arg1: number) => T): T[] {
+        return this._groups.map(callback)
+    }
+
+    public static empty: LocationsGroup = new LocationsGroup([])
+
+    /** Attempt to combine the existing locations with the new set
+     * into a new LocationsGroup.
+     *
+     * Some of the Locations in `newLocations` may be dropped if they
+     * are search-based and we already had precise references for the
+     * same file.
+     */
+    public combine(newLocations: Location[]): LocationsGroup {
+        let newGroup = new LocationsGroup([])
+        newGroup.resetLocations([...this.allLocations(), ...newLocations])
+        return newGroup
+    }
+
+    private allLocations(): Location[] {
+        const out: Location[] = []
+        for (const group of this._groups) {
+            for (const locs of group.perFileGroups) {
+                out.push(...locs.locations)
+            }
+        }
+        return out
+    }
+
+    /** reset the state of this LocationsGroup to only contain entries from `locations` */
+    private resetLocations(locations: Location[]): void {
+        this._locationsCount = 0
+        this._groups = []
+        const urlsSeen = new Set<string>()
+        const groupingMap = new Map<string, Map<string, Location[]>>()
+        for (const loc of locations) {
+            if (urlsSeen.has(loc.url)) {
+                continue
+            }
+            urlsSeen.add(loc.url)
+            const repoMap = groupingMap.get(loc.repo)
+            if (repoMap) {
+                const pathMap = repoMap.get(loc.file)
+                if (pathMap) {
+                    pathMap.push(loc)
+                } else {
+                    repoMap.set(loc.file, [loc])
+                }
+            } else {
+                const repoMap = new Map<string, Location[]>()
+                repoMap.set(loc.file, [loc])
+                groupingMap.set(loc.repo, repoMap)
+            }
+        }
+        groupingMap.forEach((repoMap, repoName) => {
+            const perFileLocations: LocationsGroupedByFile[] = []
+            for (const [_, locations] of repoMap) {
+                console.assert(locations.length > 0, 'bug in grouping logic')
+                const g = new LocationsGroupedByFile(locations)
+                this._locationsCount += g.locations.length
+                perFileLocations.push(g)
+            }
+            this._groups.push({ repoName, perFileGroups: perFileLocations })
+        })
+    }
 }
 
 export const buildSearchBasedLocation = (node: Result): Location => ({
@@ -66,29 +209,4 @@ export const buildPreciseLocation = (node: LocationFields): Location => {
     }
     location.lines = location.content.split(/\r?\n/)
     return location
-}
-
-export const buildRepoLocationGroups = (locations: Location[]): RepoLocationGroup[] => {
-    const byRepoAndFile: Record<string, Record<string, Location[]>> = {}
-    for (const location of locations) {
-        if (byRepoAndFile[location.repo] === undefined) {
-            byRepoAndFile[location.repo] = {}
-        }
-        if (byRepoAndFile[location.repo][location.file] === undefined) {
-            byRepoAndFile[location.repo][location.file] = []
-        }
-        byRepoAndFile[location.repo][location.file].push(location)
-    }
-
-    return Object.keys(byRepoAndFile).map(repoName => {
-        const byFile = byRepoAndFile[repoName]
-
-        const referenceGroups: LocationGroup[] = Object.keys(byFile).map(path => ({
-            path,
-            locations: byFile[path],
-            repoName,
-        }))
-
-        return { repoName, referenceGroups }
-    })
 }

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -106,7 +106,7 @@ export class LocationsGroup {
 
     constructor(locations: Location[]) {
         let locationsCount = 0
-        let groups: LocationsGroupedByRepo[] = []
+        const groups: LocationsGroupedByRepo[] = []
 
         const urlsSeen = new Set<string>()
         const repoMap = new Map<string, Map<string, Location[]>>()

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -15,7 +15,7 @@ export interface Location {
     precise: boolean
 }
 
-export type LocationsGroupedByRepo = {
+export interface LocationsGroupedByRepo {
     /** Invariant: `repoName` matches the 'repo' key in all Locations in `perFileGroups` */
     repoName: string
     /** Invariant: This array is non-empty */
@@ -53,7 +53,7 @@ export class LocationsGroupedByFile {
      *
      * If one attempts to mix them, precise locations will be preferred.
      */
-    private tryAdd(location: Location) {
+    private tryAdd(location: Location): void {
         if (this._precise && !location.precise) {
             return
         }
@@ -62,8 +62,8 @@ export class LocationsGroupedByFile {
             this._locations = [location]
             return
         }
-        console.assert(location.file == this.path, 'pre-condition failure')
-        console.assert(location.precise == this._precise)
+        console.assert(location.file === this.path, 'pre-condition failure')
+        console.assert(location.precise === this._precise)
         this._locations.push(location)
     }
 
@@ -88,7 +88,7 @@ export class LocationsGroup {
     /** Invariant: Every Location stored in the group has a distinct URL. */
     private _groups: LocationsGroupedByRepo[]
 
-    public constructor(locations: Location[]) {
+    constructor(locations: Location[]) {
         this._locationsCount = 0
         this._groups = []
         this.resetLocations(locations)
@@ -129,9 +129,7 @@ export class LocationsGroup {
      * same file.
      */
     public combine(newLocations: Location[]): LocationsGroup {
-        let newGroup = new LocationsGroup([])
-        newGroup.resetLocations([...this.allLocations(), ...newLocations])
-        return newGroup
+        return new LocationsGroup([...this.allLocations(), ...newLocations])
     }
 
     private allLocations(): Location[] {
@@ -169,7 +167,7 @@ export class LocationsGroup {
                 repoMap.set(loc.repo, pathToLocMap)
             }
         }
-        repoMap.forEach((pathToLocMap, repoName) => {
+        for (const [repoName, pathToLocMap] of repoMap) {
             const perFileLocations: LocationsGroupedByFile[] = []
             for (const [_, locations] of pathToLocMap) {
                 console.assert(locations.length > 0, 'bug in grouping logic')
@@ -179,7 +177,7 @@ export class LocationsGroup {
                 perFileLocations.push(g)
             }
             this._groups.push({ repoName, perFileGroups: perFileLocations })
-        })
+        }
     }
 }
 

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -32,7 +32,8 @@ export class LocationsGroupedByFile {
     /** Invariant: This array is non-empty */
     private locations: Location[]
 
-    /** Pre-condition: `locations` should be non-empty, and every entry
+    /**
+     * Pre-condition: `locations` should be non-empty, and every entry
      * should have the same value for 'file'.
      */
     constructor(locations: Location[]) {
@@ -50,7 +51,8 @@ export class LocationsGroupedByFile {
         }
     }
 
-    /** Attempt to add the Location to this group without mixing
+    /**
+     * Attempt to add the Location to this group without mixing
      * search-based and precise Locations.
      *
      * If one attempts to mix them, precise locations will be preferred.
@@ -83,12 +85,13 @@ export class LocationsGroupedByFile {
     }
 }
 
-/** Type to store locations grouped by (repo, file) pairs.
+/**
+ * Type to store locations grouped by (repo, file) pairs.
  *
  * This type is specialized for use in the reference panel code.
  * So if a given (repo, file) pair contains both search-based Locations
  * and precise Locations, the search-based Locations are discarded.
- * */
+  */
 export class LocationsGroup {
     /** Invariant: `locationsCount` is the sum of sizes of Location arrays in `groups` */
     private locationsCount: number
@@ -139,7 +142,8 @@ export class LocationsGroup {
         }
     }
 
-    /** Returns the total number of locations combined across all groups.
+    /**
+     * Returns the total number of locations combined across all groups.
      *
      * This may be less than the number of Locations passed to the constructor,
      * in case there are mixed search-based and precise Locations,
@@ -166,7 +170,8 @@ export class LocationsGroup {
 
     public static empty: LocationsGroup = new LocationsGroup([])
 
-    /** Attempt to combine the existing locations with the new set
+    /**
+     * Attempt to combine the existing locations with the new set
      * into a new LocationsGroup.
      *
      * Some of the Locations in `newLocations` may be dropped if they

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -36,7 +36,9 @@ export class LocationsGroupedByFile {
      * should have the same value for 'file'.
      */
     constructor(locations: Location[]) {
-        console.assert(locations.length > 0, 'pre-condition failure')
+        if (locations.length === 0) {
+            throw new Error('pre-condition failure')
+        }
         this.path = locations[0].file
         this._precise = locations[0].precise
         this._locations = [locations[0]]
@@ -62,8 +64,12 @@ export class LocationsGroupedByFile {
             this._locations = [location]
             return
         }
-        console.assert(location.file === this.path, 'pre-condition failure')
-        console.assert(location.precise === this._precise)
+        if (location.file !== this.path) {
+            throw new Error('pre-condition failure')
+        }
+        if (location.precise !== this._precise) {
+            throw new Error('already handled precise same-ness check earlier')
+        }
         this._locations.push(location)
     }
 
@@ -169,10 +175,16 @@ export class LocationsGroup {
         }
         for (const [repoName, pathToLocMap] of repoMap) {
             const perFileLocations: LocationsGroupedByFile[] = []
-            for (const [_, locations] of pathToLocMap) {
-                console.assert(locations.length > 0, 'bug in grouping logic')
+            for (const [path, locations] of pathToLocMap) {
+                if (locations.length === 0) {
+                    throw new Error(
+                        `bug in grouping logic created empty locations array for repo: ${repoName}, path: ${path}`
+                    )
+                }
                 const g = new LocationsGroupedByFile(locations)
-                console.assert(g.locations.length <= locations.length)
+                if (g.locations.length > locations.length) {
+                    throw new Error('materialized new locations out of thin air')
+                }
                 this._locationsCount += g.locations.length
                 perFileLocations.push(g)
             }

--- a/client/web/src/codeintel/location.ts
+++ b/client/web/src/codeintel/location.ts
@@ -25,9 +25,9 @@ export interface LocationsGroupedByRepo {
 export type LocationGroupQuality = 'PRECISE' | 'SEARCH-BASED'
 
 export class LocationsGroupedByFile {
-    /** Invariant: `path` matches the 'file' key in all Locations in `_locations` */
+    /** Invariant: `path` matches the 'file' key in all Locations in `locations` */
     public path: string
-    /** Invariant: `precise` matches the 'precise' key in all Locations in `_locations` */
+    /** Invariant: `precise` matches the 'precise' key in all Locations in `locations` */
     private precise: boolean
     /** Invariant: This array is non-empty */
     private locations: Location[]
@@ -90,7 +90,7 @@ export class LocationsGroupedByFile {
  * and precise Locations, the search-based Locations are discarded.
  * */
 export class LocationsGroup {
-    /** Invariant: `_totalCount` is the sum of sizes of Location arrays in `_groups` */
+    /** Invariant: `locationsCount` is the sum of sizes of Location arrays in `groups` */
     private locationsCount: number
     /** Invariant: Every Location stored in the group has a distinct URL. */
     private groups: LocationsGroupedByRepo[]

--- a/client/web/src/codeintel/useCodeIntel.ts
+++ b/client/web/src/codeintel/useCodeIntel.ts
@@ -4,25 +4,25 @@ import type { LanguageSpec } from '@sourcegraph/shared/src/codeintel/legacy-exte
 import type { ConnectionQueryArguments } from '../components/FilteredConnection'
 import type { UsePreciseCodeIntelForPositionVariables } from '../graphql-operations'
 
-import type { Location } from './location'
+import type { LocationsGroup } from './location'
 import type { SettingsGetter } from './settings'
 
 export interface CodeIntelData {
     references: {
         endCursor: string | null
-        nodes: Location[]
+        nodes: LocationsGroup
     }
     implementations: {
         endCursor: string | null
-        nodes: Location[]
+        nodes: LocationsGroup
     }
     prototypes: {
         endCursor: string | null
-        nodes: Location[]
+        nodes: LocationsGroup
     }
     definitions: {
         endCursor: string | null
-        nodes: Location[]
+        nodes: LocationsGroup
     }
 }
 

--- a/client/web/src/enterprise/codeintel/useCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntel.ts
@@ -144,7 +144,7 @@ export const useCodeIntel = ({
 
                     // When no definitions are found, the hover tooltip falls back to a search based
                     // search, regardless of the mixPreciseAndSearchBasedReferences setting.
-                    if (lsifData.definitions.nodes.locationsCount === 0) {
+                    if (lsifData.definitions.nodes.getLocationsCount === 0) {
                         fetchSearchBasedDefinitions(setDefinitions)
                     }
                 } else {

--- a/client/web/src/enterprise/codeintel/useCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntel.ts
@@ -144,7 +144,7 @@ export const useCodeIntel = ({
 
                     // When no definitions are found, the hover tooltip falls back to a search based
                     // search, regardless of the mixPreciseAndSearchBasedReferences setting.
-                    if (lsifData.definitions.nodes.getLocationsCount === 0) {
+                    if (lsifData.definitions.nodes.getLocationsCount() === 0) {
                         fetchSearchBasedDefinitions(setDefinitions)
                     }
                 } else {

--- a/client/web/src/enterprise/codeintel/useCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useCodeIntel.ts
@@ -144,7 +144,7 @@ export const useCodeIntel = ({
 
                     // When no definitions are found, the hover tooltip falls back to a search based
                     // search, regardless of the mixPreciseAndSearchBasedReferences setting.
-                    if (lsifData.definitions.nodes.getLocationsCount() === 0) {
+                    if (lsifData.definitions.nodes.locationsCount === 0) {
                         fetchSearchBasedDefinitions(setDefinitions)
                     }
                 } else {


### PR DESCRIPTION
The current ref panel code scatters calls for grouping and uniquing in a bunch of different places.
This makes the code hard to understand (which invariants hold and why?) and makes it harder
to propagate information easily at per-file or per-repo granularity.

In the future, we want to attach one SCIP Document per file for https://github.com/sourcegraph/sourcegraph/issues/58182

So I've attempted to centralize the grouping and uniquing logic here, and made
liberal use of assertions and comments to make it clear which invariants hold.

My coding style + naming is probably somewhat unidiomatic, open to suggestions for improvements.

## Test plan

TODO, not sure what kinds of tests I should add. Unit tests for the new `LocationGroup` class?

Is there any easy way to add fuzz tests to make sure that no assertions are hit?