### PR TITLE
code-search: remove redundant useState

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useApolloClient, gql as apolloGql } from '@apollo/client'
 import {
@@ -122,12 +122,15 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
 
     const navigate = useNavigate()
 
-    const [defaultVariables] = useState({
-        repoName: props.repoName,
-        revision: props.revision,
-        commitID: props.commitID,
-        first: MAX_TREE_ENTRIES,
-    })
+    const defaultVariables = useMemo(
+        () => ({
+            repoName: props.repoName,
+            revision: props.revision,
+            commitID: props.commitID,
+            first: MAX_TREE_ENTRIES,
+        }),
+        [props.repoName, props.revision, props.commitID]
+    )
 
     const { data, error, loading } = useQuery<FileTreeEntriesResult, FileTreeEntriesVariables>(QUERY, {
         variables: {


### PR DESCRIPTION
We currently save the initial values for fetching the tree at a revision in state, however this seems redundant as we can memoize so that the state isn't recreated on every render.

## Test plan

Manual testing to ensure this doesn't introduce a regression.
