### PR TITLE
Add Cody Usage Metrics

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -5,19 +5,35 @@ import { mdiHelpCircleOutline, mdiTrendingUp, mdiDownload, mdiInformation } from
 import classNames from 'classnames'
 
 import { useQuery } from '@sourcegraph/http-client'
-import { Icon, PageHeader, Link, H4, H2, Text, ButtonLink, Modal, useSearchParameters } from '@sourcegraph/wildcard'
+import {
+    Icon,
+    PageHeader,
+    Link,
+    H4,
+    H2,
+    Text,
+    ButtonLink,
+    Modal,
+    useSearchParameters,
+    LoadingSpinner,
+} from '@sourcegraph/wildcard'
 
 import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
 import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
-import type { UserCodyPlanResult, UserCodyPlanVariables } from '../../graphql-operations'
+import type {
+    UserCodyPlanResult,
+    UserCodyPlanVariables,
+    UserCodyUsageResult,
+    UserCodyUsageVariables,
+} from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
 import { CodyColorIcon } from '../chat/CodyPageIcon'
 import { isCodyEnabled } from '../isCodyEnabled'
-import { CodyOnboarding, editorGroups, IEditor } from '../onboarding/CodyOnboarding'
+import { CodyOnboarding, editorGroups, type IEditor } from '../onboarding/CodyOnboarding'
 import { ProTierIcon } from '../subscription/CodySubscriptionPage'
-import { USER_CODY_PLAN } from '../subscription/queries'
+import { USER_CODY_PLAN, USER_CODY_USAGE } from '../subscription/queries'
 
 import styles from './CodyManagementPage.module.scss'
 
@@ -35,6 +51,8 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
     }, [utm_source])
 
     const { data } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
+
+    const { data: usageData } = useQuery<UserCodyUsageResult, UserCodyUsageVariables>(USER_CODY_USAGE, {})
 
     const [isEnabled] = useFeatureFlag('cody-pro', false)
 
@@ -100,15 +118,21 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                     <Text weight="bold" className={classNames('d-inline mb-0', styles.counter)}>
                                         Unlimited
                                     </Text>
-                                ) : (
+                                ) : usageData?.currentUser ? (
                                     <>
                                         <Text weight="bold" className={classNames('d-inline mb-0', styles.counter)}>
-                                            345 /
+                                            {Math.min(
+                                                usageData?.currentUser?.codyCurrentPeriodCodeUsage || 0,
+                                                usageData?.currentUser?.codyCurrentPeriodCodeLimit || 0
+                                            )}{' '}
+                                            /
                                         </Text>{' '}
                                         <Text className="text-muted d-inline b-0" size="small">
-                                            500
+                                            {usageData?.currentUser?.codyCurrentPeriodCodeLimit || 0}
                                         </Text>
                                     </>
+                                ) : (
+                                    <LoadingSpinner />
                                 )}
                             </div>
                             <H4 className="mb-0">Autocompletes</H4>
@@ -125,15 +149,21 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                     <Text weight="bold" className={classNames('d-inline mb-0', styles.counter)}>
                                         Unlimited
                                     </Text>
-                                ) : (
+                                ) : usageData?.currentUser ? (
                                     <>
                                         <Text weight="bold" className={classNames('d-inline mb-0', styles.counter)}>
-                                            345 /
+                                            {Math.min(
+                                                usageData?.currentUser?.codyCurrentPeriodChatUsage || 0,
+                                                usageData?.currentUser?.codyCurrentPeriodChatLimit || 0
+                                            )}{' '}
+                                            /
                                         </Text>{' '}
                                         <Text className="text-muted d-inline b-0" size="small">
-                                            500
+                                            {usageData?.currentUser?.codyCurrentPeriodChatLimit || 0}
                                         </Text>
                                     </>
+                                ) : (
+                                    <LoadingSpinner />
                                 )}
                             </div>
                             <H4 className="mb-0">Chat Messages</H4>

--- a/client/web/src/cody/subscription/queries.tsx
+++ b/client/web/src/cody/subscription/queries.tsx
@@ -10,6 +10,18 @@ export const USER_CODY_PLAN = gql`
     }
 `
 
+export const USER_CODY_USAGE = gql`
+    query UserCodyUsage {
+        currentUser {
+            id
+            codyCurrentPeriodChatUsage
+            codyCurrentPeriodCodeUsage
+            codyCurrentPeriodChatLimit
+            codyCurrentPeriodCodeLimit
+        }
+    }
+`
+
 export const CHANGE_CODY_PLAN = gql`
     mutation ChangeCodyPlan($id: ID!, $pro: Boolean!) {
         changeCodyPlan(user: $id, pro: $pro) {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6555,6 +6555,14 @@ type User implements Node & SettingsSubject & Namespace {
     The count of Cody code completions in the current billing period.
     """
     codyCurrentPeriodCodeUsage: Int
+    """
+    The limit of Cody chats for the current billing period.
+    """
+    codyCurrentPeriodChatLimit: Int
+    """
+    The limit of Cody code completions for the current billing period.
+    """
+    codyCurrentPeriodCodeLimit: Int
 }
 
 """

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -192,6 +192,38 @@ func (r *UserResolver) CodyProEnabled(ctx context.Context) bool {
 	return r.CodyProEnabledAt(ctx) != nil
 }
 
+func (r *UserResolver) CodyCurrentPeriodChatLimit(ctx context.Context) (*int32, error) {
+	if !envvar.SourcegraphDotComMode() {
+		return nil, errors.New("this feature is only available on sourcegraph.com")
+	}
+
+	if r.user.CodyProEnabledAt != nil {
+		return nil, nil
+	}
+
+	cfg := conf.GetCompletionsConfig(conf.Get().SiteConfig())
+
+	limit := int32(cfg.PerCommunityUserChatMonthlyInteractionLimit)
+
+	return &limit, nil
+}
+
+func (r *UserResolver) CodyCurrentPeriodCodeLimit(ctx context.Context) (*int32, error) {
+	if !envvar.SourcegraphDotComMode() {
+		return nil, errors.New("this feature is only available on sourcegraph.com")
+	}
+
+	if r.user.CodyProEnabledAt != nil {
+		return nil, nil
+	}
+
+	cfg := conf.GetCompletionsConfig(conf.Get().SiteConfig())
+
+	limit := int32(cfg.PerCommunityUserCodeCompletionsMonthlyInteractionLimit)
+
+	return &limit, nil
+}
+
 func (r *UserResolver) CodyCurrentPeriodChatUsage(ctx context.Context) (*int32, error) {
 	if !envvar.SourcegraphDotComMode() {
 		return nil, errors.New("this feature is only available on sourcegraph.com")


### PR DESCRIPTION
This PR links the Cody Manage page UI with the usage metrics API merged previously. It additionally adds an API exposing limits as well. 

![CleanShot 2023-11-28 at 19 09 07@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/a9f3902f-6380-421f-94d3-509f932707cf)


## Test plan
- chat with cody on any client connected to sg instance running in dotcom mode
- check /cody/manage for counters
