### PR TITLE
ci: bump go to 1.21 in gitub actions

### DIFF
--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           ruby-version: "3.2.2" # Not needed with a .ruby-version file   - uses: actions/setup-ruby@v1
       - uses: actions/setup-go@v2
-        with: { go-version: "1.20" }
+        with: { go-version: "1.21" }
 
 
       - name: Install license_finder

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           repository: 'sourcegraph/pr-auditor'
       - uses: actions/setup-go@v4
-        with: { go-version: '1.20' }
+        with: { go-version: '1.21' }
 
       - run: './check-pr.sh'
         env:

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.8
+          go-version: 1.21.4
 
       - name: Build and upload macOS
         if: startsWith(matrix.os, 'macos-') == true

--- a/.github/workflows/sg-setup.yml
+++ b/.github/workflows/sg-setup.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.20.10
+          go-version: 1.21.4
 
       - name: Install asdf plugins
         uses: asdf-vm/actions/install@v1


### PR DESCRIPTION
closes https://github.com/sourcegraph/devx-support/issues/414

it started breaking since https://github.com/sourcegraph/sourcegraph/pull/58617

```
../../internal/authz/perms.go:4:2: package cmp is not in GOROOT (/opt/hostedtoolcache/go/1.20.8/x64/src/cmp)
```

![CleanShot 2023-11-28 at 19 43 35](https://github.com/sourcegraph/sourcegraph/assets/8373004/97b7de3d-58da-4749-886f-a4479c2214ee)

## Test plan

n/a