### PR TITLE
Don't show time in the past for next sync at

### DIFF
--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -3,6 +3,7 @@ import { type FC, useCallback, useState } from 'react'
 import { useApolloClient } from '@apollo/client'
 import { mdiCircle, mdiCog, mdiDelete } from '@mdi/js'
 import classNames from 'classnames'
+import { isBefore, parseISO } from 'date-fns'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { asError, isErrorLike, pluralize } from '@sourcegraph/common'
@@ -102,7 +103,13 @@ export const ExternalServiceNode: FC<ExternalServiceNodeProps> = ({ node, editin
                                 )}{' '}
                                 {node.nextSyncAt !== null && (
                                     <>
-                                        Next sync scheduled <Timestamp date={node.nextSyncAt} />.
+                                        Next sync scheduled{' '}
+                                        {isBefore(new Date(), parseISO(node.nextSyncAt)) ? (
+                                            <>now</>
+                                        ) : (
+                                            <Timestamp date={node.nextSyncAt} />
+                                        )}
+                                        .
                                     </>
                                 )}
                                 {node.nextSyncAt === null && <>No next sync scheduled.</>}


### PR DESCRIPTION
In the list of external services, for services that are overdue on scheduling, or are currently syncing but haven't finished yet we show things like "Next sync scheduled 30 minutes ago". This makes it a little less confusing as to what that means by saying "Next sync scheduled now" instead.

## Test plan

Manually tested.