### PR TITLE
generate .css.d.ts for non-SCSS (plain .css) files as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ sourcegraph-webapp-*.tgz
 *.tsbuildinfo
 graphql-operations.ts
 *.module.scss.d.ts
+*.module.css.d.ts
 dll-bundle
 
 # Extensions

--- a/client/shared/dev/generateCssModulesTypes.ts
+++ b/client/shared/dev/generateCssModulesTypes.ts
@@ -2,8 +2,8 @@ import { spawn } from 'child_process'
 import path from 'path'
 
 const REPO_ROOT = path.join(__dirname, '../../..')
-const CSS_MODULES_GLOB = path.resolve(__dirname, '../../*/src/**/*.module.scss')
-const JETBRAINS_CSS_MODULES_GLOB = path.resolve(__dirname, '../../jetbrains/webview/**/*.module.scss')
+const CSS_MODULES_GLOB = path.resolve(__dirname, '../../*/src/**/*.module.{scss,css}')
+const JETBRAINS_CSS_MODULES_GLOB = path.resolve(__dirname, '../../jetbrains/webview/**/*.module.{scss,css}')
 const TSM_COMMAND = `pnpm exec tsm --logLevel error "{${CSS_MODULES_GLOB},${JETBRAINS_CSS_MODULES_GLOB}}" --includePaths node_modules client`
 const [BIN, ...ARGS] = TSM_COMMAND.split(' ')
 


### PR DESCRIPTION
Sometimes you just want to make a `.module.css` file not a `.module.scss` file. Sometimes you just want to style it old-school.


## Test plan

CI