### PR TITLE
PLG: Add config items for interaction-based limits

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -288,22 +288,22 @@ func getSelfServeUsageLimits(scope types.CompletionsFeature, isProUser bool, cfg
 	switch scope {
 	case types.CompletionsFeatureChat:
 		if isProUser {
-			if cfg.PerProUserChatDailyLimit > 0 {
-				return oneDayInSeconds, pointers.Ptr(cfg.PerProUserChatDailyLimit), nil
+			if cfg.PerProUserChatDailyLLMRequestLimit > 0 {
+				return oneDayInSeconds, pointers.Ptr(cfg.PerProUserChatDailyLLMRequestLimit), nil
 			}
 		} else {
-			if cfg.PerCommunityUserChatMonthlyLimit > 0 {
-				return oneMonthInSeconds, pointers.Ptr(cfg.PerCommunityUserChatMonthlyLimit), nil
+			if cfg.PerCommunityUserChatMonthlyLLMRequestLimit > 0 {
+				return oneMonthInSeconds, pointers.Ptr(cfg.PerCommunityUserChatMonthlyLLMRequestLimit), nil
 			}
 		}
 	case types.CompletionsFeatureCode:
 		if isProUser {
-			if cfg.PerProUserCodeCompletionsDailyLimit > 0 {
-				return oneDayInSeconds, pointers.Ptr(cfg.PerProUserCodeCompletionsDailyLimit), nil
+			if cfg.PerProUserCodeCompletionsDailyLLMRequestLimit > 0 {
+				return oneDayInSeconds, pointers.Ptr(cfg.PerProUserCodeCompletionsDailyLLMRequestLimit), nil
 			}
 		} else {
-			if cfg.PerCommunityUserCodeCompletionsMonthlyLimit > 0 {
-				return oneMonthInSeconds, pointers.Ptr(cfg.PerCommunityUserCodeCompletionsMonthlyLimit), nil
+			if cfg.PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit > 0 {
+				return oneMonthInSeconds, pointers.Ptr(cfg.PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit), nil
 			}
 		}
 	}

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -796,10 +796,10 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 		Endpoint:                         completionsConfig.Endpoint,
 		PerUserDailyLimit:                completionsConfig.PerUserDailyLimit,
 		PerUserCodeCompletionsDailyLimit: completionsConfig.PerUserCodeCompletionsDailyLimit,
-		PerCommunityUserChatMonthlyLimit: completionsConfig.PerCommunityUserChatMonthlyLimit,
-		PerCommunityUserCodeCompletionsMonthlyLimit: completionsConfig.PerCommunityUserCodeCompletionsMonthlyLimit,
-		PerProUserChatDailyLimit:                    completionsConfig.PerProUserChatDailyLimit,
-		PerProUserCodeCompletionsDailyLimit:         completionsConfig.PerProUserCodeCompletionsDailyLimit,
+		PerCommunityUserChatMonthlyLLMRequestLimit:            completionsConfig.PerCommunityUserChatMonthlyLLMRequestLimit,
+		PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit: completionsConfig.PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit,
+		PerProUserChatDailyLLMRequestLimit:                    completionsConfig.PerProUserChatDailyLLMRequestLimit,
+		PerProUserCodeCompletionsDailyLLMRequestLimit:         completionsConfig.PerProUserCodeCompletionsDailyLLMRequestLimit,
 	}
 
 	return computedConfig

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -796,10 +796,14 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 		Endpoint:                         completionsConfig.Endpoint,
 		PerUserDailyLimit:                completionsConfig.PerUserDailyLimit,
 		PerUserCodeCompletionsDailyLimit: completionsConfig.PerUserCodeCompletionsDailyLimit,
-		PerCommunityUserChatMonthlyLLMRequestLimit:            completionsConfig.PerCommunityUserChatMonthlyLLMRequestLimit,
-		PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit: completionsConfig.PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit,
-		PerProUserChatDailyLLMRequestLimit:                    completionsConfig.PerProUserChatDailyLLMRequestLimit,
-		PerProUserCodeCompletionsDailyLLMRequestLimit:         completionsConfig.PerProUserCodeCompletionsDailyLLMRequestLimit,
+		PerCommunityUserChatMonthlyLLMRequestLimit:             completionsConfig.PerCommunityUserChatMonthlyLLMRequestLimit,
+		PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit:  completionsConfig.PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit,
+		PerProUserChatDailyLLMRequestLimit:                     completionsConfig.PerProUserChatDailyLLMRequestLimit,
+		PerProUserCodeCompletionsDailyLLMRequestLimit:          completionsConfig.PerProUserCodeCompletionsDailyLLMRequestLimit,
+		PerCommunityUserChatMonthlyInteractionLimit:            completionsConfig.PerCommunityUserChatMonthlyInteractionLimit,
+		PerCommunityUserCodeCompletionsMonthlyInteractionLimit: completionsConfig.PerCommunityUserCodeCompletionsMonthlyInteractionLimit,
+		PerProUserChatDailyInteractionLimit:                    completionsConfig.PerProUserChatDailyInteractionLimit,
+		PerProUserCodeCompletionsDailyInteractionLimit:         completionsConfig.PerProUserCodeCompletionsDailyInteractionLimit,
 	}
 
 	return computedConfig

--- a/internal/conf/conftypes/consts.go
+++ b/internal/conf/conftypes/consts.go
@@ -12,15 +12,15 @@ type CompletionsConfig struct {
 	CompletionModel          string
 	CompletionModelMaxTokens int
 
-	AccessToken                                 string
-	Provider                                    CompletionsProviderName
-	Endpoint                                    string
-	PerUserDailyLimit                           int
-	PerUserCodeCompletionsDailyLimit            int
-	PerCommunityUserChatMonthlyLimit            int
-	PerCommunityUserCodeCompletionsMonthlyLimit int
-	PerProUserChatDailyLimit                    int
-	PerProUserCodeCompletionsDailyLimit         int
+	AccessToken                                           string
+	Provider                                              CompletionsProviderName
+	Endpoint                                              string
+	PerUserDailyLimit                                     int
+	PerUserCodeCompletionsDailyLimit                      int
+	PerCommunityUserChatMonthlyLLMRequestLimit            int
+	PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit int
+	PerProUserChatDailyLLMRequestLimit                    int
+	PerProUserCodeCompletionsDailyLLMRequestLimit         int
 }
 
 type CompletionsProviderName string

--- a/internal/conf/conftypes/consts.go
+++ b/internal/conf/conftypes/consts.go
@@ -12,15 +12,19 @@ type CompletionsConfig struct {
 	CompletionModel          string
 	CompletionModelMaxTokens int
 
-	AccessToken                                           string
-	Provider                                              CompletionsProviderName
-	Endpoint                                              string
-	PerUserDailyLimit                                     int
-	PerUserCodeCompletionsDailyLimit                      int
-	PerCommunityUserChatMonthlyLLMRequestLimit            int
-	PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit int
-	PerProUserChatDailyLLMRequestLimit                    int
-	PerProUserCodeCompletionsDailyLLMRequestLimit         int
+	AccessToken                                            string
+	Provider                                               CompletionsProviderName
+	Endpoint                                               string
+	PerUserDailyLimit                                      int
+	PerUserCodeCompletionsDailyLimit                       int
+	PerCommunityUserChatMonthlyLLMRequestLimit             int
+	PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit  int
+	PerProUserChatDailyLLMRequestLimit                     int
+	PerProUserCodeCompletionsDailyLLMRequestLimit          int
+	PerCommunityUserChatMonthlyInteractionLimit            int
+	PerCommunityUserCodeCompletionsMonthlyInteractionLimit int
+	PerProUserChatDailyInteractionLimit                    int
+	PerProUserCodeCompletionsDailyInteractionLimit         int
 }
 
 type CompletionsProviderName string

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -594,14 +594,14 @@ type Completions struct {
 	FastChatModelMaxTokens int `json:"fastChatModelMaxTokens,omitempty"`
 	// Model description: DEPRECATED. Use chatModel instead.
 	Model string `json:"model,omitempty"`
-	// PerCommunityUserChatMonthlyLimit description: If > 0, limits the number of completions requests allowed for a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.
-	PerCommunityUserChatMonthlyLimit int `json:"perCommunityUserChatMonthlyLimit,omitempty"`
-	// PerCommunityUserCodeCompletionsMonthlyLimit description: If > 0, limits the number of code completions requests allowed for a Community user in a month.  This is for Self-serve Cody and applies to Dotcom only.
-	PerCommunityUserCodeCompletionsMonthlyLimit int `json:"perCommunityUserCodeCompletionsMonthlyLimit,omitempty"`
-	// PerProUserChatDailyLimit description: If > 0, limits the number of completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.
-	PerProUserChatDailyLimit int `json:"perProUserChatDailyLimit,omitempty"`
-	// PerProUserCodeCompletionsDailyLimit description: If > 0, limits the number of code completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.
-	PerProUserCodeCompletionsDailyLimit int `json:"perProUserCodeCompletionsDailyLimit,omitempty"`
+	// PerCommunityUserChatMonthlyLLMRequestLimit description: If > 0, limits the number of completions requests allowed for a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.
+	PerCommunityUserChatMonthlyLLMRequestLimit int `json:"perCommunityUserChatMonthlyLLMRequestLimit,omitempty"`
+	// PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit description: If > 0, limits the number of code completions requests allowed for a Community user in a month.  This is for Self-serve Cody and applies to Dotcom only.
+	PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit int `json:"perCommunityUserCodeCompletionsMonthlyLLMRequestLimit,omitempty"`
+	// PerProUserChatDailyLLMRequestLimit description: If > 0, limits the number of completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.
+	PerProUserChatDailyLLMRequestLimit int `json:"perProUserChatDailyLLMRequestLimit,omitempty"`
+	// PerProUserCodeCompletionsDailyLLMRequestLimit description: If > 0, limits the number of code completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.
+	PerProUserCodeCompletionsDailyLLMRequestLimit int `json:"perProUserCodeCompletionsDailyLLMRequestLimit,omitempty"`
 	// PerUserCodeCompletionsDailyLimit description: If > 0, limits the number of code completions requests allowed for a user in a day. On instances that allow anonymous requests, we enforce the rate limit by IP.
 	PerUserCodeCompletionsDailyLimit int `json:"perUserCodeCompletionsDailyLimit,omitempty"`
 	// PerUserDailyLimit description: If > 0, limits the number of completions requests allowed for a user in a day. On instances that allow anonymous requests, we enforce the rate limit by IP.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -594,12 +594,20 @@ type Completions struct {
 	FastChatModelMaxTokens int `json:"fastChatModelMaxTokens,omitempty"`
 	// Model description: DEPRECATED. Use chatModel instead.
 	Model string `json:"model,omitempty"`
+	// PerCommunityUserChatMonthlyInteractionLimit description: If > 0, enables the maximum number of completions interactions allowed to be made by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.
+	PerCommunityUserChatMonthlyInteractionLimit int `json:"perCommunityUserChatMonthlyInteractionLimit,omitempty"`
 	// PerCommunityUserChatMonthlyLLMRequestLimit description: If > 0, limits the number of completions requests allowed for a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.
 	PerCommunityUserChatMonthlyLLMRequestLimit int `json:"perCommunityUserChatMonthlyLLMRequestLimit,omitempty"`
+	// PerCommunityUserCodeCompletionsMonthlyInteractionLimit description: If > 0, enables the maximum number of code completions interactions allowed to be made by a single Community user in a month.  This is for Cody PLG and applies to Dotcom only.
+	PerCommunityUserCodeCompletionsMonthlyInteractionLimit int `json:"perCommunityUserCodeCompletionsMonthlyInteractionLimit,omitempty"`
 	// PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit description: If > 0, limits the number of code completions requests allowed for a Community user in a month.  This is for Self-serve Cody and applies to Dotcom only.
 	PerCommunityUserCodeCompletionsMonthlyLLMRequestLimit int `json:"perCommunityUserCodeCompletionsMonthlyLLMRequestLimit,omitempty"`
+	// PerProUserChatDailyInteractionLimit description: If > 0, enables the maximum number of completions interactions allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.
+	PerProUserChatDailyInteractionLimit int `json:"perProUserChatDailyInteractionLimit,omitempty"`
 	// PerProUserChatDailyLLMRequestLimit description: If > 0, limits the number of completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.
 	PerProUserChatDailyLLMRequestLimit int `json:"perProUserChatDailyLLMRequestLimit,omitempty"`
+	// PerProUserCodeCompletionsDailyInteractionLimit description: If > 0, enables the maximum number of code completions interactions allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.
+	PerProUserCodeCompletionsDailyInteractionLimit int `json:"perProUserCodeCompletionsDailyInteractionLimit,omitempty"`
 	// PerProUserCodeCompletionsDailyLLMRequestLimit description: If > 0, limits the number of code completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.
 	PerProUserCodeCompletionsDailyLLMRequestLimit int `json:"perProUserCodeCompletionsDailyLLMRequestLimit,omitempty"`
 	// PerUserCodeCompletionsDailyLimit description: If > 0, limits the number of code completions requests allowed for a user in a day. On instances that allow anonymous requests, we enforce the rate limit by IP.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2795,22 +2795,22 @@
           "type": "integer",
           "default": 0
         },
-        "perCommunityUserChatMonthlyLimit": {
+        "perCommunityUserChatMonthlyLLMRequestLimit": {
           "description": "If > 0, limits the number of completions requests allowed for a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
-        "perCommunityUserCodeCompletionsMonthlyLimit": {
+        "perCommunityUserCodeCompletionsMonthlyLLMRequestLimit": {
           "description": "If > 0, limits the number of code completions requests allowed for a Community user in a month.  This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
-        "perProUserChatDailyLimit": {
+        "perProUserChatDailyLLMRequestLimit": {
           "description": "If > 0, limits the number of completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
-        "perProUserCodeCompletionsDailyLimit": {
+        "perProUserCodeCompletionsDailyLLMRequestLimit": {
           "description": "If > 0, limits the number of code completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2814,6 +2814,26 @@
           "description": "If > 0, limits the number of code completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
+        },
+        "perCommunityUserChatMonthlyInteractionLimit": {
+          "description": "If > 0, enables the maximum number of completions interactions allowed to be made by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.",
+          "type": "integer",
+          "default": 0
+        },
+        "perCommunityUserCodeCompletionsMonthlyInteractionLimit": {
+          "description": "If > 0, enables the maximum number of code completions interactions allowed to be made by a single Community user in a month.  This is for Cody PLG and applies to Dotcom only.",
+          "type": "integer",
+          "default": 0
+        },
+        "perProUserChatDailyInteractionLimit": {
+          "description": "If > 0, enables the maximum number of completions interactions allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
+          "type": "integer",
+          "default": 0
+        },
+        "perProUserCodeCompletionsDailyInteractionLimit": {
+          "description": "If > 0, enables the maximum number of code completions interactions allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
+          "type": "integer",
+          "default": 0
         }
       },
       "examples": [


### PR DESCRIPTION
- Renamed the existing four config items to make it more explicit that they pertain to LLM requests
- Added four new config items that limit interactions.

The new set of constants is not used yet.

## Test plan

Not much to test on this: the old ones are covered by CI, and the new constants are not used yet.