### PR TITLE
gitserver: Fix removal of old clone during reclones

### DIFF
--- a/cmd/gitserver/internal/server.go
+++ b/cmd/gitserver/internal/server.go
@@ -1514,8 +1514,8 @@ func (s *Server) doClone(
 	}
 
 	if opts.Overwrite {
-		// remove the current repo by putting it into our temporary directory
-		err := fileutil.RenameAndSync(dstPath, filepath.Join(filepath.Dir(tmpDir), "old"))
+		// remove the current repo by putting it into our temporary directory, outside of the git repo.
+		err := fileutil.RenameAndSync(dstPath, filepath.Join(tmpDir, "old"))
 		if err != nil && !os.IsNotExist(err) {
 			return errors.Wrapf(err, "failed to remove old clone")
 		}


### PR DESCRIPTION
In a recent change, I accidentally broke this logic, which is causing a bunch of errors on sourcegraph.com. The stray filepath.Dir I forgot to remove around tmpDir made it so that all repos are renamed to the same path, and never actually deleted, causing ErrExists errors.

## Test plan

Verified fix by hand. 