### PR TITLE
dev/msp: render explicit outputs as locals

### DIFF
--- a/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
@@ -98,8 +98,8 @@ const tfVarKeyResolvedImageTag = "resolved_image_tag"
 // NewStack instantiates the MSP cloudrun stack, which is currently a pretty
 // monolithic stack that encompasses all the core components of an MSP service,
 // including networking and dependencies like Redis.
-func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
-	stack, outputs, err := stacks.New(StackName,
+func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOutput, _ error) {
+	stack, locals, err := stacks.New(StackName,
 		googleprovider.With(vars.ProjectID),
 		cloudflareprovider.With(gsmsecret.DataConfig{
 			Secret:    googlesecretsmanager.SecretCloudflareAPIToken,
@@ -303,8 +303,10 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	}
 
 	// Collect outputs
-	outputs.Add("cloud_run_service_account", cloudRunBuildVars.ServiceAccount.Email)
-	outputs.Add("resolved_image_tag", imageTag.StringValue)
+	locals.Add("cloud_run_service_account", cloudRunBuildVars.ServiceAccount.Email,
+		"Service Account email used as Cloud Run resource workload identity")
+	locals.Add("image_tag", imageTag.StringValue,
+		"Resolved tag of service image to deploy")
 	return &CrossStackOutput{}, nil
 }
 

--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -105,7 +105,7 @@ const (
 
 // NewStack creates a stack that provisions a GCP project.
 func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
-	stack, outputs, err := stacks.New(StackName,
+	stack, locals, err := stacks.New(StackName,
 		randomprovider.With(),
 		// ID is not known ahead of time, we can omit it
 		googleprovider.With(""))
@@ -167,7 +167,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	}
 
 	// Collect outputs
-	outputs.Add("project_id", project.ProjectId())
+	locals.Add("project_id", project.ProjectId(), "Generated project ID")
 	return &CrossStackOutput{
 		Project: project,
 		CloudRunIdentity: googleprojectserviceidentity.NewGoogleProjectServiceIdentity(stack,


### PR DESCRIPTION
This change renders any explicit outputs that are added as locals as well. This allows us to just add custom Terraform inside the same directory, and everything just works nicely OOTB, allowing us to add adjacent resources we'd like (e.g. permissions)

## Test plan

`sg msp generate` and place custom `terraform.tf` referencing the new locals. Running generate again doesn't blow the custom TF away either