### PR TITLE
syntax-highlighter: Delete Theme and CSS fields

### DIFF
--- a/docker-images/syntax-highlighter/README.md
+++ b/docker-images/syntax-highlighter/README.md
@@ -40,7 +40,7 @@ See [API](./docs/api.md)
 
 ## Configuration
 
-By default on startup, `syntect_server` will list all features (themes + file types) it supports. This can be disabled by setting `QUIET=true` in the environment.
+By default on startup, `syntect_server` will list all file types it supports. This can be disabled by setting `QUIET=true` in the environment.
 
 ## Development
 
@@ -63,15 +63,6 @@ Once published, the image version will need to be updated in the following locat
 - [`sourcegraph/sourcegraph > sg.config.yaml`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/sg.config.yaml?subtree=true#L206:7)
 
 Additionally, it's worth doing a [search](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+sourcegraph/syntect_server:&patternType=literal) for other uses in case this list is stale.
-
-## Adding themes
-
-TODO: Maybe we can just remove themes entirely. I think they are u
-
-- Copy a `.tmTheme` file anywhere under `./syntect/testdata` (make a new dir if needed) [in our fork](https://github.com/slimsag/syntect).
-- `cd syntect && make assets`
-- In this repo, `cargo update -p syntect`.
-- Build a new binary.
 
 ## Adding languages (tree-sitter):
 
@@ -100,4 +91,4 @@ $ cargo update -p syntect
 
 ## Supported languages:
 
-Run: `cargo run --bin syntect_server` to see supported languages and themes.
+Run: `cargo run --bin syntect_server` to see supported languages.

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_sciptect.rs
@@ -604,9 +604,7 @@ mod test {
                 extension: filepath.extension().unwrap().to_str().unwrap().to_string(),
                 filepath: filepath.to_str().unwrap().to_string(),
                 filetype: None,
-                css: false,
                 line_length_limit: None,
-                theme: "".to_string(),
                 code: contents.clone(),
             };
             let syntax_def = determine_language(&q, &ss).unwrap();

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_syntect.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_syntect.rs
@@ -250,8 +250,6 @@ mod tests {
             code: "package main\n".to_string(),
             line_length_limit: None,
             extension: String::new(),
-            theme: String::new(),
-            css: true,
         };
         let expected = "<table>\
                             <tbody>\
@@ -280,8 +278,6 @@ mod tests {
             code: "<div>test</div>".to_string(),
             line_length_limit: Some(10),
             extension: String::new(),
-            theme: String::new(),
-            css: true,
         };
         let expected = "<table>\
                             <tbody>\
@@ -304,8 +300,6 @@ mod tests {
             code: "package main\n".to_string(),
             line_length_limit: Some(5),
             extension: String::new(),
-            theme: String::new(),
-            css: true,
         };
         let expected = "<table>\
                             <tbody>\
@@ -329,8 +323,6 @@ mod tests {
                 .to_string(),
             line_length_limit: None,
             extension: String::new(),
-            theme: String::new(),
-            css: true,
         };
         let expected = "<table>\
                             <tbody>\
@@ -411,8 +403,6 @@ mod tests {
                 .to_string(),
             line_length_limit: None,
             extension: String::new(),
