### PR TITLE
bzl: do not show full commmand line for ctags in dev

### DIFF
--- a/dev/universal-ctags-dev
+++ b/dev/universal-ctags-dev
@@ -5,4 +5,7 @@
 # To use your own `universal-ctags` binary instead of this wrapper in your local dev server, use
 # `CTAGS_COMMAND=path/to/ctags sg start`.
 
-bazel run //dev/tools:universal-ctags -- "$@"
+# We silence a few things, because the arguments that symbols pass to this script, which are then passed to
+# the bazel run are printed out again by Bazel by default. And they're very long, so much that it hads about
+# 40 lines, adding unecessary noise to the output of `sg start`
+bazel run //dev/tools:universal-ctags --logging=0 --noshow_progress --ui_event_filters=-info,-debug,-stdout -- "$@"


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/376

## Test plan

Locally ran `sg start` and the big block of output from universal-ctags-dev is not there anymore. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
