### PR TITLE
tests: add typestest.MakeExternalService helper and use it

### DIFF
--- a/internal/repos/azuredevops_test.go
+++ b/internal/repos/azuredevops_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -19,7 +19,10 @@ import (
 func TestAzureDevOpsSource_ListRepos(t *testing.T) {
 	ratelimit.SetupForTest(t)
 
-	conf := &schema.AzureDevOpsConnection{
+	cf, save := NewClientFactory(t, t.Name())
+	defer save(t)
+
+	svc := typestest.MakeExternalService(t, extsvc.VariantAzureDevOps, &schema.AzureDevOpsConnection{
 		Url:      "https://dev.azure.com",
 		Username: os.Getenv("AZURE_DEV_OPS_USERNAME"),
 		Token:    os.Getenv("AZURE_DEV_OPS_TOKEN"),
@@ -32,14 +35,7 @@ func TestAzureDevOpsSource_ListRepos(t *testing.T) {
 				Pattern: "^sgtestazure/sgtestazure/sgtestazure[3-9]",
 			},
 		},
-	}
-	cf, save := NewClientFactory(t, t.Name())
-	defer save(t)
-
-	svc := &types.ExternalService{
-		Kind:   extsvc.KindAzureDevOps,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, conf)),
-	}
+	})
 
 	ctx := context.Background()
 	src, err := NewAzureDevOpsSource(ctx, nil, svc, cf)

--- a/internal/repos/bitbucketcloud_test.go
+++ b/internal/repos/bitbucketcloud_test.go
@@ -88,11 +88,7 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 			cf, save := NewClientFactory(t, tc.name)
 			defer save(t)
 
-			svc := &types.ExternalService{
-				Kind:   extsvc.KindBitbucketCloud,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, tc.conf)),
-			}
-
+			svc := typestest.MakeExternalService(t, extsvc.VariantBitbucketCloud, tc.conf)
 			bbcSrc, err := newBitbucketCloudSource(logtest.Scoped(t), svc, tc.conf, cf)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -178,13 +179,12 @@ func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 	rcache.SetupForTest(t)
 	ratelimit.SetupForTest(t)
 
-	svc := &types.ExternalService{
-		Kind: extsvc.KindBitbucketServer,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.BitbucketServerConnection{
+	svc := typestest.MakeExternalService(t,
+		extsvc.VariantBitbucketServer,
+		&schema.BitbucketServerConnection{
 			Url:   "https://bitbucket.sgdev.org",
 			Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
-		})),
-	}
+		})
 
 	ctx := context.Background()
 	bbsSrc, err := NewBitbucketServerSource(ctx, logtest.Scoped(t), svc, nil)

--- a/internal/repos/gerrit_test.go
+++ b/internal/repos/gerrit_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -20,18 +20,14 @@ func TestGerritSource_ListRepos(t *testing.T) {
 
 	cfName := t.Name()
 	t.Run("no filtering", func(t *testing.T) {
-		conf := &schema.GerritConnection{
-			Url:      "https://gerrit.sgdev.org",
-			Username: os.Getenv("GERRIT_USERNAME"),
-			Password: os.Getenv("GERRIT_PASSWORD"),
-		}
 		cf, save := NewClientFactory(t, cfName)
 		defer save(t)
 
-		svc := &types.ExternalService{
-			Kind:   extsvc.KindGerrit,
-			Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, conf)),
-		}
+		svc := typestest.MakeExternalService(t, extsvc.VariantGerrit, &schema.GerritConnection{
+			Url:      "https://gerrit.sgdev.org",
+			Username: os.Getenv("GERRIT_USERNAME"),
+			Password: os.Getenv("GERRIT_PASSWORD"),
+		})
 
 		ctx := context.Background()
 		src, err := NewGerritSource(ctx, svc, cf)
@@ -46,21 +42,17 @@ func TestGerritSource_ListRepos(t *testing.T) {
 	})
 
 	t.Run("with filtering", func(t *testing.T) {
-		conf := &schema.GerritConnection{
+		cf, save := NewClientFactory(t, cfName)
+		defer save(t)
+
+		svc := typestest.MakeExternalService(t, extsvc.VariantGerrit, &schema.GerritConnection{
 			Projects: []string{
 				"src-cli",
 			},
 			Url:      "https://gerrit.sgdev.org",
 			Username: os.Getenv("GERRIT_USERNAME"),
 			Password: os.Getenv("GERRIT_PASSWORD"),
-		}
-		cf, save := NewClientFactory(t, cfName)
-		defer save(t)
-
-		svc := &types.ExternalService{
-			Kind:   extsvc.KindGerrit,
-			Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, conf)),
-		}
+		})
 
 		ctx := context.Background()
 		src, err := NewGerritSource(ctx, svc, cf)

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -140,13 +140,10 @@ func TestPublicRepos_PaginationTerminatesGracefully(t *testing.T) {
 	fixtureName := "GITHUB-ENTERPRISE/list-public-repos"
 	gheToken := prepareGheToken(t, fixtureName)
 
-	service := &types.ExternalService{
-		Kind: extsvc.KindGitHub,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-			Url:   "https://ghe.sgdev.org",
-			Token: gheToken,
-		})),
-	}
+	service := typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+		Url:   "https://ghe.sgdev.org",
+		Token: gheToken,
+	})
 
 	factory, save := NewClientFactory(t, fixtureName)
 	defer save(t)
