### PR TITLE
bzl: Bump Rust version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -10,6 +10,6 @@ trivy 0.30.3
 kustomize 4.5.7
 awscli 2.4.7
 python 3.11.3 system
-rust 1.68.0
+rust 1.73.0
 ruby 3.1.3
 pnpm 8.9.2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -305,7 +305,7 @@ load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_regi
 
 rules_rust_dependencies()
 
-rust_version = "1.68.0"
+rust_version = "1.73.0"
 
 rust_register_toolchains(
     edition = "2021",

--- a/cmd/symbols/Dockerfile
+++ b/cmd/symbols/Dockerfile
@@ -4,7 +4,7 @@ FROM sourcegraph/alpine-3.14:213466_2023-04-17_5.0-bdda34a71619@sha256:6354a4ff5
 COPY cmd/symbols/ctags-install-alpine.sh /ctags-install-alpine.sh
 RUN /ctags-install-alpine.sh
 
-FROM rust:1.68.0-alpine3.17@sha256:d119a621ae12f84ec0c5fed77c24795120ed1c7874b2428b5a6ccc0f294dbe18 as scip-ctags
+FROM rust:1.73.0-alpine3.18@sha256:200be646c656b180aa9cf6cee1766f05fcf5bb0b94cf2900beeedca3bdf4016d as scip-ctags
 # hadolint ignore=DL3002
 USER root
 RUN apk add --no-cache musl-dev>=1.1.24-r10 build-base

--- a/docker-images/syntax-highlighter/.cargo/config.toml
+++ b/docker-images/syntax-highlighter/.cargo/config.toml
@@ -3,12 +3,3 @@ rustflags = ["-Clink-arg=-Wl,--dynamic-linker=/lib/ld-musl-aarch64.so.1"]
 
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-Ctarget-feature=-crt-static"]
-
-[registry]
-default = "crates-io"
-
-[registries.crates-io]
-index = "https://crates.io"
-protocol = "sparse"
-# The sparse protocol cuts down on registry + crate fetching
-# time from about 1m30s to 21s.

--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b813eddd1263bbce3f460a00f5935f2831d593422814c1ba4f5f49fd5fb340d9",
+  "checksum": "4ff68b54477009558546f8c9c22bc9ff6351813cd34a543f6c7c7af3c4462862",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",

--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4ff68b54477009558546f8c9c22bc9ff6351813cd34a543f6c7c7af3c4462862",
+  "checksum": "11f7d9a0b9555b34f58c199ad41741442c4c6c493eb30b0cdb798b46612bff41",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/locals.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/locals.rs
@@ -29,7 +29,7 @@ impl<'a> PartialEq for Scope<'a> {
 
 impl<'a> PartialOrd for Scope<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.range.partial_cmp(&other.range)
+        Some(self.cmp(other))
     }
 }
 

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/index.rs
@@ -137,7 +137,7 @@ pub fn index_command(
 
             for entry in walkdir::WalkDir::new(location)
                 .into_iter()
-                .filter_entry(|e| is_valid(e))
+                .filter_entry(is_valid)
             {
                 let entry = entry.unwrap();
                 if !entry.file_type().is_dir() {

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-languages/src/parsers.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-languages/src/parsers.rs
@@ -122,7 +122,7 @@ impl BundledParser {
             }
         };
 
-        HashSet::from_iter(ar.into_iter())
+        HashSet::from_iter(ar)
     }
 
     // TODO(SuperAuguste): language detection library

--- a/docker-images/syntax-highlighter/crates/scip-treesitter/src/types.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter/src/types.rs
@@ -69,11 +69,7 @@ impl PackedRange {
 
 impl PartialOrd for PackedRange {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        (self.start_line, self.end_line, self.start_col).partial_cmp(&(
-            other.start_line,
-            other.end_line,
-            other.start_col,
-        ))
+        Some(self.cmp(other))
     }
 }
 

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
@@ -85,7 +85,7 @@ pub fn index_language_with_config(
             // TODO: Could probably write this in a much better way.
             let mut local_occs = scip_syntax::get_locals(parser, code.as_bytes())
                 .unwrap_or(Ok(vec![]))
-                .unwrap_or(vec![]);
+                .unwrap_or_default();
 
             // Get ranges in reverse order, because we're going to pop off the back of the list.
             //  (that's why we're sorting the opposite way of the document occurrences above).

--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -4,7 +4,7 @@ This contains all the Tauri code for the Cody App. Currently it consists of star
 
 ## Required software
 
-- Rust 1.68.0
+- Rust 1.73.0
 - pnpm
 
 ## Getting started


### PR DESCRIPTION
There are a bunch of improvements since Rust 1.68.0
such as nicer panic messages, and sparse-by-default
crates.io usage when using cargo directly.

TODO:
- [x] Fix some lint errors
- [x] Remove the sparse setting from `.cargo/config.toml`

To be merged after #57894

## Test plan

Should be covered by CI, right?