### PR TITLE
sec: Allow localdev to connect to localhost

### DIFF
--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -139,7 +139,7 @@ func newExternalClientFactory(cache bool, testOpt bool, middleware ...Middleware
 	mw = append(mw, middleware...)
 
 	externalTransportOpt := ExternalTransportOpt
-	if testOpt {
+	if testOpt || env.InsecureDev {
 		externalTransportOpt = TestExternalTransportOpt
 	}
 


### PR DESCRIPTION
For local development we require localhost, for instance for Cody Gateway. We now add a check to make sure we don't block localhost access from when `INSECURE_DEV` is set to `true`. 

## Test plan
Tested locally.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
