### PR TITLE
docs: Fix wrong example in site config

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -986,8 +986,8 @@
             },
             "patterns": [
               {
-                "match": "^package main$",
-                "language": "go"
+                "match": "cobol_.*\\.txt",
+                "language": "cobol"
               }
             ]
           }


### PR DESCRIPTION
Not sure why this was documented like this in https://github.com/sourcegraph/sourcegraph/pull/51919

If you look at the [relevant code](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@dd29aab51d64de31fa265ac04c0536af47f4451c/-/blob/internal/highlight/language.go?L228-241), it has:

```
	for _, pattern := range config.Patterns {
		if pattern.pattern != nil && pattern.pattern.MatchString(path) {
			return pattern.language, true
		}
	}
```

So it's matching the file path, not the file contents.

## Test plan

n/a