### PR TITLE
repos: fix slow TestSources_ListRepos test

### DIFF
--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
+	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -39,6 +41,9 @@ func TestSources_ListRepos(t *testing.T) {
 		},
 	})
 	defer conf.Mock(nil)
+
+	rcache.SetupForTest(t)
+	ratelimit.SetupForTest(t)
 
 	type testCase struct {
 		name   string


### PR DESCRIPTION
This test requires Redis under the hood.

I do have Redis running, but since `redis-cache` and `redis-store` aren't valid hostnames on my local machine, the tests couldn't connect and would timeout, leading to a long test run time.

Before:

    $ time go test -run 'TestSources_ListRepos$' ./internal/repos -count=1
    [...]
    5.90s user 2.04s system 19% cpu 39.877 total

After:

    $ time go test -run 'TestSources_ListRepos$' ./internal/repos -count=1
    [...]
    3.78s user 1.64s system 135% cpu 3.993 total



## Test plan

- Running this test