### PR TITLE
sec: Make GraphQL cost limits configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Added configurable GraphQL query cost limitations to prevent unintended resource exhaustion. Default values are now provided and enforced, replacing the previously unlimited behaviour. For more information, please refer to: [GraphQL Cost Limits Documentation](https://docs.sourcegraph.com/api/graphql#cost-limits). See details at [#58346](https://github.com/sourcegraph/sourcegraph/pull/58346).
 
-
 ### Changed
 
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- Added configurable GraphQL query cost limitations to prevent unintended resource exhaustion. Default values are now provided and enforced, replacing the previously unlimited behaviour. For more information, please refer to: [GraphQL Cost Limits Documentation](https://docs.sourcegraph.com/api/graphql#cost-limits). See details at [#58346](https://github.com/sourcegraph/sourcegraph/pull/58346).
+
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -633,7 +633,7 @@ func NewSchema(
 	opts := []graphql.SchemaOpt{
 		graphql.Tracer(newRequestTracer(log.Scoped("GraphQL"), db)),
 		graphql.UseStringDescriptions(),
-		graphql.MaxDepth(maxDepth),
+		graphql.MaxDepth(conf.RateLimits().GraphQLMaxDepth),
 	}
 	opts = append(opts, graphqlOpts...)
 	return graphql.ParseSchema(

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -22,10 +22,6 @@ import (
 // the algorithm
 const costEstimateVersion = 2
 
-const MaxAliasCount = 500        // SECURITY: prevent too many aliased queries
-const MaxFieldCount = 500 * 1000 // SECURITY: prevent deeply nested or overly broad queries
-const maxDepth = 30              // SECURITY: prevent deep queries that consume too many resources
-
 type QueryCost struct {
 	FieldCount int
 	MaxDepth   int

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -122,7 +122,7 @@ func TestSearch(t *testing.T) {
 			sr := newSchemaResolver(db, gsClient)
 			gqlSchema, err := graphql.ParseSchema(mainSchema, sr,
 				graphql.Tracer(newRequestTracer(logtest.Scoped(t), db)),
-				graphql.MaxDepth(maxDepth))
+				graphql.MaxDepth(conf.RateLimits().GraphQLMaxDepth))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -15,6 +15,7 @@ import (
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
@@ -31,7 +32,7 @@ func mustParseGraphQLSchemaWithClient(t *testing.T, db database.DB, gitserverCli
 		gitserverClient,
 		[]OptionalResolver{},
 		graphql.PanicHandler(printStackTrace{&gqlerrors.DefaultPanicHandler{}}),
-		graphql.MaxDepth(maxDepth),
+		graphql.MaxDepth(conf.RateLimits().GraphQLMaxDepth),
 	)
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -461,29 +461,26 @@ func PasswordPolicyEnabled() bool {
 }
 
 func RateLimits() schema.RateLimits {
-	maxAliases := 500
-	maxFieldCount := 500_000
-	maxDepth := 30
-
-	rl := Get().RateLimits
-	if rl != nil {
-		if rl.GraphQLMaxAliases <= 0 {
-			rl.GraphQLMaxAliases = maxAliases
-		}
-		if rl.GraphQLMaxFieldCount <= 0 {
-			rl.GraphQLMaxFieldCount = maxFieldCount
-		}
-		if rl.GraphQLMaxDepth <= 0 {
-			rl.GraphQLMaxDepth = maxDepth
-		}
-		return *rl
+	rl := schema.RateLimits{
+		GraphQLMaxAliases:    500,
+		GraphQLMaxFieldCount: 500_000,
+		GraphQLMaxDepth:      30,
 	}
 
-	return schema.RateLimits{
-		GraphQLMaxAliases:    maxAliases,
-		GraphQLMaxFieldCount: maxFieldCount,
-		GraphQLMaxDepth:      maxDepth,
+	configured := Get().RateLimits
+
+	if configured != nil {
+		if configured.GraphQLMaxAliases <= 0 {
+			rl.GraphQLMaxAliases = configured.GraphQLMaxAliases
+		}
+		if configured.GraphQLMaxFieldCount <= 0 {
+			rl.GraphQLMaxFieldCount = configured.GraphQLMaxFieldCount
+		}
+		if configured.GraphQLMaxDepth <= 0 {
+			rl.GraphQLMaxDepth = configured.GraphQLMaxDepth
+		}
 	}
+	return rl
 }
 
 // By default, password reset links are valid for 4 hours.

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -460,6 +460,32 @@ func PasswordPolicyEnabled() bool {
 	return pc.Enabled
 }
 
+func RateLimits() schema.RateLimits {
+	maxAliases := 500
+	maxFieldCount := 500_000
+	maxDepth := 30
+
+	rl := Get().RateLimits
+	if rl != nil {
+		if rl.GraphQLMaxAliases <= 0 {
+			rl.GraphQLMaxAliases = maxAliases
+		}
+		if rl.GraphQLMaxFieldCount <= 0 {
+			rl.GraphQLMaxFieldCount = maxFieldCount
+		}
+		if rl.GraphQLMaxDepth <= 0 {
+			rl.GraphQLMaxDepth = maxDepth
+		}
+		return *rl
+	}
+
+	return schema.RateLimits{
+		GraphQLMaxAliases:    maxAliases,
+		GraphQLMaxFieldCount: maxFieldCount,
+		GraphQLMaxDepth:      maxDepth,
+	}
+}
+
 // By default, password reset links are valid for 4 hours.
 const defaultPasswordLinkExpiry = 14400
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1986,7 +1986,7 @@ type Ranking struct {
 type RateLimits struct {
 	// GraphQLMaxAliases description: Maximum number of aliases allowed in a GraphQL query
 	GraphQLMaxAliases int `json:"graphQLMaxAliases,omitempty"`
-	// GraphQLMaxDepth description: Maximum depth of nested objects allowed for GraphQL queries
+	// GraphQLMaxDepth description: Maximum depth of nested objects allowed for GraphQL queries. Changes to this setting require a restart.
 	GraphQLMaxDepth int `json:"graphQLMaxDepth,omitempty"`
 	// GraphQLMaxFieldCount description: Maximum number of estimated fields allowed in a GraphQL response
 	GraphQLMaxFieldCount int `json:"graphQLMaxFieldCount,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1985,11 +1985,11 @@ type Ranking struct {
 }
 type RateLimits struct {
 	// GraphQLMaxAliases description: Maximum number of aliases allowed in a GraphQL query
-	GraphQLMaxAliases int `json:"GraphQLMaxAliases,omitempty"`
+	GraphQLMaxAliases int `json:"graphQLMaxAliases,omitempty"`
 	// GraphQLMaxDepth description: Maximum depth of nested objects allowed for GraphQL queries
-	GraphQLMaxDepth int `json:"GraphQLMaxDepth,omitempty"`
+	GraphQLMaxDepth int `json:"graphQLMaxDepth,omitempty"`
 	// GraphQLMaxFieldCount description: Maximum number of estimated fields allowed in a GraphQL response
-	GraphQLMaxFieldCount int `json:"GraphQLMaxFieldCount,omitempty"`
+	GraphQLMaxFieldCount int `json:"graphQLMaxFieldCount,omitempty"`
 }
 
 // RepoPurgeWorker description: Configuration for repository purge worker.
@@ -2491,7 +2491,6 @@ type SettingsOpenInEditor struct {
 
 // SiteConfiguration description: Configuration for a Sourcegraph site.
 type SiteConfiguration struct {
-	RateLimits *RateLimits `json:"RateLimits,omitempty"`
 	// RedirectUnsupportedBrowser description: Prompts user to install new browser for non es5
 	RedirectUnsupportedBrowser bool `json:"RedirectUnsupportedBrowser,omitempty"`
 	// App description: Configuration options for App only.
@@ -2740,7 +2739,8 @@ type SiteConfiguration struct {
 	// PermissionsUserMapping description: Settings for Sourcegraph explicit permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This will mark repositories as restricted by default.
 	PermissionsUserMapping *PermissionsUserMapping `json:"permissions.userMapping,omitempty"`
 	// ProductResearchPageEnabled description: Enables users access to the product research page in their settings.
-	ProductResearchPageEnabled *bool `json:"productResearchPage.enabled,omitempty"`
+	ProductResearchPageEnabled *bool       `json:"productResearchPage.enabled,omitempty"`
+	RateLimits                 *RateLimits `json:"rateLimits,omitempty"`
 	// RedactOutboundRequestHeaders description: Enables redacting sensitive information from outbound requests. Important: We only respect this setting in development environments. In production, we always redact outbound requests.
 	RedactOutboundRequestHeaders *bool `json:"redactOutboundRequestHeaders,omitempty"`
 	// RepoConcurrentExternalServiceSyncers description: The number of concurrent external service syncers that can run.
@@ -2798,7 +2798,6 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
-	delete(m, "RateLimits")
 	delete(m, "RedirectUnsupportedBrowser")
 	delete(m, "app")
 	delete(m, "auth.accessRequest")
@@ -2916,6 +2915,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "permissions.syncUsersMaxConcurrency")
 	delete(m, "permissions.userMapping")
 	delete(m, "productResearchPage.enabled")
+	delete(m, "rateLimits")
 	delete(m, "redactOutboundRequestHeaders")
 	delete(m, "repoConcurrentExternalServiceSyncers")
 	delete(m, "repoListUpdateInterval")

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1983,6 +1983,14 @@ type Ranking struct {
 	// RepoScores description: a map of URI directories to numeric scores for specifying search result importance, like {"github.com": 500, "github.com/sourcegraph": 300, "github.com/sourcegraph/sourcegraph": 100}. Would rank "github.com/sourcegraph/sourcegraph" as 500+300+100=900, and "github.com/other/foo" as 500.
 	RepoScores map[string]float64 `json:"repoScores,omitempty"`
 }
+type RateLimits struct {
+	// GraphQLMaxAliases description: Maximum number of aliases allowed in a GraphQL query
+	GraphQLMaxAliases int `json:"GraphQLMaxAliases,omitempty"`
+	// GraphQLMaxDepth description: Maximum depth of nested objects allowed for GraphQL queries
+	GraphQLMaxDepth int `json:"GraphQLMaxDepth,omitempty"`
+	// GraphQLMaxFieldCount description: Maximum number of estimated fields allowed in a GraphQL response
+	GraphQLMaxFieldCount int `json:"GraphQLMaxFieldCount,omitempty"`
+}
 
 // RepoPurgeWorker description: Configuration for repository purge worker.
 type RepoPurgeWorker struct {
@@ -2483,6 +2491,7 @@ type SettingsOpenInEditor struct {
 
 // SiteConfiguration description: Configuration for a Sourcegraph site.
 type SiteConfiguration struct {
+	RateLimits *RateLimits `json:"RateLimits,omitempty"`
 	// RedirectUnsupportedBrowser description: Prompts user to install new browser for non es5
 	RedirectUnsupportedBrowser bool `json:"RedirectUnsupportedBrowser,omitempty"`
 	// App description: Configuration options for App only.
@@ -2789,6 +2798,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
+	delete(m, "RateLimits")
 	delete(m, "RedirectUnsupportedBrowser")
 	delete(m, "app")
 	delete(m, "auth.accessRequest")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -49,6 +49,27 @@
       "type": "boolean",
       "default": false
     },
+    "RateLimits": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "GraphQLMaxDepth": {
+          "description": "Maximum depth of nested objects allowed for GraphQL queries",
+          "type" : "integer",
+          "default": 30
+        },
+        "GraphQLMaxAliases": {
+          "description": "Maximum number of aliases allowed in a GraphQL query",
+          "type": "integer",
+          "default": 500
+        },
+        "GraphQLMaxFieldCount": {
+          "description": "Maximum number of estimated fields allowed in a GraphQL response",
+          "type":"integer",
+          "default": 500000
+        }
+      }
+    },
     "exportUsageTelemetry": {
       "type": "object",
       "additionalProperties": false,

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -49,21 +49,21 @@
       "type": "boolean",
       "default": false
     },
-    "RateLimits": {
+    "rateLimits": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "GraphQLMaxDepth": {
+        "graphQLMaxDepth": {
           "description": "Maximum depth of nested objects allowed for GraphQL queries",
           "type": "integer",
           "default": 30
         },
-        "GraphQLMaxAliases": {
+        "graphQLMaxAliases": {
           "description": "Maximum number of aliases allowed in a GraphQL query",
           "type": "integer",
           "default": 500
         },
-        "GraphQLMaxFieldCount": {
+        "graphQLMaxFieldCount": {
           "description": "Maximum number of estimated fields allowed in a GraphQL response",
           "type": "integer",
           "default": 500000

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -54,7 +54,7 @@
       "additionalProperties": false,
       "properties": {
         "graphQLMaxDepth": {
-          "description": "Maximum depth of nested objects allowed for GraphQL queries",
+          "description": "Maximum depth of nested objects allowed for GraphQL queries. Changes to this setting require a restart.",
           "type": "integer",
           "default": 30
         },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -55,7 +55,7 @@
       "properties": {
         "GraphQLMaxDepth": {
           "description": "Maximum depth of nested objects allowed for GraphQL queries",
-          "type" : "integer",
+          "type": "integer",
           "default": 30
         },
         "GraphQLMaxAliases": {
@@ -65,7 +65,7 @@
         },
         "GraphQLMaxFieldCount": {
           "description": "Maximum number of estimated fields allowed in a GraphQL response",
-          "type":"integer",
+          "type": "integer",
           "default": 500000
         }
       }


### PR DESCRIPTION
This makes it easier for customer site-admin to change the GraphQL limits. It adds a `RateLimits` function to fetch the structure and makes sure we have default values.

## Test plan
CI tests, test locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
