### PR TITLE
dev/msp: fixup resource IDs

### DIFF
--- a/dev/managedservicesplatform/internal/resourceid/resourceid.go
+++ b/dev/managedservicesplatform/internal/resourceid/resourceid.go
@@ -49,3 +49,9 @@ func (id ID) Append(next ID) ID {
 // DisplayName can be used for display name fields - it is the ID itself, as
 // display names generally do not need to be unique.
 func (id ID) DisplayName() string { return id.id }
+
+var _ fmt.Stringer = ID{}
+
+// String must never be used to render ID as a string. This guards against
+// accidental misuse.
+func (ID) String() string { panic("resourceid.ID must never be rendered as string") }

--- a/dev/managedservicesplatform/internal/stack/iam/iam.go
+++ b/dev/managedservicesplatform/internal/stack/iam/iam.go
@@ -111,6 +111,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 			}),
 		})
 	if imageProject := extractImageGoogleProject(vars.Image); imageProject != nil {
+		imageAccessID := id.Group("image_access")
 		for _, r := range []serviceaccount.Role{{
 			ID:   resourceid.New("object_viewer"),
 			Role: "roles/storage.objectViewer", // for gcr.io
@@ -119,7 +120,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 			Role: "roles/artifactregistry.reader", // for artifact registry
 		}} {
 			projectiammember.NewProjectIamMember(stack,
-				id.TerraformID("member_image_access_%s", r.ID),
+				imageAccessID.Append(r.ID).TerraformID("member"),
 				&projectiammember.ProjectIamMemberConfig{
 					Project: imageProject,
 					Role:    pointers.Ptr(r.Role),


### PR DESCRIPTION
Regression from #58239 - added a `Stringer` implementation that panics to guard against this in the future.

## Test plan
```
sg msp generate -all -stable
```

https://github.com/sourcegraph/managed-services/pull/68