### PR TITLE
vitest: Fix workspace config wrt client/web/

### DIFF
--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,18 +1,16 @@
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync } from 'fs'
 import path from 'path'
 
-import glob from 'glob'
 import { load } from 'js-yaml'
-import { defineWorkspace } from 'vitest/config'
 
 interface PnpmWorkspaceFile {
     packages: string[]
 }
-const workspaceFile = load(readFileSync(path.join(__dirname, 'pnpm-workspace.yaml'), 'utf8')) as PnpmWorkspaceFile
-workspaceFile.packages.push('client/web/dev') // is a tsconfig project but not a pnpm workspace package
-const projectRoots = workspaceFile.packages
-    .flatMap(p => glob.sync(`${p}/`, { cwd: __dirname }))
-    .map(p => p.replace(/\/$/, ''))
-    .filter(dir => existsSync(path.join(dir, 'vitest.config.ts')))
 
-export default defineWorkspace(projectRoots)
+function fromPnpmWorkspaceFile(filePath: string): string[] {
+    return (load(readFileSync(filePath, 'utf8')) as PnpmWorkspaceFile).packages.map(p => `${p}/vitest.config.ts`, {
+        cwd: __dirname,
+    })
+}
+
+export default fromPnpmWorkspaceFile(path.join(__dirname, 'pnpm-workspace.yaml'))


### PR DESCRIPTION
It appears that the workspace configuration is somehow broken because it doesn't include any tests defined in `client/web/src/`. This can be tested by filtering for a test inside this subtree, for example

    pnpm exec vitest RepoRevisionSidebar

vitest will error saying it didn't find any tests. The list of projects it prints also doesn't include `web`.

I don't know what exactly it is that makes it exclude `client/web/` but with the simpler version in this PR `client/web/` will be included.

**NOTE:** Or is it intentional that `client/web/` is excluded? If so it's not obvious from the code.


I removed `client/web/dev/` from the list because it will be included by `client/web/` too and seems to "just work" even though it has it's own configuration file.

Before: 
![2023-11-17_08-40](https://github.com/sourcegraph/sourcegraph/assets/179026/fc16b94f-0c41-4c08-884e-fa184aa96ef6)


After: 
![2023-11-17_08-47](https://github.com/sourcegraph/sourcegraph/assets/179026/f9b8221d-0e47-4ab4-9517-6e1be1e40605)



## Test plan

`pnpm exec vitest RepoSidebarRevision` and `pnpm exec vitest` work.