### PR TITLE
telemetry: allow env-var allowlisting of sensitive metadata export

### DIFF
--- a/internal/telemetry/sensitivemetadataallowlist/BUILD.bazel
+++ b/internal/telemetry/sensitivemetadataallowlist/BUILD.bazel
@@ -5,12 +5,13 @@ go_library(
     name = "sensitivemetadataallowlist",
     srcs = [
         "redact.go",
-        "sensitiviemetadataallowlist.go",
+        "sensitivemetadataallowlist.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/telemetry/sensitivemetadataallowlist",
     visibility = ["//:__subpackages__"],
     deps = [
         "//cmd/frontend/envvar",
+        "//internal/env",
         "//internal/telemetry",
         "//internal/telemetrygateway/v1:telemetrygateway",
         "//lib/errors",
@@ -28,6 +29,7 @@ go_test(
         "//internal/telemetry",
         "//internal/telemetrygateway/v1:telemetrygateway",
         "//lib/pointers",
+        "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//types/known/structpb",

--- a/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist_test.go
+++ b/internal/telemetry/sensitivemetadataallowlist/sensitivemetadataallowlist_test.go
@@ -3,6 +3,7 @@ package sensitivemetadataallowlist
 import (
 	"testing"
 
+	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,4 +22,53 @@ func TestIsAllowed(t *testing.T) {
 		Feature: "disallowedFeature",
 		Action:  "disallowedAction",
 	}))
+}
+
+func TestParseAdditionalAllowedEventTypes(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config string
+
+		expect      autogold.Value
+		expectError autogold.Value
+	}{
+		{
+			name:        "invalid",
+			config:      "asdf,foobar",
+			expectError: autogold.Expect(`cannot parse SRC_TELEMETRY_SENSITIVEMETADATA_ADDITIONAL_ALLOWED_EVENT_TYPES value "asdf"`),
+		},
+		{
+			name:   "1 type",
+			config: "foo::bar",
+			expect: autogold.Expect([]EventType{{
+				Feature: "foo",
+				Action:  "bar",
+			}}),
+		},
+		{
+			name:   "multiple types",
+			config: "foo::bar,baz.bar::bar.baz",
+			expect: autogold.Expect([]EventType{
+				{
+					Feature: "foo",
+					Action:  "bar",
+				},
+				{
+					Feature: "baz.bar",
+					Action:  "bar.baz",
+				},
+			}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseAdditionalAllowedEventTypes(tc.config)
+			if tc.expectError != nil {
+				require.Error(t, err)
+				tc.expectError.Equal(t, err.Error())
+			} else {
+				assert.NoError(t, err)
+				tc.expect.Equal(t, got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
In case we need more metadata from Cloud instances or a particular customer, an env var override could come in handy. It must be proactively configured.

This change also fixes a misspelling in the file name.

## Test plan

unit test on the parser