### PR TITLE
Fix input focus ring styles in MultiCombobox UI

### DIFF
--- a/client/wildcard/src/components/Combobox/MultiCombobox.module.scss
+++ b/client/wildcard/src/components/Combobox/MultiCombobox.module.scss
@@ -67,9 +67,9 @@
     padding: 0 0 0 0.5rem;
     height: 1.75rem;
 
-    &:focus-visible {
-        box-shadow: none;
-    }
+    // Override standard input box-shadow styles since root container
+    // already re-implements it.
+    box-shadow: none !important;
 }
 
 .pill {


### PR DESCRIPTION
Simply removes focus ring from input UI in the multi combobox UI 

| Before | After |
| ------- | ------- |
| <img width="591" alt="Screenshot 2023-11-08 at 16 34 02" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/f7e18cbe-1ac0-4bb2-9965-2f2b6e963263"> | <img width="586" alt="Screenshot 2023-11-08 at 16 34 32" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/06100663-bb05-424a-82c3-295f74b5fd52"> |

## Test plan
- Check multi combobox with valid/invalid states (I checked code insight creation form for it)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
