### PR TITLE
Fix soft deleted repos revived appearing as modifed

### DIFF
--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -724,6 +724,7 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		s.ObsvCtx.Logger.Debug("retrieved stored repo, falling through", log.String("stored", fmt.Sprintf("%v", stored)))
 		fallthrough
 	case 1: // Existing repo, update.
+		wasDeleted := !stored[0].DeletedAt.IsZero()
 		s.ObsvCtx.Logger.Debug("existing repo")
 		if err := UpdateRepoLicenseHook(ctx, tx, stored[0], sourced); err != nil {
 			return types.RepoSyncDiff{}, LicenseError{errors.Wrapf(err, "syncer: failed to update repo %s", sourced.Name)}
@@ -739,8 +740,13 @@ func (s *Syncer) sync(ctx context.Context, svc *types.ExternalService, sourced *
 		}
 
 		*sourced = *stored[0]
-		d.Modified = append(d.Modified, types.RepoModified{Repo: stored[0], Modified: modified})
-		s.ObsvCtx.Logger.Debug("appended to modified repos")
+		if wasDeleted {
+			d.Added = append(d.Added, stored[0])
+			s.ObsvCtx.Logger.Debug("revived soft-deleted repo")
+		} else {
+			d.Modified = append(d.Modified, types.RepoModified{Repo: stored[0], Modified: modified})
+			s.ObsvCtx.Logger.Debug("appended to modified repos")
+		}
 	case 0: // New repo, create.
 		s.ObsvCtx.Logger.Debug("new repo")
 


### PR DESCRIPTION
In the code host syncing stats, repos that were "undeleted" from our soft-deletion state on sync showed up as modified which feels weird. This fixes it and makes it so that they get counted as added repos instead.

## Test plan

CI and manually verified that they now show in the UI correctly. 