### PR TITLE
ci: add @percy/puppeteer explicity to `run_percy_with_mocha` target

### DIFF
--- a/client/shared/dev/BUILD.bazel
+++ b/client/shared/dev/BUILD.bazel
@@ -57,6 +57,7 @@ js_binary(
     name = "run_mocha_tests_with_percy",
     data = [
         "//:node_modules/@percy/cli",
+        "//:node_modules/@percy/puppeteer",
         "//:node_modules/mocha",
         "//:node_modules/puppeteer",
         "//:node_modules/resolve-bin",

--- a/client/web/src/integration/BUILD.bazel
+++ b/client/web/src/integration/BUILD.bazel
@@ -124,6 +124,5 @@ mocha_test(
     tests = [test.replace(".ts", ".js") for test in glob(["**/*.test.ts"])],
     deps = [
         ":integration_tests",
-        "//:node_modules/@percy/puppeteer",
     ],
 )

--- a/client/web/src/integration/BUILD.bazel
+++ b/client/web/src/integration/BUILD.bazel
@@ -122,5 +122,8 @@ mocha_test(
         "requires-network",
     ],
     tests = [test.replace(".ts", ".js") for test in glob(["**/*.test.ts"])],
-    deps = [":integration_tests"],
+    deps = [
+        ":integration_tests",
+        "//:node_modules/@percy/puppeteer",
+    ],
 )


### PR DESCRIPTION
Causes failure as this build https://buildkite.com/sourcegraph/sourcegraph/builds/252077. More context [here](https://sourcegraph.slack.com/archives/C05EVRLQEUR/p1700737212337599) 
## Test plan
[main-dry-run](https://buildkite.com/sourcegraph/sourcegraph/builds/252089#_) and ci
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
