### PR TITLE
remove "!" from global navbar site admin status messages

### DIFF
--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -216,10 +216,10 @@ export const StatusMessagesNavItem: React.FunctionComponent<React.PropsWithChild
                 ({ __typename: type }) => type === 'ExternalServiceSyncError' || type === 'SyncError'
             )
         ) {
-            codeHostMessage = 'Syncing repositories failed!'
+            codeHostMessage = 'Syncing repositories failed'
             iconProps = { as: CloudAlertIconRefresh }
         } else if (data.statusMessages?.some(({ __typename: type }) => type === 'GitUpdatesDisabled')) {
-            codeHostMessage = 'Syncing repositories disabled!'
+            codeHostMessage = 'Syncing repositories disabled'
             iconProps = { as: CloudAlertIconRefresh }
         } else if (data.statusMessages?.some(({ __typename: type }) => type === 'CloningProgress')) {
             codeHostMessage = 'Cloning repositories...'


### PR DESCRIPTION
The "!" is unnecessary and strikes the wrong tone.




## Test plan

CI