### PR TITLE
gitserver: do not hold connection when reading repos for purging

### DIFF
--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -37096,13 +37096,13 @@ type MockGitserverRepoStore struct {
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *GitserverRepoStoreHandleFunc
-	// IteratePurgeableReposFunc is an instance of a mock function object
-	// controlling the behavior of the method IteratePurgeableRepos.
-	IteratePurgeableReposFunc *GitserverRepoStoreIteratePurgeableReposFunc
 	// IterateRepoGitserverStatusFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// IterateRepoGitserverStatus.
 	IterateRepoGitserverStatusFunc *GitserverRepoStoreIterateRepoGitserverStatusFunc
+	// ListPurgeableReposFunc is an instance of a mock function object
+	// controlling the behavior of the method ListPurgeableRepos.
+	ListPurgeableReposFunc *GitserverRepoStoreListPurgeableReposFunc
 	// ListReposWithLastErrorFunc is an instance of a mock function object
 	// controlling the behavior of the method ListReposWithLastError.
 	ListReposWithLastErrorFunc *GitserverRepoStoreListReposWithLastErrorFunc
@@ -37177,13 +37177,13 @@ func NewMockGitserverRepoStore() *MockGitserverRepoStore {
 				return
 			},
 		},
-		IteratePurgeableReposFunc: &GitserverRepoStoreIteratePurgeableReposFunc{
-			defaultHook: func(context.Context, database.IteratePurgableReposOptions, func(repo api.RepoName) error) (r0 error) {
+		IterateRepoGitserverStatusFunc: &GitserverRepoStoreIterateRepoGitserverStatusFunc{
+			defaultHook: func(context.Context, database.IterateRepoGitserverStatusOptions) (r0 []types.RepoGitserverStatus, r1 int, r2 error) {
 				return
 			},
 		},
-		IterateRepoGitserverStatusFunc: &GitserverRepoStoreIterateRepoGitserverStatusFunc{
-			defaultHook: func(context.Context, database.IterateRepoGitserverStatusOptions) (r0 []types.RepoGitserverStatus, r1 int, r2 error) {
+		ListPurgeableReposFunc: &GitserverRepoStoreListPurgeableReposFunc{
+			defaultHook: func(context.Context, database.ListPurgableReposOptions) (r0 []api.RepoName, r1 error) {
 				return
 			},
 		},
@@ -37285,14 +37285,14 @@ func NewStrictMockGitserverRepoStore() *MockGitserverRepoStore {
 				panic("unexpected invocation of MockGitserverRepoStore.Handle")
 			},
 		},
-		IteratePurgeableReposFunc: &GitserverRepoStoreIteratePurgeableReposFunc{
-			defaultHook: func(context.Context, database.IteratePurgableReposOptions, func(repo api.RepoName) error) error {
-				panic("unexpected invocation of MockGitserverRepoStore.IteratePurgeableRepos")
-			},
-		},
 		IterateRepoGitserverStatusFunc: &GitserverRepoStoreIterateRepoGitserverStatusFunc{
 			defaultHook: func(context.Context, database.IterateRepoGitserverStatusOptions) ([]types.RepoGitserverStatus, int, error) {
 				panic("unexpected invocation of MockGitserverRepoStore.IterateRepoGitserverStatus")
+			},
+		},
+		ListPurgeableReposFunc: &GitserverRepoStoreListPurgeableReposFunc{
+			defaultHook: func(context.Context, database.ListPurgableReposOptions) ([]api.RepoName, error) {
+				panic("unexpected invocation of MockGitserverRepoStore.ListPurgeableRepos")
 			},
 		},
 		ListReposWithLastErrorFunc: &GitserverRepoStoreListReposWithLastErrorFunc{
@@ -37381,11 +37381,11 @@ func NewMockGitserverRepoStoreFrom(i database.GitserverRepoStore) *MockGitserver
 		HandleFunc: &GitserverRepoStoreHandleFunc{
 			defaultHook: i.Handle,
 		},
-		IteratePurgeableReposFunc: &GitserverRepoStoreIteratePurgeableReposFunc{
-			defaultHook: i.IteratePurgeableRepos,
-		},
 		IterateRepoGitserverStatusFunc: &GitserverRepoStoreIterateRepoGitserverStatusFunc{
 			defaultHook: i.IterateRepoGitserverStatus,
+		},
+		ListPurgeableReposFunc: &GitserverRepoStoreListPurgeableReposFunc{
+			defaultHook: i.ListPurgeableRepos,
 		},
 		ListReposWithLastErrorFunc: &GitserverRepoStoreListReposWithLastErrorFunc{
 			defaultHook: i.ListReposWithLastError,
@@ -38080,118 +38080,6 @@ func (c GitserverRepoStoreHandleFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// GitserverRepoStoreIteratePurgeableReposFunc describes the behavior when
-// the IteratePurgeableRepos method of the parent MockGitserverRepoStore
-// instance is invoked.
-type GitserverRepoStoreIteratePurgeableReposFunc struct {
-	defaultHook func(context.Context, database.IteratePurgableReposOptions, func(repo api.RepoName) error) error
-	hooks       []func(context.Context, database.IteratePurgableReposOptions, func(repo api.RepoName) error) error
-	history     []GitserverRepoStoreIteratePurgeableReposFuncCall
-	mutex       sync.Mutex
-}
-
-// IteratePurgeableRepos delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockGitserverRepoStore) IteratePurgeableRepos(v0 context.Context, v1 database.IteratePurgableReposOptions, v2 func(repo api.RepoName) error) error {
-	r0 := m.IteratePurgeableReposFunc.nextHook()(v0, v1, v2)
-	m.IteratePurgeableReposFunc.appendCall(GitserverRepoStoreIteratePurgeableReposFuncCall{v0, v1, v2, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the
-// IteratePurgeableRepos method of the parent MockGitserverRepoStore
-// instance is invoked and the hook queue is empty.
-func (f *GitserverRepoStoreIteratePurgeableReposFunc) SetDefaultHook(hook func(context.Context, database.IteratePurgableReposOptions, func(repo api.RepoName) error) error) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// IteratePurgeableRepos method of the parent MockGitserverRepoStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *GitserverRepoStoreIteratePurgeableReposFunc) PushHook(hook func(context.Context, database.IteratePurgableReposOptions, func(repo api.RepoName) error) error) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *GitserverRepoStoreIteratePurgeableReposFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, database.IteratePurgableReposOptions, func(repo api.RepoName) error) error {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverRepoStoreIteratePurgeableReposFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, database.IteratePurgableReposOptions, func(repo api.RepoName) error) error {
-		return r0
-	})
-}
-
-func (f *GitserverRepoStoreIteratePurgeableReposFunc) nextHook() func(context.Context, database.IteratePurgableReposOptions, func(repo api.RepoName) error) error {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *GitserverRepoStoreIteratePurgeableReposFunc) appendCall(r0 GitserverRepoStoreIteratePurgeableReposFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// GitserverRepoStoreIteratePurgeableReposFuncCall objects describing the
-// invocations of this function.
-func (f *GitserverRepoStoreIteratePurgeableReposFunc) History() []GitserverRepoStoreIteratePurgeableReposFuncCall {
-	f.mutex.Lock()
-	history := make([]GitserverRepoStoreIteratePurgeableReposFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// GitserverRepoStoreIteratePurgeableReposFuncCall is an object that
-// describes an invocation of method IteratePurgeableRepos on an instance of
-// MockGitserverRepoStore.
-type GitserverRepoStoreIteratePurgeableReposFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 database.IteratePurgableReposOptions
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 func(repo api.RepoName) error
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c GitserverRepoStoreIteratePurgeableReposFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c GitserverRepoStoreIteratePurgeableReposFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
-}
-
 // GitserverRepoStoreIterateRepoGitserverStatusFunc describes the behavior
 // when the IterateRepoGitserverStatus method of the parent
 // MockGitserverRepoStore instance is invoked.
@@ -38305,6 +38193,118 @@ func (c GitserverRepoStoreIterateRepoGitserverStatusFuncCall) Args() []interface
 // invocation.
 func (c GitserverRepoStoreIterateRepoGitserverStatusFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// GitserverRepoStoreListPurgeableReposFunc describes the behavior when the
+// ListPurgeableRepos method of the parent MockGitserverRepoStore instance
+// is invoked.
+type GitserverRepoStoreListPurgeableReposFunc struct {
+	defaultHook func(context.Context, database.ListPurgableReposOptions) ([]api.RepoName, error)
+	hooks       []func(context.Context, database.ListPurgableReposOptions) ([]api.RepoName, error)
+	history     []GitserverRepoStoreListPurgeableReposFuncCall
+	mutex       sync.Mutex
+}
+
+// ListPurgeableRepos delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockGitserverRepoStore) ListPurgeableRepos(v0 context.Context, v1 database.ListPurgableReposOptions) ([]api.RepoName, error) {
+	r0, r1 := m.ListPurgeableReposFunc.nextHook()(v0, v1)
+	m.ListPurgeableReposFunc.appendCall(GitserverRepoStoreListPurgeableReposFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the ListPurgeableRepos
+// method of the parent MockGitserverRepoStore instance is invoked and the
+// hook queue is empty.
+func (f *GitserverRepoStoreListPurgeableReposFunc) SetDefaultHook(hook func(context.Context, database.ListPurgableReposOptions) ([]api.RepoName, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// ListPurgeableRepos method of the parent MockGitserverRepoStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *GitserverRepoStoreListPurgeableReposFunc) PushHook(hook func(context.Context, database.ListPurgableReposOptions) ([]api.RepoName, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *GitserverRepoStoreListPurgeableReposFunc) SetDefaultReturn(r0 []api.RepoName, r1 error) {
+	f.SetDefaultHook(func(context.Context, database.ListPurgableReposOptions) ([]api.RepoName, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *GitserverRepoStoreListPurgeableReposFunc) PushReturn(r0 []api.RepoName, r1 error) {
+	f.PushHook(func(context.Context, database.ListPurgableReposOptions) ([]api.RepoName, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverRepoStoreListPurgeableReposFunc) nextHook() func(context.Context, database.ListPurgableReposOptions) ([]api.RepoName, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverRepoStoreListPurgeableReposFunc) appendCall(r0 GitserverRepoStoreListPurgeableReposFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// GitserverRepoStoreListPurgeableReposFuncCall objects describing the
+// invocations of this function.
+func (f *GitserverRepoStoreListPurgeableReposFunc) History() []GitserverRepoStoreListPurgeableReposFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverRepoStoreListPurgeableReposFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverRepoStoreListPurgeableReposFuncCall is an object that describes
+// an invocation of method ListPurgeableRepos on an instance of
+// MockGitserverRepoStore.
+type GitserverRepoStoreListPurgeableReposFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 database.ListPurgableReposOptions
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []api.RepoName
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverRepoStoreListPurgeableReposFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverRepoStoreListPurgeableReposFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // GitserverRepoStoreListReposWithLastErrorFunc describes the behavior when


### PR DESCRIPTION
We noticed this while investigating DB performance issues on dotcom.

This code would do the following:

1. Send query to database
2. Read first row of response
3. Delete repository on disk
4. Possibly wait for rate limiter
5. If more rows, repeat 2-4

Means the connection was held while the repositories were being deleted. With large repositories this can be a substantial amount of time.

Since we already have a `Limit` option and load & purge repositories in batches of 5000, we can instead load all repo names into memory at once and hand the DB connection back to the pool and _then_ delete them on disk.

A repository name might have 50 bytes, which means we'd load 5000*50 bytes into memory, which is 500kb, which is _fine_, I think, in cases where we have 5000+ repos to delete. It's definitely better than having to hold the connection open.

So what we do now:

1. Send query to database
2. Read all rows into memory (and free up DB connection)
3. Iterate over repo names in memory, for each repo
3. Delete repository on disk
4. Possibly wait for rate limiter



## Test plan

- Changed and ran unit tests
- Added a code host connection to my local instance, changed the code to delete repos after 1min every 1min, changed code host connection to remove some repos, check log output to make sure the repos have been purged.