### PR TITLE
sg: code cleanup: removed #fixme in lib/output

### DIFF
--- a/lib/output/pending_tty.go
+++ b/lib/output/pending_tty.go
@@ -154,7 +154,8 @@ func (p *pendingTTY) write(message FancyLine) {
 	// we also add a newline if the line is truncated.
 	message.write(&buf, p.o.caps)
 
-	// FIXME: This doesn't account for escape codes right now, so we may
-	// truncate shorter than we mean to.
+	// Using runewidth.Truncate ensures that we're only truncating based on
+	// visible string width. I.e. escape codes are not counted towards the
+	// string width.
 	fmt.Fprint(p.o.w, runewidth.Truncate(buf.String(), p.o.caps.Width, "...\n"))
 }


### PR DESCRIPTION
## Motivation

## Summary

Minimal code cleanup — removed a `FIXME` in `lib/output`. `runewidth` will account for escape sequences when it [calculates the `StringWidth`

## Test plan

This should still build and run without any changes — the only change is the comment.