-            theme: String::new(),
-            css: true,
         };
 
         let expected = "<table><tbody><tr><td class=\"line\" data-line=\"1\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\"><span class=\"hl-keyword hl-other hl-matlab\">function</span><span class=\"hl-meta hl-function hl-parameters hl-matlab\"> <span class=\"hl-entity hl-name hl-function hl-matlab\">setupPythonIfNeeded</span><span class=\"hl-punctuation hl-section hl-parens hl-begin hl-matlab\">(</span><span class=\"hl-punctuation hl-section hl-parens hl-end hl-matlab\">)</span></span>\n</span></div></td></tr><tr><td class=\"line\" data-line=\"2\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"3\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-comment hl-line hl-percentage hl-matlab\"><span class=\"hl-punctuation hl-definition hl-comment hl-matlab\">%</span> Python setup is only supported in R2019a (ver 9.6) and later\n</span></span></div></td></tr><tr><td class=\"line\" data-line=\"4\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"5\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-keyword hl-control hl-matlab\">if</span> <span class=\"hl-keyword hl-desktop hl-matlab\">verLessThan</span><span class=\"hl-meta hl-parens hl-matlab\"><span class=\"hl-punctuation hl-section hl-parens hl-begin hl-matlab\">(</span><span class=\"hl-string hl-quoted hl-single hl-matlab\"><span class=\"hl-punctuation hl-definition hl-string hl-begin hl-matlab\">&#39;</span>matlab<span class=\"hl-punctuation hl-definition hl-string hl-end hl-matlab\">&#39;</span></span>,<span class=\"hl-string hl-quoted hl-single hl-matlab\"><span class=\"hl-punctuation hl-definition hl-string hl-begin hl-matlab\">&#39;</span>9.6<span class=\"hl-punctuation hl-definition hl-string hl-end hl-matlab\">&#39;</span></span><span class=\"hl-punctuation hl-section hl-parens hl-end hl-matlab\">)</span></span>\n</span></div></td></tr><tr><td class=\"line\" data-line=\"6\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"7\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-keyword hl-other hl-matlab\">error</span><span class=\"hl-meta hl-parens hl-matlab\"><span class=\"hl-punctuation hl-section hl-parens hl-begin hl-matlab\">(</span><span class=\"hl-string hl-quoted hl-double hl-matlab\"><span class=\"hl-punctuation hl-definition hl-string hl-begin hl-matlab\">&quot;</span>setupPythonIfNeeded:unsupportedVersion<span class=\"hl-punctuation hl-definition hl-string hl-end hl-matlab\">&quot;</span></span>,<span class=\"hl-string hl-quoted hl-double hl-matlab\"><span class=\"hl-punctuation hl-definition hl-string hl-begin hl-matlab\">&quot;</span>Only version R2019a and later are supported<span class=\"hl-punctuation hl-definition hl-string hl-end hl-matlab\">&quot;</span></span><span class=\"hl-punctuation hl-section hl-parens hl-end hl-matlab\">)</span></span>\n</span></div></td></tr><tr><td class=\"line\" data-line=\"8\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"9\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-keyword hl-control hl-matlab\">end</span>\n</span></div></td></tr><tr><td class=\"line\" data-line=\"10\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"11\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-keyword hl-control hl-matlab\">end</span></span></div></td></tr></tbody></table>";

--- a/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
+++ b/docker-images/syntax-highlighter/crates/sg-syntax/src/sg_treesitter.rs
@@ -343,9 +343,7 @@ SELECT * FROM my_table
                 extension: filepath.extension().unwrap().to_str().unwrap().to_string(),
                 filepath: filepath.to_str().unwrap().to_string(),
                 filetype: None,
-                css: false,
                 line_length_limit: None,
-                theme: "".to_string(),
                 code: contents.clone(),
             });
 
@@ -400,9 +398,7 @@ SELECT * FROM my_table
                 extension: filepath.extension().unwrap().to_str().unwrap().to_string(),
                 filepath: filepath.to_str().unwrap().to_string(),
                 filetype: None,
-                css: false,
                 line_length_limit: None,
-                theme: "".to_string(),
                 code: contents.clone(),
             });
 

--- a/docker-images/syntax-highlighter/docs/api.md
+++ b/docker-images/syntax-highlighter/docs/api.md
@@ -11,7 +11,6 @@
     - `data` string with syntax highlighted response. The input `code` string [is properly escaped](https://github.com/sourcegraph/syntect_server/blob/ee3810f70e5701b961b7249393dbac8914c162ce/syntect/src/html.rs#L6) and as such can be directly rendered in the browser safely.
     - `plaintext` boolean indicating whether a syntax could not be found for the file and instead it was rendered as plain text.
   - An error response (`error` field), one of:
-    - `{"error": "invalid theme", "code": "invalid_theme"}`
     - `{"error": "resource not found", "code": "resource_not_found"}`
 - `GET` to `/health` to receive an `OK` health check response / ensure the service is alive.
 

--- a/docker-images/syntax-highlighter/src/bin/scip-dump-response.rs
+++ b/docker-images/syntax-highlighter/src/bin/scip-dump-response.rs
@@ -46,9 +46,7 @@ fn main() -> Result<(), std::io::Error> {
         code: contents.clone(),
         filepath: "".to_string(),
         filetype: None,
-        css: false,
         line_length_limit: None,
-        theme: "".to_string(),
     });
 
     println!("  filetype: {:?}", filetype);

