### PR TITLE
SSC: Use the user's access token for Gateway on dotcom

### DIFF
--- a/internal/completions/httpapi/BUILD.bazel
+++ b/internal/completions/httpapi/BUILD.bazel
@@ -13,8 +13,10 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//cmd/frontend/envvar",
+        "//internal/accesstoken",
         "//internal/actor",
         "//internal/auth",
+        "//internal/authz",
         "//internal/cody",
         "//internal/completions/client",
         "//internal/completions/types",

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -77,7 +77,7 @@ func newCompletionsHandler(
 			Build()
 		defer done()
 
-		// Use the user's access token for Cody Gateway on dotcom if PLG is enabled
+		// Use the user's access token for Cody Gateway on dotcom if PLG is enabled.
 		accessToken := completionsConfig.AccessToken
 		if envvar.SourcegraphDotComMode() &&
 			featureflag.FromContext(ctx).GetBoolOr("cody-pro", false) &&

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -79,9 +79,10 @@ func newCompletionsHandler(
 
 		// Use the user's access token for Cody Gateway on dotcom if PLG is enabled.
 		accessToken := completionsConfig.AccessToken
-		if envvar.SourcegraphDotComMode() &&
-			featureflag.FromContext(ctx).GetBoolOr("cody-pro", false) &&
-			completionsConfig.Provider == conftypes.CompletionsProviderNameSourcegraph {
+		isCodyProEnabled := featureflag.FromContext(ctx).GetBoolOr("cody-pro", false)
+		isDotcom := envvar.SourcegraphDotComMode()
+		isProviderCodyGateway := completionsConfig.Provider == conftypes.CompletionsProviderNameSourcegraph
+		if isCodyProEnabled && isDotcom && isProviderCodyGateway {
 			apiToken, _, err := authz.ParseAuthorizationHeader(r.Header.Get("Authorization"))
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusUnauthorized)

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -85,10 +85,12 @@ func newCompletionsHandler(
 			apiToken, _, err := authz.ParseAuthorizationHeader(r.Header.Get("Authorization"))
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
+				return
 			}
 			accessToken, err = accesstoken.GenerateDotcomUserGatewayAccessToken(apiToken)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusUnauthorized)
+				return
 			}
 		}
 

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -85,12 +85,14 @@ func newCompletionsHandler(
 		if isCodyProEnabled && isDotcom && isProviderCodyGateway {
 			apiToken, _, err := authz.ParseAuthorizationHeader(r.Header.Get("Authorization"))
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusUnauthorized)
+				trace.Logger(ctx, logger).Info("Error parsing auth header", log.String("Authorization header", r.Header.Get("Authorization")), log.Error(err))
+				http.Error(w, "Error parsing auth header", http.StatusUnauthorized)
 				return
 			}
 			accessToken, err = accesstoken.GenerateDotcomUserGatewayAccessToken(apiToken)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusUnauthorized)
+				trace.Logger(ctx, logger).Info("Access token generation failed", log.String("API token", apiToken), log.Error(err))
+				http.Error(w, "Access token generation failed", http.StatusUnauthorized)
 				return
 			}
 		}


### PR DESCRIPTION
The logic I introduced is:
- IF the `cody-pro` feature flag is enabled
  - AND we're on dotcom
  - AND the completions provider is Cody Gateway
- THEN pass the user's access token to Gateway instead of the default access token in the site config.
- ELSE just do what we did before this PR

## Test plan

I logged the access token on the Cody Gateway side; it was the correct one with the feature flag on and off, and Gateway gave me correct responses.