### PR TITLE
Add secondary telemetry for web app

### DIFF
--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -9,6 +9,7 @@ import { map } from 'rxjs/operators'
 import type { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -30,7 +31,7 @@ import { EmptyPanelView } from './views/EmptyPanelView'
 
 import styles from './TabbedPanelContent.module.scss'
 
-interface TabbedPanelContentProps extends PlatformContextProps, SettingsCascadeProps, TelemetryProps {
+interface TabbedPanelContentProps extends PlatformContextProps, SettingsCascadeProps, TelemetryProps, TelemetryV2Props {
     repoName?: string
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
 }
@@ -91,8 +92,11 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
     const [currentTabLabel, currentTabID] = hash.split('=')
 
     const trackTabClick = useCallback(
-        (title: string) => props.telemetryService.log(`ReferencePanelClicked${title}`),
-        [props.telemetryService]
+        (title: string) => {
+            props.telemetryService.log(`ReferencePanelClicked${title}`)
+            props.telemetryRecorder.recordEvent(`ReferencePanele${title}`, 'clicked')
+        },
+        [props.telemetryService, props.telemetryRecorder]
     )
 
     const panels: Panel[] | undefined = useObservable(

--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -14,6 +14,7 @@ import type { Badged } from '@sourcegraph/shared/src/codeintel/legacy-extensions
 import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
 import type { ContentMatch } from '@sourcegraph/shared/src/search/stream'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { parseRepoURI } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner, Alert, Icon } from '@sourcegraph/wildcard'
@@ -42,7 +43,7 @@ export const FileLocationsNoGroupSelected: React.FunctionComponent<React.PropsWi
     </div>
 )
 
-interface Props extends SettingsCascadeProps, TelemetryProps {
+interface Props extends SettingsCascadeProps, TelemetryProps, TelemetryV2Props {
     location: H.Location
     /**
      * The observable that emits the locations.
@@ -190,6 +191,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
             index={index}
             location={this.props.location}
             telemetryService={this.props.telemetryService}
+            telemetryRecorder={this.props.telemetryRecorder}
             defaultExpanded={true}
             result={referencesToContentMatch(uri, locationsByURI.get(uri)!)}
             onSelect={this.onSelect}

--- a/client/branded/src/search-ui/components/CopyPathAction.tsx
+++ b/client/branded/src/search-ui/components/CopyPathAction.tsx
@@ -4,6 +4,7 @@ import { mdiContentCopy } from '@mdi/js'
 import classNames from 'classnames'
 import copy from 'copy-to-clipboard'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
 
@@ -16,13 +17,15 @@ export const CopyPathAction: React.FunctionComponent<
     {
         filePath: string
         className?: string
-    } & TelemetryProps
-> = ({ filePath, className, telemetryService }) => {
+    } & TelemetryProps &
+        TelemetryV2Props
+> = ({ filePath, className, telemetryService, telemetryRecorder }) => {
     const [copied, setCopied] = useState(false)
 
     const onClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
         event.preventDefault()
         telemetryService.log('CopyFilePath')
+        telemetryRecorder.recordEvent('FilePath', 'copied')
         copy(filePath)
         setCopied(true)
         screenReaderAnnounce('Path copied to clipboard')

--- a/client/branded/src/search-ui/components/FileContentSearchResult.test.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.test.tsx
@@ -14,6 +14,7 @@ import {
 
 import '@sourcegraph/shared/src/testing/mockReactVisibilitySensor'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { FileContentSearchResult } from './FileContentSearchResult'
@@ -33,6 +34,7 @@ describe('FileContentSearchResult', () => {
         fetchHighlightedFileLineRanges: HIGHLIGHTED_FILE_LINES_REQUEST,
         settingsCascade: NOOP_SETTINGS_CASCADE,
         telemetryService: NOOP_TELEMETRY_SERVICE,
+        telemetryRecorder: noOpTelemetryRecorder,
     }
 
     it('renders one result container', () => {

--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -274,6 +274,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
                     fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                     settingsCascade={settingsCascade}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     openInNewTab={openInNewTab}
                 />
                 {collapsible && (

--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -18,6 +18,7 @@ import {
     getRevision,
 } from '@sourcegraph/shared/src/search/stream'
 import { isSettingsValid, type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Icon, Badge } from '@sourcegraph/wildcard'
 
@@ -29,7 +30,7 @@ import { ResultContainer } from './ResultContainer'
 import resultContainerStyles from './ResultContainer.module.scss'
 import styles from './SearchResult.module.scss'
 
-interface Props extends SettingsCascadeProps, TelemetryProps {
+interface Props extends SettingsCascadeProps, TelemetryProps, TelemetryV2Props {
     location: H.Location
     /**
      * The file match search result.
@@ -91,6 +92,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
     showAllMatches,
     openInNewTab,
     telemetryService,
+    telemetryRecorder,
     fetchHighlightedFileLineRanges,
     onSelect,
 }) => {
@@ -222,6 +224,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
                     className={styles.copyButton}
                     filePath={result.path}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             </span>
             {description && <span className={classNames('ml-2', styles.headerDescription)}>{description}</span>}

--- a/client/branded/src/search-ui/components/FilePathSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FilePathSearchResult.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import classNames from 'classnames'
 
 import { getFileMatchUrl, getRepositoryUrl, getRevision, type PathMatch } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { CopyPathAction } from './CopyPathAction'
@@ -19,14 +20,9 @@ export interface FilePathSearchResult {
     index: number
 }
 
-export const FilePathSearchResult: React.FunctionComponent<FilePathSearchResult & TelemetryProps> = ({
-    result,
-    repoDisplayName,
-    onSelect,
-    containerClassName,
-    index,
-    telemetryService,
-}) => {
+export const FilePathSearchResult: React.FunctionComponent<
+    FilePathSearchResult & TelemetryProps & TelemetryV2Props
+> = ({ result, repoDisplayName, onSelect, containerClassName, index, telemetryService, telemetryRecorder }) => {
     const repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
     const revisionDisplayName = getRevision(result.branches, result.commit)
 
@@ -46,7 +42,12 @@ export const FilePathSearchResult: React.FunctionComponent<FilePathSearchResult 
                 className={styles.titleInner}
                 isKeyboardSelectable={true}
             />
-            <CopyPathAction filePath={result.path} className={styles.copyButton} telemetryService={telemetryService} />
+            <CopyPathAction
+                filePath={result.path}
+                className={styles.copyButton}
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+            />
         </span>
     )
 

--- a/client/branded/src/search-ui/components/OwnerSearchResult.tsx
+++ b/client/branded/src/search-ui/components/OwnerSearchResult.tsx
@@ -8,6 +8,7 @@ import type { BuildSearchQueryURLParameters, QueryState, SearchContextProps } fr
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import { appendFilter, omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import { getOwnerMatchUrl, type OwnerMatch } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link } from '@sourcegraph/wildcard'
 
@@ -16,7 +17,10 @@ import { ResultContainer } from './ResultContainer'
 import styles from './OwnerSearchResult.module.scss'
 import resultStyles from './SearchResult.module.scss'
 
-export interface OwnerSearchResultProps extends Pick<SearchContextProps, 'selectedSearchContextSpec'>, TelemetryProps {
+export interface OwnerSearchResultProps
+    extends Pick<SearchContextProps, 'selectedSearchContextSpec'>,
+        TelemetryProps,
+        TelemetryV2Props {
     result: OwnerMatch
     onSelect: () => void
     containerClassName?: string

--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { EditorHint, type QueryState } from '@sourcegraph/shared/src/search'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -26,7 +27,7 @@ import { useQueryExamples, type QueryExamplesSection } from './useQueryExamples'
 
 import styles from './QueryExamples.module.scss'
 
-export interface QueryExamplesProps extends TelemetryProps {
+export interface QueryExamplesProps extends TelemetryProps, TelemetryV2Props {
     selectedSearchContextSpec?: string
     queryState?: QueryState
     setQueryState: (newState: QueryState) => void
@@ -55,6 +56,7 @@ export const queryToTip = (id: string | undefined): Tip | null => {
 export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
     selectedSearchContextSpec,
     telemetryService,
+    telemetryRecorder,
     queryState = { query: '' },
     setQueryState,
     isSourcegraphDotCom = false,
@@ -75,12 +77,18 @@ export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
             // Run search for dotcom longer query examples
             if (isSourcegraphDotCom && queryExampleTabActive) {
                 telemetryService.log('QueryExampleClicked', { queryExample: query }, { queryExample: query })
+                telemetryRecorder.recordEvent('QueryExample', 'clicked', {
+                    privateMetadata: { queryExample: query },
+                })
                 navigate(slug!)
             }
 
             setQueryState({ query: `${queryState.query} ${query}`.trimStart(), hint: EditorHint.Focus })
 
             telemetryService.log('QueryExampleClicked', { queryExample: query }, { queryExample: query })
+            telemetryRecorder.recordEvent('QueryExample', 'clicked', {
+                privateMetadata: { queryExample: query },
+            })
 
             // Clear any previously set timeout.
             if (selectTipTimeout) {
@@ -104,6 +112,7 @@ export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
         },
         [
             telemetryService,
+            telemetryRecorder,
             queryState.query,
             setQueryState,
             selectedTip,

--- a/client/branded/src/search-ui/components/SymbolSearchResult.tsx
+++ b/client/branded/src/search-ui/components/SymbolSearchResult.tsx
@@ -10,6 +10,7 @@ import { type HighlightLineRange, HighlightResponseFormat } from '@sourcegraph/s
 import { getFileMatchUrl, getRepositoryUrl, getRevision, type SymbolMatch } from '@sourcegraph/shared/src/search/stream'
 import { isSettingsValid, type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 
@@ -22,7 +23,7 @@ import { ResultContainer } from './ResultContainer'
 import searchResultStyles from './SearchResult.module.scss'
 import styles from './SymbolSearchResult.module.scss'
 
-export interface SymbolSearchResultProps extends TelemetryProps, SettingsCascadeProps {
+export interface SymbolSearchResultProps extends TelemetryProps, TelemetryV2Props, SettingsCascadeProps {
     result: SymbolMatch
     openInNewTab?: boolean
     repoDisplayName: string
@@ -40,6 +41,7 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
     containerClassName,
     index,
     telemetryService,
+    telemetryRecorder,
     settingsCascade,
     fetchHighlightedFileLineRanges,
 }) => {
@@ -68,6 +70,7 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
                 filePath={result.path}
                 className={searchResultStyles.copyButton}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
         </span>
     )
@@ -81,7 +84,8 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
 
     const logEventOnCopy = useCallback(() => {
         telemetryService.log(...codeCopiedEvent('file-match'))
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('file-match', 'copied')
+    }, [telemetryService, telemetryRecorder])
 
     const fetchSymbolMatchLineRanges = useCallback(
         (startLine: number, endLine: number, format: HighlightResponseFormat) => {
@@ -106,13 +110,16 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
                         { durationMs: endTime - startTime },
                         { durationMs: endTime - startTime }
                     )
+                    telemetryRecorder.recordEvent('search.latencies.frontend.code', 'loaded', {
+                        metadata: { durationMs: endTime - startTime },
+                    })
                     return lines[
                         result.symbols.findIndex(symbol => symbol.line - 1 === startLine && symbol.line === endLine)
                     ]
                 })
             )
         },
-        [result, fetchHighlightedFileLineRanges, telemetryService]
+        [result, fetchHighlightedFileLineRanges, telemetryService, telemetryRecorder]
     )
 
     const fetchHighlightedSymbolMatchLineRanges = useCallback(

--- a/client/branded/src/search-ui/input/SearchBox.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.tsx
@@ -15,6 +15,7 @@ import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import type { fetchStreamSuggestions as defaultFetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import type { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { type IEditor, LazyQueryInput, type LazyQueryInputProps } from './LazyQueryInput'
@@ -30,6 +31,7 @@ export interface SearchBoxProps
     extends Omit<TogglesProps, 'navbarSearchQuery' | 'submitSearch'>,
         SearchContextInputProps,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'requestGraphQL'>,
         Pick<
             LazyQueryInputProps,
@@ -151,6 +153,7 @@ export const SearchBox: FC<SearchBoxProps> = props => {
                             recentSearches={props.recentSearches ?? []}
                             onSelect={onSearchHistorySelect}
                             telemetryService={props.telemetryService}
+                            telemetryRecorder={props.telemetryRecorder}
                         />
                         <div className={styles.searchBoxSeparator} />
                     </>
@@ -221,6 +224,7 @@ export const SearchBox: FC<SearchBoxProps> = props => {
                     <SearchHelpDropdownButton
                         isSourcegraphDotCom={props.isSourcegraphDotCom}
                         telemetryService={props.telemetryService}
+                        telemetryRecorder={props.telemetryRecorder}
                     />
                 )}
             </div>

--- a/client/branded/src/search-ui/input/SearchContextDropdown.tsx
+++ b/client/branded/src/search-ui/input/SearchContextDropdown.tsx
@@ -7,6 +7,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import type { SearchContextInputProps, SubmitSearchProps } from '@sourcegraph/shared/src/search'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Code,
@@ -32,6 +33,7 @@ const popoverPadding = createRectangle(0, 0, 0, 2)
 export interface SearchContextDropdownProps
     extends SearchContextInputProps,
         TelemetryProps,
+        TelemetryV2Props,
         Partial<Pick<SubmitSearchProps, 'submitSearch'>>,
         PlatformContextProps<'requestGraphQL'> {
     query: string
@@ -56,6 +58,7 @@ export const SearchContextDropdown: FC<SearchContextDropdownProps> = props => {
         className,
         menuClassName,
         telemetryService,
+        telemetryRecorder,
         onEscapeMenuClose,
     } = props
 
@@ -90,8 +93,9 @@ export const SearchContextDropdown: FC<SearchContextDropdownProps> = props => {
 
             setIsOpen(false)
             telemetryService.log('SearchContextDropdownToggled')
+            telemetryRecorder.recordEvent('SearchContextDropdown', 'toggled')
         },
-        [onEscapeMenuClose, telemetryService]
+        [onEscapeMenuClose, telemetryService, telemetryRecorder]
     )
 
     const handlePopoverToggle = (event: PopoverOpenEvent): void => {
@@ -107,15 +111,18 @@ export const SearchContextDropdown: FC<SearchContextDropdownProps> = props => {
         }
 
         telemetryService.log('SearchContextDropdownToggled')
+        telemetryRecorder.recordEvent('SearchContextDropdown', 'toggled')
 
         if (isOpen && authenticatedUser) {
             // Log search context dropdown view event whenever dropdown is opened, if user is authenticated
             telemetryService.log('SearchContextsDropdownViewed')
+            telemetryRecorder.recordEvent('SearchContextDropdown', 'viewed')
         }
 
         if (isOpen && !authenticatedUser) {
             // Log CTA view event whenever dropdown is opened, if user is not authenticated
             telemetryService.log('SearchResultContextsCTAShown')
+            telemetryRecorder.recordEvent('SearchResultContextCTA', 'shown')
         }
     }
 

--- a/client/branded/src/search-ui/input/SearchHelpDropdownButton.tsx
+++ b/client/branded/src/search-ui/input/SearchHelpDropdownButton.tsx
@@ -3,6 +3,7 @@ import { useCallback, type FC } from 'react'
 import { mdiHelpCircleOutline, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     PopoverTrigger,
@@ -21,7 +22,7 @@ import {
 
 import styles from './SearchHelpDropdownButton.module.scss'
 
-interface SearchHelpDropdownButtonProps extends TelemetryProps {
+interface SearchHelpDropdownButtonProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom?: boolean
     className?: string
 }
@@ -31,11 +32,12 @@ interface SearchHelpDropdownButtonProps extends TelemetryProps {
  * syntax.
  */
 export const SearchHelpDropdownButton: FC<SearchHelpDropdownButtonProps> = props => {
-    const { isSourcegraphDotCom, className, telemetryService } = props
+    const { isSourcegraphDotCom, className, telemetryService, telemetryRecorder } = props
 
     const onQueryDocumentationLinkClicked = useCallback(() => {
         telemetryService.log('SearchHelpDropdownQueryDocsLinkClicked')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SearchHelpDropdownQueryDocsLink', 'clicked')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <Popover>

--- a/client/branded/src/search-ui/input/SearchHistoryDropdown.tsx
+++ b/client/branded/src/search-ui/input/SearchHistoryDropdown.tsx
@@ -13,6 +13,7 @@ import classNames from 'classnames'
 
 import { pluralize } from '@sourcegraph/common'
 import type { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     createRectangle,
@@ -33,7 +34,7 @@ import styles from './SearchHistoryDropdown.module.scss'
 
 const buttonContent: React.ReactElement = <Icon svgPath={mdiClockOutline} aria-hidden="true" />
 
-interface SearchHistoryDropdownProps extends TelemetryProps {
+interface SearchHistoryDropdownProps extends TelemetryProps, TelemetryV2Props {
     className?: string
     recentSearches: RecentSearch[]
     onSelect: (search: RecentSearch) => void
@@ -44,24 +45,26 @@ interface SearchHistoryDropdownProps extends TelemetryProps {
 const popoverPadding = createRectangle(0, 0, 0, 2)
 
 export const SearchHistoryDropdown: React.FunctionComponent<SearchHistoryDropdownProps> = React.memo(
-    function SearchHistoryDropdown({ recentSearches = [], onSelect, className, telemetryService }) {
+    function SearchHistoryDropdown({ recentSearches = [], onSelect, className, telemetryService, telemetryRecorder }) {
         const [isOpen, setIsOpen] = useState(false)
 
         const handlePopoverToggle = useCallback(
             (event: PopoverOpenEvent): void => {
                 setIsOpen(event.isOpen)
                 telemetryService.log(event.isOpen ? 'RecentSearchesListOpened' : 'RecentSearchesListDismissed')
+                telemetryRecorder.recordEvent('RecentSearchesList', event.isOpen ? 'opened' : 'dismissed')
             },
-            [telemetryService, setIsOpen]
+            [telemetryService, telemetryRecorder, setIsOpen]
         )
 
         const onSelectInternal = useCallback(
             (search: RecentSearch) => {
                 telemetryService.log('RecentSearchSelected')
+                telemetryRecorder.recordEvent('RecentSearch', 'selected')
                 onSelect(search)
                 setIsOpen(false)
             },
-            [telemetryService, onSelect, setIsOpen]
+            [telemetryService, telemetryRecorder, onSelect, setIsOpen]
         )
 
         return (

--- a/client/branded/src/search-ui/results/NoResultsPage.tsx
+++ b/client/branded/src/search-ui/results/NoResultsPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '@sourcegraph/shared/src/search'
 import { NoResultsSectionID as SectionID } from '@sourcegraph/shared/src/settings/temporary/searchSidebar'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Icon, H2, H3, Text } from '@sourcegraph/wildcard'
 
@@ -49,7 +50,10 @@ const Container: React.FunctionComponent<React.PropsWithChildren<ContainerProps>
     </div>
 )
 
-interface NoResultsPageProps extends TelemetryProps, Pick<SearchContextProps, 'searchContextsEnabled'> {
+interface NoResultsPageProps
+    extends TelemetryProps,
+        TelemetryV2Props,
+        Pick<SearchContextProps, 'searchContextsEnabled'> {
     isSourcegraphDotCom: boolean
     showSearchContext: boolean
     showQueryExamples?: boolean
@@ -65,6 +69,7 @@ interface NoResultsPageProps extends TelemetryProps, Pick<SearchContextProps, 's
 export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoResultsPageProps>> = ({
     searchContextsEnabled,
     telemetryService,
+    telemetryRecorder,
     isSourcegraphDotCom,
     showSearchContext,
     showQueryExamples,
@@ -81,16 +86,20 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
     const onClose = useCallback(
         (sectionID: SectionID) => {
             telemetryService.log('NoResultsPanel', { panelID: sectionID, action: 'closed' })
+            telemetryRecorder.recordEvent('NoResultPanel', 'closed', {
+                privateMetadata: { panelID: sectionID, action: 'closed' },
+            })
             setHiddenSectionIds((hiddenSectionIDs = []) =>
                 !hiddenSectionIDs.includes(sectionID) ? [...hiddenSectionIDs, sectionID] : hiddenSectionIDs
             )
         },
-        [setHiddenSectionIds, telemetryService]
+        [setHiddenSectionIds, telemetryService, telemetryRecorder]
     )
 
     useEffect(() => {
         telemetryService.logViewEvent('NoResultsPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('NoResultsPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <div className={styles.root}>
@@ -114,6 +123,7 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
                         <QueryExamples
                             selectedSearchContextSpec={selectedSearchContextSpec}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                             setQueryState={setQueryState}
                             isSourcegraphDotCom={isSourcegraphDotCom}
                         />
@@ -134,7 +144,12 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
                         <Text>Check out the docs for more tips on getting the most from Sourcegraph.</Text>
                         <Text>
                             <Link
-                                onClick={() => telemetryService.log('NoResultsMore', { link: 'Docs' })}
+                                onClick={() => {
+                                    telemetryService.log('NoResultsMore', { link: 'Docs' })
+                                    telemetryRecorder.recordEvent('NoResultsMore', 'displayed', {
+                                        privateMetadata: { link: 'Docs' },
+                                    })
+                                }}
                                 target="blank"
                                 to="https://docs.sourcegraph.com/"
                             >
@@ -150,6 +165,7 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
                                 className="p-0 border-0 align-baseline"
                                 onClick={() => {
                                     telemetryService.log('NoResultsPanel', { action: 'showAll' })
+                                    telemetryRecorder.recordEvent('NoResultsPanel', 'showAll')
                                     setHiddenSectionIds([])
                                 }}
                                 variant="link"

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -234,6 +234,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                 onSelect={() => logSearchResultClicked?.(index, 'person')}
                                 containerClassName={resultClassName}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 queryState={queryState}
                                 buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
                             />
@@ -258,6 +259,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             prefetchFile,
             location,
             telemetryService,
+            telemetryRecorder,
             allExpanded,
             fetchHighlightedFileLineRanges,
             settingsCascade,

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -24,6 +24,7 @@ import {
     type SearchMatch,
 } from '@sourcegraph/shared/src/search/stream'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { CommitSearchResult } from '../components/CommitSearchResult'
@@ -44,6 +45,7 @@ import styles from './StreamingSearchResultsList.module.scss'
 export interface StreamingSearchResultsListProps
     extends SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         PlatformContextProps<'requestGraphQL'> {
     isSourcegraphDotCom: boolean
@@ -105,6 +107,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     fetchHighlightedFileLineRanges,
     settingsCascade,
     telemetryService,
+    telemetryRecorder,
     isSourcegraphDotCom,
     searchContextsEnabled,
     platformContext,
@@ -156,6 +159,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                         index={index}
                                         location={location}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                         result={result}
                                         onSelect={() => logSearchResultClicked?.(index, 'fileMatch')}
                                         defaultExpanded={false}
@@ -172,6 +176,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                     <SymbolSearchResult
                                         index={index}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                         result={result}
                                         onSelect={() => logSearchResultClicked?.(index, 'symbolMatch')}
                                         fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
@@ -189,6 +194,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                         repoDisplayName={displayRepoName(result.repository)}
                                         containerClassName={resultClassName}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                     />
                                 )}
                             </PrefetchableFile>

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -308,6 +308,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                 searchContextsEnabled={searchContextsEnabled}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 showSearchContext={searchContextsEnabled}
                                 showQueryExamples={showQueryExamplesOnNoResultsPage}
                                 setQueryState={setQueryState}

--- a/client/branded/src/search-ui/results/progress/StreamingProgress.tsx
+++ b/client/branded/src/search-ui/results/progress/StreamingProgress.tsx
@@ -4,6 +4,7 @@ import { mdiClipboardPulseOutline } from '@mdi/js'
 import classNames from 'classnames'
 
 import type { Progress, StreamingResultsState } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Icon, Link } from '@sourcegraph/wildcard'
 
@@ -12,7 +13,7 @@ import { StreamingProgressSkippedButton } from './StreamingProgressSkippedButton
 
 import styles from './StreamingProgressCount.module.scss'
 
-export interface StreamingProgressProps extends TelemetryProps {
+export interface StreamingProgressProps extends TelemetryProps, TelemetryV2Props {
     query: string
     state: StreamingResultsState
     progress: Progress
@@ -29,6 +30,7 @@ export const StreamingProgress: React.FunctionComponent<React.PropsWithChildren<
     onSearchAgain,
     isSearchJobsEnabled,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const isLoading = state === 'loading'
 
@@ -42,6 +44,7 @@ export const StreamingProgress: React.FunctionComponent<React.PropsWithChildren<
                     isSearchJobsEnabled={isSearchJobsEnabled}
                     onSearchAgain={onSearchAgain}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
             <TraceLink showTrace={showTrace} trace={progress.trace} />

--- a/client/branded/src/search-ui/results/progress/StreamingProgressSkippedButton.tsx
+++ b/client/branded/src/search-ui/results/progress/StreamingProgressSkippedButton.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState, FC } from 'react'
 import { mdiAlertCircle, mdiChevronDown, mdiInformationOutline } from '@mdi/js'
 
 import { Progress } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Popover, PopoverContent, PopoverTrigger, Position, Icon } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopov
 
 import styles from './StreamingProgressSkippedButton.module.scss'
 
-interface StreamingProgressSkippedButtonProps extends TelemetryProps {
+interface StreamingProgressSkippedButtonProps extends TelemetryProps, TelemetryV2Props {
     query: string
     progress: Progress
     isSearchJobsEnabled?: boolean
@@ -19,7 +20,7 @@ interface StreamingProgressSkippedButtonProps extends TelemetryProps {
 }
 
 export const StreamingProgressSkippedButton: FC<StreamingProgressSkippedButtonProps> = props => {
-    const { query, progress, isSearchJobsEnabled, onSearchAgain, telemetryService } = props
+    const { query, progress, isSearchJobsEnabled, onSearchAgain, telemetryService, telemetryRecorder } = props
     const [isOpen, setIsOpen] = useState(false)
 
     const skippedWithWarningOrError = useMemo(
@@ -68,6 +69,7 @@ export const StreamingProgressSkippedButton: FC<StreamingProgressSkippedButtonPr
                     isSearchJobsEnabled={isSearchJobsEnabled}
                     onSearchAgain={onSearchAgainWithPopupClose}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             </PopoverContent>
         </Popover>

--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -22,6 +22,7 @@ import type { ExecuteCommandParameters } from '../api/client/mainthread-api'
 import { urlForOpenPanel } from '../commands/commands'
 import type { ExtensionsControllerProps } from '../extensions/controller'
 import type { PlatformContextProps } from '../platform/context'
+import { TelemetryV2Props } from '../telemetry'
 import type { TelemetryProps } from '../telemetry/telemetryService'
 
 import styles from './ActionItem.module.scss'
@@ -62,7 +63,7 @@ export interface ActionItemComponentProps
     actionItemStyleProps?: ActionItemStyleProps
 }
 
-export interface ActionItemProps extends ActionItemAction, ActionItemComponentProps, TelemetryProps {
+export interface ActionItemProps extends ActionItemAction, ActionItemComponentProps, TelemetryProps, TelemetryV2Props {
     variant?: 'actionItem'
 
     hideLabel?: boolean
@@ -353,6 +354,10 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State, type
 
         // Record action ID (but not args, which might leak sensitive data).
         this.props.telemetryService.log(action.id)
+
+        this.props.telemetryRecorder.recordEvent('action', 'run', {
+            privateMetadata: { action: action.id },
+        })
 
         const emitDidExecute = (): void => {
             if (this.props.onDidExecute) {

--- a/client/shared/src/actions/ActionsContainer.tsx
+++ b/client/shared/src/actions/ActionsContainer.tsx
@@ -12,6 +12,7 @@ import type { ContributionOptions } from '../api/extension/extensionHostApi'
 import { getContributedActionItems } from '../contributions/contributions'
 import type { RequiredExtensionsControllerProps } from '../extensions/controller'
 import type { PlatformContextProps } from '../platform/context'
+import { TelemetryV2Props } from '../telemetry'
 import type { TelemetryProps } from '../telemetry/telemetryService'
 
 import { ActionItem, type ActionItemAction } from './ActionItem'
@@ -24,7 +25,7 @@ export interface ActionsProps
     listClass?: string
     location: H.Location
 }
-interface Props extends ActionsProps, TelemetryProps {
+interface Props extends ActionsProps, TelemetryProps, TelemetryV2Props {
     /**
      * Called with the array of contributed items to produce the rendered component. If not set, uses a default
      * render function that renders a <ActionItem> for each item.

--- a/client/shared/src/actions/ActionsNavItems.tsx
+++ b/client/shared/src/actions/ActionsNavItems.tsx
@@ -13,6 +13,7 @@ import { useObservable } from '@sourcegraph/wildcard'
 import { wrapRemoteObservable } from '../api/client/api/common'
 import type { ContributionScope } from '../api/extension/api/context/context'
 import { getContributedActionItems } from '../contributions/contributions'
+import { TelemetryV2Props } from '../telemetry'
 import type { TelemetryProps } from '../telemetry/telemetryService'
 
 import { ActionItem, type ActionItemProps } from './ActionItem'
@@ -43,6 +44,7 @@ export interface ActionsNavItemsProps
     extends ActionsProps,
         ActionNavItemsClassProps,
         TelemetryProps,
+        TelemetryV2Props,
         Pick<ActionItemProps, 'showLoadingSpinnerDuringExecution' | 'actionItemStyleProps'> {
     /**
      * If true, it renders a `<ul className="nav">...</ul>` around the items. If there are no items, it renders `null`.

--- a/client/shared/src/hover/HoverOverlay.tsx
+++ b/client/shared/src/hover/HoverOverlay.tsx
@@ -8,6 +8,7 @@ import { Card, Icon, Button } from '@sourcegraph/wildcard'
 
 import { ActionItem, type ActionItemComponentProps } from '../actions/ActionItem'
 import type { PlatformContextProps } from '../platform/context'
+import { TelemetryV2Props } from '../telemetry'
 import type { TelemetryProps } from '../telemetry/telemetryService'
 
 import { CopyLinkIcon } from './CopyLinkIcon'
@@ -47,6 +48,7 @@ export interface HoverOverlayProps
         ActionItemComponentProps,
         HoverOverlayClassProps,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'settings'> {
     /** A ref callback to get the root overlay element. Use this to calculate the position. */
     hoverRef?: React.Ref<HTMLDivElement>
@@ -95,6 +97,7 @@ export const HoverOverlay: React.FunctionComponent<React.PropsWithChildren<Hover
         actionsOrError,
         platformContext,
         telemetryService,
+        telemetryRecorder,
         extensionsController,
         pinOptions,
         location,
@@ -192,6 +195,7 @@ export const HoverOverlay: React.FunctionComponent<React.PropsWithChildren<Hover
                                         showLoadingSpinnerDuringExecution={true}
                                         platformContext={platformContext}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                         extensionsController={extensionsController}
                                         location={location}
                                         actionItemStyleProps={actionItemStyleProps}

--- a/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
+++ b/client/vscode/src/webview/search-panel/components/ButtonDropdownCta.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Popover, PopoverContent, PopoverTrigger, Position } from '@sourcegraph/wildcard'
 
@@ -12,7 +13,10 @@ import styles from './ButtonDropdownCta.module.scss'
 
 // Debt: this is a fork of the web <ButtonDropdownCta>.
 
-export interface ButtonDropdownCtaProps extends TelemetryProps, Pick<WebviewPageProps, 'extensionCoreAPI'> {
+export interface ButtonDropdownCtaProps
+    extends TelemetryProps,
+        TelemetryV2Props,
+        Pick<WebviewPageProps, 'extensionCoreAPI'> {
     button: JSX.Element
     icon: JSX.Element
     title: string
@@ -31,6 +35,7 @@ export const ButtonDropdownCta: React.FunctionComponent<React.PropsWithChildren<
     title,
     copyText,
     telemetryService,
+    telemetryRecorder,
     source,
     viewEventName,
     returnTo,
@@ -49,6 +54,9 @@ export const ButtonDropdownCta: React.FunctionComponent<React.PropsWithChildren<
     useEffect(() => {
         if (isDropdownOpen) {
             telemetryService.log(viewEventName)
+            telemetryRecorder.recordEvent('dropdown', 'viewed', {
+                privateMetadata: { viewEventName },
+            })
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isDropdownOpen])
@@ -62,6 +70,7 @@ export const ButtonDropdownCta: React.FunctionComponent<React.PropsWithChildren<
 
     const onClick = (): void => {
         telemetryService.log(`VSCE${source}SignUpModalClick`)
+        telemetryRecorder.recordEvent(`VSCE${source}SignUpModal`, 'clicked')
         extensionCoreAPI.openLink(signUpURL).catch(() => {
             console.error('Error opening sign up link')
         })

--- a/client/vscode/src/webview/search-panel/components/HomeFooter.tsx
+++ b/client/vscode/src/webview/search-panel/components/HomeFooter.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/branded'
 import type { QueryState } from '@sourcegraph/shared/src/search'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Card, Text } from '@sourcegraph/wildcard'
 
@@ -13,10 +14,10 @@ import { type SearchExample, exampleQueries } from './SearchExamples'
 
 import styles from './HomeFooter.module.scss'
 
-export interface HomeFooterProps extends TelemetryProps {
+export interface HomeFooterProps extends TelemetryProps, TelemetryV2Props {
     setQuery: (newState: QueryState) => void
 }
-interface SearchExamplesProps extends TelemetryProps {
+interface SearchExamplesProps extends TelemetryProps, TelemetryV2Props {
     title: string
     subtitle: string
     examples: SearchExample[]
@@ -30,14 +31,18 @@ const SearchExamples: React.FunctionComponent<React.PropsWithChildren<SearchExam
     examples,
     icon,
     telemetryService,
+    telemetryRecorder,
     setQuery,
 }) => {
     const searchExampleClicked = useCallback(
         (trackEventName: string, fullQuery: string) => (): void => {
             setQuery({ query: fullQuery })
             telemetryService.log(trackEventName)
+            telemetryRecorder.recordEvent('footer', 'clicked', {
+                privateMetadata: { trackEventName },
+            })
         },
-        [setQuery, telemetryService]
+        [setQuery, telemetryService, telemetryRecorder]
     )
     return (
         <div className={styles.searchExamplesWrapper}>
@@ -93,7 +98,10 @@ export const HomeFooter: React.FunctionComponent<React.PropsWithChildren<HomeFoo
                                 src: 'DtL9ZJs/vsce-watch-and-learn.png',
                                 alt: 'Watch and learn video thumbnail',
                             }}
-                            onToggle={() => props.telemetryService.log('VSCEHomeWatch&Lean')}
+                            onToggle={() => {
+                                props.telemetryService.log('VSCEHomeWatch&Lean')
+                                props.telemetryRecorder.recordEvent('VSCEHomeWatch&Learn', 'toggled')
+                            }}
                             // assetsRoot="https://sourcegraph.com/.assets/"
                             assetsRoot="https://i.ibb.co/"
                         />

--- a/client/web/dev/BUILD.bazel
+++ b/client/web/dev/BUILD.bazel
@@ -56,7 +56,6 @@ ts_project(
         "//:node_modules/webpack",
         "//:node_modules/webpack-dev-server",
         "//client/web:node_modules/@sourcegraph/build-config",
-        "//client/web:node_modules/@sourcegraph/shared",
         "//client/web:web_lib",
     ],
 )

--- a/client/web/dev/BUILD.bazel
+++ b/client/web/dev/BUILD.bazel
@@ -56,6 +56,7 @@ ts_project(
         "//:node_modules/webpack",
         "//:node_modules/webpack-dev-server",
         "//client/web:node_modules/@sourcegraph/build-config",
+        "//client/web:node_modules/@sourcegraph/telemetry",
         "//client/web:web_lib",
     ],
 )

--- a/client/web/dev/BUILD.bazel
+++ b/client/web/dev/BUILD.bazel
@@ -56,6 +56,7 @@ ts_project(
         "//:node_modules/webpack",
         "//:node_modules/webpack-dev-server",
         "//client/web:node_modules/@sourcegraph/build-config",
+        "//client/web:node_modules/@sourcegraph/shared",
         "//client/web:web_lib",
     ],
 )

--- a/client/web/dev/tsconfig.json
+++ b/client/web/dev/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "module": "commonjs",
   },
-  "include": ["**/*"],
+  "include": ["**/*", "../src/jscontext.ts"],
 }

--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -1,5 +1,3 @@
-import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
-
 import type { SourcegraphContext } from '../../src/jscontext'
 
 import { ENVIRONMENT_CONFIG } from './environment-config'
@@ -79,7 +77,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         },
         embeddingsEnabled: false,
         primaryLoginProvidersCount: 5,
-        telemetryRecorder: noOpTelemetryRecorder,
+        telemetryRecorder: undefined,
         // Site-config overrides default JS context
         ...siteConfig,
     }

--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -1,4 +1,5 @@
 import type { SourcegraphContext } from '../../src/jscontext'
+import { noOpTelemetryRecorder } from '../utils'
 
 import { ENVIRONMENT_CONFIG } from './environment-config'
 import { getSiteConfig } from './get-site-config'
@@ -77,7 +78,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         },
         embeddingsEnabled: false,
         primaryLoginProvidersCount: 5,
-        telemetryRecorder: undefined,
+        telemetryRecorder: noOpTelemetryRecorder,
         // Site-config overrides default JS context
         ...siteConfig,
     }

--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -1,3 +1,5 @@
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import type { SourcegraphContext } from '../../src/jscontext'
 
 import { ENVIRONMENT_CONFIG } from './environment-config'
@@ -77,6 +79,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         },
         embeddingsEnabled: false,
         primaryLoginProvidersCount: 5,
+        telemetryRecorder: noOpTelemetryRecorder,
         // Site-config overrides default JS context
         ...siteConfig,
     }

--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -1,4 +1,5 @@
 import type { SourcegraphContext } from '../../src/jscontext'
+// eslint-disable-next-line import/no-useless-path-segments
 import { noOpTelemetryRecorder } from '../utils'
 
 import { ENVIRONMENT_CONFIG } from './environment-config'

--- a/client/web/dev/utils/index.ts
+++ b/client/web/dev/utils/index.ts
@@ -1,3 +1,10 @@
+import {
+    TelemetryRecorderProvider as BaseTelemetryRecorderProvider,
+    NoOpTelemetryExporter,
+    type TelemetryProcessor,
+    CallbackTelemetryProcessor,
+} from '@sourcegraph/telemetry'
+
 export * from './constants'
 export * from './create-js-context'
 export * from './environment-config'
@@ -5,3 +12,58 @@ export * from './get-api-proxy-settings'
 export * from './get-index-html'
 export * from './should-compress-response'
 export * from './success-banner'
+
+/**
+ * TelemetryRecorderProvider type used in Sourcegraph clients.
+ */
+export type TelemetryRecorderProvider = typeof noOptelemetryRecorderProvider
+
+/**
+ * TelemetryRecorder type used in Sourcegraph clients.
+ */
+export type TelemetryRecorder = typeof noOpTelemetryRecorder
+
+/**
+ * Events accept billing metadata for ease of categorization in analytics
+ * pipelines - this type enumerates known categories.
+ */
+export type BillingCategory = 'exampleBillingCategory'
+
+/**
+ * Events accept billing metadata for ease of categorization in analytics
+ * pipelines - this type enumerates known products.
+ */
+export type BillingProduct = 'exampleBillingProduct'
+
+/**
+ * Props interface that can be extended by React components depending on the
+ * new telemetry framework: https://docs.sourcegraph.com/dev/background-information/telemetry
+ * These properties are part of {@link PlatformContext}.
+ */
+export interface TelemetryV2Props {
+    /**
+     * Telemetry recorder for the new telemetry framework, superseding
+     * 'telemetryService' and 'logEvent' variants. Learn more here:
+     * https://docs.sourcegraph.com/dev/background-information/telemetry
+     *
+     * It is backed by a '@sourcegraph/telemetry' implementation.
+     */
+    telemetryRecorder: TelemetryRecorder
+}
+
+export class NoOpTelemetryRecorderProvider extends BaseTelemetryRecorderProvider<BillingCategory, BillingProduct> {
+    constructor(opts?: { errorOnRecord?: boolean }) {
+        const processors: TelemetryProcessor[] = []
+        if (opts?.errorOnRecord) {
+            processors.push(
+                new CallbackTelemetryProcessor(() => {
+                    throw new Error('telemetry: unexpected use of no-op telemetry recorder')
+                })
+            )
+        }
+        super({ client: '' }, new NoOpTelemetryExporter(), processors)
+    }
+}
+
+export const noOptelemetryRecorderProvider = new NoOpTelemetryRecorderProvider()
+export const noOpTelemetryRecorder = noOptelemetryRecorderProvider.getRecorder()

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, Icon, H2 } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import { type SignUpArguments, SignUpForm } from './SignUpForm'
 
 import styles from './CloudSignUpPage.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     source: string | null
     showEmailForm: boolean
     /** Called to perform the signup on the server. */
@@ -55,6 +56,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     onSignUp,
     context,
     telemetryService,
+    telemetryRecorder,
     isSourcegraphDotCom,
 }) => {
     const location = useLocation()
@@ -81,6 +83,9 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     const logEventAndSetFlags = (type: AuthProvider['serviceType']): void => {
         const eventType = type === 'builtin' ? 'form' : type
         telemetryService.log('SignupInitiated', { type: eventType }, { type: eventType })
+        telemetryRecorder.recordEvent('Signup', 'initiated', {
+            privateMetadata: { type: eventType },
+        })
     }
 
     const signUpForm = (

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react'
 import classNames from 'classnames'
 import { Navigate, useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Link, Text } from '@sourcegraph/wildcard'
@@ -22,7 +23,7 @@ import { VsCodeSignUpPage } from './VsCodeSignUpPage'
 
 import signInSignUpCommonStyles from './SignInSignUpCommon.module.scss'
 
-export interface SignUpPageProps extends TelemetryProps {
+export interface SignUpPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     context: Pick<
         SourcegraphContext,
@@ -39,6 +40,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
     authenticatedUser,
     context,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const location = useLocation()
     const query = new URLSearchParams(location.search)
@@ -49,6 +51,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
 
     useEffect(() => {
         eventLogger.logViewEvent('SignUp', null, false)
+        telemetryRecorder.recordEvent('SignUp', 'succeeded')
 
         if (invitedBy !== null) {
             const parameters = {
@@ -56,8 +59,11 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
                 allowSignup: context.allowSignup,
             }
             eventLogger.log('SignUpInvitedByUser', parameters, parameters)
+            telemetryRecorder.recordEvent('SignUpInvitedByUser', 'succeeded', {
+                privateMetadata: { parameters },
+            })
         }
-    }, [invitedBy, authenticatedUser, context.allowSignup])
+    }, [telemetryRecorder, invitedBy, authenticatedUser, context.allowSignup])
 
     if (authenticatedUser) {
         return <Navigate to={returnTo} replace={true} />
@@ -97,6 +103,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
                 showEmailForm={query.has(ShowEmailFormQueryParameter)}
                 context={context}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
         )
     }
@@ -110,6 +117,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
                 showEmailForm={query.has(ShowEmailFormQueryParameter)}
                 context={context}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 isSourcegraphDotCom={context.sourcegraphDotComMode}
             />
         )

--- a/client/web/src/auth/VsCodeSignUpPage.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.tsx
@@ -4,6 +4,7 @@ import { mdiChevronLeft } from '@mdi/js'
 import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, Icon, H2 } from '@sourcegraph/wildcard'
 
@@ -16,7 +17,7 @@ import { type SignUpArguments, SignUpForm } from './SignUpForm'
 import styles from './VsCodeSignUpPage.module.scss'
 
 export const ShowEmailFormQueryParameter = 'showEmail'
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     source: string | null
     showEmailForm: boolean
     /** Called to perform the signup on the server. */
@@ -43,6 +44,7 @@ export const VsCodeSignUpPage: React.FunctionComponent<React.PropsWithChildren<P
     onSignUp,
     context,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const location = useLocation()
 
@@ -62,6 +64,9 @@ export const VsCodeSignUpPage: React.FunctionComponent<React.PropsWithChildren<P
             { type: eventType, source: 'vs-code' },
             { type: eventType, source: 'vs-code' }
         )
+        telemetryRecorder.recordEvent('Signup', 'initiated', {
+            privateMetadata: { type: eventType, source: 'vs-code' },
+        })
     }
 
     const signUpForm = (

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -22,6 +22,7 @@ import { HighlightResponseFormat } from '@sourcegraph/shared/src/graphql-operati
 import { getModeFromPath } from '@sourcegraph/shared/src/languages'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     type RepoSpec,
@@ -86,6 +87,7 @@ export interface ReferencesPanelProps
         PlatformContextProps,
         Pick<CodeIntelligenceProps, 'useCodeIntel'>,
         TelemetryProps,
+        TelemetryV2Props,
         HoverThresholdProps,
         ExtensionsControllerProps,
         HighlightedFileLineRangesProps {

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -39,7 +39,10 @@ import styles from './ChatUi.module.scss'
 
 export const SCROLL_THRESHOLD = 100
 
-const onFeedbackSubmit = (feedback: string): void => eventLogger.log(`web:cody:feedbackSubmit:${feedback}`)
+const onFeedbackSubmit = (feedback: string): void => {
+    eventLogger.log(`web:cody:feedbackSubmit:${feedback}`)
+    window.context.telemetryRecorder.recordEvent(`web.cody.feedbacksubmit.${feedback}`, 'submitted')
+}
 
 interface IChatUIProps {
     codyChatStore: CodyChatStore
@@ -279,7 +282,12 @@ const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = React.mem
             <Link
                 to="/get-cody"
                 className="d-inline-block w-100 ml-auto text-right font-italic"
-                onClick={() => eventLogger.log(EventName.CODY_CTA, { location: EventLocation.CHAT_RESPONSE })}
+                onClick={() => {
+                    eventLogger.log(EventName.CODY_CTA, { location: EventLocation.CHAT_RESPONSE })
+                    window.context.telemetryRecorder.recordEvent(EventName.CODY_CTA, 'clicked', {
+                        privateMetadata: { location: EventLocation.CHAT_RESPONSE },
+                    })
+                }}
             >
                 Use commands, autocomplete and more in your IDE.
             </Link>

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -24,9 +24,16 @@ interface CodyPlatformCardProps {
     illustration: string
 }
 
-const onSpeakToAnEngineer = (): void => eventLogger.log(EventName.SPEAK_TO_AN_ENGINEER_CTA)
-const onClickCTAButton = (type: string): void =>
+const onSpeakToAnEngineer = (): void => {
+    eventLogger.log(EventName.SPEAK_TO_AN_ENGINEER_CTA)
+    window.context.telemetryRecorder.recordEvent(EventName.SPEAK_TO_AN_ENGINEER_CTA, 'clicked')
+}
+const onClickCTAButton = (type: string): void => {
     eventLogger.log('SignupInitiated', { type, source: 'cody-signed-out' }, { type, page: 'cody-signed-out' })
+    window.context.telemetryRecorder.recordEvent('Signup', 'initiated', {
+        privateMetadata: { type, source: 'cody-signed-out' },
+    })
+}
 
 const IDEIcon: React.FunctionComponent<{}> = () => (
     <svg viewBox="-4 -4 31 31" fill="none" xmlns="http://www.w3.org/2000/svg" className={styles.codyPlatformCardIcon}>

--- a/client/web/src/cody/search/CodySearchPage.tsx
+++ b/client/web/src/cody/search/CodySearchPage.tsx
@@ -30,6 +30,7 @@ interface CodeSearchPageProps {
 
 export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ authenticatedUser }) => {
     useEffect(() => {
+        window.context.telemetryRecorder.recordEvent('CodySearch', 'viewed')
         eventLogger.logPageView('CodySearch')
     }, [])
 
@@ -64,6 +65,9 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
             !isPrivateInstance ? { input: sanitizedInput } : null,
             !isPrivateInstance ? { input: sanitizedInput } : null
         )
+        window.context.telemetryRecorder.recordEvent('web.codySearch', 'submitted', {
+            privateMetadata: { input: !isPrivateInstance ? { input: sanitizedInput } : null },
+        })
         setLoading(true)
         translateToQuery(sanitizedInput, authenticatedUser).then(
             query => {
@@ -75,6 +79,11 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
                         !isPrivateInstance ? { input: sanitizedInput, translatedQuery: query } : null,
                         !isPrivateInstance ? { input: sanitizedInput, translatedQuery: query } : null
                     )
+                    window.context.telemetryRecorder.recordEvent('web.codySearch.submit', 'succeeded', {
+                        privateMetadata: {
+                            input: !isPrivateInstance ? { input: sanitizedInput, translatedQuery: query } : null,
+                        },
+                    })
                     setCodySearchInput(JSON.stringify({ input: sanitizedInput, translatedQuery: query }))
                     navigate({
                         pathname: '/search',
@@ -86,6 +95,11 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
                         !isPrivateInstance ? { input: sanitizedInput, reason: 'untranslatable' } : null,
                         !isPrivateInstance ? { input: sanitizedInput, reason: 'untranslatable' } : null
                     )
+                    window.context.telemetryRecorder.recordEvent('web.codySearch.submit', 'failed', {
+                        privateMetadata: {
+                            input: !isPrivateInstance ? { input: sanitizedInput, reason: 'untranslatable' } : null,
+                        },
+                    })
                     setInputError('Cody does not understand this query. Try rephrasing it.')
                 }
             },
@@ -107,6 +121,17 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({ a
                           }
                         : null
                 )
+                window.context.telemetryRecorder.recordEvent('web.codySearch.submit', 'failed', {
+                    privateMetadata: {
+                        input: !isPrivateInstance
+                            ? {
+                                  input: sanitizedInput,
+                                  reason: 'unreachable',
+                                  error: error?.message,
+                              }
+                            : null,
+                    },
+                })
                 setLoading(false)
                 setInputError(`Unable to reach Cody. Error: ${error?.message}`)
             }

--- a/client/web/src/cody/sidebar/Provider.tsx
+++ b/client/web/src/cody/sidebar/Provider.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState, useCallback, useMemo } from 'react'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 
 import { useCodyChat, type CodyChatStore, codyChatStoreMock } from '../useCodyChat'
 
@@ -24,7 +25,7 @@ const CodySidebarContext = React.createContext<CodySidebarStore | null>({
     setFocusProvided: () => {},
 })
 
-interface ICodySidebarStoreProviderProps {
+interface ICodySidebarStoreProviderProps extends TelemetryV2Props {
     children?: React.ReactNode
     authenticatedUser: AuthenticatedUser | null
 }

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -173,6 +173,10 @@ export const useCodyChat = ({
             if (!transcript) {
                 return
             }
+            const feature = eventLabel as EventName
+            window.context.telemetryRecorder.recordEvent(feature, 'clicked', {
+                privateMetadata: { transcriptId: transcript.id, ...eventProperties },
+            })
             eventLogger.log(eventLabel, { transcriptId: transcript.id, ...eventProperties })
         },
         [transcript]
@@ -228,6 +232,7 @@ export const useCodyChat = ({
             return
         }
 
+        window.context.telemetryRecorder.recordEvent(EventName.CODY_CHAT_HISTORY_CLEARED, 'cleared')
         eventLogger.log(EventName.CODY_CHAT_HISTORY_CLEARED)
 
         const newTranscript = initializeNewChatInternal()
@@ -399,6 +404,7 @@ export const useCodyChat = ({
 
     const executeRecipe = useCallback<typeof executeRecipeInternal>(
         async (recipeId, options): Promise<Transcript | null> => {
+            window.context.telemetryRecorder.recordEvent(`web.codyChat.recipe.${recipeId}`, 'executed')
             eventLogger.log(`web:codyChat:recipe:${recipeId}:executed`, { recipeId })
 
             const transcript = await executeRecipeInternal(recipeId, options)

--- a/client/web/src/cody/widgets/CodyRecipesWidget.tsx
+++ b/client/web/src/cody/widgets/CodyRecipesWidget.tsx
@@ -17,7 +17,8 @@ import { Recipes } from './components/Recipes'
 
 export const CodyRecipesWidget: React.FC<{ editor?: CodeMirrorEditor }> = ({ editor }) => {
     useEffect(() => {
-        eventLogger.log(EventName.CODY_CHAT_EDITOR_WIDGET_VIEWED)
+        window.context.telemetryRecorder.recordEvent(EventName.CODY_CHAT_EDITOR_WIDGET_VIEWED, 'viewed')
+        eventLogger.log(EventName.CODY_CHAT_EDITOR_WIDGET_VIEWED, { hasV2Telemetry: true })
     }, [])
 
     // dirty fix becasue it is rendered under a separate React DOM tree.

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
@@ -12,6 +12,7 @@ import type { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensio
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { QueryState, SearchContextInputProps, SearchContextProps } from '@sourcegraph/shared/src/search'
 import type { SettingsCascadeProps, Settings } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, useObservable, Link, Card, Icon, Code, H2, H3, Text } from '@sourcegraph/wildcard'
 
@@ -30,6 +31,7 @@ import styles from './CommunitySearchContextPage.module.scss'
 export interface CommunitySearchContextPageProps
     extends SettingsCascadeProps<Settings>,
         TelemetryProps,
+        TelemetryV2Props,
         ExtensionsControllerProps<'executeCommand'>,
         PlatformContextProps<'settings' | 'sourcegraphURL' | 'requestGraphQL'>,
         SearchContextInputProps,
@@ -52,11 +54,13 @@ export const CommunitySearchContextPage: React.FunctionComponent<
         query: '',
     })
 
-    useEffect(
-        () =>
-            props.telemetryService.logViewEvent(`CommunitySearchContext:${props.communitySearchContextMetadata.spec}`),
-        [props.communitySearchContextMetadata.spec, props.telemetryService]
-    )
+    useEffect(() => {
+        props.telemetryService.logViewEvent(`CommunitySearchContext:${props.communitySearchContextMetadata.spec}`)
+        props.telemetryRecorder.recordEvent(
+            `CommunitySearchContext:${props.communitySearchContextMetadata.spec}`,
+            'viewed'
+        )
+    }, [props.communitySearchContextMetadata.spec, props.telemetryService, props.telemetryRecorder])
     const caseSensitive = useNavbarQueryState(state => state.searchCaseSensitivity)
 
     const contextQuery = `context:${props.communitySearchContextMetadata.spec}`

--- a/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
+++ b/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
@@ -3,12 +3,13 @@ import React from 'react'
 import { mdiArrowRight } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, Icon, H3 } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../MarketingBlock'
 
-export interface SelfHostedCtaProps extends TelemetryProps {
+export interface SelfHostedCtaProps extends TelemetryProps, TelemetryV2Props {
     className?: string
     contentClassName?: string
     // the name of the page the CTA will be posted. DO NOT include full URLs
@@ -21,6 +22,7 @@ export const SelfHostedCta: React.FunctionComponent<React.PropsWithChildren<Self
     className,
     contentClassName,
     telemetryService,
+    telemetryRecorder,
     page,
     children,
 }) => {
@@ -28,10 +30,16 @@ export const SelfHostedCta: React.FunctionComponent<React.PropsWithChildren<Self
 
     const gettingStartedCTAOnClick = (): void => {
         telemetryService.log('InstallSourcegraphCTAClicked', { page }, { page })
+        telemetryRecorder.recordEvent('InstallSourcegraphCTA', 'clicked', {
+            privateMetadata: { page },
+        })
     }
 
     const helpGettingStartedCTAOnClick = (): void => {
         telemetryService.log('HelpGettingStartedCTA', { page }, { page })
+        telemetryRecorder.recordEvent('HelpGettingStartedCTA', 'clicked', {
+            privateMetadata: { page },
+        })
     }
 
     return (

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -4,6 +4,7 @@ import { RouterProvider, createMemoryRouter, type MemoryRouterProps } from 'reac
 
 import { EMPTY_SETTINGS_CASCADE, SettingsProvider } from '@sourcegraph/shared/src/settings/settings'
 import { MockedStoryProvider, type MockedStoryProviderProps } from '@sourcegraph/shared/src/stories'
+import { noOpTelemetryRecorder, TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE, type TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeContext, ThemeSetting } from '@sourcegraph/shared/src/theme'
 import { WildcardThemeContext } from '@sourcegraph/wildcard'
@@ -25,6 +26,7 @@ if (!window.context) {
 
 export type WebStoryChildrenProps = BreadcrumbSetters &
     BreadcrumbsProps &
+    TelemetryV2Props &
     TelemetryProps & {
         isLightTheme: boolean
     }
@@ -63,6 +65,7 @@ export const WebStory: FC<WebStoryProps> = ({
                     {...breadcrumbSetters}
                     isLightTheme={isLightTheme}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             ),
         },

--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -4,6 +4,7 @@ import type { FetchResult } from '@apollo/client'
 import { useNavigate } from 'react-router-dom'
 
 import { logger, renderMarkdown } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Container, H3, H4, Markdown, PageHeader } from '@sourcegraph/wildcard'
 
@@ -16,7 +17,7 @@ import { ExternalServiceCard } from './ExternalServiceCard'
 import { ExternalServiceForm } from './ExternalServiceForm'
 import type { AddExternalServiceOptions } from './externalServices'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     externalService: AddExternalServiceOptions
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
@@ -31,6 +32,7 @@ interface Props extends TelemetryProps {
 export const AddExternalServicePage: FC<Props> = ({
     externalService,
     telemetryService,
+    telemetryRecorder,
     autoFocusForm,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
@@ -42,7 +44,8 @@ export const AddExternalServicePage: FC<Props> = ({
 
     useEffect(() => {
         telemetryService.logPageView('AddExternalService')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('AddExternalService', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     useEffect(() => {
         setConfig(externalService.defaultConfig)
@@ -79,15 +82,17 @@ export const AddExternalServicePage: FC<Props> = ({
                 },
                 onCompleted: data => {
                     telemetryService.log('AddExternalServiceSucceeded')
+                    telemetryRecorder.recordEvent('AddExternalService', 'succeeded')
                     refreshSiteFlags(client).catch((error: Error) => logger.error(error))
                     navigate(`/site-admin/external-services/${data.addExternalService.id}`)
                 },
                 onError: () => {
                     telemetryService.log('AddExternalServiceFailed')
+                    telemetryRecorder.recordEvent('AddExternalService', 'failed')
                 },
             })
         },
-        [addExternalService, telemetryService, getExternalServiceInput, client, navigate]
+        [addExternalService, telemetryService, telemetryRecorder, getExternalServiceInput, client, navigate]
     )
     const createdExternalService = addExternalServiceResult?.addExternalService
 
@@ -128,6 +133,7 @@ export const AddExternalServicePage: FC<Props> = ({
                         )}
                         <ExternalServiceForm
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                             error={error}
                             input={getExternalServiceInput()}
                             editorActions={externalService.editorActions}

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -9,6 +9,7 @@ import { useLocation } from 'react-router-dom'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Alert, H3, Icon, Text, Container, PageHeader } from '@sourcegraph/wildcard'
 
@@ -19,7 +20,7 @@ import { AddExternalServicePage } from './AddExternalServicePage'
 import { ExternalServiceGroup, type AddExternalServiceOptionsWithID } from './ExternalServiceGroup'
 import { allExternalServices, type AddExternalServiceOptions, gitHubAppConfig } from './externalServices'
 
-export interface AddExternalServicesPageProps extends TelemetryProps {
+export interface AddExternalServicesPageProps extends TelemetryProps, TelemetryV2Props {
     /**
      * The list of code host external services to be displayed.
      * Pick items from externalServices.codeHostExternalServices.
@@ -46,6 +47,7 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
     codeHostExternalServices,
     nonCodeHostExternalServices,
     telemetryService,
+    telemetryRecorder,
     autoFocusForm,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
@@ -91,6 +93,7 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
         return (
             <AddExternalServicePage
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 externalService={externalService}
                 autoFocusForm={autoFocusForm}
                 externalServicesFromFile={externalServicesFromFile}

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -2,6 +2,7 @@ import React, { type FC, useEffect, useState, useCallback, useMemo } from 'react
 
 import { useNavigate, useParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, ErrorAlert, PageHeader, ButtonLink } from '@sourcegraph/wildcard'
 
@@ -21,7 +22,7 @@ import { ExternalServiceForm } from './ExternalServiceForm'
 import { resolveExternalServiceCategory } from './externalServices'
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
 
@@ -31,6 +32,7 @@ interface Props extends TelemetryProps {
 
 export const ExternalServiceEditPage: FC<Props> = ({
     telemetryService,
+    telemetryRecorder,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
     autoFocusForm,
@@ -40,7 +42,8 @@ export const ExternalServiceEditPage: FC<Props> = ({
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminExternalService', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const [externalService, setExternalService] = useState<ExternalServiceFieldsWithConfig>()
 
@@ -138,6 +141,7 @@ export const ExternalServiceEditPage: FC<Props> = ({
                         onSubmit={onSubmit}
                         onChange={onChange}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         autoFocus={autoFocusForm}
                         externalServicesFromFile={externalServicesFromFile}
                         allowEditExternalServicesWithFile={allowEditExternalServicesWithFile}

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -5,6 +5,7 @@ import addFormats from 'ajv-formats'
 import { parse } from 'jsonc-parser'
 
 import type { ErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -28,7 +29,10 @@ import { ExternalServiceEditingDisabledAlert } from './ExternalServiceEditingDis
 import { ExternalServiceEditingTemporaryAlert } from './ExternalServiceEditingTemporaryAlert'
 import type { AddExternalServiceOptions } from './externalServices'
 
-interface Props extends Pick<AddExternalServiceOptions, 'jsonSchema' | 'editorActions'>, TelemetryProps {
+interface Props
+    extends Pick<AddExternalServiceOptions, 'jsonSchema' | 'editorActions'>,
+        TelemetryProps,
+        TelemetryV2Props {
     input: AddExternalServiceInput
     externalServiceID?: string
     error?: ErrorLike
@@ -53,6 +57,7 @@ addFormats(ajv)
  */
 export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
     jsonSchema,
     editorActions,
     input,
@@ -142,6 +147,7 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
                     actions={editorActions}
                     className="test-external-service-editor"
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     explanation={
                         <Text className="form-text text-muted">
                             <small>

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Subject } from 'rxjs'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Alert, Button, Container, ErrorAlert, H2, Icon, Link, PageHeader, Tooltip } from '@sourcegraph/wildcard'
@@ -35,7 +36,7 @@ import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 
 import styles from './ExternalServicePage.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     afterDeleteRoute: string
 
     externalServicesFromFile: boolean
@@ -52,6 +53,7 @@ const NotFoundPage: FC = () => (
 export const ExternalServicePage: FC<Props> = props => {
     const {
         telemetryService,
+        telemetryRecorder,
         afterDeleteRoute,
         externalServicesFromFile,
         allowEditExternalServicesWithFile,
@@ -64,7 +66,8 @@ export const ExternalServicePage: FC<Props> = props => {
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminExternalService', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const [syncInProgress, setSyncInProgress] = useState<boolean>(false)
     // Callback used in ExternalServiceSyncJobsList to update the state in current component.
@@ -269,6 +272,7 @@ export const ExternalServicePage: FC<Props> = props => {
                         isLightTheme={isLightTheme}
                         className="test-external-service-editor"
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 )}
                 <ExternalServiceWebhook externalService={externalService} className="mt-3" />

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -3,6 +3,7 @@ import { type FC, useEffect } from 'react'
 import { mdiPlus } from '@mdi/js'
 import { Navigate, useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, ButtonLink, Icon, PageHeader, Container } from '@sourcegraph/wildcard'
 
@@ -22,7 +23,7 @@ import { ExternalServiceEditingDisabledAlert } from './ExternalServiceEditingDis
 import { ExternalServiceEditingTemporaryAlert } from './ExternalServiceEditingTemporaryAlert'
 import { ExternalServiceNode } from './ExternalServiceNode'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
     isCodyApp: boolean
@@ -33,13 +34,15 @@ interface Props extends TelemetryProps {
  */
 export const ExternalServicesPage: FC<Props> = ({
     telemetryService,
+    telemetryRecorder,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
     isCodyApp,
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalServices')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminExternalServices', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const location = useLocation()
     const searchParameters = new URLSearchParams(location.search)

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -4,6 +4,7 @@ import type * as H from 'history'
 
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { FuzzyModal } from './FuzzyModal'
@@ -14,6 +15,7 @@ const DEFAULT_MAX_RESULTS = 50
 
 export interface FuzzyFinderContainerProps
     extends TelemetryProps,
+        TelemetryV2Props,
         Pick<FuzzyFinderProps, 'location'>,
         SettingsCascadeProps,
         FuzzyTabsProps {
@@ -83,15 +85,21 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
     useEffect(() => {
         if (isVisible) {
             props.telemetryService.log('FuzzyFinderViewed', { action: 'shortcut open' })
+            props.telemetryRecorder.recordEvent('FuzzyFinder', 'viewed', {
+                privateMetadata: { action: 'shortcut open' },
+            })
         }
-    }, [props.telemetryService, isVisible])
+    }, [props.telemetryService, props.telemetryRecorder, isVisible])
 
     const handleItemClick = useCallback(
         (eventName: 'FuzzyFinderResultClicked' | 'FuzzyFinderGoToResultsPageClicked') => {
             props.telemetryService.log(eventName, { activeTab, scope }, { activeTab, scope })
+            props.telemetryRecorder.recordEvent('FuzyFinderResult', 'clicked', {
+                privateMetadata: { activeTab, scope },
+            })
             setIsVisible(false)
         },
-        [props.telemetryService, setIsVisible, activeTab, scope]
+        [props.telemetryService, props.telemetryRecorder, setIsVisible, activeTab, scope]
     )
 
     if (tabs.isAllDisabled()) {

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import type { ErrorLike } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Container,
@@ -37,7 +38,7 @@ import { RemoveGitHubAppModal } from './RemoveGitHubAppModal'
 
 import styles from './GitHubAppCard.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     /**
      * The parent breadcrumb item to show for this page in the header.
      */
@@ -46,14 +47,20 @@ interface Props extends TelemetryProps {
     headerAnnotation?: React.ReactNode
 }
 
-export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcrumb, headerAnnotation }) => {
+export const GitHubAppPage: FC<Props> = ({
+    telemetryService,
+    telemetryRecorder,
+    headerParentBreadcrumb,
+    headerAnnotation,
+}) => {
     const { appID } = useParams()
     const navigate = useNavigate()
     const [removeModalOpen, setRemoveModalOpen] = useState<boolean>(false)
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminGitHubApp')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminGitHubApp', 'viewed')
+    }, [telemetryService, telemetryRecorder])
     const [fetchError, setError] = useState<ErrorLike>()
 
     const { data, loading, error } = useQuery<GitHubAppByIDResult, GitHubAppByIDVariables>(GITHUB_APP_BY_ID_QUERY, {

--- a/client/web/src/enterprise/app/routes.tsx
+++ b/client/web/src/enterprise/app/routes.tsx
@@ -60,6 +60,7 @@ export const APP_ROUTES: RouteObject[] = [
                         sideBarGroups={props.siteAdminSideBarGroups}
                         overviewComponents={props.siteAdminOverviewComponents}
                         codeInsightsEnabled={!!props.codeInsightsEnabled}
+                        telemetryRecorder={window.context.telemetryRecorder}
                     />
                 )}
             />

--- a/client/web/src/enterprise/app/settings/AppSettingsArea.tsx
+++ b/client/web/src/enterprise/app/settings/AppSettingsArea.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import AboutOutlineIcon from 'mdi-react/AboutOutlineIcon'
 import { Routes, Route, Outlet, Navigate, useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, MenuDivider, PageHeader } from '@sourcegraph/wildcard'
 
@@ -21,13 +22,15 @@ enum AppSettingURL {
     About = 'about',
 }
 
-export const AppSettingsArea: FC<TelemetryProps> = ({ telemetryService }) => (
+export const AppSettingsArea: FC<TelemetryProps & TelemetryV2Props> = ({ telemetryService, telemetryRecorder }) => (
     <Routes>
         <Route path="*" element={<AppSettingsLayout />}>
             <Route path={AppSettingURL.LocalRepositories} element={<LocalRepositoriesTab />} />
             <Route
                 path={`${AppSettingURL.RemoteRepositories}/*`}
-                element={<RemoteRepositoriesTab telemetryService={telemetryService} />}
+                element={
+                    <RemoteRepositoriesTab telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
+                }
             />
             <Route path={AppSettingURL.About} element={<AboutTab />} />
             <Route path={AppSettingURL.RateLimits} element={<RateLimitsTab />} />
@@ -86,7 +89,7 @@ const AppSettingsLayout: FC = () => {
     )
 }
 
-const RemoteRepositoriesTab: FC<TelemetryProps> = ({ telemetryService }) => (
+const RemoteRepositoriesTab: FC<TelemetryProps & TelemetryV2Props> = ({ telemetryService, telemetryRecorder }) => (
     <div className={styles.content}>
         <PageHeader headingElement="h2" path={[{ text: 'Remote repositories' }]} className="mb-3" />
 
@@ -95,6 +98,7 @@ const RemoteRepositoriesTab: FC<TelemetryProps> = ({ telemetryService }) => (
             description={false}
             progressBar={false}
             telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
             isCodyApp={true}
         />
     </div>

--- a/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
+++ b/client/web/src/enterprise/app/setup/AppSetupWizard.tsx
@@ -6,6 +6,7 @@ import { appWindow, LogicalSize } from '@tauri-apps/api/window'
 import { useNavigate } from 'react-router-dom'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Theme, ThemeContext, ThemeSetting, useTheme } from '@sourcegraph/shared/src/theme'
 
@@ -60,7 +61,7 @@ const APP_SETUP_STEPS: StepConfiguration[] = [
  * App related setup wizard component, see {@link SetupWizard} component
  * for any other deploy type setup flows.
  */
-export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
+export const AppSetupWizard: FC<TelemetryProps & TelemetryV2Props> = ({ telemetryService, telemetryRecorder }) => {
     const { theme } = useTheme()
     const [activeStepId, setStepId, status] = useTemporarySetting('app-setup.activeStepId')
 
@@ -157,6 +158,7 @@ export const AppSetupWizard: FC<TelemetryProps> = ({ telemetryService }) => {
                 >
                     <SetupStepsContent
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         className={styles.content}
                         isCodyApp={true}
                         setStepId={setStepId}

--- a/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
+++ b/client/web/src/enterprise/batches/batch-spec/execute/ExecuteBatchSpecPage.tsx
@@ -9,6 +9,7 @@ import { Navigate, Route, Routes, useParams } from 'react-router-dom'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge, Icon, LoadingSpinner, ErrorMessage, LinkOrSpan } from '@sourcegraph/wildcard'
 
@@ -42,7 +43,7 @@ import { ExecutionWorkspaces } from './workspaces/ExecutionWorkspaces'
 import layoutStyles from '../Layout.module.scss'
 import styles from './ExecuteBatchSpecPage.module.scss'
 
-export interface AuthenticatedExecuteBatchSpecPageProps extends TelemetryProps, NamespaceProps {
+export interface AuthenticatedExecuteBatchSpecPageProps extends TelemetryProps, TelemetryV2Props, NamespaceProps {
     authenticatedUser: AuthenticatedUser
     /** FOR TESTING ONLY */
     testContextState?: Partial<BatchSpecContextState<BatchSpecExecutionFields>>
@@ -107,7 +108,7 @@ export const AuthenticatedExecuteBatchSpecPage: FC<AuthenticatedExecuteBatchSpec
     )
 }
 
-interface ExecuteBatchSpecPageContentProps extends TelemetryProps {
+interface ExecuteBatchSpecPageContentProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
     queryWorkspacesList?: typeof _queryWorkspacesList
 }
@@ -128,6 +129,7 @@ type MemoizedExecuteBatchSpecContentProps = ExecuteBatchSpecPageContentProps &
 const MemoizedExecuteBatchSpecContent: FC<MemoizedExecuteBatchSpecContentProps> = React.memo(
     function MemoizedExecuteBatchSpecContent({
         telemetryService,
+        telemetryRecorder,
         authenticatedUser,
         batchChange,
         batchSpec,
@@ -261,6 +263,7 @@ const MemoizedExecuteBatchSpecContent: FC<MemoizedExecuteBatchSpecContentProps> 
                                     <NewBatchChangePreviewPage
                                         authenticatedUser={authenticatedUser}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                     />
                                 </>
                             ) : (

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -4,6 +4,7 @@ import { mdiSourceBranch, mdiChartLineVariant, mdiFileDocument, mdiArchive, mdiM
 import { useNavigate, useLocation } from 'react-router-dom'
 
 import type { Settings, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge, Container, Icon, Link, Tab, TabPanel, TabPanels, Text } from '@sourcegraph/wildcard'
 
@@ -55,7 +56,7 @@ const getTabName = (tabIndex: number, shouldDisplayExecutionsTab: boolean): TabN
     ][tabIndex]
 
 /** `BatchChangeDetailsPage` and `BatchChangeDetailsTabs` share all these props */
-export interface BatchChangeDetailsProps extends TelemetryProps {
+export interface BatchChangeDetailsProps extends TelemetryProps, TelemetryV2Props {
     /** The name of the tab that should be initially open */
     initialTab?: TabName
 

--- a/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Modal, H3, Text, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -8,7 +9,7 @@ import { LoaderButton } from '../../../../components/LoaderButton'
 import type { Scalars } from '../../../../graphql-operations'
 import { detachChangesets as _detachChangesets } from '../backend'
 
-export interface DetachChangesetsModalProps extends TelemetryProps {
+export interface DetachChangesetsModalProps extends TelemetryProps, TelemetryV2Props {
     onCancel: () => void
     afterCreate: () => void
     batchChangeID: Scalars['ID']
@@ -24,6 +25,7 @@ export const DetachChangesetsModal: React.FunctionComponent<React.PropsWithChild
     batchChangeID,
     changesetIDs,
     telemetryService,
+    telemetryRecorder,
     detachChangesets = _detachChangesets,
 }) => {
     const [isLoading, setIsLoading] = useState<boolean | Error>(false)
@@ -33,11 +35,12 @@ export const DetachChangesetsModal: React.FunctionComponent<React.PropsWithChild
         try {
             await detachChangesets(batchChangeID, changesetIDs)
             telemetryService.logViewEvent('BatchChangeDetailsPageDetachArchivedChangesets')
+            telemetryRecorder.recordEvent('BatchChangeDetailsPageDetachArchivedChangesets', 'viewed')
             afterCreate()
         } catch (error) {
             setIsLoading(asError(error))
         }
-    }, [changesetIDs, detachChangesets, batchChangeID, telemetryService, afterCreate])
+    }, [changesetIDs, detachChangesets, batchChangeID, telemetryService, telemetryRecorder, afterCreate])
 
     const labelId = 'detach-changesets-modal-title'
 

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -4,6 +4,7 @@ import { Routes, Route } from 'react-router-dom'
 
 import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -43,7 +44,7 @@ const BatchChangeClosePage = lazyComponent<BatchChangeClosePageProps, 'BatchChan
     'BatchChangeClosePage'
 )
 
-interface Props extends TelemetryProps, SettingsCascadeProps {
+interface Props extends TelemetryProps, TelemetryV2Props, SettingsCascadeProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
 }

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -7,6 +7,7 @@ import { pluralize } from '@sourcegraph/common'
 import { dataOrThrowErrors, useQuery } from '@sourcegraph/http-client'
 import type { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, PageHeader, Link, Container, H3, Text, screenReaderAnnounce } from '@sourcegraph/wildcard'
 
@@ -48,7 +49,7 @@ import { useBatchChangeListFilters } from './useBatchChangeListFilters'
 
 import styles from './BatchChangeListPage.module.scss'
 
-export interface BatchChangeListPageProps extends TelemetryProps, SettingsCascadeProps<Settings> {
+export interface BatchChangeListPageProps extends TelemetryProps, TelemetryV2Props, SettingsCascadeProps<Settings> {
     // canCreate indicates whether or not the currently-authenticated user has sufficient
     // permissions to create a batch change in whatever context this list page is being
     // presented. If not, canCreate will be a string reason why the user cannot create.
@@ -75,11 +76,15 @@ export const BatchChangeListPage: React.FunctionComponent<React.PropsWithChildre
     openTab,
     settingsCascade,
     telemetryService,
+    telemetryRecorder,
     isSourcegraphDotCom,
     authenticatedUser,
 }) => {
     const location = useLocation()
-    useEffect(() => telemetryService.logViewEvent('BatchChangesListPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('BatchChangesListPage')
+        telemetryRecorder.recordEvent('BatchChangesListPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const isExecutionEnabled = isBatchChangesExecutionEnabled(settingsCascade)
     const isBatchChangesLicensed = !!window.context.licenseInfo?.batchChanges?.unrestricted

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
@@ -35,7 +35,7 @@ export interface BatchChangePreviewPageProps extends Omit<BatchChangePreviewProp
 export const BatchChangePreviewPage: FC<BatchChangePreviewPageProps> = props => {
     const { batchSpecID } = useParams()
 
-    const { authenticatedUser, telemetryService, queryApplyPreviewStats } = props
+    const { authenticatedUser, telemetryService, telemetryRecorder, queryApplyPreviewStats } = props
 
     const { data, loading } = useQuery<BatchSpecByIDResult, BatchSpecByIDVariables>(BATCH_SPEC_BY_ID, {
         variables: {
@@ -47,7 +47,8 @@ export const BatchChangePreviewPage: FC<BatchChangePreviewPageProps> = props => 
 
     useEffect(() => {
         telemetryService.logViewEvent('BatchChangeApplyPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('BatchChangeApplyPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     if (loading) {
         return (
@@ -96,6 +97,7 @@ export const BatchChangePreviewPage: FC<BatchChangePreviewPageProps> = props => 
                         batchChange={spec.appliesToBatchChange}
                         viewerCanAdminister={spec.viewerCanAdminister}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                     <Description description={spec.description.description} />
                     <BatchChangePreviewTabs spec={spec} {...props} batchSpecID={spec.id} />
@@ -119,6 +121,7 @@ export const NewBatchChangePreviewPage: FC<BatchChangePreviewPageProps> = props 
         queryChangesetSpecFileDiffs,
         authenticatedUser,
         telemetryService,
+        telemetryRecorder,
         queryApplyPreviewStats,
     } = props
 
@@ -132,7 +135,8 @@ export const NewBatchChangePreviewPage: FC<BatchChangePreviewPageProps> = props 
 
     useEffect(() => {
         telemetryService.logViewEvent('BatchChangeApplyPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('BatchChangeApplyPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const { maxUnlicensedChangesets, exceedsLicense } = useBatchChangesLicense()
 
@@ -175,6 +179,7 @@ export const NewBatchChangePreviewPage: FC<BatchChangePreviewPageProps> = props 
                             batchChange={spec.appliesToBatchChange}
                             viewerCanAdminister={spec.viewerCanAdminister}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     )}
                     {exceedsLicense(spec.applyPreview.totalCount) && (

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewTabs.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewTabs.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react'
 import { mdiSourceBranch, mdiFileDocument } from '@mdi/js'
 import { useNavigate, useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge, Container, Icon, Tab, TabPanel, TabPanels } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import { PreviewList } from './list/PreviewList'
 
 import styles from './BatchChangePreviewTabs.module.scss'
 
-export interface BatchChangePreviewProps extends TelemetryProps {
+export interface BatchChangePreviewProps extends TelemetryProps, TelemetryV2Props {
     batchSpecID: string
     authenticatedUser: PreviewPageAuthenticatedUser
 

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
 import { isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Button, Code, Link, Tooltip, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -16,7 +17,7 @@ import { BatchChangePreviewContext } from './BatchChangePreviewContext'
 
 import styles from './CreateUpdateBatchChangeAlert.module.scss'
 
-export interface CreateUpdateBatchChangeAlertProps extends TelemetryProps {
+export interface CreateUpdateBatchChangeAlertProps extends TelemetryProps, TelemetryV2Props {
     specID: string
     toBeArchived: number
     batchChange: BatchSpecFields['appliesToBatchChange']
@@ -25,7 +26,7 @@ export interface CreateUpdateBatchChangeAlertProps extends TelemetryProps {
 
 export const CreateUpdateBatchChangeAlert: React.FunctionComponent<
     React.PropsWithChildren<CreateUpdateBatchChangeAlertProps>
-> = ({ specID, toBeArchived, batchChange, viewerCanAdminister, telemetryService }) => {
+> = ({ specID, toBeArchived, batchChange, viewerCanAdminister, telemetryService, telemetryRecorder }) => {
     const navigate = useNavigate()
 
     const batchChangeID = batchChange?.id
@@ -73,10 +74,21 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<
                 navigate(batchChange.url)
             }
             telemetryService.logViewEvent(`BatchChangeDetailsPageAfter${batchChangeID ? 'Create' : 'Update'}`)
+            telemetryRecorder.recordEvent('BatchChangeDetailsPageAfter', `${batchChangeID ? 'created' : 'updated'}`)
         } catch (error) {
             setIsLoading(error)
         }
-    }, [canApply, specID, setIsLoading, navigate, batchChangeID, telemetryService, toBeArchived, publicationStates])
+    }, [
+        canApply,
+        specID,
+        setIsLoading,
+        navigate,
+        batchChangeID,
+        telemetryService,
+        telemetryRecorder,
+        toBeArchived,
+        publicationStates,
+    ])
 
     return (
         <>

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -4,13 +4,14 @@ import { Routes, Route } from 'react-router-dom'
 
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
 import type { AuthenticatedUser } from '../../../auth'
 import { Page } from '../../../components/Page'
 
-interface Props extends TelemetryProps, PlatformContextProps, SettingsCascadeProps {
+interface Props extends TelemetryProps, TelemetryV2Props, PlatformContextProps, SettingsCascadeProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
     isCodyApp: boolean

--- a/client/web/src/enterprise/codeintel/admin/AdminCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/admin/AdminCodeIntelArea.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import { Routes, Route, Navigate, useParams } from 'react-router-dom'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -16,7 +17,7 @@ import type { CodeIntelPreciseIndexesPageProps } from '../indexes/pages/CodeInte
 import type { CodeIntelPreciseIndexPageProps } from '../indexes/pages/CodeIntelPreciseIndexPage'
 import type { CodeIntelRankingPageProps } from '../ranking/pages/CodeIntelRankingPage'
 
-export interface AdminCodeIntelAreaRouteContext extends TelemetryProps {
+export interface AdminCodeIntelAreaRouteContext extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 

--- a/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
@@ -2,6 +2,7 @@ import { type FunctionComponent, useCallback, useMemo, useState } from 'react'
 
 import type { editor } from 'monaco-editor'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { LoadingSpinner, screenReaderAnnounce, ErrorAlert, BeforeUnloadPrompt } from '@sourcegraph/wildcard'
@@ -16,7 +17,7 @@ import allConfigSchema from '../schema.json'
 
 import { IndexConfigurationSaveToolbar, type IndexConfigurationSaveToolbarProps } from './IndexConfigurationSaveToolbar'
 
-export interface ConfigurationEditorProps extends TelemetryProps {
+export interface ConfigurationEditorProps extends TelemetryProps, TelemetryV2Props {
     repoId: string
     authenticatedUser: AuthenticatedUser | null
 }
@@ -25,6 +26,7 @@ export const ConfigurationEditor: FunctionComponent<ConfigurationEditorProps> = 
     repoId,
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const isLightTheme = useIsLightTheme()
     const { inferredConfiguration, loadingInferred, inferredError } = useInferredConfig(repoId)
@@ -103,6 +105,7 @@ export const ConfigurationEditor: FunctionComponent<ConfigurationEditorProps> = 
                         height={600}
                         isLightTheme={isLightTheme}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         customSaveToolbar={authenticatedUser?.siteAdmin ? customToolbar : undefined}
                         onDirtyChange={setDirty}
                         onEditor={setEditor}

--- a/client/web/src/enterprise/codeintel/configuration/components/ConfigurationForm.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ConfigurationForm.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, ErrorAlert, screenReaderAnnounce } from '@sourcegraph/wildcard'
 
@@ -12,7 +13,7 @@ import { autoIndexJobsToFormData } from './inference-form/auto-index-to-form-job
 import { InferenceForm } from './inference-form/InferenceForm'
 import type { InferenceFormData, SchemaCompatibleInferenceFormData } from './inference-form/types'
 
-interface ConfigurationFormProps extends TelemetryProps {
+interface ConfigurationFormProps extends TelemetryProps, TelemetryV2Props {
     repoId: string
     authenticatedUser: AuthenticatedUser | null
 }

--- a/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptEditor.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptEditor.tsx
@@ -1,5 +1,6 @@
 import { type FunctionComponent, useCallback, useMemo, useState } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { screenReaderAnnounce, ErrorAlert } from '@sourcegraph/wildcard'
@@ -14,7 +15,7 @@ import { DynamicallyImportedMonacoSettingsEditor } from '../../../../../settings
 import { INFERENCE_SCRIPT } from '../../hooks/useInferenceScript'
 import { useUpdateInferenceScript } from '../../hooks/useUpdateInferenceScript'
 
-export interface InferenceScriptEditorProps extends TelemetryProps {
+export interface InferenceScriptEditorProps extends TelemetryProps, TelemetryV2Props {
     script: string
     authenticatedUser: AuthenticatedUser | null
     setPreviewScript: (script: string) => void
@@ -25,6 +26,7 @@ export const InferenceScriptEditor: FunctionComponent<InferenceScriptEditorProps
     setPreviewScript,
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const { updateInferenceScript, isUpdating, updatingError } = useUpdateInferenceScript()
 
@@ -77,6 +79,7 @@ export const InferenceScriptEditor: FunctionComponent<InferenceScriptEditorProps
                 height={600}
                 isLightTheme={isLightTheme}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 customSaveToolbar={authenticatedUser?.siteAdmin ? customToolbar : undefined}
                 onDirtyChange={setDirty}
             />

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -19,6 +19,7 @@ import { Subject } from 'rxjs'
 
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { GitObjectType } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryRecorder, TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps, TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge, Button, Container, ErrorAlert, H3, Icon, Link, PageHeader, Text, Tooltip } from '@sourcegraph/wildcard'
 
@@ -36,12 +37,13 @@ import { hasGlobalPolicyViolation } from '../shared'
 
 import styles from './CodeIntelConfigurationPage.module.scss'
 
-export interface CodeIntelConfigurationPageProps extends TelemetryProps {
+export interface CodeIntelConfigurationPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     queryPolicies?: typeof defaultQueryPolicies
     repo?: { id: string; name: string }
     indexingEnabled?: boolean
     telemetryService: TelemetryService
+    telemetryRecorder: TelemetryRecorder
 }
 
 export const CodeIntelConfigurationPage: FunctionComponent<CodeIntelConfigurationPageProps> = ({
@@ -50,8 +52,12 @@ export const CodeIntelConfigurationPage: FunctionComponent<CodeIntelConfiguratio
     repo,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
     telemetryService,
+    telemetryRecorder,
 }) => {
-    useEffect(() => telemetryService.logViewEvent('CodeIntelConfiguration'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelConfiguration')
+        telemetryRecorder.recordEvent('CodeIntelConfiguration', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const navigate = useNavigate()
     const location = useLocation()

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -11,6 +11,7 @@ import { useLazyQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { displayRepoName, RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { GitObjectType } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Alert,
@@ -57,7 +58,7 @@ const DEBOUNCED_WAIT = 250
 
 const MS_IN_HOURS = 60 * 60 * 1000
 
-export interface CodeIntelConfigurationPolicyPageProps extends TelemetryProps {
+export interface CodeIntelConfigurationPolicyPageProps extends TelemetryProps, TelemetryV2Props {
     repo?: { id: string; name: string }
     authenticatedUser: AuthenticatedUser | null
     indexingEnabled?: boolean
@@ -76,12 +77,16 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<CodeIntelConfig
     allowGlobalPolicies = window.context?.codeIntelAutoIndexingAllowGlobalPolicies,
     domain = 'scip',
     telemetryService,
+    telemetryRecorder,
 }) => {
     const navigate = useNavigate()
     const location = useLocation()
     const { id } = useParams<{ id: string }>()
 
-    useEffect(() => telemetryService.logViewEvent('CodeIntelConfigurationPolicy'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelConfigurationPolicy')
+        telemetryRecorder.recordEvent('CodeIntelConfigurationPolicy', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     // Handle local policy state
     const [policy, setPolicy] = useState<CodeIntelligenceConfigurationPolicyFields | undefined>()

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
@@ -1,5 +1,6 @@
 import { type FunctionComponent, useState } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ErrorAlert, Link, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import { useInferenceScript } from '../hooks/useInferenceScript'
 
 import styles from './CodeIntelInferenceConfigurationPage.module.scss'
 
-export interface CodeIntelInferenceConfigurationPageProps extends TelemetryProps {
+export interface CodeIntelInferenceConfigurationPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
@@ -2,6 +2,7 @@ import { type FunctionComponent, useEffect, useState } from 'react'
 
 import { useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Link, Tabs, TabList, Tab, TabPanels, TabPanel } from '@sourcegraph/wildcard'
 
@@ -11,15 +12,18 @@ import { CodeIntelConfigurationPageHeader } from '../components/CodeIntelConfigu
 import { ConfigurationEditor } from '../components/ConfigurationEditor'
 import { ConfigurationForm } from '../components/ConfigurationForm'
 
-export interface CodeIntelRepositoryIndexConfigurationPageProps extends TelemetryProps {
+export interface CodeIntelRepositoryIndexConfigurationPageProps extends TelemetryProps, TelemetryV2Props {
     repo: { id: string }
     authenticatedUser: AuthenticatedUser | null
 }
 
 export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
     CodeIntelRepositoryIndexConfigurationPageProps
-> = ({ repo, authenticatedUser, telemetryService, ...props }) => {
-    useEffect(() => telemetryService.logViewEvent('CodeIntelRepositoryIndexConfiguration'), [telemetryService])
+> = ({ repo, authenticatedUser, telemetryService, telemetryRecorder, ...props }) => {
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelRepositoryIndexConfiguration')
+        telemetryRecorder.recordEvent('CodeIntelRepositoryIndexConfiguration', 'viewed')
+    }, [telemetryService, telemetryRecorder])
     const location = useLocation()
 
     const [activeTabIndex, setActiveTabIndex] = useState<number>(0)
@@ -72,6 +76,7 @@ export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
                             repoId={repo.id}
                             authenticatedUser={authenticatedUser}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     </TabPanel>
                     <TabPanel>
@@ -79,6 +84,7 @@ export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
                             repoId={repo.id}
                             authenticatedUser={authenticatedUser}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                             {...props}
                         />
                     </TabPanel>

--- a/client/web/src/enterprise/codeintel/dashboard/pages/GlobalDashboardPage.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/pages/GlobalDashboardPage.tsx
@@ -4,6 +4,7 @@ import { mdiChevronRight, mdiCircleOffOutline } from '@mdi/js'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge, Container, ErrorAlert, H3, Icon, Link, LoadingSpinner, PageHeader, Text } from '@sourcegraph/wildcard'
 
@@ -78,17 +79,19 @@ const DashboardNode: React.FunctionComponent<DashboardNodeProps> = props => {
     )
 }
 
-export interface GlobalDashboardPageProps extends TelemetryProps {
+export interface GlobalDashboardPageProps extends TelemetryProps, TelemetryV2Props {
     indexingEnabled?: boolean
 }
 
 export const GlobalDashboardPage: React.FunctionComponent<GlobalDashboardPageProps> = ({
     telemetryService,
+    telemetryRecorder,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
 }) => {
     useEffect(() => {
         telemetryService.logPageView('CodeIntelGlobalDashboard')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('CodeIntelGlobalDashbaord', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, error, loading } = useQuery<GlobalCodeIntelStatusResult>(globalCodeIntelStatusQuery, {
         notifyOnNetworkStatusChange: false,

--- a/client/web/src/enterprise/codeintel/dashboard/pages/RepoDashboardPage.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/pages/RepoDashboardPage.tsx
@@ -6,6 +6,7 @@ import { type Location, useLocation, useNavigate } from 'react-router-dom'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Alert,
@@ -28,7 +29,7 @@ import { useRepoCodeIntelStatus } from '../hooks/useRepoCodeIntelStatus'
 
 import styles from './RepoDashboardPage.module.scss'
 
-export interface RepoDashboardPageProps extends TelemetryProps {
+export interface RepoDashboardPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     repo: { id: string; name: string }
     now?: () => Date
@@ -94,6 +95,7 @@ const buildFilterStateFromParams = ({ search }: Location, indexingEnabled: boole
 
 export const RepoDashboardPage: React.FunctionComponent<RepoDashboardPageProps> = ({
     telemetryService,
+    telemetryRecorder,
     repo,
     authenticatedUser,
     now,
@@ -101,7 +103,8 @@ export const RepoDashboardPage: React.FunctionComponent<RepoDashboardPageProps> 
 }) => {
     useEffect(() => {
         telemetryService.logPageView('CodeIntelRepoDashboard')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('CodeIntelRepoDashboard', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const location = useLocation()
     const navigate = useNavigate()

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexPage.tsx
@@ -8,6 +8,7 @@ import { takeWhile } from 'rxjs/operators'
 
 import { type ErrorLike, isErrorLike } from '@sourcegraph/common'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Alert,
@@ -48,7 +49,7 @@ import { useReindexPreciseIndex as defaultUseReindexPreciseIndex } from '../hook
 
 import styles from './CodeIntelPreciseIndexPage.module.scss'
 
-export interface CodeIntelPreciseIndexPageProps extends TelemetryProps {
+export interface CodeIntelPreciseIndexPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     now?: () => Date
     queryDependencyGraph?: typeof defaultQueryDependencyGraph
@@ -71,12 +72,16 @@ export const CodeIntelPreciseIndexPage: FunctionComponent<CodeIntelPreciseIndexP
     useReindexPreciseIndex = defaultUseReindexPreciseIndex,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const { id } = useParams<{ id: string }>()
     const navigate = useNavigate()
     const location = useLocation()
 
-    useEffect(() => telemetryService.logViewEvent('CodeIntelPreciseIndexPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelPreciseIndexPage')
+        telemetryRecorder.recordEvent('CodeIntelPreciseIndexPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const apolloClient = useApolloClient()
     const { handleReindexPreciseIndex, reindexError } = useReindexPreciseIndex()

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
@@ -11,6 +11,7 @@ import { isErrorLike } from '@sourcegraph/common'
 import { gql, useQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -59,7 +60,7 @@ export const INDEXER_LIST = gql`
     }
 `
 
-export interface CodeIntelPreciseIndexesPageProps extends TelemetryProps {
+export interface CodeIntelPreciseIndexesPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     repo?: { id: string; name: string }
     queryPreciseIndexes?: typeof defaultQueryPreciseIndexes
@@ -125,9 +126,13 @@ export const CodeIntelPreciseIndexesPage: FunctionComponent<CodeIntelPreciseInde
     useReindexPreciseIndexes = defaultUseReindexPreciseIndexes,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const location = useLocation()
-    useEffect(() => telemetryService.logViewEvent('CodeIntelPreciseIndexesPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelPreciseIndexesPage')
+        telemetryRecorder.recordEvent('CodeIntelPreciseIndexesPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const apolloClient = useApolloClient()
     const { handleDeletePreciseIndex, deleteError } = useDeletePreciseIndex()

--- a/client/web/src/enterprise/codeintel/ranking/pages/CodeIntelRankingPage.tsx
+++ b/client/web/src/enterprise/codeintel/ranking/pages/CodeIntelRankingPage.tsx
@@ -6,6 +6,7 @@ import { format, formatDistance, parseISO } from 'date-fns'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryRecorder, TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps, TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Badge,
@@ -36,16 +37,21 @@ import {
 
 import styles from './CodeIntelRankingPage.module.scss'
 
-export interface CodeIntelRankingPageProps extends TelemetryProps {
+export interface CodeIntelRankingPageProps extends TelemetryProps, TelemetryV2Props {
     useRankingSummary?: typeof defaultUseRankingSummary
     telemetryService: TelemetryService
+    telemetryRecorder: TelemetryRecorder
 }
 
 export const CodeIntelRankingPage: FunctionComponent<CodeIntelRankingPageProps> = ({
     useRankingSummary = defaultUseRankingSummary,
     telemetryService,
+    telemetryRecorder,
 }) => {
-    useEffect(() => telemetryService.logViewEvent('CodeIntelRankingPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelRankingPage')
+        telemetryRecorder.recordEvent('CodeIntelRankingPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error, refetch } = useRankingSummary({})
 

--- a/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 
 import { Routes, Route, Navigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -20,7 +21,7 @@ import type { CodeIntelPreciseIndexPageProps } from '../indexes/pages/CodeIntelP
 
 import { CodeIntelSidebar, type CodeIntelSideBarGroups } from './CodeIntelSidebar'
 
-export interface CodeIntelAreaRouteContext extends TelemetryProps {
+export interface CodeIntelAreaRouteContext extends TelemetryProps, TelemetryV2Props {
     repo: { id: string; name: string }
     authenticatedUser: AuthenticatedUser | null
 }
@@ -111,7 +112,7 @@ export const codeIntelAreaRoutes: readonly CodeIntelAreaRoute[] = [
 /**
  * Properties passed to all page components in the repository code navigation area.
  */
-export interface RepositoryCodeIntelAreaPageProps extends BreadcrumbSetters, TelemetryProps {
+export interface RepositoryCodeIntelAreaPageProps extends BreadcrumbSetters, TelemetryProps, TelemetryV2Props {
     /** The active repository. */
     repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null

--- a/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
+++ b/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
@@ -7,6 +7,7 @@ import { Subject } from 'rxjs'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Container, ErrorAlert, Link, PageHeader } from '@sourcegraph/wildcard'
 
@@ -25,7 +26,7 @@ import { EmptyPoliciesList } from '../components/EmptyPoliciesList'
 
 import styles from '../../../codeintel/configuration/pages/CodeIntelConfigurationPage.module.scss'
 
-export interface CodyConfigurationPageProps extends TelemetryProps {
+export interface CodyConfigurationPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     queryPolicies?: typeof defaultQueryPolicies
     repo?: { id: string; name: string }
@@ -36,10 +37,12 @@ export const CodyConfigurationPage: FC<CodyConfigurationPageProps> = ({
     queryPolicies = defaultQueryPolicies,
     repo,
     telemetryService,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
-        telemetryService.logPageView('CodyConfigurationPage')
-    }, [telemetryService])
+        telemetryService.logPageView('CodyConfigurationPage', { hasV2Event: true })
+        telemetryRecorder.recordEvent('CodyConfigurationPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const navigate = useNavigate()
     const location = useLocation()

--- a/client/web/src/enterprise/cody/repo/CodyRepoArea.tsx
+++ b/client/web/src/enterprise/cody/repo/CodyRepoArea.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 
 import { Navigate, Route, Routes } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -15,7 +16,7 @@ import { CodyConfigurationPage } from '../configuration/pages/CodyConfigurationP
 
 import { CodyRepoSidebar, type CodyRepoSidebarGroups } from './CodyRepoSidebar'
 
-export interface CodyRepoAreaRouteContext extends TelemetryProps {
+export interface CodyRepoAreaRouteContext extends TelemetryProps, TelemetryV2Props {
     repo: { id: string; name: string }
     authenticatedUser: AuthenticatedUser | null
 }
@@ -45,7 +46,7 @@ export const codyRepoAreaRoutes: readonly CodyRepoAreaRoute[] = [
     },
 ]
 
-export interface CodyRepoAreaProps extends BreadcrumbSetters, TelemetryProps {
+export interface CodyRepoAreaProps extends BreadcrumbSetters, TelemetryProps, TelemetryV2Props {
     repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null
 }

--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -4,6 +4,7 @@ import { gql, useLazyQuery } from '@apollo/client'
 import { Route, Routes, Navigate } from 'react-router-dom'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -28,7 +29,7 @@ const EditInsightLazyPage = lazyComponent(
     'EditInsightPage'
 )
 
-export interface CodeInsightsAppRouter extends TelemetryProps {
+export interface CodeInsightsAppRouter extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
 }
 
@@ -39,7 +40,7 @@ const rootPagePathsToTab = {
 }
 
 export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter>(props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const fetched = useLicense()
     const api = useApi()
@@ -55,20 +56,36 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
             <Routes>
                 <Route index={true} element={<CodeInsightsSmartRoutingRedirect />} />
 
-                <Route path="create/*" element={<CreationRoutes telemetryService={telemetryService} />} />
+                <Route
+                    path="create/*"
+                    element={
+                        <CreationRoutes telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
+                    }
+                />
 
                 <Route path="dashboards/:dashboardId/edit" element={<EditDashboardPage />} />
 
                 <Route
                     path="add-dashboard"
-                    element={<InsightsDashboardCreationPage telemetryService={telemetryService} />}
+                    element={
+                        <InsightsDashboardCreationPage
+                            telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
+                        />
+                    }
                 />
 
                 {Object.entries(rootPagePathsToTab).map(([path, activeTab]) => (
                     <Route
                         key="hardcoded-key"
                         path={path}
-                        element={<CodeInsightsRootPage activeTab={activeTab} telemetryService={telemetryService} />}
+                        element={
+                            <CodeInsightsRootPage
+                                activeTab={activeTab}
+                                telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
+                            />
+                        }
                     />
                 ))}
 
@@ -84,7 +101,15 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
                     path="insight/:insightId"
                     element={<RedirectRoute getRedirectURL={({ params }) => `/insights/${params.insightId}`} />}
                 />
-                <Route path=":insightId" element={<CodeInsightIndependentPage telemetryService={telemetryService} />} />
+                <Route
+                    path=":insightId"
+                    element={
+                        <CodeInsightIndependentPage
+                            telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
+                        />
+                    }
+                />
 
                 <Route path="*" element={<NotFoundPage pageType="code insights" />} />
             </Routes>

--- a/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -12,22 +13,29 @@ const CodeInsightsDotComGetStartedLazy = lazyComponent(
     'CodeInsightsDotComGetStarted'
 )
 
-export interface CodeInsightsRouterProps extends TelemetryProps {
+export interface CodeInsightsRouterProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
 }
 
 export const CodeInsightsRouter: FC<CodeInsightsRouterProps> = props => {
-    const { authenticatedUser, telemetryService } = props
+    const { authenticatedUser, telemetryService, telemetryRecorder } = props
 
     if (!window.context?.codeInsightsEnabled) {
         return (
             <CodeInsightsDotComGetStartedLazy
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 authenticatedUser={authenticatedUser}
             />
         )
     }
 
-    return <CodeInsightsAppLazyRouter authenticatedUser={authenticatedUser} telemetryService={telemetryService} />
+    return (
+        <CodeInsightsAppLazyRouter
+            authenticatedUser={authenticatedUser}
+            telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
+        />
+    )
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
@@ -2,6 +2,7 @@ import { type HTMLAttributes, forwardRef, useEffect } from 'react'
 
 import { useMergeRefs } from 'use-callback-ref'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useSearchParameters } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import { BackendInsightView } from './backend-insight/BackendInsight'
 import { LangStatsInsightCard } from './lang-stats-insight-card/LangStatsInsightCard'
 import { ViewGridItem } from './view-grid/ViewGrid'
 
-export interface SmartInsightProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
+export interface SmartInsightProps extends TelemetryProps, TelemetryV2Props, HTMLAttributes<HTMLElement> {
     insight: Insight
     resizing?: boolean
 }
@@ -21,7 +22,7 @@ export interface SmartInsightProps extends TelemetryProps, HTMLAttributes<HTMLEl
  * actions.
  */
 export const SmartInsight = forwardRef<HTMLElement, SmartInsightProps>((props, reference) => {
-    const { insight, resizing = false, telemetryService, children, ...attributes } = props
+    const { insight, resizing = false, telemetryService, telemetryRecorder, children, ...attributes } = props
 
     const mergedReference = useMergeRefs([reference])
     const search = useSearchParameters()
@@ -42,11 +43,21 @@ export const SmartInsight = forwardRef<HTMLElement, SmartInsightProps>((props, r
     return (
         <ViewGridItem id={insight.id} ref={mergedReference} {...attributes}>
             {isBackendInsight(insight) ? (
-                <BackendInsightView insight={insight} resizing={resizing} telemetryService={telemetryService}>
+                <BackendInsightView
+                    insight={insight}
+                    resizing={resizing}
+                    telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
+                >
                     {children}
                 </BackendInsightView>
             ) : (
-                <LangStatsInsightCard insight={insight} resizing={resizing} telemetryService={telemetryService}>
+                <LangStatsInsightCard
+                    insight={insight}
+                    resizing={resizing}
+                    telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
+                >
                     {children}
                 </LangStatsInsightCard>
             )}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -5,6 +5,7 @@ import { useMergeRefs } from 'use-callback-ref'
 
 import { isDefined } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, useDebounce, useDeepMemo, Text } from '@sourcegraph/wildcard'
 
@@ -36,13 +37,13 @@ import {
 
 import styles from './BackendInsight.module.scss'
 
-interface BackendInsightProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
+interface BackendInsightProps extends TelemetryProps, TelemetryV2Props, HTMLAttributes<HTMLElement> {
     insight: BackendInsight
     resizing?: boolean
 }
 
 export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((props, ref) => {
-    const { telemetryService, insight, resizing, children, className, ...attributes } = props
+    const { telemetryService, telemetryRecorder, insight, resizing, children, className, ...attributes } = props
 
     const { currentDashboard } = useContext(InsightContext)
     const { updateInsight } = useContext(CodeInsightsBackendContext)
@@ -122,6 +123,7 @@ export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((
         await updateInsight({ insightId: insight.id, nextInsightData: insightWithNewFilters }).toPromise()
 
         telemetryService.log('CodeInsightsSearchBasedFilterUpdating')
+        telemetryRecorder.recordEvent('CodeInsightsSearchBasedFilter', 'updated')
         setOriginalInsightFilters(filters)
         setIsFiltersOpen(false)
     }
@@ -137,12 +139,14 @@ export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((
         })
 
         telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
+        telemetryRecorder.recordEvent('CodeInsightsSearchBasedFilterInsight', 'created')
         setOriginalInsightFilters(filters)
         setIsFiltersOpen(false)
     }
 
     const { trackMouseLeave, trackMouseEnter, trackDatumClicks } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/lang-stats-insight-card/LangStatsInsightCard.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/lang-stats-insight-card/LangStatsInsightCard.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useContext, useState, type HTMLAttributes } from 'react'
 
 import { useMergeRefs } from 'use-callback-ref'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, ParentSize, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -23,13 +24,13 @@ import { InsightContext } from '../InsightContext'
 
 import styles from './LangStatsInsightCard.module.scss'
 
-interface BuiltInInsightProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
+interface BuiltInInsightProps extends TelemetryProps, TelemetryV2Props, HTMLAttributes<HTMLElement> {
     insight: LangStatsInsight
     resizing: boolean
 }
 
 export const LangStatsInsightCard = forwardRef<HTMLElement, BuiltInInsightProps>((props, ref) => {
-    const { insight, resizing, telemetryService, children, ...attributes } = props
+    const { insight, resizing, telemetryService, telemetryRecorder, children, ...attributes } = props
 
     const { currentDashboard } = useContext(InsightContext)
     const cardRef = useMergeRefs([ref])
@@ -46,6 +47,7 @@ export const LangStatsInsightCard = forwardRef<HTMLElement, BuiltInInsightProps>
 
     const { trackDatumClicks, trackMouseLeave, trackMouseEnter } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
 

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -3,6 +3,7 @@ import { Suspense, type FC, memo, useMemo } from 'react'
 import { mdiPlus } from '@mdi/js'
 import { useParams, useNavigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import {
@@ -41,13 +42,13 @@ export enum CodeInsightsRootPageTab {
     GettingStarted,
 }
 
-interface CodeInsightsRootPageProps extends TelemetryProps {
+interface CodeInsightsRootPageProps extends TelemetryProps, TelemetryV2Props {
     dashboardId?: string
     activeTab: CodeInsightsRootPageTab
 }
 
 export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props => {
-    const { activeTab, telemetryService } = props
+    const { activeTab, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const { dashboardId } = useParams()
@@ -79,7 +80,11 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props =>
             <PageHeader
                 path={[{ icon: CodeInsightsIcon, text: 'Insights' }]}
                 actions={
-                    <CodeInsightHeaderActions dashboardId={absoluteDashboardId} telemetryService={telemetryService} />
+                    <CodeInsightHeaderActions
+                        dashboardId={absoluteDashboardId}
+                        telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
+                    />
                 }
                 className={styles.header}
             />
@@ -98,14 +103,21 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props =>
                 </TabList>
                 <TabPanels className={styles.tabPanels}>
                     <TabPanel tabIndex={-1}>
-                        <DashboardsView dashboardId={dashboardId} telemetryService={telemetryService} />
+                        <DashboardsView
+                            dashboardId={dashboardId}
+                            telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
+                        />
                     </TabPanel>
                     <TabPanel tabIndex={-1}>
-                        <AllInsightsView telemetryService={telemetryService} />
+                        <AllInsightsView telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
                     </TabPanel>
                     <TabPanel tabIndex={-1}>
                         <Suspense fallback={<LoadingSpinner aria-label="Loading Code Insights Getting started page" />}>
-                            <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
+                            <LazyCodeInsightsGettingStartedPage
+                                telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
+                            />
                         </Suspense>
                     </TabPanel>
                 </TabPanels>
@@ -114,12 +126,12 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props =>
     )
 })
 
-interface CodeInsightHeaderActionsProps extends TelemetryProps {
+interface CodeInsightHeaderActionsProps extends TelemetryProps, TelemetryV2Props {
     dashboardId?: string
 }
 
 const CodeInsightHeaderActions: FC<CodeInsightHeaderActionsProps> = props => {
-    const { dashboardId, telemetryService } = props
+    const { dashboardId, telemetryService, telemetryRecorder } = props
 
     const { insight } = useUiFeatures()
     const creationPermission = useObservable(useMemo(() => insight.getCreationPermissions(), [insight]))
@@ -143,7 +155,10 @@ const CodeInsightHeaderActions: FC<CodeInsightHeaderActionsProps> = props => {
                     as={Link}
                     to={encodeDashboardIdQueryParam('/insights/create', dashboardId)}
                     variant="primary"
-                    onClick={() => telemetryService.log('InsightAddMoreClick')}
+                    onClick={() => {
+                        telemetryService.log('InsightAddMoreClick')
+                        telemetryRecorder.recordEvent('InsightAddMore', 'clicked')
+                    }}
                     disabled={!available}
                 >
                     <Icon aria-hidden={true} svgPath={mdiPlus} /> Create insight

--- a/client/web/src/enterprise/insights/pages/all-insights-view/AllInsightsView.tsx
+++ b/client/web/src/enterprise/insights/pages/all-insights-view/AllInsightsView.tsx
@@ -4,6 +4,7 @@ import { mdiPlus } from '@mdi/js'
 
 import { isDefined } from '@sourcegraph/common'
 import { dataOrThrowErrors } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Card, Icon, Link, LoadingSpinner, Button, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import { GET_ALL_INSIGHT_CONFIGURATIONS } from './query'
 
 import styles from './AllInsightsView.module.scss'
 
-interface AllInsightsViewProps extends TelemetryProps {}
+interface AllInsightsViewProps extends TelemetryProps, TelemetryV2Props {}
 
 export const AllInsightsView: FC<AllInsightsViewProps> = props => {
     const { connection, loading, hasNextPage, error, fetchMore } = useShowMorePagination<
@@ -55,6 +56,7 @@ export const AllInsightsView: FC<AllInsightsViewProps> = props => {
                 insights={insights}
                 persistSizeAndOrder={false}
                 telemetryService={props.telemetryService}
+                telemetryRecorder={props.telemetryRecorder}
             />
 
             <footer className={styles.footer}>

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useMemo } from 'react'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Container, Button, LoadingSpinner, useObservable, Link, Tooltip } from '@sourcegraph/wildcard'
 
@@ -19,12 +20,12 @@ import {
 
 import styles from './InsightsDashboardCreationPage.module.scss'
 
-interface InsightsDashboardCreationPageProps extends TelemetryProps {}
+interface InsightsDashboardCreationPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export const InsightsDashboardCreationPage: React.FunctionComponent<
     React.PropsWithChildren<InsightsDashboardCreationPageProps>
 > = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const { dashboard } = useUiFeatures()
@@ -43,6 +44,7 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<
         const createdDashboard = await createDashboard({ name, owners: [owner] }).toPromise()
 
         telemetryService.log('CodeInsightsDashboardCreationPageSubmitClick')
+        telemetryRecorder.recordEvent('CodyInsightsDashboardCreataionPageSubmit', 'clicked')
 
         // Navigate user to the dashboard page with new created dashboard
         navigate(`/insights/dashboards/${createdDashboard.id}`)

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/DashboardsView.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/DashboardsView.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 
 import { Navigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -10,7 +11,7 @@ import { isPersonalDashboard, useInsightDashboards } from '../../../core'
 
 import { DashboardsContent } from './components/dashboards-content/DashboardsContent'
 
-export interface DashboardsViewProps extends TelemetryProps {
+export interface DashboardsViewProps extends TelemetryProps, TelemetryV2Props {
     /**
      * Possible dashboard id. All insights on the page will be got from
      * dashboard's info from the user or org settings by the dashboard id.
@@ -21,7 +22,7 @@ export interface DashboardsViewProps extends TelemetryProps {
 }
 
 export const DashboardsView: FC<DashboardsViewProps> = props => {
-    const { dashboardId, telemetryService } = props
+    const { dashboardId, telemetryService, telemetryRecorder } = props
 
     const { dashboards } = useInsightDashboards()
 
@@ -51,6 +52,7 @@ export const DashboardsView: FC<DashboardsViewProps> = props => {
                 currentDashboard={currentDashboard}
                 dashboards={dashboards}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
         </>
     )

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/DashboardsContent.tsx
@@ -6,6 +6,7 @@ import ViewDashboardOutlineIcon from 'mdi-react/ViewDashboardOutlineIcon'
 import { useNavigate } from 'react-router-dom'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Tooltip } from '@sourcegraph/wildcard'
 
@@ -23,13 +24,13 @@ import { DashboardInsights } from './components/dashboard-inisghts/DashboardInsi
 
 import styles from './DashboardsContent.module.scss'
 
-export interface DashboardsContentProps extends TelemetryProps {
+export interface DashboardsContentProps extends TelemetryProps, TelemetryV2Props {
     currentDashboard: CustomInsightDashboard | undefined
     dashboards: CustomInsightDashboard[]
 }
 
 export const DashboardsContent: FC<DashboardsContentProps> = props => {
-    const { currentDashboard, dashboards, telemetryService } = props
+    const { currentDashboard, dashboards, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const [, setLasVisitedDashboard] = useTemporarySetting('insights.lastVisitedDashboardId', null)
@@ -40,7 +41,10 @@ export const DashboardsContent: FC<DashboardsContentProps> = props => {
     const [isDeleteDashboardActive, setDeleteDashboardActive] = useState<boolean>(false)
     const [dashboardGridApi, setDashboardGridApi] = useState<GridApi>()
 
-    useEffect(() => telemetryService.logViewEvent('Insights'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('Insights')
+        telemetryRecorder.recordEvent('Insights', 'viewed')
+    }, [telemetryService, telemetryRecorder])
     useEffect(() => setLasVisitedDashboard(currentDashboard?.id ?? null), [currentDashboard, setLasVisitedDashboard])
 
     const handleDashboardSelect = (dashboard: CustomInsightDashboard): void =>
@@ -113,6 +117,7 @@ export const DashboardsContent: FC<DashboardsContentProps> = props => {
                 <DashboardInsights
                     currentDashboard={currentDashboard}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     className={styles.insights}
                     onAddInsightRequest={() => setAddInsightsState(true)}
                     onDashboardCreate={setDashboardGridApi}

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -1,6 +1,7 @@
 import { type FC, useContext, useMemo } from 'react'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
@@ -8,7 +9,7 @@ import { SmartInsightsViewGrid, InsightContext, type GridApi } from '../../../..
 import { CodeInsightsBackendContext, type CustomInsightDashboard } from '../../../../../../../core'
 import { EmptyCustomDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
 
-interface DashboardInsightsProps extends TelemetryProps {
+interface DashboardInsightsProps extends TelemetryProps, TelemetryV2Props {
     currentDashboard: CustomInsightDashboard
     className?: string
     onAddInsightRequest?: () => void
@@ -16,7 +17,8 @@ interface DashboardInsightsProps extends TelemetryProps {
 }
 
 export const DashboardInsights: FC<DashboardInsightsProps> = props => {
-    const { currentDashboard, telemetryService, className, onAddInsightRequest, onDashboardCreate } = props
+    const { currentDashboard, telemetryService, telemetryRecorder, className, onAddInsightRequest, onDashboardCreate } =
+        props
 
     const { getInsights } = useContext(CodeInsightsBackendContext)
     const codeInsightsCompute = useExperimentalFeatures(settings => settings.codeInsightsCompute ?? false)
@@ -45,6 +47,7 @@ export const DashboardInsights: FC<DashboardInsightsProps> = props => {
                     id={currentDashboard.id}
                     insights={insights}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     className={className}
                     onGridCreate={onDashboardCreate}
                 />

--- a/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import { Routes, Route } from 'react-router-dom'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -11,20 +12,25 @@ import { InsightCreationPageType } from './InsightCreationPage'
 const IntroCreationLazyPage = lazyComponent(() => import('./intro/IntroCreationPage'), 'IntroCreationPage')
 const InsightCreationLazyPage = lazyComponent(() => import('./InsightCreationPage'), 'InsightCreationPage')
 
-interface CreationRoutesProps extends TelemetryProps {}
+interface CreationRoutesProps extends TelemetryProps, TelemetryV2Props {}
 
 /**
  * Code insight sub-router for the creation area/routes.
  * Renders code insights creation routes (insight creation UI pages, creation intro page)
  */
 export const CreationRoutes: FC<CreationRoutesProps> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const codeInsightsCompute = useExperimentalFeatures(settings => settings.codeInsightsCompute)
 
     return (
         <Routes>
-            <Route index={true} element={<IntroCreationLazyPage telemetryService={telemetryService} />} />
+            <Route
+                index={true}
+                element={
+                    <IntroCreationLazyPage telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
+                }
+            />
 
             <Route
                 path="search"
@@ -32,6 +38,7 @@ export const CreationRoutes: FC<CreationRoutesProps> = props => {
                     <InsightCreationLazyPage
                         mode={InsightCreationPageType.Search}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 }
             />
@@ -42,6 +49,7 @@ export const CreationRoutes: FC<CreationRoutesProps> = props => {
                     <InsightCreationLazyPage
                         mode={InsightCreationPageType.CaptureGroup}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 }
             />
@@ -52,6 +60,7 @@ export const CreationRoutes: FC<CreationRoutesProps> = props => {
                     <InsightCreationLazyPage
                         mode={InsightCreationPageType.LangStats}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 }
             />
@@ -63,6 +72,7 @@ export const CreationRoutes: FC<CreationRoutesProps> = props => {
                         <InsightCreationLazyPage
                             mode={InsightCreationPageType.Compute}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     }
                 />

--- a/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
@@ -3,6 +3,7 @@ import { type FC, useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { CodeInsightsBackendContext, type CreationInsightInput } from '../../../core'
@@ -25,12 +26,12 @@ interface InsightCreateEvent {
     insight: CreationInsightInput
 }
 
-interface InsightCreationPageProps extends TelemetryProps {
+interface InsightCreationPageProps extends TelemetryProps, TelemetryV2Props {
     mode: InsightCreationPageType
 }
 
 export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
-    const { mode, telemetryService } = props
+    const { mode, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const { createInsight } = useContext(CodeInsightsBackendContext)
@@ -72,6 +73,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
             <CaptureGroupCreationPage
                 backUrl={backCreateUrl}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 onInsightCreateRequest={handleInsightCreateRequest}
                 onSuccessfulCreation={handleInsightSuccessfulCreation}
                 onCancel={handleCancel}
@@ -84,6 +86,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
             <SearchInsightCreationPage
                 backUrl={backCreateUrl}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 onInsightCreateRequest={handleInsightCreateRequest}
                 onSuccessfulCreation={handleInsightSuccessfulCreation}
                 onCancel={handleCancel}
@@ -96,6 +99,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
             <ComputeInsightCreationPage
                 backUrl={backCreateUrl}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 onInsightCreateRequest={handleInsightCreateRequest}
                 onSuccessfulCreation={handleInsightSuccessfulCreation}
                 onCancel={handleCancel}
@@ -107,6 +111,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
         <LangStatsInsightCreationPage
             backUrl={backCreateUrl}
             telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
             onInsightCreateRequest={handleInsightCreateRequest}
             onSuccessfulCreation={handleInsightSuccessfulCreation}
             onCancel={handleCancel}

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Link } from '@sourcegraph/wildcard'
 
@@ -19,11 +20,11 @@ import {
 
 import styles from './IntroCreationPage.module.scss'
 
-interface IntroCreationPageProps extends TelemetryProps {}
+interface IntroCreationPageProps extends TelemetryProps, TelemetryV2Props {}
 
 /** Displays intro page for insights creation UI. */
 export const IntroCreationPage: React.FunctionComponent<React.PropsWithChildren<IntroCreationPageProps>> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const { search } = useLocation()
@@ -31,27 +32,32 @@ export const IntroCreationPage: React.FunctionComponent<React.PropsWithChildren<
 
     const handleCreateSearchBasedInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateSearchBasedInsightClick')
+        telemetryRecorder.recordEvent('CodeInsightsCreateSearchBasedInsight', 'clicked')
         navigate(`/insights/create/search${search}`)
     }
 
     const handleCaptureGroupInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateCaptureGroupInsightClick')
+        telemetryRecorder.recordEvent('CodeInsightsCreateCaptureGroupInsight', 'clicked')
         navigate(`/insights/create/capture-group${search}`)
     }
 
     const handleCreateComputeInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateComputeInsightClick')
+        telemetryRecorder.recordEvent('CodeInsightsCreateComputeInsight', 'clicked')
         navigate(`/insights/create/group-results${search}`)
     }
 
     const handleCreateCodeStatsInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateCodeStatsInsightClick')
+        telemetryRecorder.recordEvent('CodeInsightsCreateCodeStatsInsight', 'clicked')
         navigate(`/insights/create/lang-stats${search}`)
     }
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeInsightsCreationPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('CodeInsightsCreationPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <CodeInsightsPage className={styles.container}>

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -2,6 +2,7 @@ import { type FunctionComponent, useContext, useEffect, useMemo } from 'react'
 
 import { useParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
@@ -17,10 +18,10 @@ import { Standalone404Insight } from './components/standalone-404-insight/Standa
 
 import styles from './CodeInsightIndependentPage.module.scss'
 
-interface CodeInsightIndependentPage extends TelemetryProps {}
+interface CodeInsightIndependentPage extends TelemetryProps, TelemetryV2Props {}
 
 export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependentPage> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const { insightId } = useParams()
     const { getInsightById } = useContext(CodeInsightsBackendContext)
@@ -29,7 +30,8 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
 
     useEffect(() => {
         telemetryService.logPageView('StandaloneInsightPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('StandaloneInsightPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     if (insight === undefined) {
         return <LoadingSpinner inline={false} />
@@ -44,18 +46,29 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
             <PageTitle title={`${insight.title} - Code Insights`} />
             <PageHeader
                 path={[{ to: '/insights/all', icon: CodeInsightsIcon }, { text: insight.title }]}
-                actions={<CodeInsightIndependentPageActions insight={insight} telemetryService={telemetryService} />}
+                actions={
+                    <CodeInsightIndependentPageActions
+                        insight={insight}
+                        telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
+                    />
+                }
             />
 
             <StandaloneInsightDashboardPills
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 dashboards={insight.dashboards}
                 insightId={insight.id}
                 className={styles.dashboards}
             />
 
             <div className={styles.content}>
-                <SmartStandaloneInsight insight={insight} telemetryService={telemetryService} />
+                <SmartStandaloneInsight
+                    insight={insight}
+                    telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
+                />
             </div>
         </CodeInsightsPage>
     )

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/SmartStandaloneInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/SmartStandaloneInsight.tsx
@@ -1,5 +1,6 @@
 import type { FunctionComponent } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { type Insight, isBackendInsight } from '../../../../core'
@@ -7,18 +8,32 @@ import { type Insight, isBackendInsight } from '../../../../core'
 import { StandaloneBackendInsight } from './standalone-backend-insight/StandaloneBackendInsight'
 import { StandaloneLangStatsInsight } from './standalone-lang-stats-insight/StandaloneLangStatsInsight'
 
-interface SmartStandaloneInsightProps extends TelemetryProps {
+interface SmartStandaloneInsightProps extends TelemetryProps, TelemetryV2Props {
     insight: Insight
     className?: string
 }
 
 export const SmartStandaloneInsight: FunctionComponent<SmartStandaloneInsightProps> = props => {
-    const { insight, telemetryService, className } = props
+    const { insight, telemetryService, telemetryRecorder, className } = props
 
     if (isBackendInsight(insight)) {
-        return <StandaloneBackendInsight insight={insight} telemetryService={telemetryService} className={className} />
+        return (
+            <StandaloneBackendInsight
+                insight={insight}
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+                className={className}
+            />
+        )
     }
 
     // Search based extension and lang stats insight are handled by built-in fetchers
-    return <StandaloneLangStatsInsight insight={insight} telemetryService={telemetryService} className={className} />
+    return (
+        <StandaloneLangStatsInsight
+            insight={insight}
+            telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
+            className={className}
+        />
+    )
 }

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -4,6 +4,7 @@ import { mdiLinkVariant } from '@mdi/js'
 import { escapeRegExp } from 'lodash'
 import { useNavigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Icon, Tooltip } from '@sourcegraph/wildcard'
 
@@ -14,12 +15,12 @@ import { useCopyURLHandler } from '../../../../../hooks/use-copy-url-handler'
 
 import styles from './CodeInsightIndependentPageActions.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     insight: Insight
 }
 
 export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props => {
-    const { insight, telemetryService } = props
+    const { insight, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
 
@@ -44,6 +45,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
 
     const handleEditClick = (): void => {
         telemetryService.log('StandaloneInsightPageEditClick')
+        telemetryRecorder.recordEvent('StandaloneInsightPageEdit', 'clicked')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
@@ -3,6 +3,7 @@ import type { FunctionComponent, HTMLAttributes } from 'react'
 import { mdiViewDashboard } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
 
@@ -10,16 +11,20 @@ import type { InsightDashboardReference } from '../../../../../core'
 
 import styles from './StandaloneInsightDashboardPills.module.scss'
 
-interface StandaloneInsightDashboardPillsProps extends HTMLAttributes<HTMLDivElement>, TelemetryProps {
+interface StandaloneInsightDashboardPillsProps
+    extends HTMLAttributes<HTMLDivElement>,
+        TelemetryProps,
+        TelemetryV2Props {
     dashboards: InsightDashboardReference[]
     insightId: string
 }
 
 export const StandaloneInsightDashboardPills: FunctionComponent<StandaloneInsightDashboardPillsProps> = props => {
-    const { dashboards, insightId, className, telemetryService, ...attributes } = props
+    const { dashboards, insightId, className, telemetryService, telemetryRecorder, ...attributes } = props
 
     const handleDashboardClick = (): void => {
         telemetryService.log('StandaloneInsightDashboardClick')
+        telemetryRecorder.recordEvent('StandaloneInsightDashboard', 'clicked')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Card, CardBody, useDebounce, useDeepMemo, type FormChangeEvent } from '@sourcegraph/wildcard'
 
@@ -41,13 +42,13 @@ import { StandaloneInsightContextMenu } from '../context-menu/StandaloneInsightC
 
 import styles from './StandaloneBackendInsight.module.scss'
 
-interface StandaloneBackendInsight extends TelemetryProps {
+interface StandaloneBackendInsight extends TelemetryProps, TelemetryV2Props {
     insight: BackendInsight
     className?: string
 }
 
 export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackendInsight> = props => {
-    const { telemetryService, insight, className } = props
+    const { telemetryService, telemetryRecorder, insight, className } = props
     const navigate = useNavigate()
     const { updateInsight } = useContext(CodeInsightsBackendContext)
     const [saveAsNewView] = useSaveInsightAsNewView({ dashboard: null })
@@ -109,6 +110,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
 
     const { trackMouseLeave, trackMouseEnter, trackDatumClicks } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
 
@@ -122,6 +124,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         await updateInsight({ insightId: insight.id, nextInsightData: { ...insight, filters } }).toPromise()
         setOriginalInsightFilters(filters)
         telemetryService.log('CodeInsightsSearchBasedFilterUpdating')
+        telemetryRecorder.recordEvent('CodeInsightsSearchBasedFilter', 'updated')
     }
 
     const handleInsightFilterCreation = async (values: DrillDownInsightCreationFormValues): Promise<void> => {
@@ -135,6 +138,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         setOriginalInsightFilters(filters)
         navigate('/insights/all')
         telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
+        telemetryRecorder.recordEvent('CodeInsightsSearchBasedFilterInsight', 'created')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-lang-stats-insight/StandaloneLangStatsInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-lang-stats-insight/StandaloneLangStatsInsight.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ParentSize, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -19,13 +20,13 @@ import { StandaloneInsightContextMenu } from '../context-menu/StandaloneInsightC
 
 import styles from './StandaloneLangStatsInsight.module.scss'
 
-interface StandaloneLangStatsInsightProps extends TelemetryProps {
+interface StandaloneLangStatsInsightProps extends TelemetryProps, TelemetryV2Props {
     insight: LangStatsInsight
     className?: string
 }
 
 export function StandaloneLangStatsInsight(props: StandaloneLangStatsInsightProps): React.ReactElement {
-    const { insight, telemetryService, className } = props
+    const { insight, telemetryService, telemetryRecorder, className } = props
 
     const { state } = useLivePreviewLangStatsInsight(insight)
 
@@ -34,6 +35,7 @@ export function StandaloneLangStatsInsight(props: StandaloneLangStatsInsightProp
 
     const { trackDatumClicks, trackMouseLeave, trackMouseEnter } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
 

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react'
 import classNames from 'classnames'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Card, CardBody, Link, PageHeader } from '@sourcegraph/wildcard'
 
@@ -20,19 +21,20 @@ import styles from './CodeInsightsDotComGetStarted.module.scss'
 
 const DOT_COM_CONTEXT = { mode: CodeInsightsLandingPageType.Cloud }
 
-export interface CodeInsightsDotComGetStartedProps extends TelemetryProps {
+export interface CodeInsightsDotComGetStartedProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 
 export const CodeInsightsDotComGetStarted: React.FunctionComponent<
     React.PropsWithChildren<CodeInsightsDotComGetStartedProps>
 > = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
     const isSourcegraphDotCom = window.context.sourcegraphDotComMode
 
     useEffect(() => {
         telemetryService.logViewEvent('CloudInsightsGetStartedPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('CloudInsightsGetStartedPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <CodeInsightsLandingPageContext.Provider value={DOT_COM_CONTEXT}>
@@ -92,7 +94,10 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<
                         .
                     </CallToActionBanner>
 
-                    <CodeInsightsExamplesPicker telemetryService={telemetryService} />
+                    <CodeInsightsExamplesPicker
+                        telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
+                    />
                 </main>
             </Page>
         </CodeInsightsLandingPageContext.Provider>

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/CodeInsightsExamplesPicker.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/CodeInsightsExamplesPicker.tsx
@@ -3,6 +3,7 @@ import { type FunctionComponent, useLayoutEffect, useState } from 'react'
 import classNames from 'classnames'
 import { throttle } from 'lodash'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Card, CardBody, Link, H2 } from '@sourcegraph/wildcard'
 
@@ -13,10 +14,10 @@ import { EXAMPLES } from './examples'
 
 import styles from './CodeInsightsExamplesPicker.module.scss'
 
-interface CodeInsightsExamplesPickerProps extends TelemetryProps {}
+interface CodeInsightsExamplesPickerProps extends TelemetryProps, TelemetryV2Props {}
 
 export const CodeInsightsExamplesPicker: FunctionComponent<CodeInsightsExamplesPickerProps> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
     const [activeExampleIndex, setActiveExampleIndex] = useState(0)
     const [windowSize, setWindowSize] = useState(0)
 
@@ -32,6 +33,7 @@ export const CodeInsightsExamplesPicker: FunctionComponent<CodeInsightsExamplesP
     const handleUseCaseButtonClick = (useCaseIndex: number): void => {
         setActiveExampleIndex(useCaseIndex)
         telemetryService.log('CloudCodeInsightsGetStartedUseCase')
+        telemetryRecorder.recordEvent('CloudCodeInsightsGetStartedUseCase', 'clicked')
     }
 
     const isMobileLayout = windowSize <= 900
@@ -78,10 +80,13 @@ export const CodeInsightsExamplesPicker: FunctionComponent<CodeInsightsExamplesP
                     {...EXAMPLES[activeExampleIndex]}
                     className={styles.section}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
 
-            {isMobileLayout && <CodeInsightsExamplesSlider telemetryService={telemetryService} />}
+            {isMobileLayout && (
+                <CodeInsightsExamplesSlider telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
+            )}
         </Card>
     )
 }

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { useMergeRefs } from 'use-callback-ref'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, type ForwardReferenceComponent, H3 } from '@sourcegraph/wildcard'
 
@@ -11,12 +12,12 @@ import { EXAMPLES } from '../examples'
 
 import styles from './CodeInsightsExamplesSlider.module.scss'
 
-interface CodeInsightsExamplesSliderProps extends TelemetryProps {}
+interface CodeInsightsExamplesSliderProps extends TelemetryProps, TelemetryV2Props {}
 
 export const CodeInsightsExamplesSlider: React.FunctionComponent<
     React.PropsWithChildren<CodeInsightsExamplesSliderProps>
 > = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
     const itemElementReferences = useRef<Map<number, HTMLElement | null>>(new Map())
     const [activeExampleIndex, setActiveExampleIndex] = useState<number>(0)
 
@@ -27,6 +28,7 @@ export const CodeInsightsExamplesSlider: React.FunctionComponent<
         if (nextElementReference) {
             nextElementReference.scrollIntoView({ block: 'nearest', inline: 'start' })
             telemetryService.log('CloudCodeInsightsGetStartedUseCase')
+            telemetryRecorder.recordEvent('CloudCodeInsightsGetStartedUseCase', 'clicked')
         }
     }
 
@@ -37,6 +39,7 @@ export const CodeInsightsExamplesSlider: React.FunctionComponent<
         if (nextElementReference) {
             nextElementReference.scrollIntoView({ block: 'nearest', inline: 'start' })
             telemetryService.log('CloudCodeInsightsGetStartedUseCase')
+            telemetryRecorder.recordEvent('CloudCodeInsightsGetStartedUseCase', 'clicked')
         }
     }
 
@@ -83,6 +86,7 @@ export const CodeInsightsExamplesSlider: React.FunctionComponent<
                             {...example}
                             className={styles.sliderChart}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     </CodeInsightsExamplesSliderItem>
                 ))}

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { PageTitle } from '../../../../../components/PageTitle'
@@ -10,23 +11,32 @@ import { DynamicCodeInsightExample } from './components/dynamic-code-insight-exa
 
 import styles from './CodeInsightsGettingStartedPage.module.scss'
 
-interface CodeInsightsGettingStartedPageProps extends TelemetryProps {}
+interface CodeInsightsGettingStartedPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export const CodeInsightsGettingStartedPage: React.FunctionComponent<
     React.PropsWithChildren<CodeInsightsGettingStartedPageProps>
 > = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     useEffect(() => {
         telemetryService.logViewEvent('InsightsGetStartedPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('InsightsGetStartedPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <main className="pb-5">
             <PageTitle title="Code Insights" />
-            <DynamicCodeInsightExample telemetryService={telemetryService} />
-            <CodeInsightsExamples telemetryService={telemetryService} className={styles.section} />
-            <CodeInsightsTemplates telemetryService={telemetryService} className={styles.section} />
+            <DynamicCodeInsightExample telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
+            <CodeInsightsExamples
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+                className={styles.section}
+            />
+            <CodeInsightsTemplates
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+                className={styles.section}
+            />
         </main>
     )
 }

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -2,6 +2,7 @@ import type { FunctionComponent } from 'react'
 
 import { useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, H2, Text } from '@sourcegraph/wildcard'
 
@@ -14,7 +15,10 @@ import { ALPINE_VERSIONS_INSIGHT, CSS_MODULES_VS_GLOBAL_STYLES_INSIGHT } from '.
 
 import styles from './CodeInsightsExamples.module.scss'
 
-export interface CodeInsightsExamplesProps extends TelemetryProps, React.HTMLAttributes<HTMLElement> {}
+export interface CodeInsightsExamplesProps
+    extends TelemetryProps,
+        TelemetryV2Props,
+        React.HTMLAttributes<HTMLElement> {}
 
 const SEARCH_INSIGHT_CREATION_UI_URL_PARAMETERS = encodeSearchInsightUrl({
     title: CSS_MODULES_VS_GLOBAL_STYLES_INSIGHT.title,
@@ -33,7 +37,7 @@ const CAPTURE_GROUP_INSIGHT_CREATION_UI_URL_PARAMETERS = encodeCaptureInsightURL
  * code insights landing pages.
  */
 export const CodeInsightsExamples: FunctionComponent<CodeInsightsExamplesProps> = props => {
-    const { telemetryService, ...otherProps } = props
+    const { telemetryService, telemetryRecorder, ...otherProps } = props
     const { pathname, search } = useLocation()
 
     return (
@@ -50,6 +54,7 @@ export const CodeInsightsExamples: FunctionComponent<CodeInsightsExamplesProps> 
                     content={CSS_MODULES_VS_GLOBAL_STYLES_INSIGHT}
                     templateLink={`/insights/create/search?${SEARCH_INSIGHT_CREATION_UI_URL_PARAMETERS}`}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     className={styles.card}
                 />
 
@@ -58,6 +63,7 @@ export const CodeInsightsExamples: FunctionComponent<CodeInsightsExamplesProps> 
                     content={ALPINE_VERSIONS_INSIGHT}
                     templateLink={`/insights/create/capture-group?${CAPTURE_GROUP_INSIGHT_CREATION_UI_URL_PARAMETERS}`}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     className={styles.card}
                 />
             </div>

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/code-insight-example-card/CodeInsightExampleCard.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/code-insight-example-card/CodeInsightExampleCard.tsx
@@ -1,6 +1,7 @@
 import { type FunctionComponent, useContext } from 'react'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/branded'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, LegendItem, LegendList, ParentSize, LegendItemPoint } from '@sourcegraph/wildcard'
 
@@ -37,7 +38,7 @@ export const CodeInsightExampleCard: FunctionComponent<CodeInsightExampleProps> 
     return <CodeInsightCaptureExample {...props} />
 }
 
-interface CodeInsightSearchExampleProps extends TelemetryProps {
+interface CodeInsightSearchExampleProps extends TelemetryProps, TelemetryV2Props {
     type: InsightType.SearchBased
     content: SearchInsightExampleContent<any>
     templateLink?: string
@@ -45,7 +46,7 @@ interface CodeInsightSearchExampleProps extends TelemetryProps {
 }
 
 const CodeInsightSearchExample: FunctionComponent<CodeInsightSearchExampleProps> = props => {
-    const { templateLink, className, content, telemetryService } = props
+    const { templateLink, className, content, telemetryService, telemetryRecorder } = props
     const seriesToggleState = useSeriesToggle()
 
     const { mode } = useContext(CodeInsightsLandingPageContext)
@@ -54,6 +55,7 @@ const CodeInsightSearchExample: FunctionComponent<CodeInsightSearchExampleProps>
 
     const { trackMouseEnter, trackMouseLeave } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType:
             mode === CodeInsightsLandingPageType.Cloud
                 ? CodeInsightTrackType.CloudLandingPageInsight
@@ -62,6 +64,7 @@ const CodeInsightSearchExample: FunctionComponent<CodeInsightSearchExampleProps>
 
     const handleTemplateLinkClick = (): void => {
         telemetryService.log(bigTemplateClickPingName)
+        telemetryRecorder.recordEvent('InsightsGetStartedBigTemplate', 'clicked')
     }
 
     return (
@@ -115,7 +118,7 @@ const CodeInsightSearchExample: FunctionComponent<CodeInsightSearchExampleProps>
     )
 }
 
-interface CodeInsightCaptureExampleProps extends TelemetryProps {
+interface CodeInsightCaptureExampleProps extends TelemetryProps, TelemetryV2Props {
     type: InsightType.CaptureGroup
     content: CaptureGroupExampleContent<any>
     templateLink?: string
@@ -128,6 +131,7 @@ const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProp
         templateLink,
         className,
         telemetryService,
+        telemetryRecorder,
     } = props
     const seriesToggleState = useSeriesToggle()
 
@@ -136,6 +140,7 @@ const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProp
 
     const { trackMouseEnter, trackMouseLeave } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType:
             mode === CodeInsightsLandingPageType.Cloud
                 ? CodeInsightTrackType.CloudLandingPageInsight
@@ -144,6 +149,7 @@ const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProp
 
     const handleTemplateLinkClick = (): void => {
         telemetryService.log(bigTemplateClickPingName)
+        telemetryRecorder.recordEvent('InsightsGetStartedBigTemplate', 'clicked')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -2,9 +2,11 @@ import { type FC, useEffect } from 'react'
 
 import { mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
+import { te } from 'date-fns/locale'
 import { noop } from 'rxjs'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -39,10 +41,13 @@ const INITIAL_INSIGHT_VALUES: CodeInsightExampleFormValues = {
     query: 'TODO',
 }
 
-interface DynamicCodeInsightExampleProps extends TelemetryProps, React.HTMLAttributes<HTMLDivElement> {}
+interface DynamicCodeInsightExampleProps
+    extends TelemetryProps,
+        TelemetryV2Props,
+        React.HTMLAttributes<HTMLDivElement> {}
 
 export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = props => {
-    const { telemetryService, ...otherProps } = props
+    const { telemetryService, telemetryRecorder, ...otherProps } = props
 
     const { repositoryUrl, loading: repositoryValueLoading } = useExampleRepositoryUrl()
 
@@ -81,17 +86,20 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
     useEffect(() => {
         if (debouncedQuery !== INITIAL_INSIGHT_VALUES.query) {
             telemetryService.log('InsightsGetStartedPageQueryModification')
+            telemetryRecorder.recordEvent('InsightsGetStartedPageQueryModification', 'rendered')
         }
-    }, [debouncedQuery, telemetryService])
+    }, [debouncedQuery, telemetryService, telemetryRecorder])
 
     useEffect(() => {
         if (debouncedRepositories !== INITIAL_INSIGHT_VALUES.repositories) {
             telemetryService.log('InsightsGetStartedPageRepositoriesModification')
+            telemetryRecorder.recordEvent('InsightsGetStartedPageRepositoriesModification', 'rendered')
         }
-    }, [debouncedRepositories, telemetryService])
+    }, [debouncedRepositories, telemetryService, telemetryRecorder])
 
     const handleGetStartedClick = (): void => {
         telemetryService.log('InsightsGetStartedPrimaryCTAClick')
+        telemetryRecorder.recordEvent('InsightsGetStartedPrimaryCTA', 'clicked')
     }
 
     const hasValidLivePreview =
@@ -105,6 +113,7 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
             <form ref={form.ref} noValidate={true} onSubmit={form.handleSubmit} className={styles.chartSection}>
                 <DynamicInsightPreview
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     disabled={!hasValidLivePreview}
                     repositories={repositories.input.value}
                     query={query.input.value}

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicInsightPreview.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicInsightPreview.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { type Series, useDeepMemo, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -32,7 +33,7 @@ const createExampleDataSeries = (query: string): SeriesWithStroke[] => [
     },
 ]
 
-interface DynamicInsightPreviewProps extends TelemetryProps {
+interface DynamicInsightPreviewProps extends TelemetryProps, TelemetryV2Props {
     disabled: boolean
     repositories: string[]
     query: string
@@ -40,7 +41,7 @@ interface DynamicInsightPreviewProps extends TelemetryProps {
 }
 
 export const DynamicInsightPreview: FC<DynamicInsightPreviewProps> = props => {
-    const { disabled, repositories, query, className, telemetryService } = props
+    const { disabled, repositories, query, className, telemetryService, telemetryRecorder } = props
 
     // Compare live insight settings with deep check to avoid unnecessary
     // search insight content fetching
@@ -58,6 +59,7 @@ export const DynamicInsightPreview: FC<DynamicInsightPreviewProps> = props => {
 
     const { trackMouseEnter, trackMouseLeave, trackDatumClicks } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType: CodeInsightTrackType.InProductLandingPageInsight,
     })
 

--- a/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { mdiAccount } from '@mdi/js'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { H1, Icon, Link, PageHeader, ProductStatusBadge } from '@sourcegraph/wildcard'
 
@@ -17,7 +18,10 @@ import { RepositoryOwnPageContents } from './RepositoryOwnPageContents'
 /**
  * Properties passed to all page components in the repository code navigation area.
  */
-export interface RepositoryOwnAreaPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'>, TelemetryProps {
+export interface RepositoryOwnAreaPageProps
+    extends Pick<BreadcrumbSetters, 'useBreadcrumb'>,
+        TelemetryProps,
+        TelemetryV2Props {
     /** The active repository. */
     repo: RepositoryFields
     authenticatedUser: Pick<AuthenticatedUser, 'siteAdmin'> | null
@@ -25,11 +29,9 @@ export interface RepositoryOwnAreaPageProps extends Pick<BreadcrumbSetters, 'use
 
 const EDIT_PAGE_BREADCRUMB = { key: 'edit-own', element: 'Upload CODEOWNERS' }
 
-export const RepositoryOwnEditPage: React.FunctionComponent<Omit<RepositoryOwnAreaPageProps, 'telemetryService'>> = ({
-    useBreadcrumb,
-    repo,
-    authenticatedUser,
-}) => {
+export const RepositoryOwnEditPage: React.FunctionComponent<
+    Omit<RepositoryOwnAreaPageProps, 'telemetryService' & 'telemetryRecorder'>
+> = ({ useBreadcrumb, repo, authenticatedUser }) => {
     const breadcrumbSetters = useBreadcrumb({ key: 'own', element: <Link to={`/${repo.name}/-/own`}>Ownership</Link> })
     breadcrumbSetters.useBreadcrumb(EDIT_PAGE_BREADCRUMB)
 

--- a/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
+++ b/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState, useCallback } from 'react'
 import { mdiPlus } from '@mdi/js'
 import { groupBy, noop } from 'lodash'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Button, Icon, ProductStatusBadge, ErrorAlert, LoadingSpinner, Link } from '@sourcegraph/wildcard'
 
@@ -14,14 +15,16 @@ import { RoleNode } from './components/RoleNode'
 
 import styles from './SiteAdminRolesPage.module.scss'
 
-export interface SiteAdminRolesPageProps extends TelemetryProps {}
+export interface SiteAdminRolesPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export const SiteAdminRolesPage: React.FunctionComponent<React.PropsWithChildren<SiteAdminRolesPageProps>> = ({
     telemetryService,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminRoles')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminRoles', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const [permissions, setPermissions] = useState<PermissionsMap>({} as PermissionsMap)
 

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -10,6 +10,7 @@ import { SyntaxHighlightedSearchQuery } from '@sourcegraph/branded'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { SearchJobsOrderBy, SearchJobState } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -119,12 +120,12 @@ export const SEARCH_JOBS_QUERY = gql`
     }
 `
 
-interface SearchJobsPageProps extends TelemetryProps {
+interface SearchJobsPageProps extends TelemetryProps, TelemetryV2Props {
     isAdmin: boolean
 }
 
 export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
-    const { isAdmin, telemetryService } = props
+    const { isAdmin, telemetryService, telemetryRecorder } = props
 
     const [searchTerm, setSearchTerm] = useState<string>('')
     const [searchStateTerm, setSearchStateTerm] = useState('')
@@ -164,7 +165,8 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
 
     useEffect(() => {
         telemetryService.logViewEvent('SearchJobsListPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SearchJobsListPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const handleSearchJobCreate = (): void => {
         setJobToRestart(null)
@@ -273,6 +275,7 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
                                 job={searchJob}
                                 withCreatorColumn={isAdmin}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 onRerun={setJobToRestart}
                                 onCancel={setJobToCancel}
                                 onDelete={setJobToDelete}
@@ -303,7 +306,7 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
 const formatDate = timeFormat('%Y-%m-%d %H:%M:%S')
 const formatDateSlim = timeFormat('%Y-%m-%d')
 
-interface SearchJobProps extends TelemetryProps {
+interface SearchJobProps extends TelemetryProps, TelemetryV2Props {
     job: SearchJobNode
     withCreatorColumn: boolean
     onRerun: (job: SearchJobNode) => void
@@ -312,7 +315,7 @@ interface SearchJobProps extends TelemetryProps {
 }
 
 const SearchJob: FC<SearchJobProps> = props => {
-    const { job, withCreatorColumn, telemetryService, onRerun, onCancel, onDelete } = props
+    const { job, withCreatorColumn, telemetryService, telemetryRecorder, onRerun, onCancel, onDelete } = props
     const { repoStats } = job
 
     const startDate = useMemo(() => (job.startedAt ? formatDateSlim(new Date(job.startedAt)) : ''), [job.startedAt])
@@ -353,6 +356,7 @@ const SearchJob: FC<SearchJobProps> = props => {
                     className={styles.jobViewLogs}
                     onClick={() => {
                         telemetryService.log('SearchJobsResultViewLogsClick', {}, {})
+                        telemetryRecorder.recordEvent('SearchJobsResultViewLogs', 'clicked')
                     }}
                 >
                     View logs
@@ -407,6 +411,7 @@ const SearchJob: FC<SearchJobProps> = props => {
                     className={styles.jobDownload}
                     onClick={() => {
                         telemetryService.log('SearchJobsResultDownloadClick', {}, {})
+                        telemetryRecorder.recordEvent('SearchJobsResultDownload', 'clicked')
                     }}
                 >
                     <Icon svgPath={mdiDownload} aria-hidden={true} />

--- a/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Link } from '@sourcegraph/wildcard'
 
@@ -25,6 +26,7 @@ import { SearchContextForm } from './SearchContextForm'
 
 export interface CreateSearchContextPageProps
     extends TelemetryProps,
+        TelemetryV2Props,
         Pick<SearchContextProps, 'createSearchContext' | 'deleteSearchContext'>,
         PlatformContextProps<'requestGraphQL'> {
     authenticatedUser: AuthenticatedUser

--- a/client/web/src/enterprise/searchContexts/EditSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/EditSearchContextPage.tsx
@@ -14,6 +14,7 @@ import type {
 } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, LoadingSpinner, useObservable, Alert } from '@sourcegraph/wildcard'
 
@@ -26,6 +27,7 @@ import { SearchContextForm } from './SearchContextForm'
 
 export interface EditSearchContextPageProps
     extends TelemetryProps,
+        TelemetryV2Props,
         Pick<SearchContextProps, 'updateSearchContext' | 'fetchSearchContextBySpec' | 'deleteSearchContext'>,
         PlatformContextProps<'requestGraphQL'> {
     authenticatedUser: AuthenticatedUser

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -17,6 +17,7 @@ import {
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { QueryState, SearchContextProps } from '@sourcegraph/shared/src/search'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -111,6 +112,7 @@ const LOADING = 'loading' as const
 
 export interface SearchContextFormProps
     extends TelemetryProps,
+        TelemetryV2Props,
         Pick<SearchContextProps, 'deleteSearchContext'>,
         PlatformContextProps<'requestGraphQL'> {
     searchContext?: SearchContextFields

--- a/client/web/src/enterprise/searchContexts/SearchContextRepositoriesFormArea.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextRepositoriesFormArea.tsx
@@ -6,6 +6,7 @@ import type { Observable } from 'rxjs'
 import { delay, mergeMap, startWith, tap } from 'rxjs/operators'
 
 import type { SearchContextRepositoryRevisionsFields } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, useEventObservable, Alert, Icon } from '@sourcegraph/wildcard'
 
@@ -73,7 +74,7 @@ const actions: {
     },
 ]
 
-export interface SearchContextRepositoriesFormAreaProps extends TelemetryProps {
+export interface SearchContextRepositoriesFormAreaProps extends TelemetryProps, TelemetryV2Props {
     isLightTheme: boolean
     repositories: SearchContextRepositoryRevisionsFields[] | undefined
     validateRepositories: () => Observable<Error[]>
@@ -82,7 +83,7 @@ export interface SearchContextRepositoriesFormAreaProps extends TelemetryProps {
 
 export const SearchContextRepositoriesFormArea: React.FunctionComponent<
     React.PropsWithChildren<SearchContextRepositoriesFormAreaProps>
-> = ({ isLightTheme, telemetryService, repositories, onChange, validateRepositories }) => {
+> = ({ isLightTheme, telemetryService, telemetryRecorder, repositories, onChange, validateRepositories }) => {
     const [hasTestedConfig, setHasTestedConfig] = useState(false)
     const [triggerTestConfig, triggerTestConfigErrors] = useEventObservable(
         useCallback(
@@ -139,6 +140,7 @@ export const SearchContextRepositoriesFormArea: React.FunctionComponent<
                 height={300}
                 isLightTheme={isLightTheme}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 blockNavigationIfDirty={false}
             />
             {triggerTestConfigErrors && triggerTestConfigErrors !== LOADING && triggerTestConfigErrors.length > 0 && (

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -5,6 +5,7 @@ import { capitalize } from 'lodash'
 import { useLocation } from 'react-router-dom'
 
 import { RepoEmbeddingJobState } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -43,7 +44,7 @@ import { RepoEmbeddingJobNode } from './RepoEmbeddingJobNode'
 
 import styles from './SiteAdminCodyPage.module.scss'
 
-export interface SiteAdminCodyPageProps extends TelemetryProps {}
+export interface SiteAdminCodyPageProps extends TelemetryProps, TelemetryV2Props {}
 
 interface RepoEmbeddingJobsFormValues {
     repositories: string[]
@@ -72,12 +73,13 @@ const enumToFilterValues = <T extends string>(enumeration: { [key in T]: T }): F
     return values
 }
 
-export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService }) => {
+export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService, telemetryRecorder }) => {
     const isCodyApp = window.context?.codyAppMode
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminCodyPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminCodyPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const location = useLocation()
     const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search])

--- a/client/web/src/enterprise/site-admin/routes.tsx
+++ b/client/web/src/enterprise/site-admin/routes.tsx
@@ -157,6 +157,7 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = (
                     headerParentBreadcrumb={{ to: '/site-admin/batch-changes', text: 'Batch Changes settings' }}
                     headerAnnotation={<FeedbackBadge status="beta" feedback={{ mailto: 'support@sourcegraph.com' }} />}
                     telemetryService={props.telemetryService}
+                    telemetryRecorder={props.telemetryRecorder}
                 />
             ),
             condition: ({ batchChangesEnabled }) => batchChangesEnabled,

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -1,5 +1,6 @@
 import { currentUserMock } from '@sourcegraph/shared/src/testing/integration/graphQlResults'
 
+import { noOpTelemetryRecorder } from '../../dev/utils'
 import type { SourcegraphContext } from '../jscontext'
 
 export const siteID = 'TestSiteID'
@@ -66,4 +67,5 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     runningOnMacOS: true,
     srcServeGitUrl: 'http://127.0.0.1:3434',
     primaryLoginProvidersCount: 5,
+    telemetryRecorder: noOpTelemetryRecorder,
 })

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -284,7 +284,7 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether the feedback survey is enabled. */
     disableFeedbackSurvey?: boolean
 
-    telemetryRecorder?: TelemetryRecorder
+    telemetryRecorder: TelemetryRecorder
 }
 
 export interface BrandAssets {

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -1,5 +1,6 @@
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { SiteConfiguration } from '@sourcegraph/shared/src/schema/site.schema'
+import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { BatchChangesLicenseInfo } from '@sourcegraph/shared/src/testing/batches'
 
 import type { TemporarySettingsResult } from './graphql-operations'
@@ -282,6 +283,8 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
 
     /** Whether the feedback survey is enabled. */
     disableFeedbackSurvey?: boolean
+
+    telemetryRecorder: TelemetryRecorder
 }
 
 export interface BrandAssets {

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -284,7 +284,7 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether the feedback survey is enabled. */
     disableFeedbackSurvey?: boolean
 
-    telemetryRecorder: TelemetryRecorder
+    telemetryRecorder?: TelemetryRecorder
 }
 
 export interface BrandAssets {

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -14,6 +14,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import type { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import type { SearchContextInputProps } from '@sourcegraph/shared/src/search'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Button, ButtonLink, Link, ProductStatusBadge, useWindowSize } from '@sourcegraph/wildcard'
@@ -53,6 +54,7 @@ export interface GlobalNavbarProps
     extends SettingsCascadeProps<Settings>,
         PlatformContextProps,
         TelemetryProps,
+        TelemetryV2Props,
         SearchContextInputProps,
         CodeInsightsProps,
         SentinelProps,

--- a/client/web/src/nav/UserNavItem.tsx
+++ b/client/web/src/nav/UserNavItem.tsx
@@ -8,6 +8,7 @@ import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useTheme, ThemeSetting } from '@sourcegraph/shared/src/theme'
 import {
@@ -41,7 +42,7 @@ type MinimalAuthenticatedUser = Pick<
     'username' | 'avatarURL' | 'settingsURL' | 'organizations' | 'siteAdmin' | 'session' | 'displayName'
 >
 
-export interface UserNavItemProps extends TelemetryProps {
+export interface UserNavItemProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: MinimalAuthenticatedUser
     isSourcegraphDotCom: boolean
     isCodyApp: boolean
@@ -63,6 +64,7 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
         showFeedbackModal,
         showKeyboardShortcutsHelp,
         telemetryService,
+        telemetryRecorder,
     } = props
 
     const { themeSetting, setThemeSetting } = useTheme()
@@ -91,9 +93,10 @@ export const UserNavItem: FC<UserNavItemProps> = props => {
     const onExperimentalQueryInputChange = useCallback(
         (enabled: boolean) => {
             telemetryService.log(`SearchInputToggle${enabled ? 'On' : 'Off'}`)
+            telemetryRecorder.recordEvent(`SearchInputToggle${enabled ? 'On' : 'Off'}`, 'toggled')
             setExperimentalQueryInputEnabled(enabled)
         },
-        [telemetryService, setExperimentalQueryInputEnabled]
+        [telemetryService, telemetryRecorder, setExperimentalQueryInputEnabled]
     )
 
     return (

--- a/client/web/src/notebooks/GlobalNotebooksArea.tsx
+++ b/client/web/src/notebooks/GlobalNotebooksArea.tsx
@@ -7,6 +7,7 @@ import type { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -23,6 +24,7 @@ const NotebooksListPage = lazyComponent(() => import('./listPage/NotebooksListPa
 
 export interface GlobalNotebooksAreaProps
     extends TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps,
         SettingsCascadeProps,
         NotebookProps,

--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
@@ -9,6 +9,7 @@ import { startWith } from 'rxjs/operators'
 import { CodeExcerpt } from '@sourcegraph/branded'
 import { isErrorLike } from '@sourcegraph/common'
 import { getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
@@ -28,7 +29,7 @@ import { NotebookFileBlockInputs } from './NotebookFileBlockInputs'
 
 import styles from './NotebookFileBlock.module.scss'
 
-interface NotebookFileBlockProps extends BlockProps<FileBlock>, TelemetryProps {
+interface NotebookFileBlockProps extends BlockProps<FileBlock>, TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
 }
 
@@ -40,6 +41,7 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
         input,
         output,
         telemetryService,
+        telemetryRecorder,
         isSelected,
         showMenu,
         isReadOnly,
@@ -154,7 +156,8 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
 
         const logEventOnCopy = useCallback(() => {
             telemetryService.log(...codeCopiedEvent('notebook-file-block'))
-        }, [telemetryService])
+            telemetryRecorder.recordEvent('notebook-file-block', 'copied')
+        }, [telemetryService, telemetryRecorder])
 
         return (
             <NotebookBlock

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.story.tsx
@@ -4,6 +4,7 @@ import { of } from 'rxjs'
 
 import type { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     HIGHLIGHTED_FILE_LINES_LONG,
@@ -63,6 +64,7 @@ export const Default: Story = () => (
                 searchContextsEnabled={true}
                 ownEnabled={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
                 platformContext={NOOP_PLATFORM_CONTEXT}
@@ -87,6 +89,7 @@ export const Selected: Story = () => (
                 searchContextsEnabled={true}
                 ownEnabled={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
                 authenticatedUser={null}
@@ -112,6 +115,7 @@ export const ReadOnlySelected: Story = () => (
                 searchContextsEnabled={true}
                 ownEnabled={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 fetchHighlightedFileLineRanges={() => of(HIGHLIGHTED_FILE_LINES_LONG)}
                 settingsCascade={EMPTY_SETTINGS_CASCADE}
                 authenticatedUser={null}

--- a/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
+++ b/client/web/src/notebooks/blocks/query/NotebookQueryBlock.tsx
@@ -17,6 +17,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { LoadingSpinner, useObservable, Icon } from '@sourcegraph/wildcard'
@@ -40,6 +41,7 @@ interface NotebookQueryBlockProps
         Pick<SearchContextProps, 'searchContextsEnabled'>,
         SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings'>,
         OwnConfigProps {
     isSourcegraphDotCom: boolean
@@ -64,6 +66,7 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
         input,
         output,
         telemetryService,
+        telemetryRecorder,
         settingsCascade,
         isSelected,
         onBlockInputChange,
@@ -202,6 +205,7 @@ export const NotebookQueryBlock: React.FunctionComponent<React.PropsWithChildren
                                 results={searchResults}
                                 fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 settingsCascade={settingsCascade}
                                 platformContext={props.platformContext}
                                 openMatchesInNewTab={true}

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
@@ -12,6 +12,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import { getRepositoryUrl } from '@sourcegraph/shared/src/search/stream'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 import { toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
@@ -32,6 +33,7 @@ import styles from './NotebookSymbolBlock.module.scss'
 interface NotebookSymbolBlockProps
     extends BlockProps<SymbolBlock>,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'requestGraphQL' | 'urlToFile' | 'settings'> {
     isSourcegraphDotCom: boolean
 }
@@ -51,6 +53,7 @@ export const NotebookSymbolBlock: React.FunctionComponent<React.PropsWithChildre
             input,
             output,
             telemetryService,
+            telemetryRecorder,
             isSelected,
             showMenu,
             isReadOnly,
@@ -139,7 +142,8 @@ export const NotebookSymbolBlock: React.FunctionComponent<React.PropsWithChildre
 
             const logEventOnCopy = useCallback(() => {
                 telemetryService.log(...codeCopiedEvent('notebook-symbols'))
-            }, [telemetryService])
+                telemetryRecorder.recordEvent('notebook-symbols', 'copied')
+            }, [telemetryService, telemetryRecorder])
 
             return (
                 <NotebookBlock

--- a/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
+++ b/client/web/src/notebooks/createPage/CreateNotebookPage.tsx
@@ -4,6 +4,7 @@ import { Navigate } from 'react-router-dom'
 import { catchError, startWith } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable, Alert } from '@sourcegraph/wildcard'
 
@@ -15,8 +16,8 @@ import { createNotebook } from '../backend'
 const LOADING = 'loading' as const
 
 export const CreateNotebookPage: React.FunctionComponent<
-    React.PropsWithChildren<TelemetryProps & { authenticatedUser: AuthenticatedUser }>
-> = ({ telemetryService, authenticatedUser }) => {
+    React.PropsWithChildren<TelemetryProps & TelemetryV2Props & { authenticatedUser: AuthenticatedUser }>
+> = ({ telemetryService, telemetryRecorder, authenticatedUser }) => {
     const notebookOrError = useObservable(
         useMemo(
             () =>
@@ -32,6 +33,7 @@ export const CreateNotebookPage: React.FunctionComponent<
 
     if (notebookOrError && !isErrorLike(notebookOrError) && notebookOrError !== LOADING) {
         telemetryService.log('SearchNotebookCreated')
+        telemetryRecorder.recordEvent('SearchNotebook', 'created')
         return <Navigate to={EnterprisePageRoutes.Notebook.replace(':id', notebookOrError.id)} replace={true} />
     }
 

--- a/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksGettingStartedTab.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { addSourcegraphAppOutboundUrlParameters } from '@sourcegraph/shared/src/util/url'
@@ -16,7 +17,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 
 import styles from './NotebooksGettingStartedTab.module.scss'
 
-interface NotebooksGettingStartedTabProps extends TelemetryProps {
+interface NotebooksGettingStartedTabProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 
@@ -55,8 +56,11 @@ const functionalityPanels = [
 
 export const NotebooksGettingStartedTab: React.FunctionComponent<
     React.PropsWithChildren<NotebooksGettingStartedTabProps>
-> = ({ telemetryService, authenticatedUser }) => {
-    useEffect(() => telemetryService.log('NotebooksGettingStartedTabViewed'), [telemetryService])
+> = ({ telemetryService, telemetryRecorder, authenticatedUser }) => {
+    useEffect(() => {
+        telemetryService.log('NotebooksGettingStartedTabViewed')
+        telemetryRecorder.recordEvent('NotebooksGettingStartedTab', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const [, setHasSeenGettingStartedTab] = useTemporarySetting('search.notebooks.gettingStartedTabSeen', false)
     const isSourcegraphDotCom: boolean = window.context?.sourcegraphDotComMode || false

--- a/client/web/src/notebooks/listPage/NotebooksList.tsx
+++ b/client/web/src/notebooks/listPage/NotebooksList.tsx
@@ -1,5 +1,6 @@
 import { type FC, useCallback, useEffect } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { H2 } from '@sourcegraph/wildcard'
 
@@ -16,7 +17,7 @@ import { NotebookNode, type NotebookNodeProps } from './NotebookNode'
 
 import styles from './NotebooksList.module.scss'
 
-export interface NotebooksListProps extends TelemetryProps {
+export interface NotebooksListProps extends TelemetryProps, TelemetryV2Props {
     title: string
     logEventName: string
     orderOptions: FilteredConnectionFilter[]
@@ -35,11 +36,12 @@ export const NotebooksList: FC<NotebooksListProps> = ({
     namespace,
     fetchNotebooks,
     telemetryService,
+    telemetryRecorder,
 }) => {
-    useEffect(
-        () => telemetryService.logViewEvent(`SearchNotebooksList${logEventName}`),
-        [logEventName, telemetryService]
-    )
+    useEffect(() => {
+        telemetryService.logViewEvent(`SearchNotebooksList${logEventName}`)
+        telemetryRecorder.recordEvent(`SearchNotebooksList${logEventName}`, 'viewed')
+    }, [logEventName, telemetryService, telemetryRecorder])
 
     const queryConnection = useCallback(
         (args: Partial<ListNotebooksVariables>) => {

--- a/client/web/src/notebooks/notebook/NotebookComponent.tsx
+++ b/client/web/src/notebooks/notebook/NotebookComponent.tsx
@@ -10,6 +10,7 @@ import { catchError, delay, startWith, switchMap, tap } from 'rxjs/operators'
 import type { StreamingSearchResultsListProps } from '@sourcegraph/branded'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import type { PlatformContext } from '@sourcegraph/shared/src/platform/context'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, useEventObservable, Icon } from '@sourcegraph/wildcard'
 
@@ -34,6 +35,7 @@ import styles from './NotebookComponent.module.scss'
 export interface NotebookComponentProps
     extends SearchStreamingProps,
         TelemetryProps,
+        TelemetryV2Props,
         Omit<StreamingSearchResultsListProps, 'location' | 'allExpanded' | 'executedQuery' | 'enableOwnershipSearch'>,
         OwnConfigProps {
     isReadOnly?: boolean
@@ -83,6 +85,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
         isEmbedded,
         authenticatedUser,
         telemetryService,
+        telemetryRecorder,
         isSourcegraphDotCom,
         platformContext,
         blocks: initialBlocks,
@@ -122,8 +125,11 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                     { blocksCount: blocks.length, blockCountsPerType },
                     { blocksCount: blocks.length, blockCountsPerType }
                 )
+                telemetryRecorder.recordEvent('SearchcNotebookBlocksUpdated', 'updated', {
+                    privateMetadata: { blocksCount: blocks.length, blockCountsPerType },
+                })
             },
-            [notebook, setBlocks, debouncedOnSerializeBlocks, telemetryService]
+            [notebook, setBlocks, debouncedOnSerializeBlocks, telemetryService, telemetryRecorder]
         )
 
         const selectBlock = useCallback(
@@ -155,8 +161,11 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                     { type: notebook.getBlockById(id)?.type },
                     { type: notebook.getBlockById(id)?.type }
                 )
+                telemetryRecorder.recordEvent('SearchNotebookRunBlock', 'run', {
+                    privateMetadata: { type: notebook.getBlockById(id)?.type },
+                })
             },
-            [notebook, telemetryService, updateBlocks]
+            [notebook, telemetryService, telemetryRecorder, updateBlocks]
         )
 
         const [runAllBlocks, runningAllBlocks] = useEventObservable(
@@ -167,9 +176,10 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                         tap(() => {
                             updateBlocks(false)
                             telemetryService.log('SearchNotebookRunAllBlocks')
+                            telemetryRecorder.recordEvent('SearchNotebookRunAllBlocks', 'run')
                         })
                     ),
-                [notebook, telemetryService, updateBlocks]
+                [notebook, telemetryService, telemetryRecorder, updateBlocks]
             )
         )
 
@@ -181,9 +191,10 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                         tap(exportedMarkdown => {
                             downloadTextAsFile(exportedMarkdown, exportedFileName)
                             telemetryService.log('SearchNotebookExportNotebook')
+                            telemetryRecorder.recordEvent('SearchNotebookExportNotebook', 'exported')
                         })
                     ),
-                [notebook, exportedFileName, telemetryService]
+                [notebook, exportedFileName, telemetryService, telemetryRecorder]
             )
         )
 
@@ -205,8 +216,9 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 return
             }
             telemetryService.log('SearchNotebookCopyNotebookButtonClick')
+            telemetryRecorder.recordEvent('SearchNotebookCopyNotebookButton', 'clicked')
             copyNotebook({ namespace: authenticatedUser.id, blocks: notebook.getBlocks() })
-        }, [authenticatedUser, copyNotebook, notebook, telemetryService])
+        }, [authenticatedUser, copyNotebook, notebook, telemetryService, telemetryRecorder])
 
         const onBlockInputChange = useCallback(
             (id: string, blockInput: BlockInput) => {
@@ -258,8 +270,11 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 updateBlocks()
 
                 telemetryService.log('SearchNotebookAddBlock', { type: addedBlock.type }, { type: addedBlock.type })
+                telemetryRecorder.recordEvent('SearchNotebookAddBlock', 'added', {
+                    privateMetadata: { type: addedBlock.type },
+                })
             },
-            [isReadOnly, notebook, selectBlock, focusBlock, updateBlocks, telemetryService]
+            [isReadOnly, notebook, selectBlock, focusBlock, updateBlocks, telemetryService, telemetryRecorder]
         )
 
         const onDeleteBlock = useCallback(
@@ -278,8 +293,11 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 updateBlocks()
 
                 telemetryService.log('SearchNotebookDeleteBlock', { type: block?.type }, { type: block?.type })
+                telemetryRecorder.recordEvent('SearchNotebookDeleteBlock', 'deleted', {
+                    privateMetadata: { type: block?.type },
+                })
             },
-            [notebook, isReadOnly, telemetryService, selectBlock, updateBlocks, focusBlock]
+            [notebook, isReadOnly, telemetryService, telemetryRecorder, selectBlock, updateBlocks, focusBlock]
         )
 
         const onMoveBlock = useCallback(
@@ -297,8 +315,11 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                     { type: notebook.getBlockById(id)?.type, direction },
                     { type: notebook.getBlockById(id)?.type, direction }
                 )
+                telemetryRecorder.recordEvent('SearchNotebookMoveBlock', 'moved', {
+                    privateMetadata: { type: notebook.getBlockById(id)?.type, direction },
+                })
             },
-            [notebook, isReadOnly, telemetryService, updateBlocks, focusBlock]
+            [notebook, isReadOnly, telemetryService, telemetryRecorder, updateBlocks, focusBlock]
         )
 
         const onDuplicateBlock = useCallback(
@@ -322,8 +343,11 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                     { type: duplicateBlock?.type },
                     { type: duplicateBlock?.type }
                 )
+                telemetryRecorder.recordEvent('SearchNotebookDuplicateBlock', 'duplicated', {
+                    privateMetadata: { type: duplicateBlock?.type },
+                })
             },
-            [notebook, isReadOnly, telemetryService, selectBlock, updateBlocks, focusBlock]
+            [notebook, isReadOnly, telemetryService, telemetryRecorder, selectBlock, updateBlocks, focusBlock]
         )
 
         const onFocusLastBlock = useCallback(() => {
@@ -389,6 +413,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                                 {...block}
                                 {...blockProps}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
                             />
                         )
@@ -403,6 +428,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                                 ownEnabled={ownEnabled}
                                 settingsCascade={settingsCascade}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 platformContext={platformContext}
                                 authenticatedUser={authenticatedUser}
                             />
@@ -414,6 +440,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                                 {...blockProps}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 platformContext={platformContext}
                             />
                         )
@@ -432,6 +459,7 @@ export const NotebookComponent: React.FunctionComponent<React.PropsWithChildren<
                 isReadOnly,
                 isEmbedded,
                 telemetryService,
+                telemetryRecorder,
                 isSourcegraphDotCom,
                 fetchHighlightedFileLineRanges,
                 searchContextsEnabled,

--- a/client/web/src/notebooks/notebookPage/DeleteNotebookModal.tsx
+++ b/client/web/src/notebooks/notebookPage/DeleteNotebookModal.tsx
@@ -5,12 +5,13 @@ import type { Observable } from 'rxjs'
 import { mergeMap, startWith, tap, catchError } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useEventObservable, Modal, Button, Alert, H3, Text } from '@sourcegraph/wildcard'
 
 import type { deleteNotebook as _deleteNotebook } from '../backend'
 
-interface DeleteNotebookModalProps extends TelemetryProps {
+interface DeleteNotebookModalProps extends TelemetryProps, TelemetryV2Props {
     notebookId: string
     isOpen: boolean
     toggleDeleteModal: () => void
@@ -26,20 +27,25 @@ export const DeleteNotebookModal: FC<DeleteNotebookModalProps> = ({
     isOpen,
     toggleDeleteModal,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const navigate = useNavigate()
 
     useEffect(() => {
         if (isOpen) {
             telemetryService.log('SearchNotebookDeleteModalOpened')
+            telemetryRecorder.recordEvent('SearchNotebookDeleteModal', 'opened')
         }
-    }, [isOpen, telemetryService])
+    }, [isOpen, telemetryService, telemetryRecorder])
 
     const [onDelete, deleteCompletedOrError] = useEventObservable(
         useCallback(
             (click: Observable<React.MouseEvent<HTMLButtonElement>>) =>
                 click.pipe(
-                    tap(() => telemetryService.log('SearchNotebookDeleteButtonClicked')),
+                    tap(() => {
+                        telemetryService.log('SearchNotebookDeleteButtonClicked')
+                        telemetryRecorder.recordEvent('SearchNotebookDeleteButton', 'clicked')
+                    }),
                     mergeMap(() =>
                         deleteNotebook(notebookId).pipe(
                             tap(() => {
@@ -50,7 +56,7 @@ export const DeleteNotebookModal: FC<DeleteNotebookModalProps> = ({
                         )
                     )
                 ),
-            [deleteNotebook, navigate, notebookId, telemetryService]
+            [deleteNotebook, navigate, notebookId, telemetryService, telemetryRecorder]
         )
     )
 

--- a/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/EmbeddedNotebookPage.tsx
@@ -32,7 +32,10 @@ const LOADING = 'loading' as const
 export const EmbeddedNotebookPage: FC<EmbeddedNotebookPageProps> = ({ platformContext, ...props }) => {
     const { notebookId } = useParams()
 
-    useEffect(() => eventLogger.logPageView('EmbeddedNotebookPage'), [])
+    useEffect(() => {
+        eventLogger.logPageView('EmbeddedNotebookPage')
+        window.context.telemetryRecorder.recordEvent('EmbeddedNotebookPage', 'viewed')
+    }, [window.context.telemetryRecorder])
 
     const notebookOrError = useObservable(
         useMemo(
@@ -78,6 +81,7 @@ export const EmbeddedNotebookPage: FC<EmbeddedNotebookPageProps> = ({ platformCo
                     fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                     streamSearch={aggregateStreamingSearch}
                     telemetryService={eventLogger}
+                    telemetryRecorder={window.context.telemetryRecorder}
                     platformContext={platformContext}
                     exportedFileName={convertNotebookTitleToFileName(notebookOrError.title)}
                     // Copying is not supported in embedded notebooks

--- a/client/web/src/notebooks/notebookPage/NotebookContent.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookContent.tsx
@@ -6,6 +6,7 @@ import type { Observable } from 'rxjs'
 import type { StreamingSearchResultsListProps } from '@sourcegraph/branded'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import type { Block, BlockInit } from '..'
@@ -18,6 +19,7 @@ import { NotebookComponent } from '../notebook/NotebookComponent'
 export interface NotebookContentProps
     extends SearchStreamingProps,
         TelemetryProps,
+        TelemetryV2Props,
         Omit<
             StreamingSearchResultsListProps,
             'allExpanded' | 'platformContext' | 'executedQuery' | 'enableOwnershipSearch'
@@ -43,6 +45,7 @@ export const NotebookContent: React.FunctionComponent<React.PropsWithChildren<No
         onUpdateBlocks,
         streamSearch,
         telemetryService,
+        telemetryRecorder,
         searchContextsEnabled,
         ownEnabled,
         isSourcegraphDotCom,
@@ -82,6 +85,7 @@ export const NotebookContent: React.FunctionComponent<React.PropsWithChildren<No
             <NotebookComponent
                 streamSearch={streamSearch}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 searchContextsEnabled={searchContextsEnabled}
                 ownEnabled={ownEnabled}
                 isSourcegraphDotCom={isSourcegraphDotCom}

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -12,6 +12,7 @@ import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -55,6 +56,7 @@ import styles from './NotebookPage.module.scss'
 interface NotebookPageProps
     extends SearchStreamingProps,
         TelemetryProps,
+        TelemetryV2Props,
         Omit<
             StreamingSearchResultsListProps,
             'allExpanded' | 'platformContext' | 'executedQuery' | 'enableOwnershipSearch'

--- a/client/web/src/notebooks/notebookPage/NotebookPage.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPage.tsx
@@ -85,6 +85,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
     copyNotebook = _copyNotebook,
     streamSearch,
     telemetryService,
+    telemetryRecorder,
     searchContextsEnabled,
     ownEnabled,
     isSourcegraphDotCom,
@@ -95,7 +96,10 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
 }) => {
     const { id: notebookId } = useParams()
 
-    useEffect(() => telemetryService.logPageView('SearchNotebookPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logPageView('SearchNotebookPage')
+        telemetryRecorder.recordEvent('SearchNotebookPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const [notebookTitle, setNotebookTitle] = useState('')
     const [updateQueue, setUpdateQueue] = useState<Partial<NotebookInput>[]>([])
@@ -242,6 +246,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                         createNotebookStar={createNotebookStar}
                                         deleteNotebookStar={deleteNotebookStar}
                                         telemetryService={telemetryService}
+                                        telemetryRecorder={telemetryRecorder}
                                     />
                                 }
                             >
@@ -257,6 +262,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                             viewerCanManage={notebookOrError.viewerCanManage}
                                             onUpdateTitle={onUpdateTitle}
                                             telemetryService={telemetryService}
+                                            telemetryRecorder={telemetryRecorder}
                                         />
                                     </PageHeader.Breadcrumb>
                                 </PageHeader.Heading>
@@ -312,6 +318,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                                 exportedFileName={exportedFileName}
                                 streamSearch={streamSearch}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 searchContextsEnabled={searchContextsEnabled}
                                 ownEnabled={ownEnabled}
                                 isSourcegraphDotCom={isSourcegraphDotCom}
@@ -329,6 +336,7 @@ export const NotebookPage: React.FunctionComponent<React.PropsWithChildren<Noteb
                         <NotepadCTA
                             onEnable={() => {
                                 telemetryService.log(NOTEPAD_ENABLED_EVENT)
+                                telemetryRecorder.recordEvent(NOTEPAD_ENABLED_EVENT, 'enabled')
                                 setNotepadCTASeen(true)
                                 setNotepadEnabled(true)
                             }}

--- a/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookPageHeaderActions.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import type { Observable } from 'rxjs'
 import { catchError, switchMap, tap } from 'rxjs/operators'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Menu,
@@ -34,7 +35,7 @@ import { ShareNotebookModal } from './ShareNotebookModal'
 
 import styles from './NotebookPageHeaderActions.module.scss'
 
-export interface NotebookPageHeaderActionsProps extends TelemetryProps {
+export interface NotebookPageHeaderActionsProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
     namespace: NotebookFields['namespace']
@@ -65,6 +66,7 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
     createNotebookStar,
     deleteNotebookStar,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [showShareModal, setShowShareModal] = useState(false)
     const toggleShareModal = useCallback(() => setShowShareModal(show => !show), [setShowShareModal])
@@ -119,6 +121,7 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
                 createNotebookStar={createNotebookStar}
                 deleteNotebookStar={deleteNotebookStar}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
             {authenticatedUser && viewerCanManage && namespace && selectedShareOption && (
                 <>
@@ -135,6 +138,7 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         toggleModal={toggleShareModal}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         authenticatedUser={authenticatedUser}
                         selectedShareOption={selectedShareOption}
                         setSelectedShareOption={setSelectedShareOption}
@@ -147,13 +151,14 @@ export const NotebookPageHeaderActions: React.FunctionComponent<
                     notebookId={notebookId}
                     deleteNotebook={deleteNotebook}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
         </div>
     )
 }
 
-interface NotebookSettingsDropdownProps extends TelemetryProps {
+interface NotebookSettingsDropdownProps extends TelemetryProps, TelemetryV2Props {
     notebookId: string
     deleteNotebook: typeof _deleteNotebook
 }
@@ -162,6 +167,7 @@ const NotebookSettingsDropdown: React.FunctionComponent<React.PropsWithChildren<
     notebookId,
     deleteNotebook,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [showDeleteModal, setShowDeleteModal] = useState(false)
     const toggleDeleteModal = useCallback(() => setShowDeleteModal(show => !show), [setShowDeleteModal])
@@ -191,12 +197,13 @@ const NotebookSettingsDropdown: React.FunctionComponent<React.PropsWithChildren<
                 toggleDeleteModal={toggleDeleteModal}
                 deleteNotebook={deleteNotebook}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
         </>
     )
 }
 
-interface NotebookStarsButtonProps extends TelemetryProps {
+interface NotebookStarsButtonProps extends TelemetryProps, TelemetryV2Props {
     notebookId: string
     disabled: boolean
     starsCount: number
@@ -213,6 +220,7 @@ const NotebookStarsButton: React.FunctionComponent<React.PropsWithChildren<Noteb
     createNotebookStar,
     deleteNotebookStar,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [starsCount, setStarsCount] = useState(initialStarsCount)
     const [viewerHasStarred, setViewerHasStarred] = useState(initialViewerHasStarred)
@@ -224,6 +232,7 @@ const NotebookStarsButton: React.FunctionComponent<React.PropsWithChildren<Noteb
                     // Immediately update the UI.
                     tap(viewerHasStarred => {
                         telemetryService.log(`SearchNotebook${viewerHasStarred ? 'Remove' : 'Add'}Star`)
+                        telemetryRecorder.recordEvent('SearchNotebookStar', `${viewerHasStarred ? 'removed' : 'added'}`)
                         if (viewerHasStarred) {
                             setStarsCount(starsCount => starsCount - 1)
                             setViewerHasStarred(() => false)
@@ -248,6 +257,7 @@ const NotebookStarsButton: React.FunctionComponent<React.PropsWithChildren<Noteb
                 initialStarsCount,
                 initialViewerHasStarred,
                 telemetryService,
+                telemetryRecorder,
             ]
         )
     )

--- a/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookShareOptionsDropdown.tsx
@@ -2,6 +2,7 @@ import React, { type FC, useMemo } from 'react'
 
 import { mdiChevronDown, mdiChevronUp, mdiDomain, mdiLock, mdiWeb } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Icon, Menu, MenuButton, MenuItem, MenuList } from '@sourcegraph/wildcard'
 
@@ -17,7 +18,7 @@ export interface ShareOption {
     isPublic: boolean
 }
 
-interface NotebookShareOptionsDropdownProps extends TelemetryProps {
+interface NotebookShareOptionsDropdownProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser
     selectedShareOption: ShareOption
@@ -66,10 +67,18 @@ const ShareOptionComponent: React.FunctionComponent<
 }
 
 export const NotebookShareOptionsDropdown: FC<NotebookShareOptionsDropdownProps> = props => {
-    const { isSourcegraphDotCom, telemetryService, authenticatedUser, selectedShareOption, onSelectShareOption } = props
+    const {
+        isSourcegraphDotCom,
+        telemetryService,
+        telemetryRecorder,
+        authenticatedUser,
+        selectedShareOption,
+        onSelectShareOption,
+    } = props
 
     const handleTriggerClick = (): void => {
         telemetryService.log('NotebookVisibilitySettingsDropdownToggled')
+        telemetryRecorder.recordEvent('NotebookVisibilitySettingsDropdown', 'toggled')
     }
 
     const shareOptions: ShareOption[] = useMemo(

--- a/client/web/src/notebooks/notebookPage/NotebookTitle.tsx
+++ b/client/web/src/notebooks/notebookPage/NotebookTitle.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useRef, useState } from 'react'
 
 import { mdiPencilOutline } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useOnClickOutside, Icon, Input } from '@sourcegraph/wildcard'
 
 import styles from './NotebookTitle.module.scss'
 
-export interface NotebookTitleProps extends TelemetryProps {
+export interface NotebookTitleProps extends TelemetryProps, TelemetryV2Props {
     title: string
     viewerCanManage: boolean
     onUpdateTitle: (title: string) => void
@@ -18,6 +19,7 @@ export const NotebookTitle: React.FunctionComponent<React.PropsWithChildren<Note
     viewerCanManage,
     onUpdateTitle,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [isEditing, setIsEditing] = useState(false)
     const [title, setTitle] = useState(initialTitle)
@@ -31,6 +33,7 @@ export const NotebookTitle: React.FunctionComponent<React.PropsWithChildren<Note
 
     const updateTitle = (): void => {
         telemetryService.log('SearchNotebookTitleUpdated')
+        telemetryRecorder.recordEvent('SearchNotebookTitle', 'updated')
         setIsEditing(false)
         onUpdateTitle(title)
     }

--- a/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
+++ b/client/web/src/notebooks/notebookPage/ShareNotebookModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useEffect } from 'react'
 
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Modal, Button, Checkbox, H3 } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import { NotebookShareOptionsDropdown, type ShareOption } from './NotebookShareO
 
 import styles from './ShareNotebookModal.module.scss'
 
-interface ShareNotebookModalProps extends TelemetryProps {
+interface ShareNotebookModalProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     selectedShareOption: ShareOption
     setSelectedShareOption: (option: ShareOption) => void
@@ -39,13 +40,15 @@ export const ShareNotebookModal: React.FunctionComponent<React.PropsWithChildren
     toggleModal,
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
     onUpdateVisibility,
 }) => {
     useEffect(() => {
         if (isOpen) {
             telemetryService.log('SearchNotebookShareModalOpened')
+            telemetryRecorder.recordEvent('SearchNotebookShareModal', 'opened')
         }
-    }, [isOpen, telemetryService])
+    }, [isOpen, telemetryService, telemetryRecorder])
 
     const shareLabelId = 'shareNotebookId'
 
@@ -66,6 +69,7 @@ export const ShareNotebookModal: React.FunctionComponent<React.PropsWithChildren
                 <NotebookShareOptionsDropdown
                     isSourcegraphDotCom={isSourcegraphDotCom}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     authenticatedUser={authenticatedUser}
                     selectedShareOption={selectedShareOption}
                     onSelectShareOption={setSelectedShareOption}

--- a/client/web/src/org/OrgsArea.tsx
+++ b/client/web/src/org/OrgsArea.tsx
@@ -4,6 +4,7 @@ import { Routes, Route, useParams, useLocation, useNavigate } from 'react-router
 
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import type { AuthenticatedUser } from '../auth'
@@ -23,6 +24,7 @@ export interface Props
     extends PlatformContextProps,
         SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         BreadcrumbsProps,
         BreadcrumbSetters,
         BatchChangesProps {

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -11,6 +11,7 @@ import { type ErrorLike, isErrorLike, asError, logger } from '@sourcegraph/commo
 import { gql, dataOrThrowErrors } from '@sourcegraph/http-client'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, ErrorMessage } from '@sourcegraph/wildcard'
 
@@ -90,6 +91,7 @@ export interface OrgAreaProps
     extends PlatformContextProps,
         SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         BreadcrumbsProps,
         BreadcrumbSetters,
         BatchChangesProps {
@@ -124,6 +126,7 @@ export interface OrgAreaRouteContext
     extends PlatformContextProps,
         SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         NamespaceProps,
         BreadcrumbsProps,
         BreadcrumbSetters,
@@ -238,6 +241,7 @@ export class OrgArea extends React.Component<OrgAreaProps> {
             settingsCascade: this.props.settingsCascade,
             namespace: this.state.orgOrError,
             telemetryService: this.props.telemetryService,
+            telemetryRecorder: this.props.telemetryRecorder,
             isSourcegraphDotCom: this.props.isSourcegraphDotCom,
             isCodyApp: this.props.isCodyApp,
             batchChangesEnabled: this.props.batchChangesEnabled,

--- a/client/web/src/repo/FilePathBreadcrumbs.tsx
+++ b/client/web/src/repo/FilePathBreadcrumbs.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react'
 
 import { CopyPathAction } from '@sourcegraph/branded'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { type RepoRevision, toPrettyBlobURL } from '@sourcegraph/shared/src/util/url'
 import { Breadcrumbs } from '@sourcegraph/wildcard'
@@ -9,7 +10,7 @@ import { toTreeURL } from '../util/url'
 
 import styles from './FilePathBreadcrumbs.module.scss'
 
-interface FilePathBreadcrumbsProps extends RepoRevision, TelemetryProps {
+interface FilePathBreadcrumbsProps extends RepoRevision, TelemetryProps, TelemetryV2Props {
     isDir: boolean
     filePath: string
 }
@@ -19,7 +20,7 @@ interface FilePathBreadcrumbsProps extends RepoRevision, TelemetryProps {
  * links.
  */
 export const FilePathBreadcrumbs: FC<FilePathBreadcrumbsProps> = props => {
-    const { repoName, revision, filePath, isDir, telemetryService } = props
+    const { repoName, revision, filePath, isDir, telemetryService, telemetryRecorder } = props
 
     const partToUrl = (segment: string, index: number, segments: string[]): string => {
         const partPath = segments.slice(0, index + 1).join('/')
@@ -31,7 +32,11 @@ export const FilePathBreadcrumbs: FC<FilePathBreadcrumbsProps> = props => {
 
     return (
         <Breadcrumbs filename={filePath} getSegmentLink={partToUrl} className={styles.filePathBreadcrumbs}>
-            <CopyPathAction filePath={filePath} telemetryService={telemetryService} />
+            <CopyPathAction
+                filePath={filePath}
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+            />
         </Breadcrumbs>
     )
 }

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -388,6 +388,7 @@ export const RepoContainer: FC<RepoContainerProps> = props => {
                         authenticatedUser={authenticatedUser}
                         platformContext={props.platformContext}
                         telemetryService={props.telemetryService}
+                        telemetryRecorder={props.telemetryRecorder}
                     />
 
                     <RepoHeaderContributionPortal

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -24,6 +24,7 @@ import type { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { EditorHint, type SearchContextProps } from '@sourcegraph/shared/src/search'
 import { escapeSpaces } from '@sourcegraph/shared/src/search/query/filters'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { makeRepoURI } from '@sourcegraph/shared/src/util/url'
@@ -78,6 +79,7 @@ export interface RepoContainerContext
         PlatformContextProps,
         HoverThresholdProps,
         TelemetryProps,
+        TelemetryV2Props,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
         BreadcrumbSetters,
         SearchStreamingProps,
@@ -111,6 +113,7 @@ interface RepoContainerProps
     extends SettingsCascadeProps<Settings>,
         PlatformContextProps,
         TelemetryProps,
+        TelemetryV2Props,
         ExtensionsControllerProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
         BreadcrumbSetters,

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -24,7 +24,7 @@ import type { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { EditorHint, type SearchContextProps } from '@sourcegraph/shared/src/search'
 import { escapeSpaces } from '@sourcegraph/shared/src/search/query/filters'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
-import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryRecorder, TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { makeRepoURI } from '@sourcegraph/shared/src/util/url'
@@ -133,6 +133,7 @@ interface RepoContainerProps
     authenticatedUser: AuthenticatedUser | null
     isMacPlatform: boolean
     isSourcegraphDotCom: boolean
+    telemetryRecorder: TelemetryRecorder
 }
 
 export interface HoverThresholdProps {

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom'
 
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Menu, MenuList, Position, Icon } from '@sourcegraph/wildcard'
 
@@ -117,7 +118,7 @@ export interface RepoHeaderContext {
 
 export interface RepoHeaderActionButton extends ActionButtonDescriptor<RepoHeaderContext> {}
 
-interface Props extends PlatformContextProps, TelemetryProps, BreadcrumbsProps {
+interface Props extends PlatformContextProps, TelemetryProps, TelemetryV2Props, BreadcrumbsProps {
     /**
      * An array of render functions for action buttons that can be configured *in addition* to action buttons
      * contributed through {@link RepoHeaderContributionsLifecycleProps} and through extensions.

--- a/client/web/src/repo/RepoMetadataPage/index.tsx
+++ b/client/web/src/repo/RepoMetadataPage/index.tsx
@@ -4,6 +4,7 @@ import { Navigate } from 'react-router-dom'
 
 import { RepoMetadata, type RepoMetadataItem } from '@sourcegraph/branded'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, PageHeader, ErrorAlert, Input, Text, LoadingSpinner, Link } from '@sourcegraph/wildcard'
 
@@ -24,22 +25,29 @@ import { DELETE_REPO_METADATA_GQL, GET_REPO_METADATA_GQL } from './query'
 
 const BREADCRUMB = { key: 'metadata', element: 'Metadata' }
 
-interface RepoMetadataPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'>, TelemetryProps {
+interface RepoMetadataPageProps extends Pick<BreadcrumbSetters, 'useBreadcrumb'>, TelemetryProps, TelemetryV2Props {
     repo: Pick<RepositoryFields, 'name' | 'url' | 'metadata' | 'id'>
 }
 
 /**
  * The repository metadata page.
  */
-export const RepoMetadataPage: FC<RepoMetadataPageProps> = ({ telemetryService, useBreadcrumb, repo, ...props }) => {
+export const RepoMetadataPage: FC<RepoMetadataPageProps> = ({
+    telemetryService,
+    telemetryRecorder,
+    useBreadcrumb,
+    repo,
+    ...props
+}) => {
     useBreadcrumb(BREADCRUMB)
     const [repoMetadataEnabled, status] = useFeatureFlag('repository-metadata', true)
 
     useEffect(() => {
         if (repoMetadataEnabled) {
             telemetryService.log('repoPage:ownershipPage:viewed')
+            telemetryRecorder.recordEvent('repoPage.ownershipPage', 'viewed')
         }
-    }, [repoMetadataEnabled, telemetryService])
+    }, [repoMetadataEnabled, telemetryService, telemetryRecorder])
 
     const {
         data,

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -222,6 +222,7 @@ export const RepoRevisionContainer: FC<RepoRevisionContainerProps> = props => {
                         <GoToPermalinkAction
                             key="go-to-permalink"
                             telemetryService={props.telemetryService}
+                            telemetryRecorder={props.telemetryRecorder}
                             revision={props.revision}
                             commitID={resolvedRevision.commitID}
                             {...context}

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -8,6 +8,7 @@ import type { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensio
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import type { RevisionSpec } from '@sourcegraph/shared/src/util/url'
 import { Button, LoadingSpinner, Popover, PopoverContent, PopoverTrigger, Position } from '@sourcegraph/wildcard'
@@ -43,6 +44,7 @@ export interface RepoRevisionContainerContext
         ExtensionsControllerProps,
         PlatformContextProps,
         TelemetryProps,
+        TelemetryV2Props,
         HoverThresholdProps,
         Omit<RepoContainerContext, 'onDidUpdateExternalLinks' | 'repo' | 'resolvedRevisionOrError'>,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,
@@ -73,6 +75,7 @@ interface RepoRevisionContainerProps
         SettingsCascadeProps,
         PlatformContextProps,
         TelemetryProps,
+        TelemetryV2Props,
         HoverThresholdProps,
         ExtensionsControllerProps,
         Pick<SearchContextProps, 'selectedSearchContextSpec' | 'searchContextsEnabled'>,

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -7,6 +7,7 @@ import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/useKeyboardShortcut'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import type { RepoFile } from '@sourcegraph/shared/src/util/url'
 import {
@@ -34,7 +35,7 @@ import { RepoRevisionSidebarSymbols } from './RepoRevisionSidebarSymbols'
 
 import styles from './RepoRevisionSidebar.module.scss'
 
-interface RepoRevisionSidebarProps extends RepoFile, TelemetryProps, SettingsCascadeProps {
+interface RepoRevisionSidebarProps extends RepoFile, TelemetryProps, TelemetryV2Props, SettingsCascadeProps {
     repoID?: Scalars['ID']
     isDir: boolean
     defaultBranch: string
@@ -76,15 +77,21 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
                 action: 'click',
                 label: 'expand / collapse file tree view',
             })
+            props.telemetryRecorder.recordEvent('FileTreeView', 'clicked', {
+                privateMetadata: {
+                    action: 'click',
+                    label: 'expand / collapse file tree view',
+                },
+            })
             setPersistedIsVisible(value)
             setIsVisible(value)
         },
-        [setPersistedIsVisible, props.telemetryService]
+        [setPersistedIsVisible, props.telemetryService, props.telemetryRecorder]
     )
-    const handleSymbolClick = useCallback(
-        () => props.telemetryService.log('SymbolTreeViewClicked'),
-        [props.telemetryService]
-    )
+    const handleSymbolClick = useCallback(() => {
+        props.telemetryService.log('SymbolTreeViewClicked')
+        props.telemetryRecorder.recordEvent('SymbolTreeView', 'clicked')
+    }, [props.telemetryService, props.telemetryRecorder])
 
     const [enableBlobPageSwitchAreasShortcuts] = useFeatureFlag('blob-page-switch-areas-shortcuts')
     const focusFileTreeShortcut = useKeyboardShortcut('focusFileTree')
@@ -107,6 +114,7 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
                             <GettingStartedTour
                                 className="mr-3"
                                 telemetryService={props.telemetryService}
+                                telemetryRecorder={props.telemetryRecorder}
                                 authenticatedUser={props.authenticatedUser}
                             />
                         )}
@@ -164,6 +172,7 @@ export const RepoRevisionSidebar: FC<RepoRevisionSidebarProps> = props => {
                                                 filePath={props.filePath}
                                                 filePathIsDirectory={props.isDir}
                                                 telemetryService={props.telemetryService}
+                                                telemetryRecorder={props.telemetryRecorder}
                                             />
                                         </TabPanel>
                                         <TabPanel>

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -13,6 +13,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { dirname } from '@sourcegraph/common'
 import { gql, useQuery } from '@sourcegraph/http-client'
+import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Alert,
@@ -87,10 +88,11 @@ interface Props extends FocusableTreeProps {
     repoName: string
     revision: string
     telemetryService: TelemetryService
+    telemetryRecorder: TelemetryRecorder
 }
 
 export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props => {
-    const { telemetryService, onExpandParent } = props
+    const { telemetryService, telemetryRecorder, onExpandParent } = props
 
     // Ensure that the initial file path does not update when the props change
     const [initialFilePath] = useState(() =>
@@ -189,6 +191,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
             }
 
             telemetryService.log('FileTreeLoadDirectory')
+            telemetryRecorder.recordEvent('FileTreeLoadDirectory', 'rendered')
             await fetchEntries({
                 ...defaultVariables,
                 filePath: fullPath,
@@ -197,7 +200,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
 
             setTreeData(treeData => setLoadedPath(treeData!, fullPath))
         },
-        [defaultVariables, fetchEntries, treeData?.loadedIds, telemetryService]
+        [defaultVariables, fetchEntries, treeData?.loadedIds, telemetryService, telemetryRecorder]
     )
 
     const defaultSelectFiredRef = useRef<boolean>(false)
@@ -221,6 +224,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
 
             if (element.dotdot) {
                 telemetryService.log('FileTreeLoadParent')
+                telemetryRecorder.recordEvent('FileTreeLoadParent', 'rendered')
                 navigate(element.dotdot)
 
                 let parent = props.initialFilePathIsDirectory
@@ -235,6 +239,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
 
             if (element.entry) {
                 telemetryService.log('FileTreeClick')
+                telemetryRecorder.recordEvent('FileTree', 'clicked')
                 navigate(element.entry.url)
             }
             setSelectedIds([element.id])
@@ -243,6 +248,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
             selectedIds,
             defaultNodeId,
             telemetryService,
+            telemetryRecorder,
             navigate,
             props.initialFilePathIsDirectory,
             initialFilePath,

--- a/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.tsx
+++ b/client/web/src/repo/RepositoriesPopover/RepositoriesPopover.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useDebounce } from '@sourcegraph/wildcard'
 
@@ -49,7 +50,7 @@ export const REPOSITORIES_FOR_POPOVER = gql`
     }
 `
 
-export interface RepositoriesPopoverProps extends TelemetryProps {
+export interface RepositoriesPopoverProps extends TelemetryProps, TelemetryV2Props {
     /**
      * The current repository (shown as selected in the list), if any.
      */
@@ -64,14 +65,17 @@ export const BATCH_COUNT = 10
 export const RepositoriesPopover: React.FunctionComponent<React.PropsWithChildren<RepositoriesPopoverProps>> = ({
     currentRepo,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const [searchValue, setSearchValue] = useState('')
     const query = useDebounce(searchValue, 200)
 
     useEffect(() => {
+        // TODO: redundant legacy event logging. Remove once we have a new event for this page.
         eventLogger.logViewEvent('RepositoriesPopover')
         telemetryService.log('RepositoriesPopover')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('RepositoriesPopover', 'displayed')
+    }, [telemetryService, telemetryRecorder])
 
     const { connection, loading, error, hasNextPage, fetchMore } = useShowMorePagination<
         RepositoriesForPopoverResult,

--- a/client/web/src/repo/actions/GoToPermalinkAction.tsx
+++ b/client/web/src/repo/actions/GoToPermalinkAction.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { fromEvent } from 'rxjs'
 import { filter } from 'rxjs/operators'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { isInputElement } from '@sourcegraph/shared/src/util/dom'
 import { Icon, Link, Tooltip } from '@sourcegraph/wildcard'
@@ -13,7 +14,7 @@ import { replaceRevisionInURL } from '../../util/url'
 import { RepoHeaderActionButtonLink, RepoHeaderActionMenuLink } from '../components/RepoHeaderActions'
 import type { RepoHeaderContext } from '../RepoHeader'
 
-interface GoToPermalinkActionProps extends RepoHeaderContext, TelemetryProps {
+interface GoToPermalinkActionProps extends RepoHeaderContext, TelemetryProps, TelemetryV2Props {
     /**
      * The current (possibly undefined or non-full-SHA) Git revision.
      */
@@ -30,7 +31,7 @@ interface GoToPermalinkActionProps extends RepoHeaderContext, TelemetryProps {
  * Git commit SHA.
  */
 export const GoToPermalinkAction: React.FunctionComponent<GoToPermalinkActionProps> = props => {
-    const { revision, commitID, actionType, repoName, telemetryService } = props
+    const { revision, commitID, actionType, repoName, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const location = useLocation()
@@ -63,6 +64,12 @@ export const GoToPermalinkAction: React.FunctionComponent<GoToPermalinkActionPro
 
     const onClick = (): void => {
         telemetryService.log('PermalinkClicked', { repoName, commitID })
+        telemetryRecorder.recordEvent('Permalink', 'clicked', {
+            privateMetadata: {
+                repoName,
+                commitID,
+            },
+        })
     }
 
     if (actionType === 'dropdown') {

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -448,6 +448,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                     <GoToRawAction
                         {...context}
                         telemetryService={props.telemetryService}
+                        telemetryRecorder={props.telemetryRecorder}
                         key="raw-action"
                         repoName={repoName}
                         revision={props.revision}
@@ -603,6 +604,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                         settingsCascade={props.settingsCascade}
                         onHoverShown={props.onHoverShown}
                         telemetryService={props.telemetryService}
+                        telemetryRecorder={props.telemetryRecorder}
                         role="region"
                         ariaLabel="File blob"
                         isBlameVisible={isBlameVisible}

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -26,6 +26,7 @@ import { HighlightResponseFormat } from '@sourcegraph/shared/src/graphql-operati
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextProps } from '@sourcegraph/shared/src/search'
 import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { type ModeSpec, parseQueryAndHash, type RepoFile } from '@sourcegraph/shared/src/util/url'
@@ -96,6 +97,7 @@ interface BlobPageProps
         SettingsCascadeProps,
         PlatformContextProps,
         TelemetryProps,
+        TelemetryV2Props,
         ExtensionsControllerProps,
         HoverThresholdProps,
         BreadcrumbSetters,
@@ -149,7 +151,10 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
     // Log view event whenever a new Blob, or a Blob with a different render mode, is visited.
     useEffect(() => {
         props.telemetryService.logViewEvent('Blob', { repoName, filePath })
-    }, [repoName, commitID, filePath, renderMode, props.telemetryService])
+        props.telemetryRecorder.recordEvent('Blob', 'viewed', {
+            privateMetadata: { repoName, filePath },
+        })
+    }, [repoName, commitID, filePath, renderMode, props.telemetryService, props.telemetryRecorder])
 
     useNotepad(
         useMemo(
@@ -186,6 +191,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                         filePath={filePath}
                         isDir={false}
                         telemetryService={props.telemetryService}
+                        telemetryRecorder={props.telemetryRecorder}
                     />
                 ),
             }
@@ -366,6 +372,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
             {(props.isSourcegraphDotCom || isCodyEnabled()) && (
                 <TryCodyWidget
                     telemetryService={props.telemetryService}
+                    telemetryRecorder={props.telemetryRecorder}
                     type="blob"
                     authenticatedUser={props.authenticatedUser}
                     context={context}

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -22,6 +22,7 @@ import { useKeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts/u
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { type AbsoluteRepoFile, type ModeSpec, parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
@@ -65,6 +66,7 @@ export interface BlobProps
     extends SettingsCascadeProps,
         PlatformContextProps,
         TelemetryProps,
+        TelemetryV2Props,
         HoverThresholdProps,
         ExtensionsControllerProps,
         CodeMirrorBlobProps {

--- a/client/web/src/repo/blob/GoToRawAction.tsx
+++ b/client/web/src/repo/blob/GoToRawAction.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { mdiFileDownloadOutline } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { encodeRepoRevision, type RepoSpec, type RevisionSpec, type FileSpec } from '@sourcegraph/shared/src/util/url'
 import { Icon, Link, Tooltip } from '@sourcegraph/wildcard'
@@ -9,7 +10,13 @@ import { Icon, Link, Tooltip } from '@sourcegraph/wildcard'
 import { RepoHeaderActionAnchor, RepoHeaderActionMenuLink } from '../components/RepoHeaderActions'
 import type { RepoHeaderContext } from '../RepoHeader'
 
-interface Props extends RepoSpec, Partial<RevisionSpec>, FileSpec, RepoHeaderContext, TelemetryProps {}
+interface Props
+    extends RepoSpec,
+        Partial<RevisionSpec>,
+        FileSpec,
+        RepoHeaderContext,
+        TelemetryProps,
+        TelemetryV2Props {}
 
 /**
  * A repository header action that replaces the blob in the URL with the raw URL.
@@ -19,6 +26,12 @@ export class GoToRawAction extends React.PureComponent<Props> {
         this.props.telemetryService.log('RawFileDownload', {
             repoName: this.props.repoName,
             filePath: this.props.filePath,
+        })
+        this.props.telemetryRecorder.recordEvent('RawFileDownload', 'initiated', {
+            privateMetadata: {
+                repoName: this.props.repoName,
+                filePath: this.props.filePath,
+            },
         })
     }
 

--- a/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/FileOwnershipPanel.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { logger } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -18,15 +19,17 @@ import type { OwnershipPanelProps } from './TreeOwnershipPanel'
 
 import styles from './FileOwnershipPanel.module.scss'
 
-export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & TelemetryProps> = ({
+export const FileOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & TelemetryProps & TelemetryV2Props> = ({
     repoID,
     revision,
     filePath,
     telemetryService,
+    telemetryRecorder,
 }) => {
     React.useEffect(() => {
         telemetryService.log('OwnershipPanelOpened')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('OwnershipPanel', 'opened')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error, refetch } = useQuery<FetchOwnershipResult, FetchOwnershipVariables>(FETCH_OWNERS, {
         variables: {

--- a/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
+++ b/client/web/src/repo/blob/own/TreeOwnershipPanel.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 
 import { logger } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -24,16 +25,18 @@ export interface OwnershipPanelProps {
     showAddOwnerButton?: boolean
 }
 
-export const TreeOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & TelemetryProps> = ({
+export const TreeOwnershipPanel: React.FunctionComponent<OwnershipPanelProps & TelemetryProps & TelemetryV2Props> = ({
     repoID,
     revision,
     filePath,
     telemetryService,
+    telemetryRecorder,
     showAddOwnerButton,
 }) => {
     useEffect(() => {
         telemetryService.log('OwnershipPanelOpened')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('OwnershipPanel', 'opened')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error, refetch } = useQuery<FetchTreeOwnershipResult, FetchTreeOwnershipVariables>(
         FETCH_TREE_OWNERS,

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -11,6 +11,7 @@ import type { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensio
 import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { Settings, SettingsCascadeOrError, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { type AbsoluteRepoFile, type ModeSpec, parseQueryAndHash } from '@sourcegraph/shared/src/util/url'
 import { Text } from '@sourcegraph/wildcard'
@@ -30,7 +31,8 @@ interface Props
         PlatformContextProps,
         Pick<CodeIntelligenceProps, 'useCodeIntel'>,
         OwnConfigProps,
-        TelemetryProps {
+        TelemetryProps,
+        TelemetryV2Props {
     repoID: Scalars['ID']
     isPackage: boolean
     repoName: string
@@ -54,6 +56,7 @@ function useBlobPanelViews({
     platformContext,
     useCodeIntel,
     telemetryService,
+    telemetryRecorder,
     fetchHighlightedFileLineRanges,
     ownEnabled,
 }: Props): void {
@@ -90,6 +93,7 @@ function useBlobPanelViews({
                                   platformContext={platformContext}
                                   extensionsController={extensionsController}
                                   telemetryService={telemetryService}
+                                  telemetryRecorder={telemetryRecorder}
                                   key="references"
                                   fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                                   useCodeIntel={useCodeIntel}
@@ -138,6 +142,7 @@ function useBlobPanelViews({
                                       revision={revision}
                                       filePath={filePath}
                                       telemetryService={telemetryService}
+                                      telemetryRecorder={telemetryRecorder}
                                   />
                               </PanelContent>
                           ),
@@ -153,6 +158,7 @@ function useBlobPanelViews({
             platformContext,
             extensionsController,
             telemetryService,
+            telemetryRecorder,
             fetchHighlightedFileLineRanges,
             useCodeIntel,
             repoID,

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -9,6 +9,7 @@ import { useQuery } from '@sourcegraph/http-client'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -33,7 +34,11 @@ import { CHANGELIST_QUERY, COMMIT_QUERY } from './backend'
 
 import styles from './RepositoryCommitPage.module.scss'
 
-interface RepositoryCommitPageProps extends TelemetryProps, PlatformContextProps, SettingsCascadeProps {
+interface RepositoryCommitPageProps
+    extends TelemetryProps,
+        TelemetryV2Props,
+        PlatformContextProps,
+        SettingsCascadeProps {
     repo: RepositoryFields
     onDidUpdateExternalLinks: (externalLinks: ExternalLinkFields[] | undefined) => void
 }
@@ -107,7 +112,11 @@ export const RepositoryChangelistPage: React.FunctionComponent<RepositoryCommitP
     )
 }
 
-interface RepositoryRevisionNodesProps extends TelemetryProps, PlatformContextProps, SettingsCascadeProps {
+interface RepositoryRevisionNodesProps
+    extends TelemetryProps,
+        TelemetryV2Props,
+        PlatformContextProps,
+        SettingsCascadeProps {
     error?: ApolloError
     loading: boolean
 
@@ -126,7 +135,8 @@ const RepositoryRevisionNodes: React.FunctionComponent<RepositoryRevisionNodesPr
 
     useEffect(() => {
         props.telemetryService.logViewEvent('RepositoryCommit')
-    }, [props.telemetryService])
+        props.telemetryRecorder.recordEvent('RepositoryCommit', 'viewed')
+    }, [props.telemetryService, props.telemetryRecorder])
 
     useEffect(() => {
         if (commit) {

--- a/client/web/src/repo/commits/RepositoryCommitsPage.tsx
+++ b/client/web/src/repo/commits/RepositoryCommitsPage.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom'
 import { basename, pluralize } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import type { RevisionSpec } from '@sourcegraph/shared/src/util/url'
 import { Code, Heading, ErrorAlert } from '@sourcegraph/wildcard'
@@ -124,7 +125,7 @@ export const REPOSITORY_GIT_COMMITS_QUERY = gql`
     ${gitCommitFragment}
 `
 
-export interface RepositoryCommitsPageProps extends RevisionSpec, BreadcrumbSetters, TelemetryProps {
+export interface RepositoryCommitsPageProps extends RevisionSpec, BreadcrumbSetters, TelemetryProps, TelemetryV2Props {
     repo: RepositoryFields
 }
 
@@ -200,10 +201,11 @@ export const RepositoryCommitsPage: FC<RepositoryCommitsPageProps> = props => {
                         filePath={filePath}
                         isDir={true}
                         telemetryService={props.telemetryService}
+                        telemetryRecorder={props.telemetryRecorder}
                     />
                 ),
             }
-        }, [filePath, repo, props.revision, props.telemetryService])
+        }, [filePath, repo, props.revision, props.telemetryService, props.telemetryRecorder])
     )
     // We need to resolve the Commits breadcrumb at the same time as the
     // filePath, so that the order is correct (otherwise Commits will show

--- a/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
+++ b/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
@@ -216,7 +216,7 @@ export const TryCodyWidget: React.FC<TryCodyWidgetProps> = ({
         telemetryRecorder.recordEvent(EventName.TRY_CODY_WEB_ONBOARDING_DISPLAYED, 'clicked', {
             privateMetadata: { type: eventPage },
         })
-    }, [isDismissed, telemetryService, type])
+    }, [isDismissed, telemetryService, telemetryRecorder, type])
 
     if (isDismissed) {
         return null

--- a/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
+++ b/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
@@ -67,6 +67,9 @@ const NoAuthWidgetContent: React.FC<NoAuhWidgetContentProps> = ({ type, telemetr
             description: '',
         }
         telemetryService.log(EventName.TRY_CODY_SIGNUP_INITIATED, eventArguments, eventArguments)
+        window.context.telemetryRecorder.recordEvent(EventName.TRY_CODY_SIGNUP_INITIATED, 'initiated', {
+            privateMetadata: { eventArguments },
+        })
     }
 
     const title = type === 'blob' ? 'Sign up to get Cody, our AI assistant, free' : 'Meet Cody, your AI assistant'
@@ -203,6 +206,9 @@ export const TryCodyWidget: React.FC<TryCodyWidgetProps> = ({
         }
         const eventPage = type === 'blob' ? 'BlobPage' : 'RepoPage'
         telemetryService.log(EventName.TRY_CODY_WEB_ONBOARDING_DISPLAYED, { type: eventPage }, { type: eventPage })
+        window.context.telemetryRecorder.recordEvent(EventName.TRY_CODY_WEB_ONBOARDING_DISPLAYED, 'clicked', {
+            privateMetadata: { type: eventPage },
+        })
     }, [isDismissed, telemetryService, type])
 
     if (isDismissed) {

--- a/client/web/src/repo/stats/RepositoryStatsArea.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsArea.tsx
@@ -2,6 +2,7 @@ import { type FC, useMemo } from 'react'
 
 import { useSearchParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
 
 import { RepositoryStatsContributorsPage } from './RepositoryStatsContributorsPage'
 
-interface Props extends BreadcrumbSetters, TelemetryProps {
+interface Props extends BreadcrumbSetters, TelemetryProps, TelemetryV2Props {
     repo: RepositoryFields | undefined
 }
 
@@ -31,7 +32,7 @@ const BREADCRUMB = { key: 'contributors', element: 'Contributors' }
  * Renders pages related to repository stats.
  */
 export const RepositoryStatsArea: FC<Props> = props => {
-    const { useBreadcrumb, repo, telemetryService } = props
+    const { useBreadcrumb, repo, telemetryService, telemetryRecorder } = props
     const [searchParams] = useSearchParams()
     const filePath = searchParams.get('path') ?? ''
 
@@ -51,6 +52,7 @@ export const RepositoryStatsArea: FC<Props> = props => {
                         filePath={filePath}
                         isDir={true}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 ),
             }

--- a/client/web/src/repo/tree/TreePage.test.tsx
+++ b/client/web/src/repo/tree/TreePage.test.tsx
@@ -59,6 +59,7 @@ describe('TreePage', () => {
             telemetryRecorder: noOpTelemetryRecorder,
         },
         telemetryService: NOOP_TELEMETRY_SERVICE,
+        telemetryRecorder: noOpTelemetryRecorder,
         codeIntelligenceEnabled: false,
         batchChangesExecutionEnabled: false,
         batchChangesEnabled: false,

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -415,6 +415,7 @@ export const TreePage: FC<Props> = ({
                             commitID={commitID}
                             isPackage={isPackage}
                             authenticatedUser={authenticatedUser}
+                            telemetryRecorder={telemetryRecorder}
                             {...props}
                         />
                     )}

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -15,6 +15,7 @@ import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import type { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { RepositoryType, SearchPatternType, type TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import { Badge, ButtonLink, Card, CardHeader, Icon, Link, Text, Tooltip } from '@sourcegraph/wildcard'
@@ -267,7 +268,11 @@ const ExtraInfoSection: React.FC<{
     )
 }
 
-interface TreePageContentProps extends ExtensionsControllerProps, TelemetryProps, PlatformContextProps {
+interface TreePageContentProps
+    extends ExtensionsControllerProps,
+        TelemetryProps,
+        TelemetryV2Props,
+        PlatformContextProps {
     filePath: string
     tree: TreeFields
     repo: TreePageRepositoryFields

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -74,7 +74,17 @@ export const routes: RouteObject[] = [
     },
     {
         path: PageRoutes.SignUp,
-        element: <LegacyRoute render={props => <SignUpPage {...props} context={window.context} />} />,
+        element: (
+            <LegacyRoute
+                render={props => (
+                    <SignUpPage
+                        {...props}
+                        context={window.context}
+                        telemetryRecorder={window.context.telemetryRecorder}
+                    />
+                )}
+            />
+        ),
     },
     {
         path: PageRoutes.UnlockAccount,
@@ -103,7 +113,11 @@ export const routes: RouteObject[] = [
     },
     {
         path: PageRoutes.Organizations,
-        element: <LegacyRoute render={props => <OrgsArea {...props} />} />,
+        element: (
+            <LegacyRoute
+                render={props => <OrgsArea {...props} telemetryRecorder={window.context.telemetryRecorder} />}
+            />
+        ),
     },
     {
         path: PageRoutes.SiteAdminInit,
@@ -136,7 +150,11 @@ export const routes: RouteObject[] = [
     },
     {
         path: PageRoutes.UserArea,
-        element: <LegacyRoute render={props => <UserArea {...props} />} />,
+        element: (
+            <LegacyRoute
+                render={props => <UserArea {...props} telemetryRecorder={window.context.telemetryRecorder} />}
+            />
+        ),
     },
     {
         path: PageRoutes.Survey,

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -185,7 +185,7 @@ function SearchConsolePageOrRedirect(props: LegacyLayoutRouteContext): JSX.Eleme
     const showMultilineSearchConsole = useExperimentalFeatures(features => features.showMultilineSearchConsole)
 
     return showMultilineSearchConsole ? (
-        <SearchConsolePage {...props} />
+        <SearchConsolePage {...props} telemetryRecorder={window.context.telemetryRecorder} />
     ) : (
         <Navigate replace={true} to={PageRoutes.Search} />
     )

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -120,6 +120,7 @@ export const routes: RouteObject[] = [
                         sideBarGroups={props.siteAdminSideBarGroups}
                         overviewComponents={props.siteAdminOverviewComponents}
                         codeInsightsEnabled={window.context.codeInsightsEnabled}
+                        telemetryRecorder={window.context.telemetryRecorder}
                     />
                 )}
             />
@@ -155,8 +156,11 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => (
-                    <CodySidebarStoreProvider authenticatedUser={props.authenticatedUser}>
-                        <RepoContainer {...props} />
+                    <CodySidebarStoreProvider
+                        authenticatedUser={props.authenticatedUser}
+                        telemetryRecorder={window.context.telemetryRecorder}
+                    >
+                        <RepoContainer {...props} telemetryRecorder={window.context.telemetryRecorder} />
                     </CodySidebarStoreProvider>
                 )}
             />

--- a/client/web/src/search/SearchConsolePage.tsx
+++ b/client/web/src/search/SearchConsolePage.tsx
@@ -17,6 +17,7 @@ import {
 import { LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
 import { fetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { LoadingSpinner, Button, useObservable } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../components/PageTitle'
@@ -32,7 +33,8 @@ import styles from './SearchConsolePage.module.scss'
 interface SearchConsolePageProps
     extends SearchStreamingProps,
         Omit<StreamingSearchResultsListProps, 'allExpanded' | 'executedQuery' | 'showSearchContext'>,
-        OwnConfigProps {
+        OwnConfigProps,
+        TelemetryV2Props {
     isMacPlatform: boolean
 }
 

--- a/client/web/src/search/input/ExperimentalSearchInput.tsx
+++ b/client/web/src/search/input/ExperimentalSearchInput.tsx
@@ -19,6 +19,7 @@ import type { SearchContextProps, SubmitSearchParameters } from '@sourcegraph/sh
 import { FILTERS, FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { resolveFilterMemoized } from '@sourcegraph/shared/src/search/query/utils'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { createSuggestionsSource, type SuggestionsSourceConfig } from './suggestions'
@@ -90,6 +91,7 @@ export interface ExperimentalSearchInputProps
     extends Omit<CodeMirrorQueryInputWrapperProps, 'suggestionSource' | 'extensions' | 'placeholder'>,
         Pick<SearchContextProps, 'selectedSearchContextSpec'>,
         TelemetryProps,
+        TelemetryV2Props,
         Omit<SuggestionsSourceConfig, 'getSearchContext'> {
     submitSearch(parameters: Partial<SubmitSearchParameters>): void
 }
@@ -100,6 +102,7 @@ export interface ExperimentalSearchInputProps
 export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInputProps>> = ({
     children,
     telemetryService,
+    telemetryRecorder,
     platformContext,
     authenticatedUser,
     fetchSearchContexts,
@@ -169,6 +172,9 @@ export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInp
                     type: option.kind,
                     source,
                 })
+                telemetryRecorder.recordEvent(`SearchInput${eventNameMap[action.type]}`, 'rendered', {
+                    privateMetadata: { type: option.kind, source },
+                })
             }),
             Prec.low(
                 exampleSuggestions({
@@ -178,7 +184,7 @@ export const ExperimentalSearchInput: FC<PropsWithChildren<ExperimentalSearchInp
                 })
             ),
         ],
-        [telemetryService, addExample]
+        [telemetryService, telemetryRecorder, addExample]
     )
 
     return (

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -7,6 +7,7 @@ import { SearchBox, Toggles } from '@sourcegraph/branded'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextInputProps, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Form } from '@sourcegraph/wildcard'
 
@@ -22,6 +23,7 @@ interface Props
     extends SettingsCascadeProps,
         SearchContextInputProps,
         TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'requestGraphQL'> {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
@@ -90,6 +92,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 <LazyExperimentalSearchInput
                     visualMode="compact"
                     telemetryService={props.telemetryService}
+                    telemetryRecorder={props.telemetryRecorder}
                     patternType={searchPatternType}
                     interpretComments={false}
                     queryState={queryState}

--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -15,6 +15,7 @@ import { merge, of } from 'rxjs'
 import { last, share, tap, throttleTime } from 'rxjs/operators'
 
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/wildcard'
 
@@ -42,7 +43,8 @@ export function useCachedSearchResults(
     streamSearch: SearchStreamingProps['streamSearch'],
     query: string,
     options: StreamSearchOptions,
-    telemetryService: TelemetryService
+    telemetryService: TelemetryService,
+    telemetryRecorder: TelemetryRecorder
 ): AggregateStreamingSearchResults | undefined {
     const cachedResults = useContext(SearchResultsCacheContext)
 
@@ -97,6 +99,9 @@ export function useCachedSearchResults(
 
         if (navigationType === 'POP') {
             telemetryService.log('SearchResultsCacheRetrieved', { cacheHit: cacheExists }, { cacheHit: cacheExists })
+            telemetryRecorder.recordEvent('SearchResultsCache', 'retrieved', {
+                metadata: { cacheHit: cacheExists ? 1 : 0 },
+            })
         }
         // Only log on first render
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -15,7 +15,6 @@ import { merge, of } from 'rxjs'
 import { last, share, tap, throttleTime } from 'rxjs/operators'
 
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
-import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/wildcard'
 
@@ -43,8 +42,7 @@ export function useCachedSearchResults(
     streamSearch: SearchStreamingProps['streamSearch'],
     query: string,
     options: StreamSearchOptions,
-    telemetryService: TelemetryService,
-    telemetryRecorder: TelemetryRecorder
+    telemetryService: TelemetryService
 ): AggregateStreamingSearchResults | undefined {
     const cachedResults = useContext(SearchResultsCacheContext)
 
@@ -99,9 +97,9 @@ export function useCachedSearchResults(
 
         if (navigationType === 'POP') {
             telemetryService.log('SearchResultsCacheRetrieved', { cacheHit: cacheExists }, { cacheHit: cacheExists })
-            telemetryRecorder.recordEvent('SearchResultsCache', 'retrieved', {
-                metadata: { cacheHit: cacheExists ? 1 : 0 },
-            })
+            // window.context.telemetryRecorder.recordEvent('SearchResultsCache', 'retrieved', {
+            //     metadata: { cacheHit: cacheExists ? 1 : 0 },
+            // })
         }
         // Only log on first render
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/web/src/search/results/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.test.tsx
@@ -1,6 +1,7 @@
 import { noop } from 'lodash'
 import { NEVER } from 'rxjs'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
@@ -23,6 +24,7 @@ const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
     onExportCsvClick: noop,
     stats: <div />,
     telemetryService: NOOP_TELEMETRY_SERVICE,
+    telemetryRecorder: noOpTelemetryRecorder,
     patternType: SearchPatternType.standard,
     caseSensitive: false,
     setSidebarCollapsed: noop,

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -8,6 +8,7 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import type { CaseSensitivityProps, SearchPatternTypeProps } from '@sourcegraph/shared/src/search'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, Alert, useSessionStorage, Link, Text } from '@sourcegraph/wildcard'
 
@@ -29,6 +30,7 @@ import styles from './SearchResultsInfoBar.module.scss'
 
 export interface SearchResultsInfoBarProps
     extends TelemetryProps,
+        TelemetryV2Props,
         PlatformContextProps<'settings' | 'sourcegraphURL'>,
         SearchPatternTypeProps,
         Pick<CaseSensitivityProps, 'caseSensitive'> {

--- a/client/web/src/search/results/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.story.tsx
@@ -4,6 +4,7 @@ import { EMPTY, NEVER, of } from 'rxjs'
 
 import { SearchQueryStateStoreProvider } from '@sourcegraph/shared/src/search'
 import type { AggregateStreamingSearchResults } from '@sourcegraph/shared/src/search/stream'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     HIGHLIGHTED_FILE_LINES_LONG_REQUEST,
@@ -33,6 +34,7 @@ const streamingSearchResult: AggregateStreamingSearchResults = {
 
 const defaultProps: StreamingSearchResultsProps = {
     telemetryService: NOOP_TELEMETRY_SERVICE,
+    telemetryRecorder: noOpTelemetryRecorder,
 
     authenticatedUser: {
         url: '/users/alice',

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -21,6 +21,7 @@ import {
 } from '@sourcegraph/shared/src/search/stream'
 import { type SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useDeepMemo } from '@sourcegraph/wildcard'
 
@@ -58,6 +59,7 @@ export interface StreamingSearchResultsProps
         SettingsCascadeProps,
         PlatformContextProps<'settings' | 'requestGraphQL' | 'sourcegraphURL'>,
         TelemetryProps,
+        TelemetryV2Props,
         CodeInsightsProps,
         SearchAggregationProps,
         CodeMonitoringProps,
@@ -72,6 +74,7 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         streamSearch,
         authenticatedUser,
         telemetryService,
+        telemetryRecorder,
         isSourcegraphDotCom,
         searchAggregationEnabled,
         codeMonitoringEnabled,
@@ -125,7 +128,13 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
         [caseSensitive, patternType, searchMode, trace, featureOverrides]
     )
 
-    const results = useCachedSearchResults(streamSearch, submittedURLQuery, options, telemetryService)
+    const results = useCachedSearchResults(
+        streamSearch,
+        submittedURLQuery,
+        options,
+        telemetryService,
+        telemetryRecorder
+    )
 
     const resultsLength = results?.results.length || 0
     const logSearchResultClicked = useCallback(

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.story.tsx
@@ -3,6 +3,7 @@ import type { Meta, Story } from '@storybook/react'
 import { noop } from 'lodash'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { BrandedStory } from '@sourcegraph/wildcard/src/stories'
@@ -147,6 +148,7 @@ export const SearchAggregationResultDemo: Story = () => (
                     patternType={SearchPatternType.literal}
                     caseSensitive={false}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
                     onQuerySubmit={noop}
                 />
             </MockedTestProvider>

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.tsx
@@ -2,6 +2,7 @@ import { type FC, type HTMLAttributes, useEffect, useState } from 'react'
 
 import { mdiArrowCollapse } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, H2, Icon, Code, Card, CardBody } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import { AggregationUIMode } from './types'
 
 import styles from './SearchAggregationResult.module.scss'
 
-interface SearchAggregationResultProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
+interface SearchAggregationResultProps extends TelemetryProps, TelemetryV2Props, HTMLAttributes<HTMLElement> {
     /**
      * Current submitted query, note that this query isn't a live query
      * that is synced with typed query in the search box, this query is submitted
@@ -42,7 +43,8 @@ interface SearchAggregationResultProps extends TelemetryProps, HTMLAttributes<HT
 }
 
 export const SearchAggregationResult: FC<SearchAggregationResultProps> = props => {
-    const { query, patternType, caseSensitive, onQuerySubmit, telemetryService, ...attributes } = props
+    const { query, patternType, caseSensitive, onQuerySubmit, telemetryService, telemetryRecorder, ...attributes } =
+        props
 
     const [extendedTimeout, setExtendedTimeoutLocal] = useState(false)
     const [, setAggregationUIMode] = useAggregationUIMode()
@@ -55,11 +57,15 @@ export const SearchAggregationResult: FC<SearchAggregationResultProps> = props =
         proactive: true,
         extendedTimeout,
         telemetryService,
+        telemetryRecorder,
     })
 
     const handleCollapseClick = (): void => {
         setAggregationUIMode(AggregationUIMode.Sidebar)
         telemetryService.log(GroupResultsPing.CollapseFullViewPanel, { aggregationMode }, { aggregationMode })
+        telemetryRecorder.recordEvent(GroupResultsPing.CollapseFullViewPanel, 'clicked', {
+            privateMetadata: { aggregationMode },
+        })
     }
 
     const handleBarLinkClick = (query: string, index: number): void => {

--- a/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
+++ b/client/web/src/search/results/export/SearchResultsCsvExportModal.tsx
@@ -4,6 +4,7 @@ import { type ErrorLike, isErrorLike, logger } from '@sourcegraph/common'
 import type { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/query'
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Button, Code, H3, Modal, Text } from '@sourcegraph/wildcard'
 
@@ -12,7 +13,10 @@ import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 
 import { downloadSearchResults, EXPORT_RESULT_DISPLAY_LIMIT } from './searchResultsExport'
 
-interface SearchResultsCsvExportModalProps extends Pick<PlatformContext, 'sourcegraphURL'>, TelemetryProps {
+interface SearchResultsCsvExportModalProps
+    extends Pick<PlatformContext, 'sourcegraphURL'>,
+        TelemetryProps,
+        TelemetryV2Props {
     query?: string
     options: StreamSearchOptions
     results?: AggregateStreamingSearchResults
@@ -23,6 +27,7 @@ const MODAL_LABEL_ID = 'search-results-export-csv-modal-id'
 
 export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsCsvExportModalProps> = ({
     telemetryService,
+    telemetryRecorder,
     sourcegraphURL,
     query = '',
     options,
@@ -53,6 +58,7 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
 
         if (query.includes('select:file.owners')) {
             telemetryService.log('searchResults:ownershipCsv:exported')
+            telemetryRecorder.recordEvent('searchResults.ownershipCsv', 'exported')
         }
 
         setLoading(true)
@@ -88,6 +94,7 @@ export const SearchResultsCsvExportModal: React.FunctionComponent<SearchResultsC
         results,
         shouldRerunSearch,
         telemetryService,
+        telemetryRecorder,
         onClose,
     ])
 

--- a/client/web/src/search/results/sidebar/SearchAggregations.tsx
+++ b/client/web/src/search/results/sidebar/SearchAggregations.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect, useState, memo } from 'react'
 
 import { mdiArrowExpand } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import {
 
 import styles from './SearchAggregations.module.scss'
 
-interface SearchAggregationsProps extends TelemetryProps {
+interface SearchAggregationsProps extends TelemetryProps, TelemetryV2Props {
     /**
      * Current submitted query, note that this query isn't a live query
      * that is synced with typed query in the search box, this query is submitted
@@ -45,7 +46,7 @@ interface SearchAggregationsProps extends TelemetryProps {
 }
 
 export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
-    const { query, patternType, proactive, caseSensitive, telemetryService, onQuerySubmit } = props
+    const { query, patternType, proactive, caseSensitive, telemetryService, telemetryRecorder, onQuerySubmit } = props
 
     const [extendedTimeout, setExtendedTimeoutLocal] = useState(false)
 
@@ -59,6 +60,7 @@ export const SearchAggregations: FC<SearchAggregationsProps> = memo(props => {
         caseSensitive,
         extendedTimeout,
         telemetryService,
+        telemetryRecorder,
     })
 
     // When query is updated reset extendedTimeout as per business rules

--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -5,6 +5,7 @@ import type * as _monaco from 'monaco-editor'
 import { Subscription } from 'rxjs'
 
 import { logger } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, BeforeUnloadPrompt } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,8 @@ const disposableToFunc = (disposable: _monaco.IDisposable) => () => disposable.d
 
 interface Props<T extends object>
     extends Pick<_monacoSettingsEditorModule.Props, 'id' | 'readOnly' | 'height' | 'jsonSchema' | 'language'>,
-        TelemetryProps {
+        TelemetryProps,
+        TelemetryV2Props {
     value: string
     isLightTheme: boolean
 

--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -10,6 +10,7 @@ import { gql } from '@sourcegraph/http-client'
 import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps, SettingsSubject } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, ErrorMessage } from '@sourcegraph/wildcard'
 
@@ -23,7 +24,11 @@ import { eventLogger } from '../tracking/eventLogger'
 import { SettingsPage } from './SettingsPage'
 
 /** Props shared by SettingsArea and its sub-pages. */
-interface SettingsAreaPageCommonProps extends PlatformContextProps, SettingsCascadeProps, TelemetryProps {
+interface SettingsAreaPageCommonProps
+    extends PlatformContextProps,
+        SettingsCascadeProps,
+        TelemetryProps,
+        TelemetryV2Props {
     /** The subject whose settings to edit. */
     subject: Pick<SettingsSubject, '__typename' | 'id'>
 
@@ -155,6 +160,7 @@ export class SettingsArea extends React.Component<Props, State> {
             platformContext: this.props.platformContext,
             settingsCascade: this.props.settingsCascade,
             telemetryService: this.props.telemetryService,
+            telemetryRecorder: this.props.telemetryRecorder,
         }
 
         return (

--- a/client/web/src/settings/SettingsFile.tsx
+++ b/client/web/src/settings/SettingsFile.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { Subject, Subscription } from 'rxjs'
 import { distinctUntilChanged, filter, map, startWith } from 'rxjs/operators'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, BeforeUnloadPrompt } from '@sourcegraph/wildcard'
 
@@ -14,7 +15,7 @@ import { eventLogger } from '../tracking/eventLogger'
 
 import styles from './SettingsFile.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     settings: SiteAdminSettingsCascadeFields['subjects'][number]['latestSettings'] | null
 
     /**

--- a/client/web/src/settings/SettingsPage.tsx
+++ b/client/web/src/settings/SettingsPage.tsx
@@ -2,13 +2,14 @@ import * as React from 'react'
 
 import { logger } from '@sourcegraph/common'
 import { overwriteSettings } from '@sourcegraph/shared/src/settings/edit'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container } from '@sourcegraph/wildcard'
 
 import type { SettingsAreaPageProps } from './SettingsArea'
 import { SettingsFile } from './SettingsFile'
 
-interface Props extends SettingsAreaPageProps, TelemetryProps {
+interface Props extends SettingsAreaPageProps, TelemetryProps, TelemetryV2Props {
     /** Optional description to render above the editor. */
     description?: JSX.Element
     isLightTheme: boolean
@@ -34,6 +35,7 @@ export class SettingsPage extends React.PureComponent<Props, State> {
                     onDidDiscard={this.onDidDiscard}
                     isLightTheme={this.props.isLightTheme}
                     telemetryService={this.props.telemetryService}
+                    telemetryRecorder={this.props.telemetryRecorder}
                 />
             </Container>
         )

--- a/client/web/src/setup-wizard/SetupWizard.tsx
+++ b/client/web/src/setup-wizard/SetupWizard.tsx
@@ -4,6 +4,7 @@ import type { ApolloClient } from '@apollo/client'
 import { useNavigate } from 'react-router-dom'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { H1, H2, useLocalStorage } from '@sourcegraph/wildcard'
 
@@ -55,10 +56,10 @@ const CORE_STEPS: StepConfiguration[] = [
     },
 ]
 
-interface SetupWizardProps extends TelemetryProps {}
+interface SetupWizardProps extends TelemetryProps, TelemetryV2Props {}
 
 export const SetupWizard: FC<SetupWizardProps> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const [activeStepId, setStepId, status] = useTemporarySetting('setup.activeStepId')
@@ -85,8 +86,9 @@ export const SetupWizard: FC<SetupWizardProps> = props => {
     const handleSkip = useCallback(() => {
         setSkipWizardState(true)
         telemetryService.log('SetupWizardQuits')
+        telemetryRecorder.recordEvent('SetupWizard', 'quit')
         navigate('/search')
-    }, [navigate, telemetryService, setSkipWizardState])
+    }, [navigate, telemetryService, telemetryRecorder, setSkipWizardState])
 
     if (status !== 'loaded') {
         return null
@@ -114,6 +116,7 @@ export const SetupWizard: FC<SetupWizardProps> = props => {
                     <SetupStepsContent
                         contentContainerClass={styles.contentContainer}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         isCodyApp={false}
                     />
                 </div>

--- a/client/web/src/setup-wizard/components/SyncRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/SyncRepositoriesStep.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement, useEffect } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Text } from '@sourcegraph/wildcard'
 
@@ -7,21 +8,24 @@ import { SiteAdminRepositoriesContainer } from '../../site-admin/SiteAdminReposi
 
 import { CustomNextButton } from './setup-steps'
 
-interface SyncRepositoriesStepProps extends TelemetryProps {
+interface SyncRepositoriesStepProps extends TelemetryProps, TelemetryV2Props {
     baseURL: string
 }
 
 export function SyncRepositoriesStep({
     telemetryService,
+    telemetryRecorder,
     baseURL,
     ...attributes
 }: SyncRepositoriesStepProps): ReactElement {
     useEffect(() => {
         telemetryService.log('SetupWizardLandedSyncRepositories')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SetupWizardLandedSyncRepositories', 'rendered')
+    }, [telemetryService, telemetryRecorder])
 
     const handleFinishButtonClick = (): void => {
         telemetryService.log('SetupWizardFinishedSuccessfully')
+        telemetryRecorder.recordEvent('SetupWizardFinishedSuccessfully', 'clicked')
     }
 
     return (

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostEdit.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 
 import { useMutation } from '@sourcegraph/http-client'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Button, ErrorAlert, H4, Link, LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -38,7 +39,7 @@ interface EditableCodeHost {
     config: string
 }
 
-interface CodeHostEditProps extends TelemetryProps {
+interface CodeHostEditProps extends TelemetryProps, TelemetryV2Props {
     onCodeHostDelete: (codeHost: EditableCodeHost) => void
 }
 
@@ -47,7 +48,7 @@ interface CodeHostEditProps extends TelemetryProps {
  * Also performs edit, delete actions over opened code host connection
  */
 export const CodeHostEdit: FC<CodeHostEditProps> = props => {
-    const { onCodeHostDelete, telemetryService } = props
+    const { onCodeHostDelete, telemetryService, telemetryRecorder } = props
     const { codehostId } = useParams()
 
     const { data, loading, error, refetch } = useQuery<GetExternalServiceByIdResult, GetExternalServiceByIdVariables>(
@@ -94,6 +95,7 @@ export const CodeHostEdit: FC<CodeHostEditProps> = props => {
             displayName={data.node.displayName}
             configuration={data.node.config}
             telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
         >
             {state => (
                 <footer className={styles.footer}>
@@ -125,7 +127,7 @@ export const CodeHostEdit: FC<CodeHostEditProps> = props => {
     )
 }
 
-interface CodeHostEditViewProps extends TelemetryProps {
+interface CodeHostEditViewProps extends TelemetryProps, TelemetryV2Props {
     codeHostId: string
     codeHostKind: ExternalServiceKind
     displayName: string
@@ -134,7 +136,8 @@ interface CodeHostEditViewProps extends TelemetryProps {
 }
 
 const CodeHostEditView: FC<CodeHostEditViewProps> = props => {
-    const { codeHostId, codeHostKind, displayName, configuration, telemetryService, children } = props
+    const { codeHostId, codeHostKind, displayName, configuration, telemetryService, telemetryRecorder, children } =
+        props
 
     const navigate = useNavigate()
     const [updateRemoteCodeHost] = useMutation<UpdateRemoteCodeHostResult, UpdateRemoteCodeHostVariables>(
@@ -162,6 +165,7 @@ const CodeHostEditView: FC<CodeHostEditViewProps> = props => {
                 initialValues={initialValues}
                 externalServiceId={codeHostId}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 onSubmit={handleSubmit}
             >
                 {children}

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -14,6 +14,7 @@ import { parse as parseJSONC } from 'jsonc-parser'
 
 import { modify } from '@sourcegraph/common'
 import { gql, useLazyQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Tabs,
@@ -56,7 +57,7 @@ import { getAccessTokenValue, getRepositoriesSettings } from './helpers'
 
 import styles from './GithubConnectView.module.scss'
 
-interface GithubConnectViewProps extends TelemetryProps {
+interface GithubConnectViewProps extends TelemetryProps, TelemetryV2Props {
     initialValues: CodeHostConnectFormFields
     externalServiceId?: string
 
@@ -76,13 +77,15 @@ interface GithubConnectViewProps extends TelemetryProps {
  * storage
  */
 export const GithubConnectView: FC<GithubConnectViewProps> = props => {
-    const { initialValues, externalServiceId, telemetryService, children, onChange, onSubmit } = props
+    const { initialValues, externalServiceId, telemetryService, telemetryRecorder, children, onChange, onSubmit } =
+        props
 
     return (
         <GithubConnectForm
             initialValues={initialValues}
             externalServiceId={externalServiceId}
             telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
             onChange={onChange}
             onSubmit={onSubmit}
         >
@@ -96,7 +99,7 @@ enum GithubConnectFormTab {
     JSONC,
 }
 
-interface GithubConnectFormProps extends TelemetryProps {
+interface GithubConnectFormProps extends TelemetryProps, TelemetryV2Props {
     initialValues: CodeHostConnectFormFields
     externalServiceId?: string
     children: (state: CodeHostJSONFormState) => ReactNode
@@ -109,7 +112,8 @@ interface GithubConnectFormProps extends TelemetryProps {
  * configuration UI.
  */
 export const GithubConnectForm: FC<GithubConnectFormProps> = props => {
-    const { initialValues, externalServiceId, telemetryService, children, onChange, onSubmit } = props
+    const { initialValues, externalServiceId, telemetryService, telemetryRecorder, children, onChange, onSubmit } =
+        props
 
     const [activeTab, setActiveTab] = useState(GithubConnectFormTab.Form)
     const form = useForm<CodeHostConnectFormFields>({
@@ -133,7 +137,10 @@ export const GithubConnectForm: FC<GithubConnectFormProps> = props => {
     useEffect(() => {
         const view = getViewKindByIndex(activeTab)
         telemetryService.log('SetupWizardCreationTabView', { view }, { view })
-    }, [activeTab, telemetryService])
+        telemetryRecorder.recordEvent('SetupWizardCreationTabView', 'viewed', {
+            privateMetadata: { view },
+        })
+    }, [activeTab, telemetryService, telemetryRecorder])
 
     return (
         <Tabs

--- a/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
+++ b/client/web/src/setup-wizard/components/setup-steps/SetupSteps.tsx
@@ -19,12 +19,13 @@ import { noop } from 'lodash'
 import { createPortal } from 'react-dom'
 import { useLocation, useNavigate, Routes, Route, Navigate, matchPath } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './SetupSteps.module.scss'
 
-export interface StepComponentProps extends TelemetryProps {
+export interface StepComponentProps extends TelemetryProps, TelemetryV2Props {
     baseURL: string
     className?: string
     isCodyApp: boolean
@@ -164,14 +165,22 @@ export const SetupStepsRoot: FC<SetupStepsProps> = props => {
     return <SetupStepsContext.Provider value={cachedContext}>{children}</SetupStepsContext.Provider>
 }
 
-interface SetupStepsContentProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
+interface SetupStepsContentProps extends TelemetryProps, TelemetryV2Props, HTMLAttributes<HTMLElement> {
     contentContainerClass?: string
     isCodyApp: boolean
     setStepId?: (stepId: string) => void
 }
 
 export const SetupStepsContent: FC<SetupStepsContentProps> = props => {
-    const { contentContainerClass, className, telemetryService, isCodyApp, setStepId, ...attributes } = props
+    const {
+        contentContainerClass,
+        className,
+        telemetryService,
+        telemetryRecorder,
+        isCodyApp,
+        setStepId,
+        ...attributes
+    } = props
     const { steps, activeStepIndex } = useContext(SetupStepsContext)
 
     return (
@@ -187,6 +196,7 @@ export const SetupStepsContent: FC<SetupStepsContentProps> = props => {
                                 setStepId={setStepId}
                                 className={classNames(contentContainerClass, styles.content)}
                                 telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
                                 isCodyApp={isCodyApp}
                             />
                         }

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -7,6 +7,7 @@ import { Routes, Route } from 'react-router-dom'
 import type { SiteSettingFields } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -48,7 +49,8 @@ export interface SiteAdminAreaRouteContext
     extends PlatformContextProps,
         SettingsCascadeProps,
         BatchChangesProps,
-        TelemetryProps {
+        TelemetryProps,
+        TelemetryV2Props {
     site: Pick<SiteSettingFields, '__typename' | 'id'>
     authenticatedUser: AuthenticatedUser
     isSourcegraphDotCom: boolean
@@ -64,7 +66,12 @@ export interface SiteAdminAreaRouteContext
 
 export interface SiteAdminAreaRoute extends RouteV6Descriptor<SiteAdminAreaRouteContext> {}
 
-interface SiteAdminAreaProps extends PlatformContextProps, SettingsCascadeProps, BatchChangesProps, TelemetryProps {
+interface SiteAdminAreaProps
+    extends PlatformContextProps,
+        SettingsCascadeProps,
+        BatchChangesProps,
+        TelemetryProps,
+        TelemetryV2Props {
     routes: readonly SiteAdminAreaRoute[]
     sideBarGroups: SiteAdminSideBarGroups
     overviewComponents: readonly React.ComponentType<React.PropsWithChildren<unknown>>[]
@@ -136,6 +143,7 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
         site: { __typename: 'Site' as const, id: window.context.siteGQLID },
         overviewComponents: props.overviewComponents,
         telemetryService: props.telemetryService,
+        telemetryRecorder: props.telemetryRecorder,
         codeInsightsEnabled: props.codeInsightsEnabled,
         endUserOnboardingEnabled,
     }

--- a/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
@@ -16,6 +16,7 @@ import format from 'date-fns/format'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -40,7 +41,7 @@ import { BACKGROUND_JOBS, BACKGROUND_JOBS_PAGE_POLL_INTERVAL_MS } from './backen
 
 import styles from './SiteAdminBackgroundJobsPage.module.scss'
 
-export interface SiteAdminBackgroundJobsPageProps extends TelemetryProps {}
+export interface SiteAdminBackgroundJobsPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export type BackgroundJob = BackgroundJobsResult['backgroundJobs']['nodes'][0]
 export type BackgroundRoutine = BackgroundJob['routines'][0]
@@ -63,11 +64,12 @@ const routineTypeToIcon: Record<BackgroundRoutineType, string> = {
 
 export const SiteAdminBackgroundJobsPage: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminBackgroundJobsPageProps>
-> = ({ telemetryService }) => {
+> = ({ telemetryService, telemetryRecorder }) => {
     // Log page view
     useEffect(() => {
         telemetryService.logPageView('SiteAdminBackgroundJobs')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminBackgroundJobs', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     // Data query and polling setting
     const { data, loading, error, stopPolling, startPolling } = useQuery<BackgroundJobsResult, BackgroundJobsVariables>(

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -9,6 +9,7 @@ import { delay, mergeMap, retryWhen, tap, timeout } from 'rxjs/operators'
 
 import { logger } from '@sourcegraph/common'
 import type { SiteConfiguration } from '@sourcegraph/shared/src/schema/site.schema'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -212,7 +213,7 @@ const quickConfigureActions: {
     },
 ]
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     isLightTheme: boolean
     client: ApolloClient<{}>
     isCodyApp: boolean
@@ -231,7 +232,7 @@ interface State {
 
 const EXPECTED_RELOAD_WAIT = 7 * 1000 // 7 seconds
 
-export const SiteAdminConfigurationPage: FC<TelemetryProps & { isCodyApp: boolean }> = props => {
+export const SiteAdminConfigurationPage: FC<TelemetryProps & TelemetryV2Props & { isCodyApp: boolean }> = props => {
     const client = useApolloClient()
     return <SiteAdminConfigurationContent {...props} isLightTheme={useIsLightTheme()} client={client} />
 }
@@ -437,6 +438,7 @@ class SiteAdminConfigurationContent extends React.Component<Props, State> {
                                 onSave={this.onSave}
                                 actions={this.props.isCodyApp ? [] : quickConfigureActions}
                                 telemetryService={this.props.telemetryService}
+                                telemetryRecorder={this.props.telemetryRecorder}
                                 explanation={
                                     <Text className="form-text text-muted">
                                         <small>

--- a/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
+++ b/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { LoadingSpinner, ErrorAlert } from '@sourcegraph/wildcard'
@@ -32,7 +33,7 @@ const AddExternalServicesPage = lazyComponent(
     'AddExternalServicesPage'
 )
 
-interface Props extends TelemetryProps, PlatformContextProps, SettingsCascadeProps {
+interface Props extends TelemetryProps, TelemetryV2Props, PlatformContextProps, SettingsCascadeProps {
     authenticatedUser: AuthenticatedUser
     isCodyApp: boolean
 }

--- a/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagConfigurationPage.tsx
@@ -9,6 +9,7 @@ import { catchError, map } from 'rxjs/operators'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { asError, type ErrorLike, isErrorLike, pluralize } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -41,7 +42,7 @@ import { UserSelect } from './user-select/UserSelect'
 
 import styles from './SiteAdminFeatureFlagConfigurationPage.module.scss'
 
-export interface SiteAdminFeatureFlagConfigurationProps extends TelemetryProps {
+export interface SiteAdminFeatureFlagConfigurationProps extends TelemetryProps, TelemetryV2Props {
     fetchFeatureFlags?: typeof defaultFetchFeatureFlags
     productVersion?: string
 }

--- a/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminFeatureFlagsPage.tsx
@@ -7,6 +7,7 @@ import { catchError, map, mergeMap } from 'rxjs/operators'
 
 import { asError, type ErrorLike, isErrorLike, pluralize } from '@sourcegraph/common'
 import { aggregateStreamingSearch, type ContentMatch, LATEST_VERSION } from '@sourcegraph/shared/src/search/stream'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, PageHeader, Container, Code, H3, Text, Icon, Tooltip, ButtonLink } from '@sourcegraph/wildcard'
 
@@ -18,7 +19,7 @@ import { fetchFeatureFlags as defaultFetchFeatureFlags } from './backend'
 
 import styles from './SiteAdminFeatureFlagsPage.module.scss'
 
-interface SiteAdminFeatureFlagsPageProps extends TelemetryProps {
+interface SiteAdminFeatureFlagsPageProps extends TelemetryProps, TelemetryV2Props {
     fetchFeatureFlags?: typeof defaultFetchFeatureFlags
     productVersion?: string
 }

--- a/client/web/src/site-admin/SiteAdminGitHubAppsArea.tsx
+++ b/client/web/src/site-admin/SiteAdminGitHubAppsArea.tsx
@@ -5,6 +5,7 @@ import { Routes, Route } from 'react-router-dom'
 import { useQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { LoadingSpinner, ErrorAlert } from '@sourcegraph/wildcard'
@@ -24,7 +25,7 @@ const CreateGitHubAppPage = lazyComponent(
 const GitHubAppPage = lazyComponent(() => import('../components/gitHubApps/GitHubAppPage'), 'GitHubAppPage')
 const GitHubAppsPage = lazyComponent(() => import('../components/gitHubApps/GitHubAppsPage'), 'GitHubAppsPage')
 
-interface Props extends TelemetryProps, PlatformContextProps {
+interface Props extends TelemetryProps, TelemetryV2Props, PlatformContextProps {
     authenticatedUser: AuthenticatedUser
     isCodyApp: boolean
     batchChangesEnabled: boolean

--- a/client/web/src/site-admin/SiteAdminGitserversPage.tsx
+++ b/client/web/src/site-admin/SiteAdminGitserversPage.tsx
@@ -3,6 +3,7 @@ import { type FC, useEffect } from 'react'
 import { mdiServer } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { H3, PageHeader, Text, ErrorAlert, LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -13,12 +14,13 @@ import { useGitserversConnection } from './backend'
 
 import styles from './SiteAdminGitserversPage.module.scss'
 
-export interface GitserversPageProps extends TelemetryProps {}
+export interface GitserversPageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const SiteAdminGitserversPage: FC<GitserversPageProps> = ({ telemetryService }) => {
+export const SiteAdminGitserversPage: FC<GitserversPageProps> = ({ telemetryService, telemetryRecorder }) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminGitserversPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminGitserversPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error } = useGitserversConnection()
 

--- a/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminMigrationsPage.tsx
@@ -8,6 +8,7 @@ import { parse as _parseVersion, type SemVer } from 'semver'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { asError, type ErrorLike, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     LoadingSpinner,
@@ -35,7 +36,7 @@ import {
 
 import styles from './SiteAdminMigrationsPage.module.scss'
 
-export interface SiteAdminMigrationsPageProps extends TelemetryProps {
+export interface SiteAdminMigrationsPageProps extends TelemetryProps, TelemetryV2Props {
     fetchAllMigrations?: typeof defaultFetchAllMigrations
     fetchSiteUpdateCheck?: () => Observable<{ productVersion: string }>
     now?: () => Date
@@ -85,6 +86,7 @@ export const SiteAdminMigrationsPage: React.FunctionComponent<
     fetchSiteUpdateCheck = defaultFetchSiteUpdateCheck,
     now,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const migrationsOrError = useObservable(
         useMemo(

--- a/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOnboardingTourPage.tsx
@@ -10,6 +10,7 @@ import type {
 } from 'src/graphql-operations'
 
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -49,7 +50,7 @@ const DEFAULT_VALUE = JSON.stringify(
 const ajv = new AJV({ strict: false })
 addFormats(ajv)
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 
 export const SiteAdminOnboardingTourPage: FC<PropsWithChildren<Props>> = () => {
     const isLightTheme = useIsLightTheme()

--- a/client/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -4,6 +4,7 @@ import { mdiCog, mdiAccount, mdiDelete, mdiPlus } from '@mdi/js'
 import { Subject } from 'rxjs'
 
 import { asError, isErrorLike, pluralize } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Icon, H2, Text, Tooltip, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -91,18 +92,22 @@ const OrgNode: React.FunctionComponent<React.PropsWithChildren<OrgNodeProps>> = 
     )
 }
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 
 /**
  * A page displaying the orgs on this site.
  */
-export const SiteAdminOrgsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({ telemetryService }) => {
+export const SiteAdminOrgsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    telemetryService,
+    telemetryRecorder,
+}) => {
     const orgUpdates = useMemo(() => new Subject<void>(), [])
     const onDidUpdateOrg = useCallback((): void => orgUpdates.next(), [orgUpdates])
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminOrgs')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminOrgs', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <div className="site-admin-orgs-page">

--- a/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOutboundRequestsPage.tsx
@@ -9,6 +9,7 @@ import { delay, map } from 'rxjs/operators'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useQuery } from '@sourcegraph/http-client/src'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -40,7 +41,7 @@ import { parseProductReference } from './SiteAdminFeatureFlagsPage'
 
 import styles from './SiteAdminOutboundRequestsPage.module.scss'
 
-export interface SiteAdminOutboundRequestsPageProps extends TelemetryProps {}
+export interface SiteAdminOutboundRequestsPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export type OutboundRequest = OutboundRequestsResult['outboundRequests']['nodes'][0]
 
@@ -74,12 +75,13 @@ const filters: FilteredConnectionFilter[] = [
 
 export const SiteAdminOutboundRequestsPage: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminOutboundRequestsPageProps>
-> = ({ telemetryService }) => {
+> = ({ telemetryService, telemetryRecorder }) => {
     const [items, setItems] = useState<OutboundRequest[]>([])
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminOutboundRequests')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminOutboundRequests', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const lastId = items[items.length - 1]?.id ?? null
     const { data, loading, error, stopPolling, refetch, startPolling } = useQuery<

--- a/client/web/src/site-admin/SiteAdminPackagesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminPackagesPage.tsx
@@ -6,6 +6,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 
 import { dataOrThrowErrors, useQuery } from '@sourcegraph/http-client'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Container,
@@ -147,7 +148,7 @@ const PackageNode: React.FunctionComponent<React.PropsWithChildren<PackageNodePr
     )
 }
 
-interface SiteAdminPackagesPageProps extends TelemetryProps {}
+interface SiteAdminPackagesPageProps extends TelemetryProps, TelemetryV2Props {}
 
 const DEFAULT_FIRST = 15
 
@@ -161,6 +162,7 @@ interface PackagesModalState {
  */
 export const SiteAdminPackagesPage: React.FunctionComponent<React.PropsWithChildren<SiteAdminPackagesPageProps>> = ({
     telemetryService,
+    telemetryRecorder,
 }) => {
     const location = useLocation()
     const navigate = useNavigate()
@@ -168,7 +170,8 @@ export const SiteAdminPackagesPage: React.FunctionComponent<React.PropsWithChild
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminPackages')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminPackages', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const {
         loading: extSvcLoading,

--- a/client/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/client/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react'
 import { mapValues, values } from 'lodash'
 
 import type { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { LoadingSpinner, useObservable, Alert, Link, H2, Text } from '@sourcegraph/wildcard'
@@ -111,12 +112,13 @@ const allConfigSchema = {
         .reduce((allDefinitions, definitions) => ({ ...allDefinitions, ...definitions }), {}),
 }
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     isCodyApp: boolean
 }
 
 export const SiteAdminReportBugPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
     isCodyApp,
 }) => {
     const isLightTheme = useIsLightTheme()
@@ -161,6 +163,7 @@ export const SiteAdminReportBugPage: React.FunctionComponent<React.PropsWithChil
                     isLightTheme={isLightTheme}
                     readOnly={true}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
         </div>

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -4,6 +4,7 @@ import { useApolloClient } from '@apollo/client'
 import { useLocation } from 'react-router-dom'
 
 import { logger } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, H4, Link, PageHeader } from '@sourcegraph/wildcard'
 
@@ -13,20 +14,22 @@ import { refreshSiteFlags } from '../site/backend'
 
 import { SiteAdminRepositoriesContainer } from './SiteAdminRepositoriesContainer'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     isCodyApp: boolean
 }
 
 /** A page displaying the repositories on this site */
 export const SiteAdminRepositoriesPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
     isCodyApp,
 }) => {
     const location = useLocation()
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminRepos')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminRepos', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     // Refresh global alert about enabling repositories when the user visits & navigates away from this page.
     const client = useApolloClient()

--- a/client/web/src/site-admin/SiteAdminSettingsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSettingsPage.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Text } from '@sourcegraph/wildcard'
@@ -11,7 +12,7 @@ import { PageTitle } from '../components/PageTitle'
 import type { SiteResult } from '../graphql-operations'
 import { SettingsArea } from '../settings/SettingsArea'
 
-interface Props extends PlatformContextProps, SettingsCascadeProps, TelemetryProps {
+interface Props extends PlatformContextProps, SettingsCascadeProps, TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
     site: Pick<SiteResult['site'], '__typename' | 'id'>
 }

--- a/client/web/src/site-admin/SiteAdminSlowRequestsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminSlowRequestsPage.tsx
@@ -7,6 +7,7 @@ import { map } from 'rxjs/operators'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { dataOrThrowErrors } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -36,7 +37,7 @@ import { SLOW_REQUESTS } from './backend'
 
 import styles from './SiteAdminSlowRequestsPage.module.scss'
 
-export interface SiteAdminSlowRequestsPageProps extends TelemetryProps {}
+export interface SiteAdminSlowRequestsPageProps extends TelemetryProps, TelemetryV2Props {}
 
 type SlowRequest = SlowRequestsResult['slowRequests']['nodes'][0]
 
@@ -70,10 +71,11 @@ const filters: FilteredConnectionFilter[] = [
 
 export const SiteAdminSlowRequestsPage: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminSlowRequestsPageProps>
-> = ({ telemetryService }) => {
+> = ({ telemetryService, telemetryRecorder }) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminSlowRequests')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminSlowRequests', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const querySlowRequests = useCallback(
         (args: FilteredConnectionQueryArguments & { failed?: boolean }) =>

--- a/client/web/src/site-admin/SiteAdminTokensPage.tsx
+++ b/client/web/src/site-admin/SiteAdminTokensPage.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { mdiPlus } from '@mdi/js'
 import { Subject } from 'rxjs'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, ButtonLink, Container, Icon, PageHeader } from '@sourcegraph/wildcard'
 
@@ -14,7 +15,7 @@ import { AccessTokenNode, type AccessTokenNodeProps } from '../settings/tokens/A
 
 import { queryAccessTokens } from './backend'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
 }
 
@@ -24,10 +25,12 @@ interface Props extends TelemetryProps {
 export const SiteAdminTokensPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
 }) => {
     useMemo(() => {
         telemetryService.logViewEvent('SiteAdminTokens')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminTokens', 'viewed')
+    }, [telemetryService, telemetryRecorder])
     const accessTokenUpdates = useMemo(() => new Subject<void>(), [])
     const onDidUpdateAccessToken = useCallback(() => accessTokenUpdates.next(), [accessTokenUpdates])
     const accessTokensEnabled = window.context.accessTokensAllow !== 'none'

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -15,6 +15,7 @@ import type {
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { useQuery, useMutation } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     LoadingSpinner,
@@ -43,7 +44,7 @@ import { SITE_UPDATE_CHECK, SITE_UPGRADE_READINESS, SET_AUTO_UPGRADE } from './b
 
 import styles from './SiteAdminUpdatesPage.module.scss'
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 const capitalize = (text: string): string => (text && text[0].toUpperCase() + text.slice(1)) || ''
 
 const SiteUpdateCheck: React.FC = () => {
@@ -391,10 +392,11 @@ const SiteUpgradeReadiness: FunctionComponent = () => {
 /**
  * A page displaying information about available updates for the Sourcegraph instance. As well as the readiness status of the instance for upgrade.
  */
-export const SiteAdminUpdatesPage: React.FC<Props> = ({ telemetryService }) => {
+export const SiteAdminUpdatesPage: React.FC<Props> = ({ telemetryService, telemetryRecorder }) => {
     useMemo(() => {
         telemetryService.logViewEvent('SiteAdminUpdates')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminUpdates', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <div>

--- a/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookCreatePage.tsx
@@ -2,6 +2,7 @@ import { type FC, useEffect } from 'react'
 
 import { mdiWebhook } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
@@ -9,12 +10,16 @@ import { PageTitle } from '../components/PageTitle'
 
 import { WebhookCreateUpdatePage } from './WebhookCreateUpdatePage'
 
-export interface SiteAdminWebhookCreatePageProps extends TelemetryProps {}
+export interface SiteAdminWebhookCreatePageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const SiteAdminWebhookCreatePage: FC<SiteAdminWebhookCreatePageProps> = ({ telemetryService }) => {
+export const SiteAdminWebhookCreatePage: FC<SiteAdminWebhookCreatePageProps> = ({
+    telemetryService,
+    telemetryRecorder,
+}) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminWebhookCreatePage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminWebhookCreatePage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <Container>

--- a/client/web/src/site-admin/SiteAdminWebhookPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookPage.tsx
@@ -5,6 +5,7 @@ import { noop } from 'lodash'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -39,10 +40,10 @@ import { WebhookLogNode } from './webhooks/WebhookLogNode'
 
 import styles from './SiteAdminWebhookPage.module.scss'
 
-export interface WebhookPageProps extends TelemetryProps {}
+export interface WebhookPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const { id = '' } = useParams<{ id: string }>()
     const navigate = useNavigate()
@@ -53,7 +54,8 @@ export const SiteAdminWebhookPage: FC<WebhookPageProps> = props => {
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminWebhook')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminWebhook', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const [deleteWebhook, { error: deleteError, loading: isDeleting }] = useMutation<
         DeleteWebhookResult,

--- a/client/web/src/site-admin/SiteAdminWebhookUpdatePage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhookUpdatePage.tsx
@@ -3,6 +3,7 @@ import { type FC, useEffect } from 'react'
 import { mdiWebhook } from '@mdi/js'
 import { useParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
@@ -13,12 +14,16 @@ import { PageTitle } from '../components/PageTitle'
 import { useWebhookQuery } from './backend'
 import { WebhookCreateUpdatePage } from './WebhookCreateUpdatePage'
 
-export interface SiteAdminWebhookUpdatePageProps extends TelemetryProps {}
+export interface SiteAdminWebhookUpdatePageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const SiteAdminWebhookUpdatePage: FC<SiteAdminWebhookUpdatePageProps> = ({ telemetryService }) => {
+export const SiteAdminWebhookUpdatePage: FC<SiteAdminWebhookUpdatePageProps> = ({
+    telemetryService,
+    telemetryRecorder,
+}) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminWebhookUpdatePage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminWebhookUpdatePage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const { id = '' } = useParams<{ id: string }>()
 

--- a/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
+++ b/client/web/src/site-admin/SiteAdminWebhooksPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 
 import { mdiWebhook, mdiMapSearch, mdiPlus } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ButtonLink, Container, Icon, PageHeader } from '@sourcegraph/wildcard'
 
@@ -22,14 +23,16 @@ import { PerformanceGauge } from './webhooks/PerformanceGauge'
 
 import styles from './SiteAdminWebhooksPage.module.scss'
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 
 export const SiteAdminWebhooksPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminWebhooks')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('SiteAdminWebhooks', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const { loading, hasNextPage, fetchMore, connection, error } = useWebhooksConnection()
     const headerTotals = useWebhookPageHeader()

--- a/client/web/src/site-admin/outbound-webhooks/CreatePage.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/CreatePage.tsx
@@ -5,6 +5,7 @@ import { noop } from 'lodash'
 import { useNavigate } from 'react-router-dom'
 
 import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, ErrorAlert, Form, Input, PageHeader } from '@sourcegraph/wildcard'
 
@@ -16,13 +17,14 @@ import { CREATE_OUTBOUND_WEBHOOK } from './backend'
 import { EventTypes } from './create-edit/EventTypes'
 import { SubmitButton } from './create-edit/SubmitButton'
 
-export interface CreatePageProps extends TelemetryProps {}
+export interface CreatePageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const CreatePage: FC<CreatePageProps> = ({ telemetryService }) => {
+export const CreatePage: FC<CreatePageProps> = ({ telemetryService, telemetryRecorder }) => {
     const navigate = useNavigate()
     useEffect(() => {
         telemetryService.logPageView('OutboundWebhooksCreatePage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('OutboundWebhooksCreatePage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const [url, setURL] = useState('')
     const [secret, setSecret] = useState(generateSecret())

--- a/client/web/src/site-admin/outbound-webhooks/EditPage.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/EditPage.tsx
@@ -5,6 +5,7 @@ import { noop } from 'lodash'
 import { useNavigate, useParams } from 'react-router-dom'
 
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, ErrorAlert, Form, Input, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
 
@@ -23,15 +24,16 @@ import { SubmitButton } from './create-edit/SubmitButton'
 import { DeleteButton } from './delete/DeleteButton'
 import { Logs } from './logs/Logs'
 
-export interface EditPageProps extends TelemetryProps {}
+export interface EditPageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const EditPage: FC<EditPageProps> = ({ telemetryService }) => {
+export const EditPage: FC<EditPageProps> = ({ telemetryService, telemetryRecorder }) => {
     const navigate = useNavigate()
     const { id = '' } = useParams<{ id: string }>()
 
     useEffect(() => {
         telemetryService.logPageView('OutboundWebhooksEditPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('OutboundWebhooksEditPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error, refetch } = useQuery<OutboundWebhookByIDResult, OutboundWebhookByIDVariables>(
         OUTBOUND_WEBHOOK_BY_ID,

--- a/client/web/src/site-admin/outbound-webhooks/OutboundWebhooksPage.tsx
+++ b/client/web/src/site-admin/outbound-webhooks/OutboundWebhooksPage.tsx
@@ -3,6 +3,7 @@ import { type FC, useEffect } from 'react'
 import { mdiAlertCircle, mdiWebhook, mdiMapSearch, mdiPencil, mdiPlus } from '@mdi/js'
 
 import { pluralize } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ButtonLink, Container, H3, Icon, Link, PageHeader, Tooltip } from '@sourcegraph/wildcard'
 
@@ -23,12 +24,13 @@ import { DeleteButton } from './delete/DeleteButton'
 
 import styles from './OutboundWebhooksPage.module.scss'
 
-export interface OutboundWebhooksPageProps extends TelemetryProps {}
+export interface OutboundWebhooksPageProps extends TelemetryProps, TelemetryV2Props {}
 
-export const OutboundWebhooksPage: FC<OutboundWebhooksPageProps> = ({ telemetryService }) => {
+export const OutboundWebhooksPage: FC<OutboundWebhooksPageProps> = ({ telemetryService, telemetryRecorder }) => {
     useEffect(() => {
         telemetryService.logPageView('OutboundWebhooksPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('OutboundWebhooksPage', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     const { loading, hasNextPage, fetchMore, refetchAll, connection, error } = useOutboundWebhooksConnection()
 

--- a/client/web/src/storm/pages/SearchPage/TryCodyCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/TryCodyCtaSection.tsx
@@ -4,6 +4,7 @@ import { mdiArrowRight, mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, ButtonLink, H2, H3, Icon, Link, Text } from '@sourcegraph/wildcard'
 
@@ -68,7 +69,7 @@ const MeetCodySVG: React.FC = () => (
     </svg>
 )
 
-interface TryCodyCtaSectionProps extends TelemetryProps {
+interface TryCodyCtaSectionProps extends TelemetryProps, TelemetryV2Props {
     isSourcegraphDotCom: boolean
     className?: string
 }
@@ -76,12 +77,17 @@ interface TryCodyCtaSectionProps extends TelemetryProps {
 export const TryCodyCtaSection: React.FC<TryCodyCtaSectionProps> = ({
     className,
     telemetryService,
+    telemetryRecorder,
     isSourcegraphDotCom,
 }) => {
     const [isDismissed = true, setIsDismissed] = useTemporarySetting('cody.searchPageCta.dismissed', false)
     const onDismiss = (): void => setIsDismissed(true)
-    const logEvent = (eventName: EventName): void =>
+    const logEvent = (eventName: EventName): void => {
         telemetryService.log(eventName, { type: 'ComHome' }, { type: 'ComHome' })
+        telemetryRecorder.recordEvent(eventName, 'clicked', {
+            privateMetadata: { type: 'ComHome' },
+        })
+    }
     const onViewEditorExtensionsClick = (): void => logEvent(EventName.VIEW_EDITOR_EXTENSIONS)
     const onTryWebClick = (): void => logEvent(EventName.TRY_CODY_WEB)
 

--- a/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/TryCodySignUpCtaSection.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { mdiChevronRight, mdiMicrosoftVisualStudioCode } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ButtonLink, H1, H2, Icon, Link, ProductStatusBadge, Text } from '@sourcegraph/wildcard'
 
@@ -66,12 +67,16 @@ const MeetCodySVG: React.FC = () => (
     </svg>
 )
 
-export const TryCodySignUpCtaSection: React.FC<TelemetryProps & { className?: string }> = ({
+export const TryCodySignUpCtaSection: React.FC<TelemetryProps & TelemetryV2Props & { className?: string }> = ({
     className,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const onSignUpClick = (): void =>
         telemetryService.log(EventName.CODY_SIGNUP, { type: 'ComHome' }, { type: 'ComHome' })
+    telemetryRecorder.recordEvent(EventName.CODY_SIGNUP, 'clicked', {
+        privateMetadata: { type: 'ComHome' },
+    })
 
     return (
         <div className={classNames('d-flex', className, styles.container)}>

--- a/client/web/src/tour/GettingStartedTour.tsx
+++ b/client/web/src/tour/GettingStartedTour.tsx
@@ -1,6 +1,7 @@
 import { type FC, memo } from 'react'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 
 import type { AuthenticatedUser } from '../auth'
 import { withFeatureFlag } from '../featureFlags/withFeatureFlag'
@@ -15,7 +16,8 @@ import { useShowOnboardingSetup } from './hooks'
 const GatedTour = withFeatureFlag('end-user-onboarding', Tour)
 
 interface TourWrapperProps
-    extends Omit<TourProps, 'useStore' | 'eventPrefix' | 'tasks' | 'id' | 'defaultSnippets' | 'userInfo'> {
+    extends TelemetryV2Props,
+        Omit<TourProps, 'useStore' | 'eventPrefix' | 'tasks' | 'id' | 'defaultSnippets' | 'userInfo'> {
     authenticatedUser: AuthenticatedUser | null
 }
 

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -5,6 +5,7 @@ import { useParams, Routes, Route } from 'react-router-dom'
 import { gql, useQuery } from '@sourcegraph/http-client'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -79,6 +80,7 @@ interface UserAreaProps
     extends PlatformContextProps,
         SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         BreadcrumbsProps,
         BreadcrumbSetters,
         BatchChangesProps {
@@ -104,6 +106,7 @@ export interface UserAreaRouteContext
     extends PlatformContextProps,
         SettingsCascadeProps,
         TelemetryProps,
+        TelemetryV2Props,
         NamespaceProps,
         BreadcrumbsProps,
         BreadcrumbSetters,

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Text } from '@sourcegraph/wildcard'
 
@@ -8,14 +9,16 @@ import { SelfHostedCta } from '../../../components/SelfHostedCta'
 
 import styles from './AboutOrganizationPage.module.scss'
 
-interface AboutOrganizationPageProps extends TelemetryProps {}
+interface AboutOrganizationPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export const AboutOrganizationPage: React.FunctionComponent<React.PropsWithChildren<AboutOrganizationPageProps>> = ({
     telemetryService,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('AboutOrg')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('AboutOrg', 'viewed')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <>
@@ -30,6 +33,7 @@ export const AboutOrganizationPage: React.FunctionComponent<React.PropsWithChild
                 contentClassName={styles.selfHostedCtaContent}
                 page="organizations"
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             >
                 <Text className="mb-2">
                     <strong>Need more enterprise features? Run Sourcegraph self-hosted</strong>

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -5,6 +5,7 @@ import { NEVER, type Observable } from 'rxjs'
 import { catchError, startWith, switchMap, tap } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Button, Link, Text, ErrorAlert, Card, H1, H2, useEventObservable } from '@sourcegraph/wildcard'
@@ -21,7 +22,10 @@ import { createAccessToken } from './create'
 
 import styles from './UserSettingsCreateAccessTokenCallbackPage.module.scss'
 
-interface Props extends Pick<UserSettingsAreaRouteContext, 'authenticatedUser' | 'user'>, TelemetryProps {
+interface Props
+    extends Pick<UserSettingsAreaRouteContext, 'authenticatedUser' | 'user'>,
+        TelemetryProps,
+        TelemetryV2Props {
     /**
      * Called when a new access token is created and should be temporarily displayed to the user.
      */
@@ -107,6 +111,7 @@ export function isAccessTokenCallbackPage(): boolean {
  */
 export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
     telemetryService,
+    telemetryRecorder,
     onDidCreateAccessToken,
     user,
     isSourcegraphDotCom,
@@ -117,7 +122,8 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
     const location = useLocation()
     useEffect(() => {
         telemetryService.logPageView('NewAccessTokenCallback')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('NewAccessTokenCallback', 'completed')
+    }, [telemetryService, telemetryRecorder])
 
     /** Get the requester, port, and destination from the url parameters */
     const urlSearchParams = useMemo(() => new URLSearchParams(location.search), [location.search])

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
@@ -6,6 +6,7 @@ import { concat, Subject } from 'rxjs'
 import { catchError, concatMap, tap } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Container,
@@ -30,7 +31,7 @@ import type { UserSettingsAreaRouteContext } from '../UserSettingsArea'
 
 import { createAccessToken } from './create'
 
-interface Props extends Pick<UserSettingsAreaRouteContext, 'user'>, TelemetryProps {
+interface Props extends Pick<UserSettingsAreaRouteContext, 'user'>, TelemetryProps, TelemetryV2Props {
     /**
      * Called when a new access token is created and should be temporarily displayed to the user.
      */
@@ -42,6 +43,7 @@ interface Props extends Pick<UserSettingsAreaRouteContext, 'user'>, TelemetryPro
  */
 export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
     onDidCreateAccessToken,
     user,
 }) => {
@@ -49,7 +51,8 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<React.Pr
 
     useMemo(() => {
         telemetryService.logViewEvent('NewAccessToken')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('NewAccessToken', 'created')
+    }, [telemetryService, telemetryRecorder])
 
     /** The contents of the note input field. */
     const defaultNoteValue = new URLSearchParams(location.search).get('description') || undefined

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react'
 
 import { Route, Routes } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { NotFoundPage } from '../../../components/HeroPage'
@@ -12,7 +13,10 @@ import { UserSettingsCreateAccessTokenCallbackPage } from './UserSettingsCreateA
 import { UserSettingsCreateAccessTokenPage } from './UserSettingsCreateAccessTokenPage'
 import { UserSettingsTokensPage } from './UserSettingsTokensPage'
 
-interface Props extends Pick<UserSettingsAreaRouteContext, 'user' | 'authenticatedUser'>, TelemetryProps {
+interface Props
+    extends Pick<UserSettingsAreaRouteContext, 'user' | 'authenticatedUser'>,
+        TelemetryProps,
+        TelemetryV2Props {
     isSourcegraphDotCom: boolean
     isCodyApp: boolean
 }

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
@@ -5,6 +5,7 @@ import { type Observable, Subject } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, PageHeader, Button, Link, Icon, Text } from '@sourcegraph/wildcard'
 
@@ -25,7 +26,10 @@ import {
 } from '../../../settings/tokens/AccessTokenNode'
 import type { UserSettingsAreaRouteContext } from '../UserSettingsArea'
 
-interface Props extends Pick<UserSettingsAreaRouteContext, 'authenticatedUser' | 'user'>, TelemetryProps {
+interface Props
+    extends Pick<UserSettingsAreaRouteContext, 'authenticatedUser' | 'user'>,
+        TelemetryProps,
+        TelemetryV2Props {
     /**
      * The newly created token, if any. This component must call onDidPresentNewToken
      * when it is finished presenting the token secret to the user.
@@ -44,6 +48,7 @@ interface Props extends Pick<UserSettingsAreaRouteContext, 'authenticatedUser' |
  */
 export const UserSettingsTokensPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
     authenticatedUser,
     user,
     newToken,
@@ -51,7 +56,8 @@ export const UserSettingsTokensPage: React.FunctionComponent<React.PropsWithChil
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('UserSettingsTokens')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('UserSettingsTokens', 'displayed')
+    }, [telemetryService, telemetryRecorder])
 
     useEffect(
         () => () => {

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -4,6 +4,7 @@ import { Navigate } from 'react-router-dom'
 
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
@@ -65,7 +66,11 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     },
 ]
 
-interface UserSettingAreaIndexPageProps extends PlatformContextProps, SettingsCascadeProps, TelemetryProps {
+interface UserSettingAreaIndexPageProps
+    extends PlatformContextProps,
+        SettingsCascadeProps,
+        TelemetryProps,
+        TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser
     user: UserSettingsAreaUserFields


### PR DESCRIPTION
## Background

We've changed the entire infrastructure around recording telemetry ([background on the approach](https://docs.sourcegraph.com/dev/background-information/telemetry) from the application side, specifically for the [web app here](https://docs.sourcegraph.com/dev/background-information/telemetry#sourcegraph-web-app)) and the idea on frontend was to implement the new telemetry side-by-side with the legacy telemetry during the transition period so that we do not lose any data (since we use this for calculating usage, billing customers, measuring company performance metrics, etc) and then remove the legacy telemetry after we instrumented and verified everything is functional using the Telemetry Gateway.

## Test plan

Our legacy events are covered by automated tests, ensure tests are updated/pass.

run `sg start`
trigger events
verify in `event_logs`