### PR TITLE
Prevent error log and sentry spam from HTTP client errors

### DIFF
--- a/cmd/frontend/internal/app/ui/BUILD.bazel
+++ b/cmd/frontend/internal/app/ui/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
+        "@org_uber_go_zap//zapcore",
     ],
 )
 

--- a/cmd/frontend/internal/app/ui/BUILD.bazel
+++ b/cmd/frontend/internal/app/ui/BUILD.bazel
@@ -66,7 +66,6 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
-        "@org_uber_go_zap//zapcore",
     ],
 )
 

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel/attribute"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
@@ -429,7 +428,7 @@ func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, db database.DB, e
 		tr.SetAttributes(attribute.String("error-id", errorID))
 		traceURL = trace.URL(trace.ID(r.Context()), conf.DefaultClient())
 	}
-	logFields := []zapcore.Field{
+	logFields := []log.Field{
 		log.String("method", r.Method),
 		log.String("request_uri", r.URL.RequestURI()),
 		log.Int("status_code", statusCode),


### PR DESCRIPTION
We log a ton of events to Sentry about 404 routes and the likes. I don't think 4xx errors should cause error logs, so I'm downgrading these to warning level instead.

## Test plan

Code review.