### PR TITLE
bzl: add gcloud/gsutil to //dev/tools

### DIFF
--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -1,3 +1,5 @@
+"Third party dev tooling dependencies"
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 DOCSITE_VERSION = "1.9.4"
@@ -12,7 +14,18 @@ filegroup(
 )
 """
 
+GCLOUD_VERSION = "415.0.0"
+GCLOUD_BUILDFILE = """package(default_visibility = ["//visibility:public"])\nexports_files(["gcloud", "gsutil", "bq", "git-credential-gcloud"])"""
+GCLOUD_PATCH_CMDS = [
+    "ln -s google-cloud-sdk/bin/gcloud gcloud",
+    "ln -s google-cloud-sdk/bin/gsutil gsutil",
+    "ln -s google-cloud-sdk/bin/bq bq",
+    "ln -s google-cloud-sdk/bin/git-credential-gcloud.sh git-credential-gcloud",
+]
+
 def tool_deps():
+    "Repository rules to fetch third party tooling used for dev purposes"
+
     # Docsite #
     http_file(
         name = "docsite_darwin_amd64",
@@ -81,4 +94,28 @@ def tool_deps():
         sha256 = "e99b942754ce9d55c9445513236c010753d26decbb38ed932780bec098ac0809",
         url = "https://storage.googleapis.com/universal_ctags/x86_64-linux/dist/universal-ctags-{0}".format(CTAGS_VERSION),
         executable = True,
+    )
+
+    http_archive(
+        name = "gcloud-darwin-arm64",
+        build_file_content = GCLOUD_BUILDFILE,
+        patch_cmds = GCLOUD_PATCH_CMDS,
+        sha256 = "974ed4f37f8bde2f7a9731eba90b033f7c97d24d835ecc62b58eee87c8f29776",
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{}-darwin-arm.tar.gz".format(GCLOUD_VERSION),
+    )
+
+    http_archive(
+        name = "gcloud-darwin-amd64",
+        build_file_content = GCLOUD_BUILDFILE,
+        patch_cmds = GCLOUD_PATCH_CMDS,
+        sha256 = "f05cc45ffc6c1f3ff73854989f3ea3d6bee40287d23047917e4c845aeb027f98",
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{}-darwin-x86_64.tar.gz".format(GCLOUD_VERSION),
+    )
+
+    http_archive(
+        name = "gcloud-linux-amd64",
+        build_file_content = GCLOUD_BUILDFILE,
+        patch_cmds = GCLOUD_PATCH_CMDS,
+        sha256 = "5f9ed1862a82f393be3b16634309e9e8edb6da13a8704952be9c4c59963f9cd4",
+        url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{}-linux-x86_64.tar.gz".format(GCLOUD_VERSION),
     )

--- a/dev/tools/BUILD.bazel
+++ b/dev/tools/BUILD.bazel
@@ -27,3 +27,23 @@ sh_binary(
     }),
     visibility = ["//visibility:public"],
 )
+
+sh_binary(
+    name = "gcloud",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin_x86_64": ["@gcloud-darwin-amd64//:gcloud"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["@gcloud-darwin-arm64//:gcloud"],
+        "@bazel_tools//src/conditions:linux_x86_64": ["@gcloud-linux-amd64//:gcloud"],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "gsutil",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin_x86_64": ["@gcloud-darwin-amd64//:gsutil"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["@gcloud-darwin-arm64//:gsutil"],
+        "@bazel_tools//src/conditions:linux_x86_64": ["@gcloud-linux-amd64//:gsutil"],
+    }),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
As I was looking at migrating to bazel some scripts involving packer, we also need `gcloud` in there, which ultimately is also needed for local tooling. 

## Test plan

CI + local:

Running `gsutil` exactly like I would normally yields the same output: 

```
~/work/other U jh/bzl-gcloud $ bazel run //dev/tools:gsutil -- ls gs://schemas-migrations/dist/schemas-v5.2.1.tar.gz
INFO: Analyzed target //dev/tools:gsutil (1 packages loaded, 2 targets configured).
INFO: Found 1 target...
Target //dev/tools:gsutil up-to-date:
  bazel-bin/dev/tools/gsutil
Aspect @rules_rust//rust/private:clippy.bzl%rust_clippy_aspect of //dev/tools:gsutil up-to-date (nothing to build)
INFO: Elapsed time: 0.119s, Critical Path: 0.02s
INFO: 5 processes: 5 internal.
INFO: Build completed successfully, 5 total actions
INFO: Running command line: bazel-bin/dev/tools/gsutil ls gs://schemas-migrations/dist/schemas-v5.2.1.tar.gz
gs://schemas-migrations/dist/schemas-v5.2.1.tar.gz
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
