### PR TITLE
cleanup: Make evaluator code more idiomatic

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "8a50a86b222ab4b14a54b3d53795b37e54be32f0b6af68530c986218a08b5f3a",
+  "checksum": "1babd3f814104d679ee0d3ba6edb5cfefa69ac7aaa3c576be84b3a9f5e8377e6",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -69,6 +69,81 @@
         "version": "1.0.2"
       },
       "license": "0BSD OR MIT OR Apache-2.0"
+    },
+    "ahash 0.7.7": {
+      "name": "ahash",
+      "version": "0.7.7",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/ahash/0.7.7/download",
+          "sha256": "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "ahash",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "ahash",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "ahash 0.7.7",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {
+            "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": [
+              {
+                "id": "getrandom 0.2.10",
+                "target": "getrandom"
+              }
+            ],
+            "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
+              {
+                "id": "once_cell 1.18.0",
+                "target": "once_cell"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.7.7"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "version_check 0.9.4",
+              "target": "version_check"
+            }
+          ],
+          "selects": {}
+        }
+      },
+      "license": "MIT OR Apache-2.0"
     },
     "aho-corasick 1.0.4": {
       "name": "aho-corasick",
@@ -4451,6 +4526,52 @@
         "version": "1.8.2"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "hashbrown 0.11.2": {
+      "name": "hashbrown",
+      "version": "0.11.2",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/hashbrown/0.11.2/download",
+          "sha256": "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "hashbrown",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "hashbrown",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "ahash",
+            "inline-more"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "ahash 0.7.7",
+              "target": "ahash"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.11.2"
+      },
+      "license": "Apache-2.0/MIT"
     },
     "hashbrown 0.12.3": {
       "name": "hashbrown",
@@ -10388,18 +10509,8 @@
       "name": "scip-treesitter-cli",
       "version": "0.1.0",
       "repository": null,
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "scip_treesitter_cli",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "scip_treesitter_cli",
+      "targets": [],
+      "library_target_name": null,
       "common_attrs": {
         "compile_data_glob": [
           "**"
@@ -10453,6 +10564,10 @@
             {
               "id": "serde_json 1.0.99",
               "target": "serde_json"
+            },
+            {
+              "id": "string-interner 0.14.0",
+              "target": "string_interner"
             },
             {
               "id": "walkdir 2.3.3",
@@ -11507,6 +11622,64 @@
         "version": "1.0.6"
       },
       "license": "BSL-1.0"
+    },
+    "string-interner 0.14.0": {
+      "name": "string-interner",
+      "version": "0.14.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/string-interner/0.14.0/download",
+          "sha256": "91e2531d8525b29b514d25e275a43581320d587b86db302b9a7e464bac579648"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "string_interner",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "string_interner",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": {
+          "common": [
+            "backends",
+            "default",
+            "inline-more",
+            "serde",
+            "serde-1",
+            "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "cfg-if 1.0.0",
+              "target": "cfg_if"
+            },
+            {
+              "id": "hashbrown 0.11.2",
+              "target": "hashbrown"
+            },
+            {
+              "id": "serde 1.0.164",
+              "target": "serde"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2021",
+        "version": "0.14.0"
+      },
+      "license": "MIT/Apache-2.0"
     },
     "strsim 0.10.0": {
       "name": "strsim",
@@ -17133,6 +17306,33 @@
     "cfg(all(target_arch = \"x86_64\", target_env = \"msvc\", not(windows_raw_dylib)))": [
       "x86_64-pc-windows-msvc"
     ],
+    "cfg(any(target_os = \"linux\", target_os = \"android\", target_os = \"windows\", target_os = \"macos\", target_os = \"ios\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"dragonfly\", target_os = \"solaris\", target_os = \"illumos\", target_os = \"fuchsia\", target_os = \"redox\", target_os = \"cloudabi\", target_os = \"haiku\", target_os = \"vxworks\", target_os = \"emscripten\", target_os = \"wasi\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
+    ],
     "cfg(any(target_pointer_width = \"8\", target_pointer_width = \"16\", target_pointer_width = \"32\"))": [
       "arm-unknown-linux-gnueabi",
       "armv7-linux-androideabi",
@@ -17174,6 +17374,37 @@
       "x86_64-unknown-linux-gnu"
     ],
     "cfg(loom)": [],
+    "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "riscv32imc-unknown-none-elf",
+      "riscv64gc-unknown-none-elf",
+      "s390x-unknown-linux-gnu",
+      "wasm32-unknown-unknown",
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-none"
+    ],
     "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +838,15 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1916,6 +1936,7 @@ dependencies = [
  "scip-treesitter-languages",
  "serde",
  "serde_json",
+ "string-interner",
  "walkdir",
 ]
 
@@ -2116,6 +2137,17 @@ name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
+name = "string-interner"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e2531d8525b29b514d25e275a43581320d587b86db302b9a7e464bac579648"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.11.2",
+ "serde",
+]
 
 [[package]]
 name = "strsim"

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -58,6 +58,7 @@ rocket = { version = "0.5.0-rc.1", features = ["json"] }
 # See https://stackoverflow.com/questions/76905691/bazel-unable-to-build-external-rust-dependency-with-feature-serde1
 serde = { version = "=1.0.164", features = ["derive"] }
 serde_json = "1.0"
+string-interner = "0.14.0"
 # Since there is no version tag, we pin the dependency to a specific revision
 syntect = { git = "https://github.com/sourcegraph/syntect", rev = "7e02c5b4085e6d935b960b8106cdd85da04532d2" }
 tree-sitter = "0.20.9"

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/Cargo.toml
@@ -21,6 +21,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+string-interner = { workspace = true }
 
 scip-syntax = { path = "../scip-syntax" }
 scip-treesitter-languages = { path = "../scip-treesitter-languages" }

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/evaluate.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/evaluate.rs
@@ -1,6 +1,6 @@
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap, HashSet},
-    hash::Hasher,
+    collections::{HashMap, HashSet},
+    marker::PhantomData,
     path::PathBuf,
 };
 
