### PR TITLE
aspect: use different dep step key if running as part of aspect

### DIFF
--- a/dev/ci/bazel-prechecks-apply.sh
+++ b/dev/ci/bazel-prechecks-apply.sh
@@ -9,4 +9,6 @@ if [[ $status -ne 0 && "$response" == *"No artifacts found for downloading"* ]];
   exit 0
 fi
 
-git apply bazel-configure.diff
+if [ -f bazel-configure.diff ]; then
+  git apply bazel-configure.diff
+fi

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -42,13 +42,21 @@ func bazelCmd(args ...string) string {
 }
 
 // Used in default run type
-func bazelPushImagesCandidates(version string) func(*bk.Pipeline) {
-	return bazelPushImagesCmd(version, true, "bazel-tests")
+func bazelPushImagesCandidates(version string, isAspectBuild bool) func(*bk.Pipeline) {
+	depKey := "bazel-tests"
+	if isAspectBuild {
+		depKey = "__main__::test"
+	}
+	return bazelPushImagesCmd(version, true, depKey)
 }
 
 // Used in default run type
-func bazelPushImagesFinal(version string) func(*bk.Pipeline) {
-	return bazelPushImagesCmd(version, false, "bazel-tests")
+func bazelPushImagesFinal(version string, isAspectBuild bool) func(*bk.Pipeline) {
+	depKey := "bazel-tests"
+	if isAspectBuild {
+		depKey = "__main__::test"
+	}
+	return bazelPushImagesCmd(version, false, depKey)
 }
 
 // Used in CandidateNoTest run type

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -304,7 +304,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		// Publish candidate images to dev registry
 		publishOpsDev := operations.NewNamedSet("Publish candidate images")
-		publishOpsDev.Append(bazelPushImagesCandidates(c.Version))
+		publishOpsDev.Append(bazelPushImagesCandidates(c.Version, isAspectWorkflowBuild))
 		ops.Merge(publishOpsDev)
 
 		// End-to-end tests
@@ -340,7 +340,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			}
 		}
 		// Final Bazel images
-		publishOps.Append(bazelPushImagesFinal(c.Version))
+		publishOps.Append(bazelPushImagesFinal(c.Version, isAspectWorkflowBuild))
 		ops.Merge(publishOps)
 	}
 


### PR DESCRIPTION
Need to update the dependent keys otherwise you run into this scenario where steps wait indefinitely

![Screenshot 2023-11-30 at 10 27 42](https://github.com/sourcegraph/sourcegraph/assets/1001709/0a60a29c-5568-4a4b-b9cc-14e94facb244)

## Test plan
CI + main-dry-run

