### PR TITLE
dev/sg: build sg-msp with bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -301,3 +301,18 @@ exports_files([
     "CONTRIBUTING.md",
     ".swcrc",
 ])
+
+# sg msp settings
+
+bool_flag(
+    name = "sg_msp",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "sg_msp_flag",
+    flag_values = {
+        "//:sg_msp": "True",
+    },
+)

--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -127,6 +127,11 @@ go_library(
 go_binary(
     name = "sg",
     embed = [":sg_lib"],
+    # keep
+    gotags = select({
+        "//:sg_msp_flag": ["msp"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
     x_defs = {
         "github.com/sourcegraph/sourcegraph/internal/version.version": "{STABLE_VERSION}",


### PR DESCRIPTION
## Test plan

```sh
bazel build //dev/sg:sg --//:sg_msp=True
```

```sh
bazel run //dev/sg:sg --//:sg_msp=True -- msp help                                                            14:56:46
INFO: Analyzed target //dev/sg:sg (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //dev/sg:sg up-to-date:
  bazel-bin/dev/sg/sg_/sg
Aspect @rules_rust//rust/private:clippy.bzl%rust_clippy_aspect of //dev/sg:sg up-to-date (nothing to build)
INFO: Elapsed time: 0.317s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/dev/sg/sg_/sg msp help
NAME:
   sg managed-services-platform - EXPERIMENTAL: Generate and manage services deployed on the Sourcegraph Managed Services Platform

USAGE:

   # Create a service specification
   sg msp init $SERVICE

   # Provision Terraform Cloud workspaces
   sg msp tfc sync $SERVICE $ENVIRONMENT

   # Generate Terraform manifests
   sg msp generate $SERVICE $ENVIRONMENT


CATEGORY:
   2 - Company

DESCRIPTION:
   WARNING: This is currently still an experimental project.
   To learm more, refer to go/rfc-msp and go/msp (https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform)

   MSP commands are currently build-flagged to avoid increasing 'sg' binary sizes. To install a build of 'sg' that includes 'sg msp', run:

     go build -tags=msp -o=./sg ./dev/sg && ./sg install -f -p=false

   MSP commands should then be available under 'sg msp --help'.

OPTIONS:
   --help, -h  show help
```