@@ -268,12 +265,9 @@ func TestGithubSource_GetRepo(t *testing.T) {
 			cf, save := NewClientFactory(t, tc.name)
 			defer save(t)
 
-			svc := &types.ExternalService{
-				Kind: extsvc.KindGitHub,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-					Url: "https://github.com",
-				})),
-			}
+			svc := typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+				Url: "https://github.com",
+			})
 
 			ctx := context.Background()
 			githubSrc, err := NewGitHubSource(ctx, logtest.Scoped(t), dbmocks.NewMockDB(), svc, cf)
@@ -371,13 +365,10 @@ func TestGithubSource_GetRepo_Enterprise(t *testing.T) {
 				t.Fatalf("GHE_TOKEN needs to be set to a token that can access ghe.sgdev.org to update this test fixture")
 			}
 
-			svc := &types.ExternalService{
-				Kind: extsvc.KindGitHub,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-					Url:   "https://ghe.sgdev.org",
-					Token: gheToken,
-				})),
-			}
+			svc := typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+				Url:   "https://ghe.sgdev.org",
+				Token: gheToken,
+			})
 
 			cf, save := NewClientFactory(t, tc.name)
 			defer save(t)
@@ -403,16 +394,13 @@ func TestGithubSource_GetRepo_Enterprise(t *testing.T) {
 
 			// Configure external service to mark internal repositories as public
 			// and sync again
-			svc = &types.ExternalService{
-				Kind: extsvc.KindGitHub,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-					Url:   "https://ghe.sgdev.org",
-					Token: gheToken,
-					Authorization: &schema.GitHubAuthorization{
-						MarkInternalReposAsPublic: true,
-					},
-				})),
-			}
+			svc = typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+				Url:   "https://ghe.sgdev.org",
+				Token: gheToken,
+				Authorization: &schema.GitHubAuthorization{
+					MarkInternalReposAsPublic: true,
+				},
+			})
 
 			githubSrc, err = NewGitHubSource(ctx, logtest.Scoped(t), dbmocks.NewMockDB(), svc, cf)
 			if err != nil {
@@ -789,10 +777,7 @@ func TestGithubSource_ListRepos(t *testing.T) {
 
 			defer save(t)
 
-			svc := &types.ExternalService{
-				Kind:   extsvc.KindGitHub,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, tc.conf)),
-			}
+			svc := typestest.MakeExternalService(t, extsvc.VariantGitHub, tc.conf)
 
 			ctx := context.Background()
 			githubSrc, err := NewGitHubSource(ctx, logtest.Scoped(t), dbmocks.NewMockDB(), svc, cf)
@@ -827,13 +812,10 @@ func TestGithubSource_WithAuthenticator(t *testing.T) {
 	// We need to clear the cache before we run the tests
 	rcache.SetupForTest(t)
 
-	svc := &types.ExternalService{
-		Kind: extsvc.KindGitHub,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-			Url:   "https://github.com",
-			Token: os.Getenv("GITHUB_TOKEN"),
-		})),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+		Url:   "https://github.com",
+		Token: os.Getenv("GITHUB_TOKEN"),
+	})
 
 	ctx := context.Background()
 	githubSrc, err := NewGitHubSource(ctx, logtest.Scoped(t), dbmocks.NewMockDB(), svc, nil)
@@ -861,13 +843,10 @@ func TestGithubSource_excludes_disabledAndLocked(t *testing.T) {
 	// We need to clear the cache before we run the tests
 	rcache.SetupForTest(t)
 
-	svc := &types.ExternalService{
-		Kind: extsvc.KindGitHub,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-			Url:   "https://github.com",
-			Token: os.Getenv("GITHUB_TOKEN"),
-		})),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+		Url:   "https://github.com",
+		Token: os.Getenv("GITHUB_TOKEN"),
+	})
 
 	ctx := context.Background()
 	githubSrc, err := NewGitHubSource(ctx, logtest.Scoped(t), dbmocks.NewMockDB(), svc, nil)
@@ -894,12 +873,9 @@ func TestGithubSource_GetVersion(t *testing.T) {
 		// We need to clear the cache before we run the tests
 		rcache.SetupForTest(t)
 
-		svc := &types.ExternalService{
-			Kind: extsvc.KindGitHub,
-			Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-				Url: "https://github.com",
-			})),
-		}
+		svc := typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+			Url: "https://github.com",
+		})
 
 		ctx := context.Background()
 		githubSrc, err := NewGitHubSource(ctx, logger, dbmocks.NewMockDB(), svc, nil)
@@ -932,13 +908,10 @@ func TestGithubSource_GetVersion(t *testing.T) {
 		cf, save := NewClientFactory(t, fixtureName)
 		defer save(t)
 
-		svc := &types.ExternalService{
-			Kind: extsvc.KindGitHub,
-			Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-				Url:   "https://ghe.sgdev.org",
-				Token: gheToken,
-			})),
-		}
+		svc := typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+			Url:   "https://ghe.sgdev.org",
+			Token: gheToken,
+		})
 
 		ctx := context.Background()
 		githubSrc, err := NewGitHubSource(ctx, logger, dbmocks.NewMockDB(), svc, cf)
