### PR TITLE
[Backport 5.2 (manual)] Return better error for GQL cost violations

### DIFF
--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -24,6 +24,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+func writeViolationError(w http.ResponseWriter, message string) error {
+	w.WriteHeader(http.StatusBadRequest) // 400 because retrying won't help
+	return writeJSON(w, graphql.Response{
+		Errors: []*gqlerrors.QueryError{
+			{
+				Message: message,
+			},
+		},
+	})
+}
+
 func serveGraphQL(logger log.Logger, schema *graphql.Schema, rlw graphqlbackend.LimitWatcher, isInternal bool) func(w http.ResponseWriter, r *http.Request) (err error) {
 	return func(w http.ResponseWriter, r *http.Request) (err error) {
 		if r.Method != "POST" {
@@ -87,35 +98,36 @@ func serveGraphQL(logger log.Logger, schema *graphql.Schema, rlw graphqlbackend.
 			if costErr != nil {
 				logger.Debug("failed to estimate GraphQL cost",
 					log.Error(costErr))
-			}
-			traceData.costError = costErr
-			traceData.cost = cost
+				traceData.costError = costErr
+			} else if cost != nil {
+				traceData.cost = cost
 
-			if !isInternal && (cost.AliasCount > graphqlbackend.MaxAliasCount) {
-				return errors.New("query exceeds maximum alias count")
-			}
+				if !isInternal && (cost.AliasCount > graphqlbackend.MaxAliasCount) {
+					return writeViolationError(w, "query exceeds maximum query cost")
+				}
 
-			if !isInternal && (cost.FieldCount > graphqlbackend.MaxFieldCount) {
-				return errors.New("query exceeds maximum query cost")
-			}
+				if !isInternal && (cost.FieldCount > graphqlbackend.MaxFieldCount) {
+					return writeViolationError(w, "query exceeds maximum query cost")
+				}
 
-			if rl, enabled := rlw.Get(); enabled && cost != nil {
-				limited, result, err := rl.RateLimit(r.Context(), uid, cost.FieldCount, graphqlbackend.LimiterArgs{
-					IsIP:          isIP,
-					Anonymous:     anonymous,
-					RequestName:   requestName,
-					RequestSource: requestSource,
-				})
-				if err != nil {
-					logger.Error("checking GraphQL rate limit", log.Error(err))
-					traceData.limitError = err
-				} else {
-					traceData.limited = limited
-					traceData.limitResult = result
-					if limited {
-						w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
-						w.WriteHeader(http.StatusTooManyRequests)
-						return nil
+				if rl, enabled := rlw.Get(); enabled {
+					limited, result, err := rl.RateLimit(r.Context(), uid, cost.FieldCount, graphqlbackend.LimiterArgs{
+						IsIP:          isIP,
+						Anonymous:     anonymous,
+						RequestName:   requestName,
+						RequestSource: requestSource,
+					})
+					if err != nil {
+						logger.Error("checking GraphQL rate limit", log.Error(err))
+						traceData.limitError = err
+					} else {
+						traceData.limited = limited
+						traceData.limitResult = result
+						if limited {
+							w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
+							w.WriteHeader(http.StatusTooManyRequests)
+							return nil
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Previously we returned an error, which resulted in a 500 error. This will return 400 with a clear message indicating a cost violation.

Backport from: https://github.com/sourcegraph/sourcegraph/pull/58230
Manually backported to include change: https://github.com/sourcegraph/sourcegraph/pull/58192. 

## Test plan
Tested locally, CI.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
