### PR TITLE
update: set default chat model to claude-2.0

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -592,7 +592,7 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 	if completionsConfig == nil {
 		completionsConfig = &schema.Completions{
 			Provider:        string(conftypes.CompletionsProviderNameSourcegraph),
-			ChatModel:       "anthropic/claude-2",
+			ChatModel:       "anthropic/claude-2.0",
 			FastChatModel:   "anthropic/claude-instant-1",
 			CompletionModel: "anthropic/claude-instant-1",
 		}
@@ -632,7 +632,7 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 
 		// Set a default chat model.
 		if completionsConfig.ChatModel == "" {
-			completionsConfig.ChatModel = "anthropic/claude-2"
+			completionsConfig.ChatModel = "anthropic/claude-2.0"
 		}
 
 		// Set a default fast chat model.
@@ -682,7 +682,7 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 
 		// Set a default chat model.
 		if completionsConfig.ChatModel == "" {
-			completionsConfig.ChatModel = "claude-2"
+			completionsConfig.ChatModel = "claude-2.0"
 		}
 
 		// Set a default fast chat model.
@@ -1119,10 +1119,13 @@ func anthropicDefaultMaxPromptTokens(model string) int {
 		return 100_000
 
 	}
-	if model == "claude-2" || model == "claude-v2" {
+	if model == "claude-2" || model == "claude-2.0" || model == "claude-v2" {
 		// TODO: Technically, v2 also uses a 100k window, but we should validate
 		// that returning 100k here is the right thing to do.
 		return 12_000
+	}
+	if model == "claude-2.1" {
+		return 200_000
 	}
 	// For now, all other claude models have a 9k token window.
 	return 9_000


### PR DESCRIPTION
FOLLOW UP FROM https://github.com/sourcegraph/sourcegraph/pull/58451#discussion_r1401349931

This PR updates to set default chat model from claude 2 (unpinned version) to claude 2.0 (pinned).

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


Check existing tests