### PR TITLE
Code Navigation: tokens highlight immediately on hover

### DIFF
--- a/client/branded/src/search-ui/input/codemirror/token-info.ts
+++ b/client/branded/src/search-ui/input/codemirror/token-info.ts
@@ -86,7 +86,7 @@ export function tokenInfo(): Extension {
                 effect.is(setHighlighedTokenPosition)
             )
             if (effect) {
-                position = effect?.value
+                position = effect.value
             }
             if (position !== null) {
                 // Mapping the position might not be necessary since we clear

--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -556,6 +556,21 @@
         color: var(--hl-pink);
     }
 
+    // The following hl-typed-* that have associated tooltips.
+    // This ensures that tokens highlight before tooltip is available.
+    .hl-typed-Identifier:hover,
+    .hl-typed-IdentifierParameter:hover,
+    .hl-typed-IdentifierAttribute:hover,
+    .hl-typed-IdentifierType:hover,
+    .hl-typed-IdentifierFunction:hover,
+    .hl-typed-IdentifierModule:hover,
+    .hl-typed-IdentifierFunctionDefinition:hover,
+    .hl-typed-IdentifierNamespace:hover,
+    .hl-typed-IdentifierConstant:hover,
+    .hl-typed-IdentifierBuiltin:hover {
+        background-color: var(--mark-bg);
+    }
+
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
     // .hl-typed-RegexEscape {
     // }
@@ -976,6 +991,21 @@
     }
     .hl-typed-IdentifierAttribute {
         color: var(--hl-purple);
+    }
+
+    // The following hl-typed-* that have associated tooltips.
+    // This ensures that tokens highlight before tooltip is available.
+    .hl-typed-Identifier:hover,
+    .hl-typed-IdentifierAttribute:hover,
+    .hl-typed-IdentifierBuiltin:hover,
+    .hl-typed-IdentifierConstant:hover,
+    .hl-typed-IdentifierFunction:hover,
+    .hl-typed-IdentifierFunctionDefinition:hover,
+    .hl-typed-IdentifierModule:hover,
+    .hl-typed-IdentifierNamespace:hover,
+    .hl-typed-IdentifierParameter:hover,
+    .hl-typed-IdentifierType:hover {
+        background-color: var(--mark-bg);
     }
 
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995


### PR DESCRIPTION
Before, when a user hovered over a token with a tooltip, the immediate lack of highlighting created a state of uncertainty. No indication precedes the appearance of a tooltip, as they take several seconds to fully load upon the initial page load, and highlighting will not appear until they are fully loaded. This behavior contributed to a sluggish and somewhat frustrating user experience. 

Video of behavior before: 
https://github.com/sourcegraph/sourcegraph/assets/62355966/1824c361-2a9f-4762-a3fe-c51aa3057b71

Now, highlighting occurs instantly upon hover, signaling to the user that an interaction is imminent.

## Test plan
1. Test manually on various file types:
    - go
    - javascript
    - typescript
    - cpp
    - C
    - ruby
    - python
    - java
    - rust