### PR TITLE
dev/msp: fix custom role ID, update resourceid with warnings

### DIFF
--- a/dev/managedservicesplatform/internal/resource/cloudflare/cloudflare.go
+++ b/dev/managedservicesplatform/internal/resource/cloudflare/cloudflare.go
@@ -32,14 +32,14 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 	// Get the Cloudflare zone requested in configuration, and create a Cloudflare
 	// record that points to our external address
 	cfZone := datacloudflarezones.NewDataCloudflareZones(scope,
-		id.ResourceID("domain"),
+		id.TerraformID("domain"),
 		&datacloudflarezones.DataCloudflareZonesConfig{
 			Filter: &datacloudflarezones.DataCloudflareZonesFilter{
 				Name: pointers.Ptr(config.Spec.Zone),
 			},
 		})
 	_ = record.NewRecord(scope,
-		id.ResourceID("record"),
+		id.TerraformID("record"),
 		&record.RecordConfig{
 			ZoneId:  cfZone.Zones().Get(pointers.Float64(0)).Id(),
 			Name:    &config.Spec.Subdomain,

--- a/dev/managedservicesplatform/internal/resource/cloudflareorigincert/cloudflareorigincert.go
+++ b/dev/managedservicesplatform/internal/resource/cloudflareorigincert/cloudflareorigincert.go
@@ -29,16 +29,16 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
 	// computesslcertificate.NewComputeSslCertificate, see sourcegraph/controller
 	return &Output{
 		Certificate: computesslcertificate.NewComputeSslCertificate(scope,
-			id.ResourceID("origin-cert"),
+			id.TerraformID("origin-cert"),
 			&computesslcertificate.ComputeSslCertificateConfig{
 				Name:    pointers.Ptr(id.DisplayName()),
 				Project: pointers.Ptr(config.ProjectID),
 
-				PrivateKey: &gsmsecret.Get(scope, id.SubID("secret-origin-private-key"), gsmsecret.DataConfig{
+				PrivateKey: &gsmsecret.Get(scope, id.Group("secret-origin-private-key"), gsmsecret.DataConfig{
 					Secret:    googlesecretsmanager.SecretSourcegraphWildcardKey,
 					ProjectID: googlesecretsmanager.ProjectID,
 				}).Value,
-				Certificate: &gsmsecret.Get(scope, id.SubID("secret-origin-cert"), gsmsecret.DataConfig{
+				Certificate: &gsmsecret.Get(scope, id.Group("secret-origin-cert"), gsmsecret.DataConfig{
 					Secret:    googlesecretsmanager.SecretSourcegraphWildcardCert,
 					ProjectID: googlesecretsmanager.ProjectID,
 				}).Value,

--- a/dev/managedservicesplatform/internal/resource/gsmsecret/gsmsecret.go
+++ b/dev/managedservicesplatform/internal/resource/gsmsecret/gsmsecret.go
@@ -24,7 +24,7 @@ type Config struct {
 
 func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
 	secret := secretmanagersecret.NewSecretManagerSecret(scope,
-		id.ResourceID("secret"),
+		id.TerraformID("secret"),
 		&secretmanagersecret.SecretManagerSecretConfig{
 			Project:  &config.ProjectID,
 			SecretId: &config.ID,
@@ -34,7 +34,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
 		})
 
 	version := secretmanagersecretversion.NewSecretManagerSecretVersion(scope,
-		id.ResourceID("secret_version"),
+		id.TerraformID("secret_version"),
 		&secretmanagersecretversion.SecretManagerSecretVersionConfig{
 			Secret:     secret.Id(),
 			SecretData: &config.Value,
@@ -57,7 +57,7 @@ type DataConfig struct {
 
 func Get(scope constructs.Construct, id resourceid.ID, config DataConfig) *Data {
 	data := datagooglesecretmanagersecretversion.NewDataGoogleSecretManagerSecretVersion(scope,
-		id.ResourceID("version_data"),
+		id.TerraformID("version_data"),
 		&datagooglesecretmanagersecretversion.DataGoogleSecretManagerSecretVersionConfig{
 			Secret:  &config.Secret,
 			Project: &config.ProjectID,

--- a/dev/managedservicesplatform/internal/resource/loadbalancer/loadbalancer.go
+++ b/dev/managedservicesplatform/internal/resource/loadbalancer/loadbalancer.go
@@ -63,7 +63,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 
 	// Endpoint group represents the Cloud Run service.
 	endpointGroup := computeregionnetworkendpointgroup.NewComputeRegionNetworkEndpointGroup(scope,
-		id.ResourceID("endpoint_group"),
+		id.TerraformID("endpoint_group"),
 		&computeregionnetworkendpointgroup.ComputeRegionNetworkEndpointGroupConfig{
 			Name:    pointers.Ptr(id.DisplayName()),
 			Project: pointers.Ptr(config.ProjectID),
@@ -77,7 +77,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 
 	// Set up a group of virtual machines that will serve traffic for load balancing
 	backendService := computebackendservice.NewComputeBackendService(scope,
-		id.ResourceID("backend_service"),
+		id.TerraformID("backend_service"),
 		&computebackendservice.ComputeBackendServiceConfig{
 			Name:    pointers.Ptr(id.DisplayName()),
 			Project: pointers.Ptr(config.ProjectID),
@@ -96,7 +96,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 	// Enable routing requests to the backend service working serving traffic
 	// for load balancing
 	urlMap := computeurlmap.NewComputeUrlMap(scope,
-		id.ResourceID("url_map"),
+		id.TerraformID("url_map"),
 		&computeurlmap.ComputeUrlMapConfig{
 			Name:           pointers.Ptr(id.DisplayName()),
 			Project:        pointers.Ptr(config.ProjectID),
@@ -106,7 +106,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 	// Set up an HTTPS proxy to route incoming HTTPS requests to our target's
 	// URL map, which handles load balancing for a service.
 	httpsProxy := computetargethttpsproxy.NewComputeTargetHttpsProxy(scope,
-		id.ResourceID("https-proxy"),
+		id.TerraformID("https-proxy"),
 		&computetargethttpsproxy.ComputeTargetHttpsProxyConfig{
 			Name:    pointers.Ptr(id.DisplayName()),
 			Project: pointers.Ptr(config.ProjectID),
@@ -118,7 +118,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 			}),
 			SslPolicy: computesslpolicy.NewComputeSslPolicy(
 				scope,
-				id.ResourceID("ssl-policy"),
+				id.TerraformID("ssl-policy"),
 				&computesslpolicy.ComputeSslPolicyConfig{
 					Name:    pointers.Ptr(id.DisplayName()),
 					Project: pointers.Ptr(config.ProjectID),
@@ -132,7 +132,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 	// Set up an external address to receive traffic
 	externalAddress := computeglobaladdress.NewComputeGlobalAddress(
 		scope,
-		id.ResourceID("external-address"),
+		id.TerraformID("external-address"),
 		&computeglobaladdress.ComputeGlobalAddressConfig{
 			Name:        pointers.Ptr(id.DisplayName()),
 			Project:     pointers.Ptr(config.ProjectID),
@@ -144,7 +144,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 	// Forward traffic from the external address to the HTTPS proxy that then
 	// routes request to our target
 	_ = computeglobalforwardingrule.NewComputeGlobalForwardingRule(scope,
-		id.ResourceID("forwarding-rule"),
+		id.TerraformID("forwarding-rule"),
 		&computeglobalforwardingrule.ComputeGlobalForwardingRuleConfig{
 			Name:    pointers.Ptr(id.DisplayName()),
 			Project: pointers.Ptr(config.ProjectID),

--- a/dev/managedservicesplatform/internal/resource/managedcert/managedcert.go
+++ b/dev/managedservicesplatform/internal/resource/managedcert/managedcert.go
@@ -28,7 +28,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
 	//
 	// That said, the cert is considered created when it's still provisioning,
 	// so CreateBeforeDestroy doesn't seem to do much - oh well.
-	certName := random.New(scope, id.SubID("cert-name"), random.Config{
+	certName := random.New(scope, id.Group("cert-name"), random.Config{
 		ByteLength: 4,
 		Prefix:     id.DisplayName(),
 		Keepers: map[string]*string{
@@ -38,7 +38,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
 
 	return &Output{
 		Certificate: computemanagedsslcertificate.NewComputeManagedSslCertificate(scope,
-			id.ResourceID("managed-cert"),
+			id.TerraformID("managed-cert"),
 			&computemanagedsslcertificate.ComputeManagedSslCertificateConfig{
 				Project: pointers.Ptr(config.ProjectID),
 				Name:    pointers.Ptr(certName.HexValue),

--- a/dev/managedservicesplatform/internal/resource/random/random.go
+++ b/dev/managedservicesplatform/internal/resource/random/random.go
@@ -33,7 +33,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
 	}
 	rid := randomid.NewId(
 		scope,
-		id.ResourceID("random"),
+		id.TerraformID("random"),
 		&randomid.IdConfig{
 			ByteLength: pointers.Float64(config.ByteLength),
 			Prefix:     prefix,

--- a/dev/managedservicesplatform/internal/resource/redis/redis.go
+++ b/dev/managedservicesplatform/internal/resource/redis/redis.go
@@ -30,7 +30,7 @@ type Config struct {
 
 func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, error) {
 	redis := redisinstance.NewRedisInstance(scope,
-		id.ResourceID("instance"),
+		id.TerraformID("instance"),
 		&redisinstance.RedisInstanceConfig{
 			Project: pointers.Ptr(config.ProjectID),
 			Region:  &config.Region,
@@ -50,7 +50,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 		})
 
 	// Share CA certificate for connecting to Redis over TLS as a GSM secret
-	redisCACert := gsmsecret.New(scope, id.SubID("ca-cert"), gsmsecret.Config{
+	redisCACert := gsmsecret.New(scope, id.Group("ca-cert"), gsmsecret.Config{
 		ProjectID: config.ProjectID,
 		ID:        strings.ToUpper(id.DisplayName()) + "_CA_CERT",
 		Value:     *redis.ServerCaCerts().Get(pointers.Float64(0)).Cert(),

--- a/dev/managedservicesplatform/internal/resource/serviceaccount/serviceaccount.go
+++ b/dev/managedservicesplatform/internal/resource/serviceaccount/serviceaccount.go
@@ -11,7 +11,7 @@ import (
 
 type Role struct {
 	// ID is used to generate a resource ID for the role grant. Must be provided
-	ID string
+	ID resourceid.ID
 	// Role is sourced from https://cloud.google.com/iam/docs/understanding-roles#predefined
 	Role string
 }
@@ -32,7 +32,7 @@ type Output struct {
 // New provisions a service account, including roles for it to inherit.
 func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
 	serviceAccount := serviceaccount.NewServiceAccount(scope,
-		id.ResourceID("account"),
+		id.TerraformID("account"),
 		&serviceaccount.ServiceAccountConfig{
 			Project: pointers.Ptr(config.ProjectID),
 
@@ -41,7 +41,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
 		})
 	for _, role := range config.Roles {
 		_ = projectiammember.NewProjectIamMember(scope,
-			id.ResourceID("member_%s", role.ID),
+			id.Append(role.ID).TerraformID("member"),
 			&projectiammember.ProjectIamMemberConfig{
 				Project: pointers.Ptr(config.ProjectID),
 

--- a/dev/managedservicesplatform/internal/resource/tfvar/tfvar.go
+++ b/dev/managedservicesplatform/internal/resource/tfvar/tfvar.go
@@ -18,7 +18,7 @@ type Output struct {
 }
 
 func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
-	v := cdktf.NewTerraformVariable(scope, id.ResourceID(config.VariableKey),
+	v := cdktf.NewTerraformVariable(scope, id.TerraformID(config.VariableKey),
 		&cdktf.TerraformVariableConfig{
 			Type:        pointers.Ptr("string"), // only strings for now
 			Description: pointers.Ptr(config.Description),

--- a/dev/managedservicesplatform/internal/resourceid/resourceid.go
+++ b/dev/managedservicesplatform/internal/resourceid/resourceid.go
@@ -11,21 +11,39 @@ import (
 // never be used as a Terraform resource ID to avoid collisions.
 type ID struct{ id string }
 
+// New constructs a base ID for grouping resources.
+//
+// ❗ Inputs MUST NOT reference CDKTF values, as CDKTF values cannot be used as
+// resource identifiers.
 func New(id string) ID { return ID{id: id} }
 
-// ResourceID must be used to construct IDs for Terraform resources within a
+// TerraformID must be used to construct IDs for Terraform resources within a
 // resource group. The IDs it creates are automatically prefixed with the parent
-// ID.
-func (id ID) ResourceID(format string, args ...any) *string {
+// ID. Argument is required to safely create non-conflicting IDs.
+//
+// ❗ Inputs MUST NOT reference CDKTF values, as CDKTF values cannot be used as
+// resource identifiers.
+func (id ID) TerraformID(format string, args ...any) *string {
 	subID := fmt.Sprintf(format, args...)
 	return pointers.Ptr(fmt.Sprintf("%s-%s", id.id, subID))
 }
 
-// SubID can be used by resource groups that use other resource groups to safely
+// Group can be used by resource groups that use other resource groups to safely
 // create non-conflicting sub-IDs.
-func (id ID) SubID(format string, args ...any) ID {
+//
+// ❗ Inputs MUST NOT reference CDKTF values, as CDKTF values cannot be used as
+// resource identifiers.
+func (id ID) Group(format string, args ...any) ID {
 	subID := fmt.Sprintf(format, args...)
 	return ID{id: fmt.Sprintf("%s-%s", id.id, subID)}
+}
+
+// Append combines 2 IDs.
+//
+// ❗ Inputs MUST NOT reference CDKTF values, as CDKTF values cannot be used as
+// resource identifiers.
+func (id ID) Append(next ID) ID {
+	return ID{id: fmt.Sprintf("%s-%s", id.id, next.id)}
 }
 
 // DisplayName can be used for display name fields - it is the ID itself, as

--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -127,7 +127,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	})
 
 	project := project.NewProject(stack,
-		id.ResourceID("project"),
+		id.TerraformID("project"),
 		&project.ProjectConfig{
 			Name:              pointers.Ptr(vars.DisplayName),
 			ProjectId:         &projectID.HexValue,
@@ -151,7 +151,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 
 	for _, service := range append(gcpServices, vars.Services...) {
 		projectservice.NewProjectService(stack,
-			id.ResourceID("project-service-%s", strings.ReplaceAll(service, ".", "-")),
+			id.TerraformID("project-service-%s", strings.ReplaceAll(service, ".", "-")),
 			&projectservice.ProjectServiceConfig{
 				Project:                  project.ProjectId(),
 				Service:                  pointers.Ptr(service),

--- a/dev/managedservicesplatform/internal/stack/stacks.go
+++ b/dev/managedservicesplatform/internal/stack/stacks.go
@@ -87,7 +87,7 @@ type StackLocals struct{ s Stack }
 // accessed under 'local.${name}' in custom resources.
 func (l *StackLocals) Add(name string, value any, description string) {
 	_ = cdktf.NewTerraformOutput(l.s.Stack,
-		resourceid.New("output").ResourceID(name),
+		resourceid.New("output").TerraformID(name),
 		&cdktf.TerraformOutputConfig{
 			Value:       value,
 			Sensitive:   pointers.Ptr(false),


### PR DESCRIPTION
Fix a regression from #58216 where I changed a resource ID from a static string to a CDKTF variable, breaking generation for the cloud-ops-dashboard service. CDKTF variables cannot be used as resource IDs.

This changes the role ID to the `resourceid` type to guard against misuse, and also adds some docstring warnings on various `resourceid.ID` constructors.

## Test plan
https://github.com/sourcegraph/managed-services/pull/65