### PR TITLE
Auto-update Wolfi base images to latest (#58322)

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -34,19 +34,19 @@ load("@rules_oci//oci:pull.bzl", "oci_pull")
 def oci_deps():
     oci_pull(
         name = "wolfi_base",
-        digest = "sha256:ddac091c8c7aa8672c3ad097fc0df016f5cf86a2e5e5e915a5e6f0327b2cc48e",
+        digest = "sha256:04fe3ffb3ccee7a6b5a958e9b68696d1df65402597473edd86e32eb9c1482178",
         image = "index.docker.io/sourcegraph/wolfi-sourcegraph-base",
     )
 
     oci_pull(
         name = "wolfi_cadvisor_base",
-        digest = "sha256:d20378947f0b7df72ee6166a70ccf3839c7547dfe918a02f920ee5d4cb031f62",
+        digest = "sha256:97c40d7556aa59709d5b6fbfc1055271dbdd6a05b7c3dce052edf8959696602e",
         image = "index.docker.io/sourcegraph/wolfi-cadvisor-base",
     )
 
     oci_pull(
         name = "wolfi_symbols_base",
-        digest = "sha256:d699c86891e976b68a7e4611951a90400805db552e222750e04cf3f846e09a2a",
+        digest = "sha256:ff850ff119266997b8a1be28c212b68d5d3049f0576e39777b05f11c49df06e6",
         image = "index.docker.io/sourcegraph/wolfi-symbols-base",
     )
 
@@ -70,133 +70,133 @@ def oci_deps():
 
     oci_pull(
         name = "wolfi_postgres_exporter_base",
-        digest = "sha256:109a393c6bc3e5db15413ddb913890fdd26f0531a225ff12aedf5021f57c5bd0",
+        digest = "sha256:d87b630de2a16291f6644c501a25376513eddb778416a201e40945b18d91a96a",
         image = "index.docker.io/sourcegraph/wolfi-postgres-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_all_in_one_base",
-        digest = "sha256:0be08d4aa088c945f1cbdf6d69a618d3b803786e21d540d24d0ca6a2f7a9a044",
+        digest = "sha256:6ef2ca500d978d37dd20d0010a020935534b681f19ebde3843c4c75935cb0af0",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-all-in-one-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_agent_base",
-        digest = "sha256:7486c7418c6905f84cc95b2bb58ab3fa0779033d5da3045217ecf96c211bed7d",
+        digest = "sha256:87d0549c5f3365688644b5dbbb44abc82eb683ae31fb089dd17b413a0df3c3bb",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-agent-base",
     )
 
     oci_pull(
         name = "wolfi_redis_base",
-        digest = "sha256:8ecedf267d9d017f7defe0ce9de7596b6e0f8d3dc434e4e54069d07a7f1d6f2f",
+        digest = "sha256:dabedab967e27330d474ed4eb0f47d7954a07b8a86f7fcdb3b7830865c16c9b4",
         image = "index.docker.io/sourcegraph/wolfi-redis-base",
     )
 
     oci_pull(
         name = "wolfi_redis_exporter_base",
-        digest = "sha256:b60ee6c59823598a4bf6ff9e97a887947cb7b1a925d67f30e0448adcd540743b",
+        digest = "sha256:0ed382bc737790879b643b67ab48bf183418aee290605189925340e8dbd9c8a1",
         image = "index.docker.io/sourcegraph/wolfi-redis-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_syntax_highlighter_base",
-        digest = "sha256:874544e9e2ac04ac3e7004437b55882b96e4f9b444f81d359afb89361c01c8a9",
+        digest = "sha256:9e0bbaeed967ef87e3e9499962d0fae997f0d4446f68df00c4a60063f4e8e0c9",
         image = "index.docker.io/sourcegraph/wolfi-syntax-highlighter-base",
     )
 
     oci_pull(
         name = "wolfi_search_indexer_base",
-        digest = "sha256:26c41915424166a79b4e622d2b804ef28409df9d10123b05722467911e15550b",
+        digest = "sha256:036b552907944acd986f6140b7165facdd15a99a630fba852fb7907b762f2f23",
         image = "index.docker.io/sourcegraph/wolfi-search-indexer-base",
     )
 
     oci_pull(
         name = "wolfi_repo_updater_base",
-        digest = "sha256:69890df98e79031d3cb8bdb1b91d25eec585d987d9c3a77b7b2034f5f233107b",
+        digest = "sha256:288f60d65ad281516c030bdc03beb6d437ce0a7bead37a10a039e606a72b3708",
         image = "index.docker.io/sourcegraph/wolfi-repo-updater-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:b4a4b8a0afe40c514b62ab7e9f0e4b499f193e0ea7d22dc3b702b34ad2781799",
+        digest = "sha256:9529888fa1cb0abe5806ce3b466523ae53518d12178640953e9a7d039bbe26f9",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_executor_base",
-        digest = "sha256:82b3d39633915ddff0ba45a9c04eb627e10d0b2e698ede36386240faa91c5a29",
+        digest = "sha256:17adec2e52fd5dc9a89d86b5224684c66b76380b2db9db10f6426bf83be26923",
         image = "index.docker.io/sourcegraph/wolfi-executor-base",
     )
 
     # ???
     oci_pull(
         name = "wolfi_bundled_executor_base",
-        digest = "sha256:414df1099deb034bd46aa10432a2571fa342b129a3e59fde20c2bd63e84c4ca2",
+        digest = "sha256:2ec4c35a901a919b50722d82f1d0eb19cfc341cacec85acac3b059eb4b864e87",
         image = "index.docker.io/sourcegraph/wolfi-bundled-executor-base",
     )
 
     oci_pull(
         name = "wolfi_executor_kubernetes_base",
-        digest = "sha256:ceb89c7b756b0134a8d512be72276e7d536921fb2619117059970c5d252389fd",
+        digest = "sha256:94921f555efcd91ff75e22fdb5f24de035a1688b2e05a5f0506f7c13f12e4ef0",
         image = "index.docker.io/sourcegraph/wolfi-executor-kubernetes-base",
     )
 
     oci_pull(
         name = "wolfi_batcheshelper_base",
-        digest = "sha256:bc26a76ce432e2d2263024d7e285ef9a28801fba0e23f2c1f71d56d6a30bc2a6",
+        digest = "sha256:e6c96b4d0ac78d6982fa903b2c4936d65def1a5da144f3c2fd3d1513318e1550",
         image = "index.docker.io/sourcegraph/wolfi-batcheshelper-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_base",
-        digest = "sha256:75ea7711988255d037e6d6239d915d1d2594452fc343b0b98bfec014c6b6fa9a",
+        digest = "sha256:e0abf1763ac6967451ff1239744b320ff08c09bcc50bb1cc67b43eb3419bd5c0",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_gcp_base",
-        digest = "sha256:be32b3432ab03a153461bee8c604b23413cf28c978556c30a483f8630f491b82",
+        digest = "sha256:b7318f12e19caea342a5d2e9c4fae5d46eb50e804fc48bded6b11c7e642ddae1",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-gcp-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12_base",
-        digest = "sha256:94cc57d7d62443784dc113ca6fdf072f4b3e58ec3636779b59dc9f96e238d56a",
+        digest = "sha256:8857309f8e3234782119d67880b1418943eaa8ca22b287c9ef71a6b982363844",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12-codeinsights_base",
-        digest = "sha256:4915ea39e5ab816f935f85cb7e2ace2824d4aade17525f8d9d2863f27f8f27e7",
+        digest = "sha256:6954a84e772195968e7ef053db811052af20a0f107783c6c494a53272629ab91",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-codeinsights-base",
     )
 
     oci_pull(
         name = "wolfi_node_exporter_base",
-        digest = "sha256:a0615019fe6961519c994cfe0de2b595571f9b79a3e60a58b9d452279bcee79a",
+        digest = "sha256:e9ea035b2446e75fb0d55c1372883b97dd8407c26fbad0485e5dc6e04cfcfbe9",
         image = "index.docker.io/sourcegraph/wolfi-node-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_opentelemetry_collector_base",
-        digest = "sha256:d23cae6f2fe2db4c229c3db5dcbee25dac95de8b6d8c857d409fbc7c797f660d",
+        digest = "sha256:58bdd2fe8bed1ba35f1e9e7522ea1c4aa35e654ced9e89f515236afa3e564bfc",
         image = "index.docker.io/sourcegraph/wolfi-opentelemetry-collector-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:b4a4b8a0afe40c514b62ab7e9f0e4b499f193e0ea7d22dc3b702b34ad2781799",
+        digest = "sha256:9529888fa1cb0abe5806ce3b466523ae53518d12178640953e9a7d039bbe26f9",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_s3proxy_base",
-        digest = "sha256:afec08789b60252c51163227e416a40deec5f34bce7b5db43b3f0647f7691ba5",
+        digest = "sha256:ad0c8791d1a9a3a2a2f7e30933da0aa031c55c3b5bc3263802fcee4d9d955031",
         image = "index.docker.io/sourcegraph/wolfi-blobstore-base",
     )
 
     oci_pull(
         name = "wolfi_qdrant_base",
-        digest = "sha256:1d9cb0e1eef19467bc7b42ef36f40571eb37abb5f6eeb04742717cc837050ae0",
+        digest = "sha256:dcc08b0228a5abd8a542efc7ee86ec58299591a737cafe19e92af6c1e1301c26",
         image = "index.docker.io/sourcegraph/wolfi-qdrant-base",
     )


### PR DESCRIPTION
Auto-update Wolfi base image hashes at 2023-11-28 03:10:20 UTC

Co-authored-by: Buildkite <buildkite@sourcegraph.com>
Co-authored-by: Mohammad Alam <mohammad.alam@sourcegraph.com>
(cherry picked from commit 411e0b7cb5a4ac1a3be4f589a06aedd211436b5c)

This PR updates wolfi base images but keeps the 2 images that are using a stable version of p4-fusion

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
CI checks pass
CVE check to resolve any pending CVEs