### PR TITLE
[Cody GA Docs] Add info for enabling Code Graph with VS Code extension

### DIFF
--- a/doc/cody/overview/install-vscode.md
+++ b/doc/cody/overview/install-vscode.md
@@ -166,12 +166,21 @@ In addition, to support customization and advanced use cases, you can create Cus
 
 ## Enable code graph context for context-aware answers (Optional)
 
-You can optionally configure code graph content, which gives Cody the ability to provide context-aware answers. For example, Cody can write example API calls if has context of a codebase's API schema.
+After connecting Cody with VS Code, you can optionally use and configure [Code Graph Context](./../core-concepts/code-graph.md) to improve Cody's context of existing code.
 
 Learn more about how to:
 
 - [Configure code graph context for Sourcegraph.com][cody-with-sourcegraph-config-graph]
 - [Configure code graph context for Sourcegraph Enterprise][enable-cody-enterprise-config-graph]
+
+### Enable Code Graph Context
+
+The `Cody: Codebase` setting in VS Code enables codebase-aware answers for the Cody extension. Enter the repository's name with embeddings, and Cody can provide more accurate and relevant answers to your coding questions based on that repository's content. To configure this setting in VS Code:
+
+- Open the **Cody Extension Settings**
+- Search for the `Cody: Codebase`
+- Enter the repository name
+- For example: `github.com/sourcegraph/sourcegraph` without the `https` protocol
 
 ## Updating the extension
 

--- a/doc/cody/overview/install-vscode.md
+++ b/doc/cody/overview/install-vscode.md
@@ -173,7 +173,7 @@ Learn more about how to:
 - [Configure code graph context for Sourcegraph.com][cody-with-sourcegraph-config-graph]
 - [Configure code graph context for Sourcegraph Enterprise][enable-cody-enterprise-config-graph]
 
-### Enable Code Graph Context
+### Configure Code Graph Context
 
 The `Cody: Codebase` setting in VS Code enables codebase-aware answers for the Cody extension. Enter the repository's name with embeddings, and Cody can provide more accurate and relevant answers to your coding questions based on that repository's content. To configure this setting in VS Code:
 


### PR DESCRIPTION
The PR adds info about configuring Code Graph Context for Cody via VS Code extension settings.

## Test plan

Docs added.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@cody-vs-cg)