### PR TITLE
gomod: bump Zoekt version for 5.2

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -6413,8 +6413,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:zrClxAF4C5g8B3G9Ejs/R0un6uU6c0MHgI0YHwVnvJk=",
-        version = "v0.0.0-20231101131556-379ed5a0bb34",
+        sum = "h1:htJHVvYKqfeYeyo+83qlFDI1UyeOrQsjzvM/BB80OtU=",
+        version = "v0.0.0-20231116180229-61edc95ba097",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -552,7 +552,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20230106004439-7026e28cef67
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20231101131556-379ed5a0bb34
+	github.com/sourcegraph/zoekt v0.0.0-20231116180229-61edc95ba097
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2052,8 +2052,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20231101131556-379ed5a0bb34 h1:zrClxAF4C5g8B3G9Ejs/R0un6uU6c0MHgI0YHwVnvJk=
-github.com/sourcegraph/zoekt v0.0.0-20231101131556-379ed5a0bb34/go.mod h1:gHfSe997J5w8zX5MGHFei/darZmml75Xvpoykwtknlo=
+github.com/sourcegraph/zoekt v0.0.0-20231116180229-61edc95ba097 h1:htJHVvYKqfeYeyo+83qlFDI1UyeOrQsjzvM/BB80OtU=
+github.com/sourcegraph/zoekt v0.0.0-20231116180229-61edc95ba097/go.mod h1:gHfSe997J5w8zX5MGHFei/darZmml75Xvpoykwtknlo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This change bumps the Zoekt version to include important fixes to prevent OOMs
during search indexing. Zoekt has a dedicated release branch called
`sourcegraph-5.2`, so we just bump the dependency on that branch to pull in new
commits.

Command: `./dev/zoekt/update sourcegraph-5.2`

https://github.com/sourcegraph/zoekt/compare/379ed5a0bb34...61edc95ba097

- https://github.com/sourcegraph/zoekt/commit/943fc74746 Indexing: respect indexing buffer limit
- https://github.com/sourcegraph/zoekt/commit/61edc95ba0 Indexing: properly block on shard building

## Test plan

Zoekt and Sourcegraph CI, also these changes have been running on S2 and dot
com for around a week.