### PR TITLE
svelte: Fix suggestions interfering with sticky search result headers

### DIFF
--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -223,9 +223,13 @@
 
 <style lang="scss">
     @use '$lib/breakpoints';
+
     form {
         width: 100%;
         position: relative;
+        // Necessary to ensure that the search input (especially the suggestions) are rendered above sticky headers
+        // in the search results page ("position: sticky" creates a new stacking context).
+        z-index: 1;
         padding: 0.75rem;
 
         &:focus-within {


### PR DESCRIPTION
Due to CSS stacking context issues the sticky search results headers are "bleeding into" the suggestions. Adding a z-index places the whole input above other elements on the page.



## Test plan

Manual testing.
