### PR TITLE
Replace default httpclient for cody requests 

### DIFF
--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -33,17 +33,17 @@ func Get(
 func getBasic(endpoint string, provider conftypes.CompletionsProviderName, accessToken string) (types.CompletionsClient, error) {
 	switch provider {
 	case conftypes.CompletionsProviderNameAnthropic:
-		return anthropic.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
+		return anthropic.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken), nil
 	case conftypes.CompletionsProviderNameOpenAI:
-		return openai.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
+		return openai.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken), nil
 	case conftypes.CompletionsProviderNameAzureOpenAI:
-		return azureopenai.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
+		return azureopenai.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken), nil
 	case conftypes.CompletionsProviderNameSourcegraph:
-		return codygateway.NewClient(httpcli.ExternalDoer, endpoint, accessToken)
+		return codygateway.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken)
 	case conftypes.CompletionsProviderNameFireworks:
-		return fireworks.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
+		return fireworks.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken), nil
 	case conftypes.CompletionsProviderNameAWSBedrock:
-		return awsbedrock.NewClient(httpcli.ExternalDoer, endpoint, accessToken), nil
+		return awsbedrock.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken), nil
 	default:
 		return nil, errors.Newf("unknown completion stream provider: %s", provider)
 	}

--- a/internal/embeddings/embed/embed.go
+++ b/internal/embeddings/embed/embed.go
@@ -25,11 +25,11 @@ import (
 func NewEmbeddingsClient(config *conftypes.EmbeddingsConfig) (client.EmbeddingsClient, error) {
 	switch config.Provider {
 	case conftypes.EmbeddingsProviderNameSourcegraph:
-		return sourcegraph.NewClient(httpcli.ExternalClient, config), nil
+		return sourcegraph.NewClient(httpcli.UncachedExternalClient, config), nil
 	case conftypes.EmbeddingsProviderNameOpenAI:
-		return openai.NewClient(httpcli.ExternalClient, config), nil
+		return openai.NewClient(httpcli.UncachedExternalClient, config), nil
 	case conftypes.EmbeddingsProviderNameAzureOpenAI:
-		return azureopenai.NewClient(httpcli.ExternalClient, config), nil
+		return azureopenai.NewClient(httpcli.UncachedExternalClient, config), nil
 	default:
 		return nil, errors.Newf("invalid provider %q", config.Provider)
 	}

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -160,8 +160,13 @@ func newExternalClientFactory(cache bool, middleware ...Middleware) *Factory {
 // convenience for existing uses of http.DefaultClient.
 // WARN: This client caches entire responses for etag matching. Do not use it for
 // one-off requests if possible, and definitely not for larger payloads, like
-// downloading arbitrarily sized files! See UncachedExternalClient instead.
+// downloading arbitrarily sized files! See UncachedExternalDoer instead.
 var ExternalDoer, _ = ExternalClientFactory.Doer()
+
+// UncachedExternalDoer is a shared client for external communication. This is a
+// convenience for existing uses of http.DefaultClient.
+// This client does not cache responses. To cache responses see ExternalDoer instead.
+var UncachedExternalDoer, _ = UncachedExternalClientFactory.Doer()
 
 // ExternalClient returns a shared client for external communication. This is
 // a convenience for existing uses of http.DefaultClient.
@@ -169,6 +174,11 @@ var ExternalDoer, _ = ExternalClientFactory.Doer()
 // one-off requests if possible, and definitely not for larger payloads, like
 // downloading arbitrarily sized files! See UncachedExternalClient instead.
 var ExternalClient, _ = ExternalClientFactory.Client()
+
+// UncachedExternalClient returns a shared client for external communication. This is
+// a convenience for existing uses of http.DefaultClient.
+// WARN: This client does not cache responses. To cache responses see ExternalClient instead.
+var UncachedExternalClient, _ = UncachedExternalClientFactory.Client()
 
 // InternalClientFactory is a httpcli.Factory with common options
 // and middleware pre-set for communicating with internal services.


### PR DESCRIPTION
Switched the completions & embeddings clients to use an uncached client, as the requests should be unique and caching would not be helpful.
## Test plan
CI 
Chatted with Cody web successfully, embedded a repo successfully 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
