### PR TITLE
gomod: bump Zoekt for index concurrency change

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5979,8 +5979,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:Px4kf1DfoJIlQR1oog0+GJoDEm7lHw9qKDdT90xaaH0=",
-        version = "v0.0.0-20231115091004-137eb8f22610",
+        sum = "h1:Pn9dVnAOZ7z8p+4BH32G1U9XtMCBVATy8vAq0ObHFdo=",
+        version = "v0.0.0-20231121165958-0959170c1623",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -554,7 +554,7 @@ require (
 	github.com/sourcegraph/conc v0.2.0
 	github.com/sourcegraph/mountinfo v0.0.0-20231018142932-e00da332dac5
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20231115091004-137eb8f22610
+	github.com/sourcegraph/zoekt v0.0.0-20231121165958-0959170c1623
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1612,8 +1612,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20231115091004-137eb8f22610 h1:Px4kf1DfoJIlQR1oog0+GJoDEm7lHw9qKDdT90xaaH0=
-github.com/sourcegraph/zoekt v0.0.0-20231115091004-137eb8f22610/go.mod h1:WVDDy51tFgeKy8zXtujTSbqzgyJrqhrLC9sjWiEfAII=
+github.com/sourcegraph/zoekt v0.0.0-20231121165958-0959170c1623 h1:Pn9dVnAOZ7z8p+4BH32G1U9XtMCBVATy8vAq0ObHFdo=
+github.com/sourcegraph/zoekt v0.0.0-20231121165958-0959170c1623/go.mod h1:WVDDy51tFgeKy8zXtujTSbqzgyJrqhrLC9sjWiEfAII=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This bumps the Zoekt version to pull in a fix to limit shard parallelism when
`SRC_INDEX_CONCURRENCY` is set. It's super are to set this environment
variable, so this should only really affect dot com once we roll it out there.

This commit was generated by running `./dev/zoekt/update`. Notable changes:

https://github.com/sourcegraph/zoekt/compare/137eb8f22610...0959170c1623

- https://github.com/sourcegraph/zoekt/commit/c02b6e0f52 matchtree: always use evalMatchTree
- https://github.com/sourcegraph/zoekt/commit/7c14b93bdf ctags: require scip-ctags to be present
- https://github.com/sourcegraph/zoekt/commit/ef907c2371 Indexing: limit shard parallelism when index concurrency is set
- https://github.com/sourcegraph/zoekt/commit/2a4f4a4265 Indexing: improve doc content checks

## Test plan

Zoekt and Sourcegraph CI