### PR TITLE
cody web: evaluate the mock feature flag

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -39,6 +39,7 @@ import {
 import { MarketingBlock } from '../../components/MarketingBlock'
 import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
+import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import type { SourcegraphContext } from '../../jscontext'
 import { EventName } from '../../util/constants'
 import { ChatUI } from '../components/ChatUI'
@@ -97,6 +98,9 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
 }) => {
     const { pathname } = useLocation()
     const navigate = useNavigate()
+
+    // Evaluate a mock feature flag for the purpose of an A/A test. No functionality is affected by this flag.
+    const [_codyChatMockTestValue] = useFeatureFlag('cody-chat-mock-test')
 
     const codyChatStore = useCodyChat({
         userID: authenticatedUser?.id,

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -32,6 +32,7 @@ export const FEATURE_FLAGS = [
     'search-content-based-lang-detection',
     'search-new-keyword',
     'search-debug',
+    'cody-chat-mock-test',
 ] as const
 
 export type FeatureFlagName = typeof FEATURE_FLAGS[number]


### PR DESCRIPTION
Adds and evaluates a mock feature flag for the Cody chat A/A test. This will help us construct metrics to evaluate chat performance and verify that results are consistent between both groups.

## Test plan

<!-- Required. See https://docs.sourcegraph.com/dev/background-information/testing_principles. -->
- Logged the feature flag with different users to verify it evaluated to different values (for a 50/50 rollout feature flag)