### PR TITLE
dev/msp: migrate service accounts, IAM to 'iam' module

### DIFF
--- a/dev/managedservicesplatform/BUILD.bazel
+++ b/dev/managedservicesplatform/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//dev/managedservicesplatform/internal/stack",
         "//dev/managedservicesplatform/internal/stack/cloudrun",
+        "//dev/managedservicesplatform/internal/stack/iam",
         "//dev/managedservicesplatform/internal/stack/options/terraformversion",
         "//dev/managedservicesplatform/internal/stack/options/tfcbackend",
         "//dev/managedservicesplatform/internal/stack/project",

--- a/dev/managedservicesplatform/internal/stack/cloudrun/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/BUILD.bazel
@@ -1,4 +1,3 @@
-load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -27,23 +26,7 @@ go_library(
         "//dev/managedservicesplatform/spec",
         "//lib/errors",
         "//lib/pointers",
-        "@com_github_aws_jsii_runtime_go//:jsii-runtime-go",
-        "@com_github_grafana_regexp//:regexp",
-        "@com_github_hashicorp_terraform_cdk_go_cdktf//:cdktf",
-        "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//projectiamcustomrole",
-        "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//projectiammember",
         "@org_golang_x_exp//maps",
         "@org_golang_x_exp//slices",
-    ],
-)
-
-go_test(
-    name = "cloudrun_test",
-    srcs = ["cloudrun_test.go"],
-    embed = [":cloudrun"],
-    deps = [
-        "//lib/pointers",
-        "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
@@ -2,16 +2,10 @@ package cloudrun
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
 	"strconv"
 	"strings"
 
-	"github.com/aws/jsii-runtime-go"
-	"github.com/grafana/regexp"
-	"github.com/hashicorp/terraform-cdk-go/cdktf"
-	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/projectiamcustomrole"
-	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/projectiammember"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
@@ -40,8 +34,8 @@ import (
 type CrossStackOutput struct{}
 
 type Variables struct {
-	ProjectID             string
-	CloudRunIdentityEmail string
+	ProjectID                      string
+	CloudRunWorkloadServiceAccount *serviceaccount.Output
 
 	Service     spec.ServiceSpec
 	Image       string
@@ -56,18 +50,6 @@ const StackName = "cloudrun"
 var (
 	// gcpRegion is currently hardcoded.
 	gcpRegion = "us-central1"
-	// serviceAccountRoles are granted to the service account for the Cloud Run service.
-	serviceAccountRoles = []serviceaccount.Role{
-		// Allow env vars to source from secrets
-		{ID: "role_secret_accessor", Role: "roles/secretmanager.secretAccessor"},
-		// Allow service to access private networks
-		{ID: "role_compute_networkuser", Role: "roles/compute.networkUser"},
-		// Allow service to emit observability
-		{ID: "role_cloudtrace_agent", Role: "roles/cloudtrace.agent"},
-		{ID: "role_monitoring_metricwriter", Role: "roles/monitoring.metricWriter"},
-		// Allow service to publish Cloud Profiler profiles
-		{ID: "role_cloudprofiler_agent", Role: "roles/cloudprofiler.agent"},
-	}
 )
 
 // makeServiceEnvVarPrefix returns the env var prefix for service-specific
@@ -125,45 +107,6 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 
 	id := resourceid.New("cloudrun")
 
-	var customRole projectiamcustomrole.ProjectIamCustomRole
-	if vars.Service.IAM != nil && len(vars.Service.IAM.Permissions) > 0 {
-		customRole = projectiamcustomrole.NewProjectIamCustomRole(stack, id.ResourceID("custom-role"), &projectiamcustomrole.ProjectIamCustomRoleConfig{
-			RoleId:      pointers.Ptr(fmt.Sprintf("%s_custom_role", id.DisplayName())),
-			Title:       pointers.Ptr(fmt.Sprintf("%s custom role", id.DisplayName())),
-			Project:     &vars.ProjectID,
-			Permissions: jsii.Strings(vars.Service.IAM.Permissions...),
-		})
-	}
-
-	// cloudRunDependencies collects terraform resources that must be provisioned
-	// before the core Cloud Run resource is provisioned. Only resources that
-	// are not directly referenced by the Cloud Run Builder need to be included
-	// in this set.
-	var cloudRunDependencies []cdktf.ITerraformDependable
-
-	// If the service image is published to a private image repository, grant
-	// the Cloud Run robot account access to the target project to pull the
-	// image.
-	if imageProject := extractImageGoogleProject(vars.Image); imageProject != nil {
-		for _, r := range []serviceaccount.Role{{
-			ID:   "object_viewer",
-			Role: "roles/storage.objectViewer", // for gcr.io
-		}, {
-			ID:   "artifact_reader",
-			Role: "roles/artifactregistry.reader", // for artifact registry
-		}} {
-			cloudRunDependencies = append(cloudRunDependencies,
-				projectiammember.NewProjectIamMember(stack,
-					id.ResourceID("member_image_access_%s", r.ID),
-					&projectiammember.ProjectIamMemberConfig{
-						Project: imageProject,
-						Role:    pointers.Ptr(r.Role),
-						Member: pointers.Ptr(fmt.Sprintf("serviceAccount:%s",
-							vars.CloudRunIdentityEmail)),
-					}))
-		}
-	}
-
 	// Set up configuration for the Cloud Run resources
 	var cloudRunBuilder builder.Builder
 	switch pointers.Deref(vars.Service.Kind, spec.ServiceKindService) {
@@ -203,42 +146,15 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 
 	// Set up build configuration.
 	cloudRunBuildVars := builder.Variables{
-		Service:          vars.Service,
-		Image:            vars.Image,
-		ResolvedImageTag: *imageTag.StringValue,
-		Environment:      vars.Environment,
-		GCPProjectID:     vars.ProjectID,
-		GCPRegion:        gcpRegion,
-		ServiceAccount: serviceaccount.New(stack,
-			id,
-			serviceaccount.Config{
-				ProjectID: vars.ProjectID,
-				AccountID: fmt.Sprintf("%s-sa", vars.Service.ID),
-				DisplayName: fmt.Sprintf("%s Service Account",
-					pointers.Deref(vars.Service.Name, vars.Service.ID)),
-				Roles: func() []serviceaccount.Role {
-					if vars.Service.IAM != nil && len(vars.Service.IAM.Roles) > 0 {
-						var rs []serviceaccount.Role
-						for _, r := range vars.Service.IAM.Roles {
-							rs = append(rs, serviceaccount.Role{
-								ID:   matchNonAlphaNumericRegex.ReplaceAllString(r, "_"),
-								Role: r,
-							})
-						}
-						serviceAccountRoles = append(rs, serviceAccountRoles...)
-					}
-					if customRole != nil {
-						serviceAccountRoles = append(serviceAccountRoles, serviceaccount.Role{
-							ID:   "role_cloudrun_custom_role",
-							Role: *customRole.Name(),
-						})
-					}
-					return serviceAccountRoles
-				}(),
-			}),
+		Service:           vars.Service,
+		Image:             vars.Image,
+		ResolvedImageTag:  *imageTag.StringValue,
+		Environment:       vars.Environment,
+		GCPProjectID:      vars.ProjectID,
+		GCPRegion:         gcpRegion,
+		ServiceAccount:    vars.CloudRunWorkloadServiceAccount,
 		DiagnosticsSecret: diagnosticsSecret,
 		ResourceLimits:    makeContainerResourceLimits(vars.Environment.Instances.Resources),
-		DependsOn:         cloudRunDependencies,
 	}
 
 	if vars.Environment.Resources.NeedsCloudRunConnector() {
@@ -303,14 +219,10 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 	}
 
 	// Collect outputs
-	locals.Add("cloud_run_service_account", cloudRunBuildVars.ServiceAccount.Email,
-		"Service Account email used as Cloud Run resource workload identity")
 	locals.Add("image_tag", imageTag.StringValue,
 		"Resolved tag of service image to deploy")
 	return &CrossStackOutput{}, nil
 }
-
-var matchNonAlphaNumericRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
 
 type envVariablesData struct {
 	ProjectID      string
@@ -357,22 +269,4 @@ func makeContainerResourceLimits(r spec.EnvironmentInstancesResourcesSpec) map[s
 		"cpu":    pointers.Ptr(strconv.Itoa(r.CPU)),
 		"memory": pointers.Ptr(r.Memory),
 	}
-}
-
-func extractImageGoogleProject(image string) *string {
-	// Private images in our GCP projects have patterns like:
-	// - us-central1-docker.pkg.dev/control-plane-5e9ee072/docker/apiserver
-	// - us.gcr.io/sourcegraph-dev/abuse-banbot
-	// If the root matches particular patterns, the second component is the
-	// project ID.
-	imageRepoParts := strings.SplitN(image, "/", 3)
-	if len(imageRepoParts) != 3 {
-		return nil
-	}
-	repoRoot := imageRepoParts[0]
-	if strings.HasSuffix(repoRoot, ".gcr.io") ||
-		strings.HasSuffix(repoRoot, "-docker.pkg.dev") {
-		return &imageRepoParts[1]
-	}
-	return nil
 }

--- a/dev/managedservicesplatform/internal/stack/iam/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/iam/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "iam",
+    srcs = ["iam.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack/iam",
+    visibility = ["//dev/managedservicesplatform:__subpackages__"],
+    deps = [
+        "//dev/managedservicesplatform/internal/resource/serviceaccount",
+        "//dev/managedservicesplatform/internal/resourceid",
+        "//dev/managedservicesplatform/internal/stack",
+        "//dev/managedservicesplatform/internal/stack/options/googleprovider",
+        "//dev/managedservicesplatform/spec",
+        "//lib/pointers",
+        "@com_github_aws_jsii_runtime_go//:jsii-runtime-go",
+        "@com_github_grafana_regexp//:regexp",
+        "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//projectiamcustomrole",
+        "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//projectiammember",
+        "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google_beta//googleprojectserviceidentity",
+        "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google_beta//provider",
+    ],
+)
+
+go_test(
+    name = "iam_test",
+    srcs = ["iam_test.go"],
+    embed = [":iam"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/dev/managedservicesplatform/internal/stack/iam/iam.go
+++ b/dev/managedservicesplatform/internal/stack/iam/iam.go
@@ -1,0 +1,157 @@
+package iam
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/regexp"
+
+	"github.com/aws/jsii-runtime-go"
+	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/projectiamcustomrole"
+	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/projectiammember"
+	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google_beta/googleprojectserviceidentity"
+	google_beta "github.com/sourcegraph/managed-services-platform-cdktf/gen/google_beta/provider"
+
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/serviceaccount"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack/options/googleprovider"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+type CrossStackOutput struct {
+	CloudRunWorkloadServiceAccount *serviceaccount.Output
+}
+
+type Variables struct {
+	ProjectID string
+	Image     string
+	Service   spec.ServiceSpec
+}
+
+const StackName = "iam"
+
+var (
+	// serviceAccountRoles are granted to the service account for the Cloud Run service.
+	serviceAccountRoles = []serviceaccount.Role{
+		// Allow env vars to source from secrets
+		{ID: "role_secret_accessor", Role: "roles/secretmanager.secretAccessor"},
+		// Allow service to access private networks
+		{ID: "role_compute_networkuser", Role: "roles/compute.networkUser"},
+		// Allow service to emit observability
+		{ID: "role_cloudtrace_agent", Role: "roles/cloudtrace.agent"},
+		{ID: "role_monitoring_metricwriter", Role: "roles/monitoring.metricWriter"},
+		// Allow service to publish Cloud Profiler profiles
+		{ID: "role_cloudprofiler_agent", Role: "roles/cloudprofiler.agent"},
+	}
+)
+
+func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
+	stack, locals, err := stacks.New(StackName,
+		googleprovider.With(vars.ProjectID))
+	if err != nil {
+		return nil, err
+	}
+
+	id := resourceid.New("iam")
+
+	var customRole projectiamcustomrole.ProjectIamCustomRole
+	if vars.Service.IAM != nil && len(vars.Service.IAM.Permissions) > 0 {
+		customRole = projectiamcustomrole.NewProjectIamCustomRole(stack,
+			id.ResourceID("custom-role"),
+			&projectiamcustomrole.ProjectIamCustomRoleConfig{
+				RoleId:      pointers.Ptr("msp_workload_custom_role"),
+				Title:       pointers.Ptr("Managed Services Platform workload custom role"),
+				Project:     &vars.ProjectID,
+				Permissions: jsii.Strings(vars.Service.IAM.Permissions...),
+			})
+	}
+	workloadServiceAccount := serviceaccount.New(stack,
+		id.SubID("workload"),
+		serviceaccount.Config{
+			ProjectID: vars.ProjectID,
+			AccountID: fmt.Sprintf("%s-sa", vars.Service.ID),
+			DisplayName: fmt.Sprintf("%s Service Account",
+				pointers.Deref(vars.Service.Name, vars.Service.ID)),
+			Roles: func() []serviceaccount.Role {
+				if vars.Service.IAM != nil && len(vars.Service.IAM.Roles) > 0 {
+					var rs []serviceaccount.Role
+					for _, r := range vars.Service.IAM.Roles {
+						rs = append(rs, serviceaccount.Role{
+							ID:   matchNonAlphaNumericRegex.ReplaceAllString(r, "_"),
+							Role: r,
+						})
+					}
+					serviceAccountRoles = append(rs, serviceAccountRoles...)
+				}
+				if customRole != nil {
+					serviceAccountRoles = append(serviceAccountRoles, serviceaccount.Role{
+						ID:   *customRole.Id(),
+						Role: *customRole.Name(),
+					})
+				}
+				return serviceAccountRoles
+			}(),
+		})
+
+	// If the service image is published to a private image repository, grant
+	// the Cloud Run robot account access to the target project to pull the
+	// image.
+	cloudRunIdentity := googleprojectserviceidentity.NewGoogleProjectServiceIdentity(stack,
+		id.ResourceID("cloudrun-identity"),
+		&googleprojectserviceidentity.GoogleProjectServiceIdentityConfig{
+			Project: &vars.ProjectID,
+			Service: pointers.Ptr("run.googleapis.com"),
+			// Only available via beta provider:
+			// https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service_identity
+			Provider: google_beta.NewGoogleBetaProvider(stack, pointers.Ptr("google_beta"), &google_beta.GoogleBetaProviderConfig{
+				Project: &vars.ProjectID,
+			}),
+		})
+	if imageProject := extractImageGoogleProject(vars.Image); imageProject != nil {
+		for _, r := range []serviceaccount.Role{{
+			ID:   "object_viewer",
+			Role: "roles/storage.objectViewer", // for gcr.io
+		}, {
+			ID:   "artifact_reader",
+			Role: "roles/artifactregistry.reader", // for artifact registry
+		}} {
+			projectiammember.NewProjectIamMember(stack,
+				id.ResourceID("member_image_access_%s", r.ID),
+				&projectiammember.ProjectIamMemberConfig{
+					Project: imageProject,
+					Role:    pointers.Ptr(r.Role),
+					Member: pointers.Ptr(fmt.Sprintf("serviceAccount:%s",
+						*cloudRunIdentity.Email())),
+				})
+		}
+	}
+
+	// Collect outputs
+	locals.Add("cloud_run_service_account", workloadServiceAccount.Email,
+		"Service Account email used as Cloud Run resource workload identity")
+	return &CrossStackOutput{
+		CloudRunWorkloadServiceAccount: workloadServiceAccount,
+	}, nil
+}
+
+var matchNonAlphaNumericRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
+
+func extractImageGoogleProject(image string) *string {
+	// Private images in our GCP projects have patterns like:
+	// - us-central1-docker.pkg.dev/control-plane-5e9ee072/docker/apiserver
+	// - us.gcr.io/sourcegraph-dev/abuse-banbot
+	// If the root matches particular patterns, the second component is the
+	// project ID.
+	imageRepoParts := strings.SplitN(image, "/", 3)
+	if len(imageRepoParts) != 3 {
+		return nil
+	}
+	repoRoot := imageRepoParts[0]
+	if strings.HasSuffix(repoRoot, ".gcr.io") ||
+		strings.HasSuffix(repoRoot, "-docker.pkg.dev") {
+		return &imageRepoParts[1]
+	}
+	return nil
+}

--- a/dev/managedservicesplatform/internal/stack/iam/iam_test.go
+++ b/dev/managedservicesplatform/internal/stack/iam/iam_test.go
@@ -1,4 +1,4 @@
-package cloudrun
+package iam
 
 import (
 	"testing"

--- a/dev/managedservicesplatform/internal/stack/project/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/project/BUILD.bazel
@@ -18,7 +18,5 @@ go_library(
         "@com_github_grafana_regexp//:regexp",
         "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//project",
         "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//projectservice",
-        "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google_beta//googleprojectserviceidentity",
-        "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google_beta//provider",
     ],
 )

--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -36,6 +36,7 @@ var gcpServices = []string{
 	"storage-component.googleapis.com",
 	"bigquery.googleapis.com",
 	"cloudprofiler.googleapis.com",
+	"cloudscheduler.googleapis.com",
 }
 
 const (

--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/project"
 	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/projectservice"
-	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google_beta/googleprojectserviceidentity"
-	google_beta "github.com/sourcegraph/managed-services-platform-cdktf/gen/google_beta/provider"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/random"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
@@ -62,10 +60,6 @@ var EnvironmentCategoryFolders = map[spec.EnvironmentCategory]string{
 type CrossStackOutput struct {
 	// Project is created with a generated project ID.
 	Project project.Project
-
-	// CloudRunIdentity is the robot account provisioned by GCP to manage
-	// Cloud Run services and jobs.
-	CloudRunIdentity googleprojectserviceidentity.GoogleProjectServiceIdentity
 }
 
 type Variables struct {
@@ -168,21 +162,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 
 	// Collect outputs
 	locals.Add("project_id", project.ProjectId(), "Generated project ID")
-	return &CrossStackOutput{
-		Project: project,
-		CloudRunIdentity: googleprojectserviceidentity.NewGoogleProjectServiceIdentity(stack,
-			id.ResourceID("cloudrun-identity"),
-			&googleprojectserviceidentity.GoogleProjectServiceIdentityConfig{
-				Project: project.ProjectId(),
-				Service: pointers.Ptr("run.googleapis.com"),
-
-				// Only available via beta provider:
-				// https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service_identity
-				Provider: google_beta.NewGoogleBetaProvider(stack, pointers.Ptr("google_beta"), &google_beta.GoogleBetaProviderConfig{
-					Project: project.ProjectId(),
-				}),
-			}),
-	}, nil
+	return &CrossStackOutput{Project: project}, nil
 }
 
 var regexpMatchNonLowerAlphaNumericUnderscoreDash = regexp.MustCompile(`[^a-z0-9_-]`)

--- a/dev/managedservicesplatform/terraformcloud/BUILD.bazel
+++ b/dev/managedservicesplatform/terraformcloud/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/terraformcloud",
     visibility = ["//visibility:public"],
     deps = [
-        "//dev/managedservicesplatform/internal/stack/project",
         "//dev/managedservicesplatform/internal/terraform",
         "//dev/managedservicesplatform/spec",
         "//lib/errors",


### PR DESCRIPTION
This change moves service accounts etc to a new `iam` module that can be configured and applied before deploying any Cloud Run resources. MSP services will frequently need the workload service account to have access to other resources outside the project - this will resolve the chicken-and-egg problem with provisioning new services that we frequently run into.

However, to do this safely, we must avoid recreating the service account entirely, so that existing permission grants are preserved. See test plan for manual migration process, which does some surgery on the Terraform state to avoid any destructive changes.

## Test plan

```sh
export SERVICE_ID=telemetry-gateway
export ENV_ID=dev
export SERVICE_ACCOUNT=telemetry-gateway-sa@telemetry-gateway-dev-0050.iam.gserviceaccount.com
```

Generate:

```sh
sg msp generate $SERVICE_ID $ENV_ID
sg msp tfc sync --workspace-run-mode=cli $SERVICE_ID $ENV_ID
```

Import:

```sh
cd services/$SERVICE_ID/terraform/$ENV_ID/stacks/iam
terraform init
terraform import google_service_account.iam-workload-account $SERVICE_ACCOUNT
cd -
```

Remove:

```sh
cd services/$SERVICE_ID/terraform/$ENV_ID/stacks/cloudrun
terraform init
terraform state rm google_service_account.cloudrun-account
terraform state list | grep google_project_iam_member | xargs terraform state rm # will be recreated by `iam` module
cd -
```

Apply: `iam` -> `cloudrun` -> `project`

```sh
cd services/$SERVICE_ID/terraform/$ENV_ID/stacks/iam
terraform apply # note that SA is not recreated
cd -
```

```sh
cd services/$SERVICE_ID/terraform/$ENV_ID/stacks/cloudrun
terraform apply # no diff
cd -
```

```sh
cd services/$SERVICE_ID/terraform/$ENV_ID/stacks/project
terraform apply # service agent cannot be destroyed
cd -
```

Check: 
![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/f396773d-67f6-4bfc-b42e-d5437f8f0ef6), light test traffic has no errors in logs, and succeeds locally:

```
[         worker] INFO worker.telemetrygateway-exporter telemetrygatewayexporter/exporter.go:129 events exported {"TraceId": "436306953ddee6c66e9f5759cee78386", "SpanId": "17db2ff973a8f93a", "maxBatchSize": 10000, "succeeded": 1}
```



PR (e.g. https://github.com/sourcegraph/managed-services/pull/57), merge, then:


```sh
sg msp tfc sync $SERVICE_ID $ENV_ID # switch back to VCS
```