### PR TITLE
completions/codygateway: fix actor propagation

### DIFF
--- a/internal/completions/client/codygateway/codygateway.go
+++ b/internal/completions/client/codygateway/codygateway.go
@@ -123,7 +123,7 @@ func gatewayDoer(upstream httpcli.Doer, feature types.CompletionsFeature, gatewa
 		// but it doesn't seem to work.
 		resp, err := (&actor.HTTPTransport{
 			RoundTripper: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-				return upstream.Do(req)
+				return upstream.Do(r)
 			}),
 		}).RoundTrip(req)
 


### PR DESCRIPTION
Some discussion around transport misuse in https://github.com/sourcegraph/sourcegraph/pull/58016#discussion_r1397367483 caused me to preemptively add `req.Clone` calls in our transport implementations to adhere by Go documentation to not mutate requests in RoundTripper. This broke the actor propagation to Cody Gateway because so far, it has only worked by _accidentally_ using a mutated request, and with cloning, the original request is not mutated to include the appropriate headers.

This change correctly uses the parameterized request in the Cody Gateway client, which has been cloned and mutated by the actor transport.

There is an outstanding TODO here that I never addressed for why we are using this hack - will revisit after https://github.com/sourcegraph/sourcegraph/pull/58279

## Test plan

There are test cases on actor transport that covers this exact pattern: https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/actor/http_test.go?L46:1-57:5