### PR TITLE
repo: Show last commit information in file list

### DIFF
--- a/client/shared/src/backend/apolloCache.ts
+++ b/client/shared/src/backend/apolloCache.ts
@@ -35,6 +35,8 @@ export const generateCache = (): InMemoryCache =>
             Changeset: ['ExternalChangeset', 'HiddenExternalChangeset'],
             TeamMember: ['User'],
             Owner: ['Person', 'Team'],
+            TreeEntry: ['GitBlob', 'GitTree'],
+            File2: ['GitBlob', 'VirtualFile'],
         },
     })
 

--- a/client/web/src/repo/tree/TreePageContent.module.scss
+++ b/client/web/src/repo/tree/TreePageContent.module.scss
@@ -15,16 +15,11 @@
         grid-template-areas:
             'files files files'
             'contributors contributors contributors'
-            'commits commits commits';
     }
 }
 
 .files {
     grid-area: files;
-}
-
-.commits {
-    grid-area: commits;
 }
 
 .contributors {
@@ -40,14 +35,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     border-top: 1px solid var(--border-color);
-}
-
-.git-commit-node {
-    padding: 0.25rem 0;
-
-    &-message-subject {
-        font-weight: normal;
-    }
 }
 
 .table {

--- a/client/web/src/repo/tree/TreePagePanels.module.scss
+++ b/client/web/src/repo/tree/TreePagePanels.module.scss
@@ -40,77 +40,48 @@
     height: 31.5rem;
 }
 
-.card-col-header-wrapper {
-    background-color: var(--color-bg-2);
+table.files {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 0;
+    margin-bottom: 0;
+    display: table;
 
-    a {
-        color: var(--link-color-2);
-    }
-}
-
-.file-item {
-    border-bottom: 1px solid var(--border-color);
-
-    &:last-child {
-        border-bottom: none;
-    }
-}
-
-.card-col-header {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-}
-
-.bar-svg {
-    border-radius: 5px;
-}
-
-.diff-stat-added {
-    fill: var(--diff-add-fg);
-}
-
-.diff-stat-deleted {
-    fill: var(--diff-remove-fg);
-}
-
-.meter-container {
-    padding-top: 0.125rem;
-}
-
-.tree-entry {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-
-    margin-left: -0.25rem;
-    margin-right: -0.25rem;
-    padding: 0.125rem 0.25rem;
-
-    break-inside: avoid-column;
-
-    &:hover {
-        background-color: var(--color-bg-1);
+    th {
+        padding: 0.5rem;
+        font-weight: normal;
+        box-sizing: content-box;
     }
 
-    &--no-columns {
-        max-width: 18rem;
+    td {
+        padding: 0.5rem;
     }
-}
 
-.sort-dsc-icon {
-    padding: 0;
-    margin: -0.125rem 0 0 0;
-    color: var(--icon-muted);
-}
+    .file-name-column {
+        width: 30%;
+    }
 
-.sort-asc-icon {
-    padding: 0;
-    margin: -0.625rem 0 0 0;
-    color: var(--icon-muted);
-}
+    .commit-date-column {
+        width: 120px;
+    }
 
-.sort-selected-icon {
-    color: var(--icon-color);
+    th,
+    .file-name,
+    .commit-message,
+    .commit-date {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        max-width: 100%;
+    }
+
+    .commit-date,
+    .commit-date-column {
+        text-align: right;
+    }
+
+    tbody td {
+        border-top: 1px solid var(--border-color);
+    }
 }


### PR DESCRIPTION
Closes #57827 

This commit changes the files panel to show the last commit message and date that changed the respective file.

The commits panel is removed to avoid confusion and unnecessarily duplicating information. I originally planned to add the history toggle button to the "actions" bar for tree pages, so that users can still get the same information via the history panel.
However the whole panel logic is currently part of the blob page and making that work fro the tree page that would require some refactoring. This is better be done in a separate PR, but maybe we also find out that we don't need this functionality.

The history data is loaded separately because it's generally slower to load than just the file list. While the commit data is loading the file panel will appear as a table with a single column. Once the data is available the other column headers and data appear. Without a loading state this felt better than having empty columns.

The GraphQL query for fetching the history data specifies repo and commit IDs to cache this data client side.

![2023-11-15_10-17](https://github.com/sourcegraph/sourcegraph/assets/179026/e22eecc3-20e3-48fd-8860-8b061c8e71e2)



## Test plan

- Open repository root page
- Open tree page 
