### PR TITLE
Repo embedding jobs ordered by a qualified column

### DIFF
--- a/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "resolvers_test.go",
     ],
     embed = [":resolvers"],
+    tags = ["requires-network"],
     deps = [
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",

--- a/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
@@ -33,14 +33,19 @@ go_library(
 
 go_test(
     name = "resolvers_test",
-    srcs = ["resolvers_test.go"],
+    srcs = [
+        "repo_embedding_jobs_test.go",
+        "resolvers_test.go",
+    ],
     embed = [":resolvers"],
     deps = [
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
         "//internal/api",
         "//internal/conf",
+        "//internal/database",
         "//internal/database/dbmocks",
+        "//internal/database/dbtest",
         "//internal/embeddings",
         "//internal/embeddings/background/repo",
         "//internal/featureflag",

--- a/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
+++ b/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
@@ -32,7 +32,12 @@ func NewRepoEmbeddingJobsResolver(
 		store:           repoEmbeddingJobsStore,
 		args:            args,
 	}
-	return graphqlutil.NewConnectionResolver[graphqlbackend.RepoEmbeddingJobResolver](store, &args.ConnectionResolverArgs, nil)
+	opts := &graphqlutil.ConnectionResolverOptions{
+		OrderBy: database.OrderBy{
+			{Field: "repo_embedding_jobs.id"},
+		},
+	}
+	return graphqlutil.NewConnectionResolver[graphqlbackend.RepoEmbeddingJobResolver](store, &args.ConnectionResolverArgs, opts)
 }
 
 type repoEmbeddingJobsConnectionStore struct {

--- a/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
@@ -1,0 +1,87 @@
+package resolvers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/embeddings/background/repo"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// TestDBPaginationWithRepoFilter exercises a bug filed in #58313 where
+// a unscoped default ordering column from graphqlutil.ConnectionResolver ("id")
+// makes into a query joining two tables (both having an id column),
+// causing ambiguous SQL.
+func TestDBPaginationWithRepoFilter(t *testing.T) {
+	logger := logtest.Scoped(t)
+	db := database.NewDB(logger, dbtest.NewDB(t))
+	ctx := context.Background()
+
+	// Make a repo and an embedding job:
+	err := db.Repos().Create(ctx, &types.Repo{
+		Name: "testrepo",
+	})
+	require.NoError(t, err)
+	r, err := db.Repos().GetByName(ctx, "testrepo")
+	require.NoError(t, err)
+	jobs := repo.NewRepoEmbeddingJobsStore(db)
+	jobID, err := jobs.CreateRepoEmbeddingJob(ctx, r.ID, "commitID")
+	require.NoError(t, err)
+
+	// Enable embeddings, so that resolvers work:
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			CodyEnabled: pointers.Ptr(true),
+			LicenseKey:  "foobar",
+			Embeddings: &schema.Embeddings{
+				Provider: "sourcegraph",
+			},
+		},
+	})
+	t.Cleanup(func() { conf.Mock(nil) })
+	require.True(t, conf.EmbeddingsEnabled())
+
+	// Authenticate with a site-admin.
+	user, err := db.Users().Create(ctx, database.NewUser{Username: "admin"})
+	require.NoError(t, err)
+	require.NoError(t, db.Users().SetIsSiteAdmin(ctx, user.ID, true))
+	a := actor.FromUser(user.ID)
+	ctx = actor.WithActor(ctx, a)
+
+	// Exercise pagination and filtering via graphQL:
+	schema, err := graphqlbackend.NewSchema(db, nil, []graphqlbackend.OptionalResolver{{EmbeddingsResolver: NewResolver(db, logger, nil, nil, jobs)}})
+	require.NoError(t, err)
+	graphqlbackend.RunTest(t, &graphqlbackend.Test{
+		Schema:  schema,
+		Context: ctx,
+		Query: `query RepoEmbeddingJobsList($first: Int, $after: String, $query: String) {
+				repoEmbeddingJobs(first: $first, after: $after, query: $query) {
+					nodes {
+						id
+					}
+				}
+			}`,
+		// Want no error:
+		ExpectedResult: `{
+			"repoEmbeddingJobs": {
+				"nodes": []
+			}
+		}`,
+		Variables: map[string]any{
+			"first": 1,
+			"after": marshalRepoEmbeddingJobID(jobID),
+			"query": r.Name,
+		},
+	})
+
+}


### PR DESCRIPTION
Fixes #58313

Order by column for a connection resolver needs to have table name prefix, rather than default `id`. This is because when using a repo name filter, the `repo` table is `JOIN`ed to the query. Now there are two tables - repos and jobs that both have the `id` column and filtering by unqualified `id` is ambiguous SQL.

## Test plan

Add a test case reproducing the problem. Without the explicit order by column:

```
--- FAIL: TestDBPaginationWithRepoFilter (1.39s)
    /Users/cbart/sourcegraph/cmd/frontend/internal/embeddings/resolvers/dbtest.go:150: testdb: postgres://sourcegraph:sourcegraph@127.0.0.1:5432/sourcegraph-test-3696020003995722875?sslmode=disable&timezone=UTC
    /Users/cbart/sourcegraph/cmd/frontend/internal/embeddings/resolvers/core.go:57: [33mWARN[0m TestDBPaginationWithRepoFilter ]8;;vscode://file//Users/cbart/sourcegraph/internal/database/repos.go:512database/repos.go:512]8;; failed to parse service type {"r.ExternalRepo.ServiceType": ""}
    /Users/cbart/sourcegraph/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go:64:   []*errors.QueryError(
        - 	nil,
        + 	{
        + 		e"graphql: SQL Error\n----- Args: \"%testrepo%, 2\"\n----- SQL Query:\nSELECT repo_embedding_jobs.id ,  repo_embedding_jobs.state ,  re"...,
        + 	},
          )
```
