### PR TITLE
aspect: work-around flags issue with .aspect/workflows/bazelrc

### DIFF
--- a/.aspect/workflows/bazelrc
+++ b/.aspect/workflows/bazelrc
@@ -1,3 +1,0 @@
-common --remote_download_minimal
-common --nobuild_runfile_links
-common --noexperimental_reuse_sandbox_directories

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -8,6 +8,9 @@ bazel:
     # when the container exits the files that are left over are root.
     # TODO(burmudar): launch containers with uid/guid mapped in
     - --noexperimental_reuse_sandbox_directories
+    # TODO(gregmagolan): can be moved to .aspect/workflows/bazelrc in the future
+    - --remote_download_minimal
+    - --nobuild_runfile_links
 env:
     REDIS_CACHE_ENDPOINT: ":6379"
     GIT_PAGER: ''


### PR DESCRIPTION
There is a Workflows issue with `--bazelrc=.aspect/workflows/bazelrc` not being applied to all bazel invocations. This will work-around that issue. Will be fixed in Workflows in a future release.

## Test plan

Check that these bazel flags are applied on all bazel invocations.