### PR TITLE
internal/tracer: silence opentelemetry debug logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -443,7 +443,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.4.1 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/stdr v1.2.2
 	github.com/go-openapi/analysis v0.21.4 // indirect
 	github.com/go-openapi/errors v0.20.3 // indirect

--- a/internal/tracer/BUILD.bazel
+++ b/internal/tracer/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//internal/version",
         "//lib/errors",
         "//schema",
+        "@com_github_go_logr_logr//:logr",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//semconv/v1.4.0:v1_4_0",

--- a/internal/tracer/watch_test.go
+++ b/internal/tracer/watch_test.go
@@ -32,7 +32,7 @@ func TestConfigWatcher(t *testing.T) {
 		noopProcessor = oteltracesdk.NewBatchSpanProcessor(tracetest.NewNoopExporter())
 	)
 
-	otelTracerProvider := newTracer(logger, provider, debugMode)
+	otelTracerProvider := newLoggedOtelTracerProvider(logger, provider, debugMode)
 	// otelTracer represents a tracer a caller might hold. All tracers should be updated
 	// by updating the underlying provider.
 	otelTracer := otelTracerProvider.Tracer(t.Name())
@@ -177,7 +177,7 @@ func TestConfigWatcher(t *testing.T) {
 		}
 
 		// should have debug set
-		assert.True(t, otelTracerProvider.(*loggedOtelTracerProvider).debug.Load())
+		assert.True(t, otelTracerProvider.debug.Load())
 
 		// should set global policy
 		assert.Equal(t, policy.TraceAll, policy.GetTracePolicy())


### PR DESCRIPTION
We see the OpenTelemetry debug logs emit a lot of output in Cloud - it's not all that important, and we already register an error handler, so this sets the default OpenTelemetry output to discard.

I'm still not sure what caused this to start happening but this should fix the problem.

## Test plan

CI