@@ -1266,10 +1239,7 @@ func TestGithubSource_SearchRepositories(t *testing.T) {
 
 			defer save(t)
 
-			svc := &types.ExternalService{
-				Kind:   extsvc.KindGitHub,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, tc.conf)),
-			}
+			svc := typestest.MakeExternalService(t, extsvc.VariantGitHub, tc.conf)
 
 			ctx := context.Background()
 			githubSrc, err := NewGitHubSource(ctx, logtest.Scoped(t), dbmocks.NewMockDB(), svc, cf)
@@ -1402,10 +1372,7 @@ EyAO2RYQG7mSE6w6CtTFiCjjmELpvdD2s1ygvPdCO1MJlCX264E3og==
 
 			defer save(t)
 
-			svc := &types.ExternalService{
-				Kind:   extsvc.KindGitHub,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, tc.conf)),
-			}
+			svc := typestest.MakeExternalService(t, extsvc.VariantGitHub, tc.conf)
 
 			ctx := context.Background()
 			githubSrc, err := NewGitHubSource(ctx, logtest.Scoped(t), db, svc, cf)

--- a/internal/repos/gitlab_test.go
+++ b/internal/repos/gitlab_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -141,12 +142,9 @@ func TestGitLabSource_GetRepo(t *testing.T) {
 			cf, save := NewClientFactory(t, tc.name)
 			defer save(t)
 
-			svc := &types.ExternalService{
-				Kind: extsvc.KindGitLab,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitLabConnection{
-					Url: "https://gitlab.com",
-				})),
-			}
+			svc := typestest.MakeExternalService(t, extsvc.VariantGitLab, &schema.GitLabConnection{
+				Url: "https://gitlab.com",
+			})
 
 			ctx := context.Background()
 			gitlabSrc, err := NewGitLabSource(ctx, logtest.Scoped(t), svc, cf)
@@ -311,10 +309,7 @@ func TestGitlabSource_ListRepos(t *testing.T) {
 	cf, save := NewClientFactory(t, t.Name())
 	defer save(t)
 
-	svc := &types.ExternalService{
-		Kind:   extsvc.KindGitLab,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, conf)),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantGitLab, conf)
 
 	ctx := context.Background()
 	src, err := NewGitLabSource(ctx, nil, svc, cf)

--- a/internal/repos/gitolite_test.go
+++ b/internal/repos/gitolite_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -14,10 +14,7 @@ func TestGitoliteSource(t *testing.T) {
 	cf, save := newClientFactoryWithOpt(t, "basic", httpcli.ExternalTransportOpt)
 	defer save(t)
 
-	svc := &types.ExternalService{
-		Kind:   extsvc.KindGitolite,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitoliteConnection{})),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantGitolite, &schema.GitoliteConnection{})
 
 	ctx := context.Background()
 	_, err := NewGitoliteSource(ctx, svc, cf)

--- a/internal/repos/go_packages_test.go
+++ b/internal/repos/go_packages_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -37,25 +37,22 @@ func TestGoPackagesSource_ListRepos(t *testing.T) {
 		},
 	})
 
-	svc := types.ExternalService{
-		Kind: extsvc.KindGoPackages,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GoModulesConnection{
-			Urls: []string{
-				"https://proxy.golang.org",
-			},
-			Dependencies: []string{
-				"github.com/tsenart/vegeta/v12@v12.8.4",
-				"github.com/coreos/go-oidc@v2.2.1+incompatible",
-				"github.com/google/zoekt@v0.0.0-20211108135652-f8e8ada171c7",
-				"github.com/gorilla/mux@v1.8.0",
-			},
-		})),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantGoPackages, &schema.GoModulesConnection{
+		Urls: []string{
+			"https://proxy.golang.org",
+		},
+		Dependencies: []string{
+			"github.com/tsenart/vegeta/v12@v12.8.4",
+			"github.com/coreos/go-oidc@v2.2.1+incompatible",
+			"github.com/google/zoekt@v0.0.0-20211108135652-f8e8ada171c7",
+			"github.com/gorilla/mux@v1.8.0",
+		},
+	})
 
 	cf, save := NewClientFactory(t, t.Name())
 	t.Cleanup(func() { save(t) })
 
-	src, err := NewGoPackagesSource(ctx, &svc, cf)
+	src, err := NewGoPackagesSource(ctx, svc, cf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/localgit_test.go
+++ b/internal/repos/localgit_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -74,14 +74,11 @@ func TestLocalGitSource_ListRepos(t *testing.T) {
 
 	ctx := context.Background()
 
-	svc := types.ExternalService{
-		Kind: extsvc.VariantLocalGit.AsKind(),
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.LocalGitExternalService{
-			Repos: repoPatterns,
-		})),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantLocalGit, &schema.LocalGitExternalService{
+		Repos: repoPatterns,
+	})
 
-	src, err := NewLocalGitSource(ctx, logtest.Scoped(t), &svc)
+	src, err := NewLocalGitSource(ctx, logtest.Scoped(t), svc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/npm_packages_test.go
+++ b/internal/repos/npm_packages_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -162,18 +162,15 @@ func TestNPMPackagesSource_ListRepos(t *testing.T) {
 		},
 	})
 
