### PR TITLE
azuredevops: Add support for SSH cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Added the ability to use Workload Identity, Managed Identity and Environmental credentials when using the Azure OpenAI completions and embeddings providers [#58289](https://github.com/sourcegraph/sourcegraph/pull/58289)
+- Added support for cloning via SSH from Azure DevOps. [#58655](https://github.com/sourcegraph/sourcegraph/pull/58655)
 
 ### Fixed
 

--- a/cmd/gitserver/internal/cloneurl/clone_url.go
+++ b/cmd/gitserver/internal/cloneurl/clone_url.go
@@ -129,7 +129,11 @@ func awsCodeCloneURL(logger log.Logger, repo *awscodecommit.Repository, cfg *sch
 }
 
 func azureDevOpsCloneURL(logger log.Logger, repo *azuredevops.Repository, cfg *schema.AzureDevOpsConnection) string {
-	u, err := url.Parse(repo.CloneURL)
+	if cfg.GitURLType == "ssh" {
+		return repo.SSHURL
+	}
+
+	u, err := url.Parse(repo.RemoteURL)
 	if err != nil {
 		logger.Warn("Error adding authentication to Azure DevOps repo remote URL.", log.String("url", cfg.Url), log.Error(err))
 		return cfg.Url

--- a/cmd/gitserver/internal/cloneurl/clone_url_test.go
+++ b/cmd/gitserver/internal/cloneurl/clone_url_test.go
@@ -63,8 +63,8 @@ func TestAzureDevOpsCloneURL(t *testing.T) {
 	}
 
 	repo := &azuredevops.Repository{
-		ID:       "test-project",
-		CloneURL: "https://sgtestazure@dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure",
+		ID:        "test-project",
+		RemoteURL: "https://sgtestazure@dev.azure.com/sgtestazure/sgtestazure/_git/sgtestazure",
 	}
 
 	got := azureDevOpsCloneURL(logtest.Scoped(t), repo, &cfg)

--- a/internal/batches/sources/azuredevops_test.go
+++ b/internal/batches/sources/azuredevops_test.go
@@ -24,7 +24,7 @@ var (
 	testProjectName           = "testproject"
 	testOrgName               = "testorg"
 	testPRID                  = "42"
-	testRepository            = azuredevops.Repository{ID: "testrepoid", Name: testRepoName, Project: azuredevops.Project{ID: "testprojectid", Name: testProjectName}, APIURL: fmt.Sprintf("https://dev.azure.com/%s/%s/_git/%s", testOrgName, testProjectName, testRepoName), CloneURL: fmt.Sprintf("https://dev.azure.com/%s/%s/_git/%s", testOrgName, testProjectName, testRepoName)}
+	testRepository            = azuredevops.Repository{ID: "testrepoid", Name: testRepoName, Project: azuredevops.Project{ID: "testprojectid", Name: testProjectName}, APIURL: fmt.Sprintf("https://dev.azure.com/%s/%s/_git/%s", testOrgName, testProjectName, testRepoName), RemoteURL: fmt.Sprintf("https://dev.azure.com/%s/%s/_git/%s", testOrgName, testProjectName, testRepoName)}
 	testCommonPullRequestArgs = azuredevops.PullRequestCommonArgs{Org: testOrgName, Project: testProjectName, RepoNameOrID: testRepoName, PullRequestID: testPRID}
 	testOrgProjectRepoArgs    = azuredevops.OrgProjectRepoArgs{Org: testOrgName, Project: testProjectName, RepoNameOrID: testRepoName}
 )

--- a/internal/extsvc/azuredevops/types.go
+++ b/internal/extsvc/azuredevops/types.go
@@ -226,7 +226,7 @@ type PullRequestStatusState string
 type Repository struct {
 	ID         string  `json:"id"`
 	Name       string  `json:"name"`
-	CloneURL   string  `json:"remoteURL"`
+	RemoteURL  string  `json:"remoteURL"`
 	APIURL     string  `json:"url"`
 	SSHURL     string  `json:"sshUrl"`
 	WebURL     string  `json:"webUrl"`

--- a/internal/repos/azuredevops.go
+++ b/internal/repos/azuredevops.go
@@ -158,6 +158,11 @@ func (s *AzureDevOpsSource) makeRepo(p azuredevops.Repository) (*types.Repo, err
 		return nil, err
 	}
 
+	cloneURL := p.RemoteURL
+	if s.config.GitURLType == "ssh" {
+		cloneURL = p.SSHURL
+	}
+
 	name := path.Join(fullURL.Host, fullURL.Path)
 	return &types.Repo{
 		Name: api.RepoName(name),
@@ -171,7 +176,7 @@ func (s *AzureDevOpsSource) makeRepo(p azuredevops.Repository) (*types.Repo, err
 		Sources: map[string]*types.SourceInfo{
 			urn: {
 				ID:       urn,
-				CloneURL: p.CloneURL,
+				CloneURL: cloneURL,
 			},
 		},
 		Metadata: p,

--- a/schema/azuredevops.schema.json
+++ b/schema/azuredevops.schema.json
@@ -19,6 +19,12 @@
       "format": "uri",
       "examples": ["https://dev.azure.com"]
     },
+    "gitURLType": {
+      "description": "The type of Git URLs to use for cloning and fetching Git repositories.\n\nIf \"http\", Sourcegraph will access repositories using Git URLs of the form http(s)://dev.azure.com/myrepo.git.\n\nIf \"ssh\", Sourcegraph will access repositories using Git URLs of the form git@ssh.dev.azure.com:v3/myrepo. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
+      "type": "string",
+      "enum": ["http", "ssh"],
+      "default": "http"
+    },
     "enforcePermissions": {
       "description": "A flag to enforce Azure DevOps repository access permissions",
       "type": "boolean",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -224,6 +224,12 @@ type AzureDevOpsConnection struct {
 	EnforcePermissions bool `json:"enforcePermissions,omitempty"`
 	// Exclude description: A list of repositories to never mirror from Azure DevOps Services.
 	Exclude []*ExcludedAzureDevOpsServerRepo `json:"exclude,omitempty"`
+	// GitURLType description: The type of Git URLs to use for cloning and fetching Git repositories.
+	//
+	// If "http", Sourcegraph will access repositories using Git URLs of the form http(s)://dev.azure.com/myrepo.git.
+	//
+	// If "ssh", Sourcegraph will access repositories using Git URLs of the form git@ssh.dev.azure.com:v3/myrepo. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.
+	GitURLType string `json:"gitURLType,omitempty"`
 	// Orgs description: An array of organization names identifying Azure DevOps organizations whose repositories should be mirrored on Sourcegraph.
 	Orgs []string `json:"orgs,omitempty"`
 	// Projects description: An array of projects "org/project" strings specifying which Azure DevOps projects' repositories should be mirrored on Sourcegraph.


### PR DESCRIPTION
In line with other code hosts, adding SSH clone support here via gitURLType.

## Test plan

Verified locally by configuring it and seeing a repo clone successfully via ssh.
