### PR TITLE
aspect+ci: omit bazel tests when running as part of the aspect workflow pipeline

### DIFF
--- a/dev/ci/internal/buildkite/buildkite.go
+++ b/dev/ci/internal/buildkite/buildkite.go
@@ -74,12 +74,11 @@ type Group struct {
 }
 
 type BuildOptions struct {
-	Message     string            `json:"message,omitempty"`
-	Commit      string            `json:"commit,omitempty"`
-	Branch      string            `json:"branch,omitempty"`
-	MetaData    map[string]any    `json:"meta_data,omitempty"`
-	Env         map[string]string `json:"env,omitempty"`
-	AspectBuild bool
+	Message  string            `json:"message,omitempty"`
+	Commit   string            `json:"commit,omitempty"`
+	Branch   string            `json:"branch,omitempty"`
+	MetaData map[string]any    `json:"meta_data,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
 }
 
 func (bo BuildOptions) MarshalJSON() ([]byte, error) {

--- a/dev/ci/internal/buildkite/buildkite.go
+++ b/dev/ci/internal/buildkite/buildkite.go
@@ -74,11 +74,12 @@ type Group struct {
 }
 
 type BuildOptions struct {
-	Message  string            `json:"message,omitempty"`
-	Commit   string            `json:"commit,omitempty"`
-	Branch   string            `json:"branch,omitempty"`
-	MetaData map[string]any    `json:"meta_data,omitempty"`
-	Env      map[string]string `json:"env,omitempty"`
+	Message     string            `json:"message,omitempty"`
+	Commit      string            `json:"commit,omitempty"`
+	Branch      string            `json:"branch,omitempty"`
+	MetaData    map[string]any    `json:"meta_data,omitempty"`
+	Env         map[string]string `json:"env,omitempty"`
+	AspectBuild bool
 }
 
 func (bo BuildOptions) MarshalJSON() ([]byte, error) {

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -15,16 +15,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func BazelOperations(buildOpts bk.BuildOptions, isMain bool) []operations.Operation {
+func BazelOperations(buildOpts bk.BuildOptions, opts CoreTestOperationsOptions) []operations.Operation {
 	ops := []operations.Operation{}
-	if buildOpts.OmitBazel {
-		return ops
-	}
 	ops = append(ops, bazelPrechecks())
-	if isMain {
-		ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test", "//testing:grpc_backend_integration_test"))
-	} else {
-		ops = append(ops, bazelTest("//...", "//client/web:test"))
+	if !opts.AspectWorkflows {
+		if opts.IsMainBranch {
+			ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test", "//testing:grpc_backend_integration_test"))
+		} else {
+			ops = append(ops, bazelTest("//...", "//client/web:test"))
+		}
 	}
 
 	ops = append(ops, triggerBackCompatTest(buildOpts), bazelGoModTidy())

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -186,14 +186,15 @@ func triggerBackCompatTest(buildOpts bk.BuildOptions, isAspectWorkflows bool) fu
 	}
 	return func(pipeline *bk.Pipeline) {
 		steps := []bk.StepOpt{
-			bk.Async(true),
 			bk.Key("trigger-backcompat"),
 			bk.AllowDependencyFailure(),
 			bk.Build(buildOpts),
 		}
 
 		if !isAspectWorkflows {
-			steps = append(steps, bk.DependsOn("bazel-prechecks"))
+			steps = append(steps, bk.Async(true), bk.DependsOn("bazel-prechecks"))
+		} else {
+			steps = append(steps, bk.Async(false))
 		}
 		pipeline.AddTrigger(":bazel::snail: Async BackCompat Tests", "sourcegraph-backcompat", steps...)
 	}

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -181,17 +181,19 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 }
 
 func triggerBackCompatTest(buildOpts bk.BuildOptions, isAspectWorkflows bool) func(*bk.Pipeline) {
+	if isAspectWorkflows {
+		buildOpts.Message += " (Aspect)"
+	}
 	return func(pipeline *bk.Pipeline) {
 		steps := []bk.StepOpt{
+			bk.Async(true),
 			bk.Key("trigger-backcompat"),
 			bk.AllowDependencyFailure(),
 			bk.Build(buildOpts),
 		}
 
 		if !isAspectWorkflows {
-			steps = append(steps, bk.Async(true), bk.DependsOn("bazel-prechecks"))
-		} else {
-			steps = append(steps, bk.Async(false))
+			steps = append(steps, bk.DependsOn("bazel-prechecks"))
 		}
 		pipeline.AddTrigger(":bazel::snail: Async BackCompat Tests", "sourcegraph-backcompat", steps...)
 	}

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -26,7 +26,8 @@ func BazelOperations(buildOpts bk.BuildOptions, opts CoreTestOperationsOptions) 
 		}
 	}
 
-	ops = append(ops, triggerBackCompatTest(buildOpts), bazelGoModTidy())
+	runBackcompatAsync := !opts.AspectWorkflows
+	ops = append(ops, triggerBackCompatTest(buildOpts, runBackcompatAsync), bazelGoModTidy())
 	return ops
 }
 
@@ -180,9 +181,10 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 	}
 }
 
-func triggerBackCompatTest(buildOpts bk.BuildOptions) func(*bk.Pipeline) {
+func triggerBackCompatTest(buildOpts bk.BuildOptions, async bool) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddTrigger(":bazel::snail: Async BackCompat Tests", "sourcegraph-backcompat",
+			bk.Async(async),
 			bk.Key("trigger-backcompat"),
 			bk.DependsOn("bazel-prechecks"),
 			bk.AllowDependencyFailure(),

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -17,8 +17,8 @@ import (
 
 func BazelOperations(buildOpts bk.BuildOptions, opts CoreTestOperationsOptions) []operations.Operation {
 	ops := []operations.Operation{}
-	ops = append(ops, bazelPrechecks())
 	if !opts.AspectWorkflows {
+		ops = append(ops, bazelPrechecks())
 		if opts.IsMainBranch {
 			ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test", "//testing:grpc_backend_integration_test"))
 		} else {
@@ -345,7 +345,7 @@ func legacyBuildCandidateDockerImage(app string, version string, tag string, rt 
 		cmds = append(cmds,
 			bk.Key(candidateImageStepKey(app)),
 			bk.Env("VERSION", version),
-			bk.Agent("queue", "stateless"),
+			bk.Agent("queue", "bazel"),
 		)
 
 		// Allow all build scripts to emit info annotations

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -181,9 +181,6 @@ func bazelTest(targets ...string) func(*bk.Pipeline) {
 }
 
 func triggerBackCompatTest(buildOpts bk.BuildOptions, isAspectWorkflows bool) func(*bk.Pipeline) {
-	if !isAspectWorkflows {
-		buildOpts.Message += " (Aspect)"
-	}
 	return func(pipeline *bk.Pipeline) {
 		steps := []bk.StepOpt{
 			bk.Key("trigger-backcompat"),

--- a/dev/ci/internal/ci/operations.go
+++ b/dev/ci/internal/ci/operations.go
@@ -28,6 +28,9 @@ type CoreTestOperationsOptions struct {
 	CreateBundleSizeDiff bool // for addWebAppEnterpriseBuild
 
 	IsMainBranch bool
+
+	// AspectWorkflows is set to true when we generate steps as part of the Aspect Workflows pipeline
+	AspectWorkflows bool
 }
 
 // CoreTestOperations is a core set of tests that should be run in most CI cases. More
@@ -45,7 +48,7 @@ func CoreTestOperations(buildOpts bk.BuildOptions, diff changed.Diff, opts CoreT
 	ops := operations.NewSet()
 
 	// Simple, fast-ish linter checks
-	ops.Append(BazelOperations(buildOpts, opts.IsMainBranch)...)
+	ops.Append(BazelOperations(buildOpts, opts)...)
 	linterOps := operations.NewNamedSet("Linters and static analysis")
 	if targets := changed.GetLinterTargets(diff); len(targets) > 0 {
 		linterOps.Append(addSgLints(targets))

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -89,7 +89,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 	// We generate the pipeline slightly differently when running as part of the Aspect Workflows pipeline.
 	// Primarily, we don't run any `bazel test` since Aspect has got that covered
-	isAspectWorkflowBuild := os.Getenv("ASPECT_WORKFLOWS_BUILD") != "1"
+	isAspectWorkflowBuild := os.Getenv("ASPECT_WORKFLOWS_BUILD") == "1"
 
 	// Test upgrades from mininum upgradeable Sourcegraph version - updated by release tool
 	const minimumUpgradeableVersion = "5.2.0"

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -143,9 +143,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			AspectWorkflows:           isAspectWorkflowBuild,
 		}))
 
-		securityOps := operations.NewNamedSet("Security Scanning")
-		securityOps.Append(sonarcloudScan())
-		ops.Merge(securityOps)
+		if !isAspectWorkflowBuild {
+			securityOps := operations.NewNamedSet("Security Scanning")
+			securityOps.Append(sonarcloudScan())
+			ops.Merge(securityOps)
+		}
 
 		// Wolfi package and base images
 		packageOps, baseImageOps := addWolfiOps(c)
@@ -293,9 +295,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		}))
 
 		// Security scanning - sonarcloud
-		securityOps := operations.NewNamedSet("Security Scanning")
-		securityOps.Append(sonarcloudScan())
-		ops.Merge(securityOps)
+		if isAspectWorkflowBuild {
+			securityOps := operations.NewNamedSet("Security Scanning")
+			securityOps.Append(sonarcloudScan())
+			ops.Merge(securityOps)
+		}
 
 		// Publish candidate images to dev registry
 		publishOpsDev := operations.NewNamedSet("Publish candidate images")

--- a/dev/ci/internal/ci/wolfi_operations.go
+++ b/dev/ci/internal/ci/wolfi_operations.go
@@ -113,7 +113,6 @@ func buildWolfiBaseImage(target string, tag string, dependOnPackages bool) (func
 			}),
 			// We want to run on the bazel queue, so we have a pretty minimal agent.
 			bk.Agent("queue", "bazel"),
-			bk.Env("DOCKER_BAZEL", "true"),
 			bk.Key(stepKey),
 			bk.SoftFail(222),
 		}


### PR DESCRIPTION
In addition to the normal aspect workflow steps, we aslo want to run our normal pipeline steps so that it is siimilar to our main pipeline.

Poor out one for my homies ... Aspect steps done in under 3 mins and then our steps came 📈 


## Test plan
Altered the steps of the Aspect pipeline as per the following

```yaml
steps:
  - key: aspect-workflows-setup
    label: ":aspect: Setup Aspect Workflows"
    commands:
      - "rosetta steps | buildkite-agent pipeline upload"
    agents:
      queue: aspect-default
  - key: sg-gen-pipeline
    label: ":pipeline: Generate pipeline"
    if: build.branch == "wb/bazel-aspect/gen-pipeline"
    commands:
      - "./dev/ci/gen-pipeline.sh"
    agents:
      queue: bazel
    env:
      ASPECT_WORKFLOWS_BUILD: "1"
```
![Screenshot 2023-11-27 at 17 21 33](https://github.com/sourcegraph/sourcegraph/assets/1001709/a2384d5a-6838-413f-bad8-da1f26ee60a2)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
