### PR TITLE
gitserver: Add debug endpoint to inspect repository locker

### DIFF
--- a/cmd/gitserver/internal/lock.go
+++ b/cmd/gitserver/internal/lock.go
@@ -35,6 +35,8 @@ type RepositoryLocker interface {
 	// Status returns the status of the locked directory dir. If dir is not
 	// locked, then locked is false.
 	Status(dir common.GitDir) (status string, locked bool)
+	// AllStatuses returns the status of all locked directories.
+	AllStatuses() map[common.GitDir]string
 }
 
 func NewRepositoryLocker() RepositoryLocker {
@@ -86,6 +88,18 @@ func (rl *repositoryLocker) Status(dir common.GitDir) (status string, locked boo
 	defer rl.mu.RUnlock()
 	status, locked = rl.status[dir]
 	return
+}
+
+func (rl *repositoryLocker) AllStatuses() map[common.GitDir]string {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	statuses := make(map[common.GitDir]string, len(rl.status))
+	for dir, status := range rl.status {
+		statuses[dir] = status
+	}
+
+	return statuses
 }
 
 type repositoryLock struct {

--- a/cmd/gitserver/shared/debug.go
+++ b/cmd/gitserver/shared/debug.go
@@ -1,11 +1,23 @@
 package shared
 
 import (
+	"net/http"
+
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 )
 
-// GRPCWebUIDebugEndpoint returns a debug endpoint that serves the GRPCWebUI that targets
-// this gitserver instance.
-func GRPCWebUIDebugEndpoint(addr string) debugserver.Endpoint {
-	return debugserver.NewGRPCWebUIEndpoint("gitserver", addr)
+func createDebugServerEndpoints(ready chan struct{}, addr string, debugserverEndpoints *LazyDebugserverEndpoint) []debugserver.Endpoint {
+	return []debugserver.Endpoint{
+		debugserver.NewGRPCWebUIEndpoint("gitserver", addr),
+		{
+			Name: "Repository Locker State",
+			Path: "/repository-locker-state",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// wait until we're healthy to respond
+				<-ready
+				// lockerStatusEndpoint is guaranteed to be assigned now
+				debugserverEndpoints.lockerStatusEndpoint(w, r)
+			}),
+		},
+	}
 }

--- a/cmd/gitserver/shared/service.go
+++ b/cmd/gitserver/shared/service.go
@@ -9,21 +9,31 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/service"
 )
 
-type svc struct{}
+type svc struct {
+	ready                chan struct{}
+	debugServerEndpoints LazyDebugserverEndpoint
+}
 
 func (svc) Name() string { return "gitserver" }
 
-func (svc) Configure() (env.Config, []debugserver.Endpoint) {
+func (s *svc) Configure() (env.Config, []debugserver.Endpoint) {
+	s.ready = make(chan struct{})
+
 	c := LoadConfig()
-	endpoints := []debugserver.Endpoint{
-		GRPCWebUIDebugEndpoint(c.ListenAddress),
-	}
 
-	return c, endpoints
+	return c, createDebugServerEndpoints(s.ready, c.ListenAddress, &s.debugServerEndpoints)
 }
 
-func (svc) Start(ctx context.Context, observationCtx *observation.Context, ready service.ReadyFunc, config env.Config) error {
-	return Main(ctx, observationCtx, ready, config.(*Config))
+func (s *svc) Start(ctx context.Context, observationCtx *observation.Context, signalReadyToParent service.ReadyFunc, config env.Config) error {
+	// This service's debugserver endpoints should start responding when this service is ready (and
+	// not ewait for *all* services to be ready). Therefore, we need to track whether we are ready
+	// separately.
+	ready := service.ReadyFunc(func() {
+		close(s.ready)
+		signalReadyToParent()
+	})
+
+	return Main(ctx, observationCtx, ready, &s.debugServerEndpoints, config.(*Config))
 }
 
-var Service service.Service = svc{}
+var Service service.Service = &svc{}


### PR DESCRIPTION
There's little insight into what's currently being done by the syncer, so adding this endpoint as a stopgap until we have a DB backed queue and more insight for free through that.

## Test plan

Tested manually locally. 