--- a/internal/gosyntect/gosyntect.go
+++ b/internal/gosyntect/gosyntect.go
@@ -84,22 +84,8 @@ type Query struct {
 	// Filetype is the language name.
 	Filetype string `json:"filetype"`
 
-	// Theme is the color theme to use for highlighting.
-	// If CSS is true, theme is ignored.
-	//
-	// See https://github.com/sourcegraph/syntect_server#embedded-themes
-	Theme string `json:"theme"`
-
 	// Code is the literal code to highlight.
 	Code string `json:"code"`
-
-	// CSS causes results to be returned in HTML table format with CSS class
-	// names annotating the spans rather than inline styles.
-	//
-	// TODO: I think we can just delete this? And theme? We don't use these.
-	// Then we could remove themes from syntect as well. I don't think we
-	// have any use case for these anymore (and haven't for awhile).
-	CSS bool `json:"css"`
 
 	// LineLengthLimit is the maximum length of line that will be highlighted if set.
 	// Defaults to no max if zero.
@@ -129,9 +115,6 @@ type Response struct {
 }
 
 var (
-	// ErrInvalidTheme is returned when the Query.Theme is not a valid theme.
-	ErrInvalidTheme = errors.New("invalid theme")
-
 	// ErrRequestTooLarge is returned when the request is too large for syntect_server to handle (e.g. file is too large to highlight).
 	ErrRequestTooLarge = errors.New("request too large")
 
@@ -177,9 +160,7 @@ func (c *Client) Highlight(ctx context.Context, q *Query, format HighlightRespon
 	q.Filetype = languages.NormalizeLanguage(q.Filetype)
 
 	tr, ctx := trace.New(ctx, "gosyntect.Highlight",
-		attribute.String("filepath", q.Filepath),
-		attribute.String("theme", q.Theme),
-		attribute.Bool("css", q.CSS))
+		attribute.String("filepath", q.Filepath))
 	defer tr.EndWithErr(&err)
 
 	if isTreesitterBased(q.Engine) && !IsTreesitterSupported(q.Filetype) {
@@ -231,8 +212,6 @@ func (c *Client) Highlight(ctx context.Context, q *Query, format HighlightRespon
 	if r.Error != "" {
 		var err error
 		switch r.Code {
-		case "invalid_theme":
-			err = ErrInvalidTheme
 		case "resource_not_found":
 			// resource_not_found is returned in the event of a 404, indicating a bug
 			// in gosyntect.

--- a/internal/highlight/highlight.go
+++ b/internal/highlight/highlight.go
@@ -417,7 +417,6 @@ func Code(ctx context.Context, p Params) (response *HighlightedCode, aborted boo
 		Filepath:         p.Filepath,
 		StabilizeTimeout: stabilizeTimeout,
 		LineLengthLimit:  maxLineLength,
-		CSS:              true,
 		Engine:           getEngineParameter(filetypeQuery.Engine),
 	}
 


### PR DESCRIPTION
In the code, the [CSS field was always set to be true](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/highlight/highlight.go?L420), which meant that the Theme field would
be ignored in the query to syntect server. This patch removes both fields, keeping only
the `q.css == true` code path, and deleting all the mentions of themes.

## Test plan

Run `cargo run --bin syntect_server` followed by `SRC_SYNTECT_SERVER=http://127.0.0.1:8000 sg start enterprise-codeintel` and check highlighting is still working fine.