### PR TITLE
sec: Show error message to user before creating webhook

### DIFF
--- a/cmd/frontend/graphqlbackend/outbound_webhooks.go
+++ b/cmd/frontend/graphqlbackend/outbound_webhooks.go
@@ -136,6 +136,12 @@ func (r *schemaResolver) CreateOutboundWebhook(ctx context.Context, args CreateO
 		return nil, auth.ErrMustBeSiteAdmin
 	}
 
+	// Validate the URL
+	err = outbound.CheckURL(args.Input.URL)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid webhook address")
+	}
+
 	webhook := &types.OutboundWebhook{
 		CreatedBy:  user.ID,
 		UpdatedBy:  user.ID,


### PR DESCRIPTION
This PR brings back previously removed code from the frontend, to show the user a nice error message. 

## Test plan
Tested locally, no longer creates the webhook.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
