### PR TITLE
build: Point to /search URL in help text

### DIFF
--- a/client/web/dev/esbuild/server.ts
+++ b/client/web/dev/esbuild/server.ts
@@ -68,7 +68,7 @@ export const esbuildDevelopmentServer = async (
     return await new Promise<void>((_resolve, reject) => {
         proxyServer.once('listening', () => {
             signale.success(`esbuild server is ready after ${Math.round(performance.now() - start)}ms`)
-            printSuccessBanner(['✱ Sourcegraph is really ready now!', `Click here: ${HTTPS_WEB_SERVER_URL}`])
+            printSuccessBanner(['✱ Sourcegraph is really ready now!', `Click here: ${HTTPS_WEB_SERVER_URL}/search`])
         })
         proxyServer.once('error', error => reject(error))
     })


### PR DESCRIPTION
Recently, the plain URL became the marketing site, so the previous message:

```
[web-standal...p] ===================================================
[web-standal...p]
[web-standal...p]         ✱ Sourcegraph is really ready now!
[web-standal...p]
[web-standal...p]      Click here: https://sourcegraph.test:3443
[web-standal...p]
[web-standal...p] ===================================================
```

Would take you to an empty page, potentially leading one to the incorrect
conclusion that something was wrong.

## Test plan

Run `SOURCEGRAPH_API_URL=https://sourcegraph.com sg start web-standalone`