### PR TITLE
Code Navigation: add background inline code and code blocks

### DIFF
--- a/client/web/src/repo/blob/RenderedFile.module.scss
+++ b/client/web/src/repo/blob/RenderedFile.module.scss
@@ -13,4 +13,25 @@
         // maybe intentional, to get the h1 ruler all the way across?
         width: 100%;
     }
+
+    // Apply background styling to README <code> blocks
+    // to distinguish code snippets from body text.
+
+    // for inline code
+    code {
+        border-radius: var(--border-radius);
+        background-color: var(--subtle-bg);
+        padding-left: 0.25rem;
+        padding-right: 0.25rem;
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+
+    // for code blocks
+    pre code {
+        padding-left: 1.2rem;
+        padding-right: 1.2rem;
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+    }
 }


### PR DESCRIPTION
This commit introduces a minor enhancement by incorporating background colors for code snippets, both inline and block, during the rendering of markdown. This addition enhances the clarity of code sections, contributing to an improved overall viewing experience.

Loom video of changes: 
https://www.loom.com/share/d9228c8e4ae444e1ace5c13ad9bcda45?sid=57c09212-ab48-4dec-b0dd-54b83fa39c88

## Test plan
Manual testing in light and dark mode on many different repos. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
