### PR TITLE
Reimplement fix for setting p4trust consistently in 5.2

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1709,7 +1709,7 @@ func (s *Server) handleP4Exec(w http.ResponseWriter, r *http.Request) {
 	)
 
 	// Make sure credentials are valid before heavier operation
-	err := p4testWithTrust(r.Context(), req.P4Port, req.P4User, req.P4Passwd)
+	err := p4testWithTrust(r.Context(), req.P4Port, req.P4User, req.P4Passwd, filepath.Join(s.ReposDir, P4HomeName))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -1833,6 +1833,7 @@ func (s *Server) p4Exec(ctx context.Context, logger log.Logger, req *protocol.P4
 		"P4PORT="+req.P4Port,
 		"P4USER="+req.P4User,
 		"P4PASSWD="+req.P4Passwd,
+		"HOME="+filepath.Join(s.ReposDir, P4HomeName),
 	)
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stderrW

--- a/cmd/gitserver/server/server_grpc.go
+++ b/cmd/gitserver/server/server_grpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -292,7 +293,7 @@ func (gs *GRPCServer) P4Exec(req *proto.P4ExecRequest, ss proto.GitserverService
 	)
 
 	// Make sure credentials are valid before heavier operation
-	err := p4testWithTrust(ss.Context(), req.GetP4Port(), req.GetP4User(), req.GetP4Passwd())
+	err := p4testWithTrust(ss.Context(), req.GetP4Port(), req.GetP4User(), req.GetP4Passwd(), filepath.Join(gs.Server.ReposDir, P4HomeName))
 	if err != nil {
 		if ctxErr := ss.Context().Err(); ctxErr != nil {
 			return status.FromContextError(ctxErr).Err()


### PR DESCRIPTION
Since there were a lot of changes around this code base including new gitserver RPC endpoints, I decided to implement a minimal fix here from scratch vs trying to backport maybe 5000 loc or going through rebase hell.
This PR fixes the integration test for perforce since we switched to SSL. This fixes a real issue, not just CI. 

## Test plan

CI passes now, was red before.