### PR TITLE
bzl: containerize scip-ctags

### DIFF
--- a/docker-images/syntax-highlighter/BUILD.bazel
+++ b/docker-images/syntax-highlighter/BUILD.bazel
@@ -54,6 +54,27 @@ rust_binary(
 )
 
 pkg_tar(
+    name = "tar_scip-ctags",
+    srcs = [":scip-ctags"],
+)
+
+# We are shipping a minimal scip-ctags container, which is used for testing purposes
+# in the zoekt repository, so we can test it against it instead of scip-ctags,
+# reflecting better real production usage.
+oci_image(
+    name = "scip-ctags_image",
+    base = "@wolfi_base",
+    entrypoint = ["/scip-ctags"],
+    tars = [":tar_scip-ctags"],
+)
+
+oci_tarball(
+    name = "scip-ctags_image_tarball",
+    image = ":scip-ctags_image",
+    repo_tags = ["scip-ctags:candidate"],
+)
+
+pkg_tar(
     name = "tar_syntect_server",
     srcs = [":syntect_server"],
 )


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/58333 

I created a repo for `scip-ctags` in our Docker org accordingly. 

## Test plan

CI + ran the container locally 

```
~/work/sourcegraph U main $ docker load --input=bazel-bin/docker-images/syntax-highlighter/scip-ctags_image_tarball/tarball.tar
7bd31829c240: Loading layer [==================================================>]  8.535MB/8.535MB
Loaded image: scip-ctags:candidate
~/work/sourcegraph U main $ docker run scip-ctags:candidate -- -h
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
{"_type":"program","name":"SCIP Ctags","version":"5.9.0"}
``` 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