-	svc := types.ExternalService{
-		Kind: extsvc.KindNpmPackages,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.NpmPackagesConnection{
-			Registry:     "https://registry.npmjs.org",
-			Dependencies: []string{"@sourcegraph/prettierrc@2.2.0"},
-		})),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantNpmPackages, &schema.NpmPackagesConnection{
+		Registry:     "https://registry.npmjs.org",
+		Dependencies: []string{"@sourcegraph/prettierrc@2.2.0"},
+	})
 
 	cf, save := NewClientFactory(t, t.Name())
 	t.Cleanup(func() { save(t) })
 
-	src, err := NewNpmPackagesSource(ctx, &svc, cf)
+	src, err := NewNpmPackagesSource(ctx, svc, cf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/pagure_test.go
+++ b/internal/repos/pagure_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -19,10 +19,7 @@ func TestPagureSource_ListRepos(t *testing.T) {
 	cf, save := NewClientFactory(t, t.Name())
 	defer save(t)
 
-	svc := &types.ExternalService{
-		Kind:   extsvc.KindPagure,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, conf)),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantPagure, conf)
 
 	ctx := context.Background()
 	src, err := NewPagureSource(ctx, svc, cf)

--- a/internal/repos/perforce_test.go
+++ b/internal/repos/perforce_test.go
@@ -78,10 +78,7 @@ func TestPerforceSource_ListRepos(t *testing.T) {
 		tc := tc
 		tc.name = "PERFORCE-LIST-REPOS/" + tc.name
 		t.Run(tc.name, func(t *testing.T) {
-			svc := &types.ExternalService{
-				Kind:   extsvc.KindPerforce,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, tc.conf)),
-			}
+			svc := typestest.MakeExternalService(t, extsvc.VariantPerforce, tc.conf)
 
 			gc := gitserver.NewMockClient()
 			gc.IsPerforcePathCloneableFunc.SetDefaultHook(func(ctx context.Context, _ protocol.PerforceConnectionDetails, depotPath string) error {

--- a/internal/repos/python_packages_test.go
+++ b/internal/repos/python_packages_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
-	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -35,9 +35,9 @@ func TestPythonPackagesSource_ListRepos(t *testing.T) {
 		},
 	})
 
-	svc := types.ExternalService{
-		Kind: extsvc.KindPythonPackages,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.PythonPackagesConnection{
+	svc := typestest.MakeExternalService(t,
+		extsvc.VariantPythonPackages,
+		&schema.PythonPackagesConnection{
 			Urls: []string{
 				"https://pypi.org/simple",
 			},
@@ -47,13 +47,12 @@ func TestPythonPackagesSource_ListRepos(t *testing.T) {
 				"randio==0.1.1",
 				"pytimeparse==1.1.8",
 			},
-		})),
-	}
+		})
 
 	cf, save := NewClientFactory(t, t.Name())
 	t.Cleanup(func() { save(t) })
 
