### PR TITLE
File tree: get rid of single child logic

### DIFF
--- a/client/shared/src/backend/repo.ts
+++ b/client/shared/src/backend/repo.ts
@@ -74,7 +74,7 @@ export const fetchTreeEntries = memoizeObservable(
                 fragment TreeFields on GitTree {
                     isRoot
                     url
-                    entries(first: $first, recursiveSingleChild: true) {
+                    entries(first: $first) {
                         ...TreeEntryFields
                     }
                 }
@@ -87,7 +87,6 @@ export const fetchTreeEntries = memoizeObservable(
                         url
                         commit
                     }
-                    isSingleChild
                 }
             `,
             variables: args,

--- a/client/web-sveltekit/src/lib/repo/api/tree.ts
+++ b/client/web-sveltekit/src/lib/repo/api/tree.ts
@@ -40,8 +40,7 @@ const treeEntriesQuery = gql`
             submodule {
                 commit
             }
-            isSingleChild
-            entries(first: $first, recursiveSingleChild: false) {
+            entries(first: $first) {
                 canonicalURL
                 name
                 path
@@ -49,7 +48,6 @@ const treeEntriesQuery = gql`
                 submodule {
                     commit
                 }
-                isSingleChild
             }
         }
     }
@@ -129,7 +127,7 @@ interface FileTreeProviderArgs {
 }
 
 export class FileTreeProvider implements TreeProvider<FileTreeNodeValue> {
-    constructor(private args: FileTreeProviderArgs) {}
+    constructor(private args: FileTreeProviderArgs) { }
 
     getRoot(): FileTreeNodeValue {
         return this.args.root

--- a/client/web-sveltekit/src/lib/repo/api/tree.ts
+++ b/client/web-sveltekit/src/lib/repo/api/tree.ts
@@ -127,7 +127,7 @@ interface FileTreeProviderArgs {
 }
 
 export class FileTreeProvider implements TreeProvider<FileTreeNodeValue> {
-    constructor(private args: FileTreeProviderArgs) { }
+    constructor(private args: FileTreeProviderArgs) {}
 
     getRoot(): FileTreeNodeValue {
         return this.args.root

--- a/client/web/src/integration/graphQlResponseHelpers.ts
+++ b/client/web/src/integration/graphQlResponseHelpers.ts
@@ -25,7 +25,6 @@ export const createTreeEntriesResult = (url: string, toplevelFiles: string[]): T
                     isDirectory: false,
                     url: `${url}/-/blob/${name}`,
                     submodule: null,
-                    isSingleChild: false,
                 })),
             },
         },

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -68,7 +68,7 @@ describe('Repository', () => {
     })
     after(() => driver?.close())
     let testContext: WebIntegrationTestContext
-    beforeEach(async function () {
+    beforeEach(async function() {
         testContext = await createWebIntegrationTestContext({
             driver,
             currentTest: this.currentTest!,
@@ -497,7 +497,6 @@ describe('Repository', () => {
                                     isDirectory: false,
                                     url: '/github.com/ggilmore/q-test/-/blob/Geoffrey%27s%20random%20queries.32r242442bf/%25%20token.4288249258.sql',
                                     submodule: null,
-                                    isSingleChild: false,
                                 },
                             ],
                         },

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -68,7 +68,7 @@ describe('Repository', () => {
     })
     after(() => driver?.close())
     let testContext: WebIntegrationTestContext
-    beforeEach(async function() {
+    beforeEach(async function () {
         testContext = await createWebIntegrationTestContext({
             driver,
             currentTest: this.currentTest!,

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -656,8 +656,7 @@ function nodeIsImmediateParentOf(nodeA: TreeNode, nodeB: TreeNode): boolean {
     if (nodeB.path === '') {
         return false
     }
-    let bParentPath = getParentPath(nodeB.path)
-    return nodeA.path === bParentPath
+    return nodeA.path === getParentPath(nodeB.path)
 }
 
 function isImmediateParentOf(fullPathA: string, fullPathB: string): boolean {

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -48,7 +48,7 @@ const QUERY = gql`
                 tree(path: $filePath) {
                     isRoot
                     url
-                    entries(first: $first, ancestors: $ancestors, recursiveSingleChild: true) {
+                    entries(first: $first, ancestors: $ancestors) {
                         name
                         path
                         isDirectory
@@ -57,7 +57,6 @@ const QUERY = gql`
                             url
                             commit
                         }
-                        isSingleChild
                     }
                 }
             }
@@ -486,11 +485,8 @@ type TreeNode = WildcardTreeNode & {
     entry: FileTreeEntry | null
     error: string | null
     dotdot: string | null
-
-    // In case of a single child expansion, this is the path that should be used
-    // when finding the right parent
-    singleChildParentPath: string | null
 }
+
 interface TreeData {
     // The flat nodes list used by react-accessible-treeview
     nodes: TreeNode[]
@@ -524,23 +520,6 @@ function appendTreeData(tree: TreeData, entries: FileTreeEntry[], rootTreeUrl: s
         insertRootNode(tree, rootTreeUrl)
     }
 
-    // Bookkeeping for single child expansion:
-    //
-    // - `singleChildFolderPath`: This is a list of all folder names that are
-    //   to be combined into the single child. This is needed to update the
-    //   parent name properly.
-    // - `singleChildParentPathForPath`: When set, this tuple is used to find
-    //   the parent for a single child substitution.
-    let singleChildFolderPath: string[] = []
-    let singleChildParentPathForPath:
-        | null
-        | [
-              // parent path to use for the next entries
-              string,
-              // entry parent path for which the substitution is valid
-              string
-          ] = null
-
     let siblingCount = 0
     for (let idx = 0; idx < entries.length; idx++) {
         const entry = entries[idx]
@@ -556,61 +535,9 @@ function appendTreeData(tree: TreeData, entries: FileTreeEntry[], rootTreeUrl: s
             siblingCount = 0
         }
 
-        // When entry.isSingleChild is true, it means that the entry is the only
-        // child of its parents.
-        //
-        // When we encounter such entries, we skip over them and instead update
-        // the respective parent when we finish the list. Since this child
-        // is already entered before, we need to update it.
-        //
-        // If we start the tree on a single child, we add the first entry to
-        // have a visible parent to append things to.
-        if (entry.isSingleChild && !(isNewTree && idx === 0)) {
-            if (singleChildParentPathForPath === null) {
-                singleChildParentPathForPath = [getParentPath(entry.path), entry.path]
-            } else {
-                singleChildParentPathForPath = [singleChildParentPathForPath[0], entry.path]
-            }
-            singleChildFolderPath.push(entry.name)
-
-            // Store the path id in our lookup map and point to the single child
-            // parent (where this path name will be appended to)
-            const parentId = tree.pathToId.get(singleChildParentPathForPath[0])
-            if (parentId) {
-                tree.pathToId.set(entry.path, parentId)
-            }
-
-            // Single child entries are not rendered, so we're skipping over
-            // them.
-            continue
-        }
-
-        // If we skipped over various single child entries, we need to find the
-        // parent and update it.
-        //
-        // This is only done for the first entry after a series of single child
-        // entries are skipped over.
-        if (singleChildFolderPath.length > 0 && singleChildParentPathForPath) {
-            const parentId = tree.pathToId.get(singleChildParentPathForPath[0])
-            if (parentId) {
-                const parent = tree.nodes[parentId]
-                tree.nodes[parentId] = {
-                    ...parent,
-                    name: parent.name + '/' + singleChildFolderPath.join('/'),
-                    entry: entries[idx - 1],
-                }
-            }
-            singleChildFolderPath = []
-        }
-
-        // Unset singleChildParentPathForPath when the parent path no longer matches
-        if (singleChildParentPathForPath !== null && singleChildParentPathForPath[1] !== getParentPath(entry.path)) {
-            singleChildParentPathForPath = null
-        }
-
         const id = tree.nodes.length
         const node: TreeNode = {
-            name: singleChildFolderPath.length > 0 ? `${singleChildFolderPath.join('/')}/${entry.name}` : entry.name,
+            name: entry.name,
             id,
             isBranch: entry.isDirectory,
             parent: 0,
@@ -619,7 +546,6 @@ function appendTreeData(tree: TreeData, entries: FileTreeEntry[], rootTreeUrl: s
             entry,
             error: null,
             dotdot: null,
-            singleChildParentPath: singleChildParentPathForPath ? singleChildParentPathForPath[0] : null,
         }
         appendNode(tree, node)
 
@@ -648,7 +574,6 @@ function appendTreeData(tree: TreeData, entries: FileTreeEntry[], rootTreeUrl: s
                 entry: null,
                 error: errorMessage,
                 dotdot: null,
-                singleChildParentPath: singleChildParentPathForPath ? singleChildParentPathForPath[0] : null,
             }
             appendNode(tree, node)
         }
@@ -668,7 +593,6 @@ function insertRootNode(tree: TreeData, rootTreeUrl: string): void {
         entry: null,
         error: null,
         dotdot: null,
-        singleChildParentPath: null,
     }
     tree.nodes.push(root)
     tree.pathToId.set(tree.rootPath, 0)
@@ -688,7 +612,6 @@ function insertRootNode(tree: TreeData, rootTreeUrl: string): void {
             entry: null,
             error: null,
             dotdot: dirname(rootTreeUrl),
-            singleChildParentPath: null,
         }
         appendNode(tree, node)
     }
@@ -734,9 +657,6 @@ function nodeIsImmediateParentOf(nodeA: TreeNode, nodeB: TreeNode): boolean {
         return false
     }
     let bParentPath = getParentPath(nodeB.path)
-    if (nodeB.singleChildParentPath !== null) {
-        bParentPath = nodeB.singleChildParentPath
-    }
     return nodeA.path === bParentPath
 }
 

--- a/client/web/src/repo/tree/TreePagePanels.tsx
+++ b/client/web/src/repo/tree/TreePagePanels.tsx
@@ -225,8 +225,8 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                     className={classNames(
                                         styles.sortDscIcon,
                                         sortColumn.column === 'Files' &&
-                                        sortColumn.direction === 'desc' &&
-                                        styles.sortSelectedIcon
+                                            sortColumn.direction === 'desc' &&
+                                            styles.sortSelectedIcon
                                     )}
                                 />
                                 <Icon
@@ -235,8 +235,8 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                     className={classNames(
                                         styles.sortAscIcon,
                                         sortColumn.column === 'Files' &&
-                                        sortColumn.direction === 'asc' &&
-                                        styles.sortSelectedIcon
+                                            sortColumn.direction === 'asc' &&
+                                            styles.sortSelectedIcon
                                     )}
                                 />
                             </div>
@@ -259,8 +259,8 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                     className={classNames(
                                         styles.sortDscIcon,
                                         sortColumn.column === 'Activity' &&
-                                        sortColumn.direction === 'desc' &&
-                                        styles.sortSelectedIcon
+                                            sortColumn.direction === 'desc' &&
+                                            styles.sortSelectedIcon
                                     )}
                                 />
                                 <Icon
@@ -269,8 +269,8 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                     className={classNames(
                                         styles.sortAscIcon,
                                         sortColumn.column === 'Activity' &&
-                                        sortColumn.direction === 'asc' &&
-                                        styles.sortSelectedIcon
+                                            sortColumn.direction === 'asc' &&
+                                            styles.sortSelectedIcon
                                     )}
                                 />
                             </div>

--- a/client/web/src/repo/tree/TreePagePanels.tsx
+++ b/client/web/src/repo/tree/TreePagePanels.tsx
@@ -1,10 +1,10 @@
-import React, { type FC, useCallback, useRef, useState, useMemo, useEffect } from 'react'
+import React, { type FC, useCallback, useRef, useState, useEffect } from 'react'
 
 import { mdiFileDocumentOutline, mdiFolderOutline, mdiMenuDown, mdiMenuUp } from '@mdi/js'
 import classNames from 'classnames'
 
 import { NoopEditor } from '@sourcegraph/cody-shared/dist/editor'
-import { basename, dirname } from '@sourcegraph/common'
+import { basename } from '@sourcegraph/common'
 import type { TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 import {
     Card,
@@ -122,49 +122,14 @@ export interface DiffStat {
 }
 
 export interface FilePanelProps {
-    entries: Pick<TreeFields['entries'][number], 'name' | 'url' | 'isDirectory' | 'path' | 'isSingleChild'>[]
+    entries: Pick<TreeFields['entries'][number], 'name' | 'url' | 'isDirectory' | 'path'>[]
     diffStats?: DiffStat[]
     className?: string
     filePath: string
 }
 
 export const FilesCard: FC<FilePanelProps> = props => {
-    const { entries, diffStats, className, filePath } = props
-
-    const entriesWithSingleChildExpanded = useMemo(
-        () =>
-            entries.flatMap((entry, index) => {
-                // The GraphQL query with "recurse single child" will return entries
-                // that are not in the current directory. We filter them out for the
-                // view here.
-                let parentDir = dirname(entry.path)
-                if (parentDir === '.') {
-                    parentDir = ''
-                }
-                if (parentDir !== filePath) {
-                    return []
-                }
-
-                // Single child nodes may be expanded so we can skip over them more
-                // efficiently.
-                if (entry.isSingleChild) {
-                    // Find the entry before the one that is no longer a single child
-                    // and add this to the list of entries to render instead of the
-                    // entry.
-                    let idx
-                    for (idx = index; idx < entries.length && entries[idx].isSingleChild; idx++) {
-                        // Do nothing
-                    }
-                    if (idx > index && idx < entries.length && idx > 1) {
-                        const lastSingleChild = entries[idx - 1]
-                        return [lastSingleChild]
-                    }
-                }
-
-                return [entry]
-            }),
-        [entries, filePath]
-    )
+    const { entries, diffStats, className } = props
 
     const [sortColumn, setSortColumn] = useState<{
         column: 'Files' | 'Activity'
@@ -182,17 +147,17 @@ export const FilesCard: FC<FilePanelProps> = props => {
         }
     }
 
-    let sortedEntries = [...entriesWithSingleChildExpanded]
+    let sortedEntries = [...entries]
     const { column, direction } = sortColumn
     switch (column) {
         case 'Files': {
             if (direction === 'desc') {
-                sortedEntries.reverse()
+                entries.reverse()
             }
             break
         }
         case 'Activity': {
-            sortedEntries = [...entriesWithSingleChildExpanded]
+            sortedEntries = [...entries]
             if (diffStats) {
                 sortedEntries.sort((entry1, entry2) => {
                     const stats1: DiffStat = diffStatsByPath[entry1.name]
@@ -260,8 +225,8 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                     className={classNames(
                                         styles.sortDscIcon,
                                         sortColumn.column === 'Files' &&
-                                            sortColumn.direction === 'desc' &&
-                                            styles.sortSelectedIcon
+                                        sortColumn.direction === 'desc' &&
+                                        styles.sortSelectedIcon
                                     )}
                                 />
                                 <Icon
@@ -270,8 +235,8 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                     className={classNames(
                                         styles.sortAscIcon,
                                         sortColumn.column === 'Files' &&
-                                            sortColumn.direction === 'asc' &&
-                                            styles.sortSelectedIcon
+                                        sortColumn.direction === 'asc' &&
+                                        styles.sortSelectedIcon
                                     )}
                                 />
                             </div>
@@ -294,8 +259,8 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                     className={classNames(
                                         styles.sortDscIcon,
                                         sortColumn.column === 'Activity' &&
-                                            sortColumn.direction === 'desc' &&
-                                            styles.sortSelectedIcon
+                                        sortColumn.direction === 'desc' &&
+                                        styles.sortSelectedIcon
                                     )}
                                 />
                                 <Icon
@@ -304,8 +269,8 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                     className={classNames(
                                         styles.sortAscIcon,
                                         sortColumn.column === 'Activity' &&
-                                            sortColumn.direction === 'asc' &&
-                                            styles.sortSelectedIcon
+                                        sortColumn.direction === 'asc' &&
+                                        styles.sortSelectedIcon
                                     )}
                                 />
                             </div>
@@ -344,9 +309,7 @@ export const FilesCard: FC<FilePanelProps> = props => {
                                             // In case of single child expansion, we need to get the name relative to
                                             // the start of the directory (to include subdirectories)
                                         }
-                                        {entry.isSingleChild && filePath !== ''
-                                            ? entry.path.slice(filePath.length + 1)
-                                            : entry.name}
+                                        {entry.name}
                                         {entry.isDirectory && '/'}
                                     </span>
                                 </div>


### PR DESCRIPTION
This PR removes the ability to collapse single-child directories. This feature has been pretty unstable and has been the source of quite a few bugs lately. Additionally, it's surprisingly expensive to implement, requiring fetching ton of extra data (the _entire_ recursive git tree) from gitserver, which adds significant latency to interactions with the file tree. Between the complexity, bugginess, and fundamental perf issues, I don't think it's worth keeping around. Especially since it's pretty rare for directories to contain only a single subdirectory. 

Before:
![CleanShot 2023-11-14 at 12 16 06@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/c76b951c-5607-4881-aba0-298219c3758c)

After:
![CleanShot 2023-11-10 at 13 11 50@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/228b8377-88c8-4d46-ad70-81f34dfbeec9)

There is a lot of very complex backend code that I will clean up as a followup. 

## Test plan

Tested that single-file directories now get rendered consistently.
