### PR TITLE
sg: improve PG_UTILS_PATH error msg

### DIFF
--- a/dev/sg/dependencies/helpers.go
+++ b/dev/sg/dependencies/helpers.go
@@ -489,7 +489,7 @@ func checkPGUtilsPath(ctx context.Context, out *std.Output, args CheckArgs) erro
 
 	// If the file exists, but doesn't reference PG_UTILS_PATH, that's an error as well.
 	if pgUtilsPath == "" {
-		return errors.Newf("%s doesn't define PG_UTILS_PATH", userBazelRcPath)
+		return errors.Newf("none on the content in %s matched %q", userBazelRcPath, pgUtilsPathRe.String())
 	}
 
 	// Check that this path contains createdb as expected.


### PR DESCRIPTION
Improve the error message from:

![Screenshot 2023-11-16 at 10 24 57](https://github.com/sourcegraph/sourcegraph/assets/1001709/8e75440f-4a04-45ed-8ec7-a7b505f0bd72)

To

![Screenshot 2023-11-16 at 10 26 33](https://github.com/sourcegraph/sourcegraph/assets/1001709/0047bde8-4c49-464b-bdb5-8bda12a5b5fc)

The first error message makes you think you only have to define `PG_UTILS_PATH=...`, but you actually need to know that you need to do `build --action_env`. Granted auto fix should also fix this in the correct way.


## Test plan
Tested locally
