### PR TITLE
[Cody] fix cody install event typo

### DIFF
--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -165,7 +165,7 @@ func (r *schemaResolver) LogEvents(ctx context.Context, args *EventBatch) (*Empt
 
 			ide := getIdeFromEvent(&args)
 
-			if ide == "vscode" {
+			if strings.ToLower(ide) == "vscode" {
 				if ffs := featureflag.FromContext(ctx); ffs != nil {
 					emailsEnabled = ffs.GetBoolOr("vscodeCodyEmailsEnabled", false)
 				}


### PR DESCRIPTION
IDE can be in a capital case. 

## Test plan
-
