### PR TITLE
[Repository page]: Show initial repository query value in initial picker state

### DIFF
--- a/client/web/src/repo/RepoLinkPicker.tsx
+++ b/client/web/src/repo/RepoLinkPicker.tsx
@@ -74,8 +74,14 @@ export const RepoLinkPicker: FC<RepoLinkPickerProps> = props => {
 
     const rootRef = useRef<HTMLDivElement>(null)
     const [isSuggestionOpen, setSuggestionOpen] = useState<boolean>(false)
-    const [searchTerm, setSearchTerm] = useState<string>('')
-    const debouncedSearchTerm = useDebounce(searchTerm, 500)
+    const [searchTerm, setSearchTerm] = useState<string>(getInitialSearchTerm(repositoryName))
+
+    // Still narrow down the repository picker search to prevent timeout
+    // on instance with big number of repositories.
+    const debouncedSearchTerm = useDebounce(
+        searchTerm.length === 0 ? getInitialSearchTerm(repositoryName) : searchTerm,
+        500
+    )
 
     const {
         data: currentData,
@@ -84,15 +90,14 @@ export const RepoLinkPicker: FC<RepoLinkPickerProps> = props => {
         loading,
     } = useQuery<RepositoriesSuggestionsResult, RepositoriesSuggestionsVariables>(REPOSITORIES_QUERY, {
         skip: !isSuggestionOpen,
-        variables: {
-            query: searchTerm.length === 0 ? getInitialSearchTerm(repositoryName) : debouncedSearchTerm,
-        },
+        variables: { query: debouncedSearchTerm },
         fetchPolicy: 'cache-first',
     })
 
     const handleSelect = (selectedValue: string): void => {
-        navigate(`/${selectedValue}`)
+        setSearchTerm(selectedValue)
         setSuggestionOpen(false)
+        navigate(`/${selectedValue}`)
     }
 
     const data = currentData ?? previousData

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -21,7 +21,7 @@ export const getInitialSearchTerm = (repo: string): string => {
     const r = repo.split('/')
     // This is what the linter required instead of r[r.length - 1].
     // *shrugs*
-    return at(r, r.length - 1)[0]
+    return at(r, r.length - 1)[0].trim()
 }
 
 export const stringToCodeHostType = (codeHostType: string): CodeHostType => {

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -1,5 +1,3 @@
-import { at } from 'lodash'
-
 import { type GitCommitFields, RepositoryType } from '../graphql-operations'
 
 import { CodeHostType } from './constants'
@@ -19,9 +17,7 @@ export const getCanonicalURL = (sourceType: RepositoryType | string, node: GitCo
 
 export const getInitialSearchTerm = (repo: string): string => {
     const r = repo.split('/')
-    // This is what the linter required instead of r[r.length - 1].
-    // *shrugs*
-    return at(r, r.length - 1)[0].trim()
+    return r.at(-1)?.trim() ?? ''
 }
 
 export const stringToCodeHostType = (codeHostType: string): CodeHostType => {


### PR DESCRIPTION
Follow up from this convo https://github.com/sourcegraph/sourcegraph/pull/58025#discussion_r1379139554

This PR improves a bit behaviour of the repository picker makes it a bit more explicit about what value exactly we use to fetch list of repositories in the suggestion panel. Prior this PR we fetch list by repository name but input doesn't have any value. This PR include initial value in the input so user can see why they see what they see in the suggestion panel. 

## Test plan
- Check that when you open repository picker it has initial value with repository name

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
