### PR TITLE
repo exclusion: switch to dynamic rule builder

### DIFF
--- a/internal/repos/awscodecommit.go
+++ b/internal/repos/awscodecommit.go
@@ -33,7 +33,7 @@ type AWSCodeCommitSource struct {
 	awsRegion    string
 	client       *awscodecommit.Client
 
-	exclude excludeFunc
+	excluder repoExcluder
 }
 
 // NewAWSCodeCommitSource returns a new AWSCodeCommitSource from the given external service.
@@ -85,21 +85,21 @@ func newAWSCodeCommitSource(svc *types.ExternalService, c *schema.AWSCodeCommitC
 		return nil, err
 	}
 
-	var eb excludeBuilder
+	var ex repoExcluder
 	for _, r := range c.Exclude {
-		eb.Exact(r.Name)
-		eb.Exact(r.Id)
+		ex.AddRule().
+			Exact(r.Name).
+			Exact(r.Id)
 	}
-	exclude, err := eb.Build()
-	if err != nil {
+	if err := ex.RuleErrors(); err != nil {
 		return nil, err
 	}
 
 	s := &AWSCodeCommitSource{
-		svc:     svc,
-		config:  c,
-		exclude: exclude,
-		client:  awscodecommit.NewClient(awsConfig),
+		svc:      svc,
+		config:   c,
+		excluder: ex,
+		client:   awscodecommit.NewClient(awsConfig),
 	}
 
 	endpoint, err := codecommit.NewDefaultEndpointResolver().ResolveEndpoint(c.Region, codecommit.EndpointResolverOptions{})
@@ -176,7 +176,7 @@ func (s *AWSCodeCommitSource) listAllRepositories(ctx context.Context, results c
 }
 
 func (s *AWSCodeCommitSource) excludes(r *awscodecommit.Repository) bool {
-	return s.exclude(r.Name) || s.exclude(r.ID)
+	return s.excluder.ShouldExclude(r.Name) || s.excluder.ShouldExclude(r.ID)
 }
 
 // The code below is copied from

--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -23,11 +23,11 @@ import (
 // A BitbucketCloudSource yields repositories from a single BitbucketCloud connection configured
 // in Sourcegraph via the external services configuration.
 type BitbucketCloudSource struct {
-	svc     *types.ExternalService
-	config  *schema.BitbucketCloudConnection
-	exclude excludeFunc
-	client  bitbucketcloud.Client
-	logger  log.Logger
+	svc      *types.ExternalService
+	config   *schema.BitbucketCloudConnection
+	excluder repoExcluder
+	client   bitbucketcloud.Client
+	logger   log.Logger
 }
 
 var _ UserSource = &BitbucketCloudSource{}
@@ -55,14 +55,14 @@ func newBitbucketCloudSource(logger log.Logger, svc *types.ExternalService, c *s
 		return nil, err
 	}
 
-	var eb excludeBuilder
+	var ex repoExcluder
 	for _, r := range c.Exclude {
-		eb.Exact(r.Name)
-		eb.Exact(r.Uuid)
-		eb.Pattern(r.Pattern)
+		ex.AddRule().
+			Exact(r.Name).
+			Exact(r.Uuid).
+			Pattern(r.Pattern)
 	}
-	exclude, err := eb.Build()
-	if err != nil {
+	if err := ex.RuleErrors(); err != nil {
 		return nil, err
 	}
 
@@ -72,11 +72,11 @@ func newBitbucketCloudSource(logger log.Logger, svc *types.ExternalService, c *s
 	}
 
 	return &BitbucketCloudSource{
-		svc:     svc,
-		config:  c,
-		exclude: exclude,
-		client:  client,
-		logger:  logger,
+		svc:      svc,
+		config:   c,
+		excluder: ex,
+		client:   client,
+		logger:   logger,
 	}, nil
 }
 
@@ -161,7 +161,7 @@ func (s *BitbucketCloudSource) remoteURL(repo *bitbucketcloud.Repo) string {
 }
 
 func (s *BitbucketCloudSource) excludes(r *bitbucketcloud.Repo) bool {
-	return s.exclude(r.FullName) || s.exclude(r.UUID)
+	return s.excluder.ShouldExclude(r.FullName) || s.excluder.ShouldExclude(r.UUID)
 }
 
 func (s *BitbucketCloudSource) listAllRepos(ctx context.Context, results chan SourceResult) {

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -24,11 +24,11 @@ import (
 // A BitbucketServerSource yields repositories from a single BitbucketServer connection configured
 // in Sourcegraph via the external services configuration.
 type BitbucketServerSource struct {
-	svc     *types.ExternalService
-	config  *schema.BitbucketServerConnection
-	exclude excludeFunc
-	client  *bitbucketserver.Client
-	logger  log.Logger
+	svc      *types.ExternalService
+	config   *schema.BitbucketServerConnection
+	excluder repoExcluder
+	client   *bitbucketserver.Client
+	logger   log.Logger
 }
 
 var _ Source = &BitbucketServerSource{}
@@ -64,14 +64,18 @@ func newBitbucketServerSource(logger log.Logger, svc *types.ExternalService, c *
 		return nil, err
 	}
 
-	var eb excludeBuilder
+	var ex repoExcluder
 	for _, r := range c.Exclude {
-		eb.Exact(r.Name)
-		eb.Exact(strconv.Itoa(r.Id))
-		eb.Pattern(r.Pattern)
+		rule := ex.AddRule()
+		rule.
+			Exact(r.Name).
+			Pattern(r.Pattern)
+
+		if r.Id != 0 {
+			rule.Exact(strconv.Itoa(r.Id))
+		}
 	}
-	exclude, err := eb.Build()
-	if err != nil {
+	if err := ex.RuleErrors(); err != nil {
 		return nil, err
 	}
 
@@ -81,11 +85,11 @@ func newBitbucketServerSource(logger log.Logger, svc *types.ExternalService, c *
 	}
 
 	return &BitbucketServerSource{
-		svc:     svc,
-		config:  c,
-		exclude: exclude,
-		client:  client,
-		logger:  logger,
+		svc:      svc,
+		config:   c,
+		excluder: ex,
+		client:   client,
+		logger:   logger,
 	}, nil
 }
 
@@ -203,8 +207,8 @@ func (s *BitbucketServerSource) excludes(r *bitbucketserver.Repo) bool {
 		name = r.Project.Key + "/" + name
 	}
 	if r.State != "AVAILABLE" ||
-		s.exclude(name) ||
-		s.exclude(strconv.Itoa(r.ID)) ||
+		s.excluder.ShouldExclude(name) ||
+		s.excluder.ShouldExclude(strconv.Itoa(r.ID)) ||
 		(s.config.ExcludePersonalRepositories && r.IsPersonalRepository()) {
 		return true
 	}

--- a/internal/repos/exclude.go
+++ b/internal/repos/exclude.go
@@ -9,124 +9,127 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/bytesize"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // excludeFunc takes either a generic object and returns true if the repo should be excluded. In
 // the case of repo sourcing it will take a repository name, ID, or the repo itself as input.
 type excludeFunc func(input any) bool
 
-// excludeBuilder builds an excludeFunc.
-type excludeBuilder struct {
-	exact    map[string]struct{}
-	patterns []*regexp.Regexp
-	generic  []excludeFunc
-	err      error
+// repoExcluder is made up of several rules that can be chained together to
+// exclude a repository.
+//
+// Rules can be added by calling `repoExcluder.AddRule()`.
+//
+// After rules have been added, the caller uses `ShouldExclude` to check if a
+// repo should be excluded. In that call, all the rules are OR'd together. If
+// one rule excludes, the repo is excluded.
+type repoExcluder struct {
+	rules []*rule
 }
 
-// Exact will case-insensitively exclude the string name.
-func (e *excludeBuilder) Exact(name string) {
-	if e.exact == nil {
-		e.exact = map[string]struct{}{}
+func (e *repoExcluder) ShouldExclude(input any) bool {
+	for _, r := range e.rules {
+		if r.Excludes(input) {
+			return true
+		}
 	}
+
+	return false
+}
+
+func (e *repoExcluder) AddRule() *rule {
+	r := &rule{}
+	e.rules = append(e.rules, r)
+	return r
+}
+
+func (e *repoExcluder) RuleErrors() error {
+	var err errors.MultiError
+	for _, r := range e.rules {
+		err = errors.Append(err, r.err)
+	}
+	return err
+}
+
+// rule represents a single exclusion, whose conditions must all be bet in
+// order to exclude a repository.
+type rule struct {
+	exact    string
+	patterns []*regexp.Regexp
+	generic  []excludeFunc
+
+	// err can be set during construction if any patterns failed to compile.
+	err error
+}
+
+// Exact will keep track of the exact value passed in and then match it against
+// the input of the `Excludes` method.
+//
+// If the input is an empty string, it will be ignored.
+func (r *rule) Exact(name string) *rule {
 	if name == "" {
-		return
+		return r
 	}
-	e.exact[strings.ToLower(name)] = struct{}{}
+	r.exact = strings.ToLower(name)
+	return r
 }
 
 // Pattern will exclude strings matching the regex pattern.
-func (e *excludeBuilder) Pattern(pattern string) {
+func (r *rule) Pattern(pattern string) *rule {
 	if pattern == "" {
-		return
+		return r
 	}
 
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		e.err = err
-		return
+		r.err = err
+		return r
 	}
-	e.patterns = append(e.patterns, re)
+	r.patterns = append(r.patterns, re)
+	return r
 }
 
 // Generic registers the passed in exclude function that will be used to determine whether a repo
 // should be excluded.
-func (e *excludeBuilder) Generic(ef excludeFunc) {
+func (r *rule) Generic(ef excludeFunc) *rule {
 	if ef == nil {
-		return
+		return r
 	}
-	e.generic = append(e.generic, ef)
+	r.generic = append(r.generic, ef)
+	return r
 }
 
-// Build will return an excludeFunc based on the previous calls to Exact, Pattern, and
-// Generic.
-func (e *excludeBuilder) Build() (excludeFunc, error) {
-	return func(input any) bool {
-		if inputString, ok := input.(string); ok {
-			if _, ok := e.exact[strings.ToLower(inputString)]; ok {
-				return true
-			}
+// Excludes returns true if the input matches ALL of the previously set
+// attributes of the rule.
+func (r *rule) Excludes(input any) bool {
+	exclude := false
 
-			for _, re := range e.patterns {
-				if re.MatchString(inputString) {
-					return true
-				}
-			}
-		} else {
-			for _, ef := range e.generic {
-				if ef(input) {
-					return true
-				}
-			}
+	if inputString, ok := input.(string); ok {
+		if r.exact == strings.ToLower(inputString) {
+			exclude = true
 		}
 
-		return false
-	}, e.err
-}
-
-func buildGitHubExcludeRule(rule *schema.ExcludedGitHubRepo) (excludeFunc, error) {
-	var fns []gitHubExcludeFunc
-	if rule.Stars != "" {
-		fn, err := buildStarsConstraintsExcludeFn(rule.Stars)
-		if err != nil {
-			return nil, err
-		}
-		fns = append(fns, fn)
-	}
-
-	if rule.Size != "" {
-		fn, err := buildSizeConstraintsExcludeFn(rule.Size)
-		if err != nil {
-			return nil, err
-		}
-		fns = append(fns, fn)
-	}
-
-	return func(repo any) bool {
-		githubRepo, ok := repo.(github.Repository)
-		if !ok {
-			return false
-		}
-
-		// We're AND'ing the functions together. If one of them does NOT exclude
-		// the repository, then we don't exclude it.
-		for _, fn := range fns {
-			excluded := fn(githubRepo)
-			if !excluded {
+		for _, re := range r.patterns {
+			exclude = re.MatchString(inputString)
+			if !exclude {
 				return false
 			}
 		}
+	}
 
-		return true
-	}, nil
+	for _, ef := range r.generic {
+		exclude = ef(input)
+		if !exclude {
+			return false
+		}
+	}
+
+	return exclude
 }
 
-type gitHubExcludeFunc func(github.Repository) bool
-
 var starsConstraintRegex = regexp.MustCompile(`([<>=]{1,2})\s*(\d+)`)
-var sizeConstraintRegex = regexp.MustCompile(`([<>=]{1,2})\s*(\d+\s*\w+)`)
 
-func buildStarsConstraintsExcludeFn(constraint string) (gitHubExcludeFunc, error) {
+func buildStarsConstraintsExcludeFn(constraint string) (excludeFunc, error) {
 	matches := starsConstraintRegex.FindStringSubmatch(constraint)
 	if matches == nil {
 		return nil, errors.Newf("invalid stars constraint format: %q", constraint)
@@ -142,12 +145,18 @@ func buildStarsConstraintsExcludeFn(constraint string) (gitHubExcludeFunc, error
 		return nil, err
 	}
 
-	return func(r github.Repository) bool {
+	return func(input any) bool {
+		r, ok := input.(github.Repository)
+		if !ok {
+			return false
+		}
 		return operator.Eval(r.StargazerCount, count)
 	}, nil
 }
 
-func buildSizeConstraintsExcludeFn(constraint string) (gitHubExcludeFunc, error) {
+var sizeConstraintRegex = regexp.MustCompile(`([<>=]{1,2})\s*(\d+\s*\w+)`)
+
+func buildSizeConstraintsExcludeFn(constraint string) (excludeFunc, error) {
 	sizeMatch := sizeConstraintRegex.FindStringSubmatch(constraint)
 	if sizeMatch == nil {
 		return nil, errors.Newf("invalid size constraint format: %q", constraint)
@@ -163,7 +172,12 @@ func buildSizeConstraintsExcludeFn(constraint string) (gitHubExcludeFunc, error)
 		return nil, err
 	}
 
-	return func(r github.Repository) bool {
+	return func(input any) bool {
+		r, ok := input.(github.Repository)
+		if !ok {
+			return false
+		}
+
 		repoSize := int(r.SizeBytes())
 
 		// If we don't have a repository size, we don't exclude

--- a/internal/repos/exclude_test.go
+++ b/internal/repos/exclude_test.go
@@ -1,26 +1,114 @@
 package repos
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-func TestBuildGitHubExcludeRule(t *testing.T) {
-	assertExcluded := func(t *testing.T, rule *schema.ExcludedGitHubRepo, repo github.Repository, wantExcluded bool) {
+func TestRepoExcluderRuleErrors(t *testing.T) {
+	var ex repoExcluder
+
+	ex.AddRule().Pattern("valid")
+	require.NoError(t, ex.RuleErrors())
+
+	ex.AddRule().Pattern("[\\\\")
+	require.Error(t, ex.RuleErrors())
+}
+
+func TestRuleExcludes(t *testing.T) {
+	startsWithFoo := func(input any) bool {
+		if s, ok := input.(string); ok {
+			return strings.HasPrefix(s, "foo")
+		}
+		return false
+	}
+
+	t.Run("ExactName", func(t *testing.T) {
+		r := &rule{}
+		r.Exact("foobar")
+
+		assert.Equal(t, true, r.Excludes("foobar"))
+		assert.Equal(t, false, r.Excludes("barfoo"))
+
+		// Only one exact value can exist
+		r.Exact("barfoo")
+		assert.Equal(t, false, r.Excludes("foobar"))
+		assert.Equal(t, true, r.Excludes("barfoo"))
+	})
+
+	t.Run("Pattern", func(t *testing.T) {
+		r := &rule{}
+		r.Pattern("^foo.*")
+
+		assert.Equal(t, true, r.Excludes("foobar"))
+		assert.Equal(t, false, r.Excludes("barfoo"))
+	})
+
+	t.Run("Generic", func(t *testing.T) {
+		r := &rule{}
+		r.Generic(startsWithFoo)
+
+		assert.Equal(t, true, r.Excludes("foobar"))
+		assert.Equal(t, false, r.Excludes("barfoo"))
+	})
+
+	t.Run("multiple conditions", func(t *testing.T) {
+		r := &rule{}
+		r.Exact("foobar")
+		r.Pattern("^foo.*")
+
+		assert.Equal(t, true, r.Excludes("foobar"))
+		assert.Equal(t, false, r.Excludes("barfoo"))
+
+		r.Generic(startsWithFoo)
+
+		assert.Equal(t, true, r.Excludes("foobar"))
+		assert.Equal(t, false, r.Excludes("barfoo"))
+
+		endsWithFoo := func(input any) bool {
+			if s, ok := input.(string); ok {
+				return strings.HasSuffix(s, "foo")
+			}
+			return false
+		}
+
+		r.Generic(endsWithFoo)
+		// All conditions have to be true and no argument here fulfills all of them
+		assert.Equal(t, false, r.Excludes("foobar"))
+		assert.Equal(t, false, r.Excludes("barfoo"))
+	})
+}
+
+func TestGitHubStarsAndSize(t *testing.T) {
+	assertExcluded := func(t *testing.T, githubRule *schema.ExcludedGitHubRepo, repo github.Repository, wantExcluded bool) {
 		t.Helper()
-		fn, err := buildGitHubExcludeRule(rule)
-		assert.Nil(t, err)
+		rule := &rule{}
+
+		if githubRule.Stars != "" {
+			fn, err := buildStarsConstraintsExcludeFn(githubRule.Stars)
+			require.NoError(t, err)
+			rule.Generic(fn)
+		}
+
+		if githubRule.Size != "" {
+			fn, err := buildSizeConstraintsExcludeFn(githubRule.Size)
+			require.NoError(t, err)
+			rule.Generic(fn)
+		}
+
 		assert.Equal(
 			t,
 			wantExcluded,
-			fn(repo),
+			rule.Excludes(repo),
 			"rule.Stars=%q, rule.Size=%q, repo.StarGazerCount=%d, repo.DiskUsageKibibytes=%d",
-			rule.Stars,
-			rule.Size,
+			githubRule.Stars,
+			githubRule.Size,
 			repo.StargazerCount,
 			repo.DiskUsageKibibytes,
 		)

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -36,7 +36,7 @@ import (
 type GitHubSource struct {
 	svc          *types.ExternalService
 	config       *schema.GitHubConnection
-	exclude      excludeFunc
+	excluder     repoExcluder
 	githubDotCom bool
 	baseURL      *url.URL
 	v3Client     *github.V3Client
@@ -121,7 +121,7 @@ func newGitHubSource(
 		return nil, err
 	}
 
-	var eb excludeBuilder
+	var ex repoExcluder
 	excludeArchived := func(repo any) bool {
 		if githubRepo, ok := repo.(github.Repository); ok {
 			return githubRepo.IsArchived
@@ -136,33 +136,37 @@ func newGitHubSource(
 	}
 
 	for _, r := range c.Exclude {
-		// TODO: Size/Stars are special-case'd here and are AND'ed if both set.
-		// This condition here should be replace with something that builds an
-		// exclude-function for all possible values a schema.ExcludedGitHubRepo
-		// could have.
-		if r.Size != "" || r.Stars != "" {
-			fn, err := buildGitHubExcludeRule(r)
+		rule := ex.AddRule().
+			Exact(r.Name).
+			Exact(r.Id).
+			Pattern(r.Pattern)
+
+		if r.Size != "" {
+			fn, err := buildSizeConstraintsExcludeFn(r.Size)
 			if err != nil {
 				return nil, err
 			}
-			eb.Generic(fn)
+			rule.Generic(fn)
+		}
+		if r.Stars != "" {
+			fn, err := buildStarsConstraintsExcludeFn(r.Stars)
+			if err != nil {
+				return nil, err
+			}
+			rule.Generic(fn)
 		}
 
 		if r.Archived {
-			eb.Generic(excludeArchived)
+			rule.Generic(excludeArchived)
 		}
 		if r.Forks {
-			eb.Generic(excludeFork)
+			rule.Generic(excludeFork)
 		}
-		eb.Exact(r.Name)
-		eb.Exact(r.Id)
-		eb.Pattern(r.Pattern)
 	}
-
-	exclude, err := eb.Build()
-	if err != nil {
+	if err := ex.RuleErrors(); err != nil {
 		return nil, err
 	}
+
 	auther, err := ghauth.FromConnection(ctx, c, db.GitHubApps(), keyring.Default().GitHubAppKey)
 	if err != nil {
 		return nil, err
@@ -201,7 +205,7 @@ func newGitHubSource(
 	return &GitHubSource{
 		svc:                       svc,
 		config:                    c,
-		exclude:                   exclude,
+		excluder:                  ex,
 		baseURL:                   baseURL,
 		githubDotCom:              githubDotCom,
 		v3Client:                  v3Client,
@@ -327,16 +331,11 @@ func (s *GitHubSource) fetchReposAffiliated(ctx context.Context, first int, excl
 		close(unfiltered)
 	}()
 
-	var eb excludeBuilder
-	// Only exclude on exact nameWithOwner match
+	set := make(map[string]struct{})
 	for _, r := range excludedRepos {
-		eb.Exact(r)
+		set[r] = struct{}{}
 	}
-	exclude, err := eb.Build()
-	if err != nil {
-		results <- SourceResult{Source: s, Err: err}
-		return
-	}
+	excluded := func(name string) bool { _, ok := set[name]; return ok }
 
 	s.logger.Debug("fetch github repos by affiliation", log.Int("excluded repos count", len(excludedRepos)))
 	for res := range unfiltered {
@@ -348,7 +347,7 @@ func (s *GitHubSource) fetchReposAffiliated(ctx context.Context, first int, excl
 			continue
 		}
 		s.logger.Debug("unfiltered", log.String("repo", res.repo.NameWithOwner))
-		if !exclude(res.repo.NameWithOwner) {
+		if !excluded(res.repo.NameWithOwner) {
 			results <- SourceResult{Source: s, Repo: s.makeRepo(res.repo)}
 			s.logger.Debug("sent to result", log.String("repo", res.repo.NameWithOwner))
 			first--
@@ -457,7 +456,9 @@ func (s *GitHubSource) excludes(r *github.Repository) bool {
 		return true
 	}
 
-	if s.exclude(r.NameWithOwner) || s.exclude(r.ID) || s.exclude(*r) {
+	if s.excluder.ShouldExclude(r.NameWithOwner) ||
+		s.excluder.ShouldExclude(r.ID) ||
+		s.excluder.ShouldExclude(*r) {
 		return true
 	}
 

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -222,7 +222,7 @@ func TestSources_ListRepos_Excluded(t *testing.T) {
 					{Pattern: ".*public-repo.*"},
 					{Pattern: ".*secret-repo.*"},
 					{Pattern: ".*private-repo.*"},
-					{Pattern: `.*SGDEMO.*`},
+					{Pattern: ".*SGDEMO.*"},
 				},
 			}),
 			wantNames: []string{


### PR DESCRIPTION
This is a follow-up to https://github.com/sourcegraph/sourcegraph/pull/58377 and changes how `exclude` works by AND'ing all conditions in a single rule together.

It does this mostly by refactoring the code and turning things upside down (inside out?):
- instead of each `[]exclude` entry in a code host connection config being turned into a separate condition, one of which had to be true
- each entry is turned into a `*rule` that can have multiple conditions and all of them have to be true for a repo to be excluded.

Best explained with an example.

Old code:

```go
var eb excludeBuilder
for _, r := range c.Exclude {
  eb.Exact(r.Name)
  eb.Exact(r.Id)
}
exclude, err := eb.Build()
if err != nil {
  return nil, err
}

// then:

exclude(r.Id) || exclude(r.Name) || exclude(r)
```

New code:

```go
var ex repoExcluder
for _, r := range c.Exclude {
  ex.AddRule().
    Exact(r.Name).
    Exact(r.Id)
}

// then:

ex.ShouldExclude(r.Id) || ex.ShouldExclude(r.Name) || ex.ShouldExclude(r)
```


Comparison not totally fair because stil need to add error handling for invalid patterns.

## Downsides

Currently it's a lot more function calls per exclusion-check... we could probably amortize the cost but I'm not sure yet what the nicest way is.


## Test plan

- unit tests, extended