### PR TITLE
Backport setting for gitserver bandwidth from sourcegraph.com

### DIFF
--- a/cmd/gitserver/internal/gitservice.go
+++ b/cmd/gitserver/internal/gitservice.go
@@ -24,8 +24,8 @@ import (
 var (
 	envGitServiceMaxEgressBytesPerSecond = env.Get(
 		"SRC_GIT_SERVICE_MAX_EGRESS_BYTES_PER_SECOND",
-		"1000000000",
-		"Git service egress rate limit in bytes per second (-1 = no limit, default = 1Gbps)")
+		"10000000000",
+		"Git service egress rate limit in bytes per second (-1 = no limit, default = 10Gbps)")
 
 	// gitServiceMaxEgressBytesPerSecond must be retrieved by getGitServiceMaxEgressBytesPerSecond,
 	// which parses envGitServiceMaxEgressBytesPerSecond once and logs any error encountered
@@ -41,7 +41,7 @@ func getGitServiceMaxEgressBytesPerSecond(logger log.Logger) int64 {
 		var err error
 		gitServiceMaxEgressBytesPerSecond, err = strconv.ParseInt(envGitServiceMaxEgressBytesPerSecond, 10, 64)
 		if err != nil {
-			gitServiceMaxEgressBytesPerSecond = 1000 * 1000 * 1000 // 1Gbps
+			gitServiceMaxEgressBytesPerSecond = 10 * 1000 * 1000 * 1000 // 1G0bps
 			logger.Error("failed parsing SRC_GIT_SERVICE_MAX_EGRESS_BYTES_PER_SECOND, defaulting to 1Gbps",
 				log.Int64("bps", gitServiceMaxEgressBytesPerSecond),
 				log.Error(err))


### PR DESCRIPTION
We tested this forever on dotcom and no issue with it. Let's bump it here.

## Test plan

Was tested on dotcom for a while.