### PR TITLE
Stop running deprecated code monitors on dotcom

### DIFF
--- a/cmd/worker/internal/codemonitors/BUILD.bazel
+++ b/cmd/worker/internal/codemonitors/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/worker/internal/codemonitors",
     visibility = ["//cmd/worker:__subpackages__"],
     deps = [
+        "//cmd/frontend/envvar",
         "//cmd/worker/job",
         "//cmd/worker/shared/init/db",
         "//internal/codemonitors/background",

--- a/cmd/worker/internal/codemonitors/codemonitor_job.go
+++ b/cmd/worker/internal/codemonitors/codemonitor_job.go
@@ -3,6 +3,7 @@ package codemonitors
 import (
 	"context"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
 	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
 	"github.com/sourcegraph/sourcegraph/internal/codemonitors/background"
@@ -26,6 +27,14 @@ func (j *codeMonitorJob) Config() []env.Config {
 }
 
 func (j *codeMonitorJob) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	// Code monitors have been deprecated on dotcom and are set to be fully disabled
+	// after November 29th 2023.
+	// This is a temporary line to disable the background workers that execute them,
+	// before we simply turn off the feature via a feature gate or similar.
+	if envvar.SourcegraphDotComMode() {
+		return nil, nil
+	}
+
 	db, err := workerdb.InitDB(observationCtx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This executes on the deprecation plan of monitors on dotcom. See Slack here: https://sourcegraph.slack.com/archives/C05EA9KQUTA/p1698878170295189

This only stops them from running, but doesn't hide them from the UI and prunes the DBs yet, which is scheduled for November 29.

## Test plan

Code review, CI.