### PR TITLE
Fix panic for empty blobs

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -181,7 +181,7 @@ func pageContent(content []byte, startLine, endLine *int) []byte {
 func lineCount(in []byte) int {
 	c := bytes.Count(in, []byte("\n"))
 	// Final newline doesn't mark a new line.
-	if in[len(in)-1] != '\n' {
+	if len(in) > 0 && in[len(in)-1] != '\n' {
 		return c + 1
 	}
 	return c


### PR DESCRIPTION
When `len(in) == 0`, this code panics because `in` will be indexed with a negative value. 

## Test plan

The file I was trying to view no longer panics.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
