### PR TITLE
Add datname property to SQL statement

### DIFF
--- a/cmd/frontend/internal/cli/autoupgrade.go
+++ b/cmd/frontend/internal/cli/autoupgrade.go
@@ -327,7 +327,7 @@ func heartbeatLoop(logger log.Logger, db database.DB) (func(), error) {
 
 func checkForDisconnects(ctx context.Context, _ log.Logger, db database.DB) (remaining []string, err error) {
 	query := sqlf.Sprintf(`SELECT DISTINCT(application_name) FROM pg_stat_activity
-			WHERE application_name <> '' AND application_name <> %s AND application_name <> 'psql'`,
+	WHERE application_name <> '' AND application_name <> %s AND application_name <> 'psql' AND datname <> '' AND datname <> %s`,
 		appName)
 	store := basestore.NewWithHandle(db.Handle())
 	remaining, err = basestore.ScanStrings(store.Query(ctx, query))


### PR DESCRIPTION
This PR adds the datname row to make sure we exclude rows with empty database names and also database names assed in a parameter

## Test plan
Tested locally.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
