### PR TITLE
Fix link to Enterprise page

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -204,7 +204,7 @@ const SignUpNotice: React.FunctionComponent<{
     const dotcomCTAs = (
         <>
             <Link
-                to="https://sourcegraph.com/get-started?t=enterprise"
+                to="https://about.sourcegraph.com/get-started?t=enterprise"
                 onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })}
             >
                 consider Sourcegraph Enterprise


### PR DESCRIPTION
The current link is pointing to the public Code Search, instead of the page in about.sourcegraph.com.

## Test plan

N/A