### PR TITLE
doc: add notes that new telemetry docs only apply to some events

### DIFF
--- a/doc/admin/telemetry/index.md
+++ b/doc/admin/telemetry/index.md
@@ -12,6 +12,9 @@ If you have any questions about telemetry collection, please reach out to your S
 
 <span class="badge badge-note">Sourcegraph 5.2.1+</span>
 
+> WARNING: This section refers to a new system for collecting telemetry introduced in Sourcegraph 5.2.1, and only applies to telemetry that has been migrated to use this new system.
+> Certain Sourcegraph components - namely [Cody editor extensions](../../cody/index.md) - will continue to use a legacy mechanism for reporting telemetry directly to Sourcegraph.com until the migration is complete.
+
 Sourcegraph instances 5.2.1 and later collect telemetry events to understand usage patterns and help improve the product. Telemetry events can be generated when certain user actions occur, like opening files or performing searches. This data helps us provide the highest level of support to Sourcegraph's customers.
 
 Sensitive data/PII exfiltration, intentional or not, is a significant concern to Sourcegraph that we take very seriously.

--- a/doc/dev/background-information/telemetry/architecture.md
+++ b/doc/dev/background-information/telemetry/architecture.md
@@ -10,6 +10,8 @@ In the [lifecycle of an event](./index.md#event-lifecycle), events are first [st
 
 See [testing events](./index.md#testing-events) for a summary of how to observe your events during development.
 
+> WARNING: This page primarily pertains to the new telemetry system introduced in Sourcegraph 5.2.1 - refer to [DEPRECATED: Telemetry](deprecated.md) for the legacy system which may still be in use if a callsite has not been migrated yet.
+
 ## Storing events
 
 Once [recorded](./index.md#recording-events), telemetry events are stored in two places:

--- a/doc/dev/background-information/telemetry/protocol.md
+++ b/doc/dev/background-information/telemetry/protocol.md
@@ -8,6 +8,8 @@
 
 This page contains generated documentation for telemetry event data that gets exported to Sourcegraph from individual Sourcegraph instances.
 
+> WARNING: This page primarily pertains to the new telemetry system introduced in Sourcegraph 5.2.1 - refer to [DEPRECATED: Telemetry](deprecated.md) for the legacy system which may still be in use if a callsite has not been migrated yet.
+
 ## Table of Contents
 
 - [telemetrygateway/v1/telemetrygateway.proto](#telemetrygateway_v1_telemetrygateway-proto)

--- a/internal/telemetrygateway/v1/protoc-gen-doc.tmpl
+++ b/internal/telemetrygateway/v1/protoc-gen-doc.tmpl
@@ -8,6 +8,8 @@
 
 This page contains generated documentation for telemetry event data that gets exported to Sourcegraph from individual Sourcegraph instances.
 
+> WARNING: This page primarily pertains to the new telemetry system introduced in Sourcegraph 5.2.1 - refer to [DEPRECATED: Telemetry](deprecated.md) for the legacy system which may still be in use if a callsite has not been migrated yet.
+
 ## Table of Contents
 {{range .Files}}
 {{$file_name := .Name}}- [{{.Name}}](#{{.Name | anchor}})


### PR DESCRIPTION
In 5.2.1, we've rolled out a new telemetry export framework and associated docs, but not all events use it yet - this change adds disclaimers that the new content does not apply to a lot of existing events. Migrations are being tracked by the analytics team. In most cases, there isn't an equivalent reference for the existing events, particularly Cody extension events, so I haven't added any links. There's a discussion about this in [this thread](https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1699627360154729).

I also made a few misc updates to other sections to hopefully improve the wording and clarity a bit.

## Test plan

n/a

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@telemetry-doc-update)