### PR TITLE
Code Navigation: add close button to blobview search

### DIFF
--- a/client/web/src/repo/blob/codemirror/search.module.scss
+++ b/client/web/src/repo/blob/codemirror/search.module.scss
@@ -9,12 +9,12 @@
     border-left: none;
 }
 
-.hovered {
+.close-button {
     border-radius: 100%;
     padding: 0.2rem;
 }
 
-.hovered:hover {
+.close-button:hover {
     background-color: var(--subtle-bg);
 }
 

--- a/client/web/src/repo/blob/codemirror/search.module.scss
+++ b/client/web/src/repo/blob/codemirror/search.module.scss
@@ -8,3 +8,16 @@
     border-bottom-left-radius: 0;
     border-left: none;
 }
+
+.hovered {
+    border-radius: 100%;
+    padding: 0.2rem;
+}
+
+.hovered:hover {
+    background-color: var(--subtle-bg);
+}
+
+.x {
+    color: var(--text-muted);
+}

--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -3,8 +3,6 @@
  * UI.
  */
 
-import React from 'react'
-
 import {
     findNext,
     findPrevious,
@@ -285,7 +283,7 @@ class SearchPanel implements Panel {
                         {searchKeybinding}
                     </Label>
                     {searchKeybindingTooltip}
-                    <span className={classNames(styles.closeButton, 'ml-2')}>
+                    <span className={classNames(styles.closeButton, 'ml-4')}>
                         <Icon
                             className={classNames(styles.x)}
                             onClick={() => closeSearchPanel(this.view)}

--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -3,11 +3,14 @@
  * UI.
  */
 
+import React from 'react'
+
 import {
     findNext,
     findPrevious,
     getSearchQuery,
     openSearchPanel,
+    closeSearchPanel,
     search as codemirrorSearch,
     searchKeymap,
     SearchQuery,
@@ -30,7 +33,14 @@ import {
     ViewPlugin,
     type ViewUpdate,
 } from '@codemirror/view'
-import { mdiChevronLeft, mdiChevronRight, mdiFormatLetterCase, mdiInformationOutline, mdiRegex } from '@mdi/js'
+import {
+    mdiChevronLeft,
+    mdiChevronRight,
+    mdiClose,
+    mdiFormatLetterCase,
+    mdiInformationOutline,
+    mdiRegex,
+} from '@mdi/js'
 import classNames from 'classnames'
 import { createRoot, type Root } from 'react-dom/client'
 import type { NavigateFunction } from 'react-router-dom'
@@ -275,6 +285,16 @@ class SearchPanel implements Panel {
                         {searchKeybinding}
                     </Label>
                     {searchKeybindingTooltip}
+                    <span className={classNames(styles.hovered, 'ml-2')}>
+                        <Icon
+                            className={classNames(styles.x)}
+                            onClick={() => closeSearchPanel(this.view)}
+                            size="sm"
+                            svgPath={mdiClose}
+                            aria-hidden={true}
+                            aria-label="close search"
+                        />
+                    </span>
                 </div>
             </CodeMirrorContainer>
         )

--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -285,13 +285,13 @@ class SearchPanel implements Panel {
                         {searchKeybinding}
                     </Label>
                     {searchKeybindingTooltip}
-                    <span className={classNames(styles.hovered, 'ml-2')}>
+                    <span className={classNames(styles.closeButton, 'ml-2')}>
                         <Icon
                             className={classNames(styles.x)}
                             onClick={() => closeSearchPanel(this.view)}
                             size="sm"
                             svgPath={mdiClose}
-                            aria-hidden={true}
+                            aria-hidden={false}
                             aria-label="close search"
                         />
                     </span>


### PR DESCRIPTION
Add a close button to the blobview search component. 

Inactive: 
![Screenshot 2023-11-15 at 2 44 13 PM](https://github.com/sourcegraph/sourcegraph/assets/62355966/c18910fb-599c-4a36-b0a3-ecca69ea899a)

hover:
![Screenshot 2023-11-15 at 2 44 33 PM](https://github.com/sourcegraph/sourcegraph/assets/62355966/6cde4014-7960-4450-a77a-2b48038be87a)

## Test plan
Manual testing in light and dark mode. 