-	src, err := NewPythonPackagesSource(ctx, &svc, cf)
+	src, err := NewPythonPackagesSource(ctx, svc, cf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -37,73 +38,61 @@ func TestSources_ListRepos_YieldExistingRepos(t *testing.T) {
 		wantNames []string
 	}{
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindGitHub,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-					Url:   "https://github.com",
-					Token: os.Getenv("GITHUB_ACCESS_TOKEN"),
-					Repos: []string{
-						"sourcegraph/Sourcegraph",
-						"tsenart/Vegeta",
-						"tsenart/vegeta-missing",
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+				Url:   "https://github.com",
+				Token: os.Getenv("GITHUB_ACCESS_TOKEN"),
+				Repos: []string{
+					"sourcegraph/Sourcegraph",
+					"tsenart/Vegeta",
+					"tsenart/vegeta-missing",
+				},
+			}),
 			wantNames: []string{
 				"github.com/sourcegraph/sourcegraph",
 				"github.com/tsenart/vegeta",
 			},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindGitLab,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitLabConnection{
-					Url:          "https://gitlab.com",
-					Token:        os.Getenv("GITLAB_ACCESS_TOKEN"),
-					ProjectQuery: []string{"none"},
-					Projects: []*schema.GitLabProject{
-						{Name: "gnachman/iterm2"},
-						{Name: "gnachman/iterm2-missing"},
-						{Id: 13083}, // https://gitlab.com/gitlab-org/gitlab-ce
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantGitLab, &schema.GitLabConnection{
+				Url:          "https://gitlab.com",
+				Token:        os.Getenv("GITLAB_ACCESS_TOKEN"),
+				ProjectQuery: []string{"none"},
+				Projects: []*schema.GitLabProject{
+					{Name: "gnachman/iterm2"},
+					{Name: "gnachman/iterm2-missing"},
+					{Id: 13083}, // https://gitlab.com/gitlab-org/gitlab-ce
+				},
+			}),
 			wantNames: []string{
 				"gitlab.com/gitlab-org/gitlab-ce",
 				"gitlab.com/gnachman/iterm2",
 			},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindBitbucketServer,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.BitbucketServerConnection{
-					Url:             "https://bitbucket.sgdev.org",
-					Token:           os.Getenv("BITBUCKET_SERVER_TOKEN"),
-					RepositoryQuery: []string{"none"},
-					Repos: []string{
-						"Sour/vegetA",
-						"sour/sourcegraph",
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantBitbucketServer, &schema.BitbucketServerConnection{
+				Url:             "https://bitbucket.sgdev.org",
+				Token:           os.Getenv("BITBUCKET_SERVER_TOKEN"),
+				RepositoryQuery: []string{"none"},
+				Repos: []string{
+					"Sour/vegetA",
+					"sour/sourcegraph",
+				},
+			}),
 			wantNames: []string{
 				"bitbucket.sgdev.org/SOUR/sourcegraph",
 				"bitbucket.sgdev.org/SOUR/vegeta",
 			},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindAWSCodeCommit,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.AWSCodeCommitConnection{
-					AccessKeyID:     getAWSEnv("AWS_ACCESS_KEY_ID"),
-					SecretAccessKey: getAWSEnv("AWS_SECRET_ACCESS_KEY"),
-					Region:          "us-west-1",
-					GitCredentials: schema.AWSCodeCommitGitCredentials{
-						Username: "git-username",
-						Password: "git-password",
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantAWSCodeCommit, &schema.AWSCodeCommitConnection{
+				AccessKeyID:     getAWSEnv("AWS_ACCESS_KEY_ID"),
+				SecretAccessKey: getAWSEnv("AWS_SECRET_ACCESS_KEY"),
+				Region:          "us-west-1",
+				GitCredentials: schema.AWSCodeCommitGitCredentials{
+					Username: "git-username",
+					Password: "git-password",
+				},
+			}),
 			wantNames: []string{
 				"__WARNING_DO_NOT_PUT_ANY_PRIVATE_CODE_IN_HERE",
 				"empty-repo",
@@ -113,15 +102,12 @@ func TestSources_ListRepos_YieldExistingRepos(t *testing.T) {
 			},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindOther,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.OtherExternalServiceConnection{
-					Url: "https://github.com",
-					Repos: []string{
-						"google/go-cmp",
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantOther, &schema.OtherExternalServiceConnection{
+				Url: "https://github.com",
+				Repos: []string{
+					"google/go-cmp",
+				},
+			}),
 			wantNames: []string{
 				"github.com/google/go-cmp",
 			},
@@ -170,84 +156,75 @@ func TestSources_ListRepos_Excluded(t *testing.T) {
 		wantNames []string
 	}{
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindGitHub,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-					Url:   "https://github.com",
-					Token: os.Getenv("GITHUB_ACCESS_TOKEN"),
-					RepositoryQuery: []string{
-						"user:tsenart in:name patrol", // yields only the tsenart/patrol repo
-					},
-					Repos: []string{
-						"sourcegraph/sourcegraph",
-						"keegancsmith/sqlf",
-						"tsenart/VEGETA",
-						"tsenart/go-tsz",     // fork
-						"sourcegraph/about",  // has >500MB and < 200 stars
-						"facebook/react",     // has 215k stars as of now
-						"torvalds/linux",     // has ~4GB
-						"avelino/awesome-go", // has < 20 MB and > 100k stars
-					},
-					Exclude: []*schema.ExcludedGitHubRepo{
-						{Name: "tsenart/Vegeta"},
-						{Id: "MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU="}, // tsenart/patrol ID
-						{Pattern: "^keegancsmith/.*"},
-						{Forks: true},
-						{Stars: "> 215000"},                  // exclude facebook/react
-						{Size: "> 3GB"},                      // exclude torvalds/linux
-						{Size: ">= 500MB", Stars: "< 200"},   // exclude about repo
-						{Size: "<= 20MB", Stars: "> 100000"}, // exclude awesome-go
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+				Url:   "https://github.com",
+				Token: os.Getenv("GITHUB_ACCESS_TOKEN"),
+				RepositoryQuery: []string{
+					"user:tsenart in:name patrol", // yields only the tsenart/patrol repo
+				},
+				Repos: []string{
+					"sourcegraph/sourcegraph",
+					"keegancsmith/sqlf",
+					"tsenart/VEGETA",
+					"tsenart/go-tsz",     // fork
+					"sourcegraph/about",  // has >500MB and < 200 stars
+					"facebook/react",     // has 215k stars as of now
+					"torvalds/linux",     // has ~4GB
+					"avelino/awesome-go", // has < 20 MB and > 100k stars
+				},
+				Exclude: []*schema.ExcludedGitHubRepo{
+					{Name: "tsenart/Vegeta"},
+					{Id: "MDEwOlJlcG9zaXRvcnkxNTM2NTcyNDU="}, // tsenart/patrol ID
+					{Pattern: "^keegancsmith/.*"},
+					{Forks: true},
+					{Stars: "> 215000"},                  // exclude facebook/react
+					{Size: "> 3GB"},                      // exclude torvalds/linux
+					{Size: ">= 500MB", Stars: "< 200"},   // exclude about repo
+					{Size: "<= 20MB", Stars: "> 100000"}, // exclude awesome-go
+				},
+			}),
 			wantNames: []string{
 				"github.com/sourcegraph/sourcegraph",
 			},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindGitLab,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitLabConnection{
-					Url:   "https://gitlab.com",
-					Token: os.Getenv("GITLAB_ACCESS_TOKEN"),
-					ProjectQuery: []string{
-						"?search=gokulkarthick",
-						"?search=dotfiles-vegetableman",
-					},
-					Exclude: []*schema.ExcludedGitLabProject{
-						{Name: "gokulkarthick/gokulkarthick"},
-						{Id: 7789240},
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantGitLab, &schema.GitLabConnection{
+				Url:   "https://gitlab.com",
+				Token: os.Getenv("GITLAB_ACCESS_TOKEN"),
+				ProjectQuery: []string{
+					"?search=gokulkarthick",
+					"?search=dotfiles-vegetableman",
+				},
+				Exclude: []*schema.ExcludedGitLabProject{
+					{Name: "gokulkarthick/gokulkarthick"},
+					{Id: 7789240},
+				},
+			}),
 			wantNames: []string{
 				"gitlab.com/guld/dotfiles-vegetableman",
 			},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindBitbucketServer,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.BitbucketServerConnection{
-					Url:   "https://bitbucket.sgdev.org",
-					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
-					Repos: []string{
-						"SOUR/vegeta",
-						"sour/sourcegraph",
-					},
-					RepositoryQuery: []string{
-						"?visibility=private",
-					},
-					Exclude: []*schema.ExcludedBitbucketServerRepo{
-						{Name: "SOUR/Vegeta"},      // test case insensitivity
-						{Id: 10067},                // sourcegraph repo id
-						{Pattern: ".*/automation"}, // only matches automation-testing repo
-						{Pattern: ".*public-repo.*"},
-						{Pattern: ".*secret-repo.*"},
-						{Pattern: ".*private-repo.*"},
-						{Pattern: `.*SGDEMO.*`},
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantBitbucketServer, &schema.BitbucketServerConnection{
+				Url:   "https://bitbucket.sgdev.org",
+				Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
+				Repos: []string{
+					"SOUR/vegeta",
+					"sour/sourcegraph",
+				},
+				RepositoryQuery: []string{
+					"?visibility=private",
+				},
+				Exclude: []*schema.ExcludedBitbucketServerRepo{
+					{Name: "SOUR/Vegeta"},      // test case insensitivity
+					{Id: 10067},                // sourcegraph repo id
+					{Pattern: ".*/automation"}, // only matches automation-testing repo
+					{Pattern: ".*public-repo.*"},
+					{Pattern: ".*secret-repo.*"},
+					{Pattern: ".*private-repo.*"},
+					{Pattern: `.*SGDEMO.*`},
+				},
+			}),
 			wantNames: []string{
 				"bitbucket.sgdev.org/IJ/ijt-repo-testing-sg-3.6",
 				"bitbucket.sgdev.org/K8S/zoekt",
@@ -257,40 +234,34 @@ func TestSources_ListRepos_Excluded(t *testing.T) {
 			},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindAWSCodeCommit,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.AWSCodeCommitConnection{
-					AccessKeyID:     getAWSEnv("AWS_ACCESS_KEY_ID"),
-					SecretAccessKey: getAWSEnv("AWS_SECRET_ACCESS_KEY"),
-					Region:          "us-west-1",
-					GitCredentials: schema.AWSCodeCommitGitCredentials{
-						Username: "git-username",
-						Password: "git-password",
-					},
-					Exclude: []*schema.ExcludedAWSCodeCommitRepo{
-						{Name: "stRIPE-gO"},
-						{Id: "020a4751-0f46-4e19-82bf-07d0989b67dd"},                // ID of `test`
-						{Name: "test2", Id: "2686d63d-bff4-4a3e-a94f-3e6df904238d"}, // ID of `test2`
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantAWSCodeCommit, &schema.AWSCodeCommitConnection{
+				AccessKeyID:     getAWSEnv("AWS_ACCESS_KEY_ID"),
+				SecretAccessKey: getAWSEnv("AWS_SECRET_ACCESS_KEY"),
+				Region:          "us-west-1",
+				GitCredentials: schema.AWSCodeCommitGitCredentials{
+					Username: "git-username",
+					Password: "git-password",
+				},
+				Exclude: []*schema.ExcludedAWSCodeCommitRepo{
+					{Name: "stRIPE-gO"},
+					{Id: "020a4751-0f46-4e19-82bf-07d0989b67dd"},                // ID of `test`
+					{Name: "test2", Id: "2686d63d-bff4-4a3e-a94f-3e6df904238d"}, // ID of `test2`
+				},
+			}),
 			wantNames: []string{
 				"__WARNING_DO_NOT_PUT_ANY_PRIVATE_CODE_IN_HERE",
 				"empty-repo",
 			},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindGitolite,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitoliteConnection{
-					Prefix: "gitolite.mycorp.com/",
-					Host:   "ssh://git@127.0.0.1:2222",
-					Exclude: []*schema.ExcludedGitoliteRepo{
-						{Name: "bar"},
-						{Pattern: "gitolite-ad.*"},
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantGitolite, &schema.GitoliteConnection{
+				Prefix: "gitolite.mycorp.com/",
+				Host:   "ssh://git@127.0.0.1:2222",
+				Exclude: []*schema.ExcludedGitoliteRepo{
+					{Name: "bar"},
+					{Pattern: "gitolite-ad.*"},
+				},
+			}),
 			wantNames: []string{
 				"gitolite.mycorp.com/baz",
 				"gitolite.mycorp.com/foo",
@@ -343,63 +314,51 @@ func TestSources_ListRepos_RepositoryPathPattern(t *testing.T) {
 		wantURIs  []string
 	}{
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindGitHub,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitHubConnection{
-					Url:                   "https://github.com",
-					Token:                 os.Getenv("GITHUB_ACCESS_TOKEN"),
-					RepositoryPathPattern: "{host}/a/b/c/{nameWithOwner}",
-					RepositoryQuery:       []string{"none"},
-					Repos:                 []string{"tsenart/vegeta"},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantGitHub, &schema.GitHubConnection{
+				Url:                   "https://github.com",
+				Token:                 os.Getenv("GITHUB_ACCESS_TOKEN"),
+				RepositoryPathPattern: "{host}/a/b/c/{nameWithOwner}",
+				RepositoryQuery:       []string{"none"},
+				Repos:                 []string{"tsenart/vegeta"},
+			}),
 			wantNames: []string{"github.com/a/b/c/tsenart/vegeta"},
 			wantURIs:  []string{"github.com/tsenart/vegeta"},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindGitLab,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitLabConnection{
-					Url:                   "https://gitlab.com",
-					Token:                 os.Getenv("GITLAB_ACCESS_TOKEN"),
-					RepositoryPathPattern: "{host}/a/b/c/{pathWithNamespace}",
-					ProjectQuery:          []string{"none"},
-					Projects: []*schema.GitLabProject{
-						{Name: "gnachman/iterm2"},
-					},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantGitLab, &schema.GitLabConnection{
+				Url:                   "https://gitlab.com",
+				Token:                 os.Getenv("GITLAB_ACCESS_TOKEN"),
+				RepositoryPathPattern: "{host}/a/b/c/{pathWithNamespace}",
+				ProjectQuery:          []string{"none"},
+				Projects: []*schema.GitLabProject{
+					{Name: "gnachman/iterm2"},
+				},
+			}),
 			wantNames: []string{"gitlab.com/a/b/c/gnachman/iterm2"},
 			wantURIs:  []string{"gitlab.com/gnachman/iterm2"},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindBitbucketServer,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.BitbucketServerConnection{
-					Url:                   "https://bitbucket.sgdev.org",
-					Token:                 os.Getenv("BITBUCKET_SERVER_TOKEN"),
-					RepositoryPathPattern: "{host}/a/b/c/{projectKey}/{repositorySlug}",
-					RepositoryQuery:       []string{"none"},
-					Repos:                 []string{"sour/vegeta"},
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantBitbucketServer, &schema.BitbucketServerConnection{
+				Url:                   "https://bitbucket.sgdev.org",
+				Token:                 os.Getenv("BITBUCKET_SERVER_TOKEN"),
+				RepositoryPathPattern: "{host}/a/b/c/{projectKey}/{repositorySlug}",
+				RepositoryQuery:       []string{"none"},
+				Repos:                 []string{"sour/vegeta"},
+			}),
 			wantNames: []string{"bitbucket.sgdev.org/a/b/c/SOUR/vegeta"},
 			wantURIs:  []string{"bitbucket.sgdev.org/SOUR/vegeta"},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindAWSCodeCommit,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.AWSCodeCommitConnection{
-					AccessKeyID:     getAWSEnv("AWS_ACCESS_KEY_ID"),
-					SecretAccessKey: getAWSEnv("AWS_SECRET_ACCESS_KEY"),
-					Region:          "us-west-1",
-					GitCredentials: schema.AWSCodeCommitGitCredentials{
-						Username: "git-username",
-						Password: "git-password",
-					},
-					RepositoryPathPattern: "a/b/c/{name}",
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantAWSCodeCommit, &schema.AWSCodeCommitConnection{
+				AccessKeyID:     getAWSEnv("AWS_ACCESS_KEY_ID"),
+				SecretAccessKey: getAWSEnv("AWS_SECRET_ACCESS_KEY"),
+				Region:          "us-west-1",
+				GitCredentials: schema.AWSCodeCommitGitCredentials{
+					Username: "git-username",
+					Password: "git-password",
+				},
+				RepositoryPathPattern: "a/b/c/{name}",
+			}),
 			wantNames: []string{
 				"a/b/c/empty-repo",
 				"a/b/c/stripe-go",
@@ -416,14 +375,11 @@ func TestSources_ListRepos_RepositoryPathPattern(t *testing.T) {
 			},
 		},
 		{
-			svc: &types.ExternalService{
-				Kind: extsvc.KindGitolite,
-				Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitoliteConnection{
-					// Prefix serves as a sort of repositoryPathPattern for Gitolite
-					Prefix: "gitolite.mycorp.com/",
-					Host:   "ssh://git@127.0.0.1:2222",
-				})),
-			},
+			svc: typestest.MakeExternalService(t, extsvc.VariantGitolite, &schema.GitoliteConnection{
+				// Prefix serves as a sort of repositoryPathPattern for Gitolite
+				Prefix: "gitolite.mycorp.com/",
+				Host:   "ssh://git@127.0.0.1:2222",
+			}),
 			wantNames: []string{
 				"gitolite.mycorp.com/bar",
 				"gitolite.mycorp.com/baz",
@@ -470,13 +426,10 @@ func TestSources_Phabricator(t *testing.T) {
 	cf, save := NewClientFactory(t, "PHABRICATOR/phabricator")
 	defer save(t)
 
-	svc := &types.ExternalService{
-		Kind: extsvc.KindPhabricator,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.PhabricatorConnection{
-			Url:   "https://secure.phabricator.com",
-			Token: os.Getenv("PHABRICATOR_TOKEN"),
-		})),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantPhabricator, &schema.PhabricatorConnection{
+		Url:   "https://secure.phabricator.com",
+		Token: os.Getenv("PHABRICATOR_TOKEN"),
+	})
 
 	repos := listRepos(t, cf, svc)
 
@@ -517,29 +470,26 @@ func TestSources_ListRepos_GitLab_NameTransformations(t *testing.T) {
 	cf, save := NewClientFactory(t, "GITLAB/nameTransformations-updates-the-repo-name")
 	defer save(t)
 
-	svc := &types.ExternalService{
-		Kind: extsvc.KindGitLab,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.GitLabConnection{
-			Url:                   "https://gitlab.com",
-			Token:                 os.Getenv("GITLAB_ACCESS_TOKEN"),
-			RepositoryPathPattern: "{host}/{pathWithNamespace}",
-			ProjectQuery:          []string{"none"},
-			Projects: []*schema.GitLabProject{
-				{Name: "sg-test.d/repo-git"},
-				{Name: "sg-test.d/repo-gitrepo"},
+	svc := typestest.MakeExternalService(t, extsvc.VariantGitLab, &schema.GitLabConnection{
+		Url:                   "https://gitlab.com",
+		Token:                 os.Getenv("GITLAB_ACCESS_TOKEN"),
+		RepositoryPathPattern: "{host}/{pathWithNamespace}",
+		ProjectQuery:          []string{"none"},
+		Projects: []*schema.GitLabProject{
+			{Name: "sg-test.d/repo-git"},
+			{Name: "sg-test.d/repo-gitrepo"},
+		},
+		NameTransformations: []*schema.GitLabNameTransformation{
+			{
+				Regex:       "\\.d/",
+				Replacement: "/",
 			},
-			NameTransformations: []*schema.GitLabNameTransformation{
-				{
-					Regex:       "\\.d/",
-					Replacement: "/",
-				},
-				{
-					Regex:       "-git$",
-					Replacement: "",
-				},
+			{
+				Regex:       "-git$",
+				Replacement: "",
 			},
-		})),
-	}
+		},
+	})
 
 	repos := listRepos(t, cf, svc)
 	haveNames := types.Repos(repos).Names()
@@ -562,16 +512,13 @@ func TestSources_ListRepos_BitbucketServer_Archived(t *testing.T) {
 	cf, save := NewClientFactory(t, "BITBUCKETSERVER/bitbucketserver-archived")
 	defer save(t)
 
-	svc := &types.ExternalService{
-		Kind: extsvc.KindBitbucketServer,
-		Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, &schema.BitbucketServerConnection{
-			Url:                   "https://bitbucket.sgdev.org",
-			Token:                 os.Getenv("BITBUCKET_SERVER_TOKEN"),
-			RepositoryPathPattern: "{repositorySlug}",
-			RepositoryQuery:       []string{"none"},
-			Repos:                 []string{"sour/vegeta", "PUBLIC/archived-repo"},
-		})),
-	}
+	svc := typestest.MakeExternalService(t, extsvc.VariantBitbucketServer, &schema.BitbucketServerConnection{
+		Url:                   "https://bitbucket.sgdev.org",
+		Token:                 os.Getenv("BITBUCKET_SERVER_TOKEN"),
+		RepositoryPathPattern: "{repositorySlug}",
+		RepositoryQuery:       []string{"none"},
+		Repos:                 []string{"sour/vegeta", "PUBLIC/archived-repo"},
+	})
 
 	repos := listRepos(t, cf, svc)
 

--- a/internal/repos/sources_test_utils.go
+++ b/internal/repos/sources_test_utils.go
@@ -1,7 +1,6 @@
 package repos
 
 import (
-	"encoding/json"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -91,15 +90,4 @@ func NewRecorder(t testing.TB, file string, record bool) *recorder.Recorder {
 	}
 
 	return rec
-}
-
-func MarshalJSON(t testing.TB, v any) string {
-	t.Helper()
-
-	bs, err := json.Marshal(v)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return string(bs)
 }

--- a/internal/types/typestest/typestest.go
+++ b/internal/types/typestest/typestest.go
@@ -1,6 +1,7 @@
 package typestest
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 	"time"
@@ -113,6 +114,20 @@ func MakeGitLabExternalService() *types.ExternalService {
 		Config:      extsvc.NewUnencryptedConfig(`{"url": "https://gitlab.com", "token": "abc", "projectQuery": ["projects?membership=true&archived=no"]}`),
 		CreatedAt:   now,
 		UpdatedAt:   now,
+	}
+}
+
+func MakeExternalService(t *testing.T, variant extsvc.Variant, config any) *types.ExternalService {
+	t.Helper()
+
+	bs, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &types.ExternalService{
+		Kind:   variant.AsKind(),
+		Config: extsvc.NewUnencryptedConfig(string(bs)),
 	}
 }
 


### PR DESCRIPTION
I noticed that we've started to copy&paste this

    types.ExternalService{
        Kind:   FOO
        Config: extsvc.NewUnencryptedConfig(MarshalJSON(t, conf)),
    }

into a lot of places, including the `MarshalJSON` and `NewUnencryptedConfig` calls.

Started to abstract these away and then noticed I can create a helper for the whole thing.

So here we are.

## Test plan

- existing tests