### PR TITLE
Support Claude 2.1 for flagging purposes

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/grafana/regexp"
 
@@ -37,7 +38,7 @@ const (
 func isFlaggedAnthropicRequest(tk *tokenizer.Tokenizer, ar anthropicRequest, promptRegexps []*regexp.Regexp) (*flaggingResult, error) {
 	// Only usage of chat models us currently flagged, so if the request
 	// is using another model, we skip other checks.
-	if ar.Model != "claude-2" && ar.Model != "claude-v1" {
+	if !strings.HasPrefix(ar.Model, "claude-2") && ar.Model != "claude-v1" {
 		return nil, nil
 	}
 	reasons := []string{}

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
@@ -30,8 +30,15 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 		require.Contains(t, result.reasons, "unknown_prompt")
 	})
 
-	t.Run("preamble not configured ", func(t *testing.T) {
+	t.Run("preamble not configured", func(t *testing.T) {
 		ar := anthropicRequest{Model: "claude-2", Prompt: "some prompt without known preamble"}
+		result, err := isFlaggedAnthropicRequest(tk, ar, []*regexp.Regexp{})
+		require.NoError(t, err)
+		require.False(t, result.IsFlagged())
+	})
+
+	t.Run("preamble not configured for claude-2.1", func(t *testing.T) {
+		ar := anthropicRequest{Model: "claude-2.1", Prompt: "some prompt without known preamble"}
 		result, err := isFlaggedAnthropicRequest(tk, ar, []*regexp.Regexp{})
 		require.NoError(t, err)
 		require.False(t, result.IsFlagged())


### PR DESCRIPTION
Support Claude 2.0 and Claude 2.1 for request flagging purposes.

## Test plan

- unit tests
