### PR TITLE
bzl: bump db schemas to 5.2.2

### DIFF
--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -194,5 +194,5 @@ new schemas to the bucket to ensure that the next release from `main`, i.e 5.3.X
 
 > How do I see which schemas where used to build the _migrator_ container.
 
-`tar tf $(bazel cquery //cmd/migrator:tar_schema_descriptions --output=files)` will show the content the container layer used
+`bazel build //cmd/migrator:tar_schema_descriptions && tar tf $(bazel cquery //cmd/migrator:tar_schema_descriptions --output=files)` will show the content the container layer used
 to inject the schemas in the final _migrator_ container image.

--- a/tools/release/schema_deps.bzl
+++ b/tools/release/schema_deps.bzl
@@ -8,6 +8,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def schema_deps():
     http_file(
         name = "schemas_archive",
-        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.2.1.tar.gz"],
-        sha256 = "3ec54f2d132ba5fc4f084f3bc76650f1c759ab32b5b73aba2ac9df91098ffeaf",
+        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.2.2.tar.gz"],
+        sha256 = "a60fb3311e164eb4b3061e56f5049c4b6324ccb1a301065b1c773b3dd04d2334",
     )


### PR DESCRIPTION
Update the database schema tarball so `main` includes 5.2.2 

## Test plan

CI 
`tar tf $(bazel cquery //cmd/migrator:tar_schema_descriptions --output=files)`

Spotted a missing file while doing the above, BRB fixing this. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
