### PR TITLE
fix sg in CI

### DIFF
--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -120,9 +120,10 @@ var Mac = []category{
 				},
 			},
 			{
-				Name:  "p4 CLI (Perforce)",
-				Check: checkAction(check.InPath("p4")),
-				Fix:   cmdFix(`brew install --cask p4`),
+				Name:    "p4 CLI (Perforce)",
+				Check:   checkAction(check.InPath("p4")),
+				Enabled: disableInCI(), // giving a SHA256 mismatch error in CI
+				Fix:     cmdFix(`brew install --cask p4`),
 			},
 		},
 	},

--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -330,6 +330,7 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 	{
 		Name:      "Cloud services",
 		DependsOn: []string{depsHomebrew},
+		Enabled:   disableInCI(),
 		Checks: []*dependency{
 			dependencyGcloud(),
 		},

--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -30,6 +30,7 @@ func categoryCloneRepositories() category {
 See here on how to set that up:
 
 https://docs.github.com/en/authentication/connecting-to-github-with-ssh`,
+				Enabled: disableInCI(),
 				Check: func(ctx context.Context, out *std.Output, args CheckArgs) error {
 					return check.CommandOutputContains(
 						"ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -T git@github.com",
@@ -40,6 +41,7 @@ https://docs.github.com/en/authentication/connecting-to-github-with-ssh`,
 			{
 				Name:        "github.com/sourcegraph/sourcegraph",
 				Description: `The 'sourcegraph' repository contains the Sourcegraph codebase and everything to run Sourcegraph locally.`,
+				Enabled:     disableInCI(),
 				Check: func(ctx context.Context, out *std.Output, args CheckArgs) error {
 					if _, err := root.RepositoryRoot(); err == nil {
 						return nil
@@ -70,6 +72,7 @@ so they sit alongside each other, like this:
     |-- dev-private
     +-- sourcegraph
 `,
+				Enabled: disableInCI(),
 				Check: func(ctx context.Context, out *std.Output, args CheckArgs) error {
 					ok, err := pathExists("dev-private")
 					if ok && err == nil {

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -268,6 +268,7 @@ YOU NEED TO RESTART 'sg setup' AFTER RUNNING THIS COMMAND!`,
 	{
 		Name:      "Cloud services",
 		DependsOn: []string{depsBaseUtilities},
+		Enabled:   disableInCI(),
 		Checks: []*dependency{
 			dependencyGcloud(),
 		},


### PR DESCRIPTION
The "is Sourcegraph teammate" check was removed from `sg`, but we need to skip those same steps as before in CI.




## Test plan

CI