### PR TITLE
Extensions: some prep work for removal

### DIFF
--- a/client/shared/src/api/contract.ts
+++ b/client/shared/src/api/contract.ts
@@ -31,6 +31,7 @@ export interface ScipParameters {
 
 // Extracted from FlatExtensionHostAPI so it can be implemented separately.
 // The goal is to unify this with the CodeIntelAPI in client/shared/src/codeintel/api.ts
+// TODO(camdencheek)
 export interface CodeIntelExtensionHostAPI {
     getHover: (parameters: TextDocumentPositionParameters) => ProxySubscribable<MaybeLoadingResult<HoverMerged | null>>
     getDocumentHighlights: (parameters: TextDocumentPositionParameters) => ProxySubscribable<DocumentHighlight[]>

--- a/client/shared/src/api/contract.ts
+++ b/client/shared/src/api/contract.ts
@@ -29,25 +29,9 @@ export interface ScipParameters {
     documentOccurrences: Occurrence[]
 }
 
-/**
- * This is exposed from the extension host thread to the main thread
- * e.g. for communicating  direction "main -> ext host"
- * Note this API object lives in the extension host thread
- */
-export interface FlatExtensionHostAPI {
-    /**
-     * Updates the settings exposed to extensions.
-     */
-    syncSettingsData: (data: Readonly<SettingsCascade<object>>) => void
-
-    // Workspace
-    addWorkspaceRoot: (root: clientType.WorkspaceRoot) => void
-    getWorkspaceRoots: () => ProxySubscribable<clientType.WorkspaceRoot[]>
-    removeWorkspaceRoot: (uri: string) => void
-
-    setSearchContext: (searchContext: string | undefined) => void
-
-    // Languages
+// Extracted from FlatExtensionHostAPI so it can be implemented separately.
+// The goal is to unify this with the CodeIntelAPI in client/shared/src/codeintel/api.ts
+export interface CodeIntelExtensionHostAPI {
     getHover: (parameters: TextDocumentPositionParameters) => ProxySubscribable<MaybeLoadingResult<HoverMerged | null>>
     getDocumentHighlights: (parameters: TextDocumentPositionParameters) => ProxySubscribable<DocumentHighlight[]>
     getDefinition: (
@@ -65,6 +49,25 @@ export interface FlatExtensionHostAPI {
     ) => ProxySubscribable<MaybeLoadingResult<clientType.Location[]>>
 
     hasReferenceProvidersForDocument: (parameters: TextDocumentPositionParameters) => ProxySubscribable<boolean>
+}
+
+/**
+ * This is exposed from the extension host thread to the main thread
+ * e.g. for communicating  direction "main -> ext host"
+ * Note this API object lives in the extension host thread
+ */
+export interface FlatExtensionHostAPI extends CodeIntelExtensionHostAPI {
+    /**
+     * Updates the settings exposed to extensions.
+     */
+    syncSettingsData: (data: Readonly<SettingsCascade<object>>) => void
+
+    // Workspace
+    addWorkspaceRoot: (root: clientType.WorkspaceRoot) => void
+    getWorkspaceRoots: () => ProxySubscribable<clientType.WorkspaceRoot[]>
+    removeWorkspaceRoot: (uri: string) => void
+
+    setSearchContext: (searchContext: string | undefined) => void
 
     // CONTEXT + CONTRIBUTIONS
 

--- a/client/shared/src/api/extension/extensionHost.ts
+++ b/client/shared/src/api/extension/extensionHost.ts
@@ -131,7 +131,9 @@ function createExtensionAndExtensionHostAPIs(
     // Create extension host state
     const extensionHostState = createExtensionHostState(initData, proxy, mainThreadAPIInitializations)
     // Create extension host API
+    // TODO: override the codeintel bits with injectNewCodeIntel
     const extensionHostAPINew = createExtensionHostAPI(extensionHostState)
+
     // Create extension API factory
     const createExtensionAPI = createExtensionAPIFactory(extensionHostState, proxy, initData)
 

--- a/client/shared/src/api/extension/extensionHost.ts
+++ b/client/shared/src/api/extension/extensionHost.ts
@@ -131,7 +131,7 @@ function createExtensionAndExtensionHostAPIs(
     // Create extension host state
     const extensionHostState = createExtensionHostState(initData, proxy, mainThreadAPIInitializations)
     // Create extension host API
-    // TODO: override the codeintel bits with injectNewCodeIntel
+    // TODO: override the codeintel bits with injectNewCodeIntel or pass in CodeIntelAPI
     const extensionHostAPINew = createExtensionHostAPI(extensionHostState)
 
     // Create extension API factory

--- a/client/shared/src/api/extension/extensionHost.ts
+++ b/client/shared/src/api/extension/extensionHost.ts
@@ -131,9 +131,8 @@ function createExtensionAndExtensionHostAPIs(
     // Create extension host state
     const extensionHostState = createExtensionHostState(initData, proxy, mainThreadAPIInitializations)
     // Create extension host API
-    // TODO: override the codeintel bits with injectNewCodeIntel or pass in CodeIntelAPI
+    // TODO(camdencheek): override the codeintel bits with injectNewCodeIntel or pass in CodeIntelAPI
     const extensionHostAPINew = createExtensionHostAPI(extensionHostState)
-
     // Create extension API factory
     const createExtensionAPI = createExtensionAPIFactory(extensionHostState, proxy, initData)
 

--- a/client/shared/src/codeintel/api.ts
+++ b/client/shared/src/codeintel/api.ts
@@ -14,7 +14,7 @@ import { isDefined } from '@sourcegraph/common/src/types'
 import type * as clientType from '@sourcegraph/extension-api-types'
 
 import { match } from '../api/client/types/textDocument'
-import type { FlatExtensionHostAPI, ScipParameters } from '../api/contract'
+import type { CodeIntelExtensionHostAPI, FlatExtensionHostAPI, ScipParameters } from '../api/contract'
 import { proxySubscribable } from '../api/extension/api/common'
 import { toPosition } from '../api/extension/api/types'
 import { getModeFromPath } from '../languages'
@@ -230,10 +230,30 @@ function newSettingsGetter(settingsCascade: SettingsCascade<Settings>): sourcegr
 // extensions, we monkey patch the old implementation with new implementations.
 // The benefit of monkey patching is that we can optionally disable if for
 // customers that choose to enable the legacy extensions.
+//
+// TODO(camdencheek): USE THIS to patch code intel into extensions
 export function injectNewCodeintel(
     old: FlatExtensionHostAPI,
     codeintelContext: sourcegraph.CodeIntelContext
 ): FlatExtensionHostAPI {
+    const codeintelOverrides = newCodeIntelExtensionHostAPI(codeintelContext)
+
+    return new Proxy(old, {
+        get(target, prop) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+            const codeintelFunction = (codeintelOverrides as any)[prop]
+            if (codeintelFunction) {
+                return codeintelFunction
+            }
+            // eslint-disable-next-line prefer-rest-params
+            return Reflect.get(target, prop, ...arguments)
+        },
+    })
+}
+
+export function newCodeIntelExtensionHostAPI(
+    codeintelContext: sourcegraph.CodeIntelContext
+): CodeIntelExtensionHostAPI {
     const codeintel = createCodeIntelAPI(codeintelContext)
     function thenMaybeLoadingResult<T>(promise: Observable<T>): Observable<MaybeLoadingResult<T>> {
         return promise.pipe(
@@ -244,15 +264,7 @@ export function injectNewCodeintel(
         )
     }
 
-    const codeintelOverrides: Pick<
-        FlatExtensionHostAPI,
-        | 'getHover'
-        | 'getDocumentHighlights'
-        | 'getReferences'
-        | 'getDefinition'
-        | 'getLocations'
-        | 'hasReferenceProvidersForDocument'
-    > = {
+    return {
         hasReferenceProvidersForDocument(textParameters) {
             return proxySubscribable(from(codeintel.hasReferenceProvidersForDocument(textParameters)))
         },
@@ -275,18 +287,6 @@ export function injectNewCodeintel(
         getHover: (textParameters: TextDocumentPositionParameters) =>
             proxySubscribable(thenMaybeLoadingResult(from(codeintel.getHover(textParameters)))),
     }
-
-    return new Proxy(old, {
-        get(target, prop) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-            const codeintelFunction = (codeintelOverrides as any)[prop]
-            if (codeintelFunction) {
-                return codeintelFunction
-            }
-            // eslint-disable-next-line prefer-rest-params
-            return Reflect.get(target, prop, ...arguments)
-        },
-    })
 }
 
 export function localReferences(params: ScipParameters): Occurrence[] {


### PR DESCRIPTION
This is some setup for getting rid of all the cruft from extensions. The first step is to make the browser extension use the codeintel packages directly rather than requiring codeintel extensions running in a web worker. This extracts and simplifies few functions to prepare for that.

## Test plan

Existing tests. Everything here should be semantics-preserving. I'll do more careful tests of the browser extension before making another release, but I'd like to move as fast as I can on the removal of the extensions cruft because it's causing pain. This should not break anything in the webapp because the webapp does not use extensions.

