### PR TITLE
dotcom: Make repo with last errors syncer faster

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -166,7 +166,7 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 	)
 
 	if envvar.SourcegraphDotComMode() {
-		rateLimiter := ratelimit.NewInstrumentedLimiter("SyncReposWithLastErrors", rate.NewLimiter(.05, 1))
+		rateLimiter := ratelimit.NewInstrumentedLimiter("SyncReposWithLastErrors", rate.NewLimiter(1, 1))
 		routines = append(routines, syncer.NewSyncReposWithLastErrorsWorker(ctx, rateLimiter))
 	}
 


### PR DESCRIPTION
Realistically, in the past it never got to a steady state because it just waits for too long. Trying to sync at most one a second seems fine to me, let's try it.

## Test plan

Will monitor grafana after rollout.