@@ -8,24 +8,15 @@ use anyhow::*;
 use colored::Colorize;
 use scip::types::Index;
 use scip_treesitter::types::PackedRange;
+use string_interner::{symbol::SymbolU32, StringInterner, Symbol};
 
 use crate::{io::read_index_from_file, progress::*};
 
 pub fn evaluate_command(candidate: PathBuf, ground_truth: PathBuf, options: ScipEvaluateOptions) {
-    let evaluation_result = evaluate_files(candidate, ground_truth, options);
-    print_evaluation_summary(evaluation_result.unwrap(), options);
-}
-
-pub fn evaluate_files(
-    candidate: PathBuf,
-    ground_truth: PathBuf,
-    options: ScipEvaluateOptions,
-) -> Result<EvaluationResult> {
-    evaluate_indexes(
-        &read_index_from_file(candidate),
-        &read_index_from_file(ground_truth),
-        options,
-    )
+    Evaluator::default()
+        .evaluate_files(candidate, ground_truth, options)
+        .unwrap()
+        .print_summary()
 }
 
 fn validate_index(idx: &Index) -> Result<()> {
@@ -45,291 +36,55 @@ fn validate_index(idx: &Index) -> Result<()> {
 }
 // These unfortunately don't help the typesafety and are only here to aid readability
 // TODO: newtype https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#using-the-newtype-pattern-to-implement-external-traits-on-external-types
-type GroundTruthSymbol = String;
-type CandidateSymbol = String;
 
-pub fn evaluate_indexes(
-    candidate: &Index,
-    ground_truth: &Index,
-    options: ScipEvaluateOptions,
-) -> Result<EvaluationResult> {
-    validate_index(candidate)?;
-    validate_index(ground_truth)?;
-
-    let bar = create_spinner();
-    bar.set_message("Indexing candidate symbols by location");
-    let candidate_occurrences: HashMap<LocationInFile, CandidateSymbol> =
-        index_occurrences(candidate);
-    bar.tick();
-
-    bar.set_message("Indexing ground truth symbols by location");
-    let ground_truth_occurrences: HashMap<LocationInFile, GroundTruthSymbol> =
-        index_occurrences(ground_truth);
-    bar.tick();
-
-    // For each symbol pair we maintain an Overlap instance
-    let mut overlaps: HashMap<SymbolPair, Overlap> = HashMap::new();
-
-    // Lookup table where key is ground truth symbol, and the value
-    // is all the symbol pairs.
-    // Each symbol from ground truth dataset can be mapped to any number of
-    // symbols from the candidate set
-    let mut ground_truth_alternatives: HashMap<GroundTruthSymbol, HashSet<SymbolPair>> =
-        HashMap::new();
-
-    bar.set_message("Analysing occurrences in candidate SCIP");
-    for (candidate_loc, candidate_symbol) in candidate_occurrences.clone() {
-        // At given location from the candidate SCIP, see
-        // if ground truth dataset contains any symbol at same location
-        match ground_truth_occurrences.get(&candidate_loc) {
-            // If ground truth dataset doesn't have any symbol at this location,
-            // we treat it as a false positive, to be handled later
-            None => {}
-            Some(ground_truth_symbol) => {
-                let pair = SymbolPair {
-                    ground_truth: ground_truth_symbol.clone(),
-                    candidate: candidate_symbol,
-                };
-
-                // See if we already have a lookup entry for this ground truth symbol
-                match ground_truth_alternatives.get_mut(ground_truth_symbol) {
-                    None => {
-                        // If this is the first time we're seeing this symbol,
-                        // create a lookup entry and put a single pair in there
-                        ground_truth_alternatives
-                            .insert(ground_truth_symbol.clone(), HashSet::from([pair.clone()]));
-                    }
-                    Some(s) => {
-                        // Otherwise, add the symbol pair to the set (it might already be there)
-                        s.insert(pair.clone());
-                    }
-                }
-
-                // As we are currently iterating over candidate occurrences,
-                // we don't know how many occurrences there are in total in the
-                // ground truth dataset.
-                // That's why here we only manage the number of occurrences
-                // the datasets have in common
-                match overlaps.get_mut(&pair) {
-                    None => {
-                        overlaps.insert(
-                            pair,
-                            Overlap {
-                                total: 0,
-                                common: 1,
-                            },
-                        );
-                    }
-                    Some(overlap) => overlap.common += 1,
-                }
-            }
-        }
-    }
-    bar.tick();
-
-    bar.set_message("Computing overlap with ground truth SCIP occurrences");
-    for ground_truth_symbol in ground_truth_occurrences.values() {
-        // now that we're iterating over all the ground truth occurrences,
-        // we can update the `total` counter for each symbol pair
-        // associated with that ground truth symbol
-        ground_truth_alternatives
-            .get(ground_truth_symbol)
-            .into_iter()
-            .for_each(|pairs| {
-                for pair in pairs {
-                    if let Some(overlap) = overlaps.get_mut(pair) {
-                        overlap.total += 1
-                    }
-                }
-            });
-    }
-    bar.tick();
-
-    // For each candidate symbol we collect all possible ground truth symbols
-    // it can be mapped to
-    let candidate_mapping: HashMap<CandidateSymbol, HashMap<GroundTruthSymbol, Overlap>> = {
-        let mut result: HashMap<CandidateSymbol, HashMap<GroundTruthSymbol, Overlap>> =
-            HashMap::new();
-
-        for (symbol_pair, overlap) in overlaps.clone() {
-            match result.get_mut(&symbol_pair.candidate) {
-                None => {
-                    result.insert(
-                        symbol_pair.candidate,
-                        HashMap::from([(symbol_pair.ground_truth, overlap)]),
-                    );
-                }
-                Some(map) => {
-                    map.insert(symbol_pair.ground_truth, overlap);
-                }
-            }
-        }
-
-        result
-    };
-
-    // We have produced the final counts for all symbol pairs -
-    // it's time to produce final weights
-    let symbol_pair_weight: HashMap<SymbolPair, f32> = {
-        let mut result: HashMap<SymbolPair, f32> = HashMap::new();
-
-        for (candidate_symbol, alternatives) in &candidate_mapping {
-            let total_weight: f32 = alternatives.values().map(|i| i.jaccard()).sum();
-
-            for (ground_truth_symbol, overlap) in alternatives {
-                let weight = overlap.jaccard();
-
-                let adjusted_weight = weight / total_weight;
-
-                result.insert(
-                    SymbolPair {
-                        candidate: candidate_symbol.clone(),
-                        ground_truth: ground_truth_symbol.clone(),
-                    },
-                    adjusted_weight,
-                );
-            }
-        }
-
-        result
-    };
-
-    if options.print_mapping {
-        let mut candidate_mapping_vec: Vec<(CandidateSymbol, HashMap<GroundTruthSymbol, Overlap>)> =
-            candidate_mapping.into_iter().collect();
-
-        candidate_mapping_vec.sort_by_key(|(sym, _)| sym.clone());
-
-        for (candidate_symbol, alternatives) in candidate_mapping_vec {
-            let candidate = shorten_symbol(&candidate_symbol);
-            let mut alternatives_vec: Vec<(GroundTruthSymbol, Overlap)> =
-                alternatives.clone().into_iter().collect();
-            alternatives_vec.sort_by_key(|(sym, _)| sym.clone());
-
-            eprintln!("{}", candidate.red());
-
-            for (ground_truth_symbol, overlap) in &alternatives_vec {
-                let ground_truth = shorten_symbol(ground_truth_symbol);
-                let adjusted_weight = symbol_pair_weight
-                    .get(&SymbolPair {
-                        candidate: candidate_symbol.clone(),
-                        ground_truth: ground_truth_symbol.clone(),
-                    })
-                    .unwrap();
-
-                eprintln!(
-                    "   {:.2} {} [{}/{} occurrences]",
-                    adjusted_weight,
-                    ground_truth.green(),
-                    overlap.common,
-                    overlap.total
-                );
-            }
-
-            eprintln!();
-        }
-    }
-
-    let mut classified_locations: Vec<ClassifiedLocation> = Vec::new();
-
-    bar.set_message("Classifying occurrences into false negatives and true positives");
-    // Now that the mapping is fully built, iterate over all ground truth occurrences
-    // and see if the canidate contains it.
-    // By iterating over ground_truth_occurrences we can only identify false negatives
-    // and true positives.
-    // False negatives are counted later
-    for (ground_truth_location, ground_truth_symbol) in ground_truth_occurrences.clone() {
-        match candidate_occurrences.get(&ground_truth_location) {
-            // if this location is not marked in the candidate dataset,
-            // this is a false negative - with full weight 1.0, as
-            // there's no ambiguity to speak of - this location *should* contain
-            // some symbol but doesn't
-            None => classified_locations.push(ClassifiedLocation {
-                location: ground_truth_location,
-                symbol: ground_truth_symbol,
-                mark: Mark::FalseNegative { weight: 1.0 },
-            }),
-            Some(candidate_symbol) => {
-                let pair = SymbolPair {
-                    ground_truth: ground_truth_symbol.clone(),
-                    candidate: candidate_symbol.clone(),
-                };
-
-                match symbol_pair_weight.get(&pair) {
-                    // At this location we found both the ground truth
-                    // and candidate occurrence. We want to reward it - but with a
-                    // weight indicating how precisely we matched candidate symbols to
-                    // ground truth symbols - this weight comes from mapping we constructed earlier.
-                    Some(weight) => classified_locations.push(ClassifiedLocation {
-                        location: ground_truth_location,
-                        symbol: ground_truth_symbol,
-                        mark: Mark::TruePositive { weight: *weight },
-                    }),
-                    // This is an impossible situation by construction
-                    None => panic!(
-                        "Couldn't find a mapping for symbol {}",
-                        ground_truth_symbol.red()
-                    ),
-                }
-            }
-        }
-    }
-
-    bar.set_message("Identifying false positives");
-    for (candidate_location, candidate_symbol) in &candidate_occurrences {
-        // If there are occurrences present in candidate dataset, but
-        // not present in the ground truth, we treat it as a false positive
-        // and penalise it will full strength.
-        //
-        // Technically this may be a mistake, in case the indexer
-        // that produces ground truth has bugs in it.
-        // But for simplicity we assume that scip-* indexers
-        // are "perfect"
-        if !ground_truth_occurrences.contains_key(candidate_location) {
-            classified_locations.push(ClassifiedLocation {
-                location: candidate_location.clone(),
-                symbol: candidate_symbol.clone(),
-                mark: Mark::FalsePositive { weight: 1.0 },
-            });
-        }
-    }
-
-    bar.finish_and_clear();
-
-    Ok(EvaluationResult::new(classified_locations))
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+struct PathId {
+    value: SymbolU32,
 }
 
-fn shorten_symbol(sym: &String) -> String {
-    let parts: Vec<&str> = sym.splitn(5, ' ').collect();
-    if parts.len() == 5 {
-        let producer = parts[0];
-        let _tpe = parts[1];
-        let _package = parts[2];
-        let _version = parts[3];
-        let symbol = parts[4];
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct SymbolId<T> {
+    value: SymbolU32,
+    _marker: PhantomData<T>,
+}
 
-        format!("{producer} . . . {symbol}")
-    } else {
-        sym.to_string()
+impl<T> SymbolId<T> {
+    fn to_any(self) -> SymbolId<Any> {
+        SymbolId {
+            value: self.value,
+            _marker: PhantomData,
+        }
     }
 }
 
-#[derive(Eq, Hash, PartialEq, Clone, Debug, Ord, PartialOrd)]
+/// Phantom marker for SymbolId
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)] // https://github.com/rust-lang/rust/issues/26925
+struct GroundTruth;
+
+/// Phantom marker for SymbolId
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)] // https://github.com/rust-lang/rust/issues/26925
+struct Candidate;
+
+/// Phantom marker for SymbolId
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)] // https://github.com/rust-lang/rust/issues/26925
+struct Any;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 struct SymbolPair {
-    ground_truth: GroundTruthSymbol,
-    candidate: CandidateSymbol,
+    ground_truth: SymbolId<GroundTruth>,
+    candidate: SymbolId<Candidate>,
 }
 
