### PR TITLE
Update link on SignInPage.tsx

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -204,7 +204,7 @@ const SignUpNotice: React.FunctionComponent<{
     const dotcomCTAs = (
         <>
             <Link
-                to="https://sourcegraph.com/get-started?t=enterprise"
+                to="https://about.sourcegraph.com/get-started?t=enterprise"
                 onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })}
             >
                 consider Sourcegraph Enterprise


### PR DESCRIPTION
Updating a link on the dotcom login page that currently points to sourcegraph.com, while it should point to about.sourcegraph.com

## Test plan

Single link change; no new tests.