### PR TITLE
Add secondary telemetry to Web: Notebooks

### DIFF
--- a/client/branded/src/search-ui/components/CopyPathAction.tsx
+++ b/client/branded/src/search-ui/components/CopyPathAction.tsx
@@ -4,6 +4,7 @@ import { mdiContentCopy } from '@mdi/js'
 import classNames from 'classnames'
 import copy from 'copy-to-clipboard'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
 
@@ -16,13 +17,15 @@ export const CopyPathAction: React.FunctionComponent<
     {
         filePath: string
         className?: string
-    } & TelemetryProps
-> = ({ filePath, className, telemetryService }) => {
+    } & TelemetryProps &
+        TelemetryV2Props
+> = ({ filePath, className, telemetryService, telemetryRecorder }) => {
     const [copied, setCopied] = useState(false)
 
     const onClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
         event.preventDefault()
         telemetryService.log('CopyFilePath')
+        telemetryRecorder.recordEvent('CopyFilePath', 'copied')
         copy(filePath)
         setCopied(true)
         screenReaderAnnounce('Path copied to clipboard')

--- a/client/branded/src/search-ui/components/FileContentSearchResult.test.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.test.tsx
@@ -6,6 +6,7 @@ import { afterAll, describe, expect, it } from 'vitest'
 
 import type { ContentMatch } from '@sourcegraph/shared/src/search/stream'
 import type { SettingsCascade } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     HIGHLIGHTED_FILE_LINES_REQUEST,
@@ -37,7 +38,9 @@ describe('FileContentSearchResult', () => {
     }
 
     it('renders one result container', () => {
-        const { container } = renderWithBrandedContext(<FileContentSearchResult {...defaultProps} />)
+        const { container } = renderWithBrandedContext(
+            <FileContentSearchResult {...defaultProps} telemetryRecorder={noOpTelemetryRecorder} />
+        )
         expect(getByTestId(container, 'result-container')).toBeVisible()
         expect(getAllByTestId(container, 'result-container').length).toBe(1)
     })
@@ -92,7 +95,12 @@ describe('FileContentSearchResult', () => {
         } satisfies SettingsCascade
 
         const { container } = renderWithBrandedContext(
-            <FileContentSearchResult {...defaultProps} result={result} settingsCascade={settingsCascade} />
+            <FileContentSearchResult
+                {...defaultProps}
+                result={result}
+                settingsCascade={settingsCascade}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
         )
         const tableRows = container.querySelectorAll('[data-testid="code-excerpt"] tr')
         expect(tableRows.length).toBe(4)

--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -18,6 +18,7 @@ import {
     getRevision,
 } from '@sourcegraph/shared/src/search/stream'
 import { isSettingsValid, type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Icon, Badge } from '@sourcegraph/wildcard'
 
@@ -29,7 +30,7 @@ import { ResultContainer } from './ResultContainer'
 import resultContainerStyles from './ResultContainer.module.scss'
 import styles from './SearchResult.module.scss'
 
-interface Props extends SettingsCascadeProps, TelemetryProps {
+interface Props extends SettingsCascadeProps, TelemetryProps, TelemetryV2Props {
     location: H.Location
     /**
      * The file match search result.
@@ -91,6 +92,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
     showAllMatches,
     openInNewTab,
     telemetryService,
+    telemetryRecorder,
     fetchHighlightedFileLineRanges,
     onSelect,
 }) => {
@@ -220,6 +222,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
                     className={styles.copyButton}
                     filePath={result.path}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             </span>
             {description && <span className={classNames('ml-2', styles.headerDescription)}>{description}</span>}

--- a/client/branded/src/search-ui/components/FilePathSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FilePathSearchResult.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { getFileMatchUrl, getRepositoryUrl, getRevision, type PathMatch } from '@sourcegraph/shared/src/search/stream'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { CopyPathAction } from './CopyPathAction'
@@ -19,14 +20,9 @@ export interface FilePathSearchResult {
     index: number
 }
 
-export const FilePathSearchResult: React.FunctionComponent<FilePathSearchResult & TelemetryProps> = ({
-    result,
-    repoDisplayName,
-    onSelect,
-    containerClassName,
-    index,
-    telemetryService,
-}) => {
+export const FilePathSearchResult: React.FunctionComponent<
+    FilePathSearchResult & TelemetryProps & TelemetryV2Props
+> = ({ result, repoDisplayName, onSelect, containerClassName, index, telemetryService, telemetryRecorder }) => {
     const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
     const revisionDisplayName = getRevision(result.branches, result.commit)
 
@@ -46,7 +42,12 @@ export const FilePathSearchResult: React.FunctionComponent<FilePathSearchResult 
                 className={styles.titleInner}
                 isKeyboardSelectable={true}
             />
-            <CopyPathAction filePath={result.path} className={styles.copyButton} telemetryService={telemetryService} />
+            <CopyPathAction
+                filePath={result.path}
+                className={styles.copyButton}
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+            />
         </span>
     )
 

--- a/client/branded/src/search-ui/components/OwnerSearchResult.tsx
+++ b/client/branded/src/search-ui/components/OwnerSearchResult.tsx
@@ -8,6 +8,7 @@ import type { BuildSearchQueryURLParameters, QueryState, SearchContextProps } fr
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import { appendFilter, omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { getOwnerMatchUrl, type OwnerMatch } from '@sourcegraph/shared/src/search/stream'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link } from '@sourcegraph/wildcard'
 
@@ -16,7 +17,10 @@ import { ResultContainer } from './ResultContainer'
 import styles from './OwnerSearchResult.module.scss'
 import resultStyles from './SearchResult.module.scss'
 
-export interface OwnerSearchResultProps extends Pick<SearchContextProps, 'selectedSearchContextSpec'>, TelemetryProps {
+export interface OwnerSearchResultProps
+    extends Pick<SearchContextProps, 'selectedSearchContextSpec'>,
+        TelemetryProps,
+        TelemetryV2Props {
     result: OwnerMatch
     onSelect: () => void
     containerClassName?: string
@@ -38,6 +42,7 @@ export const OwnerSearchResult: React.FunctionComponent<OwnerSearchResultProps> 
     buildSearchURLQueryFromQueryState,
     selectedSearchContextSpec,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const displayName = useMemo(() => {
         let displayName = ''
@@ -95,12 +100,15 @@ export const OwnerSearchResult: React.FunctionComponent<OwnerSearchResultProps> 
     const logSearchOwnerClicked = (): void => {
         if (url.startsWith('mailto:')) {
             telemetryService.log('searchResults:ownershipMailto:clicked')
+            telemetryRecorder.recordEvent('searchResults.ownershipMailto', 'clicked')
         }
         if (url.startsWith('/users/')) {
             telemetryService.log('searchResults:ownershipUsers:clicked')
+            telemetryRecorder.recordEvent('searchResults.ownershipUsers', 'clicked')
         }
         if (url.startsWith('/teams/')) {
             telemetryService.log('searchResults:ownershipTeams:clicked')
+            telemetryRecorder.recordEvent('searchResults.ownershipTeams', 'clicked')
         }
     }
 

--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -30,8 +30,8 @@ export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
 
     const onQueryExampleClick = useCallback(
         (query: string) => {
-            telemetryService.log('QueryExampleClicked', { queryExample: query }, { queryExample: query }),
-                telemetryRecorder.recordEvent('QueryExample', 'clicked', { privateMetadata: { queryExample: query } })
+            telemetryService.log('QueryExampleClicked', { queryExample: query }, { queryExample: query })
+            telemetryRecorder.recordEvent('QueryExample', 'clicked', { privateMetadata: { queryExample: query } })
         },
         [telemetryService, telemetryRecorder]
     )

--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -4,6 +4,7 @@ import { mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { H2, Link, Icon, Tabs, TabList, TabPanels, TabPanel, Tab, ButtonLink } from '@sourcegraph/wildcard'
@@ -14,7 +15,7 @@ import { useQueryExamples, type QueryExamplesSection } from './useQueryExamples'
 
 import styles from './QueryExamples.module.scss'
 
-export interface QueryExamplesProps extends TelemetryProps {
+export interface QueryExamplesProps extends TelemetryProps, TelemetryV2Props {
     selectedSearchContextSpec?: string
     isSourcegraphDotCom?: boolean
 }
@@ -22,15 +23,17 @@ export interface QueryExamplesProps extends TelemetryProps {
 export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
     selectedSearchContextSpec,
     telemetryService,
+    telemetryRecorder,
     isSourcegraphDotCom = false,
 }) => {
     const exampleSyntaxColumns = useQueryExamples(selectedSearchContextSpec ?? 'global', isSourcegraphDotCom)
 
     const onQueryExampleClick = useCallback(
         (query: string) => {
-            telemetryService.log('QueryExampleClicked', { queryExample: query }, { queryExample: query })
+            telemetryService.log('QueryExampleClicked', { queryExample: query }, { queryExample: query }),
+                telemetryRecorder.recordEvent('QueryExample', 'clicked', { privateMetadata: { queryExample: query } })
         },
-        [telemetryService]
+        [telemetryService, telemetryRecorder]
     )
 
     return isSourcegraphDotCom ? (

--- a/client/branded/src/search-ui/components/SymbolSearchResult.tsx
+++ b/client/branded/src/search-ui/components/SymbolSearchResult.tsx
@@ -10,6 +10,7 @@ import { type HighlightLineRange, HighlightResponseFormat } from '@sourcegraph/s
 import { getFileMatchUrl, getRepositoryUrl, getRevision, type SymbolMatch } from '@sourcegraph/shared/src/search/stream'
 import { isSettingsValid, type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 
@@ -22,7 +23,7 @@ import { ResultContainer } from './ResultContainer'
 import searchResultStyles from './SearchResult.module.scss'
 import styles from './SymbolSearchResult.module.scss'
 
-export interface SymbolSearchResultProps extends TelemetryProps, SettingsCascadeProps {
+export interface SymbolSearchResultProps extends TelemetryProps, TelemetryV2Props, SettingsCascadeProps {
     result: SymbolMatch
     openInNewTab?: boolean
     repoDisplayName: string
@@ -40,6 +41,7 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
     containerClassName,
     index,
     telemetryService,
+    telemetryRecorder,
     settingsCascade,
     fetchHighlightedFileLineRanges,
 }) => {
@@ -68,6 +70,7 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
                 filePath={result.path}
                 className={searchResultStyles.copyButton}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
         </span>
     )
@@ -106,13 +109,16 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
                         { durationMs: endTime - startTime },
                         { durationMs: endTime - startTime }
                     )
+                    telemetryRecorder.recordEvent('search.latencies.frontend.code-load', 'loaded', {
+                        metadata: { durationMs: endTime - startTime },
+                    })
                     return lines[
                         result.symbols.findIndex(symbol => symbol.line - 1 === startLine && symbol.line === endLine)
                     ]
                 })
             )
         },
-        [result, fetchHighlightedFileLineRanges, telemetryService]
+        [result, fetchHighlightedFileLineRanges, telemetryService, telemetryRecorder]
     )
 
     const fetchHighlightedSymbolMatchLineRanges = useCallback(

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -24,6 +24,7 @@ import {
     type SearchMatch,
 } from '@sourcegraph/shared/src/search/stream'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { CommitSearchResult } from '../components/CommitSearchResult'
@@ -44,6 +45,7 @@ import styles from './StreamingSearchResultsList.module.scss'
 export interface StreamingSearchResultsListProps
     extends SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         PlatformContextProps<'requestGraphQL'> {
     isSourcegraphDotCom: boolean
@@ -105,6 +107,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     fetchHighlightedFileLineRanges,
     settingsCascade,
     telemetryService,
+    telemetryRecorder,
     isSourcegraphDotCom,
     searchContextsEnabled,
     platformContext,
@@ -156,6 +159,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                         index={index}
                                         location={location}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                         result={result}
                                         onSelect={() => logSearchResultClicked?.(index, 'fileMatch')}
                                         defaultExpanded={false}
@@ -172,6 +176,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                     <SymbolSearchResult
                                         index={index}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                         result={result}
                                         onSelect={() => logSearchResultClicked?.(index, 'symbolMatch')}
                                         fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
@@ -189,6 +194,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                         repoDisplayName={displayRepoName(result.repository)}
                                         containerClassName={resultClassName}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                     />
                                 )}
                             </PrefetchableFile>
@@ -231,6 +237,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                 onSelect={() => logSearchResultClicked?.(index, 'person')}
                                 containerClassName={resultClassName}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 queryState={queryState}
                                 buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
                             />
@@ -256,6 +263,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             prefetchFile,
             location,
             telemetryService,
+            telemetryRecorder,
             allExpanded,
             fetchHighlightedFileLineRanges,
             settingsCascade,
@@ -304,6 +312,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                 searchContextsEnabled={searchContextsEnabled}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 showSearchContext={searchContextsEnabled}
                                 showQueryExamples={showQueryExamplesOnNoResultsPage}
                                 setQueryState={setQueryState}

--- a/client/web/dev/BUILD.bazel
+++ b/client/web/dev/BUILD.bazel
@@ -57,6 +57,7 @@ ts_project(
         "//:node_modules/lodash",
         "//:node_modules/signale",
         "//client/web:node_modules/@sourcegraph/build-config",
+        "//client/web:node_modules/@sourcegraph/shared",
         "//client/web:web_lib",
     ],
 )

--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -1,3 +1,5 @@
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import type { SourcegraphContext } from '../../src/jscontext'
 
 import { ENVIRONMENT_CONFIG } from './environment-config'
@@ -76,6 +78,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         },
         embeddingsEnabled: false,
         primaryLoginProvidersCount: 5,
+        telemetryRecorder: noOpTelemetryRecorder,
         // Site-config overrides default JS context
         ...siteConfig,
     }

--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -307,6 +307,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                     isRepositoryRelatedPage={isRepositoryRelatedPage}
                     settingsCascade={props.settingsCascade}
                     telemetryService={props.telemetryService}
+                    telemetryRecorder={props.telemetryRecorder}
                     location={location}
                     userHistory={userHistory}
                 />

--- a/client/web/src/LegacyRouteContext.tsx
+++ b/client/web/src/LegacyRouteContext.tsx
@@ -17,6 +17,7 @@ import {
     type SearchContextProps,
 } from '@sourcegraph/shared/src/search'
 import { aggregateStreamingSearch } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { isBatchChangesExecutionEnabled } from './batches'
@@ -54,6 +55,7 @@ export interface LegacyRouteComputedContext {
  */
 export interface LegacyRouteStaticInjections
     extends Pick<TelemetryProps, 'telemetryService'>,
+        Pick<TelemetryV2Props, 'telemetryRecorder'>,
         Pick<
             SearchContextProps,
             | 'getUserSearchContextNamespaces'
@@ -144,6 +146,7 @@ export const LegacyRouteContextProvider: FC<PropsWithChildren<LegacyRouteContext
         streamSearch: aggregateStreamingSearch,
         fetchHighlightedFileLineRanges: _fetchHighlightedFileLineRanges,
         telemetryService: eventLogger,
+        telemetryRecorder: platformContext.telemetryRecorder,
 
         /**
          * Breadcrumb props

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -237,6 +237,7 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
                             batchChangesWebhookLogsEnabled={window.context.batchChangesWebhookLogsEnabled}
                             fetchHighlightedFileLineRanges={this.fetchHighlightedFileLineRanges}
                             telemetryService={eventLogger}
+                            telemetryRecorder={window.context.telemetryRecorder}
                             isSourcegraphDotCom={window.context.sourcegraphDotComMode}
                             isCodyApp={window.context.codyAppMode}
                             isSearchContextSpecAvailable={isSearchContextSpecAvailable}

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
@@ -4,6 +4,7 @@ import * as H from 'history'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import type { Settings } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import {
@@ -41,6 +42,7 @@ export const FuzzyWrapper: React.FunctionComponent<FuzzyWrapperProps> = props =>
             location={history.location}
             settingsCascade={{ final: { experimentalFeatures: props.experimentalFeatures }, subjects: null }}
             telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
             initialQuery={props.initialQuery}
             userHistory={new UserHistory()}
         />

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -4,6 +4,7 @@ import type * as H from 'history'
 
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { FuzzyModal } from './FuzzyModal'
@@ -14,6 +15,7 @@ const DEFAULT_MAX_RESULTS = 50
 
 export interface FuzzyFinderContainerProps
     extends TelemetryProps,
+        TelemetryV2Props,
         Pick<FuzzyFinderProps, 'location'>,
         SettingsCascadeProps,
         FuzzyTabsProps {
@@ -84,15 +86,19 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
     useEffect(() => {
         if (isVisible) {
             props.telemetryService.log('FuzzyFinderViewed', { action: 'shortcut open' })
+            props.telemetryRecorder.recordEvent('FuzzyFinderViewed', 'clicked', {
+                privateMetadata: { action: 'shortcut open' },
+            })
         }
-    }, [props.telemetryService, isVisible])
+    }, [props.telemetryService, props.telemetryRecorder, isVisible])
 
     const handleItemClick = useCallback(
         (eventName: 'FuzzyFinderResultClicked' | 'FuzzyFinderGoToResultsPageClicked') => {
             props.telemetryService.log(eventName, { activeTab, scope }, { activeTab, scope })
+            props.telemetryRecorder.recordEvent(eventName, 'clicked', { privateMetadata: { activeTab, scope } })
             setIsVisible(false)
         },
-        [props.telemetryService, setIsVisible, activeTab, scope]
+        [props.telemetryService, props.telemetryRecorder, setIsVisible, activeTab, scope]
     )
 
     if (tabs.isAllDisabled()) {

--- a/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
+++ b/client/web/src/enterprise/embed/EmbeddedWebApp.tsx
@@ -103,6 +103,7 @@ export const EmbeddedWebApp: FC<Props> = ({ graphqlClient }) => {
                                                 authenticatedUser={null}
                                                 settingsCascade={EMPTY_SETTINGS_CASCADE}
                                                 platformContext={platformContext}
+                                                telemetryRecorder={window.context.telemetryRecorder}
                                             />
                                         }
                                     />

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -1,5 +1,6 @@
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { SiteConfiguration } from '@sourcegraph/shared/src/schema/site.schema'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { BatchChangesLicenseInfo } from '@sourcegraph/shared/src/testing/batches'
 
 import type { TemporarySettingsResult } from './graphql-operations'
@@ -73,7 +74,9 @@ export type SourcegraphContextTemporarySettings = Pick<
     '__typename' | 'contents'
 >
 
-export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'experimentalFeatures'> {
+export interface SourcegraphContext
+    extends Pick<Required<SiteConfiguration>, 'experimentalFeatures'>,
+        TelemetryV2Props {
     xhrHeaders: { [key: string]: string }
     userAgentIsBot: boolean
 

--- a/client/web/src/notebooks/GlobalNotebooksArea.tsx
+++ b/client/web/src/notebooks/GlobalNotebooksArea.tsx
@@ -7,6 +7,7 @@ import type { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -23,6 +24,7 @@ const NotebooksListPage = lazyComponent(() => import('./listPage/NotebooksListPa
 
 export interface GlobalNotebooksAreaProps
     extends TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps,
         SettingsCascadeProps,
         NotebookProps,

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
@@ -9,6 +9,7 @@ import { startWith } from 'rxjs/operators'
 import { CodeExcerpt } from '@sourcegraph/branded'
 import { isErrorLike } from '@sourcegraph/common'
 import { getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
@@ -28,7 +29,7 @@ import { NotebookFileBlockInputs } from './NotebookFileBlockInputs'
 
 import styles from './NotebookFileBlock.module.scss'
 
-interface NotebookFileBlockProps extends BlockProps<FileBlock>, TelemetryProps {
+interface NotebookFileBlockProps extends BlockProps<FileBlock>, TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
 }
 
@@ -40,6 +41,7 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
         input,
         output,
         telemetryService,
+        telemetryRecorder,
         isSelected,
         showMenu,
         isReadOnly,
@@ -154,7 +156,8 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
 
         const logEventOnCopy = useCallback(() => {
             telemetryService.log(...codeCopiedEvent('notebook-file-block'))
-        }, [telemetryService])
+            telemetryRecorder.recordEvent('NotebookFileBlock', 'copied')
+        }, [telemetryService, telemetryRecorder])
 
         return (
             <NotebookBlock

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -12,6 +12,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner, useObservable, Icon } from '@sourcegraph/wildcard'
@@ -35,6 +36,7 @@ interface NotebookQueryBlockProps
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
     isSourcegraphDotCom: boolean
@@ -59,6 +61,7 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
         input,
         output,
         telemetryService,
+        telemetryRecorder,
         settingsCascade,
         isSelected,
         onBlockInputChange,
@@ -194,6 +197,7 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
                                 results={searchResults}
                                 fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 settingsCascade={settingsCascade}
                                 platformContext={props.platformContext}
                                 openMatchesInNewTab={true}

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
@@ -12,6 +12,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import { getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
@@ -32,6 +33,7 @@ import styles from './NotebookSymbolBlock.module.scss'
 interface NotebookSymbolBlockProps
     extends BlockProps<SymbolBlock>,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings'> {
     isSourcegraphDotCom: boolean
 }
@@ -51,6 +53,7 @@ export const NotebookSymbolBlock: React.FunctionComponent<React.PropsWithChildre
             input,
             output,
             telemetryService,
+            telemetryRecorder,
             isSelected,
             showMenu,
             isReadOnly,
@@ -139,7 +142,8 @@ export const NotebookSymbolBlock: React.FunctionComponent<React.PropsWithChildre
 
             const logEventOnCopy = useCallback(() => {
                 telemetryService.log(...codeCopiedEvent('notebook-symbols'))
-            }, [telemetryService])
+                telemetryRecorder.recordEvent('NotebookSymbol', 'copied')
+            }, [telemetryService, telemetryRecorder])
 
             return (
                 <NotebookBlock

--- a/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
+++ b/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
@@ -4,6 +4,7 @@ import { Navigate } from 'react-router-dom'
 import { catchError, startWith } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable, Alert } from '@sourcegraph/wildcard'
 
@@ -15,8 +16,8 @@ import { createNotebook } from '../backend'
 const LOADING = 'loading' as const
 
 export const CreateNotebookPage: React.FunctionComponent<
-    React.PropsWithChildren<TelemetryProps & { authenticatedUser: AuthenticatedUser }>
-> = ({ telemetryService, authenticatedUser }) => {
+    React.PropsWithChildren<TelemetryProps & TelemetryV2Props & { authenticatedUser: AuthenticatedUser }>
+> = ({ telemetryService, telemetryRecorder, authenticatedUser }) => {
     const notebookOrError = useObservable(
         useMemo(
             () =>
@@ -32,6 +33,7 @@ export const CreateNotebookPage: React.FunctionComponent<
 
     if (notebookOrError && !isErrorLike(notebookOrError) && notebookOrError !== LOADING) {
         telemetryService.log('SearchNotebookCreated')
+        telemetryRecorder.recordEvent('SearchNotebook', 'created')
         return <Navigate to={PageRoutes.Notebook.replace(':id', notebookOrError.id)} replace={true} />
     }
 

--- a/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
@@ -16,7 +17,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 
 import styles from './NotebooksGettingStartedTab.module.scss'
 
-interface NotebooksGettingStartedTabProps extends TelemetryProps {
+interface NotebooksGettingStartedTabProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 
@@ -55,8 +56,11 @@ const functionalityPanels = [
 
 export const NotebooksGettingStartedTab: React.FunctionComponent<
     React.PropsWithChildren<NotebooksGettingStartedTabProps>
-> = ({ telemetryService, authenticatedUser }) => {
-    useEffect(() => telemetryService.log('NotebooksGettingStartedTabViewed'), [telemetryService])
+> = ({ telemetryService, telemetryRecorder, authenticatedUser }) => {
+    useEffect(() => {
+        telemetryService.log('NotebooksGettingStartedTabViewed'),
+            telemetryRecorder.recordEvent('NotebooksGettingStartedTab', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const [, setHasSeenGettingStartedTab] = useTemporarySetting('search.notebooks.gettingStartedTabSeen', false)
     const isSourcegraphDotCom: boolean = window.context?.sourcegraphDotComMode || false

--- a/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
@@ -58,8 +58,8 @@ export const NotebooksGettingStartedTab: React.FunctionComponent<
     React.PropsWithChildren<NotebooksGettingStartedTabProps>
 > = ({ telemetryService, telemetryRecorder, authenticatedUser }) => {
     useEffect(() => {
-        telemetryService.log('NotebooksGettingStartedTabViewed'),
-            telemetryRecorder.recordEvent('NotebooksGettingStartedTab', 'viewed')
+        telemetryService.log('NotebooksGettingStartedTabViewed')
+        telemetryRecorder.recordEvent('NotebooksGettingStartedTab', 'viewed')
     }, [telemetryService, telemetryRecorder])
 
     const [, setHasSeenGettingStartedTab] = useTemporarySetting('search.notebooks.gettingStartedTabSeen', false)

--- a/client/web/src/notebooks/listPage/NotebooksList.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksList.tsx
@@ -1,5 +1,6 @@
 import { type FC, useCallback, useEffect } from 'react'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { H2 } from '@sourcegraph/wildcard'
 
@@ -16,7 +17,7 @@ import { NotebookNode, type NotebookNodeProps } from './NotebookNode'
 
 import styles from './NotebooksList.module.scss'
 
-export interface NotebooksListProps extends TelemetryProps {
+export interface NotebooksListProps extends TelemetryProps, TelemetryV2Props {
     title: string
     logEventName: string
     orderOptions: FilteredConnectionFilter[]
@@ -35,11 +36,12 @@ export const NotebooksList: FC<NotebooksListProps> = ({
     namespace,
     fetchNotebooks,
     telemetryService,
+    telemetryRecorder,
 }) => {
-    useEffect(
-        () => telemetryService.logViewEvent(`SearchNotebooksList${logEventName}`),
-        [logEventName, telemetryService]
-    )
+    useEffect(() => {
+        telemetryService.logViewEvent(`SearchNotebooksList${logEventName}`),
+            telemetryRecorder.recordEvent(`SearchNotebooksList${logEventName}`, 'searched')
+    }, [logEventName, telemetryService, telemetryRecorder])
 
     const queryConnection = useCallback(
         (args: Partial<ListNotebooksVariables>) => {

--- a/client/web/src/notebooks/listPage/NotebooksList.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksList.tsx
@@ -39,8 +39,8 @@ export const NotebooksList: FC<NotebooksListProps> = ({
     telemetryRecorder,
 }) => {
     useEffect(() => {
-        telemetryService.logViewEvent(`SearchNotebooksList${logEventName}`),
-            telemetryRecorder.recordEvent(`SearchNotebooksList${logEventName}`, 'searched')
+        telemetryService.logViewEvent(`SearchNotebooksList${logEventName}`)
+        telemetryRecorder.recordEvent(`SearchNotebooksList${logEventName}`, 'searched')
     }, [logEventName, telemetryService, telemetryRecorder])
 
     const queryConnection = useCallback(

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -8,6 +8,7 @@ import { catchError, startWith, switchMap } from 'rxjs/operators'
 
 import { asError, type ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Button, useEventObservable, Alert, ButtonLink } from '@sourcegraph/wildcard'
 
@@ -22,7 +23,7 @@ import { NotebooksGettingStartedTab } from './NotebooksGettingStartedTab'
 import { NotebooksList, type NotebooksListProps } from './NotebooksList'
 import { NotebooksListPageHeader } from './NotebooksListPageHeader'
 
-export interface NotebooksListPageProps extends TelemetryProps {
+export interface NotebooksListPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     fetchNotebooks?: typeof _fetchNotebooks
     createNotebook?: typeof _createNotebook
@@ -64,6 +65,7 @@ interface NotebooksFilter extends Pick<NotebooksListProps, 'creatorUserID' | 'st
 export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<NotebooksListPageProps>> = ({
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
     fetchNotebooks = _fetchNotebooks,
     createNotebook = _createNotebook,
 }) => {
@@ -93,6 +95,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
             setSelectedTab(tab)
             setSelectedLocationTab(location, navigate, tab)
             telemetryService.log(logName)
+            telemetryRecorder.recordEvent('log', 'viewed', { privateMetadata: { logName } })
         },
         [navigate, location, setSelectedTab, telemetryService]
     )
@@ -250,6 +253,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                                 importNotebook={importNotebook}
                                 setImportState={setImportState}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                             />
                         )
                     }
@@ -312,6 +316,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                                     starredByUserID={selectedFilter.starredByUserID}
                                     namespace={selectedFilter.namespace}
                                     telemetryService={telemetryService}
+                                    telemetryRecorder={telemetryRecorder}
                                 />
                             )}
                         </div>
@@ -321,6 +326,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
                 {selectedTab === 'getting-started' && (
                     <NotebooksGettingStartedTab
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         authenticatedUser={authenticatedUser}
                     />
                 )}

--- a/client/web/src/notebooks/listPage/NotebooksListPage.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPage.tsx
@@ -97,7 +97,7 @@ export const NotebooksListPage: React.FunctionComponent<React.PropsWithChildren<
             telemetryService.log(logName)
             telemetryRecorder.recordEvent('log', 'viewed', { privateMetadata: { logName } })
         },
-        [navigate, location, setSelectedTab, telemetryService]
+        [navigate, location, setSelectedTab, telemetryService, telemetryRecorder]
     )
 
     const orderOptions: FilteredConnectionFilter[] = [

--- a/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksListPageHeader.tsx
@@ -5,6 +5,7 @@ import { VisuallyHidden } from '@reach/visually-hidden'
 import * as uuid from 'uuid'
 
 import type { ErrorLike } from '@sourcegraph/common'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Link,
@@ -35,7 +36,7 @@ const INVALID_IMPORT_FILE_ERROR = new Error(
 
 const MAX_FILE_SIZE_IN_BYTES = 1000 * 1000 // 1MB
 
-interface NotebooksListPageHeaderProps extends TelemetryProps {
+interface NotebooksListPageHeaderProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
     importNotebook: (notebook: CreateNotebookVariables['notebook']) => void
     setImportState: (state: typeof LOADING | ErrorLike | undefined) => void
@@ -43,14 +44,15 @@ interface NotebooksListPageHeaderProps extends TelemetryProps {
 
 export const NotebooksListPageHeader: React.FunctionComponent<
     React.PropsWithChildren<NotebooksListPageHeaderProps>
-> = ({ authenticatedUser, telemetryService, setImportState, importNotebook }) => {
+> = ({ authenticatedUser, telemetryService, telemetryRecorder, setImportState, importNotebook }) => {
     const fileInputReference = useRef<HTMLInputElement>(null)
 
     const onImportMenuItemSelect = useCallback(() => {
         telemetryService.log('SearchNotebookImportMarkdownNotebookButtonClick')
+        telemetryRecorder.recordEvent('SearchNotebookImportMarkdownNotebookButton', 'clicked')
         // Open the system file picker.
         fileInputReference.current?.click()
-    }, [fileInputReference, telemetryService])
+    }, [fileInputReference, telemetryService, telemetryRecorder])
 
     const onFileLoad = useCallback(
         (event: ProgressEvent<FileReader>, fileName: string): void => {

--- a/client/web/src/notebooks/notebookPage/DeleteNotebookModal.tsx
+++ b/client/web/src/notebooks/notebookPage/DeleteNotebookModal.tsx
@@ -36,15 +36,15 @@ export const DeleteNotebookModal: FC<DeleteNotebookModalProps> = ({
             telemetryService.log('SearchNotebookDeleteModalOpened')
             telemetryRecorder.recordEvent('SearchNotebookDeleteModal', 'opened')
         }
-    }, [isOpen, telemetryService])
+    }, [isOpen, telemetryService, telemetryRecorder])
 
     const [onDelete, deleteCompletedOrError] = useEventObservable(
         useCallback(
             (click: Observable<React.MouseEvent<HTMLButtonElement>>) =>
                 click.pipe(
                     tap(() => {
-                        telemetryService.log('SearchNotebookDeleteButtonClicked'),
-                            telemetryRecorder.recordEvent('SearchNotebookDeleteButton', 'clicked')
+                        telemetryService.log('SearchNotebookDeleteButtonClicked')
+                        telemetryRecorder.recordEvent('SearchNotebookDeleteButton', 'clicked')
                     }),
                     mergeMap(() =>
                         deleteNotebook(notebookId).pipe(

--- a/client/web/src/notebooks/notebookPage/DeleteNotebookModal.tsx
+++ b/client/web/src/notebooks/notebookPage/DeleteNotebookModal.tsx
@@ -5,12 +5,13 @@ import type { Observable } from 'rxjs'
 import { mergeMap, startWith, tap, catchError } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useEventObservable, Modal, Button, Alert, H3, Text } from '@sourcegraph/wildcard'
 
 import type { deleteNotebook as _deleteNotebook } from '../backend'
 
-interface DeleteNotebookModalProps extends TelemetryProps {
+interface DeleteNotebookModalProps extends TelemetryProps, TelemetryV2Props {
     notebookId: string
     isOpen: boolean
     toggleDeleteModal: () => void
@@ -26,12 +27,14 @@ export const DeleteNotebookModal: FC<DeleteNotebookModalProps> = ({
     isOpen,
     toggleDeleteModal,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const navigate = useNavigate()
 
     useEffect(() => {
         if (isOpen) {
             telemetryService.log('SearchNotebookDeleteModalOpened')
+            telemetryRecorder.recordEvent('SearchNotebookDeleteModal', 'opened')
         }
     }, [isOpen, telemetryService])
 
@@ -39,7 +42,10 @@ export const DeleteNotebookModal: FC<DeleteNotebookModalProps> = ({
         useCallback(
             (click: Observable<React.MouseEvent<HTMLButtonElement>>) =>
                 click.pipe(
-                    tap(() => telemetryService.log('SearchNotebookDeleteButtonClicked')),
+                    tap(() => {
+                        telemetryService.log('SearchNotebookDeleteButtonClicked'),
+                            telemetryRecorder.recordEvent('SearchNotebookDeleteButton', 'clicked')
+                    }),
                     mergeMap(() =>
                         deleteNotebook(notebookId).pipe(
                             tap(() => {
@@ -50,7 +56,7 @@ export const DeleteNotebookModal: FC<DeleteNotebookModalProps> = ({
                         )
                     )
                 ),
-            [deleteNotebook, navigate, notebookId, telemetryService]
+            [deleteNotebook, navigate, notebookId, telemetryService, telemetryRecorder]
         )
     )
 

--- a/client/web/src/notebooks/notebookPage/NotebookContent.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookContent.tsx
@@ -6,6 +6,7 @@ import type { Observable } from 'rxjs'
 import type { StreamingSearchResultsListProps } from '@sourcegraph/branded'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import type { Block, BlockInit } from '..'
@@ -18,6 +19,7 @@ import { NotebookComponent } from '../notebook/NotebookComponent'
 export interface NotebookContentProps
     extends SearchStreamingProps,
         TelemetryProps,
+        TelemetryV2Props,
         Omit<StreamingSearchResultsListProps, 'allExpanded' | 'platformContext' | 'executedQuery'>,
         PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
@@ -40,6 +42,7 @@ export const NotebookContent: React.FunctionComponent<React.PropsWithChildren<No
         onUpdateBlocks,
         streamSearch,
         telemetryService,
+        telemetryRecorder,
         searchContextsEnabled,
         ownEnabled,
         isSourcegraphDotCom,
@@ -83,6 +86,7 @@ export const NotebookContent: React.FunctionComponent<React.PropsWithChildren<No
             <NotebookComponent
                 streamSearch={streamSearch}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 searchContextsEnabled={searchContextsEnabled}
                 ownEnabled={ownEnabled}
                 isSourcegraphDotCom={isSourcegraphDotCom}

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -11,6 +11,7 @@ import type { StreamingSearchResultsListProps } from '@sourcegraph/branded'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, useEventObservable, useObservable, Alert, Icon } from '@sourcegraph/wildcard'
 
@@ -39,6 +40,7 @@ import styles from './NotebookPage.module.scss'
 interface NotebookPageProps
     extends SearchStreamingProps,
         TelemetryProps,
+        TelemetryV2Props,
         Omit<StreamingSearchResultsListProps, 'allExpanded' | 'platformContext' | 'executedQuery'>,
         PlatformContextProps<'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
@@ -66,6 +68,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
     copyNotebook = _copyNotebook,
     streamSearch,
     telemetryService,
+    telemetryRecorder,
     searchContextsEnabled,
     ownEnabled,
     isSourcegraphDotCom,
@@ -76,7 +79,10 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
 }) => {
     const { id: notebookId } = useParams()
 
-    useEffect(() => telemetryService.logPageView('SearchNotebookPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logPageView('SearchNotebookPage'),
+            telemetryRecorder.recordEvent('SearchNotebookPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const [notebookTitle, setNotebookTitle] = useState('')
     const [updateQueue, setUpdateQueue] = useState<Partial<NotebookInput>[]>([])
@@ -212,6 +218,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                         createNotebookStar={createNotebookStar}
                                         deleteNotebookStar={deleteNotebookStar}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                     />
                                 }
                             >
@@ -227,6 +234,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                             viewerCanManage={notebookOrError.viewerCanManage}
                                             onUpdateTitle={onUpdateTitle}
                                             telemetryService={telemetryService}
+                                            telemetryRecorder={telemetryRecorder}
                                         />
                                     </PageHeader.Breadcrumb>
                                 </PageHeader.Heading>
@@ -282,6 +290,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                 exportedFileName={exportedFileName}
                                 streamSearch={streamSearch}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 searchContextsEnabled={searchContextsEnabled}
                                 ownEnabled={ownEnabled}
                                 isSourcegraphDotCom={isSourcegraphDotCom}

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -80,8 +80,8 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
     const { id: notebookId } = useParams()
 
     useEffect(() => {
-        telemetryService.logPageView('SearchNotebookPage'),
-            telemetryRecorder.recordEvent('SearchNotebookPage', 'viewed')
+        telemetryService.logPageView('SearchNotebookPage')
+        telemetryRecorder.recordEvent('SearchNotebookPage', 'viewed')
     }, [telemetryService, telemetryRecorder])
 
     const [notebookTitle, setNotebookTitle] = useState('')

--- a/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import type { Observable } from 'rxjs'
 import { catchError, switchMap, tap } from 'rxjs/operators'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Menu,
@@ -34,7 +35,7 @@ import { ShareNotebookModal } from './ShareNotebookModal'
 
 import styles from './NotebookPageHeaderActions.module.scss'
 
-export interface NotebookPageHeaderActionsProps extends TelemetryProps {
+export interface NotebookPageHeaderActionsProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
     namespace: NotebookFields['namespace']
@@ -65,6 +66,7 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
     createNotebookStar,
     deleteNotebookStar,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [showShareModal, setShowShareModal] = useState(false)
     const toggleShareModal = useCallback(() => setShowShareModal(show => !show), [setShowShareModal])
@@ -119,6 +121,7 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
                 createNotebookStar={createNotebookStar}
                 deleteNotebookStar={deleteNotebookStar}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
             {authenticatedUser && viewerCanManage && namespace && selectedShareOption && (
                 <>
@@ -135,6 +138,7 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         toggleModal={toggleShareModal}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         authenticatedUser={authenticatedUser}
                         selectedShareOption={selectedShareOption}
                         setSelectedShareOption={setSelectedShareOption}
@@ -147,13 +151,14 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
                     notebookId={notebookId}
                     deleteNotebook={deleteNotebook}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
         </div>
     )
 }
 
-interface NotebookSettingsDropdownProps extends TelemetryProps {
+interface NotebookSettingsDropdownProps extends TelemetryProps, TelemetryV2Props {
     notebookId: string
     deleteNotebook: typeof _deleteNotebook
 }
@@ -162,6 +167,7 @@ const NotebookSettingsDropdown: React.FunctionComponent<React.PropsWithChildren<
     notebookId,
     deleteNotebook,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [showDeleteModal, setShowDeleteModal] = useState(false)
     const toggleDeleteModal = useCallback(() => setShowDeleteModal(show => !show), [setShowDeleteModal])
@@ -191,12 +197,13 @@ const NotebookSettingsDropdown: React.FunctionComponent<React.PropsWithChildren<
                 toggleDeleteModal={toggleDeleteModal}
                 deleteNotebook={deleteNotebook}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
         </>
     )
 }
 
-interface NotebookStarsButtonProps extends TelemetryProps {
+interface NotebookStarsButtonProps extends TelemetryProps, TelemetryV2Props {
     notebookId: string
     disabled: boolean
     starsCount: number
@@ -213,6 +220,7 @@ const NotebookStarsButton: React.FunctionComponent<React.PropsWithChildren<Noteb
     createNotebookStar,
     deleteNotebookStar,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [starsCount, setStarsCount] = useState(initialStarsCount)
     const [viewerHasStarred, setViewerHasStarred] = useState(initialViewerHasStarred)
@@ -224,6 +232,7 @@ const NotebookStarsButton: React.FunctionComponent<React.PropsWithChildren<Noteb
                     // Immediately update the UI.
                     tap(viewerHasStarred => {
                         telemetryService.log(`SearchNotebook${viewerHasStarred ? 'Remove' : 'Add'}Star`)
+                        telemetryRecorder.recordEvent('SearchNotebookStar', viewerHasStarred ? 'added' : 'removed')
                         if (viewerHasStarred) {
                             setStarsCount(starsCount => starsCount - 1)
                             setViewerHasStarred(() => false)

--- a/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
@@ -257,6 +257,7 @@ const NotebookStarsButton: React.FunctionComponent<React.PropsWithChildren<Noteb
                 initialStarsCount,
                 initialViewerHasStarred,
                 telemetryService,
+                telemetryRecorder,
             ]
         )
     )

--- a/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
@@ -2,6 +2,7 @@ import React, { type FC, useMemo } from 'react'
 
 import { mdiChevronDown, mdiChevronUp, mdiDomain, mdiLock, mdiWeb } from '@mdi/js'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Icon, Menu, MenuButton, MenuItem, MenuList } from '@sourcegraph/wildcard'
 
@@ -17,7 +18,7 @@ export interface ShareOption {
     isPublic: boolean
 }
 
-interface NotebookShareOptionsDropdownProps extends TelemetryProps {
+interface NotebookShareOptionsDropdownProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser
     selectedShareOption: ShareOption
@@ -66,10 +67,18 @@ const ShareOptionComponent: React.FunctionComponent<
 }
 
 export const NotebookShareOptionsDropdown: FC<NotebookShareOptionsDropdownProps> = props => {
-    const { isSourcegraphDotCom, telemetryService, authenticatedUser, selectedShareOption, onSelectShareOption } = props
+    const {
+        isSourcegraphDotCom,
+        telemetryService,
+        telemetryRecorder,
+        authenticatedUser,
+        selectedShareOption,
+        onSelectShareOption,
+    } = props
 
     const handleTriggerClick = (): void => {
         telemetryService.log('NotebookVisibilitySettingsDropdownToggled')
+        telemetryRecorder.recordEvent('NotebookVisibilitySettingsDropdown', 'toggled')
     }
 
     const shareOptions: ShareOption[] = useMemo(

--- a/client/web/src/notebooks/notebookPage/NotebookTitle.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookTitle.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useRef, useState } from 'react'
 
 import { mdiPencilOutline } from '@mdi/js'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useOnClickOutside, Icon, Input } from '@sourcegraph/wildcard'
 
 import styles from './NotebookTitle.module.scss'
 
-export interface NotebookTitleProps extends TelemetryProps {
+export interface NotebookTitleProps extends TelemetryProps, TelemetryV2Props {
     title: string
     viewerCanManage: boolean
     onUpdateTitle: (title: string) => void
@@ -18,6 +19,7 @@ export const NotebookTitle: React.FunctionComponent<React.PropsWithChildren<Note
     viewerCanManage,
     onUpdateTitle,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [isEditing, setIsEditing] = useState(false)
     const [title, setTitle] = useState(initialTitle)
@@ -31,6 +33,7 @@ export const NotebookTitle: React.FunctionComponent<React.PropsWithChildren<Note
 
     const updateTitle = (): void => {
         telemetryService.log('SearchNotebookTitleUpdated')
+        telemetryRecorder.recordEvent('SearchNotebookTitle', 'updated')
         setIsEditing(false)
         onUpdateTitle(title)
     }

--- a/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
+++ b/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
@@ -69,6 +69,7 @@ export const ShareNotebookModal: React.FunctionComponent<React.PropsWithChildren
                 <NotebookShareOptionsDropdown
                     isSourcegraphDotCom={isSourcegraphDotCom}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     authenticatedUser={authenticatedUser}
                     selectedShareOption={selectedShareOption}
                     onSelectShareOption={setSelectedShareOption}

--- a/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
+++ b/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useEffect } from 'react'
 
 import classNames from 'classnames'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Modal, Button, Checkbox, H3 } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import { NotebookShareOptionsDropdown, type ShareOption } from './NotebookShareO
 
 import styles from './ShareNotebookModal.module.scss'
 
-interface ShareNotebookModalProps extends TelemetryProps {
+interface ShareNotebookModalProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     selectedShareOption: ShareOption
     setSelectedShareOption: (option: ShareOption) => void
@@ -39,13 +40,15 @@ export const ShareNotebookModal: React.FunctionComponent<React.PropsWithChildren
     toggleModal,
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
     onUpdateVisibility,
 }) => {
     useEffect(() => {
         if (isOpen) {
             telemetryService.log('SearchNotebookShareModalOpened')
+            telemetryRecorder.recordEvent('SearchNotebookShareModal', 'opened')
         }
-    }, [isOpen, telemetryService])
+    }, [isOpen, telemetryService, telemetryRecorder])
 
     const shareLabelId = 'shareNotebookId'
 

--- a/client/web/src/repo/FilePathBreadcrumbs.tsx
+++ b/client/web/src/repo/FilePathBreadcrumbs.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 
 import { CopyPathAction } from '@sourcegraph/branded'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { type RepoRevision, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 import { Breadcrumbs } from '@sourcegraph/wildcard'
@@ -9,7 +10,7 @@ import { toTreeURL } from '../util/url'
 
 import styles from './FilePathBreadcrumbs.module.scss'
 
-interface FilePathBreadcrumbsProps extends RepoRevision, TelemetryProps {
+interface FilePathBreadcrumbsProps extends RepoRevision, TelemetryProps, TelemetryV2Props {
     isDir: boolean
     filePath: string
 }
@@ -19,7 +20,7 @@ interface FilePathBreadcrumbsProps extends RepoRevision, TelemetryProps {
  * links.
  */
 export const FilePathBreadcrumbs: FC<FilePathBreadcrumbsProps> = props => {
-    const { repoName, revision, filePath, isDir, telemetryService } = props
+    const { repoName, revision, filePath, isDir, telemetryService, telemetryRecorder } = props
 
     const partToUrl = (segment: string, index: number, segments: string[]): string => {
         const partPath = segments.slice(0, index + 1).join('/')
@@ -31,7 +32,11 @@ export const FilePathBreadcrumbs: FC<FilePathBreadcrumbsProps> = props => {
 
     return (
         <Breadcrumbs filename={filePath} getSegmentLink={partToUrl} className={styles.filePathBreadcrumbs}>
-            <CopyPathAction filePath={filePath} telemetryService={telemetryService} />
+            <CopyPathAction
+                filePath={filePath}
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+            />
         </Breadcrumbs>
     )
 }

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -7,6 +7,7 @@ import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import type { RepoFile } from '@sourcegraph/shared/src/util/url'
 import {
@@ -34,7 +35,7 @@ import { RepoRevisionSidebarSymbols } from './RepoRevisionSidebarSymbols'
 
 import styles from './RepoRevisionSidebar.module.scss'
 
-interface RepoRevisionSidebarProps extends RepoFile, TelemetryProps, SettingsCascadeProps {
+interface RepoRevisionSidebarProps extends RepoFile, TelemetryProps, TelemetryV2Props, SettingsCascadeProps {
     repoID?: Scalars['ID']
     isDir: boolean
     defaultBranch: string
@@ -107,6 +108,7 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
                             <GettingStartedTour
                                 className="mr-3"
                                 telemetryService={props.telemetryService}
+                                telemetryRecorder={props.telemetryRecorder}
                                 authenticatedUser={props.authenticatedUser}
                             />
                         )}

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -5,6 +5,7 @@ import { Navigate, useLocation } from 'react-router-dom'
 import { appendLineRangeQueryParameter } from '@sourcegraph/common'
 import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { getModeFromPath } from '@sourcegraph/shared/src/languages'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { isLegacyFragment, parseQueryAndHash, toRepoURL } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -22,7 +23,11 @@ import { TreePage } from './tree/TreePage'
 
 import styles from './RepositoryFileTreePage.module.scss'
 
-export interface RepositoryFileTreePageProps extends RepoRevisionContainerContext, NotebookProps, OwnConfigProps {
+export interface RepositoryFileTreePageProps
+    extends RepoRevisionContainerContext,
+        NotebookProps,
+        OwnConfigProps,
+        TelemetryV2Props {
     objectType: 'blob' | 'tree' | undefined
     globalContext: Pick<SourcegraphContext, 'authProviders'>
 }
@@ -33,7 +38,15 @@ const hideRepoRevisionContent = localStorage.getItem('hideRepoRevContent')
 /** A page that shows a file or a directory (tree view) in a repository at the
  * current revision. */
 export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => {
-    const { repo, resolvedRevision, repoName, objectType: maybeObjectType, globalContext, ...context } = props
+    const {
+        telemetryRecorder,
+        repo,
+        resolvedRevision,
+        repoName,
+        objectType: maybeObjectType,
+        globalContext,
+        ...context
+    } = props
 
     const location = useLocation()
     const { filePath = '' } = parseBrowserRepoURL(location.pathname) // empty string is root
@@ -78,6 +91,7 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
                 revision={context.revision}
                 settingsCascade={context.settingsCascade}
                 telemetryService={context.telemetryService}
+                telemetryRecorder={props.telemetryRecorder}
                 authenticatedUser={context.authenticatedUser}
                 isSourcegraphDotCom={context.isSourcegraphDotCom}
                 commitID={resolvedRevision?.commitID}
@@ -108,6 +122,7 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
                                     fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
                                     className={styles.pageContent}
                                     context={globalContext}
+                                    telemetryRecorder={telemetryRecorder}
                                 />
                             </TraceSpanProvider>
                         ) : resolvedRevision ? (

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -26,6 +26,7 @@ import { HighlightResponseFormat } from '@sourcegraph/shared/src/graphql-operati
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { type ModeSpec, parseQueryAndHash, type RepoFile } from '@sourcegraph/shared/src/util/url'
@@ -95,6 +96,7 @@ interface BlobPageProps
         SettingsCascadeProps,
         PlatformContextProps,
         TelemetryProps,
+        TelemetryV2Props,
         ExtensionsControllerProps,
         HoverThresholdProps,
         BreadcrumbSetters,

--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -1,19 +1,25 @@
 import type { FC } from 'react'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 
 import type { AuthenticatedUser } from '../../auth'
 import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import type { ExternalServicesTotalCountResult } from '../../graphql-operations'
 import { SearchPageContent, getShouldShowAddCodeHostWidget } from '../../storm/pages/SearchPage/SearchPageContent'
 
-export interface SearchPageProps {
+export interface SearchPageProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 
 export const SearchPage: FC<SearchPageProps> = props => {
     const shouldShowAddCodeHostWidget = useShouldShowAddCodeHostWidget(props.authenticatedUser)
-    return <SearchPageContent shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget} />
+    return (
+        <SearchPageContent
+            shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget}
+            telemetryRecorder={props.telemetryRecorder}
+        />
+    )
 }
 
 const EXTERNAL_SERVICES_TOTAL_COUNT = gql`

--- a/client/web/src/search/results/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.test.tsx
@@ -2,6 +2,7 @@ import { noop } from 'lodash'
 import { NEVER } from 'rxjs'
 import { describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
@@ -24,6 +25,7 @@ const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
     onExportCsvClick: noop,
     stats: <div />,
     telemetryService: NOOP_TELEMETRY_SERVICE,
+    telemetryRecorder: noOpTelemetryRecorder,
     patternType: SearchPatternType.standard,
     caseSensitive: false,
     setSidebarCollapsed: noop,

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -8,6 +8,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import type { CaseSensitivityProps, SearchPatternTypeProps } from '@sourcegraph/shared/src/search'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, Alert, useSessionStorage, Link, Text } from '@sourcegraph/wildcard'
 
@@ -29,6 +30,7 @@ import styles from './SearchResultsInfoBar.module.scss'
 
 export interface SearchResultsInfoBarProps
     extends TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'settings' | 'sourcegraphURL'>,
         SearchPatternTypeProps,
         Pick<CaseSensitivityProps, 'caseSensitive'> {

--- a/client/web/src/search/results/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.story.tsx
@@ -4,6 +4,7 @@ import { EMPTY, NEVER, of } from 'rxjs'
 
 import { SearchQueryStateStoreProvider } from '@sourcegraph/shared/src/search'
 import type { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     HIGHLIGHTED_FILE_LINES_LONG_REQUEST,
@@ -33,6 +34,7 @@ const streamingSearchResult: AggregateStreamingSearchResults = {
 
 const defaultProps: StreamingSearchResultsProps = {
     telemetryService: NOOP_TELEMETRY_SERVICE,
+    telemetryRecorder: noOpTelemetryRecorder,
 
     authenticatedUser: {
         url: '/users/alice',

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GitRefType, SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchMode, SearchQueryStateStoreProvider } from '@sourcegraph/shared/src/search'
 import type { AggregateStreamingSearchResults, Skipped } from '@sourcegraph/shared/src/search/stream'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import {
@@ -35,6 +36,7 @@ describe('StreamingSearchResults', () => {
 
     const defaultProps: StreamingSearchResultsProps = {
         telemetryService: NOOP_TELEMETRY_SERVICE,
+        telemetryRecorder: noOpTelemetryRecorder,
 
         authenticatedUser: null,
 

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -21,6 +21,7 @@ import {
 } from '@sourcegraph/shared/src/search/stream'
 import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import type { SearchAggregationProps, SearchStreamingProps } from '..'
@@ -64,6 +65,7 @@ export interface StreamingSearchResultsProps
         SettingsCascadeProps,
         PlatformContextProps<'settings' | 'requestGraphQL' | 'sourcegraphURL'>,
         TelemetryProps,
+        TelemetryV2Props,
         CodeInsightsProps,
         SearchAggregationProps,
         CodeMonitoringProps,
@@ -78,6 +80,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         streamSearch,
         authenticatedUser,
         telemetryService,
+        telemetryRecorder,
         isSourcegraphDotCom,
         searchAggregationEnabled,
         codeMonitoringEnabled,
@@ -129,7 +132,13 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         [patternType, caseSensitive, trace, featureOverrides, searchMode, searchOptions]
     )
 
-    const results = useCachedSearchResults(streamSearch, submittedURLQuery, options, telemetryService)
+    const results = useCachedSearchResults(
+        streamSearch,
+        submittedURLQuery,
+        options,
+        telemetryService,
+        telemetryRecorder
+    )
 
     const resultsLength = results?.results.length || 0
     const logSearchResultClicked = useCallback(
@@ -381,6 +390,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                 aggregationUIMode={aggregationUIMode}
                 settingsCascade={props.settingsCascade}
                 telemetryService={props.telemetryService}
+                telemetryRecorder={props.telemetryRecorder}
                 caseSensitive={caseSensitive}
                 className={classNames(styles.sidebar, showMobileSidebar && styles.sidebarShowMobile)}
                 onNavbarQueryChange={setQueryState}
@@ -391,6 +401,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                     <GettingStartedTour
                         className="mb-1"
                         telemetryService={props.telemetryService}
+                        telemetryRecorder={props.telemetryRecorder}
                         authenticatedUser={authenticatedUser}
                     />
                 )}
@@ -405,6 +416,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
                     className={styles.contents}
                     onQuerySubmit={handleSearchAggregationBarClick}
                     telemetryService={props.telemetryService}
+                    telemetryRecorder={props.telemetryRecorder}
                 />
             )}
 

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -147,6 +148,7 @@ export const SearchAggregationResultDemo: StoryFn = () => (
                     patternType={SearchPatternType.literal}
                     caseSensitive={false}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
                     onQuerySubmit={noop}
                 />
             </MockedTestProvider>

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -2,6 +2,7 @@ import { type FC, type HTMLAttributes, useEffect, useState } from 'react'
 
 import { mdiArrowCollapse } from '@mdi/js'
 
+import type { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, H2, Icon, Code, Card, CardBody } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import { AggregationUIMode } from './types'
 
 import styles from './SearchAggregationResult.module.scss'
 
-interface SearchAggregationResultProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
+interface SearchAggregationResultProps extends TelemetryProps, TelemetryV2Props, HTMLAttributes<HTMLElement> {
     /**
      * Current submitted query, note that this query isn't a live query
      * that is synced with typed query in the search box, this query is submitted
@@ -42,7 +43,8 @@ interface SearchAggregationResultProps extends TelemetryProps, HTMLAttributes<HT
 }
 
 export const SearchAggregationResult: FC<SearchAggregationResultProps> = props => {
-    const { query, patternType, caseSensitive, onQuerySubmit, telemetryService, ...attributes } = props
+    const { query, patternType, caseSensitive, onQuerySubmit, telemetryService, telemetryRecorder, ...attributes } =
+        props
 
     const [extendedTimeout, setExtendedTimeoutLocal] = useState(false)
     const [, setAggregationUIMode] = useAggregationUIMode()
@@ -55,11 +57,15 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
         proactive: true,
         extendedTimeout,
         telemetryService,
+        telemetryRecorder,
     })
 
     const handleCollapseClick = (): void => {
         setAggregationUIMode(AggregationUIMode.Sidebar)
         telemetryService.log(GroupResultsPing.CollapseFullViewPanel, { aggregationMode }, { aggregationMode })
+        telemetryRecorder.recordEvent(GroupResultsPing.CollapseFullViewPanel, 'collapsed', {
+            privateMetadata: { aggregationMode },
+        })
     }
 
     const handleBarLinkClick = (query: string, index: number): void => {
@@ -74,6 +80,9 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
             { aggregationMode, index, uiMode: 'resultsScreen' },
             { aggregationMode, index, uiMode: 'resultsScreen' }
         )
+        telemetryRecorder.recordEvent(GroupResultsPing.ChartBarClick, 'clicked', {
+            privateMetadata: { aggregationMode, index, uiMode: 'resultsScreen' },
+        })
     }
 
     const handleBarHover = (): void => {
@@ -82,6 +91,9 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
             { aggregationMode, uiMode: 'resultsScreen' },
             { aggregationMode, uiMode: 'resultsScreen' }
         )
+        telemetryRecorder.recordEvent(GroupResultsPing.ChartBarHover, 'hovered', {
+            privateMetadata: { aggregationMode, uiMode: 'resultsScreen' },
+        })
     }
 
     const handleAggregationModeChange = (mode: SearchAggregationMode): void => {
@@ -91,6 +103,9 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
             { aggregationMode: mode, uiMode: 'resultsScreen' },
             { aggregationMode: mode, uiMode: 'resultsScreen' }
         )
+        telemetryRecorder.recordEvent(GroupResultsPing.ModeClick, 'clicked', {
+            privateMetadata: { aggregationMode: mode, uiMode: 'resultsScreen' },
+        })
     }
 
     const handleAggregationModeHover = (aggregationMode: SearchAggregationMode, available: boolean): void => {
@@ -100,6 +115,9 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
                 { aggregationMode, uiMode: 'resultsScreen' },
                 { aggregationMode, uiMode: 'resultsScreen' }
             )
+            telemetryRecorder.recordEvent(GroupResultsPing.ModeDisabledHover, 'disabled', {
+                privateMetadata: { aggregationMode, uiMode: 'resultsScreen' },
+            })
         }
     }
 

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -3,6 +3,7 @@ import { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import { gql, useQuery } from '@apollo/client'
 import { useNavigate, useLocation } from 'react-router-dom'
 
+import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import {
@@ -240,6 +241,7 @@ interface SearchAggregationDataInput {
     extendedTimeout: boolean
     proactive?: boolean
     telemetryService: TelemetryService
+    telemetryRecorder: TelemetryRecorder
 }
 
 interface AggregationState {

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useState, memo } from 'react'
 
 import { mdiArrowExpand } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import {
 
 import styles from './SearchAggregations.module.scss'
 
-interface SearchAggregationsProps extends TelemetryProps {
+interface SearchAggregationsProps extends TelemetryProps, TelemetryV2Props {
     /**
      * Current submitted query, note that this query isn't a live query
      * that is synced with typed query in the search box, this query is submitted
@@ -45,7 +46,7 @@ interface SearchAggregationsProps extends TelemetryProps {
 }
 
 export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
-    const { query, patternType, proactive, caseSensitive, telemetryService, onQuerySubmit } = props
+    const { query, patternType, proactive, caseSensitive, telemetryService, telemetryRecorder, onQuerySubmit } = props
 
     const [extendedTimeout, setExtendedTimeoutLocal] = useState(false)
 
@@ -59,6 +60,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         caseSensitive,
         extendedTimeout,
         telemetryService,
+        telemetryRecorder,
     })
 
     // When query is updated reset extendedTimeout as per business rules
@@ -78,6 +80,9 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
             { aggregationMode, index, uiMode: 'sidebar' },
             { aggregationMode, index, uiMode: 'sidebar' }
         )
+        telemetryRecorder.recordEvent(GroupResultsPing.ChartBarClick, 'clicked', {
+            privateMetadata: { aggregationMode, index, uiMode: 'sidebar' },
+        })
     }
 
     const handleBarHover = (): void => {
@@ -86,11 +91,17 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
             { aggregationMode, uiMode: 'sidebar' },
             { aggregationMode, uiMode: 'sidebar' }
         )
+        telemetryRecorder.recordEvent(GroupResultsPing.ChartBarHover, 'hovered', {
+            privateMetadata: { aggregationMode, uiMode: 'sidebar' },
+        })
     }
 
     const handleExpandClick = (): void => {
         setAggregationUIMode(AggregationUIMode.SearchPage)
         telemetryService.log(GroupResultsPing.ExpandFullViewPanel, { aggregationMode }, { aggregationMode })
+        telemetryRecorder.recordEvent(GroupResultsPing.ExpandFullViewPanel, 'clicked', {
+            privateMetadata: { aggregationMode },
+        })
     }
 
     const handleAggregationModeChange = (mode: SearchAggregationMode): void => {
@@ -100,6 +111,9 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
             { aggregationMode: mode, uiMode: 'sidebar' },
             { aggregationMode: mode, uiMode: 'sidebar' }
         )
+        telemetryRecorder.recordEvent(GroupResultsPing.ModeClick, 'clicked', {
+            privateMetadata: { aggregationMode: mode, uiMode: 'sidebar' },
+        })
     }
 
     const handleAggregationModeHover = (aggregationMode: SearchAggregationMode, available: boolean): void => {
@@ -109,6 +123,9 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
                 { aggregationMode, uiMode: 'sidebar' },
                 { aggregationMode, uiMode: 'sidebar' }
             )
+            telemetryRecorder.recordEvent(GroupResultsPing.ModeDisabledHover, 'hovered', {
+                privateMetadata: { aggregationMode, uiMode: 'sidebar' },
+            })
         }
     }
 

--- a/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
+++ b/client/web/src/search/results/sidebar/SearchFiltersSidebar.story.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import type { QuickLink, SearchScope } from '@sourcegraph/shared/src/schema/settings.schema'
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../components/WebStory'
@@ -33,6 +34,7 @@ const defaultProps: SearchFiltersSidebarProps = {
     selectedSearchContextSpec: 'global',
     settingsCascade: EMPTY_SETTINGS_CASCADE,
     telemetryService: NOOP_TELEMETRY_SERVICE,
+    telemetryRecorder: noOpTelemetryRecorder,
     setSidebarCollapsed: () => {},
 }
 

--- a/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
+++ b/client/web/src/storm/pages/LayoutPage/LayoutPage.tsx
@@ -250,6 +250,7 @@ export const Layout: React.FC<LegacyLayoutProps> = props => {
                     isRepositoryRelatedPage={isRepositoryRelatedPage}
                     settingsCascade={props.settingsCascade}
                     telemetryService={props.telemetryService}
+                    telemetryRecorder={props.platformContext.telemetryRecorder}
                     location={location}
                     userHistory={userHistory}
                 />

--- a/client/web/src/storm/pages/SearchPage/SearchPage.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPage.tsx
@@ -1,5 +1,7 @@
 import type { FC } from 'react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import { useLegacyContext_onlyInStormRoutes } from '../../../LegacyRouteContext'
 
 import { usePreloadedQueryData } from './SearchPage.loader'
@@ -15,5 +17,10 @@ export const SearchPage: FC = () => {
         externalServicesCount: data?.externalServices.totalCount,
     })
 
-    return <SearchPageContent shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget} />
+    return (
+        <SearchPageContent
+            shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget}
+            telemetryRecorder={noOpTelemetryRecorder}
+        />
+    )
 }

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -7,6 +7,7 @@ import { QueryExamples } from '@sourcegraph/branded/src/search-ui/components/Que
 import type { QueryState } from '@sourcegraph/shared/src/search'
 import { getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
 import { appendContextFilter, omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Label, Tooltip, useLocalStorage } from '@sourcegraph/wildcard'
 
@@ -25,14 +26,14 @@ import { TryCodySignUpCtaSection } from './TryCodySignUpCtaSection'
 
 import styles from './SearchPageContent.module.scss'
 
-interface SearchPageContentProps {
+interface SearchPageContentProps extends TelemetryV2Props {
     shouldShowAddCodeHostWidget?: boolean
 }
 
 export const SearchPageContent: FC<SearchPageContentProps> = props => {
     const { shouldShowAddCodeHostWidget } = props
 
-    const { telemetryService, selectedSearchContextSpec, isSourcegraphDotCom, authenticatedUser } =
+    const { telemetryService, telemetryRecorder, selectedSearchContextSpec, isSourcegraphDotCom, authenticatedUser } =
         useLegacyContext_onlyInStormRoutes()
 
     const isLightTheme = useIsLightTheme()
@@ -123,6 +124,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                             <GettingStartedTour
                                 className="mt-5"
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 variant="horizontal"
                                 authenticatedUser={authenticatedUser}
                             />
@@ -132,10 +134,15 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                                 <TryCodyCtaSection
                                     className="mx-auto my-5"
                                     telemetryService={telemetryService}
+                                    telemetryRecorder={telemetryRecorder}
                                     isSourcegraphDotCom={isSourcegraphDotCom}
                                 />
                             ) : (
-                                <TryCodySignUpCtaSection className="mx-auto my-5" telemetryService={telemetryService} />
+                                <TryCodySignUpCtaSection
+                                    className="mx-auto my-5"
+                                    telemetryService={telemetryService}
+                                    telemetryRecorder={telemetryRecorder}
+                                />
                             )
                         ) : null}
                     </>
@@ -147,6 +154,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                         <QueryExamples
                             selectedSearchContextSpec={selectedSearchContextSpec}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                             isSourcegraphDotCom={isSourcegraphDotCom}
                         />
                     )}

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -44,7 +44,10 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
         query: '',
     })
 
-    useEffect(() => telemetryService.logViewEvent('Home'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('Home')
+        telemetryRecorder.recordEvent('Home', 'viewed')
+    }, [telemetryService, telemetryRecorder])
     useEffect(() => {
         // TODO (#48103): Remove/simplify when new search input is released
         // Because the current and the new search input handle the context: selector differently

--- a/client/web/src/storm/pages/SearchPage/TryCodyCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/TryCodyCtaSection.tsx
@@ -4,6 +4,7 @@ import { mdiArrowRight, mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, ButtonLink, H2, H3, Icon, Link, Text } from '@sourcegraph/wildcard'
 
@@ -68,7 +69,7 @@ const MeetCodySVG: React.FC = () => (
     </svg>
 )
 
-interface TryCodyCtaSectionProps extends TelemetryProps {
+interface TryCodyCtaSectionProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     className?: string
 }
@@ -76,14 +77,17 @@ interface TryCodyCtaSectionProps extends TelemetryProps {
 export const TryCodyCtaSection: React.FC<TryCodyCtaSectionProps> = ({
     className,
     telemetryService,
+    telemetryRecorder,
     isSourcegraphDotCom,
 }) => {
     const [isDismissed = true, setIsDismissed] = useTemporarySetting('cody.searchPageCta.dismissed', false)
     const onDismiss = (): void => setIsDismissed(true)
-    const logEvent = (eventName: EventName): void =>
+    const recordEvent = (eventName: EventName): void => {
         telemetryService.log(eventName, { type: 'ComHome' }, { type: 'ComHome' })
-    const onViewEditorExtensionsClick = (): void => logEvent(EventName.VIEW_EDITOR_EXTENSIONS)
-    const onTryWebClick = (): void => logEvent(EventName.TRY_CODY_WEB)
+        telemetryRecorder.recordEvent(eventName, 'clicked', { privateMetadata: { type: 'ComHome' } })
+    }
+    const onViewEditorExtensionsClick = (): void => recordEvent(EventName.VIEW_EDITOR_EXTENSIONS)
+    const onTryWebClick = (): void => recordEvent(EventName.TRY_CODY_WEB)
 
     if (isDismissed) {
         return null

--- a/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { mdiChevronRight, mdiMicrosoftVisualStudioCode } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ButtonLink, H1, H2, Icon, Link, ProductStatusBadge, Text } from '@sourcegraph/wildcard'
 
@@ -66,12 +67,15 @@ const MeetCodySVG: React.FC = () => (
     </svg>
 )
 
-export const TryCodySignUpCtaSection: React.FC<TelemetryProps & { className?: string }> = ({
+export const TryCodySignUpCtaSection: React.FC<TelemetryProps & TelemetryV2Props & { className?: string }> = ({
     className,
     telemetryService,
+    telemetryRecorder,
 }) => {
-    const onSignUpClick = (): void =>
+    const onSignUpClick = (): void => {
         telemetryService.log(EventName.CODY_SIGNUP, { type: 'ComHome' }, { type: 'ComHome' })
+        telemetryRecorder.recordEvent(EventName.CODY_SIGNUP, 'clicked', { privateMetadata: { type: 'ComHome' } })
+    }
 
     return (
         <div className={classNames('d-flex', className, styles.container)}>

--- a/client/web/src/tour/GettingStartedTour.tsx
+++ b/client/web/src/tour/GettingStartedTour.tsx
@@ -1,6 +1,7 @@
 import { type FC, memo } from 'react'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 
 import type { AuthenticatedUser } from '../auth'
 import { withFeatureFlag } from '../featureFlags/withFeatureFlag'
@@ -15,7 +16,8 @@ import { useShowOnboardingSetup } from './hooks'
 const GatedTour = withFeatureFlag('end-user-onboarding', Tour)
 
 interface TourWrapperProps
-    extends Omit<TourProps, 'useStore' | 'eventPrefix' | 'tasks' | 'id' | 'defaultSnippets' | 'userInfo'> {
+    extends Omit<TourProps, 'useStore' | 'eventPrefix' | 'tasks' | 'id' | 'defaultSnippets' | 'userInfo'>,
+        TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 


### PR DESCRIPTION

## Test plan

run `sg start`
verify instrumented events in `event_logs` and BigQuery