### PR TITLE
dev/msp: do not mutate package variable

### DIFF
--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -472,6 +472,8 @@ func generateTerraform(serviceID string, opts generateTerraformOptions) error {
 	}
 
 	for _, env := range envs {
+		env := env
+
 		pending := std.Out.Pending(output.Styledf(output.StylePending,
 			"[%s] Preparing Terraform for environment %q", serviceID, env.ID))
 		renderer := managedservicesplatform.Renderer{


### PR DESCRIPTION
The iam stack was mutating the shared `serviceAccountRoles` variable, which affects the output of other services.

## Test plan

```
sg msp generate -all
```