### PR TITLE
msp: add artificial operators team to generated workspaces

### DIFF
--- a/dev/managedservicesplatform/terraformcloud/terraformcloud.go
+++ b/dev/managedservicesplatform/terraformcloud/terraformcloud.go
@@ -159,7 +159,7 @@ func (c *Client) SyncWorkspaces(ctx context.Context, svc spec.ServiceSpec, env s
 	if projects, err := c.client.Projects.List(ctx, c.org, &tfe.ProjectListOptions{
 		Name: tfcProjectName,
 	}); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Projects.List")
 	} else {
 		for _, p := range projects.Items {
 			if p.Name == tfcProjectName {
@@ -174,39 +174,29 @@ func (c *Client) SyncWorkspaces(ctx context.Context, svc spec.ServiceSpec, env s
 			Name: tfcProjectName,
 		})
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "Projects.Create")
 		}
 	}
 
-	// Assign access to project
-	wantTeam := "team-gGtVVgtNRaCnkhKp" // TODO: Currently Core Services, parameterize later
-	var existingAccessID string
+	// Grant access to project for Core Services
 	if resp, err := c.client.TeamProjectAccess.List(ctx, tfe.TeamProjectAccessListOptions{
 		ProjectID: tfcProject.ID,
 	}); err != nil {
-		return nil, errors.Wrap(err, "TeamAccess.List")
+		return nil, errors.Wrap(err, "TeamProjectAccess.List")
 	} else {
-		for _, a := range resp.Items {
-			if a.Team.ID == wantTeam {
-				existingAccessID = a.ID
+		for _, team := range []struct {
+			name                 string // only for reference
+			terraformCloudTeamID string
+		}{
+			{name: "Core Services", terraformCloudTeamID: "team-gGtVVgtNRaCnkhKp"},
+			// Operators should use Entitle to request access to this team to
+			// get access to workspaces, if they aren't in Core Services
+			{name: "Managed Services Platform Operators", terraformCloudTeamID: "team-Wdejc42bWrRonQEY"},
+		} {
+			if err := c.ensureAccessForTeam(ctx, tfcProject, resp, team.terraformCloudTeamID); err != nil {
+				return nil, errors.Wrapf(err, "ensure access for %q Terraform Cloud team %q",
+					team.name, team.terraformCloudTeamID)
 			}
-		}
-	}
-	if existingAccessID != "" {
-		_, err := c.client.TeamProjectAccess.Update(ctx, existingAccessID, tfe.TeamProjectAccessUpdateOptions{
-			Access: pointers.Ptr(tfe.TeamProjectAccessWrite),
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "TeamAccess.Update")
-		}
-	} else {
-		_, err := c.client.TeamProjectAccess.Add(ctx, tfe.TeamProjectAccessAddOptions{
-			Project: &tfe.Project{ID: tfcProject.ID},
-			Team:    &tfe.Team{ID: wantTeam},
-			Access:  tfe.TeamProjectAccessWrite,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "TeamAccess.Add")
 		}
 	}
 
@@ -336,4 +326,32 @@ func (c *Client) DeleteWorkspaces(ctx context.Context, svc spec.ServiceSpec, env
 	}
 
 	return errs
+}
+
+func (c *Client) ensureAccessForTeam(ctx context.Context, project *tfe.Project, currentTeams *tfe.TeamProjectAccessList, teamID string) error {
+	var existingAccessID string
+	for _, a := range currentTeams.Items {
+		if a.Team.ID == teamID {
+			existingAccessID = a.ID
+		}
+	}
+	if existingAccessID != "" {
+		_, err := c.client.TeamProjectAccess.Update(ctx, existingAccessID, tfe.TeamProjectAccessUpdateOptions{
+			Access: pointers.Ptr(tfe.TeamProjectAccessWrite),
+		})
+		if err != nil {
+			return errors.Wrap(err, "TeamAccess.Update")
+		}
+	} else {
+		_, err := c.client.TeamProjectAccess.Add(ctx, tfe.TeamProjectAccessAddOptions{
+			Project: &tfe.Project{ID: project.ID},
+			Team:    &tfe.Team{ID: teamID},
+			Access:  tfe.TeamProjectAccessWrite,
+		})
+		if err != nil {
+			return errors.Wrap(err, "TeamAccess.Add")
+		}
+	}
+
+	return nil
 }

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -273,6 +273,11 @@ sg msp generate -all <service>
 					Usage:       "Optionally provide an environment ID as well to only sync that environment.",
 					ArgsUsage:   "<service ID> [environment ID]",
 					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:  "all",
+							Usage: "Generate Terraform Cloud workspaces for all environments",
+							Value: false,
+						},
 						&cli.StringFlag{
 							Name:  "workspace-run-mode",
 							Usage: "One of 'vcs', 'cli'",
@@ -337,6 +342,9 @@ sg msp generate -all <service>
 								return errors.Wrapf(err, "sync env %q", env.ID)
 							}
 						} else {
+							if targetEnv == "" && !c.Bool("all") {
+								return errors.New("second argument environment ID is required without the '-all' flag")
+							}
 							for _, env := range service.Environments {
 								if err := syncEnvironmentWorkspaces(c, tfcClient, service.Service, service.Build, env); err != nil {
 									return errors.Wrapf(err, "sync env %q", env.ID)


### PR DESCRIPTION
Provisioned by https://github.com/sourcegraph/infrastructure/pull/5631

The idea is to have operators request membership to the new team via Entitle to get access to MSP workspaces. Will document in a follow-up.

This change also adds a `-all` guard for syncing all environment TFC workspaces, similar to the one for `sg msp generate`.

## Test plan

n/a