### PR TITLE
fix useProjectService TypeScript ESLint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,8 +43,8 @@ const config = {
     ecmaFeatures: {
       jsx: true,
     },
-    EXPERIMENTAL_projectService: true,
-    project: __dirname + '/tsconfig.all.json',
+    EXPERIMENTAL_useProjectService: true,
+    project: true,
   },
   settings: {
     react: {


### PR DESCRIPTION
It seems the correct config is actually `EXPERIMENTAL_useProjectService`, as documented in https://typescript-eslint.io/blog/parser-options-project-true#project-services. The former was "working" because of the `process.env.TYPESCRIPT_ESLINT_EXPERIMENTAL_TSSERVER = 'true'` line.

## Test plan

CI