### PR TITLE
feat: add mistral-7b-instruct-4k chat model

### DIFF
--- a/internal/completions/httpapi/chat.go
+++ b/internal/completions/httpapi/chat.go
@@ -50,6 +50,7 @@ func isAllowedCustomChatModel(model string) bool {
 		"anthropic/claude-2.0",
 		"anthropic/claude-2.1",
 		"anthropic/claude-instant-1.2-cyan",
+		"accounts/fireworks/models/mistral-7b-instruct-4k",
 		"openai/gpt-3.5-turbo",
 		"openai/gpt-4-1106-preview":
 		return true


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1700598853078489?thread_ts=1700598772.652229&cid=C05AGQYD528

This adds the "accounts/fireworks/models/mistral-7b-instruct-4k" chat model to the allowed list of custom chat models.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

Add support for the mistral-7b-instruct-4k chat model to the allowed list for chat.

The same model is already allowed for completions. 