### PR TITLE
File sidebar: minimize fetches

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -171,7 +171,6 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
         })
     }, [initialFilePath, updateTreeData])
 
-
     const fetchEntries = useCallback(
         async (variables: FileTreeEntriesVariables) => {
             const result = await client.query<FileTreeEntriesResult, FileTreeEntriesVariables>({

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -149,24 +149,8 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
         treeDataRef.current = nextTreeData
     }, [])
 
-    const client = useApolloClient()
-    const fetchEntries = useCallback(
-        async (variables: FileTreeEntriesVariables) => {
-            const result = await client.query<FileTreeEntriesResult, FileTreeEntriesVariables>({
-                query: APOLLO_QUERY,
-                variables,
-            })
-
-            if (!treeDataRef.current) {
-                return
-            }
-
-            updateTreeData(treeDataRef.current, result.data)
-        },
-        [client, updateTreeData]
-    )
-
     // Initialize the treeData from the initial query
+    const client = useApolloClient()
     useEffect(() => {
         const result = client.query<FileTreeEntriesResult, FileTreeEntriesVariables>({
             query: APOLLO_QUERY,
@@ -186,6 +170,23 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
             updateTreeData(createTreeData(initialFilePath), res.data)
         })
     }, [initialFilePath, updateTreeData])
+
+
+    const fetchEntries = useCallback(
+        async (variables: FileTreeEntriesVariables) => {
+            const result = await client.query<FileTreeEntriesResult, FileTreeEntriesVariables>({
+                query: APOLLO_QUERY,
+                variables,
+            })
+
+            if (!treeDataRef.current) {
+                return
+            }
+
+            updateTreeData(treeDataRef.current, result.data)
+        },
+        [client, updateTreeData]
+    )
 
     const onLoadData = useCallback(
         async ({ element }: { element: TreeNode }) => {

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -151,15 +151,15 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
 
     // Initialize the treeData from the initial query
     const client = useApolloClient()
+    const [initialVariables] = useState({
+        filePath: props.filePathIsDirectory ? props.filePath : getParentPath(props.filePath),
+        // Only fetch ancestors if the file tree is rooted higher than the target file.
+        ancestors: props.initialFilePath !== props.filePath,
+    })
     useEffect(() => {
         const result = client.query<FileTreeEntriesResult, FileTreeEntriesVariables>({
             query: APOLLO_QUERY,
-            variables: {
-                ...defaultVariables,
-                filePath: props.filePathIsDirectory ? props.filePath : getParentPath(props.filePath),
-                // Only fetch ancestors if the file tree is rooted higher than the target file.
-                ancestors: props.initialFilePath != props.filePath,
-            },
+            variables: { ...defaultVariables, ...initialVariables },
         })
 
         setLoading(true)
@@ -169,7 +169,7 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
             setError(res.error)
             updateTreeData(createTreeData(initialFilePath), res.data)
         })
-    }, [initialFilePath, updateTreeData])
+    }, [initialFilePath, updateTreeData, client, defaultVariables, initialVariables])
 
     const fetchEntries = useCallback(
         async (variables: FileTreeEntriesVariables) => {

--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -173,7 +173,8 @@ export const RepoRevisionSidebarFileTree: React.FunctionComponent<Props> = props
             variables: {
                 ...defaultVariables,
                 filePath: props.filePathIsDirectory ? props.filePath : getParentPath(props.filePath),
-                ancestors: true,
+                // Only fetch ancestors if the file tree is rooted higher than the target file.
+                ancestors: props.initialFilePath != props.filePath,
             },
         })
 


### PR DESCRIPTION
This makes a couple of changes to minimize the number of requests we make for the file sidebar.

Previously, we would make an initial request to populate the root level of the file tree. However, we would immediately make a followup `ancestors` request to fully-populate the tree down to the level that we've selected. I think this might be a recent regresion. For reasons I don't quite understand, this also caused us to re-run the initial query in `useQuery`. I expect it has to do with the second request busting the cache so that when we re-render, the initial response isn't in apollo's cache. 

This modifies the initial data loading query to 1) target `filePath` rather than `initialFilePath` so that we get everything we need to render the full file tree and 2) set `ancestors` when we're deeper than the root so we fetch everything needed to show the minimally expanded file tree. Additionally, it moves the initial data loading query into the `useEffect` to get around the strange cache-busting behavior.

I don't think this is anywhere close to the optimal state, but this component is pretty wild, so I'm aiming for minimum blast radius. There seems to be some confusing behavior/naming with `initialFilePath` since that is held as state even though it's passed into the component. It seems like maybe we should have a different field called something like `rootPath` or `anchorPath`.

Fixes #58657 
For reasons unclear, this also seems to fix https://github.com/sourcegraph/sourcegraph/issues/58184

## Test plan

Lots of manual testing. I tested both with and without the new `showFullTreeContext` setting enabled.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
