### PR TITLE
ci: preview commands show computed VERSION

### DIFF
--- a/dev/ci/gen-pipeline.go
+++ b/dev/ci/gen-pipeline.go
@@ -82,6 +82,8 @@ func main() {
 func previewPipeline(w io.Writer, c ci.Config, pipeline *buildkite.Pipeline) {
 	fmt.Fprintf(w, "- **Detected run type:** %s\n", c.RunType.String())
 	fmt.Fprintf(w, "- **Detected diffs:** %s\n", c.Diff.String())
+	fmt.Fprintf(w, "- **Computed variables:**\n")
+	fmt.Fprintf(w, "  - VERSION=%s\n", c.Version)
 	fmt.Fprintf(w, "- **Computed build steps:**\n")
 	printPipeline(w, "", pipeline)
 }


### PR DESCRIPTION
It's quite useful to see what will be the `$VERSION` when previewing a pipeline, and it's a really easy change.

## Test plan

Locally tested + CI 

```
~/work/other U main $ sg ci preview
If the current branch were to be pushed, the following pipeline would be run:

                                                                                                                                                                                              
  • Detected run type: Main branch                                                                                                                                                            
  • Detected diffs: None                                                                                                                                                                      
  • Computed variables:                                                                                                                                                                       
    • VERSION=00000_2023-11-27_5.2-123456789012                                                                                                                                               
  • Computed build steps:                                                                                                                                                                     
    • Image builds                                                                                                                                                                            
      • :bazel::docker: 🚧 Build Docker images                                                                                                                                                
      • :packer: 🚧 Build executor image     
(...)                              
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
