### PR TITLE
Revert "refer to `sg help` instead of auto-generating markdown docs for `sg` (#58225)"

### DIFF
--- a/dev/BUILD.bazel
+++ b/dev/BUILD.bazel
@@ -10,6 +10,7 @@ write_source_files(
         "//cmd/frontend/internal/guardrails/dotcom:write_genql_yaml",
         "//doc/admin/observability:write_monitoring_docs",
         "//doc/cli/references:write_doc_files",
+        "//doc/dev/background-information/sg:write_cli_reference_doc",
         "//doc/dev/background-information/telemetry:write_telemetrygateway_doc",
         "//internal/batches/search/syntax:write_token_type",
         "//internal/database:write_schemas",

--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -159,3 +159,25 @@ go_test(
         "@com_github_urfave_cli_v2//:cli",
     ],
 )
+
+# Refer to /doc/dev/background-information/sg/BUILD.bazel to see how this target is used to copy the
+# reference.md to the correct directory.
+#
+# Alternatively, if you just want to generate the doc:
+# bazel run //doc/dev/background-information/sg:write_cli_reference_doc
+genrule(
+    name = "generate_reference_doc",
+    srcs = ["//:sg.config.yaml"],
+    outs = ["_reference.md"],
+    cmd = """
+    SG_FORCE_REPO_ROOT="$$(pwd)" $(location :sg) \
+            --no-dev-private \
+            --disable-overwrite \
+            --disable-analytics \
+            --skip-auto-update \
+            --config sg.config.yaml \
+            help --full --output $@
+    """,
+    tools = [":sg"],
+    visibility = ["//visibility:public"],
+)

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -82,6 +82,9 @@ var (
 const sgBugReportTemplate = "https://github.com/sourcegraph/sourcegraph/issues/new?template=sg_bug.md"
 
 // sg is the main sg CLI application.
+//
+// To generate the reference.md (previously done with go generate) do:
+// bazel run //doc/dev/background-information/sg:write_cli_reference_doc
 var sg = &cli.App{
 	Usage:       "The Sourcegraph developer tool!",
 	Description: "Learn more: https://docs.sourcegraph.com/dev/background-information/sg",

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -8,6 +8,7 @@ sh_test(
         "//dev/tools:docsite",
         "//doc/admin/observability:doc_files",
         "//doc/cli/references:doc_files",
+        "//doc/dev/background-information/sg:doc_files",
         "//doc/dev/background-information/telemetry:doc_files",
     ] + glob(
         ["**/*"],

--- a/doc/dev/background-information/ci/index.md
+++ b/doc/dev/background-information/ci/index.md
@@ -164,7 +164,7 @@ Also see [Buildkite infrastructure](#buildkite-infrastructure).
 
 ##### Flaky linters
 
-Linters are all run through [`sg lint`], with linters defined in [`dev/sg/linters`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/sg/linters).
+Linters are all run through [`sg lint`](../sg/reference.md#sg-lint), with linters defined in [`dev/sg/linters`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/sg/linters).
 If a linter is flaky, you can modify the `dev/sg/linters` package to disable the specific linter (or entire category of linters) with the `Enabled: disabled(...)` helper:
 
 ```diff

--- a/doc/dev/background-information/insights/backend.md
+++ b/doc/dev/background-information/insights/backend.md
@@ -300,4 +300,4 @@ UNION
 
 `migrations/codeinsights` in the root of this repository contains the migrations for the Code Insights database, they are executed when the frontend starts up (as is the same with e.g. codeintel DB migrations.)
 
-Migrations can be created using [`sg`](../sg/index.md).
+Migrations can be created using [`sg`](../sg/reference.md#sg-migration-add) 

--- a/doc/dev/background-information/sg/BUILD.bazel
+++ b/doc/dev/background-information/sg/BUILD.bazel
@@ -1,0 +1,16 @@
+load("//dev:write_generated_to_source_files.bzl", "write_generated_to_source_files")
+
+filegroup(
+    name = "doc_files",
+    srcs = glob(
+        ["**/*"],
+    ),
+    visibility = ["//doc:__pkg__"],
+)
+
+write_generated_to_source_files(
+    name = "write_cli_reference_doc",
+    output_files = {"reference.md": "dev/sg/_reference.md"},
+    tags = ["go_generate"],
+    target = "//dev/sg:generate_reference_doc",
+)

--- a/doc/dev/background-information/sg/index.md
+++ b/doc/dev/background-information/sg/index.md
@@ -79,6 +79,10 @@ On the next command run, if a new version is detected, `sg` will auto update bef
 
 To see what's changed, use `sg version changelog`.
 
+## Usage
+
+Refer to the [generated `sg` reference](reference.md) for complete documentation of all commands.
+
 ### Help
 
 You can get help about commands locally in a variety of ways:
@@ -89,9 +93,9 @@ sg help # show all available commands
 # learn about a specific command or subcommand
 sg <command> -h
 sg <command> --help
-
-sg help -full # full reference
 ```
+
+A full reference is available in the [generated `sg` reference](reference.md). You can also view the full reference locally with `sg help -full`.
 
 ### Autocompletion
 

--- a/doc/dev/background-information/sg/reference.md
+++ b/doc/dev/background-information/sg/reference.md
@@ -75,7 +75,7 @@ $ sg start batches
 $ sg start --debug=gitserver --error=enterprise-worker,enterprise-frontend enterprise
 
 # View configuration for a commandset
-$ sg start -describe oss
+$ sg start -describe single-program
 ```
 
 Flags:

--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -71,6 +71,7 @@ Clarification and discussion about key concepts, architecture, and development s
 ### Development
 
 - [`sg` - the Sourcegraph developer tool](background-information/sg/index.md)
+  - [Full `sg` reference](background-information/sg/reference.md)
 - [Using Bazel](background-information/bazel/index.md)
   - [Bazel and Go code](background-information/bazel/go.md)
   - [Bazel and client code](background-information/bazel/web.md)

--- a/doc/dev/setup/quickstart.md
+++ b/doc/dev/setup/quickstart.md
@@ -93,6 +93,7 @@ sg start monitoring
 
 Here are some additional resources to help you go further:
 
+- [Full `sg` reference](../background-information/sg/reference.md)
 - [Troubleshooting local development](troubleshooting.md)
 - [Continuous integration](../background-information/ci/index.md)
 - [Background information](../index.md#background-information) for more context on various topics.


### PR DESCRIPTION
This reverts commit 69f927e666f6a49ed7c0a4e0353ccf4decf6036e.

I find the generated reference very useful when sharing particular commands or double-checking a command's capabilities, and would advocate to add this back. We generate Markdown docs for other changes as well, and I'm not sure it's too much of a lift to require this to be regenerated when making changes to `sg` commands.

If documenting the commandsets is too tedious we can remove that bit perhaps in a follow-up? I also raised a Slack discussion about this here: https://sourcegraph.slack.com/archives/C04MYFW01NV/p1700073708056929

## Test plan

CI

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@revert-58225-sqs/rm-sg-autogen-docs)