### PR TITLE
search: Fix suggestion being selected after applying one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed a bug where typing in the GraphQL editor in the Site Admin API console could cause the cursor to jump to the start of the editor. [#57862](https://github.com/sourcegraph/sourcegraph/pull/57862)
 - The blame column no longer ignores whitespace-only changes by default. [#58134](https://github.com/sourcegraph/sourcegraph/pull/58134)
 - Long lines now wrap correctly in the diff view. [#58138](https://github.com/sourcegraph/sourcegraph/pull/58138)
+- Fixed an issue in the search input where pressing Enter after selecting a suggestion would sometimes insert another suggestions instead of submitting the query. [#58186](https://github.com/sourcegraph/sourcegraph/pull/58186)
 
 ### Removed
 


### PR DESCRIPTION
Fixes #57848 

This issue occurred when a suggestion was applied while the extension was waiting for additional suggestions from the server.

There are various ways to fix this but the most robust one is to identify when a state update pertains to the current completion request and when it does not.

This commit adds a new field to the `Query` object to make this possible. Whenever a new request is issues this field is assigned a new value, making it easy to identify when we should preserve the current suggestion selection.



## Test plan

A relatively reliable way to test this seems to be the following:
- Prime file cache with some values, e.g. by typing `file:foo`
- Add another file filter with a single letter which is different from the first letter used in the previous step (to ensure a server request is made). The point is to select an entry quickly from the cached results before the response from the server was received. E.g. `f:o`.
- Use down arrow to select the first or second item and press enter
  -> The value gets inserted, the default suggestions are shown, none of the suggestions is selected.