### PR TITLE
SSC: Add x-is-cody-pro-user header

### DIFF
--- a/internal/completions/httpapi/chat.go
+++ b/internal/completions/httpapi/chat.go
@@ -21,6 +21,7 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 
 	return newCompletionsHandler(
 		logger,
+		db.Users(),
 		telemetryrecorder.New(db),
 		types.CompletionsFeatureChat,
 		rl,

--- a/internal/completions/httpapi/codecompletion.go
+++ b/internal/completions/httpapi/codecompletion.go
@@ -21,6 +21,7 @@ func NewCodeCompletionsHandler(logger log.Logger, db database.DB) http.Handler {
 	rl := NewRateLimiter(db, redispool.Store, types.CompletionsFeatureCode)
 	return newCompletionsHandler(
 		logger,
+		db.Users(),
 		telemetryrecorder.New(db),
 		types.CompletionsFeatureCode,
 		rl,


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/58283

The new header is only added in case of dotcom when `cody-pro` is on.
Clients can recognize this and can show the Upgrade button accordingly.

## Test plan

I haven't been able to test TBH because of the issues with hanging requests on my local instance. @thenamankumar, could you execute this test plan for me?

1. Run `sg start dotcom`, set the `cody-pro` feature flag to `false` for your user
2. Run this curl in another terminal and get a response successfully:
```
curl --location 'https://sourcegraph.test:3443/.api/completions/code' \
--header 'Authorization: token {TODO ADD A VALID TOKEN HERE FOR YOUR USER}' \
--header 'Content-Type: application/json; charset=utf-8' \
--header 'X-Sourcegraph-Should-Trace: false' \
--header 'Cookie: originalReferrer=https://sourcegraph.test:3443/site-admin?dateRange=LAST_THREE_MONTHS&aggregation=count&grouping=WEEKLY; sessionFirstUrl=https://sourcegraph.test:3443/search; sessionReferrer=; sgs=MTY3NDc0ODk5NnxOd3dBTkZJMVFVTk9URlpEVkZsR1IxTkpVMFZhUVVsVFFVZEVRa2RLVjBJMlNrMVlXRlJOVGxOS1dGcFJRbGRUTWs1RlYwazFRMUU9fF9zG18kBGDHhUPGWx_4CaphEtvsljSPzC0yD8pmv76K; sourcegraphAnonymousUid=0a078e74-d314-4b3d-a3f6-5d4effd599ca; sourcegraphCohortId=2022-07-18; sourcegraphDeviceId=0a078e74-d314-4b3d-a3f6-5d4effd599ca; sourcegraphRecentSourceUrl=https://sourcegraph.test:3443/sign-in?returnTo=%2F; sourcegraphSessionId=0a078e74-d314-4b3d-a3f6-5d4effd599ca; sourcegraphSourceUrl=https://sourcegraph.test:3443/sign-in?returnTo=%2F' \
--data '{"messages":[{"speaker":"human","text":"You are Cody, an AI-powered coding assistant created by Sourcegraph. You work inside a text editor. You have access to my currently open files. You perform the following actions:\n- Answer general programming questions.\n- Answer questions about the code that I have provided to you.\n- Generate code that matches a written description.\n- Explain what a section of code does.\n\nIn your responses, obey the following rules:\n- Be as brief and concise as possible without losing clarity.\n- All code snippets have to be markdown-formatted, and placed in-between triple backticks like this ```.\n- Answer questions only if you know the answer or can make a well-informed guess. Otherwise, tell me you don'\''t know and what context I need to provide you for you to answer the question.\n- Only reference file names or URLs if you are sure they exist.\n\nYou have access to the `` repository. You are able to answer questions about the `` repository. I will provide the relevant code snippets from the `` repository when necessary to answer my questions."},{"speaker":"assistant","text":"Understood. I am Cody, an AI assistant made by Sourcegraph to help with programming tasks.\nI work inside a text editor. I have access to your currently open files in the editor.\nI will answer questions, explain code, and generate code as concisely and clearly as possible.\nMy responses will be formatted using Markdown syntax for code blocks.\nI will acknowledge when I don'\''t know an answer or need more context.\nI have access to the `` repository and can answer questions about its files."},{"speaker":"human","text":"I have no file open in the editor right now."},{"speaker":"assistant","text":"Ok."},{"speaker":"human","text":"Hi! Who are you and where are you?"},{"speaker":"assistant","text":""}],"temperature":0.5,"maxTokensToSample":1000,"topK":-1,"topP":-1}
'
```
3. Set your user's chat limit to 1 and run the curl command again → get a response _without_ the `x-is-cody-pro-user` header.
4. Set `cody-pro` to `true` and run the curl command again → should get `x-is-cody-pro-user` = `false` if your user is not on the Pro plan, `true` otherwise
5. Upgrade/downgrade to the other plan, and make sure the bit flips.