### PR TITLE
SSC: Add "rate limits exceeded" feature flag to aid client testing

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -482,6 +482,10 @@ func (r *schemaResolver) ChangeCodyPlan(ctx context.Context, args *changeCodyPla
 		return nil, errors.New("this feature is not enabled")
 	}
 
+	if featureflag.FromContext(ctx).GetBoolOr("rate-limits-exceeded-for-testing", false) {
+		return nil, errors.New("this user is not allowed to change their plan")
+	}
+
 	userID, err := UnmarshalUserID(args.User)
 	if err != nil {
 		return nil, err

--- a/internal/completions/httpapi/limiter.go
+++ b/internal/completions/httpapi/limiter.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"context"
 	"fmt"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"time"
 
 	"github.com/gomodule/redigo/redis"
@@ -90,7 +91,7 @@ func (r *rateLimiter) TryAcquire(ctx context.Context) (err error) {
 	// If the usage exceeds the maximum, we return an error. Consumers can check if
 	// the error is of type RateLimitExceededError and extract additional information
 	// like the limit and the time by when they should retry.
-	if currentUsage >= limit {
+	if currentUsage >= limit || featureflag.FromContext(ctx).GetBoolOr("rate-limits-exceeded-for-testing", false) {
 		// Read TTL to compute the RetryAfter time.
 		ttl, err := rstore.TTL(key)
 		if err != nil {


### PR DESCRIPTION
This PR creates the `rate-limits-exceeded-for-testing` feature flag and applies a limit=1 with interval=max(int32) for users that have the FF. This override takes precedence over all other types of limits, and applies both on dotcom and Cody Gateway.

## Test plan

@thenamankumar, please test this or let's test it together—again I'm not sure why, but my cURL requests to Gateway hang.

My test plan would be this:
- Enable feature flag
- Make sure the rate limit errors get triggered consistently. Test code completions, chat, and embeddings
- Disable feature flag
- Make sure rate limit errors don't get triggered

Note that Gateway-side caching might mess things up during this testing.