### PR TITLE
GraphQL: remove recursiveSingleChild option from backend

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_test.go
@@ -370,55 +370,6 @@ func TestGitTree_Entries(t *testing.T) {
 		}, entries)
 	})
 
-	t.Run("RecursiveSingleChild", func(t *testing.T) {
-		opts := GitTreeEntryResolverOpts{
-			Commit: &GitCommitResolver{
-				repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
-			},
-			Stat: CreateFileInfo(".aspect/", true),
-		}
-		gitTree := NewGitTreeEntryResolver(db, gitserverClient, opts)
-
-		entries, err := gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{RecursiveSingleChild: true})
-		require.NoError(t, err)
-		assertEntries(t, []fs.FileInfo{
-			CreateFileInfo(".aspect/cli/", true),
-			CreateFileInfo(".aspect/rules/", true),
-		}, entries)
-
-		opts = GitTreeEntryResolverOpts{
-			Commit: &GitCommitResolver{
-				repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
-			},
-			Stat: CreateFileInfo(".aspect/rules/", true),
-		}
-		gitTree = NewGitTreeEntryResolver(db, gitserverClient, opts)
-
-		entries, err = gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{RecursiveSingleChild: true})
-		require.NoError(t, err)
-		assertEntries(t, []fs.FileInfo{
-			CreateFileInfo(".aspect/rules/external_repository_action_cache/", true),
-			CreateFileInfo(".aspect/rules/external_repository_action_cache/file", false),
-		}, entries)
-
-		opts = GitTreeEntryResolverOpts{
-			Commit: &GitCommitResolver{
-				repoResolver: NewRepositoryResolver(db, gitserverClient, &types.Repo{Name: "my/repo"}),
-			},
-			Stat: CreateFileInfo(wantPath, true),
-		}
-		gitTree = NewGitTreeEntryResolver(db, gitserverClient, opts)
-
-		entries, err = gitTree.Entries(context.Background(), &gitTreeEntryConnectionArgs{RecursiveSingleChild: true})
-		require.NoError(t, err)
-		assertEntries(t, []fs.FileInfo{
-			CreateFileInfo(".aspect/", true),
-			CreateFileInfo("folder/", true),
-			CreateFileInfo("folder2/", true),
-			CreateFileInfo("file", false),
-		}, entries)
-	})
-
 	t.Run("Ancestors", func(t *testing.T) {
 		opts := GitTreeEntryResolverOpts{
 			Commit: &GitCommitResolver{

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5645,21 +5645,9 @@ type GitTree implements TreeEntry {
         """
         first: Int
         """
-        Recurse into sub-trees. If true, implies recursiveSingleChild.
+        Recurse into sub-trees.
         """
         recursive: Boolean = false
-        """
-        If recurseSingleChild is true, and the requested path only has a single child
-        that is a directory, recurse into that directory.
-        Only respected when recursive is false.
-        Example:
-        FS structure:
-        /folder/subfolder/file
-        Request for entries of /folder:
-        Instead of returning just /folder/subfolder, this API also travserse into subfolder
-        until it hits something with more than 1 child that's not a dir.
-        """
-        recursiveSingleChild: Boolean = false
         """
         Includes all parent directories and their entries. For example, if the path is
         `/client/web/something`, it will return the following entries in this order:


### PR DESCRIPTION
This is the backend half of [this PR](https://github.com/sourcegraph/sourcegraph/pull/58272). It removes the `recursiveSingleChild` logic from the tree resolver. All consumers of this field have been removed from the client already, and it's unlikely this would be something that customers would use (or even be able to use correctly) so I think it's safe to make what is technically a breaking change. 

## Test plan

Poked around in the file tree and everything looked fine. All consumers of this API have already been removed.
