### PR TITLE
enables tree-sitter based references for Java

### DIFF
--- a/internal/highlight/language.go
+++ b/internal/highlight/language.go
@@ -135,6 +135,7 @@ var baseEngineConfig = syntaxEngineConfig{
 		// Languages enabled for advanced syntax features
 		"perl":   EngineScipSyntax,
 		"matlab": EngineScipSyntax,
+		"java": EngineScipSyntax,
 	},
 }
 

--- a/internal/highlight/language.go
+++ b/internal/highlight/language.go
@@ -135,7 +135,7 @@ var baseEngineConfig = syntaxEngineConfig{
 		// Languages enabled for advanced syntax features
 		"perl":   EngineScipSyntax,
 		"matlab": EngineScipSyntax,
-		"java": EngineScipSyntax,
+		"java":   EngineScipSyntax,
 	},
 }
 


### PR DESCRIPTION
Lets us detect local references using the tree-sitter grammar for Java

## Test plan

Locally tested with the following patch:

```patch
diff --git a/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts b/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
index 7c45907c51..84c9594549 100644
--- a/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
@@ -141,6 +141,7 @@ export async function searchBasedReferences({
                 occurrence.symbol?.startsWith('local ') &&
                 occurrence.range.contains(new ScipPosition(position.line, position.character))
             ) {
+                debugger;
                 return occurrences
                     .filter(reference => reference.symbol === occurrence.symbol)
                     .map(reference => ({
```
Steps:

1. Add `spring-projects/spring-framework` as an indexed repository
2. Open `context:global repo:^github\.com/spring-projects/spring-framework$ file:^spring-core/src/main/java/org/springframework/core/codec/ByteArrayDecoder\.java` in the search 
3. Search for references for the `result` local defined on line 51 
4. a) Before this commit the debugger is not hit
    b) After this commit it is, which means we've succesfully extracted information about locals from the tree-sitter highlighting