-#[derive(Debug, PartialEq, Eq, Default, Hash, Clone, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 struct LocationInFile {
     rng: PackedRange,
-    file: String,
+    path_id: PathId,
 }
 
-#[derive(Eq, Hash, PartialEq, Clone, Debug, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SymbolOccurrence {
     location: LocationInFile,
-    symbol: String,
+    symbol: SymbolId<Any>,
 }
 
 impl SymbolOccurrence {
@@ -362,11 +117,11 @@ enum Mark {
 #[derive(Debug, PartialEq)]
 struct ClassifiedLocation {
     location: LocationInFile,
-    symbol: String,
+    symbol: SymbolId<Any>,
     mark: Mark,
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug)]
 pub struct ScipEvaluateOptions {
     pub print_mapping: bool,
     pub print_true_positives: bool,
@@ -384,15 +139,22 @@ pub struct EvaluationSummary {
 }
 
 #[derive(Debug)]
-pub struct EvaluationResult {
-    pub summary: EvaluationSummary,
-    pub true_positives: Vec<SymbolOccurrence>,
-    pub false_positives: Vec<SymbolOccurrence>,
-    pub false_negatives: Vec<SymbolOccurrence>,
+pub struct EvaluationResult<'e> {
+    evaluator: &'e Evaluator,
+    summary: EvaluationSummary,
+    true_positives: Vec<SymbolOccurrence>,
+    false_positives: Vec<SymbolOccurrence>,
+    false_negatives: Vec<SymbolOccurrence>,
+    // What options were used for this evaluation
+    options: ScipEvaluateOptions,
 }
 
-impl EvaluationResult {
-    fn new(classified: Vec<ClassifiedLocation>) -> EvaluationResult {
+impl<'e> EvaluationResult<'e> {
+    fn new<'a>(
+        evaluator: &'a Evaluator,
+        classified: Vec<ClassifiedLocation>,
+        options: ScipEvaluateOptions,
+    ) -> EvaluationResult<'a> {
         let mut true_positives_occurrences: Vec<SymbolOccurrence> = Vec::new();
         let mut false_positives_occurrences: Vec<SymbolOccurrence> = Vec::new();
         let mut false_negatives_occurrences: Vec<SymbolOccurrence> = Vec::new();
@@ -426,6 +188,7 @@ impl EvaluationResult {
         let recall = 100.0 * true_positives / (true_positives + false_negatives);
 
         EvaluationResult {
+            evaluator,
             summary: EvaluationSummary {
                 precision_percent: precision,
                 recall_percent: recall,
@@ -436,114 +199,434 @@ impl EvaluationResult {
             true_positives: true_positives_occurrences,
             false_positives: false_positives_occurrences,
             false_negatives: false_negatives_occurrences,
+            options,
         }
     }
 }
 
-pub fn print_evaluation_summary(eval: EvaluationResult, options: ScipEvaluateOptions) {
-    println!("{}", serde_json::to_string(&eval.summary).unwrap());
+impl<'e> EvaluationResult<'e> {
+    pub fn print_summary(&self) {
+        println!("{}", serde_json::to_string(&self.summary).unwrap());
 
-    if options.print_false_negatives {
-        eprintln!();
-
-        eprintln!(
-            "{}: {}",
-            "False negatives".red(),
-            eval.false_negatives.len().to_string().bold()
-        );
-        eprintln!(
-            "{}",
-            "How many actual occurrences we DIDN'T find compared to compiler?".italic()
-        );
-
-        for symbol_occurrence in eval.false_negatives {
+        let print_occ = |occ: &SymbolOccurrence| {
             eprintln!(
                 "{}: L{} C{} -- {}",
-                symbol_occurrence.location.file,
-                symbol_occurrence.range().start_line,
-                symbol_occurrence.range().start_col,
-                symbol_occurrence.symbol
+                self.evaluator.display_path(occ.location.path_id),
+                occ.range().start_line,
+                occ.range().start_col,
+                self.evaluator.display_symbol(occ.symbol),
             );
-        }
-    }
+        };
 
-    if options.print_false_positives {
-        eprintln!();
-        eprintln!(
-            "{}: {}",
-            "False positives".red(),
-            eval.false_positives.len().to_string().bold()
-        );
-        eprintln!(
-            "{}",
-            "How many extra occurrences we reported compared to compiler?".italic()
-        );
+        if self.options.print_false_negatives {
+            eprintln!();
 
-        for symbol_occurrence in eval.false_positives {
             eprintln!(
-                "{}: L{} C{} -- {}",
-                symbol_occurrence.location.file,
-                symbol_occurrence.range().start_line,
-                symbol_occurrence.range().start_col,
-                symbol_occurrence.symbol
+                "{}: {}",
+                "False negatives".red(),
+                self.false_negatives.len().to_string().bold()
             );
-        }
-    }
+            eprintln!(
+                "{}",
+                "How many actual occurrences we DIDN'T find compared to compiler?".italic()
+            );
 
-    if options.print_true_positives {
-        eprintln!();
-        eprintln!(
-            "{}: {}",
-            "True positives".green(),
-            eval.true_positives.len().to_string().bold()
-        );
-
-        for symbol_occurrence in &eval.true_positives {
-            let file = &symbol_occurrence.location.file;
-            let rng = symbol_occurrence.range();
-            let header = format!("{file}: L{} C{} -- ", rng.start_line, rng.start_col);
-
-            eprintln!("{} {}", header.yellow(), symbol_occurrence.symbol);
-        }
-    }
-}
-
-fn calculate_hash<T: std::hash::Hash>(t: &T) -> u64 {
-    let mut s = DefaultHasher::new();
-    t.hash(&mut s);
-    s.finish()
-}
-
-fn index_occurrences(idx: &Index) -> HashMap<LocationInFile, String> {
-    let mut mp: HashMap<LocationInFile, String> = HashMap::new();
-
-    for doc in &idx.documents {
-        for occ in &doc.occurrences {
-            let rng = PackedRange::from_vec(&occ.range).unwrap();
-            let mut new_sym = occ.symbol.clone();
-            if occ.symbol.starts_with("local ") {
-                new_sym = format!(
-                    "local doc-{}-{}",
-                    calculate_hash(&doc.relative_path),
-                    occ.symbol.strip_prefix("local ").unwrap()
-                )
+            for symbol_occurrence in &self.false_negatives {
+                print_occ(symbol_occurrence);
             }
-            let loc = LocationInFile {
-                rng,
-                file: doc.relative_path.to_string(),
-            };
-            mp.insert(loc, new_sym.to_string());
+        }
+
+        if self.options.print_false_positives {
+            eprintln!();
+            eprintln!(
+                "{}: {}",
+                "False positives".red(),
+                self.false_positives.len().to_string().bold()
+            );
+            eprintln!(
+                "{}",
+                "How many extra occurrences we reported compared to compiler?".italic()
+            );
+
+            for symbol_occurrence in &self.false_positives {
+                print_occ(symbol_occurrence);
+            }
+        }
+
+        if self.options.print_true_positives {
+            eprintln!();
+            eprintln!(
+                "{}: {}",
+                "True positives".green(),
+                self.true_positives.len().to_string().bold()
+            );
+
+            for symbol_occurrence in &self.true_positives {
+                let file = self
+                    .evaluator
+                    .display_path(symbol_occurrence.location.path_id);
+                let rng = symbol_occurrence.range();
+                let header = format!("{file}: L{} C{} -- ", rng.start_line, rng.start_col);
+
+                eprintln!(
+                    "{} {}",
+                    header.yellow(),
+                    self.evaluator.display_symbol(symbol_occurrence.symbol)
+                );
+            }
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Evaluator {
+    interner: StringInterner,
+}
+
+// Public API
+impl Evaluator {
+    pub fn evaluate_files<'e>(
+        &'e mut self,
+        candidate: PathBuf,
+        ground_truth: PathBuf,
+        options: ScipEvaluateOptions,
+    ) -> Result<EvaluationResult<'e>> {
+        self.evaluate_indexes(
+            &read_index_from_file(candidate),
+            &read_index_from_file(ground_truth),
+            options,
+        )
+    }
+
+    pub fn evaluate_indexes<'e>(
+        &'e mut self,
+        candidate: &Index,
+        ground_truth: &Index,
+        options: ScipEvaluateOptions,
+    ) -> Result<EvaluationResult<'e>> {
+        validate_index(candidate)?;
+        validate_index(ground_truth)?;
+
+        let bar = create_spinner();
+        bar.set_message("Indexing candidate symbols by location");
+        let candidate_occurrences: HashMap<LocationInFile, SymbolId<Candidate>> =
+            self.index_occurrences(candidate);
+        bar.tick();
+
+        bar.set_message("Indexing ground truth symbols by location");
+        let ground_truth_occurrences: HashMap<LocationInFile, SymbolId<GroundTruth>> =
+            self.index_occurrences(ground_truth);
+        bar.tick();
+
+        // For each symbol pair we maintain an Overlap instance
+        let mut overlaps: HashMap<SymbolPair, Overlap> = HashMap::new();
+
+        // Lookup table where key is ground truth symbol, and the value
+        // is all the symbol pairs.
+        // Each symbol from ground truth dataset can be mapped to any number of
+        // symbols from the candidate set
+        let mut ground_truth_alternatives: HashMap<SymbolId<GroundTruth>, HashSet<SymbolPair>> =
+            HashMap::new();
+
+        bar.set_message("Analysing occurrences in candidate SCIP");
+        for (&candidate_loc, &candidate_symbol) in candidate_occurrences.iter() {
+            // At given location from the candidate SCIP, see
+            // if ground truth dataset contains any symbol at same location
+            match ground_truth_occurrences.get(&candidate_loc) {
+                // If ground truth dataset doesn't have any symbol at this location,
+                // we treat it as a false positive, to be handled later
+                None => {}
+                Some(&ground_truth_symbol) => {
+                    let pair = SymbolPair {
+                        ground_truth: ground_truth_symbol,
+                        candidate: candidate_symbol,
+                    };
+
+                    // See if we already have a lookup entry for this ground truth symbol
+                    match ground_truth_alternatives.get_mut(&ground_truth_symbol) {
+                        None => {
+                            // If this is the first time we're seeing this symbol,
+                            // create a lookup entry and put a single pair in there
+                            ground_truth_alternatives
+                                .insert(ground_truth_symbol, HashSet::from([pair]));
+                        }
+                        Some(s) => {
+                            // Otherwise, add the symbol pair to the set (it might already be there)
+                            s.insert(pair);
+                        }
+                    }
+
+                    // As we are currently iterating over candidate occurrences,
+                    // we don't know how many occurrences there are in total in the
+                    // ground truth dataset.
+                    // That's why here we only manage the number of occurrences
+                    // the datasets have in common
+                    match overlaps.get_mut(&pair) {
+                        None => {
+                            overlaps.insert(
+                                pair,
+                                Overlap {
+                                    total: 0,
+                                    common: 1,
+                                },
+                            );
+                        }
+                        Some(overlap) => overlap.common += 1,
+                    }
+                }
+            }
+        }
+        bar.tick();
+
+        bar.set_message("Computing overlap with ground truth SCIP occurrences");
+        for ground_truth_symbol in ground_truth_occurrences.values() {
+            // now that we're iterating over all the ground truth occurrences,
+            // we can update the `total` counter for each symbol pair
+            // associated with that ground truth symbol
+            ground_truth_alternatives
+                .get(ground_truth_symbol)
+                .into_iter()
+                .for_each(|pairs| {
+                    for pair in pairs {
+                        if let Some(overlap) = overlaps.get_mut(pair) {
+                            overlap.total += 1
+                        }
+                    }
+                });
+        }
+        bar.tick();
+
+        // For each candidate symbol we collect all possible ground truth symbols
+        // it can be mapped to
+        let candidate_mapping: HashMap<
+            SymbolId<Candidate>,
+            HashMap<SymbolId<GroundTruth>, Overlap>,
+        > = {
+            let mut result: HashMap<SymbolId<Candidate>, HashMap<SymbolId<GroundTruth>, Overlap>> =
+                HashMap::new();
+
+            for (symbol_pair, overlap) in overlaps {
+                match result.get_mut(&symbol_pair.candidate) {
+                    None => {
+                        result.insert(
+                            symbol_pair.candidate,
+                            HashMap::from([(symbol_pair.ground_truth, overlap)]),
+                        );
+                    }
+                    Some(map) => {
+                        map.insert(symbol_pair.ground_truth, overlap);
+                    }
+                }
+            }
+
+            result
+        };
+
+        // We have produced the final counts for all symbol pairs -
+        // it's time to produce final weights
+        let symbol_pair_weight: HashMap<SymbolPair, f32> = {
+            let mut result: HashMap<SymbolPair, f32> = HashMap::new();
+
+            for (&candidate_symbol, alternatives) in &candidate_mapping {
+                let total_weight: f32 = alternatives.values().map(|i| i.jaccard()).sum();
+
+                for (&ground_truth_symbol, overlap) in alternatives {
+                    let weight = overlap.jaccard();
+
+                    let adjusted_weight = weight / total_weight;
+
+                    result.insert(
+                        SymbolPair {
+                            candidate: candidate_symbol,
+                            ground_truth: ground_truth_symbol,
+                        },
+                        adjusted_weight,
+                    );
+                }
+            }
+
+            result
+        };
+
+        if options.print_mapping {
+            let mut candidate_mapping_vec: Vec<(
+                SymbolId<Candidate>,
+                HashMap<SymbolId<GroundTruth>, Overlap>,
+            )> = candidate_mapping.into_iter().collect();
+
+            candidate_mapping_vec.sort_by_key(|(sym, _)| *sym);
+
+            for (candidate_symbol, alternatives) in candidate_mapping_vec.into_iter() {
+                let candidate = self.try_strip_package_details(candidate_symbol);
+                let mut alternatives_vec: Vec<(SymbolId<GroundTruth>, Overlap)> =
+                    alternatives.into_iter().collect();
+                alternatives_vec.sort_by_key(|(sym, _)| *sym);
+
+                eprintln!("{}", self.display_symbol(candidate).red());
+
+                for (ground_truth_symbol, overlap) in &alternatives_vec {
+                    let ground_truth = self.try_strip_package_details(*ground_truth_symbol);
+                    let adjusted_weight = symbol_pair_weight
+                        .get(&SymbolPair {
+                            candidate: candidate_symbol,
+                            ground_truth: *ground_truth_symbol,
+                        })
+                        .unwrap();
+
+                    eprintln!(
+                        "   {:.2} {} [{}/{} occurrences]",
+                        adjusted_weight,
+                        self.display_symbol(ground_truth).green(),
+                        overlap.common,
+                        overlap.total
+                    );
+                }
+
+                eprintln!();
+            }
+        }
+
+        let mut classified_locations: Vec<ClassifiedLocation> = Vec::new();
+
+        bar.set_message("Classifying occurrences into false negatives and true positives");
+        // Now that the mapping is fully built, iterate over all ground truth occurrences
+        // and see if the canidate contains it.
+        // By iterating over ground_truth_occurrences we can only identify false negatives
+        // and true positives.
+        // False negatives are counted later
+        for (&ground_truth_location, &ground_truth_symbol) in ground_truth_occurrences.iter() {
+            match candidate_occurrences.get(&ground_truth_location) {
+                // if this location is not marked in the candidate dataset,
+                // this is a false negative - with full weight 1.0, as
+                // there's no ambiguity to speak of - this location *should* contain
+                // some symbol but doesn't
+                None => classified_locations.push(ClassifiedLocation {
+                    location: ground_truth_location,
+                    symbol: ground_truth_symbol.to_any(),
+                    mark: Mark::FalseNegative { weight: 1.0 },
+                }),
+                Some(candidate_symbol) => {
+                    let pair = SymbolPair {
+                        ground_truth: ground_truth_symbol,
+                        candidate: *candidate_symbol,
+                    };
+
+                    match symbol_pair_weight.get(&pair) {
+                        // At this location we found both the ground truth
+                        // and candidate occurrence. We want to reward it - but with a
+                        // weight indicating how precisely we matched candidate symbols to
+                        // ground truth symbols - this weight comes from mapping we constructed earlier.
+                        Some(weight) => classified_locations.push(ClassifiedLocation {
+                            location: ground_truth_location,
+                            symbol: ground_truth_symbol.to_any(),
+                            mark: Mark::TruePositive { weight: *weight },
+                        }),
+                        // This is an impossible situation by construction
+                        None => panic!(
+                            "Couldn't find a mapping for symbol {}",
+                            self.display_symbol(ground_truth_symbol).red()
+                        ),
+                    }
+                }
+            }
+        }
+
+        bar.set_message("Identifying false positives");
+        for (candidate_location, candidate_symbol) in &candidate_occurrences {
+            // If there are occurrences present in candidate dataset, but
+            // not present in the ground truth, we treat it as a false positive
+            // and penalise it will full strength.
+            //
+            // Technically this may be a mistake, in case the indexer
+            // that produces ground truth has bugs in it.
+            // But for simplicity we assume that scip-* indexers
+            // are "perfect"
+            if !ground_truth_occurrences.contains_key(candidate_location) {
+                classified_locations.push(ClassifiedLocation {
+                    location: *candidate_location,
+                    symbol: candidate_symbol.to_any(),
+                    mark: Mark::FalsePositive { weight: 1.0 },
+                });
+            }
+        }
+
+        bar.finish_and_clear();
+
+        Ok(EvaluationResult::new(self, classified_locations, options))
+    }
+}
+
+// Private API
+impl Evaluator {
+    fn make_symbol_id<T>(&mut self, s: &str) -> SymbolId<T> {
+        SymbolId {
+            value: self.interner.get_or_intern(s),
+            _marker: PhantomData,
         }
     }
 
-    mp
+    fn make_path_id(&mut self, s: &str) -> PathId {
+        PathId {
+            value: self.interner.get_or_intern(s),
+        }
+    }
+
+    fn display_symbol<T>(&self, s: SymbolId<T>) -> &str {
+        self.interner.resolve(s.value).unwrap()
+    }
+
+    fn display_path(&self, s: PathId) -> &str {
+        self.interner.resolve(s.value).unwrap()
+    }
+
+    fn try_strip_package_details<T: Copy>(&mut self, sym: SymbolId<T>) -> SymbolId<T> {
+        let s = self.display_symbol(sym);
+        if s.as_bytes().iter().filter(|&c| *c == b' ').count() != 5 {
+            return sym;
+        }
+        let parts: Vec<&str> = s.splitn(5, ' ').collect();
+        let scheme = parts[0];
+        let _manager = parts[1];
+        let _package_name = parts[2];
+        let _version = parts[3];
+        let descriptor = parts[4];
+        self.make_symbol_id(&format!("{scheme} . . . {descriptor}"))
+    }
+}
+
+impl Evaluator {
+    fn index_occurrences<T>(&mut self, index: &Index) -> HashMap<LocationInFile, SymbolId<T>> {
+        let mut out: HashMap<LocationInFile, SymbolId<T>> = HashMap::new();
+
+        for doc in &index.documents {
+            let path_id = self.make_path_id(&doc.relative_path);
+            out.reserve(doc.occurrences.len());
+            for occ in &doc.occurrences {
+                let rng = PackedRange::from_vec(&occ.range).unwrap();
+                let sym_id: SymbolId<T>;
+                if let Some(prefix) = occ.symbol.strip_prefix("local ") {
+                    sym_id = self.make_symbol_id(&format!(
+                        "local doc-{}-{}",
+                        path_id.value.to_usize(),
+                        prefix
+                    ));
+                } else {
+                    sym_id = self.make_symbol_id(&occ.symbol);
+                }
+                let loc = LocationInFile { rng, path_id };
+                out.insert(loc, sym_id);
+            }
+        }
+
+        out
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use scip::types::*;
 
-    use crate::evaluate::evaluate_indexes;
+    use crate::evaluate::Evaluator;
 
     fn occurrence(n: i32, symbol: &str) -> Occurrence {
         let mut occ = Occurrence::new();
@@ -586,47 +669,60 @@ mod tests {
 
         let ground_truth = index(vec![doc1, doc2]);
 
+        let mut evaluator = Evaluator::default();
+
         // Evaluating index against itself should yield 100% precision and 100% recall
-        let evaluate_with_self =
-            evaluate_indexes(&ground_truth, &ground_truth, Default::default()).unwrap();
-        assert_eq!(evaluate_with_self.summary.precision_percent, 100.0);
-        assert_eq!(evaluate_with_self.summary.recall_percent, 100.0);
-        assert_eq!(evaluate_with_self.summary.true_positives, 4.0);
-        assert_eq!(evaluate_with_self.summary.false_positives, 0.0);
-        assert_eq!(evaluate_with_self.summary.false_negatives, 0.0);
+        {
+            let evaluate_with_self = evaluator
+                .evaluate_indexes(&ground_truth, &ground_truth, Default::default())
+                .unwrap();
+            assert_eq!(evaluate_with_self.summary.precision_percent, 100.0);
+            assert_eq!(evaluate_with_self.summary.recall_percent, 100.0);
+            assert_eq!(evaluate_with_self.summary.true_positives, 4.0);
+            assert_eq!(evaluate_with_self.summary.false_positives, 0.0);
+            assert_eq!(evaluate_with_self.summary.false_negatives, 0.0);
+        }
 
         // This has no overlap at all with the ground truth
         // Should yield 0% precision, 0% recall
-        let evaluate_disjoint = evaluate_indexes(
-            &index(vec![
-                document(
-                    "bla/document1.java",
-                    vec![occurrence(1, "sym1"), occurrence(2, "sym2")],
-                ),
-                document(
-                    "bla/document2.java",
-                    vec![occurrence(1, "sym1"), occurrence(2, "sym2")],
-                ),
-            ]),
-            &ground_truth,
-            Default::default(),
-        )
-        .unwrap();
-        assert_eq!(evaluate_disjoint.summary.precision_percent, 0.0);
-        assert_eq!(evaluate_disjoint.summary.recall_percent, 0.0);
-        assert_eq!(evaluate_disjoint.summary.true_positives, 0.0);
-        assert_eq!(evaluate_disjoint.summary.false_positives, 4.0);
-        assert_eq!(evaluate_disjoint.summary.false_negatives, 4.0);
+        {
+            let evaluate_disjoint = evaluator
+                .evaluate_indexes(
+                    &index(vec![
+                        document(
+                            "bla/document1.java",
+                            vec![occurrence(1, "sym1"), occurrence(2, "sym2")],
+                        ),
+                        document(
+                            "bla/document2.java",
+                            vec![occurrence(1, "sym1"), occurrence(2, "sym2")],
+                        ),
+                    ]),
+                    &ground_truth,
+                    Default::default(),
+                )
+                .unwrap();
+            assert_eq!(evaluate_disjoint.summary.precision_percent, 0.0);
+            assert_eq!(evaluate_disjoint.summary.recall_percent, 0.0);
+            assert_eq!(evaluate_disjoint.summary.true_positives, 0.0);
+            assert_eq!(evaluate_disjoint.summary.false_positives, 4.0);
+            assert_eq!(evaluate_disjoint.summary.false_negatives, 4.0);
+        }
 
         let empty_index = index(vec![document("bla.java", vec![])]);
 
         // Evaluating empty index is an error
-        let evaluate_empty = evaluate_indexes(&empty_index, &ground_truth, Default::default());
-        assert!(evaluate_empty.is_err());
+        {
+            let evaluate_empty =
+                evaluator.evaluate_indexes(&empty_index, &ground_truth, Default::default());
+            assert!(evaluate_empty.is_err());
+        }
 
         // Evaluating against an empty index is an error
-        let evaluate_against_empty =
-            evaluate_indexes(&ground_truth, &empty_index, Default::default());
-        assert!(evaluate_against_empty.is_err());
+        {
+            let evaluate_against_empty =
+                evaluator.evaluate_indexes(&ground_truth, &empty_index, Default::default());
+            assert!(evaluate_against_empty.is_err());
+        }
     }
 }

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/evaluate.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/evaluate.rs
@@ -521,20 +521,13 @@ fn index_occurrences(idx: &Index) -> HashMap<LocationInFile, String> {
         for occ in &doc.occurrences {
             let rng = PackedRange::from_vec(&occ.range).unwrap();
             let mut new_sym = occ.symbol.clone();
-            let sanitised_relative_path: String = doc
-                .relative_path
-                .chars()
-                .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '+' || *c == '$')
-                .collect();
-
             if occ.symbol.starts_with("local ") {
                 new_sym = format!(
                     "local doc-{}-{}",
-                    calculate_hash(&sanitised_relative_path),
+                    calculate_hash(&doc.relative_path),
                     occ.symbol.strip_prefix("local ").unwrap()
                 )
             }
-
             let loc = LocationInFile {
                 rng,
                 file: doc.relative_path.to_string(),

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/index.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/index.rs
@@ -8,7 +8,7 @@ use scip_treesitter_languages::parsers::BundledParser;
 use walkdir::DirEntry;
 
 use crate::{
-    evaluate::{evaluate_indexes, print_evaluation_summary},
+    evaluate::Evaluator,
     io::read_index_from_file,
     progress::{create_progress_bar, create_spinner},
 };
@@ -162,9 +162,11 @@ pub fn index_command(
 
         let ground_truth = read_index_from_file(file);
 
-        let evaluation_result = evaluate_indexes(&index, &ground_truth, Default::default());
-
-        print_evaluation_summary(evaluation_result.unwrap(), Default::default());
+        let mut evaluator = Evaluator::default();
+        evaluator
+            .evaluate_indexes(&index, &ground_truth, Default::default())
+            .unwrap()
+            .print_summary();
     }
 
     write_message_to_file(out, index).expect("to write the file");

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/main.rs
@@ -3,11 +3,11 @@ mod index;
 mod io;
 mod progress;
 
-use clap::{Parser, Subcommand};
 use crate::{
     evaluate::ScipEvaluateOptions,
     index::{index_command, AnalysisMode, IndexMode, IndexOptions},
 };
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Parser)]

--- a/docker-images/syntax-highlighter/crates/scip-treesitter/src/types.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter/src/types.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Node;
 
-#[derive(Debug, PartialEq, Eq, Default, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Default, Hash, Copy, Clone)]
 pub struct PackedRange {
     pub start_line: i32,
     pub start_col: i32,


### PR DESCRIPTION
Major changes:

1. Use proper iteration structures like `into_iter()`/`iter()` in a bunch of places to
    avoid cloning `HashMap`/`Vec` structures (as those will be deep clones).
2. Uses string interning to avoid cloning `String`s and avoiding complicating
    lifetimes by passing `&str` everywhere. This allows marking all the interesting
    types as `Copy` so that `*` can perform a copy with needing `clone()`.
3. Introduces newtype wrappers to avoid confusing different kinds of symbols.
4. Uses more methods instead of free functions for better auto-complete and
    and code organization.

## Test plan

n/a