### PR TITLE
client: Simplify some code in useCodeIntel.ts

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -263,12 +263,8 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
             // change. This way we avoid showing stale results.
             key={shouldMixPreciseAndSearchBasedReferences.toString()}
             {...props}
-            token={props.token}
             searchToken={tokenResult?.searchToken}
             spec={spec}
-            fileContent={props.fileContent}
-            isFork={props.isFork}
-            isArchived={props.isArchived}
         />
     )
 }


### PR DESCRIPTION
Instead of having calls to `setCodeIntelData` scattered in different places,
this patch makes things a bit simpler -- we only call it at the end of having
processed the result of a query.

Stacked on top of #58183, to be merged after that.

## Test plan

Manually tested with `sg start web-standalone`