### PR TITLE
eslint: ignore client/web/dev and friends

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ const config = {
     '**/*.d.ts',
     'eslint-relative-formatter.js',
     'typedoc.js',
-    '**/dev/esbuild/*',
+    'client/web/dev/**/*',
     'graphql-schema-linter.config.js',
   ],
   extends: ['@sourcegraph/eslint-config', 'plugin:storybook/recommended'],


### PR DESCRIPTION
Spotted another file section of client code that should be ignored by eslint
## Test plan
CI and should not see `Eslint Oops` message

