### PR TITLE
Code Navigation: cleans up blob view search

### DIFF
--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -222,21 +222,20 @@ class SearchPanel implements Panel {
                     {
                         /* commenting regex filter out since it is breaking everything
                          * TODO: fix it
-                         *
-                         * <QueryInputToggle
-                        //     isActive={searchQuery.regexp}
-                        //     onToggle={() => this.commit({ regexp: !searchQuery.regexp })}
-                        //     iconSvgPath={mdiRegex}
-                        //     title="Regular expression"
-                        //     className="cm-search-toggle test-blob-view-search-regexp"
-                        />*/
+                         */
                     }
+                    <QueryInputToggle
+                        isActive={searchQuery.regexp}
+                        onToggle={() => this.commit({ regexp: !searchQuery.regexp })}
+                        iconSvgPath={mdiRegex}
+                        title="Regular expression"
+                        className="cm-search-toggle test-blob-view-search-regexp"
+                    />
                 </div>
                 {totalMatches > 1 && (
                     <>
-
                         <Button
-                            className="mr-2"
+                            className="p-1 ml-2 mr-2 mt-0 mb-0"
                             type="button"
                             size="sm"
                             outline={true}
@@ -248,7 +247,7 @@ class SearchPanel implements Panel {
                         </Button>
 
                         <Button
-                            className="mr-3"
+                            className="p-1 mr-0 mt-0 mb-0"
                             type="button"
                             size="sm"
                             outline={true}
@@ -263,7 +262,7 @@ class SearchPanel implements Panel {
 
                 {searchQuery.search ? (
                     <div>
-                        <Text className="cm-search-results m-0 small">
+                        <Text className="cm-search-results mt-0 mr-0 mb-0 ml-2 small">
                             {currentMatchIndex !== null && `${currentMatchIndex} / `}
                             {totalMatches} {pluralize('result', totalMatches)}
                         </Text>
@@ -429,8 +428,7 @@ function announceMatch(view: EditorView, { from, to }: { from: number; to: numbe
 const theme = EditorView.theme({
     '.cm-sg-search-container': {
         backgroundColor: 'var(--code-bg)',
-        padding: '0.375rem 1rem',
-        border: 'none',
+        padding: '0.5rem 0.5rem',
     },
     '.cm-sg-search-input': {
         borderRadius: 'var(--border-radius)',
@@ -449,6 +447,7 @@ const theme = EditorView.theme({
     },
     '.search-container > input.form-control': {
         width: '15rem',
+        height: '1.0rem',
     },
     '.cm-searchMatch': {
         backgroundColor: 'var(--mark-bg)',
@@ -460,11 +459,12 @@ const theme = EditorView.theme({
         color: 'var(--body-color)',
     },
     '.cm-search-results': {
-        color: 'var(--body-color)',
+        color: 'var(--gray-06)',
         fontFamily: 'var(--font-family-base)',
+        marginLeft: '2rem',
     },
     '.cm-search-toggle': {
-        color: 'var(--gray-07)',
+        color: 'var(--gray-06)',
     }
 })
 

--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -263,7 +263,7 @@ class SearchPanel implements Panel {
                 {searchQuery.search ? (
                     <div>
                         <Text className="cm-search-results mt-0 mr-0 mb-0 ml-2 small">
-                            {currentMatchIndex !== null && `${currentMatchIndex} / `}
+                            {currentMatchIndex !== null && `${currentMatchIndex} of `}
                             {totalMatches} {pluralize('result', totalMatches)}
                         </Text>
                     </div>

--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -198,7 +198,7 @@ class SearchPanel implements Panel {
                     this.input?.select()
                 }}
             >
-                <div className="cm-sg-search-input d-flex align-items-center pr-2 mr-2">
+                <div className="cm-sg-search-input d-flex align-items-center pr-2 mr-1">
                     <Input
                         ref={element => (this.input = element)}
                         type="search"
@@ -216,45 +216,54 @@ class SearchPanel implements Panel {
                         onToggle={() => this.commit({ caseSensitive: !searchQuery.caseSensitive })}
                         iconSvgPath={mdiFormatLetterCase}
                         title="Case sensitivity"
-                        className="test-blob-view-search-case-sensitive"
+                        className="cm-search-toggle test-blob-view-search-case-sensitive"
                     />
-                    <QueryInputToggle
-                        isActive={searchQuery.regexp}
-                        onToggle={() => this.commit({ regexp: !searchQuery.regexp })}
-                        iconSvgPath={mdiRegex}
-                        title="Regular expression"
-                        className="test-blob-view-search-regexp"
-                    />
-                </div>
-                <Button
-                    className="mr-2"
-                    type="button"
-                    size="sm"
-                    outline={true}
-                    variant="secondary"
-                    onClick={this.findPrevious}
-                    data-testid="blob-view-search-previous"
-                >
-                    <Icon svgPath={mdiChevronUp} aria-hidden={true} />
-                    Previous
-                </Button>
 
-                <Button
-                    className="mr-3"
-                    type="button"
-                    size="sm"
-                    outline={true}
-                    variant="secondary"
-                    onClick={this.findNext}
-                    data-testid="blob-view-search-next"
-                >
-                    <Icon svgPath={mdiChevronDown} aria-hidden={true} />
-                    Next
-                </Button>
+                    {
+                        /* commenting regex filter out since it is breaking everything
+                         * TODO: fix it
+                         *
+                         * <QueryInputToggle
+                        //     isActive={searchQuery.regexp}
+                        //     onToggle={() => this.commit({ regexp: !searchQuery.regexp })}
+                        //     iconSvgPath={mdiRegex}
+                        //     title="Regular expression"
+                        //     className="cm-search-toggle test-blob-view-search-regexp"
+                        />*/
+                    }
+                </div>
+                {totalMatches > 1 && (
+                    <>
+
+                        <Button
+                            className="mr-2"
+                            type="button"
+                            size="sm"
+                            outline={true}
+                            variant="secondary"
+                            onClick={this.findPrevious}
+                            data-testid="blob-view-search-previous"
+                        >
+                            <Icon svgPath={mdiChevronUp} aria-hidden={true} />
+                        </Button>
+
+                        <Button
+                            className="mr-3"
+                            type="button"
+                            size="sm"
+                            outline={true}
+                            variant="secondary"
+                            onClick={this.findNext}
+                            data-testid="blob-view-search-next"
+                        >
+                            <Icon svgPath={mdiChevronDown} aria-hidden={true} />
+                        </Button>
+                    </>
+                )}
 
                 {searchQuery.search ? (
                     <div>
-                        <Text className="m-0">
+                        <Text className="cm-search-results m-0 small">
                             {currentMatchIndex !== null && `${currentMatchIndex} / `}
                             {totalMatches} {pluralize('result', totalMatches)}
                         </Text>
@@ -268,7 +277,7 @@ class SearchPanel implements Panel {
                             value={overrideBrowserSearch}
                             onToggle={this.setOverrideBrowserSearch}
                         />
-                        {searchKeybinding} searches file
+                        {searchKeybinding}
                     </Label>
                     {searchKeybindingTooltip}
                 </div>
@@ -421,13 +430,13 @@ const theme = EditorView.theme({
     '.cm-sg-search-container': {
         backgroundColor: 'var(--code-bg)',
         padding: '0.375rem 1rem',
+        border: 'none',
     },
     '.cm-sg-search-input': {
         borderRadius: 'var(--border-radius)',
         border: '1px solid var(--input-border-color)',
 
         '&:focus-within': {
-            borderColor: 'var(--inpt-focus-border-color)',
             boxShadow: 'var(--input-focus-box-shadow)',
         },
 
@@ -448,8 +457,15 @@ const theme = EditorView.theme({
         backgroundColor: 'var(--oc-orange-3)',
     },
     '.cm-sg-search-info': {
-        color: 'var(--gray-06)',
+        color: 'var(--body-color)',
     },
+    '.cm-search-results': {
+        color: 'var(--body-color)',
+        fontFamily: 'var(--font-family-base)',
+    },
+    '.cm-search-toggle': {
+        color: 'var(--gray-07)',
+    }
 })
 
 interface SearchConfig {
@@ -467,20 +483,20 @@ export function search(config: SearchConfig): Extension {
             return searchKeymap.map(binding =>
                 binding.key === 'Mod-f'
                     ? {
-                          ...binding,
-                          run: view => {
-                              // By default pressing Mod+f when the search input is already focused won't select
-                              // the input value, unlike browser's built-in search feature.
-                              // We are overwriting the keybinding here to ensure that the input value is always
-                              // selected.
-                              const result = binding.run?.(view)
-                              if (result) {
-                                  view.dispatch({ effects: focusSearchInput.of(true) })
-                                  return true
-                              }
-                              return false
-                          },
-                      }
+                        ...binding,
+                        run: view => {
+                            // By default pressing Mod+f when the search input is already focused won't select
+                            // the input value, unlike browser's built-in search feature.
+                            // We are overwriting the keybinding here to ensure that the input value is always
+                            // selected.
+                            const result = binding.run?.(view)
+                            if (result) {
+                                view.dispatch({ effects: focusSearchInput.of(true) })
+                                return true
+                            }
+                            return false
+                        },
+                    }
                     : binding
             )
         }

--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -219,11 +219,9 @@ class SearchPanel implements Panel {
                         className="cm-search-toggle test-blob-view-search-case-sensitive"
                     />
 
-                    {
-                        /* commenting regex filter out since it is breaking everything
-                         * TODO: fix it
-                         */
-                    }
+                    {/* commenting regex filter out since it is breaking everything
+                     * TODO: fix it
+                     */}
                     <QueryInputToggle
                         isActive={searchQuery.regexp}
                         onToggle={() => this.commit({ regexp: !searchQuery.regexp })}
@@ -242,6 +240,7 @@ class SearchPanel implements Panel {
                             variant="secondary"
                             onClick={this.findPrevious}
                             data-testid="blob-view-search-previous"
+                            aria-label="previous result"
                         >
                             <Icon svgPath={mdiChevronUp} aria-hidden={true} />
                         </Button>
@@ -254,6 +253,7 @@ class SearchPanel implements Panel {
                             variant="secondary"
                             onClick={this.findNext}
                             data-testid="blob-view-search-next"
+                            aria-label="next result"
                         >
                             <Icon svgPath={mdiChevronDown} aria-hidden={true} />
                         </Button>
@@ -465,7 +465,7 @@ const theme = EditorView.theme({
     },
     '.cm-search-toggle': {
         color: 'var(--gray-06)',
-    }
+    },
 })
 
 interface SearchConfig {
@@ -483,20 +483,20 @@ export function search(config: SearchConfig): Extension {
             return searchKeymap.map(binding =>
                 binding.key === 'Mod-f'
                     ? {
-                        ...binding,
-                        run: view => {
-                            // By default pressing Mod+f when the search input is already focused won't select
-                            // the input value, unlike browser's built-in search feature.
-                            // We are overwriting the keybinding here to ensure that the input value is always
-                            // selected.
-                            const result = binding.run?.(view)
-                            if (result) {
-                                view.dispatch({ effects: focusSearchInput.of(true) })
-                                return true
-                            }
-                            return false
-                        },
-                    }
+                          ...binding,
+                          run: view => {
+                              // By default pressing Mod+f when the search input is already focused won't select
+                              // the input value, unlike browser's built-in search feature.
+                              // We are overwriting the keybinding here to ensure that the input value is always
+                              // selected.
+                              const result = binding.run?.(view)
+                              if (result) {
+                                  view.dispatch({ effects: focusSearchInput.of(true) })
+                                  return true
+                              }
+                              return false
+                          },
+                      }
                     : binding
             )
         }

--- a/client/wildcard/src/global-styles/code.scss
+++ b/client/wildcard/src/global-styles/code.scss
@@ -34,12 +34,14 @@ code,
 }
 
 kbd {
-    font-family: var(--code-font-family);
+    font-family: var(--font-family-base);
     font-size: var(--code-font-size);
     display: inline-block;
     line-height: (16/12);
-    height: 1.125rem;
-    padding: 0 0.25rem;
+    height: 1.2rem;
+    width: 1.2rem;
+    text-align: center;
+    padding-top: 0.1rem;
     margin: 0 0.125rem;
     vertical-align: middle;
     border-radius: 3px;

--- a/client/wildcard/src/global-styles/code.scss
+++ b/client/wildcard/src/global-styles/code.scss
@@ -46,8 +46,7 @@ kbd {
     vertical-align: middle;
     border-radius: 3px;
     color: var(--body-color);
-    background-color: var(--color-bg-2);
-    box-shadow: inset 0 -2px 0 var(--color-bg-3);
+    background-color: var(--color-bg-3);
 }
 
 // Search examples that link to the results page should use this class.


### PR DESCRIPTION
This PR cleans up the blob view search bar, which was obfuscated in a number of ways, especially in dark mode. 

Before: 
![Screenshot 2023-11-08 at 11 10 34 AM](https://github.com/sourcegraph/sourcegraph/assets/62355966/b9c18613-5ba2-4f32-913a-856d23c1e6e7)
![Screenshot 2023-11-08 at 11 11 09 AM](https://github.com/sourcegraph/sourcegraph/assets/62355966/bfb13721-81f1-4ef3-aff5-24c2200981f5)


After: 
![Screenshot 2023-11-08 at 11 11 27 AM](https://github.com/sourcegraph/sourcegraph/assets/62355966/aafa586f-2756-4456-bef6-77c5033d44f5)
![Screenshot 2023-11-08 at 11 11 57 AM](https://github.com/sourcegraph/sourcegraph/assets/62355966/ac436b6a-a39a-4d94-9c3a-a7e476f577df)


Some other changes: 
- Remove superfluous 'previous' and 'next' labels since carat up and down will suffice. 
- previous, next buttons, and results will show up dynamically based on matches. Matches must be greater than 1 for next and previous buttons to become visible.
![Screenshot 2023-11-08 at 11 15 28 AM](https://github.com/sourcegraph/sourcegraph/assets/62355966/6db1e2ae-05dc-403f-82fc-ee1e6dd478c4)
![Screenshot 2023-11-08 at 11 16 01 AM](https://github.com/sourcegraph/sourcegraph/assets/62355966/1a781249-0d4e-4be1-99b4-0a3c0418ecff)
![Screenshot 2023-11-08 at 11 16 26 AM](https://github.com/sourcegraph/sourcegraph/assets/62355966/bd062bd5-9d1b-4eeb-8f1f-56c67db95be6)
- Remove superfluous label describing command on right side of search container.
- Lighten any items that were not easily visible in dark mode.
- Fix strange looking key icons

## Test plan
Manual testing