### PR TITLE
Code Navigation: fix borked regex filter

### DIFF
--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -217,7 +217,7 @@ class SearchPanel implements Panel {
                     />
                     <QueryInputToggle
                         isActive={searchQuery.regexp}
-                        onToggle={() => this.commit({ regexp: !searchQuery.regexp, })}
+                        onToggle={() => this.commit({ regexp: !searchQuery.regexp })}
                         iconSvgPath={mdiRegex}
                         title="Regular expression"
                         className="cm-search-toggle test-blob-view-search-regexp"
@@ -342,16 +342,11 @@ class SearchPanel implements Panel {
                     topLineBlock = this.view.lineBlockAtHeight(scrollTop + topLineBlock.height)
                 }
 
-                // conditional to check regex
-                if (query.regexp) {
-                    if (!query.valid) {
-                        console.error("invalid regular expression: ", query.search)
-                        return
-                    }
+                if (query.regexp && !query.valid) {
+                    return
                 }
 
                 let result = query.getCursor(this.view.state.doc, topLineBlock.from).next()
-
                 if (result.done) {
                     // No match in the remainder of the document, wrap around
                     result = query.getCursor(this.view.state.doc).next()
@@ -390,7 +385,7 @@ function calculateMatches(query: SearchQuery, document: CodeMirrorText): SearchM
     // Regular expressions that result in matches with length 0 would
     // cause an infinite loop. So we guard against that by verifying
     // whether or not the cursor moves to the next match at a new position.
-    let prevValue: { from: number, to: number } | null = null
+    let prevValue: { from: number; to: number } | null = null
 
     while (!result.done && result.value.from !== prevValue?.from) {
         newSearchMatches.set(result.value.from, index++)
@@ -502,20 +497,20 @@ export function search(config: SearchConfig): Extension {
             return searchKeymap.map(binding =>
                 binding.key === 'Mod-f'
                     ? {
-                        ...binding,
-                        run: view => {
-                            // By default pressing Mod+f when the search input is already focused won't select
-                            // the input value, unlike browser's built-in search feature.
-                            // We are overwriting the keybinding here to ensure that the input value is always
-                            // selected.
-                            const result = binding.run?.(view)
-                            if (result) {
-                                view.dispatch({ effects: focusSearchInput.of(true) })
-                                return true
-                            }
-                            return false
-                        },
-                    }
+                          ...binding,
+                          run: view => {
+                              // By default pressing Mod+f when the search input is already focused won't select
+                              // the input value, unlike browser's built-in search feature.
+                              // We are overwriting the keybinding here to ensure that the input value is always
+                              // selected.
+                              const result = binding.run?.(view)
+                              if (result) {
+                                  view.dispatch({ effects: focusSearchInput.of(true) })
+                                  return true
+                              }
+                              return false
+                          },
+                      }
                     : binding
             )
         }


### PR DESCRIPTION
Before, the regex filter on blobview search was crashing the application when selected with an undefined or empty value. 
This commit adds conditionals that check for valid regular expressions so that the feature is now useable, and no longer crashing the application.

There are still other improvements that need to be made regarding the regex filter, but this commit makes the core feature useable.

## Test plan
Manual testing