### PR TITLE
Code Navigation: fix double line highlight in Firefox

### DIFF
--- a/client/web/src/repo/blob/codemirror/codeintel/README.md
+++ b/client/web/src/repo/blob/codemirror/codeintel/README.md
@@ -9,7 +9,7 @@ The code intel extensions provide the following functionality:
   keyboard
 - Code intel tooltips: Information about a specific token (if available)
 - Document highlights: Highlight all occurrences of a specific token
-- Got to definition: The ability to navigate to the definition for a specific
+- Go to definition: The ability to navigate to the definition for a specific
   token
 
 The main entry point for the whole set of extensions is the

--- a/client/web/src/repo/blob/codemirror/codeintel/decorations.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/decorations.ts
@@ -17,7 +17,7 @@ export const ignoreDecorations = Facet.define<{ from: number; to: number } | nul
 
 /**
  * We can't add/remove any decorations inside the selected token, because
- * that causes the node to be recreated and loosing focus, which breaks
+ * that causes the node to be recreated and lose focus, which breaks
  * token keyboard navigation.
  * This facet should be used by all codeIntel extensions to ensure that any
  * conflicting decoration is removed.

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -21,8 +21,9 @@ import {
     type ViewUpdate,
 } from '@codemirror/view'
 
-import { isValidLineRange, MOUSE_MAIN_BUTTON } from './utils'
 import { isFirefox } from '@sourcegraph/common'
+
+import { isValidLineRange, MOUSE_MAIN_BUTTON } from './utils'
 
 const selectedLinesTheme = EditorView.theme({
     /**

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -21,7 +21,7 @@ import {
     type ViewUpdate,
 } from '@codemirror/view'
 
-import { isValidLineRange, MOUSE_MAIN_BUTTON } from './utils'
+import { browserIsFirefox, isValidLineRange, MOUSE_MAIN_BUTTON } from './utils'
 
 const selectedLinesTheme = EditorView.theme({
     /**
@@ -30,14 +30,21 @@ const selectedLinesTheme = EditorView.theme({
      * are visible) more in its `top` value breaking alignment wih the line.
      * We compensate this spacing by setting negative margin-top.
      *
+     * Line highlighting breaks (highlights two lines instead of 1) in firefox if minHeight is set, so we
+     * add a conditional to check for the current browser, and set the css accordingly.
+     *
      * todo(fkling): Revisit this, styling is not correct for empty lines
      */
-    '.selected-lines-layer .selected-line': {
-        marginTop: '-1px',
+    '.selected-lines-layer .selected-line': browserIsFirefox()
+        ? {
+              marginTop: '-1px',
+          }
+        : {
+              marginTop: '-1px',
+              // Ensure selection marker height matches line height.
+              minHeight: '1.0rem',
+          },
 
-        // Ensure selection marker height matches line height.
-        minHeight: '1rem',
-    },
     '.selected-lines-layer .selected-line.blame-visible': {
         marginTop: '-5px',
 

--- a/client/web/src/repo/blob/codemirror/linenumbers.ts
+++ b/client/web/src/repo/blob/codemirror/linenumbers.ts
@@ -21,7 +21,8 @@ import {
     type ViewUpdate,
 } from '@codemirror/view'
 
-import { browserIsFirefox, isValidLineRange, MOUSE_MAIN_BUTTON } from './utils'
+import { isValidLineRange, MOUSE_MAIN_BUTTON } from './utils'
+import { isFirefox } from '@sourcegraph/common'
 
 const selectedLinesTheme = EditorView.theme({
     /**
@@ -35,7 +36,7 @@ const selectedLinesTheme = EditorView.theme({
      *
      * todo(fkling): Revisit this, styling is not correct for empty lines
      */
-    '.selected-lines-layer .selected-line': browserIsFirefox()
+    '.selected-lines-layer .selected-line': isFirefox()
         ? {
               marginTop: '-1px',
           }

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -263,7 +263,3 @@ export function isRegularEvent(event: MouseEvent | KeyboardEvent): boolean {
         !event.ctrlKey
     )
 }
-
-export function browserIsFirefox(): boolean {
-    return navigator.userAgent.includes('Firefox')
-}

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -263,3 +263,7 @@ export function isRegularEvent(event: MouseEvent | KeyboardEvent): boolean {
         !event.ctrlKey
     )
 }
+
+export function browserIsFirefox(): boolean {
+    return navigator.userAgent.includes('Firefox')
+}


### PR DESCRIPTION
Fixes a bug that caused double line highlighting when using Code Search in Firefox. 

## Test plan
1. Manually test in firefox at different zoom levels
2. Manually test in chrome and safari at different zoom levels
