### PR TITLE
docs: Add section about GraphQL cost limts

### DIFF
--- a/doc/api/graphql/index.md
+++ b/doc/api/graphql/index.md
@@ -9,7 +9,7 @@ The Sourcegraph GraphQL API supports the following types of queries:
 - Repository and user metadata
 
 > NOTE: The API is under active development. Backwards compatibility will be maintained in most
-> cases, and backwards-incompatible changes will be documented in the 
+> cases, and backwards-incompatible changes will be documented in the
 > [changelog](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md).
 
 ## Quickstart
@@ -93,3 +93,19 @@ i.e. you just need to send the `Authorization` header and a JSON object like `{"
 ## Examples
 
 See "[Sourcegraph GraphQL API examples](examples.md)".
+
+## Cost Limits
+
+To enhance system performance and stability, configurable GraphQL query cost limitations have been implemented. This feature is crucial for preventing resource exhaustion due to extensive or overly complex queries.
+
+### GraphQLMaxDepth
+- **Default Value**: 30
+- Limits the maximum depth of nested objects in GraphQL queries, preventing deep queries that consume excessive resources.
+
+### GraphQLMaxFieldCount
+- **Default Value**: 500,000
+- Restricts the number of fields in a GraphQL response to avoid overly broad queries. Use pagination where available to manage large data sets effectively.
+
+### GraphQLMaxAliases
+- **Default Value**: 500
+- Sets a cap on the number of aliases in a single GraphQL query, mitigating the risk of resource-intensive queries due to excessive aliasing.

--- a/doc/api/graphql/index.md
+++ b/doc/api/graphql/index.md
@@ -96,7 +96,7 @@ See "[Sourcegraph GraphQL API examples](examples.md)".
 
 ## Cost Limits
 
-To ensure system performance and stability, configurable GraphQL query cost limitations have been implemented. This feature is crucial for preventing resource exhaustion due to extensive or overly complex queries. The default configuration looks as follows:
+To ensure system performance and stability, configurable GraphQL query cost limitations have been implemented. This feature is crucial for preventing resource exhaustion due to extensive or overly complex queries. The default configuration looks as follows, and can be modified in site configuration:
 
 ```
   "rateLimits": {

--- a/doc/api/graphql/index.md
+++ b/doc/api/graphql/index.md
@@ -96,7 +96,15 @@ See "[Sourcegraph GraphQL API examples](examples.md)".
 
 ## Cost Limits
 
-To enhance system performance and stability, configurable GraphQL query cost limitations have been implemented. This feature is crucial for preventing resource exhaustion due to extensive or overly complex queries.
+To ensure system performance and stability, configurable GraphQL query cost limitations have been implemented. This feature is crucial for preventing resource exhaustion due to extensive or overly complex queries. The default configuration looks as follows:
+
+```
+  "rateLimits": {
+    "graphQLMaxAliases": 500,
+    "graphQLMaxDepth": 30,
+    "graphQLMaxFieldCount": 500000
+  },
+```
 
 ### GraphQLMaxDepth
 - **Default Value**: 30


### PR DESCRIPTION
Adds a section on docs.sourcegraph.com about the new costs limitations.


## Test plan
Review

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@vincent/graphql-cost-doc)