### PR TITLE
build: fix CI bazelrc settings for Aspect Workflows warming

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -5,47 +5,47 @@ try-import %workspace%/.aspect/bazelrc/ci.generated.bazelrc
 # Use repo caching for building and testing.
 # Article: https://buildkite.com/blog/how-bazel-built-its-ci-system-on-top-of-buildkite
 # Docs: https://bazel.build/reference/command-line-reference#flag--repository_cache
-build --repository_cache=/home/buildkite/repocache-sourcegraph
+common --repository_cache=/home/buildkite/repocache-sourcegraph
 
 # We need /usr/local/bin
 # TODO(DevX) we should be narrower here.
-build --test_env=PATH
+common --test_env=PATH
 
 # Needed for DB in CI
-test --test_env=PGUSER=postgres
-test --test_env=PGPASSWORD=postgres
-test --test_env=PGSSLMODE=disable
-test --test_env=PGDATABASE=postgres
+common --test_env=PGUSER=postgres
+common --test_env=PGPASSWORD=postgres
+common --test_env=PGSSLMODE=disable
+common --test_env=PGDATABASE=postgres
 
 # Allow tests to understand they're running in CI, which forces dbtest to drop database even in case of failures.
 # TODO(JH) we should instead wipe all templates after a job finishes.
-build --test_env=CI
+common --test_env=CI
 
 # Ensure we're not exhausting database connections.
-build --test_env=GOMAXPROCS=10
-build --test_env=TESTDB_MAXOPENCONNS=15
+common --test_env=GOMAXPROCS=10
+common --test_env=TESTDB_MAXOPENCONNS=15
 
 # Needed for E2E
-build --test_env=BUILDKITE
+common --test_env=BUILDKITE
 
 # Needed for mocha tests
 # We have to use the `--define` flag here instead of `--test_env` because
 # the mocha tests target is the build target and it's tested with `build_test`.
-test --define=E2E_HEADLESS=false
+common --define=E2E_HEADLESS=false
 # if we set this to localhost, chrome will refuse to conenct since local host is in its HTTP Strict Transport Security
 # by setting the loopback address we get passed that
-test --define=E2E_SOURCEGRAPH_BASE_URL="http://127.0.0.1:7080"
-test --define=DISPLAY=:99
+common --define=E2E_SOURCEGRAPH_BASE_URL="http://127.0.0.1:7080"
+common --define=DISPLAY=:99
 
 # Provides git commit, branch information to build targets like Percy via status file.
 # https://bazel.build/docs/user-manual#workspace-status
-build --workspace_status_command=./dev/bazel_buildkite_stamp_vars.sh
+common --workspace_status_command=./dev/bazel_buildkite_stamp_vars.sh
 
 # temp
-build --test_env=INCLUDE_ADMIN_ONBOARDING=false
+common --test_env=INCLUDE_ADMIN_ONBOARDING=false
 
 # Used for container_structure_tests
-build --test_env=DOCKER_HOST
+common --test_env=DOCKER_HOST
 
 # Used by migration rules
-build --action_env=PGUSER=postgres
+common --action_env=PGUSER=postgres


### PR DESCRIPTION
Bazel 6.3.0 introduced a change where `common` could be set in bazelrc and Bazel applies the flag to all commands the flag is valid for. This change uses that feature in the CI bazelrc so that all flags apply to both `bazel test` and `bazel build`. Warming calls `bazel build` and it is [broken on main](https://buildkite.com/sourcegraph/warming-aspect-workflow-sourcegraph/builds/82) since 3 required env vars set in the CI bazelrc are scoped to just the `bazel test` command:

```
test --define=E2E_HEADLESS=false
# if we set this to localhost, chrome will refuse to conenct since local host is in its HTTP Strict Transport Security
# by setting the loopback address we get passed that
test --define=E2E_SOURCEGRAPH_BASE_URL="http://127.0.0.1:7080"
test --define=DISPLAY=:99
```

## Test plan

CI & run warming on this commit manually https://buildkite.com/sourcegraph/warming-aspect-workflow-sourcegraph/builds/83