### PR TITLE
Code Navigation: clean up prev next buttons

### DIFF
--- a/client/web/src/repo/blob/codemirror/search.module.scss
+++ b/client/web/src/repo/blob/codemirror/search.module.scss
@@ -1,0 +1,10 @@
+.bgroup-left {
+    border-top-right-radius: 0%;
+    border-bottom-right-radius: 0%;
+}
+
+.bgroup-right {
+    border-top-left-radius: 0%;
+    border-bottom-left-radius: 0%;
+    border-left: none;
+}

--- a/client/web/src/repo/blob/codemirror/search.module.scss
+++ b/client/web/src/repo/blob/codemirror/search.module.scss
@@ -1,10 +1,10 @@
 .bgroup-left {
-    border-top-right-radius: 0%;
-    border-bottom-right-radius: 0%;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
 }
 
 .bgroup-right {
-    border-top-left-radius: 0%;
-    border-bottom-left-radius: 0%;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
     border-left: none;
 }

--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -30,7 +30,8 @@ import {
     ViewPlugin,
     type ViewUpdate,
 } from '@codemirror/view'
-import { mdiChevronDown, mdiChevronUp, mdiFormatLetterCase, mdiInformationOutline, mdiRegex } from '@mdi/js'
+import { mdiChevronLeft, mdiChevronRight, mdiFormatLetterCase, mdiInformationOutline, mdiRegex } from '@mdi/js'
+import classNames from 'classnames'
 import { createRoot, type Root } from 'react-dom/client'
 import type { NavigateFunction } from 'react-router-dom'
 import { Subject, Subscription } from 'rxjs'
@@ -47,6 +48,8 @@ import { Keybindings } from '../../../components/KeyboardShortcutsHelp/KeyboardS
 import { createElement } from '../../../util/dom'
 
 import { CodeMirrorContainer } from './react-interop'
+
+import styles from './search.module.scss'
 
 const searchKeybinding = <Keybindings keybindings={[{ held: ['Mod'], ordered: ['F'] }]} />
 
@@ -224,9 +227,9 @@ class SearchPanel implements Panel {
                     />
                 </div>
                 {totalMatches > 1 && (
-                    <>
+                    <div className="ml-2">
                         <Button
-                            className="p-1 ml-2 mr-2 mt-0 mb-0"
+                            className={classNames(styles.bgroupLeft, 'p-1')}
                             type="button"
                             size="sm"
                             outline={true}
@@ -235,11 +238,11 @@ class SearchPanel implements Panel {
                             data-testid="blob-view-search-previous"
                             aria-label="previous result"
                         >
-                            <Icon svgPath={mdiChevronUp} aria-hidden={true} />
+                            <Icon svgPath={mdiChevronLeft} aria-hidden={true} />
                         </Button>
 
                         <Button
-                            className="p-1 mr-0 mt-0 mb-0"
+                            className={classNames(styles.bgroupRight, 'p-1')}
                             type="button"
                             size="sm"
                             outline={true}
@@ -248,9 +251,9 @@ class SearchPanel implements Panel {
                             data-testid="blob-view-search-next"
                             aria-label="next result"
                         >
-                            <Icon svgPath={mdiChevronDown} aria-hidden={true} />
+                            <Icon svgPath={mdiChevronRight} aria-hidden={true} />
                         </Button>
-                    </>
+                    </div>
                 )}
 
                 {searchQuery.search ? (


### PR DESCRIPTION
Better looking previous and next buttons for blob view search. Now more closely resembles safari's find feature.
 
Before: 
![Screenshot 2023-11-14 at 3 06 47 PM](https://github.com/sourcegraph/sourcegraph/assets/62355966/4a6c4718-6de5-485e-b4fe-e11a3994b10b)

After:
![Screenshot 2023-11-14 at 3 07 16 PM](https://github.com/sourcegraph/sourcegraph/assets/62355966/3170827e-78cc-4b94-bd32-258411e99d88)


## Test plan
Manual testing in light and dark mode.
