### PR TITLE
search: add new pattern type to settings schema

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -11,5 +11,8 @@
   },
   "search.repositoryGroups": {
     "test": ["github.com/gorilla/mux", "github.com/gorilla/pat"]
-  }
+  },
+  // team search platform: This enables the experimental "precise (NEW)" search mode by default
+  "search.defaultMode": "precise",
+  "search.defaultPatternType": "newStandardRC1"
 }

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -390,7 +390,7 @@
     "search.defaultPatternType": {
       "description": "The default pattern type that search queries will be intepreted as. `lucky` is an experimental mode that will interpret the query in multiple ways.",
       "type": "string",
-      "pattern": "standard|literal|regexp|lucky"
+      "pattern": "standard|literal|regexp|lucky|newStandardRC1"
     },
     "search.defaultCaseSensitive": {
       "description": "Whether query patterns are treated case sensitively. Patterns are case insensitive by default.",


### PR DESCRIPTION
We add "newStandardRC1" to the list of allowed values for pattern types in the settings schema. At the same time we set the default for the local dev environment.

Once this is merged we can update the global settings for S2 as well.

The new behavior for S2 and local will be like this:
- All searches will be made in the "precise (NEW)" mode
- Users can quickly switch between different modes (smart, precise (legacy), precice (NEW)) by using the smart search toggle
- The choice is only persisted for the current session
- Users can permanently opt out in their user settings

Why?

Currently, "smart search" is hardcoded as default. However it can be overwritten by settings. The idea is to set "precise (NEW)" as new default for Sourcegraph instances (local and s2) in global settings. Users can still overwrite in their user settings.

The following user settings would effectively revert this change.

```
"search.defaultPatternType":"standard",
"search.defaultMode":"smart"
```

Note:
- The feature-flag "search-new-keyword" only determines whether the extended toggle (3 choices) is visible. 


## Test plan
- I verified that the new global settings show up locally
- I verified that the settings can be overwritten in the user settings as described
