### PR TITLE
PLG: Add embeddings rate limits

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -1029,6 +1029,8 @@ func GetEmbeddingsConfig(siteConfig schema.SiteConfiguration) *conftypes.Embeddi
 		PolicyRepositoryMatchLimit: embeddingsConfig.PolicyRepositoryMatchLimit,
 		ExcludeChunkOnError:        pointers.Deref(embeddingsConfig.ExcludeChunkOnError, true),
 		Qdrant:                     computedQdrantConfig,
+		PerCommunityUserEmbeddingsMonthlyLimit:      embeddingsConfig.PerCommunityUserEmbeddingsMonthlyLimit,
+		PerProUserEmbeddingsMonthlyLimit:            embeddingsConfig.PerProUserEmbeddingsMonthlyLimit,
 	}
 	d, err := time.ParseDuration(embeddingsConfig.MinimumInterval)
 	if err != nil {

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -1022,15 +1022,15 @@ func GetEmbeddingsConfig(siteConfig schema.SiteConfiguration) *conftypes.Embeddi
 		Endpoint:    embeddingsConfig.Endpoint,
 		Dimensions:  embeddingsConfig.Dimensions,
 		// This is definitely set at this point.
-		Incremental:                *embeddingsConfig.Incremental,
-		FileFilters:                fileFilters,
-		MaxCodeEmbeddingsPerRepo:   embeddingsConfig.MaxCodeEmbeddingsPerRepo,
-		MaxTextEmbeddingsPerRepo:   embeddingsConfig.MaxTextEmbeddingsPerRepo,
-		PolicyRepositoryMatchLimit: embeddingsConfig.PolicyRepositoryMatchLimit,
-		ExcludeChunkOnError:        pointers.Deref(embeddingsConfig.ExcludeChunkOnError, true),
-		Qdrant:                     computedQdrantConfig,
-		PerCommunityUserEmbeddingsMonthlyLimit:      embeddingsConfig.PerCommunityUserEmbeddingsMonthlyLimit,
-		PerProUserEmbeddingsMonthlyLimit:            embeddingsConfig.PerProUserEmbeddingsMonthlyLimit,
+		Incremental:                            *embeddingsConfig.Incremental,
+		FileFilters:                            fileFilters,
+		MaxCodeEmbeddingsPerRepo:               embeddingsConfig.MaxCodeEmbeddingsPerRepo,
+		MaxTextEmbeddingsPerRepo:               embeddingsConfig.MaxTextEmbeddingsPerRepo,
+		PolicyRepositoryMatchLimit:             embeddingsConfig.PolicyRepositoryMatchLimit,
+		ExcludeChunkOnError:                    pointers.Deref(embeddingsConfig.ExcludeChunkOnError, true),
+		Qdrant:                                 computedQdrantConfig,
+		PerCommunityUserEmbeddingsMonthlyLimit: embeddingsConfig.PerCommunityUserEmbeddingsMonthlyLimit,
+		PerProUserEmbeddingsMonthlyLimit:       embeddingsConfig.PerProUserEmbeddingsMonthlyLimit,
 	}
 	d, err := time.ParseDuration(embeddingsConfig.MinimumInterval)
 	if err != nil {

--- a/internal/conf/conftypes/consts.go
+++ b/internal/conf/conftypes/consts.go
@@ -35,19 +35,21 @@ const (
 )
 
 type EmbeddingsConfig struct {
-	Provider                   EmbeddingsProviderName
-	AccessToken                string
-	Model                      string
-	Endpoint                   string
-	Dimensions                 int
-	Incremental                bool
-	MinimumInterval            time.Duration
-	FileFilters                EmbeddingsFileFilters
-	MaxCodeEmbeddingsPerRepo   int
-	MaxTextEmbeddingsPerRepo   int
-	PolicyRepositoryMatchLimit *int
-	ExcludeChunkOnError        bool
-	Qdrant                     QdrantConfig
+	Provider                               EmbeddingsProviderName
+	AccessToken                            string
+	Model                                  string
+	Endpoint                               string
+	Dimensions                             int
+	Incremental                            bool
+	MinimumInterval                        time.Duration
+	FileFilters                            EmbeddingsFileFilters
+	MaxCodeEmbeddingsPerRepo               int
+	MaxTextEmbeddingsPerRepo               int
+	PolicyRepositoryMatchLimit             *int
+	ExcludeChunkOnError                    bool
+	Qdrant                                 QdrantConfig
+	PerCommunityUserEmbeddingsMonthlyLimit int
+	PerProUserEmbeddingsMonthlyLimit       int
 }
 
 type QdrantConfig struct {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -594,21 +594,17 @@ type Completions struct {
 	FastChatModelMaxTokens int `json:"fastChatModelMaxTokens,omitempty"`
 	// Model description: DEPRECATED. Use chatModel instead.
 	Model string `json:"model,omitempty"`
-	// PerCommunityUserChatMonthlyLimit description: If > 0, limits the maximum number of completions requests allowed by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.
+	// PerCommunityUserChatMonthlyLimit description: If > 0, limits the number of completions requests allowed for a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.
 	PerCommunityUserChatMonthlyLimit int `json:"perCommunityUserChatMonthlyLimit,omitempty"`
-	// PerCommunityUserCodeCompletionsMonthlyLimit description: If > 0, limits the maximum number of code completions requests allowed by a single Community user in a month.  This is for Cody PLG and applies to Dotcom only.
+	// PerCommunityUserCodeCompletionsMonthlyLimit description: If > 0, limits the number of code completions requests allowed for a Community user in a month.  This is for Self-serve Cody and applies to Dotcom only.
 	PerCommunityUserCodeCompletionsMonthlyLimit int `json:"perCommunityUserCodeCompletionsMonthlyLimit,omitempty"`
-	// PerCommunityUserEmbeddingsMonthlyLimit description: If > 0, limits the maximum MBs of code allowed to be embedded by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.
-	PerCommunityUserEmbeddingsMonthlyLimit int `json:"perCommunityUserEmbeddingsMonthlyLimit,omitempty"`
-	// PerProUserChatDailyLimit description: If > 0, limits the maximum number of completions requests allowed by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.
+	// PerProUserChatDailyLimit description: If > 0, limits the number of completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.
 	PerProUserChatDailyLimit int `json:"perProUserChatDailyLimit,omitempty"`
-	// PerProUserCodeCompletionsDailyLimit description: If > 0, limits the maximum number of code completions requests allowed by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.
+	// PerProUserCodeCompletionsDailyLimit description: If > 0, limits the number of code completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.
 	PerProUserCodeCompletionsDailyLimit int `json:"perProUserCodeCompletionsDailyLimit,omitempty"`
-	// PerProUserEmbeddingsMonthlyLimit description: If > 0, limits the maximum MBs of code allowed to be embedded by a single Pro user in a month. This is for Cody PLG and applies to Dotcom only.
-	PerProUserEmbeddingsMonthlyLimit int `json:"perProUserEmbeddingsMonthlyLimit,omitempty"`
-	// PerUserCodeCompletionsDailyLimit description: If > 0, limits the maximum number of code completions requests allowed by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.
+	// PerUserCodeCompletionsDailyLimit description: If > 0, limits the number of code completions requests allowed for a user in a day. On instances that allow anonymous requests, we enforce the rate limit by IP.
 	PerUserCodeCompletionsDailyLimit int `json:"perUserCodeCompletionsDailyLimit,omitempty"`
-	// PerUserDailyLimit description: If > 0, limits the maximum number of completions requests allowed by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.
+	// PerUserDailyLimit description: If > 0, limits the number of completions requests allowed for a user in a day. On instances that allow anonymous requests, we enforce the rate limit by IP.
 	PerUserDailyLimit int `json:"perUserDailyLimit,omitempty"`
 	// Provider description: The external completions provider. Defaults to 'sourcegraph'.
 	Provider string `json:"provider,omitempty"`
@@ -694,6 +690,10 @@ type Embeddings struct {
 	MinimumInterval string `json:"minimumInterval,omitempty"`
 	// Model description: The model used for embedding. A default model will be used for each provider, if not set.
 	Model string `json:"model,omitempty"`
+	// PerCommunityUserEmbeddingsMonthlyLimit description: If > 0, limits the MBs of code allowed to be embedded by a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.
+	PerCommunityUserEmbeddingsMonthlyLimit int `json:"perCommunityUserEmbeddingsMonthlyLimit,omitempty"`
+	// PerProUserEmbeddingsMonthlyLimit description: If > 0, limits the MBs of code allowed to be embedded by a Pro user in a month. This is for Self-serve Cody and applies to Dotcom only.
+	PerProUserEmbeddingsMonthlyLimit int `json:"perProUserEmbeddingsMonthlyLimit,omitempty"`
 	// PolicyRepositoryMatchLimit description: The maximum number of repositories that can be matched by a global embeddings policy
 	PolicyRepositoryMatchLimit *int `json:"policyRepositoryMatchLimit,omitempty"`
 	// Provider description: The provider to use for generating embeddings. Defaults to sourcegraph.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -690,9 +690,9 @@ type Embeddings struct {
 	MinimumInterval string `json:"minimumInterval,omitempty"`
 	// Model description: The model used for embedding. A default model will be used for each provider, if not set.
 	Model string `json:"model,omitempty"`
-	// PerCommunityUserEmbeddingsMonthlyLimit description: If > 0, limits the MBs of code allowed to be embedded by a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.
+	// PerCommunityUserEmbeddingsMonthlyLimit description: If > 0, limits the number of tokens allowed to be embedded by a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.
 	PerCommunityUserEmbeddingsMonthlyLimit int `json:"perCommunityUserEmbeddingsMonthlyLimit,omitempty"`
-	// PerProUserEmbeddingsMonthlyLimit description: If > 0, limits the MBs of code allowed to be embedded by a Pro user in a month. This is for Self-serve Cody and applies to Dotcom only.
+	// PerProUserEmbeddingsMonthlyLimit description: If > 0, limits the number of tokens allowed to be embedded by a Pro user in a month. This is for Self-serve Cody and applies to Dotcom only.
 	PerProUserEmbeddingsMonthlyLimit int `json:"perProUserEmbeddingsMonthlyLimit,omitempty"`
 	// PolicyRepositoryMatchLimit description: The maximum number of repositories that can be matched by a global embeddings policy
 	PolicyRepositoryMatchLimit *int `json:"policyRepositoryMatchLimit,omitempty"`

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -594,17 +594,21 @@ type Completions struct {
 	FastChatModelMaxTokens int `json:"fastChatModelMaxTokens,omitempty"`
 	// Model description: DEPRECATED. Use chatModel instead.
 	Model string `json:"model,omitempty"`
-	// PerCommunityUserChatMonthlyLimit description: If > 0, enables the maximum number of completions requests allowed to be made by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.
+	// PerCommunityUserChatMonthlyLimit description: If > 0, limits the maximum number of completions requests allowed by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.
 	PerCommunityUserChatMonthlyLimit int `json:"perCommunityUserChatMonthlyLimit,omitempty"`
-	// PerCommunityUserCodeCompletionsMonthlyLimit description: If > 0, enables the maximum number of code completions requests allowed to be made by a single Community user in a month.  This is for Cody PLG and applies to Dotcom only.
+	// PerCommunityUserCodeCompletionsMonthlyLimit description: If > 0, limits the maximum number of code completions requests allowed by a single Community user in a month.  This is for Cody PLG and applies to Dotcom only.
 	PerCommunityUserCodeCompletionsMonthlyLimit int `json:"perCommunityUserCodeCompletionsMonthlyLimit,omitempty"`
-	// PerProUserChatDailyLimit description: If > 0, enables the maximum number of completions requests allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.
+	// PerCommunityUserEmbeddingsMonthlyLimit description: If > 0, limits the maximum MBs of code allowed to be embedded by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.
+	PerCommunityUserEmbeddingsMonthlyLimit int `json:"perCommunityUserEmbeddingsMonthlyLimit,omitempty"`
+	// PerProUserChatDailyLimit description: If > 0, limits the maximum number of completions requests allowed by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.
 	PerProUserChatDailyLimit int `json:"perProUserChatDailyLimit,omitempty"`
-	// PerProUserCodeCompletionsDailyLimit description: If > 0, enables the maximum number of code completions requests allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.
+	// PerProUserCodeCompletionsDailyLimit description: If > 0, limits the maximum number of code completions requests allowed by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.
 	PerProUserCodeCompletionsDailyLimit int `json:"perProUserCodeCompletionsDailyLimit,omitempty"`
-	// PerUserCodeCompletionsDailyLimit description: If > 0, enables the maximum number of code completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.
+	// PerProUserEmbeddingsMonthlyLimit description: If > 0, limits the maximum MBs of code allowed to be embedded by a single Pro user in a month. This is for Cody PLG and applies to Dotcom only.
+	PerProUserEmbeddingsMonthlyLimit int `json:"perProUserEmbeddingsMonthlyLimit,omitempty"`
+	// PerUserCodeCompletionsDailyLimit description: If > 0, limits the maximum number of code completions requests allowed by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.
 	PerUserCodeCompletionsDailyLimit int `json:"perUserCodeCompletionsDailyLimit,omitempty"`
-	// PerUserDailyLimit description: If > 0, enables the maximum number of completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.
+	// PerUserDailyLimit description: If > 0, limits the maximum number of completions requests allowed by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.
 	PerUserDailyLimit int `json:"perUserDailyLimit,omitempty"`
 	// Provider description: The external completions provider. Defaults to 'sourcegraph'.
 	Provider string `json:"provider,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2495,12 +2495,12 @@
           "format": "uri"
         },
         "perCommunityUserEmbeddingsMonthlyLimit": {
-          "description": "If > 0, limits the MBs of code allowed to be embedded by a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.",
+          "description": "If > 0, limits the number of tokens allowed to be embedded by a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
         "perProUserEmbeddingsMonthlyLimit": {
-          "description": "If > 0, limits the MBs of code allowed to be embedded by a Pro user in a month. This is for Self-serve Cody and applies to Dotcom only.",
+          "description": "If > 0, limits the number of tokens allowed to be embedded by a Pro user in a month. This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2770,32 +2770,32 @@
           "description": "The endpoint under which to reach the provider. Currently only used for provider types \"sourcegraph\", \"openai\" and \"anthropic\". The default values are \"https://cody-gateway.sourcegraph.com\", \"https://api.openai.com/v1/chat/completions\", and \"https://api.anthropic.com/v1/complete\" for Sourcegraph, OpenAI, and Anthropic, respectively."
         },
         "perUserDailyLimit": {
-          "description": "If > 0, enables the maximum number of completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",
+          "description": "If > 0, limits the maximum number of completions requests allowed by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",
           "type": "integer",
           "default": 0
         },
         "perUserCodeCompletionsDailyLimit": {
-          "description": "If > 0, enables the maximum number of code completions requests allowed to be made by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",
+          "description": "If > 0, limits the maximum number of code completions requests allowed by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",
           "type": "integer",
           "default": 0
         },
         "perCommunityUserChatMonthlyLimit": {
-          "description": "If > 0, enables the maximum number of completions requests allowed to be made by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.",
+          "description": "If > 0, limits the maximum number of completions requests allowed by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
         "perCommunityUserCodeCompletionsMonthlyLimit": {
-          "description": "If > 0, enables the maximum number of code completions requests allowed to be made by a single Community user in a month.  This is for Cody PLG and applies to Dotcom only.",
+          "description": "If > 0, limits the maximum number of code completions requests allowed by a single Community user in a month.  This is for Cody PLG and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
         "perProUserChatDailyLimit": {
-          "description": "If > 0, enables the maximum number of completions requests allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
+          "description": "If > 0, limits the maximum number of completions requests allowed by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
         "perProUserCodeCompletionsDailyLimit": {
-          "description": "If > 0, enables the maximum number of code completions requests allowed to be made by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
+          "description": "If > 0, limits the maximum number of code completions requests allowed by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2494,6 +2494,16 @@
           "type": "string",
           "format": "uri"
         },
+        "perCommunityUserEmbeddingsMonthlyLimit": {
+          "description": "If > 0, limits the MBs of code allowed to be embedded by a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.",
+          "type": "integer",
+          "default": 0
+        },
+        "perProUserEmbeddingsMonthlyLimit": {
+          "description": "If > 0, limits the MBs of code allowed to be embedded by a Pro user in a month. This is for Self-serve Cody and applies to Dotcom only.",
+          "type": "integer",
+          "default": 0
+        },
         "fileFilters": {
           "description": "Filters that allow you to specify which files in a repository should get embedded.",
           "type": "object",
@@ -2770,32 +2780,32 @@
           "description": "The endpoint under which to reach the provider. Currently only used for provider types \"sourcegraph\", \"openai\" and \"anthropic\". The default values are \"https://cody-gateway.sourcegraph.com\", \"https://api.openai.com/v1/chat/completions\", and \"https://api.anthropic.com/v1/complete\" for Sourcegraph, OpenAI, and Anthropic, respectively."
         },
         "perUserDailyLimit": {
-          "description": "If > 0, limits the maximum number of completions requests allowed by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",
+          "description": "If > 0, limits the number of completions requests allowed for a user in a day. On instances that allow anonymous requests, we enforce the rate limit by IP.",
           "type": "integer",
           "default": 0
         },
         "perUserCodeCompletionsDailyLimit": {
-          "description": "If > 0, limits the maximum number of code completions requests allowed by a single user account in a day. On instances that allow anonymous requests, the rate limit is enforced by IP.",
+          "description": "If > 0, limits the number of code completions requests allowed for a user in a day. On instances that allow anonymous requests, we enforce the rate limit by IP.",
           "type": "integer",
           "default": 0
         },
         "perCommunityUserChatMonthlyLimit": {
-          "description": "If > 0, limits the maximum number of completions requests allowed by a single Community user in a month. This is for Cody PLG and applies to Dotcom only.",
+          "description": "If > 0, limits the number of completions requests allowed for a Community user in a month. This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
         "perCommunityUserCodeCompletionsMonthlyLimit": {
-          "description": "If > 0, limits the maximum number of code completions requests allowed by a single Community user in a month.  This is for Cody PLG and applies to Dotcom only.",
+          "description": "If > 0, limits the number of code completions requests allowed for a Community user in a month.  This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
         "perProUserChatDailyLimit": {
-          "description": "If > 0, limits the maximum number of completions requests allowed by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
+          "description": "If > 0, limits the number of completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         },
         "perProUserCodeCompletionsDailyLimit": {
-          "description": "If > 0, limits the maximum number of code completions requests allowed by a single Pro user in a day. This is for Cody PLG and applies to Dotcom only.",
+          "description": "If > 0, limits the number of code completions requests allowed for a Pro user in a day. This is for Self-serve Cody and applies to Dotcom only.",
           "type": "integer",
           "default": 0
         }


### PR DESCRIPTION
- Added two new config items for the embeddings limit for Community+Pro users.
- We're now passing the values to Gateway instead of the hard-coded values on Dotcom with the `cody-pro` feature flag _on_, otherwise falling back to the old hard-coded values.
- Clarified the descriptions for rate limiting-related config items.

## Test plan

I've set the limits in the site config. I've verified that when I run [this GraphQL query](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22query%20CodyGatewayAccess(%24token%3AString!)%20%7B%5Cn%20%20dotcom%20%7B%5Cn%20%20%20%20codyGatewayDotcomUserByToken(token%3A%20%24token)%20%7B%5Cn%20%20%20%20%20%20%20id%5Cn%20%20%20%20%20%20username%5Cn%20%20%20%20%20%20codyGatewayAccess%20%7B%5Cn%20%20%20%20%20%20%20%20enabled%5Cn%20%20%20%20%20%20%20%20embeddingsRateLimit%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20limit%5Cn%20%20%20%20%20%20%20%20%20%20intervalSeconds%5Cn%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D):
- it returns the Community limit and the one-month interval for a non-Pro user
- it returns the Pro limit and the one-month interval for a Pro user
- it returns the old limit and the max(int32) interval if the `cody-pro` feature flag is off