### PR TITLE
Update marketing homepage links from PCS

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -428,7 +428,7 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
             )}
             {isSourcegraphDotCom && (
                 <NavItem>
-                    <NavLink variant={navLinkVariant} to="https://about.sourcegraph.com" external={true}>
+                    <NavLink variant={navLinkVariant} to="https://sourcegraph.com" external={true}>
                         About Sourcegraph
                     </NavLink>
                 </NavItem>

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -252,12 +252,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
 
                             {isSourcegraphDotCom && <MenuDivider className={styles.dropdownDivider} />}
                             {isSourcegraphDotCom && (
-                                <MenuLink
-                                    as={AnchorLink}
-                                    to="https://sourcegraph.com"
-                                    target="_blank"
-                                    rel="noopener"
-                                >
+                                <MenuLink as={AnchorLink} to="https://sourcegraph.com" target="_blank" rel="noopener">
                                     About Sourcegraph <Icon aria-hidden={true} svgPath={mdiOpenInNew} />
                                 </MenuLink>
                             )}

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -254,7 +254,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
                             {isSourcegraphDotCom && (
                                 <MenuLink
                                     as={AnchorLink}
-                                    to="https://about.sourcegraph.com"
+                                    to="https://sourcegraph.com"
                                     target="_blank"
                                     rel="noopener"
                                 >

--- a/client/web/src/storm/pages/SearchPage/SearchPageFooter.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageFooter.tsx
@@ -23,7 +23,7 @@ export const SearchPageFooter: FC = () => {
                           name: 'Docs',
                           href: 'https://docs.sourcegraph.com/',
                       },
-                      { name: 'Homepage', href: 'https://sourcegraph.com' },
+                      { name: 'About', href: 'https://sourcegraph.com' },
                       {
                           name: 'Cody',
                           href: 'https://sourcegraph.com/cody',

--- a/client/web/src/storm/pages/SearchPage/SearchPageFooter.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageFooter.tsx
@@ -23,18 +23,18 @@ export const SearchPageFooter: FC = () => {
                           name: 'Docs',
                           href: 'https://docs.sourcegraph.com/',
                       },
-                      { name: 'About', href: 'https://about.sourcegraph.com' },
+                      { name: 'Homepage', href: 'https://sourcegraph.com' },
                       {
                           name: 'Cody',
-                          href: 'https://about.sourcegraph.com/cody',
+                          href: 'https://sourcegraph.com/cody',
                       },
                       {
                           name: 'Enterprise',
-                          href: 'https://about.sourcegraph.com/get-started?t=enterprise',
+                          href: 'https://sourcegraph.com/get-started?t=enterprise',
                       },
                       {
                           name: 'Security',
-                          href: 'https://about.sourcegraph.com/security',
+                          href: 'https://sourcegraph.com/security',
                       },
                       { name: 'Discord', href: 'https://srcgr.ph/discord-server' },
                   ]


### PR DESCRIPTION
Updates the most prominent marketing links (on sourcegraph.com/search) from about.sourcegraph.com to sourcegraph.com.


## Test plan

Link changes only. 