### PR TITLE
bzl: add missing oci_push rule for scip-ctags

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -19,6 +19,11 @@ function create_push_command() {
   target="$3"
   tags_args="$4"
 
+  # TODO(JH): https://github.com/sourcegraph/sourcegraph/issues/58442
+  if [[ "$target" == "//docker-images/syntax-highlighter:scip-ctags_candidate_push" ]]; then
+    repository="scip-ctags"
+  fi
+
   repositories_args=""
   for registry in "${registries[@]}"; do
     repositories_args="$repositories_args --repository ${registry}/${repository}"

--- a/docker-images/syntax-highlighter/BUILD.bazel
+++ b/docker-images/syntax-highlighter/BUILD.bazel
@@ -139,3 +139,9 @@ oci_push(
     image = ":image",
     repository = image_repository("syntax-highlighter"),
 )
+
+oci_push(
+    name = "scip-ctags_candidate_push",
+    image = ":scip-ctags_image",
+    repository = image_repository("scip-ctags"),
+)


### PR DESCRIPTION
Add `oci_push` rule so new `scip-ctags` container for test purposes in Zoekt gets published. 

## Test plan

```
~/work/sourcegraph  main $ bazel query 'kind("oci_push rule", //...)' | grep scip
Loading: 0 packages loaded
//docker-images/syntax-highlighter:scip-ctags_candidate_push
```

```
~/work/sourcegraph  main-dry-run/jh/scip-ctags $ docker run us.gcr.io/sourcegraph-dev/scip-ctags@sha256:259f2435d5af95fc14e787b08c530b400259c8e6b1ce72bb163dba5b3320887e -- -h
Unable to find image 'us.gcr.io/sourcegraph-dev/scip-ctags@sha256:259f2435d5af95fc14e787b08c530b400259c8e6b1ce72bb163dba5b3320887e' locally
us.gcr.io/sourcegraph-dev/scip-ctags@sha256:259f2435d5af95fc14e787b08c530b400259c8e6b1ce72bb163dba5b3320887e: Pulling from sourcegraph-dev/scip-ctags
13b374ce116e: Pull complete
fedaafe1220e: Pull complete
Digest: sha256:259f2435d5af95fc14e787b08c530b400259c8e6b1ce72bb163dba5b3320887e
Status: Downloaded newer image for us.gcr.io/sourcegraph-dev/scip-ctags@sha256:259f2435d5af95fc14e787b08c530b400259c8e6b1ce72bb163dba5b3320887e
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
{"_type":"program","name":"SCIP Ctags","version":"5.9.0"}
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
