### PR TITLE
code-search: update button text for stopping search jobs

### DIFF
--- a/client/web/src/enterprise/search-jobs/SearchJobModal/SearchJobModal.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobModal/SearchJobModal.tsx
@@ -177,8 +177,8 @@ export const CancelSearchJobModal: FC<SearchJobModalProps> = props => {
     })
 
     return (
-        <Modal position="center" aria-label="Delete search job" onDismiss={onDismiss}>
-            <H2>Do you want to cancel this search job?</H2>
+        <Modal position="center" aria-label="Stop search job" onDismiss={onDismiss}>
+            <H2>Do you want to stop this search job?</H2>
 
             <Text className="mt-4">
                 <b>Note:</b> All query runs across all repositories and revisions will be stopped. You can re-run this
@@ -191,7 +191,7 @@ export const CancelSearchJobModal: FC<SearchJobModalProps> = props => {
 
             <footer className={styles.footer}>
                 <Button variant="secondary" outline={true} onClick={onDismiss}>
-                    Cancel
+                    Close
                 </Button>
                 <Button
                     variant="danger"
@@ -201,10 +201,10 @@ export const CancelSearchJobModal: FC<SearchJobModalProps> = props => {
                 >
                     {loading ? (
                         <>
-                            <LoadingSpinner /> Canceling
+                            <LoadingSpinner /> Stopping
                         </>
                     ) : (
-                        <>Cancel</>
+                        <>Yes - stop this search job.</>
                     )}
                 </Button>
             </footer>


### PR DESCRIPTION
[Slack thread](https://sourcegraph.slack.com/archives/C05MHAP318B/p1700598855742019)

| Before  | After  |
|---|---|
| ![CleanShot 2023-11-21 at 22 08 29@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/fd4a513d-6cc4-4fbe-b76d-83eb1942943b) | ![CleanShot 2023-11-21 at 22 07 30@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/032f830b-a0f6-4820-88c2-79a646b2ed98)  |

This PR updates the button text for stopping search jobs.

## Test plan

* Storybook check to ensure there's no regression
