### PR TITLE
code-search: properly display disabled bulk operations

### DIFF
--- a/client/web/src/enterprise/batches/DropdownButton.module.scss
+++ b/client/web/src/enterprise/batches/DropdownButton.module.scss
@@ -12,8 +12,18 @@
 
 .menu-list-item {
     padding: 0.5rem 1rem;
+    cursor: pointer;
 
-    &[data-reach-menu-item]:active {
+    &[data-reach-menu-item][aria-disabled="false"]:active {
         --text-muted: var(--white);
+    }
+
+    &[data-reach-menu-item][aria-disabled="true"]:hover {
+        background-color: transparent;
+    }
+
+    &[data-reach-menu-item][aria-disabled="true"] {
+        cursor: not-allowed;
+        opacity: 0.7;
     }
 }

--- a/client/web/src/enterprise/batches/DropdownButton.module.scss
+++ b/client/web/src/enterprise/batches/DropdownButton.module.scss
@@ -14,15 +14,15 @@
     padding: 0.5rem 1rem;
     cursor: pointer;
 
-    &[data-reach-menu-item][aria-disabled="false"]:active {
+    &[data-reach-menu-item][aria-disabled='false']:active {
         --text-muted: var(--white);
     }
 
-    &[data-reach-menu-item][aria-disabled="true"]:hover {
+    &[data-reach-menu-item][aria-disabled='true']:hover {
         background-color: transparent;
     }
 
-    &[data-reach-menu-item][aria-disabled="true"] {
+    &[data-reach-menu-item][aria-disabled='true'] {
         cursor: not-allowed;
         opacity: 0.7;
     }

--- a/client/web/src/enterprise/batches/DropdownButton.tsx
+++ b/client/web/src/enterprise/batches/DropdownButton.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { mdiChevronDown } from '@mdi/js'
 import { VisuallyHidden } from '@reach/visually-hidden'
+import classNames from 'classnames'
 
 import {
     ProductStatusBadge,
@@ -179,7 +180,11 @@ const DropdownItem: React.FunctionComponent<React.PropsWithChildren<DropdownItem
 
     return (
         <MenuItem className={styles.menuListItem} onSelect={onSelect} disabled={action.disabled}>
-            <H4 className="mb-1">
+            <H4
+                className={classNames('mb-1', {
+                    'text-muted': action.disabled,
+                })}
+            >
                 {action.dropdownTitle}
                 {action.experimental && (
                     <>


### PR DESCRIPTION
Closes #58447

![CleanShot 2023-11-21 at 14 36 05](https://github.com/sourcegraph/sourcegraph/assets/25608335/0c8b052a-5167-4925-ba8e-67da1e572d6e)
![CleanShot 2023-11-21 at 14 35 30](https://github.com/sourcegraph/sourcegraph/assets/25608335/409c7ead-57d3-4be1-9737-32debc301016)

A UI regression was introduced some time ago that caused disabled buttons in the DropDownButton to not be styled differently. This PR fixes that by adding styles for disabled state for a MenuItem.

## Test plan

Manual testing


