### PR TITLE
Code Navigation: show full tree context

### DIFF
--- a/client/shared/src/settings/settings.tsx
+++ b/client/shared/src/settings/settings.tsx
@@ -308,6 +308,7 @@ const defaultFeatures: SettingsExperimentalFeatures = {
     showMultilineSearchConsole: false,
     codeMonitoringWebHooks: true,
     showCodeMonitoringLogs: true,
+    showFullTreeContext: true,
     codeInsightsCompute: false,
     editor: 'codemirror6',
     codeInsightsRepoUI: 'search-query-or-strict-list',

--- a/client/shared/src/settings/settings.tsx
+++ b/client/shared/src/settings/settings.tsx
@@ -308,7 +308,7 @@ const defaultFeatures: SettingsExperimentalFeatures = {
     showMultilineSearchConsole: false,
     codeMonitoringWebHooks: true,
     showCodeMonitoringLogs: true,
-    showFullTreeContext: true,
+    showFullTreeContext: false,
     codeInsightsCompute: false,
     editor: 'codemirror6',
     codeInsightsRepoUI: 'search-query-or-strict-list',

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -6,7 +6,7 @@ import classNames from 'classnames'
 import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
-import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import type { RepoFile } from '@sourcegraph/shared/src/util/url'
 import {
@@ -63,7 +63,8 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
     const isWideScreen = useMatchMedia('(min-width: 768px)', false)
     const [isVisible, setIsVisible] = useState(persistedIsVisible && isWideScreen)
 
-    const [initialFilePath, setInitialFilePath] = useState<string>(props.filePath)
+    const showFullTreeContextEnabled = useExperimentalFeatures(features => features.showFullTreeContext)
+    const [initialFilePath, setInitialFilePath] = useState<string>(showFullTreeContextEnabled ? '' : props.filePath)
     const [initialFilePathIsDir, setInitialFilePathIsDir] = useState<boolean>(props.isDir)
     const onExpandParent = useCallback((parent: string) => {
         setInitialFilePath(parent)


### PR DESCRIPTION
Before, if a user refreshed the blobview after navigating to a file from the file tree, the full tree context would disappear, leading to a frustrating experience for some users. 

Now, users can choose if they'd like to show the full context of the file tree or not. See video: 

https://www.loom.com/share/afdea775679945fd9b42a4cfc817edb0

## Test plan
1. Manual testing