### PR TITLE
Improve GQL ratelimits

### DIFF
--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -130,7 +130,10 @@ func EstimateQueryCost(query string, variables map[string]any) (totalCost *Query
 		}
 		totalCost.FieldCount += cost.FieldCount
 		totalCost.AliasCount += cost.AliasCount
-		totalCost.HighestDuplicateFieldCount += cost.HighestDuplicateFieldCount
+
+		if cost.HighestDuplicateFieldCount > totalCost.HighestDuplicateFieldCount {
+			totalCost.HighestDuplicateFieldCount = cost.HighestDuplicateFieldCount
+		}
 		totalCost.UniqueFieldCount += cost.UniqueFieldCount
 		if totalCost.MaxDepth < cost.MaxDepth {
 			totalCost.MaxDepth = cost.MaxDepth

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -23,12 +23,12 @@ import (
 const costEstimateVersion = 2
 
 type QueryCost struct {
-	FieldCount             int
-	MaxDepth               int
-	MaxDuplicateFieldCount int // TODO implement in schema
-	MaxUniqueFieldCount    int // TODO implement in schema
-	AliasCount             int
-	Version                int
+	FieldCount                 int
+	MaxDepth                   int
+	HighestDuplicateFieldCount int
+	UniqueFieldCount           int
+	AliasCount                 int
+	Version                    int
 }
 
 // EstimateQueryCost estimates the cost of the query before it is actually
@@ -80,7 +80,7 @@ func EstimateQueryCost(query string, variables map[string]any) (totalCost *Query
 
 	// Calculate fragment costs first as we'll need them for the overall operation
 	// cost.
-	fragmentCosts := make(map[string]int)
+	fragmentCosts := make(map[string]QueryCost)
 	// Fragments can reference other fragments so we need their dependencies.
 	fragmentDeps := make(map[string]map[string]struct{})
 
@@ -115,7 +115,7 @@ func EstimateQueryCost(query string, variables map[string]any) (totalCost *Query
 			if err != nil {
 				return nil, errors.Wrap(err, "calculating fragment cost")
 			}
-			fragmentCosts[frag.Name.Value] = cost.FieldCount
+			fragmentCosts[frag.Name.Value] = *cost
 			fragSeen[frag.Name.Value] = struct{}{}
 		}
 		if len(fragSeen) == len(fragments) {
@@ -130,6 +130,8 @@ func EstimateQueryCost(query string, variables map[string]any) (totalCost *Query
 		}
 		totalCost.FieldCount += cost.FieldCount
 		totalCost.AliasCount += cost.AliasCount
+		totalCost.HighestDuplicateFieldCount += cost.HighestDuplicateFieldCount
+		totalCost.UniqueFieldCount += cost.UniqueFieldCount
 		if totalCost.MaxDepth < cost.MaxDepth {
 			totalCost.MaxDepth = cost.MaxDepth
 		}
@@ -145,14 +147,14 @@ func EstimateQueryCost(query string, variables map[string]any) (totalCost *Query
 	return totalCost, nil
 }
 
-func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[string]any) (*QueryCost, error) {
+func calcNodeCost(def ast.Node, fragmentCosts map[string]QueryCost, variables map[string]any) (*QueryCost, error) {
 	// NOTE: When we encounter errors in our visit funcs we return
 	// visitor.ActionBreak to stop walking the tree and set the top level err
 	// variable so that it is returned
 	var visitErr error
 
 	if fragmentCosts == nil {
-		fragmentCosts = make(map[string]int)
+		fragmentCosts = make(map[string]QueryCost)
 	}
 	inlineFragmentDepth := 0
 	var inlineFragments []string
@@ -164,6 +166,8 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 
 	aliasCount := 0
 	fieldCount := 0
+	duplicateFieldCount := 0
+	uniqueFieldCount := 0
 	depth := 0
 	maxDepth := 0
 	multiplier := 1
@@ -187,6 +191,7 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 	defaultValues := make(map[string]any)
 
 	countNodes := make(map[string]int)
+	uniqueFields := make(map[string]struct{})
 
 	v := &visitor.VisitorOptions{
 		Enter: func(p visitor.VisitFuncParams) (string, any) {
@@ -201,16 +206,16 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 				if node.Alias != nil {
 					aliasCount++
 				}
+
+				if _, f := uniqueFields[node.Name.Value]; !f {
+					uniqueFields[node.Name.Value] = struct{}{}
+				}
+				countNodes[node.Name.Value]++
+
 				switch node.Name.Value {
 				// Values that won't appear in the result
 				case "nodes", "__typename":
 					return visitor.ActionNoChange, nil
-				default:
-					countNodes[node.Name.Value]++
-					if countNodes[node.Name.Value] > 500 {
-						// TODO return error instead of panic
-						panic("foo")
-					}
 				}
 				if inlineFragmentDepth > 0 {
 					// We don't count fields inside of inline fragments as we need to count all fragments
@@ -281,7 +286,13 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 					visitErr = errors.Errorf("unknown fragment %q", node.Name.Value)
 					return visitor.ActionBreak, nil
 				}
-				fieldCount += fragmentCost * multiplier
+				fieldCount += fragmentCost.FieldCount * multiplier
+				aliasCount += fragmentCost.AliasCount
+				uniqueFieldCount += fragmentCost.UniqueFieldCount
+
+				if fragmentCost.HighestDuplicateFieldCount > duplicateFieldCount {
+					duplicateFieldCount = fragmentCost.HighestDuplicateFieldCount
+				}
 			case *ast.InlineFragment:
 				inlineFragmentDepth++
 				// We calculate inline fragment costs and store them
@@ -291,7 +302,8 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 					visitErr = errors.Wrap(err, "calculating inline fragment cost")
 					return visitor.ActionBreak, nil
 				}
-				fragmentCosts[node.TypeCondition.Name.Value] = fragCost.FieldCount * multiplier
+				fragCost.FieldCount = fragCost.FieldCount * multiplier
+				fragmentCosts[node.TypeCondition.Name.Value] = *fragCost
 				inlineFragments = append(inlineFragments, node.TypeCondition.Name.Value)
 			}
 			return visitor.ActionNoChange, nil
@@ -314,15 +326,27 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 	var maxInlineFragmentCost int
 	for _, v := range inlineFragments {
 		fragCost := fragmentCosts[v]
-		if fragCost > maxInlineFragmentCost {
-			maxInlineFragmentCost = fragCost
+		if fragCost.FieldCount > maxInlineFragmentCost {
+			maxInlineFragmentCost = fragCost.FieldCount
 		}
 	}
 
+	for _, f := range countNodes {
+		if f > 1 && f > duplicateFieldCount {
+			duplicateFieldCount = f
+		}
+	}
+
+	if len(uniqueFields) > uniqueFieldCount {
+		uniqueFieldCount = len(uniqueFields)
+	}
+
 	return &QueryCost{
-		FieldCount: fieldCount + maxInlineFragmentCost,
-		MaxDepth:   maxDepth,
-		AliasCount: aliasCount,
+		FieldCount:                 fieldCount + maxInlineFragmentCost,
+		MaxDepth:                   maxDepth,
+		AliasCount:                 aliasCount,
+		HighestDuplicateFieldCount: duplicateFieldCount,
+		UniqueFieldCount:           uniqueFieldCount,
 	}, visitErr
 }
 

--- a/cmd/frontend/graphqlbackend/rate_limit_test.go
+++ b/cmd/frontend/graphqlbackend/rate_limit_test.go
@@ -30,8 +30,9 @@ query{
 }
 `,
 			want: QueryCost{
-				FieldCount: 2,
-				MaxDepth:   1,
+				FieldCount:       2,
+				UniqueFieldCount: 2,
+				MaxDepth:         1,
 			},
 		},
 		{
@@ -46,8 +47,9 @@ query SiteProductVersion {
             }
 `,
 			want: QueryCost{
-				FieldCount: 4,
-				MaxDepth:   2,
+				FieldCount:       4,
+				UniqueFieldCount: 4,
+				MaxDepth:         2,
 			},
 		},
 		{
@@ -64,8 +66,9 @@ query{
 }
 `,
 			want: QueryCost{
-				FieldCount: 22,
-				MaxDepth:   3,
+				FieldCount:       22,
+				UniqueFieldCount: 5,
+				MaxDepth:         3,
 			},
 		},
 		{
@@ -84,8 +87,9 @@ query fetchExternalServices($first: Int = 10){
 				"first": 5,
 			},
 			want: QueryCost{
-				FieldCount: 11,
-				MaxDepth:   3,
+				FieldCount:       11,
+				UniqueFieldCount: 4,
+				MaxDepth:         3,
 			},
 		},
 		{
@@ -102,8 +106,9 @@ query fetchExternalServices($first: Int = 10){
 `,
 			variables: map[string]any{},
 			want: QueryCost{
-				FieldCount: 21,
-				MaxDepth:   3,
+				FieldCount:       21,
+				UniqueFieldCount: 4,
+				MaxDepth:         3,
 			},
 		},
 		{
@@ -132,8 +137,10 @@ query StatusMessages {
  }
 `,
 			want: QueryCost{
-				FieldCount: 5,
-				MaxDepth:   2,
+				FieldCount:                 5,
+				UniqueFieldCount:           5,
+				HighestDuplicateFieldCount: 3,
+				MaxDepth:                   2,
 			},
 		},
 		{
@@ -151,8 +158,10 @@ query{
 }
 `,
 			want: QueryCost{
-				FieldCount: 2,
-				MaxDepth:   2,
+				FieldCount:                 2,
+				HighestDuplicateFieldCount: 2,
+				UniqueFieldCount:           3,
+				MaxDepth:                   2,
 			},
 		},
 		{
@@ -296,8 +305,10 @@ query Search($query: String!, $version: SearchVersion!, $patternType: SearchPatt
 }
 `,
 			want: QueryCost{
-				FieldCount: 50,
-				MaxDepth:   9,
+				FieldCount:                 50,
+				HighestDuplicateFieldCount: 10,
+				UniqueFieldCount:           51, // includes __typename which fieldcount skips
+				MaxDepth:                   9,
 			},
 		},
 		{
@@ -324,8 +335,9 @@ fragment FileDiffFields on FileDiff {
 }
 `,
 			want: QueryCost{
-				FieldCount: 7,
-				MaxDepth:   5,
+				FieldCount:       7,
+				MaxDepth:         5,
+				UniqueFieldCount: 5,
 			},
 			variables: map[string]any{
 				"base": "a46cf4a8b6dc42ea7b7b716e53c49dd3508a8678",
@@ -348,8 +360,9 @@ fragment BarFields on Bar {
 }
 `,
 			want: QueryCost{
-				FieldCount: 1,
-				MaxDepth:   1,
+				FieldCount:       1,
+				MaxDepth:         1,
+				UniqueFieldCount: 1,
 			},
 		},
 		{
@@ -372,8 +385,9 @@ fragment UsableFields on Usable {
 }
 `,
 			want: QueryCost{
-				FieldCount: 3,
-				MaxDepth:   2,
+				FieldCount:       3,
+				MaxDepth:         2,
+				UniqueFieldCount: 1,
 			},
 		},
 	} {

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -113,59 +113,68 @@ func serveGraphQL(logger log.Logger, schema *graphql.Schema, rlw graphqlbackend.
 		traceData.uid = uid
 		traceData.anonymous = anonymous
 
-		validationErrs := schema.ValidateWithVariables(params.Query, params.Variables)
-
 		var cost *graphqlbackend.QueryCost
 		var costErr error
 
 		// Don't attempt to estimate or rate limit a request that has failed validation
-		if len(validationErrs) == 0 {
-			cost, costErr = graphqlbackend.EstimateQueryCost(params.Query, params.Variables)
-			if costErr != nil {
-				logger.Debug("failed to estimate GraphQL cost",
-					log.Error(costErr))
-				traceData.costError = costErr
-			} else if cost != nil {
-				traceData.cost = cost
+		cost, costErr = graphqlbackend.EstimateQueryCost(params.Query, params.Variables)
+		if costErr != nil {
+			logger.Debug("failed to estimate GraphQL cost",
+				log.Error(costErr))
+			traceData.costError = costErr
+		} else if cost != nil {
+			traceData.cost = cost
 
-				// Track the cost distribution of requests in a histogram.
-				costHistogram.WithLabelValues(actorTypeLabel(isInternal, anonymous, requestSource)).Observe(float64(cost.FieldCount))
+			// Track the cost distribution of requests in a histogram.
+			costHistogram.WithLabelValues(actorTypeLabel(isInternal, anonymous, requestSource)).Observe(float64(cost.FieldCount))
 
-				rl := conf.RateLimits()
+			rl := conf.RateLimits()
 
-				if !isInternal && (cost.AliasCount > rl.GraphQLMaxAliases) {
-					return writeViolationError(w, "query exceeds maximum query cost")
+			if !isInternal && (cost.AliasCount > rl.GraphQLMaxAliases) {
+				return writeViolationError(w, "query exceeds maximum query cost")
+			}
+
+			if !isInternal && (cost.MaxDuplicateFieldCount > 500) { // TODO use defined from rate limits
+				return writeViolationError(w, "query exceeds maximum query cost")
+			}
+
+			// TODO add for unique as well: https://www.apollographql.com/docs/router/configuration/operation-limits/#max_root_fields
+
+			if !isInternal && (cost.FieldCount > rl.GraphQLMaxFieldCount) {
+				if envvar.SourcegraphDotComMode() { // temporarily logging queries that exceed field count limit on Sourcegraph.com
+					logger.Warn("GQL cost limit exceeded", log.String("query", params.Query))
 				}
 
-				if !isInternal && (cost.FieldCount > rl.GraphQLMaxFieldCount) {
-					if envvar.SourcegraphDotComMode() { // temporarily logging queries that exceed field count limit on Sourcegraph.com
-						logger.Warn("GQL cost limit exceeded", log.String("query", params.Query))
-					}
+				return writeViolationError(w, "query exceeds maximum query cost")
+			}
 
-					return writeViolationError(w, "query exceeds maximum query cost")
-				}
-
-				if rl, enabled := rlw.Get(); enabled {
-					limited, result, err := rl.RateLimit(r.Context(), uid, cost.FieldCount, graphqlbackend.LimiterArgs{
-						IsIP:          isIP,
-						Anonymous:     anonymous,
-						RequestName:   requestName,
-						RequestSource: requestSource,
-					})
-					if err != nil {
-						logger.Error("checking GraphQL rate limit", log.Error(err))
-						traceData.limitError = err
-					} else {
-						traceData.limited = limited
-						traceData.limitResult = result
-						if limited {
-							w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
-							w.WriteHeader(http.StatusTooManyRequests)
-							return nil
-						}
+			// Calculating the cost is cheaper than validating the schema. We calculate the cost first to prevent resource exhaustion.
+			if rl, enabled := rlw.Get(); enabled {
+				limited, result, err := rl.RateLimit(r.Context(), uid, cost.FieldCount, graphqlbackend.LimiterArgs{
+					IsIP:          isIP,
+					Anonymous:     anonymous,
+					RequestName:   requestName,
+					RequestSource: requestSource,
+				})
+				if err != nil {
+					logger.Error("checking GraphQL rate limit", log.Error(err))
+					traceData.limitError = err
+				} else {
+					traceData.limited = limited
+					traceData.limitResult = result
+					if limited {
+						w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
+						w.WriteHeader(http.StatusTooManyRequests)
+						return nil
 					}
 				}
 			}
+		}
+
+		validationErrs := schema.ValidateWithVariables(params.Query, params.Variables)
+		if len(validationErrs) > 0 {
+			// TODO IMPROVE MESSAGE
+			return errors.Wrap(err, "failed to marshal GraphQL response")
 		}
 
 		traceData.execStart = time.Now()

--- a/doc/api/graphql/index.md
+++ b/doc/api/graphql/index.md
@@ -102,7 +102,9 @@ To ensure system performance and stability, configurable GraphQL query cost limi
   "rateLimits": {
     "graphQLMaxAliases": 500,
     "graphQLMaxDepth": 30,
-    "graphQLMaxFieldCount": 500000
+    "graphQLMaxFieldCount": 500000,
+    "graphQLMaxDuplicateFieldCount": 500,
+    "graphQLMaxUniqueFieldCount": 500
   },
 ```
 
@@ -117,3 +119,11 @@ To ensure system performance and stability, configurable GraphQL query cost limi
 ### GraphQLMaxAliases
 - **Default Value**: 500
 - Sets a cap on the number of aliases in a single GraphQL query, mitigating the risk of resource-intensive queries due to excessive aliasing.
+
+### GraphqlMaxDuplicateFieldCount
+- **Default Value**: 500
+- Limits the number of duplicate fields in a GraphQL query to prevent queries with unnecessary duplication from consuming excessive resources.
+
+### GraphqlMaxUniqueFieldCount
+- **Default Value**: 500
+- Restricts the number of unique fields in a GraphQL query to prevent queries with unnecessary broadness from consuming excessive resources.

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -461,7 +461,6 @@ func PasswordPolicyEnabled() bool {
 }
 
 func RateLimits() schema.RateLimits {
-	// TODO add default for new variables
 	rl := schema.RateLimits{
 		GraphQLMaxAliases:             500,
 		GraphQLMaxFieldCount:          500_000,

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -463,9 +463,11 @@ func PasswordPolicyEnabled() bool {
 func RateLimits() schema.RateLimits {
 	// TODO add default for new variables
 	rl := schema.RateLimits{
-		GraphQLMaxAliases:    500,
-		GraphQLMaxFieldCount: 500_000,
-		GraphQLMaxDepth:      30,
+		GraphQLMaxAliases:             500,
+		GraphQLMaxFieldCount:          500_000,
+		GraphQLMaxDepth:               30,
+		GraphQLMaxDuplicateFieldCount: 500,
+		GraphQLMaxUniqueFieldCount:    500,
 	}
 
 	configured := Get().RateLimits

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -461,6 +461,7 @@ func PasswordPolicyEnabled() bool {
 }
 
 func RateLimits() schema.RateLimits {
+	// TODO add default for new variables
 	rl := schema.RateLimits{
 		GraphQLMaxAliases:    500,
 		GraphQLMaxFieldCount: 500_000,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2095,8 +2095,12 @@ type RateLimits struct {
 	GraphQLMaxAliases int `json:"graphQLMaxAliases,omitempty"`
 	// GraphQLMaxDepth description: Maximum depth of nested objects allowed for GraphQL queries. Changes to this setting require a restart.
 	GraphQLMaxDepth int `json:"graphQLMaxDepth,omitempty"`
+	// GraphQLMaxDuplicateFieldCount description: Maximum number of duplicate fields allowed in a GraphQL request
+	GraphQLMaxDuplicateFieldCount int `json:"graphQLMaxDuplicateFieldCount,omitempty"`
 	// GraphQLMaxFieldCount description: Maximum number of estimated fields allowed in a GraphQL response
 	GraphQLMaxFieldCount int `json:"graphQLMaxFieldCount,omitempty"`
+	// GraphQLMaxUniqueFieldCount description: Maximum number of unique fields allowed in a GraphQL request
+	GraphQLMaxUniqueFieldCount int `json:"graphQLMaxUniqueFieldCount,omitempty"`
 }
 
 // RepoPurgeWorker description: Configuration for repository purge worker.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -73,6 +73,16 @@
           "description": "Maximum number of estimated fields allowed in a GraphQL response",
           "type": "integer",
           "default": 500000
+        },
+        "graphQLMaxDuplicateFieldCount": {
+          "description": "Maximum number of duplicate fields allowed in a GraphQL request",
+          "type": "integer",
+          "default": 500
+        },
+        "graphQLMaxUniqueFieldCount": {
+          "description": "Maximum number of unique fields allowed in a GraphQL request",
+          "type": "integer",
+          "default": 500
         }
       }
     },


### PR DESCRIPTION
This will allow us to tweak our GraphQL rate limiting in more detail for overly large queries. We've added more restrictions for duplicate and unique field count. In addition to these restriction we now calculate the query cost before validating the query against the schema. The validation is quit heavy and could still lead to resource exhaustion.

See https://github.com/sourcegraph/security-issues/issues/375 for more context.

Changes: 
- Calculates QueryCost before validating the schema
- Extended QueryCost struct with new metrics
- Updated fragment cost tracking
- Added tracking of duplicate/unique fields
- Updated tests

## Test plan
CI tests, local tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
