### PR TITLE
Openid state improvements

### DIFF
--- a/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -196,6 +196,7 @@ func TestMiddleware(t *testing.T) {
 			req = req.WithContext(actor.WithActor(context.Background(), &actor.Actor{UID: mockUserID}))
 		}
 		respRecorder := httptest.NewRecorder()
+		session.SetData(respRecorder, req, "oidcState", validState)
 		authedHandler.ServeHTTP(respRecorder, req)
 		return respRecorder.Result()
 	}
@@ -388,6 +389,7 @@ func TestMiddleware_NoOpenRedirect(t *testing.T) {
 			req.AddCookie(cookie)
 		}
 		respRecorder := httptest.NewRecorder()
+		session.SetData(respRecorder, req, "oidcState", state)
 		authedHandler.ServeHTTP(respRecorder, req)
 		return respRecorder.Result()
 	}

--- a/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
+++ b/cmd/frontend/internal/auth/sourcegraphoperator/middleware.go
@@ -69,11 +69,11 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, safeErrMsg, http.StatusInternalServerError)
 				return
 			}
-			openidconnect.RedirectToAuthRequest(w, r, p, stateCookieName, r.URL.Query().Get("redirect"))
+			openidconnect.RedirectToAuthRequest(w, r, p, r.URL.Query().Get("redirect"))
 			return
 
 		case "/callback": // Endpoint for the OIDC Authorization Response, see http://openid.net/specs/openid-connect-core-1_0.html#AuthResponse.
-			result, safeErrMsg, errStatus, err := openidconnect.AuthCallback(db, r, stateCookieName, usernamePrefix, GetOIDCProvider)
+			result, safeErrMsg, errStatus, err := openidconnect.AuthCallback(db, r, usernamePrefix, GetOIDCProvider)
 			if err != nil {
 				logger.Error("failed to authenticate with Sourcegraph Operator", log.Error(err))
 				http.Error(w, safeErrMsg, errStatus)


### PR DESCRIPTION
We longer store the state in the cookie, but we now use redis.

## Test plan
CI tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
