### PR TITLE
gomod: update zoekt to include go.mod 1.21 requirement

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5722,8 +5722,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:2xAotLrNXGdj1x8I5yPh89qsesICseLEfEdKpmY3V90=",
-        version = "v0.0.0-20231122214222-d982320abe7b",
+        sum = "h1:nhxLVoE/muGcygm76NwutJC4fQ1IVgkNXY7xOLGnDI8=",
+        version = "v0.0.0-20231129132138-0d03621d45a3",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -569,7 +569,7 @@ require (
 	github.com/sourcegraph/managed-services-platform-cdktf/gen/postgresql v0.0.0-20231121191755-214be625af21
 	github.com/sourcegraph/mountinfo v0.0.0-20231018142932-e00da332dac5
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20231122214222-d982320abe7b
+	github.com/sourcegraph/zoekt v0.0.0-20231129132138-0d03621d45a3
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1665,8 +1665,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20231122214222-d982320abe7b h1:2xAotLrNXGdj1x8I5yPh89qsesICseLEfEdKpmY3V90=
-github.com/sourcegraph/zoekt v0.0.0-20231122214222-d982320abe7b/go.mod h1:WVDDy51tFgeKy8zXtujTSbqzgyJrqhrLC9sjWiEfAII=
+github.com/sourcegraph/zoekt v0.0.0-20231129132138-0d03621d45a3 h1:nhxLVoE/muGcygm76NwutJC4fQ1IVgkNXY7xOLGnDI8=
+github.com/sourcegraph/zoekt v0.0.0-20231129132138-0d03621d45a3/go.mod h1:bWvtH95V0T8hHKS3wWyo5aYDXiDKlObq5kC7nltqXqk=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
Contains the following changes:
https://github.com/sourcegraph/zoekt/compare/d982320abe7b...0d03621d45a3

- https://github.com/sourcegraph/zoekt/commit/5c51794c39 Indexing: use one ctags process per shard
- https://github.com/sourcegraph/zoekt/commit/8abf874fe1 gomod: require go1.21
- https://github.com/sourcegraph/zoekt/commit/0d03621d45 revert use of mmap-go

Test Plan: tested on zoekt CI and this one
