### PR TITLE
telemetrygatewayexporter: fix queue cleanup window

### DIFF
--- a/cmd/worker/internal/telemetrygatewayexporter/queue_cleanup.go
+++ b/cmd/worker/internal/telemetrygatewayexporter/queue_cleanup.go
@@ -24,7 +24,8 @@ type queueCleanupJob struct {
 
 func newQueueCleanupJob(obctx *observation.Context, store database.TelemetryEventsExportQueueStore, cfg config) goroutine.BackgroundRoutine {
 	job := &queueCleanupJob{
-		store: store,
+		store:           store,
+		retentionWindow: cfg.ExportedEventsRetentionWindow,
 		prunedCounter: promauto.NewCounter(prometheus.CounterOpts{
 			Namespace: "src",
 			Subsystem: "telemetrygatewayexporter",

--- a/cmd/worker/internal/telemetrygatewayexporter/telemetrygatewayexporter.go
+++ b/cmd/worker/internal/telemetrygatewayexporter/telemetrygatewayexporter.go
@@ -75,7 +75,7 @@ func (c *config) Load() {
 	}
 
 	c.ExportedEventsRetentionWindow = env.MustGetDuration("TELEMETRY_GATEWAY_EXPORTER_EXPORTED_EVENTS_RETENTION",
-		2*24*time.Hour, "Duration to retain already-exported telemetry events before deleting")
+		24*time.Hour, "Duration to retain already-exported telemetry events before deleting")
 
 	c.QueueCleanupInterval = env.MustGetDuration("TELEMETRY_GATEWAY_EXPORTER_QUEUE_CLEANUP_INTERVAL",
 		30*time.Minute, "Interval at which to clean up telemetry export queue")


### PR DESCRIPTION
I forgot to drill-down the config option to the cleanup worker, which means we always run the cleanup of already-exported events from `time.Now()`, which isn't itself all that harmful because we don't use the backlog exported events yet, but will be relevant for https://github.com/sourcegraph/sourcegraph/pull/57029 if I ever get around to that, and could come in handy for debugging.

Since this could be a big change, I reduced the retention to just 1 day by default.

## Test plan

n/a
