### PR TITLE
Code Navigation: fix test indicator positioning

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.module.scss
@@ -4,22 +4,27 @@
     align-items: center;
 }
 
-.icon {
-    flex-shrink: 0;
-    width: 1rem;
-    height: 1rem;
+.file-container {
+    display: flex;
+    flex-direction: row;
 }
 
 .test-indicator {
     border-radius: 100%;
     width: 0.5rem;
     height: 0.5rem;
-    margin-left: -0.65rem;
-    margin-bottom: 0.15rem;
+    margin-left: -0.75rem;
     margin-right: 0.15rem;
     background-color: var(--gray-05);
     align-self: end;
 }
+
+.icon {
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
+}
+
 
 .blue {
     color: var(--blue);

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.module.scss
@@ -1,10 +1,10 @@
-.icon-container {
+.file-container {
     display: flex;
     flex-direction: row;
     align-items: center;
 }
 
-.file-container {
+.icon-container {
     display: flex;
     flex-direction: row;
 }
@@ -24,7 +24,6 @@
     width: 1rem;
     height: 1rem;
 }
-
 
 .blue {
     color: var(--blue);

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -391,7 +391,7 @@ function renderNode({
     const { entry, error, dotdot, name } = element
     const submodule = entry?.submodule
     const url = entry?.url
-    const fileInfo = getFileInfo(name)
+    const fileInfo = getFileInfo(name, isBranch)
     const fileIcon = FILE_ICONS.get(fileInfo.extension)
 
     if (error) {

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -475,22 +475,24 @@ function renderNode({
             }}
         >
             <div className={styles.iconContainer}>
-                {fileInfo.extension !== FileExtension.DEFAULT ? (
-                    <Icon
-                        as={fileIcon?.icon}
-                        className={classNames('mr-1', styles.icon, fileIcon?.iconClass)}
-                        aria-hidden={true}
-                    />
-                ) : (
-                    <Icon
-                        svgPath={
-                            isBranch ? (isExpanded ? mdiFolderOpenOutline : mdiFolderOutline) : mdiFileDocumentOutline
-                        }
-                        className={classNames('mr-1', styles.icon)}
-                        aria-hidden={true}
-                    />
-                )}
-                {fileInfo.isTest && <div className={classNames(styles.testIndicator)} />}
+                <div className={styles.fileContainer}>
+                    {fileInfo.extension !== FileExtension.DEFAULT ? (
+                        <Icon
+                            as={fileIcon?.icon}
+                            className={classNames('mr-1', styles.icon, fileIcon?.iconClass)}
+                            aria-hidden={true}
+                        />
+                    ) : (
+                        <Icon
+                            svgPath={
+                                isBranch ? (isExpanded ? mdiFolderOpenOutline : mdiFolderOutline) : mdiFileDocumentOutline
+                            }
+                            className={classNames('mr-1', styles.icon)}
+                            aria-hidden={true}
+                        />
+                    )}
+                    {fileInfo.isTest && <div className={classNames(styles.testIndicator)} />}
+                </div>
                 {name}
             </div>
         </Link>

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -474,8 +474,8 @@ function renderNode({
                 }
             }}
         >
-            <div className={styles.iconContainer}>
-                <div className={styles.fileContainer}>
+            <div className={styles.fileContainer}>
+                <div className={styles.iconContainer}>
                     {fileInfo.extension !== FileExtension.DEFAULT ? (
                         <Icon
                             as={fileIcon?.icon}
@@ -485,7 +485,11 @@ function renderNode({
                     ) : (
                         <Icon
                             svgPath={
-                                isBranch ? (isExpanded ? mdiFolderOpenOutline : mdiFolderOutline) : mdiFileDocumentOutline
+                                isBranch
+                                    ? isExpanded
+                                        ? mdiFolderOpenOutline
+                                        : mdiFolderOutline
+                                    : mdiFileDocumentOutline
                             }
                             className={classNames('mr-1', styles.icon)}
                             aria-hidden={true}

--- a/client/web/src/repo/tree/TreePagePanels.tsx
+++ b/client/web/src/repo/tree/TreePagePanels.tsx
@@ -179,7 +179,7 @@ export const FilesCard: FC<FilePanelProps> = ({ entries, historyEntries, classNa
             </thead>
             <tbody>
                 {entries.map(entry => {
-                    const fileInfo = getFileInfo(entry.name)
+                    const fileInfo = getFileInfo(entry.name, entry.isDirectory)
                     const fileIcon = FILE_ICONS.get(fileInfo.extension)
 
                     return (

--- a/client/web/src/repo/utils.test.ts
+++ b/client/web/src/repo/utils.test.ts
@@ -88,7 +88,7 @@ describe('getFileInfo', () => {
 
     for (const t of tests) {
         it(t.name, () => {
-            const fileInfo = getFileInfo(t.file)
+            const fileInfo = getFileInfo(t.file, t.isDirectory)
             expect(fileInfo.extension).toBe(t.expectedExtension)
             expect(fileInfo.isTest).toBe(t.expectedIsTest)
         })

--- a/client/web/src/repo/utils.tsx
+++ b/client/web/src/repo/utils.tsx
@@ -51,7 +51,14 @@ export interface FileInfo {
     isTest: boolean
 }
 
-export const getFileInfo = (file: string): FileInfo => {
+export const getFileInfo = (file: string, isDirectory: boolean): FileInfo => {
+    if (isDirectory) {
+        return {
+            extension: 'default' as FileExtension,
+            isTest: false,
+        }
+    }
+
     const extension = file.split('.').at(-1)
     const isValidExtension = Object.values(FileExtension).includes(extension as FileExtension)
 


### PR DESCRIPTION
This PR fixes two bugs.
1) Before, the test indicator caused some strange positioning behavior with the actual file names. Now, it behaves as expected.
2) Before, folder names that happened to be named the same as a valid file extension (nix, js, ts, etc.) appeared with language icons instead of the directory icon. This has been fixed.  

### Test plan
Manual testing
