### PR TITLE
oidc: redirect to `/search` page after auth flow by default

### DIFF
--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -398,6 +398,13 @@ const stateCookieTimeout = time.Minute * 15
 // RedirectToAuthRequest redirects the user to the authentication endpoint on the
 // external authentication provider.
 func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, cookieName, returnToURL string) {
+	// NOTE: We do not have a valid screen at the root path (always gets redirected
+	// to "/search"), and it is a marketing page on Sourcegraph.com, so redirecting to
+	// "/search" is a safe default.
+	if returnToURL == "" || returnToURL == "/" {
+		returnToURL = "/search"
+	}
+
 	// The state parameter is an opaque value used to maintain state between the
 	// original Authentication Request and the callback. We generate a random unique
 	// value as the OIDC state parameter.

--- a/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -221,7 +221,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := resp.Header.Get("Location"), "/oauth2/v1/authorize?"; !strings.Contains(got, want) {
 			t.Errorf("got redirect URL %v, want contains %v", got, want)
 		}
-		if state, want := state(t, resp.Header.Get("Location")), "/"; state.Redirect != want {
+		if state, want := state(t, resp.Header.Get("Location")), "/search"; state.Redirect != want {
 			t.Errorf("got redirect destination %q, want %q", state.Redirect, want)
 		}
 	})


### PR DESCRIPTION
Please see code comments.

## Test plan

CI
