### PR TITLE
repos: refactor and clean-up the `Source.ListRepos` tests

### DIFF
--- a/internal/repos/BUILD.bazel
+++ b/internal/repos/BUILD.bazel
@@ -194,7 +194,6 @@ go_test(
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
         "@com_github_google_uuid//:uuid",
-        "@com_github_grafana_regexp//:regexp",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_sourcegraph_log//:log",

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -47,10 +47,8 @@ func TestSources_ListRepos(t *testing.T) {
 
 	type testCase struct {
 		name   string
-		ctx    context.Context
 		svcs   types.ExternalServices
 		assert func(*types.ExternalService) typestest.ReposAssertion
-		err    string
 	}
 
 	var testCases []testCase
@@ -223,7 +221,6 @@ func TestSources_ListRepos(t *testing.T) {
 					}
 				}
 			},
-			err: "<nil>",
 		})
 	}
 
@@ -335,7 +332,6 @@ func TestSources_ListRepos(t *testing.T) {
 					}
 				}
 			},
-			err: "<nil>",
 		})
 	}
 
@@ -466,7 +462,6 @@ func TestSources_ListRepos(t *testing.T) {
 					}
 				}
 			},
-			err: "<nil>",
 		})
 	}
 
@@ -521,7 +516,6 @@ func TestSources_ListRepos(t *testing.T) {
 					}
 				}
 			},
-			err: "<nil>",
 		})
 	}
 
@@ -573,7 +567,6 @@ func TestSources_ListRepos(t *testing.T) {
 					}
 				}
 			},
-			err: "<nil>",
 		})
 	}
 
@@ -612,38 +605,32 @@ func TestSources_ListRepos(t *testing.T) {
 					}
 				}
 			},
-			err: "<nil>",
 		})
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		for _, svc := range tc.svcs {
 			name := svc.Kind + "/" + tc.name
 			t.Run(name, func(t *testing.T) {
+
+				ctx := context.Background()
+
 				cf, save := NewClientFactory(t, name)
 				defer save(t)
 
 				logger := logtest.Scoped(t)
 				obs := ObservedSource(logger, NewSourceMetrics())
-				src, err := NewSourcer(logtest.Scoped(t), dbmocks.NewMockDB(), cf, obs)(tc.ctx, svc)
+				src, err := NewSourcer(logtest.Scoped(t), dbmocks.NewMockDB(), cf, obs)(ctx, svc)
 				if err != nil {
 					t.Fatal(err)
 				}
 
-				ctx := tc.ctx
-				if ctx == nil {
-					ctx = context.Background()
-				}
-
 				repos, err := ListAll(ctx, src)
-				if have, want := fmt.Sprint(err), tc.err; have != want {
-					t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+				if err != nil {
+					t.Errorf("error listing repos: %s", err)
 				}
 
-				if tc.assert != nil {
-					tc.assert(svc)(t, repos)
-				}
+				tc.assert(svc)(t, repos)
 			})
 		}
 	}


### PR DESCRIPTION
Here's some `stop-the-bleeding` for you.

I ran into these tests yesterday and really, _really_ struggled adding a new test for the `Exclude` functionality on the GitHub code host connection. Turns out that the test's `assert` method basically re-implements the implementation and is prone to false negatives and false positives.

The rest of the `testCases` also struck me as "someone added them here because this was easy" and then they've grown over the past few years.

So what I did here was to

- Split up that huge test function into separate smaller functions that can be run independently and also allow easier updating of VCR fixtures
- **Keep the VCR fixtures the same!**
- Make fixture names more visible
- Add simple but clear test assertions that assure that the `Source` yields the repos we expect and not "negative tests" where we want to check whether nothing we didn't expect was yielded.
- Remove unnecessary checks for `err` and replace with more solid ones
- Add little helper to list repos
- Tweak assertions and test setup in `Exclude` test to make it clearer what goes on.

## Test plan

- Ran these tests multiple times.