### PR TITLE
[Backport 5.2] requestclient: add country-level geolocation data (#58386)

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -2828,8 +2828,8 @@ def go_dependencies():
         name = "com_github_goccy_go_json",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/goccy/go-json",
-        sum = "h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=",
-        version = "v0.9.11",
+        sum = "h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=",
+        version = "v0.10.2",
     )
     go_repository(
         name = "com_github_godbus_dbus",
@@ -3560,8 +3560,8 @@ def go_dependencies():
         name = "com_github_hashicorp_go_hclog",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/hashicorp/go-hclog",
-        sum = "h1:K4ev2ib4LdQETX5cSZBG0DVLk1jwGqSPXBjdah3veNs=",
-        version = "v0.16.2",
+        sum = "h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=",
+        version = "v1.2.0",
     )
     go_repository(
         name = "com_github_hashicorp_go_immutable_radix",
@@ -5454,6 +5454,13 @@ def go_dependencies():
         sum = "h1:nV98dkBpqaYbDnhefmOQ+Rn4hE+jD6AtjYHXaU5WyJI=",
         version = "v1.2.13",
     )
+    go_repository(
+        name = "com_github_oschwald_maxminddb_golang",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/oschwald/maxminddb-golang",
+        sum = "h1:9FnTOD0YOhP7DGxGsq4glzpGy5+w7pq50AS6wALUMYs=",
+        version = "v1.12.0",
+    )
 
     go_repository(
         name = "com_github_ovh_go_ovh",
@@ -6043,8 +6050,8 @@ def go_dependencies():
         name = "com_github_schollz_progressbar_v3",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/schollz/progressbar/v3",
-        sum = "h1:VcmmNRO+eFN3B0m5dta6FXYXY+MEJmXdWoIS+jjssQM=",
-        version = "v3.8.5",
+        sum = "h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iHD6PEFUiE=",
+        version = "v3.13.1",
     )
     go_repository(
         name = "com_github_scim2_filter_parser_v2",
@@ -6223,8 +6230,8 @@ def go_dependencies():
         name = "com_github_sirupsen_logrus",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sirupsen/logrus",
-        sum = "h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=",
-        version = "v1.9.0",
+        sum = "h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=",
+        version = "v1.9.3",
     )
     go_repository(
         name = "com_github_skeema_knownhosts",

--- a/go.mod
+++ b/go.mod
@@ -172,7 +172,7 @@ require (
 	github.com/rjeczalik/notify v0.9.3
 	github.com/russellhaering/gosaml2 v0.9.1
 	github.com/russellhaering/goxmldsig v1.3.0
-	github.com/schollz/progressbar/v3 v3.8.5
+	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/segmentio/fasthash v1.0.3
 	github.com/segmentio/ksuid v1.0.4
 	github.com/sergi/go-diff v1.3.1
@@ -272,6 +272,7 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mroth/weightedrand/v2 v2.0.1
+	github.com/oschwald/maxminddb-golang v1.12.0
 	github.com/pkoukk/tiktoken-go v0.1.5
 	github.com/prometheus/statsd_exporter v0.22.7
 	github.com/qdrant/go-client v1.4.1
@@ -312,7 +313,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/fullstorydev/grpcurl v1.8.6 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
-	github.com/goccy/go-json v0.9.11 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/flatbuffers v2.0.8+incompatible // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
@@ -322,6 +323,7 @@ require (
 	github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-slug v0.12.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
@@ -344,7 +346,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
 	github.com/prometheus/prometheus v0.40.5 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.5 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.1.1 // indirect
 	github.com/smartystreets/assertions v1.13.0 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -999,8 +999,8 @@ github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.1.0-rc.5/go.mod h1:nzvNcVha5eUziGrbxFCo6qFIojQHjJV5cLYIbezhfL0=
 github.com/gobwas/ws v1.1.0 h1:7RFti/xnNkMJnrK7D1yQ/iCIB5OrrY/54/H930kIbHA=
-github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
-github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
@@ -1260,7 +1260,8 @@ github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9
 github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v0.16.2 h1:K4ev2ib4LdQETX5cSZBG0DVLk1jwGqSPXBjdah3veNs=
+github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
+github.com/hashicorp/go-hclog v1.2.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
@@ -1583,6 +1584,7 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -1798,6 +1800,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.13 h1:nV98dkBpqaYbDnhefmOQ+Rn4hE+jD6AtjYHXaU5WyJI=
 github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.13/go.mod h1:4OjcxgwdXzezqytxN534MooNmrxRD50geWZxTD7845s=
+github.com/oschwald/maxminddb-golang v1.12.0 h1:9FnTOD0YOhP7DGxGsq4glzpGy5+w7pq50AS6wALUMYs=
+github.com/oschwald/maxminddb-golang v1.12.0/go.mod h1:q0Nob5lTCqyQ8WT6FYgS1L7PXKVVbgiymefNwIjPzgY=
 github.com/pandatix/go-cvss v0.5.2 h1:9441i+Sn/P/TP9kNBl3kI7mwYtNYFr1eN8JdsiybiMM=
 github.com/pandatix/go-cvss v0.5.2/go.mod h1:u4HcNBqA9IY6PZHuH8Pac4VaGv5iAMyiXMex/FIfxcg=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1952,8 +1956,8 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+e
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/schollz/progressbar/v3 v3.8.5 h1:VcmmNRO+eFN3B0m5dta6FXYXY+MEJmXdWoIS+jjssQM=
-github.com/schollz/progressbar/v3 v3.8.5/go.mod h1:ewO25kD7ZlaJFTvMeOItkOZa8kXu1UvFs379htE8HMQ=
+github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iHD6PEFUiE=
+github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+jdL7HAgq2RFnO6fQ=
 github.com/scim2/filter-parser/v2 v2.2.0 h1:QGadEcsmypxg8gYChRSM2j1edLyE/2j72j+hdmI4BJM=
 github.com/scim2/filter-parser/v2 v2.2.0/go.mod h1:jWnkDToqX/Y0ugz0P5VvpVEUKcWcyHHj+X+je9ce5JA=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
@@ -1990,8 +1994,9 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.1.1 h1:MTk78x9FPgDFVFkDLTrsnnfCJl7g1C/nnKvePgrIngE=
 github.com/skeema/knownhosts v1.1.1/go.mod h1:g4fPeYpque7P0xefxtGzV81ihjC8sX2IqpAoNkjxbMo=
 github.com/slack-go/slack v0.10.1 h1:BGbxa0kMsGEvLOEoZmYs8T1wWfoZXwmQFBb6FgYCXUA=
@@ -2459,7 +2464,6 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220128200615-198e4374d7ed/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/internal/requestclient/BUILD.bazel
+++ b/internal/requestclient/BUILD.bazel
@@ -12,6 +12,8 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/grpc/propagator",
+        "//internal/requestclient/geolocation",
+        "//lib/errors",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//peer",
@@ -20,10 +22,15 @@ go_library(
 
 go_test(
     name = "requestclient_test",
-    srcs = ["grpc_test.go"],
+    srcs = [
+        "client_test.go",
+        "grpc_test.go",
+    ],
     embed = [":requestclient"],
     deps = [
-        "@com_github_google_go_cmp//cmp",
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//peer",
     ],
 )

--- a/internal/requestclient/client.go
+++ b/internal/requestclient/client.go
@@ -2,8 +2,13 @@ package requestclient
 
 import (
 	"context"
+	"strings"
+	"sync"
 
 	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/requestclient/geolocation"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type clientKey struct{}
@@ -12,7 +17,8 @@ type clientKey struct{}
 type Client struct {
 	// IP identifies the IP of the client.
 	IP string
-	// ForwardedFor identifies the originating IP address of a client.
+	// ForwardedFor identifies the originating IP address of a client. It can
+	// be a comma-separated list of IP addresses.
 	//
 	// Note: This header can be spoofed and relies on trusted clients/proxies.
 	// For sourcegraph.com we use cloudflare headers to avoid spoofing.
@@ -20,6 +26,17 @@ type Client struct {
 	// UserAgent is value of the User-Agent header:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
 	UserAgent string
+
+	// wafIPCountryCode is a ISO 3166-1 alpha-2 country code for the
+	// request client as provided by a WAF (typically Cloudlfare) behind which
+	// Sourcegraph is hosted.
+	wafIPCountryCode string
+
+	// countryCode and friends are lazily hydrated once by
+	// (*Client).OriginCountryCode().
+	countryCode      string
+	countryCodeError error
+	countryCodeOnce  sync.Once
 }
 
 // FromContext retrieves the client IP, if available, from context.
@@ -40,9 +57,53 @@ func (c *Client) LogFields() []log.Field {
 	if c == nil {
 		return []log.Field{log.String("requestClient", "<nil>")}
 	}
+
+	var ccField log.Field
+	if cc, err := c.OriginCountryCode(); err != nil {
+		ccField = log.NamedError("requestClient.countryCode.error", err)
+	} else {
+		ccField = log.String("requestClient.countryCode", cc)
+	}
+
 	return []log.Field{
 		log.String("requestClient.ip", c.IP),
 		log.String("requestClient.forwardedFor", c.ForwardedFor),
 		log.String("requestClient.userAgent", c.UserAgent),
+		ccField,
 	}
+}
+
+// OriginCountryCode returns a best-effort inference of the ISO 3166-1 alpha-2
+// country code indicating the geolocation of the request client.
+func (c *Client) OriginCountryCode() (string, error) {
+	c.countryCodeOnce.Do(func() {
+		c.countryCode, c.countryCodeError = inferOriginCountryCode(c)
+	})
+	return c.countryCode, c.countryCodeError
+}
+
+func inferOriginCountryCode(c *Client) (string, error) {
+	// If we have a trusted value already, use that directly.
+	if c.wafIPCountryCode != "" {
+		return c.wafIPCountryCode, nil
+	}
+
+	// If we're able to infer a country code from the forwarded-for header,
+	// use that. We're not too worried about spoofing here because country codes
+	// are purely for reference and analytics.
+	if c.ForwardedFor != "" {
+		// Forwarded-for is a comma-separated list of IP addresses, we only
+		// want the first one.
+		ips := strings.Split(c.ForwardedFor, ",")
+		if cc, err := geolocation.InferCountryCode(ips[0]); err == nil {
+			return cc, nil
+		}
+	}
+
+	// Otherwise, we must infer a country code from the IP address.
+	cc, err := geolocation.InferCountryCode(c.IP)
+	if err != nil {
+		return "", errors.Wrap(err, "geolocation.InferCountryCode")
+	}
+	return cc, nil
 }

--- a/internal/requestclient/client_test.go
+++ b/internal/requestclient/client_test.go
@@ -1,0 +1,62 @@
+package requestclient
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientOriginCountryCode(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		client   *Client
+		wantCode autogold.Value
+	}{
+		{
+			name: "have trusted geolocation",
+			client: &Client{
+				wafIPCountryCode: "CA",
+			},
+			wantCode: autogold.Expect("CA"),
+		},
+		{
+			name: "infer from single ForwardedFor",
+			client: &Client{
+				ForwardedFor: "93.184.216.34", // ping -c1 example.net
+			},
+			wantCode: autogold.Expect("GB"),
+		},
+		{
+			name: "infer from multiple ForwardedFor",
+			client: &Client{
+				ForwardedFor: strings.Join([]string{
+					"61.144.235.160", // example from OSS datasets with country code 'CN'
+					"93.184.216.34",  // ping -c1 example.net
+				}, ","),
+			},
+			wantCode: autogold.Expect("CN"),
+		},
+		{
+			name: "infer from IP address",
+			client: &Client{
+				IP: "93.184.216.34", // ping -c1 example.net
+			},
+			wantCode: autogold.Expect("GB"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := tc.client.OriginCountryCode()
+			assert.NoError(t, err)
+			tc.wantCode.Equal(t, code)
+
+			// Check cached state
+			tc.client.countryCodeOnce.Do(func() {
+				t.Error("countryCodeOnce should have been called already")
+			})
+			assert.Equal(t, code, tc.client.countryCode)
+			assert.NoError(t, tc.client.countryCodeError)
+		})
+	}
+}

--- a/internal/requestclient/geolocation/BUILD.bazel
+++ b/internal/requestclient/geolocation/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "geolocation",
+    srcs = ["geolocation.go"],
+    embedsrcs = ["data/dbip-country-lite-2023-11.mmdb"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/requestclient/geolocation",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/syncx",
+        "//lib/errors",
+        "@com_github_oschwald_maxminddb_golang//:maxminddb-golang",
+    ],
+)
+
+go_test(
+    name = "geolocation_test",
+    srcs = ["geolocation_test.go"],
+    embed = [":geolocation"],
+    deps = [
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/internal/requestclient/geolocation/data/README.md
+++ b/internal/requestclient/geolocation/data/README.md
@@ -1,0 +1,14 @@
+# Geolocation data
+
+This package contains a small geolocation database that gets embedded in the `internal/requestclient/geolocation` package.
+We currently use the [DB-IP.com](https://db-ip.com/)'s ["IP to Country Lite" database](https://db-ip.com/db/download/ip-to-country-lite) in MMDB format, which only includes country-level data.
+
+The free DB-IP Lite database by DB-IP is licensed under a Creative Commons Attribution 4.0 International License.
+
+The full licensing terms are available [here](https://db-ip.com/db/lite.php).
+
+## Updating the database
+
+This database was last updated 11/16/2023. We should aim to update this yearly to stay in sync with any changes.
+
+The database should be downloaded in MMDB format the ["IP to Country Lite" database page](https://db-ip.com/db/download/ip-to-country-lite).

--- a/internal/requestclient/geolocation/geolocation.go
+++ b/internal/requestclient/geolocation/geolocation.go
@@ -1,0 +1,54 @@
+// Package geolocation provides a geolocation database for IP addresses.
+// It currently uses https://db-ip.com/db/download/ip-to-country-lite
+//
+// More details are available in internal/requestclient/geolocation/data/README.md
+package geolocation
+
+import (
+	_ "embed"
+	"net"
+
+	"github.com/oschwald/maxminddb-golang"
+
+	"github.com/sourcegraph/sourcegraph/internal/syncx"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+//go:embed data/dbip-country-lite-2023-11.mmdb
+var mmdbData []byte
+
+// getLocationsDB holds the MMDB-format database embedded at mmdbData.
+// It is only evaluated once - subsequent calls will return the first initialized
+// *maxminddb.Reader instance.
+var getLocationsDB = syncx.OnceValue(func() *maxminddb.Reader {
+	db, err := maxminddb.FromBytes(mmdbData)
+	if err != nil {
+		panic(errors.Wrap(err, "initialize IP database"))
+	}
+	return db
+})
+
+// InferCountryCode returns an ISO 3166-1 alpha-2 country code for the given IP
+// address: https://en.wikipedia.org/wiki/ISO_3166-1#Codes
+func InferCountryCode(ipAddress string) (string, error) {
+	if ipAddress == "" {
+		return "", errors.New("no IP address provided")
+	}
+	ip := net.ParseIP(ipAddress)
+	if ip == nil {
+		return "", errors.Newf("invalid IP address %q provided", ipAddress)
+	}
+
+	var query struct {
+		Country struct {
+			ISOCode string `maxminddb:"iso_code"`
+		} `maxminddb:"country"`
+	}
+	if err := getLocationsDB().Lookup(ip, &query); err != nil {
+		return "", errors.Wrap(err, "lookup failed")
+	}
+	if query.Country.ISOCode == "" {
+		return "", errors.New("no country code found")
+	}
+	return query.Country.ISOCode, nil
+}

--- a/internal/requestclient/geolocation/geolocation_test.go
+++ b/internal/requestclient/geolocation/geolocation_test.go
@@ -1,0 +1,72 @@
+package geolocation
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkInferCountryCode(b *testing.B) {
+	exampleIPs := []string{
+		"61.144.235.160",
+		"93.184.216.34",
+		"2606:2800:220:1:248:1893:25c8:1946",
+	}
+	for n := 0; n < b.N; n++ {
+		_, err := InferCountryCode(exampleIPs[b.N%len(exampleIPs)])
+		if err != nil {
+			b.Log(err.Error())
+			b.FailNow()
+		}
+	}
+}
+
+func TestInferCountryCode(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ipAddress string
+
+		wantError       autogold.Value
+		wantCountryCode autogold.Value
+	}{
+		{
+			name:      "empty input",
+			ipAddress: "",
+			wantError: autogold.Expect("no IP address provided"),
+		},
+		{
+			name:      "not an IP address",
+			ipAddress: "sourcegraph.com",
+			wantError: autogold.Expect(`invalid IP address "sourcegraph.com" provided`),
+		},
+		{
+			name:            "example 1 valid IPv4",
+			ipAddress:       "61.144.235.160", // example from OSS datasets
+			wantCountryCode: autogold.Expect("CN"),
+		},
+		{
+			name:            "example 2 valid IPv4",
+			ipAddress:       "93.184.216.34", // ping -c1 example.net
+			wantCountryCode: autogold.Expect("GB"),
+		},
+		{
+			name:            "example valid IPv6",
+			ipAddress:       "2606:2800:220:1:248:1893:25c8:1946", // ping6 -c1 example.net
+			wantCountryCode: autogold.Expect("US"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, err := InferCountryCode(tc.ipAddress)
+			if tc.wantError != nil {
+				require.Error(t, err)
+				tc.wantError.Equal(t, err.Error())
+			} else {
+				assert.NoError(t, err)
+				tc.wantCountryCode.Equal(t, code)
+			}
+		})
+	}
+
+}

--- a/internal/requestclient/grpc_test.go
+++ b/internal/requestclient/grpc_test.go
@@ -5,7 +5,8 @@ import (
 	"net"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/peer"
 )
 
@@ -109,9 +110,14 @@ func TestPropagator(t *testing.T) {
 			md := propagator.FromContext(requestCtx)
 
 			resultCtx := propagator.InjectContext(requestCtx, md)
-			if diff := cmp.Diff(test.wantClient, FromContext(resultCtx)); diff != "" {
-				t.Errorf("Client mismatch (-want +got):\n%s", diff)
-			}
+
+			// Explicitly compare exported fields because cmp.Diff doesn't work
+			// when there are unexported fields
+			rc := FromContext(resultCtx)
+			require.NotNil(t, rc)
+			assert.Equal(t, test.wantClient.IP, rc.IP)
+			assert.Equal(t, test.wantClient.ForwardedFor, rc.ForwardedFor)
+			assert.Equal(t, test.wantClient.UserAgent, rc.UserAgent)
 		})
 	}
 }


### PR DESCRIPTION
This change adds country-level geolocation data to `requestclient` as discussed [here](https://sourcegraph.slack.com/archives/C01PQEVJ5A9/p1700078374822459?thread_ts=1694717740.084639&cid=C01PQEVJ5A9), provided as a 2- or 3-character ISO 3166-1 country code that seems pretty widely used. The inference strategy goes:

1. If we are behind Cloudflare, we trust [Cloudflare's originating country data](https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-ipcountry) and use it as-is
2. If a `Forwarded-For` exists, we look up the first `(*requestclient.Client).Forwarded-For` address in the embedded IP geolocation database
3. Otherwise, we look up `(*requestclient.Client).IP` in the embedded IP geolocation database

WE use [DB-IP.com](https://db-ip.com/)'s ["IP to Country Lite" database](https://db-ip.com/db/download/ip-to-country-lite) which includes only country-level data, is free, and allows redistribution with attribution (see docs included in PR). It clocks in at ~8MB, which seems manageable for embedding. Lookup performance looks okay with a trivial benchmark, and we cache the inferred country code in `*requestclient.Client` so that it only gets evaluated once:

```
goos: darwin
goarch: arm64
pkg: github.com/sourcegraph/sourcegraph/internal/requestclient/geolocation
BenchmarkInferCountryCode-10    	 2359490	       906.9 ns/op	      34 B/op	       3 allocs/op
```

This change also adds this new data to request client `LogFields`. https://github.com/sourcegraph/sourcegraph/pull/58388 adds this to telemetry events as well.

## Test plan

Unit tests

(cherry picked from commit c820b239f0df601497e08f31d6e41537943fc3ef)

