### PR TITLE
buildtracker: replace "Is this a flake" with "View test analytics"

### DIFF
--- a/dev/build-tracker/notify/slack.go
+++ b/dev/build-tracker/notify/slack.go
@@ -285,8 +285,8 @@ func (c *Client) createMessageBlocks(info *BuildNotification, author string) []s
 				},
 				&slack.ButtonBlockElement{
 					Type: slack.METButton,
-					URL:  "https://www.loom.com/share/58cedf44d44c45a292f650ddd3547337",
-					Text: &slack.TextBlockObject{Type: slack.PlainTextType, Text: "Is this a flake?"},
+					URL:  "https://buildkite.com/organizations/sourcegraph/analytics/suites/sourcegraph-bazel?branch=main",
+					Text: &slack.TextBlockObject{Type: slack.PlainTextType, Text: "View test analytics"},
 				},
 			}...,
 		),


### PR DESCRIPTION
The loom referenced in "Is this a flake?" is not relevant anymore and by adding this to the notification we can get more people to look at the test analytics.

> [!NOTE]
> We can't (more like it's too much effort now ...) provide a direct link to the builds test analytics run as the test analytics run ID is not exposed anywhere in the build events that we get from buildkite 
## Test plan
None - only a text change for the link

