### PR TITLE
build: Separate out integration test and re-add library target for scip-treesitter-cli

### DIFF
--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f1deac78768a1de9ed51dd37a32abaf1371d95d0eefb7d379b66b6c6a8b1cc97",
+  "checksum": "ae3b30d9b7f75f8e8cbe503b5263485011fc1478728c759237e33bde6a129544",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -10509,8 +10509,18 @@
       "name": "scip-treesitter-cli",
       "version": "0.1.0",
       "repository": null,
-      "targets": [],
-      "library_target_name": null,
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "scip_treesitter_cli",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "scip_treesitter_cli",
       "common_attrs": {
         "compile_data_glob": [
           "**"

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/BUILD.bazel
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/BUILD.bazel
@@ -4,7 +4,7 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 
 rust_binary(
     name = "scip-treesitter-cli",
-    srcs = glob(["src/*.rs"]),
+    srcs = glob(["src/main.rs"]),
     aliases = aliases(),
     proc_macro_deps = all_crate_deps(
         proc_macro = True,
@@ -13,15 +13,44 @@ rust_binary(
     deps = all_crate_deps(
         normal = True,
     ) + [
-        "//docker-images/syntax-highlighter/crates/scip-syntax",
-        "//docker-images/syntax-highlighter/crates/scip-treesitter",
-        "//docker-images/syntax-highlighter/crates/scip-treesitter-languages",
+        ":scip-treesitter-cli-lib",
     ],
+)
+
+WORKSPACE_DEPS = [
+    "//docker-images/syntax-highlighter/crates/scip-syntax",
+    "//docker-images/syntax-highlighter/crates/scip-treesitter",
+    "//docker-images/syntax-highlighter/crates/scip-treesitter-languages",
+]
+
+rust_library(
+    name = "scip-treesitter-cli-lib",
+    srcs = glob([
+        "src/*.rs",
+    ], exclude=["src/main.rs"], allow_empty=False),
+    aliases = aliases(),
+    crate_name = "scip_treesitter_cli",
+    crate_root = "src/lib.rs",
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+    ),
+    visibility = [":__subpackages__"],
+    deps = all_crate_deps(normal = True) + WORKSPACE_DEPS,
 )
 
 rust_test(
     name = "unit_test",
     srcs = glob(["src/*.rs"]),
+    proc_macro_deps = all_crate_deps(
+        proc_macro = True,
+    ),
+    deps = all_crate_deps(normal = True) + WORKSPACE_DEPS,
+    size = "small",
+)
+
+rust_test(
+    name = "integration_test",
+    srcs = glob(["tests/*.rs"]),
     compile_data = glob(
         [
             "testdata/**",
@@ -31,12 +60,10 @@ rust_test(
     # Make sure this name matches the crate name in cargo configuration
     # This is to ensure that snapshots produced by Bazel tests and
     # ones produced by `cargo test` command - otherwise insta testing will fail!
-    crate = ":scip-treesitter-cli",
-    data = glob(
-               ["testdata/**"],
-           ) + [":scip-treesitter-cli"] +
+    # crate = ":integration_test",
+    data = [":scip-treesitter-cli"] +
            glob(
-               ["src/snapshots/**"],
+               ["tests/snapshots/**"],
                allow_empty = False,
            ),
     env = {
@@ -46,9 +73,6 @@ rust_test(
     },
     deps = all_crate_deps(
         normal = True,
-    ) + [
-        "//docker-images/syntax-highlighter/crates/scip-syntax",
-        "//docker-images/syntax-highlighter/crates/scip-treesitter",
-        "//docker-images/syntax-highlighter/crates/scip-treesitter-languages",
-    ],
+    ) + [":scip-treesitter-cli", ":scip-treesitter-cli-lib"] + WORKSPACE_DEPS,
+    size = "small",
 )

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/lib.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod evaluate;
+pub mod index;
+pub mod io;
+pub mod progress;

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/main.rs
@@ -1,13 +1,8 @@
-mod evaluate;
-mod index;
-mod io;
-mod progress;
-
-use crate::{
+use clap::{Parser, Subcommand};
+use scip_treesitter_cli::{
     evaluate::ScipEvaluateOptions,
     index::{index_command, AnalysisMode, IndexMode, IndexOptions},
 };
-use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -123,7 +118,7 @@ pub fn main() {
             print_true_positives,
             print_false_positives,
             print_false_negatives,
-        } => crate::evaluate::evaluate_command(
+        } => scip_treesitter_cli::evaluate::evaluate_command(
             PathBuf::from(candidate),
             PathBuf::from(ground_truth),
             ScipEvaluateOptions {
@@ -133,94 +128,5 @@ pub fn main() {
                 print_false_negatives,
             },
         ),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::io::read_index_from_file;
-    use assert_cmd::cargo::cargo_bin;
-    use assert_cmd::prelude::*;
-    use std::collections::HashMap;
-    use std::path::Path;
-    use std::process::Command;
-    use std::{env::temp_dir, path::PathBuf};
-
-    lazy_static::lazy_static! {
-        static ref BINARY_LOCATION: PathBuf = {
-            match std::env::var("SCIP_CLI_LOCATION") {
-                Ok(va) => std::env::current_dir().unwrap().join(va),
-                _ => cargo_bin("scip-treesitter-cli"),
-            }
-        };
-    }
-
-    use scip_treesitter::snapshot::{dump_document_with_config, EmitSymbol, SnapshotOptions};
-
-    fn snapshot_syntax_document(doc: &scip::types::Document, source: &str) -> String {
-        dump_document_with_config(
-            doc,
-            source,
-            SnapshotOptions {
-                emit_symbol: EmitSymbol::All,
-                ..Default::default()
-            },
-        )
-        .expect("dump document")
-    }
-
-    #[test]
-    fn java_e2e_indexing() {
-        let out_dir = temp_dir();
-        let setup = HashMap::from([(
-            PathBuf::from("globals.java"),
-            include_str!("../testdata/globals.java").to_string(),
-        )]);
-
-        run_index(&out_dir, &setup, vec!["--language", "java"]);
-
-        let index = read_index_from_file(out_dir.join("index.scip"));
-
-        for doc in &index.documents {
-            let path = &doc.relative_path;
-            let dumped =
-                snapshot_syntax_document(doc, setup.get(&PathBuf::from(&path)).expect("??"));
-
-            insta::assert_snapshot!(path.clone(), dumped);
-        }
-    }
-
-    fn prepare(temp: &Path, files: &HashMap<PathBuf, String>) {
-        for (path, contents) in files.iter() {
-            let file_path = temp.join(path);
-            write_file(&file_path, contents);
-        }
-    }
-
-    fn run_index(location: &PathBuf, files: &HashMap<PathBuf, String>, extra_arguments: Vec<&str>) {
-        prepare(location, files);
-
-        let mut base_args = vec!["index"];
-        base_args.extend(extra_arguments);
-
-        let mut cmd = Command::new(BINARY_LOCATION.to_str().unwrap());
-
-        cmd.args(base_args);
-
-        for (path, _) in files.iter() {
-            cmd.arg(path.to_str().unwrap());
-        }
-
-        cmd.current_dir(location);
-
-        cmd.assert().success();
-    }
-
-    fn write_file(path: &PathBuf, contents: &String) {
-        use std::io::Write;
-
-        let output = std::fs::File::create(path).unwrap();
-        let mut writer = std::io::BufWriter::new(output);
-        writer.write_all(contents.as_bytes()).unwrap();
     }
 }

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/tests/integration_test.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+use std::{env::temp_dir, path::PathBuf};
+
+use assert_cmd::cargo::cargo_bin;
+use assert_cmd::prelude::*;
+
+use scip_treesitter_cli::io::read_index_from_file;
+
+lazy_static::lazy_static! {
+    static ref BINARY_LOCATION: PathBuf = {
+        match std::env::var("SCIP_CLI_LOCATION") {
+            Ok(va) => std::env::current_dir().unwrap().join(va),
+            _ => cargo_bin("scip-treesitter-cli"),
+        }
+    };
+}
+
+use scip_treesitter::snapshot::{dump_document_with_config, EmitSymbol, SnapshotOptions};
+
+fn snapshot_syntax_document(doc: &scip::types::Document, source: &str) -> String {
+    dump_document_with_config(
+        doc,
+        source,
+        SnapshotOptions {
+            emit_symbol: EmitSymbol::All,
+            ..Default::default()
+        },
+    )
+    .expect("dump document")
+}
+
+#[test]
+fn java_e2e_indexing() {
+    let out_dir = temp_dir();
+    let setup = HashMap::from([(
+        PathBuf::from("globals.java"),
+        include_str!("../testdata/globals.java").to_string(),
+    )]);
+
+    run_index(&out_dir, &setup, vec!["--language", "java"]);
+
+    let index = read_index_from_file(out_dir.join("index.scip"));
+
+    for doc in &index.documents {
+        let path = &doc.relative_path;
+        let dumped = snapshot_syntax_document(doc, setup.get(&PathBuf::from(&path)).expect("??"));
+
+        insta::assert_snapshot!(path.clone(), dumped);
+    }
+}
+
+fn prepare(temp: &Path, files: &HashMap<PathBuf, String>) {
+    for (path, contents) in files.iter() {
+        let file_path = temp.join(path);
+        write_file(&file_path, contents);
+    }
+}
+
+fn run_index(location: &PathBuf, files: &HashMap<PathBuf, String>, extra_arguments: Vec<&str>) {
+    prepare(location, files);
+
+    let mut base_args = vec!["index"];
+    base_args.extend(extra_arguments);
+
+    let mut cmd = Command::new(BINARY_LOCATION.to_str().unwrap());
+
+    cmd.args(base_args);
+
+    for (path, _) in files.iter() {
+        cmd.arg(path.to_str().unwrap());
+    }
+
+    cmd.current_dir(location);
+
+    cmd.assert().success();
+}
+
+fn write_file(path: &PathBuf, contents: &String) {
+    use std::io::Write;
+
+    let output = std::fs::File::create(path).unwrap();
+    let mut writer = std::io::BufWriter::new(output);
+    writer.write_all(contents.as_bytes()).unwrap();
+}

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/tests/snapshots/integration_test__globals.java.snap
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/tests/snapshots/integration_test__globals.java.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/scip-treesitter-cli/src/main.rs
+source: crates/scip-treesitter-cli/tests/integration_test.rs
 expression: dumped
 ---
   package MyPackage;


### PR DESCRIPTION
So earlier, I removed the library part from the Bazel build configuration.

However, the correct build configuration actually involves moving the
integration test (which utilizes the `scip-treesitter-cli`) binary into
a separate integration test directory, since integration tests have
an implicit dependency on the binary, whereas unit tests don't.

https://users.rust-lang.org/t/cargo-how-do-i-make-a-integration-test-a-depend-on-binary-b/9821/4

So previously, `cargo test` wouldn't have worked anyways because
of this missed dependency. However `bazel test` was working
because Bazel allows customizing the dependency graph by
adding a dependency on the binary in a way that cargo doesn't.

Moreover, because the integration test utilizes a function
`read_index_from_file` from the code, we need that to live
inside a library. That's why I've re-added the library target
and `lib.rs`

With this patch, both `bazel test` and `cargo test` should work
correctly.

## Test plan

`bazel test` and `cargo test`