### PR TITLE
Code intel: remove introspection queries

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/lsif/providers.ts
+++ b/client/shared/src/codeintel/legacy-extensions/lsif/providers.ts
@@ -151,7 +151,7 @@ function references(
     textDocument: sourcegraph.TextDocument,
     position: sourcegraph.Position
 ) => AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {
-    return async function*(
+    return async function* (
         textDocument: sourcegraph.TextDocument,
         position: sourcegraph.Position
     ): AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {
@@ -206,7 +206,7 @@ function implementations(
     textDocument: sourcegraph.TextDocument,
     position: sourcegraph.Position
 ) => AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {
-    return async function*(
+    return async function* (
         textDocument: sourcegraph.TextDocument,
         position: sourcegraph.Position
     ): AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {

--- a/client/shared/src/codeintel/legacy-extensions/lsif/providers.ts
+++ b/client/shared/src/codeintel/legacy-extensions/lsif/providers.ts
@@ -1,11 +1,8 @@
-import { once } from 'lodash'
-
 import * as scip from '../../scip'
 import type * as sourcegraph from '../api'
 import type { Logger } from '../logging'
 import type { CombinedProviders, DefinitionAndHover } from '../providers'
 import { cache } from '../util'
-import { API } from '../util/api'
 import { queryGraphQL as sgQueryGraphQL, type QueryGraphQLFn } from '../util/graphql'
 import { asyncGeneratorFromPromise } from '../util/ix'
 import { raceWithDelayOffset } from '../util/promise'
@@ -26,10 +23,7 @@ import { makeStencilFn, type StencilFn } from './stencil'
 export function createProviders(hasImplementationsField: boolean, logger: Logger): CombinedProviders {
     const providers = createGraphQLProviders(
         sgQueryGraphQL,
-        makeStencilFn(
-            sgQueryGraphQL,
-            once(() => new API().hasStencils())
-        ),
+        makeStencilFn(sgQueryGraphQL),
         makeRangeWindowFactory(hasImplementationsField, sgQueryGraphQL)
     )
 
@@ -157,7 +151,7 @@ function references(
     textDocument: sourcegraph.TextDocument,
     position: sourcegraph.Position
 ) => AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {
-    return async function* (
+    return async function*(
         textDocument: sourcegraph.TextDocument,
         position: sourcegraph.Position
     ): AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {
@@ -212,7 +206,7 @@ function implementations(
     textDocument: sourcegraph.TextDocument,
     position: sourcegraph.Position
 ) => AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {
-    return async function* (
+    return async function*(
         textDocument: sourcegraph.TextDocument,
         position: sourcegraph.Position
     ): AsyncGenerator<sourcegraph.Location[] | null, void, undefined> {

--- a/client/shared/src/codeintel/legacy-extensions/lsif/stencil.ts
+++ b/client/shared/src/codeintel/legacy-extensions/lsif/stencil.ts
@@ -40,5 +40,5 @@ const stencilQuery = gql`
 export type StencilFn = (uri: string) => Promise<sourcegraph.Range[] | undefined>
 
 export const makeStencilFn = (
-    queryGraphQL: QueryGraphQLFn<GenericLSIFResponse<{ stencil: sourcegraph.Range[] }>>,
+    queryGraphQL: QueryGraphQLFn<GenericLSIFResponse<{ stencil: sourcegraph.Range[] }>>
 ): StencilFn => cache(uri => stencil(uri, queryGraphQL), { max: 10 })

--- a/client/shared/src/codeintel/legacy-extensions/lsif/stencil.ts
+++ b/client/shared/src/codeintel/legacy-extensions/lsif/stencil.ts
@@ -8,13 +8,8 @@ import { type GenericLSIFResponse, queryLSIF } from './api'
 
 export const stencil = async (
     uri: string,
-    hasStencilSupport: () => Promise<boolean>,
     queryGraphQL: QueryGraphQLFn<GenericLSIFResponse<{ stencil: sourcegraph.Range[] }>> = sgQueryGraphQL
 ): Promise<sourcegraph.Range[] | undefined> => {
-    if (!(await hasStencilSupport())) {
-        return undefined
-    }
-
     const response = await queryLSIF({ query: stencilQuery, uri }, queryGraphQL)
     return response?.stencil
 }
@@ -46,5 +41,4 @@ export type StencilFn = (uri: string) => Promise<sourcegraph.Range[] | undefined
 
 export const makeStencilFn = (
     queryGraphQL: QueryGraphQLFn<GenericLSIFResponse<{ stencil: sourcegraph.Range[] }>>,
-    hasStencilSupport: () => Promise<boolean> = () => Promise.resolve(true)
-): StencilFn => cache(uri => stencil(uri, hasStencilSupport, queryGraphQL), { max: 10 })
+): StencilFn => cache(uri => stencil(uri, queryGraphQL), { max: 10 })

--- a/client/shared/src/codeintel/legacy-extensions/search/providers.test.ts
+++ b/client/shared/src/codeintel/legacy-extensions/search/providers.test.ts
@@ -139,9 +139,6 @@ describe('search providers', () => {
         const stubResolveRepo = sinon.stub(api, 'resolveRepo')
         stubResolveRepo.callsFake(repo => Promise.resolve({ name: repo, isFork, isArchived, id }))
 
-        const stubHasLocalCodeIntelField = sinon.stub(api, 'hasLocalCodeIntelField')
-        stubHasLocalCodeIntelField.callsFake(() => Promise.resolve(true))
-
         const stubFindSymbol = sinon.stub(api, 'findLocalSymbol')
         stubFindSymbol.callsFake(() => Promise.resolve(undefined))
 

--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -1,4 +1,3 @@
-import { once } from 'lodash'
 import gql from 'tagged-template-noop'
 
 import { isErrorLike } from '@sourcegraph/common'
@@ -86,21 +85,13 @@ export class API {
         }
 
         const metaRequest = (async (name: string): Promise<RepoMeta> => {
-            const queryWithFork = gql`
+            const query = gql`
                 query LegacyResolveRepo($name: String!) {
                     repository(name: $name) {
                         id
                         name
                         isFork
                         isArchived
-                    }
-                }
-            `
-
-            const queryWithoutFork = gql`
-                query LegacyResolveRepo2($name: String!) {
-                    repository(name: $name) {
-                        name
                     }
                 }
             `
@@ -114,7 +105,7 @@ export class API {
                 }
             }
 
-            const data = await queryGraphQL<Response>((await this.hasForkField()) ? queryWithFork : queryWithoutFork, {
+            const data = await queryGraphQL<Response>(query, {
                 name,
             })
 
@@ -130,107 +121,6 @@ export class API {
 
         return metaRequest
     }
-
-    /**
-     * Determines via introspection if the GraphQL API has isFork field on the Repository type.
-     *
-     * TODO(efritz) - Remove this when we no longer need to support pre-3.15 instances.
-     */
-    private async hasForkField(): Promise<boolean> {
-        const introspectionQuery = gql`
-            query LegacyRepositoryIntrospection {
-                __type(name: "Repository") {
-                    fields {
-                        name
-                    }
-                }
-            }
-        `
-
-        interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
-        }
-
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
-            field => field.name === 'isFork'
-        )
-    }
-
-    /**
-     * Determines via introspection if the GraphQL API has local code intelligence available
-     *
-     * TODO(chrismwendt) - Remove this when we no longer need to support versions without local code
-     * intelligence
-     */
-    public hasLocalCodeIntelField = once(async () => {
-        const introspectionQuery = gql`
-            query LegacyLocalCodeIntelIntrospectionQuery {
-                __type(name: "GitBlob") {
-                    fields {
-                        name
-                    }
-                }
-            }
-        `
-
-        interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
-        }
-
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
-            field => field.name === 'localCodeIntel'
-        )
-    })
-
-    /**
-     * Determines via introspection if the GraphQL API has symbol info available
-     *
-     * TODO(chrismwendt) - Remove this when we no longer need to support versions without symbol info
-     */
-    public hasSymbolInfo = once(async () => {
-        const introspectionQuery = gql`
-            query LegacySymbolInfoIntrospectionQuery {
-                __type(name: "GitBlob") {
-                    fields {
-                        name
-                    }
-                }
-            }
-        `
-
-        interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
-        }
-
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
-            field => field.name === 'symbolInfo'
-        )
-    })
-
-    /**
-     * Determines via introspection if the GraphQL API has symbolInfo.range available
-     *
-     * TODO(chrismwendt) - Remove this when we no longer need to support versions without symbolInfo.range
-     */
-    public hasSymbolLocationRange = once(async () => {
-        const introspectionQuery = gql`
-            query LegacySymbolLocationRangeIntrospectionQuery {
-                __type(name: "SymbolLocation") {
-                    fields {
-                        name
-                    }
-                }
-            }
-        `
-
-        interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
-        }
-
-        return (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type.fields.some(
-            field => field.name === 'range'
-        )
-    })
 
     public fetchLocalCodeIntelPayload = cache(
         async ({ repo, commit, path }: RepoCommitPath): Promise<LocalCodeIntelPayload | undefined> => {
@@ -260,10 +150,6 @@ export class API {
         document: sourcegraph.TextDocument,
         position: sourcegraph.Position
     ): Promise<LocalSymbol | undefined> => {
-        if (!(await this.hasLocalCodeIntelField())) {
-            return
-        }
-
         const { repo, commit, path } = parseGitURI(document.uri)
 
         const payload = await this.fetchLocalCodeIntelPayload({ repo, commit, path })
@@ -291,20 +177,12 @@ export class API {
         document: sourcegraph.TextDocument,
         position: sourcegraph.Position
     ): Promise<SymbolInfoCanonical | undefined> => {
-        if (!(await this.hasSymbolInfo())) {
-            return
-        }
-
-        const query = (await this.hasSymbolLocationRange())
-            ? symbolInfoDefinitionQueryWithRange
-            : symbolInfoDefinitionQueryWithoutRange
-
         const { repo, commit, path } = parseGitURI(document.uri)
 
         const vars = { repository: repo, commit, path, line: position.line, character: position.character }
         const response = await (async (): Promise<SymbolInfoResponse> => {
             try {
-                return await queryGraphQL<SymbolInfoResponse>(query, vars)
+                return await queryGraphQL<SymbolInfoResponse>(symbolInfoDefinitionQuery, vars)
             } catch (error) {
                 if (isKnownSquirrelErrorLike(error)) {
                     return { repository: null }
@@ -568,38 +446,16 @@ const symbolInfoFlexibleToCanonical = (flexible: SymbolInfoFlexible): SymbolInfo
         range:
             'line' in flexible.definition
                 ? {
-                      line: flexible.definition.line,
-                      character: flexible.definition.character,
-                      length: flexible.definition.length,
-                  }
+                    line: flexible.definition.line,
+                    character: flexible.definition.character,
+                    length: flexible.definition.length,
+                }
                 : flexible.definition.range,
     },
     hover: flexible.hover,
 })
 
-const symbolInfoDefinitionQueryWithoutRange = gql`
-    query LegacySymbolInfo($repository: String!, $commit: String!, $path: String!, $line: Int!, $character: Int!) {
-        repository(name: $repository) {
-            commit(rev: $commit) {
-                blob(path: $path) {
-                    symbolInfo(line: $line, character: $character) {
-                        definition {
-                            repo
-                            commit
-                            path
-                            line
-                            character
-                            length
-                        }
-                        hover
-                    }
-                }
-            }
-        }
-    }
-`
-
-const symbolInfoDefinitionQueryWithRange = gql`
+const symbolInfoDefinitionQuery = gql`
     query LegacySymbolInfo2($repository: String!, $commit: String!, $path: String!, $line: Int!, $character: Int!) {
         repository(name: $repository) {
             commit(rev: $commit) {

--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -418,10 +418,10 @@ const symbolInfoFlexibleToCanonical = (flexible: SymbolInfoFlexible): SymbolInfo
         range:
             'line' in flexible.definition
                 ? {
-                    line: flexible.definition.line,
-                    character: flexible.definition.character,
-                    length: flexible.definition.length,
-                }
+                      line: flexible.definition.line,
+                      character: flexible.definition.character,
+                      length: flexible.definition.length,
+                  }
                 : flexible.definition.range,
     },
     hover: flexible.hover,

--- a/client/shared/src/codeintel/legacy-extensions/util/api.ts
+++ b/client/shared/src/codeintel/legacy-extensions/util/api.ts
@@ -251,34 +251,6 @@ export class API {
         })
         return data.search.results.results.filter(isDefined)
     }
-
-    /**
-     * Determines via introspection if the GraphQL API supports stencils
-     *
-     * TODO(chrismwendt) - Remove this when we no longer need to support Sourcegraph versions that don't
-     * have stencil support
-     */
-    public async hasStencils(): Promise<boolean> {
-        const introspectionQuery = gql`
-            query LegacyStencilIntrospectionQuery {
-                __type(name: "GitBlobLSIFData") {
-                    fields {
-                        name
-                    }
-                }
-            }
-        `
-
-        interface IntrospectionResponse {
-            __type: { fields: { name: string }[] }
-        }
-
-        return Boolean(
-            (await queryGraphQL<IntrospectionResponse>(introspectionQuery)).__type?.fields.some(
-                field => field.name === 'stencil'
-            )
-        )
-    }
 }
 
 function buildSearchQuery(fileLocal: boolean): string {

--- a/client/web/src/integration/codemirror-blob-view.test.ts
+++ b/client/web/src/integration/codemirror-blob-view.test.ts
@@ -372,7 +372,7 @@ function createBlobPageData<T extends BlobInfo>({
         WebGraphQlOperations,
         'ResolveRepoRev' | 'FileTreeEntries' | 'FileExternalLinks' | 'Blob' | 'FileNames'
     > &
-        Pick<SharedGraphQlOperations, 'TreeEntries' | 'LegacyRepositoryIntrospection' | 'LegacyResolveRepo2'>
+        Pick<SharedGraphQlOperations, 'TreeEntries' | 'LegacyResolveRepo2'>
     filePaths: { [k in keyof T]: string }
 } {
     const repositorySourcegraphUrl = `/${repoName}`
@@ -399,15 +399,6 @@ function createBlobPageData<T extends BlobInfo>({
                         __typename: 'GitCommit',
                         fileNames,
                     },
-                },
-            }),
-            LegacyRepositoryIntrospection: () => ({
-                __type: {
-                    fields: [
-                        {
-                            name: 'noFork',
-                        },
-                    ],
                 },
             }),
             LegacyResolveRepo2: () => ({

--- a/client/web/src/integration/codemirror-blob-view.test.ts
+++ b/client/web/src/integration/codemirror-blob-view.test.ts
@@ -372,7 +372,7 @@ function createBlobPageData<T extends BlobInfo>({
         WebGraphQlOperations,
         'ResolveRepoRev' | 'FileTreeEntries' | 'FileExternalLinks' | 'Blob' | 'FileNames'
     > &
-        Pick<SharedGraphQlOperations, 'TreeEntries' | 'LegacyResolveRepo2'>
+        Pick<SharedGraphQlOperations, 'TreeEntries'>
     filePaths: { [k in keyof T]: string }
 } {
     const repositorySourcegraphUrl = `/${repoName}`
@@ -399,12 +399,6 @@ function createBlobPageData<T extends BlobInfo>({
                         __typename: 'GitCommit',
                         fileNames,
                     },
-                },
-            }),
-            LegacyResolveRepo2: () => ({
-                repository: {
-                    id: repoName,
-                    name: repoName,
                 },
             }),
         },


### PR DESCRIPTION
These introspection queries are leftover from a time when this code was in extensions and we didn't know what version of the server was running. Now that it is part of the bundled javascript, we can remove the GraphQL introspection since we can guarantee we've got the version as the server. 

## Test plan

CI and some clicking/hovering around