### PR TITLE
Handle Existing Verified Email on Access Request Approval

### DIFF
--- a/client/web/src/site-admin/AccessRequestsPage/index.tsx
+++ b/client/web/src/site-admin/AccessRequestsPage/index.tsx
@@ -279,7 +279,7 @@ export const AccessRequestsPage: React.FunctionComponent = () => {
                 setLastApprovedUser({
                     username,
                     email,
-                    resetPasswordURL: data?.accessRequestCreateUser.resetPasswordURL,
+                    resetPasswordURL: data?.accessRequestCreateUser?.resetPasswordURL,
                 })
                 await refetch()
             }
@@ -320,6 +320,7 @@ export const AccessRequestsPage: React.FunctionComponent = () => {
                         email={lastApprovedUser.email}
                         username={lastApprovedUser.username}
                         resetPasswordURL={lastApprovedUser.resetPasswordURL}
+                        showEmail={true}
                     />
                 )}
                 <div className="d-flex align-items-start justify-content-between">

--- a/client/web/src/site-admin/AccessRequestsPage/index.tsx
+++ b/client/web/src/site-admin/AccessRequestsPage/index.tsx
@@ -279,7 +279,7 @@ export const AccessRequestsPage: React.FunctionComponent = () => {
                 setLastApprovedUser({
                     username,
                     email,
-                    resetPasswordURL: data?.createUser.resetPasswordURL,
+                    resetPasswordURL: data?.accessRequestCreateUser.resetPasswordURL,
                 })
                 await refetch()
             }

--- a/client/web/src/site-admin/AccessRequestsPage/queries.tsx
+++ b/client/web/src/site-admin/AccessRequestsPage/queries.tsx
@@ -86,7 +86,7 @@ export const APPROVE_ACCESS_REQUEST = gql`
  */
 export const ACCESS_REQUEST_CREATE_USER = gql`
     mutation AccessRequestCreateUser($username: String!, $email: String) {
-        createUser(username: $username, email: $email, verifiedEmail: false) {
+        accessRequestCreateUser(username: $username, email: $email, verifiedEmail: false) {
             resetPasswordURL
         }
     }

--- a/client/web/src/site-admin/components/AccountCreatedAlert.tsx
+++ b/client/web/src/site-admin/components/AccountCreatedAlert.tsx
@@ -8,6 +8,7 @@ interface AccountCreatedAlertProps {
     username: string
     email?: string
     resetPasswordURL?: string | null
+    showEmail?: boolean | null
 }
 
 /**
@@ -21,10 +22,11 @@ export const AccountCreatedAlert: React.FunctionComponent<React.PropsWithChildre
     email,
     resetPasswordURL,
     children,
+    showEmail,
 }) => (
     <Alert variant="success">
         <Text>
-            Account created for <Link to={`/users/${username}`}>{username}</Link>.
+            {showEmail ? <>Account created for {email}.</> : <>Account created for <Link to={`/users/${username}`}>{username}</Link>.</>}
         </Text>
         <Text>
             {resetPasswordURL

--- a/cmd/frontend/graphqlbackend/access_requests.go
+++ b/cmd/frontend/graphqlbackend/access_requests.go
@@ -175,3 +175,29 @@ func unmarshalAccessRequestID(id graphql.ID) (userID int32, err error) {
 	err = relay.UnmarshalSpec(id, &userID)
 	return
 }
+
+func (r *schemaResolver) AccessRequestCreateUser(ctx context.Context, args *struct {
+	Username      string
+	Email         *string
+	VerifiedEmail *bool
+}) (*createUserResult, error) {
+
+	newResult, err := r.CreateUser(ctx, &struct {
+		Username      string
+		Email         *string
+		VerifiedEmail *bool
+	}{
+		Username:      args.Username,
+		Email:         args.Email,
+		VerifiedEmail: args.VerifiedEmail,
+	})
+
+	if err != nil {
+		if database.IsEmailExists(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return newResult, err
+}

--- a/cmd/frontend/graphqlbackend/access_requests.go
+++ b/cmd/frontend/graphqlbackend/access_requests.go
@@ -182,7 +182,7 @@ func (r *schemaResolver) AccessRequestCreateUser(ctx context.Context, args *stru
 	VerifiedEmail *bool
 }) (*createUserResult, error) {
 
-	newResult, err := r.CreateUser(ctx, &struct {
+	newUser, err := r.CreateUser(ctx, &struct {
 		Username      string
 		Email         *string
 		VerifiedEmail *bool
@@ -199,5 +199,5 @@ func (r *schemaResolver) AccessRequestCreateUser(ctx context.Context, args *stru
 		return nil, err
 	}
 
-	return newResult, err
+	return newUser, err
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -207,6 +207,25 @@ type Mutation {
     """
     Randomize a user's password so that they need to reset it before they can sign in again.
 
+    """
+    accessRequestCreateUser(
+        """
+        The new user's username.
+        """
+        username: String!
+        """
+        The new user's optional email address. If given, it must be verified by the user.
+        """
+        email: String
+        """
+        Whether or not to mark the provided email address as verified. If unset or set to
+        true, then the email address is immediately marked as verified - otherwise, the
+        email may be marked as unverified if SMTP and password resets are enabled.
+        """
+        verifiedEmail: Boolean
+    ): CreateUserResult!
+    """
+
     Only site admins may perform this mutation.
     """
     # 🚧 CLOUD: This mutation is used by Cloud automation - please do not

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -223,7 +223,7 @@ type Mutation {
         email may be marked as unverified if SMTP and password resets are enabled.
         """
         verifiedEmail: Boolean
-    ): CreateUserResult!
+    ): CreateUserResult
     """
 
     Only site admins may perform this mutation.


### PR DESCRIPTION

Fixes https://github.com/sourcegraph/sourcegraph/issues/58064

This PR introduces a new workflow for approving access requests involving an existing verified email. Previously, admins encountered an error when they attempted to approve an access request for a user whose email was already verified. 

- The approval now invokes accessRequestCreateUser to handle scenarios where the user might already exist in the system.
-  The access request is marked as approved without creating a duplicate user.
- Rather than displaying a link to a new account, the system will display the user's email with the approved message.


Before:

https://github.com/sourcegraph/sourcegraph/assets/69164745/5dfd4809-754a-448e-a8ef-02b9616d141e

After:

https://github.com/sourcegraph/sourcegraph/assets/69164745/6ced2f7e-2ebc-46b6-b5cd-f0d4edcf70f9

## Test plan
locally tested
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
