### PR TITLE
Code Navigation: remove white corners from tooltips in dark mode

### DIFF
--- a/client/web/src/repo/blob/codemirror/codeintel/extension.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/extension.ts
@@ -62,6 +62,7 @@ const tooltipStyles = EditorView.theme({
     },
     '.cm-tooltip.sg-code-intel-hovercard': {
         border: 'unset',
+        borderRadius: 'var(--popover-border-radius)',
     },
 })
 


### PR DESCRIPTION
This PR fixes a CSS bug where there were white corners overlapping the border radius of tooltip containers in dark mode. 

### Test plan
manual testing