### PR TITLE
Don't remove the URL number / line selection when user clicks again

### DIFF
--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -432,7 +432,3 @@ export function shouldScrollIntoView(view: EditorView, range: SelectedLineRange)
         to.top <= view.scrollDOM.scrollTop
     )
 }
-
-function isSingleLine(range: SelectedLineRange): boolean {
-    return !!range && (!range.endLine || range.line === range.endLine)
-}

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -335,11 +335,8 @@ export function selectableLineNumbers(config: SelectableLineNumbersConfig): Exte
                     }
 
                     const line = view.state.doc.lineAt(block.from).number
-                    const range = view.state.field(selectedLines)
                     view.dispatch({
-                        effects: mouseEvent.shiftKey
-                            ? setEndLine.of(line)
-                            : setSelectedLines.of(isSingleLine(range) && range?.line === line ? null : { line }),
+                        effects: mouseEvent.shiftKey ? setEndLine.of(line) : setSelectedLines.of({ line }),
                         annotations: lineSelectionSource.of('gutter'),
                         // Collapse/reset text selection
                         selection: { anchor: view.state.selection.main.anchor },


### PR DESCRIPTION
Don't remove the line selection (and URL fragment) when a user clicks on a line again - Slack discussion, other Code Editor / browsing systems (Github / Gitlab / Google Code Search) don't remove it.
## Test plan

- tested locally
