### PR TITLE
search jobs: allow repo: predicates

### DIFF
--- a/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.test.ts
+++ b/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.test.ts
@@ -11,23 +11,47 @@ describe('exhaustive search validation', () => {
         expect(validateQueryForExhaustiveSearch('context:global rev:* insights')).toStrictEqual([])
     })
 
+    test('[repo:has.content() predicate]', () => {
+        expect(validateQueryForExhaustiveSearch('context:global repo:has.content(insights) foo').length).toStrictEqual(
+            0
+        )
+    })
+
+    test('[repo:has.meta() predicate]', () => {
+        expect(validateQueryForExhaustiveSearch('context:global repo:has.meta(insights) foo').length).toStrictEqual(0)
+    })
+
     describe('works properly with invalid query', () => {
         test('[multiple rev operator case]', () => {
             expect(validateQueryForExhaustiveSearch('context:global rev:* insights rev:vk').length).toStrictEqual(1)
         })
 
-        test('[has regexp generic patter]', () => {
+        test('[has regexp generic pattern]', () => {
             expect(validateQueryForExhaustiveSearch('context:global .* patterntype:regexp').length).toStrictEqual(1)
         })
 
-        test('[repo:has.file() operator]', () => {
-            expect(validateQueryForExhaustiveSearch('context:global repo:has.file(insights)').length).toStrictEqual(1)
-        })
-
-        test('[file:has.content() operator]', () => {
+        test('[file:has.content() predicate]', () => {
             expect(validateQueryForExhaustiveSearch('context:global file:has.content(insights)').length).toStrictEqual(
                 1
             )
+        })
+
+        test('[file:has.owner() predicate]', () => {
+            expect(
+                validateQueryForExhaustiveSearch('context:global file:has.owner(insights) foo').length
+            ).toStrictEqual(1)
+        })
+
+        test('[f:has.contributor() predicate]', () => {
+            expect(
+                validateQueryForExhaustiveSearch('context:global f:has.contributor(insights) foo').length
+            ).toStrictEqual(1)
+        })
+
+        test('[f:contains.content() predicate]', () => {
+            expect(
+                validateQueryForExhaustiveSearch('context:global f:contains.content(insights) foo').length
+            ).toStrictEqual(1)
         })
 
         test('[or operator]', () => {
@@ -49,9 +73,9 @@ describe('exhaustive search validation', () => {
         test('[all cases combined]', () => {
             expect(
                 validateQueryForExhaustiveSearch(
-                    'context:global (repo:has.file(insights) rev:* ) or (file:has.content(batch-changes) rev:vk batch) or (patterntype:regexp .*)'
+                    'context:global (file:has.content(batch-changes) rev:vk batch) or (patterntype:regexp .* rev:foo)'
                 ).length
-            ).toStrictEqual(5)
+            ).toStrictEqual(4)
         })
     })
 })

--- a/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.ts
+++ b/client/branded/src/search-ui/results/progress/exhaustive-search/exhaustive-search-validation.ts
@@ -7,7 +7,6 @@ enum ValidationErrorType {
     INVALID_QUERY = 'invalid_query',
     GENERIC_REGEXP = 'generic_regexp',
     HAS_CONTENT_PREDICATE = 'has_content_predicate',
-    HAS_FILE_PREDICATE = 'has_file_predicate',
     OR_OPERATOR = 'or_operator',
     AND_OPERATOR = 'and_operator',
 }
@@ -68,21 +67,16 @@ export function validateQueryForExhaustiveSearch(query: string): ValidationError
             })
         }
 
-        const repoHasContentFilter = filters.some(filter => filter.value?.value.startsWith('has.content('))
-
-        if (repoHasContentFilter) {
+        const filePredicates = ['has.content', 'has.owner', 'has.contributor', 'contains.content']
+        const fileHasContentFilter = filters.some(
+            filter =>
+                filePredicates.some(startString => filter.value?.value.startsWith(startString)) &&
+                filter.field.value?.startsWith('f')
+        )
+        if (fileHasContentFilter) {
             validationErrors.push({
                 type: ValidationErrorType.HAS_CONTENT_PREDICATE,
-                reason: 'repo.has.content predicate is not compatible',
-            })
-        }
-
-        const repoHasFileFilter = filters.some(filter => filter.value?.value.startsWith('has.file('))
-
-        if (repoHasFileFilter) {
-            validationErrors.push({
-                type: ValidationErrorType.HAS_FILE_PREDICATE,
-                reason: 'repo.has.file predicate is not compatible',
+                reason: 'file: predicate is not compatible',
             })
         }
 

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -79,7 +79,7 @@ To use Search Jobs, you need to:
 Search Jobs supports queries of `type:file` and it automatically appends this to the search query. Other result types (like `diff`, `commit`, `path`, and `repo`) will be ignored. However, there are some limitations on the supported query syntax. These include:
 
 - `OR`, `AND` operators
-- `has.content` or `has.file` predicates
+- file predicates, such as `file:has.content`, `file:has.owner`, `file:has.contributor`, `file:contains.content`.
 - `.*` regexp search
 - Multiple `rev` filters
 - Queries with `index: filter`

--- a/doc/code_search/how-to/search-jobs.md
+++ b/doc/code_search/how-to/search-jobs.md
@@ -79,7 +79,7 @@ To use Search Jobs, you need to:
 Search Jobs supports queries of `type:file` and it automatically appends this to the search query. Other result types (like `diff`, `commit`, `path`, and `repo`) will be ignored. However, there are some limitations on the supported query syntax. These include:
 
 - `OR`, `AND` operators
-- file predicates, such as `file:has.content`, `file:has.owner`, `file:has.contributor`, `file:contains.content`.
+- file predicates, such as `file:has.content`, `file:has.owner`, `file:has.contributor`, `file:contains.content`
 - `.*` regexp search
 - Multiple `rev` filters
 - Queries with `index: filter`

--- a/internal/search/job/jobutil/exhaustive_job.go
+++ b/internal/search/job/jobutil/exhaustive_job.go
@@ -23,8 +23,6 @@ type Exhaustive struct {
 //
 // It will return an error if the input query is not supported by Exhaustive.
 func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
-	// TODO(keegan) a bunch of tests around this after branch cut pls
-
 	if inputs.Protocol != search.Exhaustive {
 		return Exhaustive{}, errors.New("only works for exhaustive search inputs")
 	}
@@ -46,15 +44,12 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 		return Exhaustive{}, errors.Errorf("expected a simple expression (no and/or/etc). Got %v", b.Pattern)
 	}
 
-	// no predicates
-	if inputs.Query.Exists(query.FieldRepoHasFile) {
-		return Exhaustive{}, errors.Errorf("repoHasFile is not supported")
-	}
-	if pred, ok := hasPredicates(query.FieldRepo, inputs.Query); ok {
-		return Exhaustive{}, errors.Errorf("repo: predicates are not supported. Got %v", pred)
-	}
+	// We don't support file: predicates, such as file:has.content(), because the
+	// search breaks in unexpected ways. For example, for interactive search
+	// file:has.content() is translated to an AND query which we don't support in
+	// Search Jobs yet.
 	if pred, ok := hasPredicates(query.FieldFile, inputs.Query); ok {
-		return Exhaustive{}, errors.Errorf("field: predicates are not supported. Got %v", pred)
+		return Exhaustive{}, errors.Errorf("file: predicates are not supported. Got %v", pred)
 	}
 
 	// This is a very weak protection but should be enough to catch simple misuse.

--- a/internal/search/job/jobutil/exhaustive_job_test.go
+++ b/internal/search/job/jobutil/exhaustive_job_test.go
@@ -157,10 +157,11 @@ func TestNewExhaustive_negative(t *testing.T) {
 		// catch-all regex
 		{query: `type:file index:no r:.* .*`, isPatterntypeRegex: true},
 		{query: `type:file index:no r:repo .*`, isPatterntypeRegex: true},
-		// predicates
-		{query: `type:file index:no repohasfile:foo.bar content`},
-		{query: `type:file index:no file:has.content("content")`},
-		{query: `type:file index:no repo:has.path("src") content`},
+		// file predicates
+		{query: `type:file index:no file:has.content(content)`},
+		{query: `type:file index:no file:has.owner(owner)`},
+		{query: `type:file index:no file:contains.content(content)`},
+		{query: `type:file index:no file:has.contributor(contributor)`},
 	}
 
 	for _, c := range tc {

--- a/internal/search/job/jobutil/exhaustive_job_test.go
+++ b/internal/search/job/jobutil/exhaustive_job_test.go
@@ -108,6 +108,56 @@ func TestNewExhaustive(t *testing.T) {
   (indexed . false))
 `),
 		},
+		{
+			Name:  "repo:has.file predicate",
+			Query: "type:file index:no foo repo:has.file(go.mod)",
+			WantPager: autogold.Expect(`
+(REPOPAGER
+  (containsRefGlobs . false)
+  (repoOpts.useIndex . no)
+  (repoOpts.hasFileContent[0].path . go.mod)
+  (PARTIALREPOS
+    (SEARCHERTEXTSEARCH
+      (useFullDeadline . true)
+      (patternInfo . TextPatternInfo{"foo",re,nopath,filematchlimit:1000000})
+      (numRepos . 0)
+      (pathRegexps . [])
+      (indexed . false))))
+`),
+			WantJob: autogold.Expect(`
+(SEARCHERTEXTSEARCH
+  (useFullDeadline . true)
+  (patternInfo . TextPatternInfo{"foo",re,nopath,filematchlimit:1000000})
+  (numRepos . 1)
+  (pathRegexps . [])
+  (indexed . false))
+`),
+		},
+		{
+			Name:  "repo:has.meta predicate",
+			Query: "type:file index:no foo repo:has.meta(cognition)",
+			WantPager: autogold.Expect(`
+(REPOPAGER
+  (containsRefGlobs . false)
+  (repoOpts.useIndex . no)
+  (repoOpts.hasKVPs[0].key . cognition)
+  (PARTIALREPOS
+    (SEARCHERTEXTSEARCH
+      (useFullDeadline . true)
+      (patternInfo . TextPatternInfo{"foo",re,nopath,filematchlimit:1000000})
+      (numRepos . 0)
+      (pathRegexps . [])
+      (indexed . false))))
+`),
+			WantJob: autogold.Expect(`
+(SEARCHERTEXTSEARCH
+  (useFullDeadline . true)
+  (patternInfo . TextPatternInfo{"foo",re,nopath,filematchlimit:1000000})
+  (numRepos . 1)
+  (pathRegexps . [])
+  (indexed . false))
+`),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
We allow repo predicates for Search Jobs by removing the corresponding validation checks. At the same time we improve the checks against file predicates.

We now support the following **repo** predicates:
- .has.meta
- .has.file
- .has.content
- .has.path
- .has.commit.after
- .has.description

Notes:
- Why don't we allow file predicates? `file:has.content()` is translated to an AND query in our (query parsing) job layer. In Search Jobs we don't call this code path. A quick copy&paste hack let to Search Jobs breaking in unexpected ways. Hence I want to leave file predicates to a separate investigation and PR.
- The validation in the client and backend are not 100% identical which is a trade-off we accepted for the EAP. The plan is to remove the client validation soon and instead call out to the backend for validation. 

Test plan:
- updated unit tests for client and backend
- manual testing
  - I ran searches with various repo predicates and compared match counts of search jobs with the match counts we display in the Search UI. Repo predicates worked without any issue. This is to be expected because repo predicates are translated to `RepoListOptions` which fits in nicely with our design of Search Jobs.

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@sh/search-jobs-enable-repo-predicates)