### PR TITLE
alter function using apollo client to achieve pagination

### DIFF
--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
+import { useApolloClient } from '@apollo/client'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 import { type Observable, of, throwError, from } from 'rxjs'
@@ -47,7 +48,6 @@ import {
 import { SearchContextRepositoriesFormArea } from './SearchContextRepositoriesFormArea'
 
 import styles from './SearchContextForm.module.scss'
-import { useApolloClient } from '@apollo/client'
 
 const MAX_DESCRIPTION_LENGTH = 1024
 const MAX_NAME_LENGTH = 32
@@ -68,8 +68,8 @@ function getVisibilityRadioButtons(selectedNamespaceType: SelectedNamespaceType)
         selectedNamespaceType === 'global-owner'
             ? 'Only site-admins can view this context.'
             : selectedNamespaceType === 'org'
-                ? 'Only organization members can view this context.'
-                : 'Only you can view this context.'
+            ? 'Only organization members can view this context.'
+            : 'Only you can view this context.'
 
     return [
         {
@@ -111,8 +111,8 @@ const LOADING = 'loading' as const
 
 export interface SearchContextFormProps
     extends TelemetryProps,
-    Pick<SearchContextProps, 'deleteSearchContext'>,
-    PlatformContextProps<'requestGraphQL'> {
+        Pick<SearchContextProps, 'deleteSearchContext'>,
+        PlatformContextProps<'requestGraphQL'> {
     searchContext?: SearchContextFields
     query?: string
     authenticatedUser: AuthenticatedUser
@@ -130,13 +130,13 @@ const searchContextVisibility = (searchContext: SearchContextFields): SelectedVi
 
 type RepositoriesParseResult =
     | {
-        type: 'errors'
-        errors: Error[]
-    }
+          type: 'errors'
+          errors: Error[]
+      }
     | {
-        type: 'repositories'
-        repositories: SearchContextRepositoryRevisionsInput[]
-    }
+          type: 'repositories'
+          repositories: SearchContextRepositoryRevisionsInput[]
+      }
 
 export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<SearchContextFormProps>> = props => {
     const { authenticatedUser, onSubmit, searchContext, deleteSearchContext, isSourcegraphDotCom, platformContext } =
@@ -242,7 +242,7 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                     )
                 })
             ),
-        [repositoriesConfig]
+        [repositoriesConfig, apolloClient]
     )
 
     const validateRepositories = useCallback(

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
 
-import { useApolloClient } from '@apollo/client'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 import { type Observable, of, throwError, from } from 'rxjs'
@@ -68,8 +67,8 @@ function getVisibilityRadioButtons(selectedNamespaceType: SelectedNamespaceType)
         selectedNamespaceType === 'global-owner'
             ? 'Only site-admins can view this context.'
             : selectedNamespaceType === 'org'
-            ? 'Only organization members can view this context.'
-            : 'Only you can view this context.'
+                ? 'Only organization members can view this context.'
+                : 'Only you can view this context.'
 
     return [
         {
@@ -111,8 +110,8 @@ const LOADING = 'loading' as const
 
 export interface SearchContextFormProps
     extends TelemetryProps,
-        Pick<SearchContextProps, 'deleteSearchContext'>,
-        PlatformContextProps<'requestGraphQL'> {
+    Pick<SearchContextProps, 'deleteSearchContext'>,
+    PlatformContextProps<'requestGraphQL'> {
     searchContext?: SearchContextFields
     query?: string
     authenticatedUser: AuthenticatedUser
@@ -130,13 +129,13 @@ const searchContextVisibility = (searchContext: SearchContextFields): SelectedVi
 
 type RepositoriesParseResult =
     | {
-          type: 'errors'
-          errors: Error[]
-      }
+        type: 'errors'
+        errors: Error[]
+    }
     | {
-          type: 'repositories'
-          repositories: SearchContextRepositoryRevisionsInput[]
-      }
+        type: 'repositories'
+        repositories: SearchContextRepositoryRevisionsInput[]
+    }
 
 export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<SearchContextFormProps>> = props => {
     const { authenticatedUser, onSubmit, searchContext, deleteSearchContext, isSourcegraphDotCom, platformContext } =
@@ -200,7 +199,6 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
         )
     }, [description, name, searchContext, selectedNamespace, visibility, queryState, hasRepositoriesConfigChanged])
 
-    const apolloClient = useApolloClient()
     const parseRepositories = useCallback(
         (): Observable<RepositoriesParseResult> =>
             of(parseConfig(repositoriesConfig)).pipe(
@@ -220,7 +218,7 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                         return of({ type: 'repositories', repositories: [] } as RepositoriesParseResult)
                     }
 
-                    return from(fetchRepositoriesByNames(repositoryNames, apolloClient)).pipe(
+                    return from(fetchRepositoriesByNames(repositoryNames)).pipe(
                         map(repositories => {
                             const repositoryNameToID = new Map(repositories.map(({ id, name }) => [name, id]))
                             const errors: Error[] = []
@@ -242,7 +240,7 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                     )
                 })
             ),
-        [repositoriesConfig, apolloClient]
+        [repositoriesConfig]
     )
 
     const validateRepositories = useCallback(

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -67,8 +67,8 @@ function getVisibilityRadioButtons(selectedNamespaceType: SelectedNamespaceType)
         selectedNamespaceType === 'global-owner'
             ? 'Only site-admins can view this context.'
             : selectedNamespaceType === 'org'
-                ? 'Only organization members can view this context.'
-                : 'Only you can view this context.'
+            ? 'Only organization members can view this context.'
+            : 'Only you can view this context.'
 
     return [
         {
@@ -110,8 +110,8 @@ const LOADING = 'loading' as const
 
 export interface SearchContextFormProps
     extends TelemetryProps,
-    Pick<SearchContextProps, 'deleteSearchContext'>,
-    PlatformContextProps<'requestGraphQL'> {
+        Pick<SearchContextProps, 'deleteSearchContext'>,
+        PlatformContextProps<'requestGraphQL'> {
     searchContext?: SearchContextFields
     query?: string
     authenticatedUser: AuthenticatedUser
@@ -129,13 +129,13 @@ const searchContextVisibility = (searchContext: SearchContextFields): SelectedVi
 
 type RepositoriesParseResult =
     | {
-        type: 'errors'
-        errors: Error[]
-    }
+          type: 'errors'
+          errors: Error[]
+      }
     | {
-        type: 'repositories'
-        repositories: SearchContextRepositoryRevisionsInput[]
-    }
+          type: 'repositories'
+          repositories: SearchContextRepositoryRevisionsInput[]
+      }
 
 export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<SearchContextFormProps>> = props => {
     const { authenticatedUser, onSubmit, searchContext, deleteSearchContext, isSourcegraphDotCom, platformContext } =

--- a/client/web/src/enterprise/searchContexts/backend.ts
+++ b/client/web/src/enterprise/searchContexts/backend.ts
@@ -38,7 +38,7 @@ export async function fetchRepositoriesByNames(
         })
 
         if (result.error) {
-            throw new Error('failed to add repositories to paginated result')
+            throw new Error(result.error.message)
         }
 
         repos = repos.concat(result.data.repositories.nodes)

--- a/client/web/src/enterprise/searchContexts/backend.ts
+++ b/client/web/src/enterprise/searchContexts/backend.ts
@@ -1,49 +1,51 @@
-import { ApolloQueryResult, gql } from '@apollo/client'
+import { ApolloQueryResult, gql, ApolloClient } from '@apollo/client'
+
 import type { InputMaybe, RepositoriesByNamesResult, RepositoriesByNamesVariables } from '../../graphql-operations'
-import { ApolloClient } from '@apollo/client'
 
 const query = gql`
-query RepositoriesByNames($names: [String!]!, $first: Int!, $after: String) {
-    repositories(names: $names, first: $first) {
-        pageInfo {
-            hasNextPage
-            endCursor
-        }
-        nodes {
-            id
-            name
+    query RepositoriesByNames($names: [String!]!, $first: Int!, $after: String) {
+        repositories(names: $names, first: $first, after: $after) {
+            pageInfo {
+                hasNextPage
+                endCursor
+            }
+            nodes {
+                id
+                name
+            }
         }
     }
-}
 `
 export async function fetchRepositoriesByNames(
     names: string[],
     apolloClient: ApolloClient<object>
 ): Promise<RepositoriesByNamesResult['repositories']['nodes']> {
-    const repos: RepositoriesByNamesResult['repositories']['nodes'] = []
+    let repos: RepositoriesByNamesResult['repositories']['nodes'] = []
     const first = names.length
     let after: InputMaybe<string> = null
 
     while (true) {
-        const result: ApolloQueryResult<RepositoriesByNamesResult> = await apolloClient.query<RepositoriesByNamesResult, RepositoriesByNamesVariables>({
-            query: query,
+        const result: ApolloQueryResult<RepositoriesByNamesResult> = await apolloClient.query<
+            RepositoriesByNamesResult,
+            RepositoriesByNamesVariables
+        >({
+            query,
             variables: {
                 names,
                 first,
-                after
+                after,
             },
         })
 
         if (result.error) {
-            throw new Error("failed to add repositories to paginated result")
+            throw new Error('failed to add repositories to paginated result')
         }
 
-        repos.concat(result.data.repositories.nodes)
+        repos = repos.concat(result.data.repositories.nodes)
         if (!result.data.repositories.pageInfo.hasNextPage) {
             break
         }
         after = result.data.repositories.pageInfo.endCursor
-
     }
     return repos
 }

--- a/client/web/src/enterprise/searchContexts/backend.ts
+++ b/client/web/src/enterprise/searchContexts/backend.ts
@@ -1,32 +1,49 @@
-import type { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { ApolloQueryResult, gql } from '@apollo/client'
+import type { InputMaybe, RepositoriesByNamesResult, RepositoriesByNamesVariables } from '../../graphql-operations'
+import { ApolloClient } from '@apollo/client'
 
-import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
-
-import { requestGraphQL } from '../../backend/graphql'
-import type { RepositoriesByNamesResult, RepositoriesByNamesVariables } from '../../graphql-operations'
-
-export function fetchRepositoriesByNames(
-    names: string[]
-): Observable<RepositoriesByNamesResult['repositories']['nodes']> {
-    const first = names.length
-    return requestGraphQL<RepositoriesByNamesResult, RepositoriesByNamesVariables>(
-        gql`
-            query RepositoriesByNames($names: [String!]!, $first: Int!) {
-                repositories(names: $names, first: $first) {
-                    nodes {
-                        id
-                        name
-                    }
-                }
-            }
-        `,
-        {
-            names,
-            first,
+const query = gql`
+query RepositoriesByNames($names: [String!]!, $first: Int!, $after: String) {
+    repositories(names: $names, first: $first) {
+        pageInfo {
+            hasNextPage
+            endCursor
         }
-    ).pipe(
-        map(dataOrThrowErrors),
-        map(data => data.repositories.nodes)
-    )
+        nodes {
+            id
+            name
+        }
+    }
+}
+`
+export async function fetchRepositoriesByNames(
+    names: string[],
+    apolloClient: ApolloClient<object>
+): Promise<RepositoriesByNamesResult['repositories']['nodes']> {
+    const repos: RepositoriesByNamesResult['repositories']['nodes'] = []
+    const first = names.length
+    let after: InputMaybe<string> = null
+
+    while (true) {
+        const result: ApolloQueryResult<RepositoriesByNamesResult> = await apolloClient.query<RepositoriesByNamesResult, RepositoriesByNamesVariables>({
+            query: query,
+            variables: {
+                names,
+                first,
+                after
+            },
+        })
+
+        if (result.error) {
+            throw new Error("failed to add repositories to paginated result")
+        }
+
+        repos.concat(result.data.repositories.nodes)
+        if (!result.data.repositories.pageInfo.hasNextPage) {
+            break
+        }
+        after = result.data.repositories.pageInfo.endCursor
+
+    }
+    return repos
 }

--- a/client/web/src/enterprise/searchContexts/backend.ts
+++ b/client/web/src/enterprise/searchContexts/backend.ts
@@ -5,17 +5,18 @@ import type { InputMaybe, RepositoriesByNamesResult, RepositoriesByNamesVariable
 const query = gql`
     query RepositoriesByNames($names: [String!]!, $first: Int!, $after: String) {
         repositories(names: $names, first: $first, after: $after) {
-            pageInfo {
-                hasNextPage
-                endCursor
-            }
             nodes {
                 id
                 name
             }
+            pageInfo {
+                endCursor
+                hasNextPage
+            }
         }
     }
 `
+
 export async function fetchRepositoriesByNames(
     names: string[],
     apolloClient: ApolloClient<object>

--- a/client/web/src/enterprise/searchContexts/backend.ts
+++ b/client/web/src/enterprise/searchContexts/backend.ts
@@ -1,4 +1,5 @@
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
+import type { GraphQLResult } from '@sourcegraph/http-client'
 
 import { requestGraphQL } from '../../backend/graphql'
 import type { InputMaybe, RepositoriesByNamesResult, RepositoriesByNamesVariables } from '../../graphql-operations'
@@ -26,7 +27,7 @@ export async function fetchRepositoriesByNames(
     let after: InputMaybe<string> = null
 
     while (true) {
-        const result = await requestGraphQL<
+        const result: GraphQLResult<RepositoriesByNamesResult> = await requestGraphQL<
             RepositoriesByNamesResult,
             RepositoriesByNamesVariables
         >(query, {
@@ -35,7 +36,7 @@ export async function fetchRepositoriesByNames(
             after,
         }).toPromise()
 
-        const data = dataOrThrowErrors(result)
+        const data: RepositoriesByNamesResult = dataOrThrowErrors(result)
 
         repos = repos.concat(data.repositories.nodes)
         if (!data.repositories.pageInfo.hasNextPage) {

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -30,7 +30,7 @@ describe('Search contexts', () => {
     })
     after(() => driver?.close())
     let testContext: WebIntegrationTestContext
-    beforeEach(async function () {
+    beforeEach(async function() {
         testContext = await createWebIntegrationTestContext({
             driver,
             currentTest: this.currentTest!,
@@ -142,9 +142,23 @@ describe('Search contexts', () => {
     test('Create static search context', async () => {
         testContext.overrideGraphQL({
             ...testContextForSearchContexts,
-            RepositoriesByNames: ({ names }) => ({
-                repositories: { nodes: names.map((name, index) => ({ id: `index-${index}`, name })) },
-            }),
+            // TODO: fix this test
+            RepositoriesByNames: ({ names, first, after }) => {
+                return {
+                    repositories: {
+                        nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
+                        pageInfo: {
+                            endCursor: null,
+                            hasNextPage: true
+                        }
+                    },
+                    variables: {
+                        names,
+                        first,
+                        after
+                    }
+                }
+            },
             CreateSearchContext: ({ searchContext, repositories }) => ({
                 createSearchContext: {
                     __typename: 'SearchContext',
@@ -291,9 +305,22 @@ describe('Search contexts', () => {
     test('Edit search context', async () => {
         testContext.overrideGraphQL({
             ...testContextForSearchContexts,
-            RepositoriesByNames: ({ names }) => ({
-                repositories: { nodes: names.map((name, index) => ({ id: `index-${index}`, name })) },
-            }),
+            RepositoriesByNames: ({ names, first, after }) => {
+                return {
+                    repositories: {
+                        nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
+                            pageInfo: {
+                            endCursor: null,
+                            hasNextPage: true
+                        }
+                    },
+                    variables: {
+                        names,
+                        first,
+                        after
+                    }
+                }
+            },
             UpdateSearchContext: ({ id, searchContext, repositories }) => ({
                 updateSearchContext: {
                     __typename: 'SearchContext',

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -30,7 +30,7 @@ describe('Search contexts', () => {
     })
     after(() => driver?.close())
     let testContext: WebIntegrationTestContext
-    beforeEach(async function() {
+    beforeEach(async function () {
         testContext = await createWebIntegrationTestContext({
             driver,
             currentTest: this.currentTest!,
@@ -149,14 +149,14 @@ describe('Search contexts', () => {
                         nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
                         pageInfo: {
                             endCursor: null,
-                            hasNextPage: true
-                        }
+                            hasNextPage: true,
+                        },
                     },
                     variables: {
                         names,
                         first,
-                        after
-                    }
+                        after,
+                    },
                 }
             },
             CreateSearchContext: ({ searchContext, repositories }) => ({
@@ -302,6 +302,7 @@ describe('Search contexts', () => {
         await driver.page.waitForSelector('[data-testid="search-contexts-list-page"]')
     })
 
+    // TODO: Fix this test
     test('Edit search context', async () => {
         testContext.overrideGraphQL({
             ...testContextForSearchContexts,
@@ -309,16 +310,16 @@ describe('Search contexts', () => {
                 return {
                     repositories: {
                         nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
-                            pageInfo: {
+                        pageInfo: {
                             endCursor: null,
-                            hasNextPage: true
-                        }
+                            hasNextPage: true,
+                        },
                     },
                     variables: {
                         names,
                         first,
-                        after
-                    }
+                        after,
+                    },
                 }
             },
             UpdateSearchContext: ({ id, searchContext, repositories }) => ({

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -143,22 +143,20 @@ describe('Search contexts', () => {
         testContext.overrideGraphQL({
             ...testContextForSearchContexts,
             // TODO: fix this test
-            RepositoriesByNames: ({ names, first, after }) => {
-                return {
-                    repositories: {
-                        nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
-                        pageInfo: {
-                            endCursor: null,
-                            hasNextPage: true,
-                        },
+            RepositoriesByNames: ({ names, first, after }) => ({
+                repositories: {
+                    nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
+                    pageInfo: {
+                        endCursor: null,
+                        hasNextPage: true,
                     },
-                    variables: {
-                        names,
-                        first,
-                        after,
-                    },
-                }
-            },
+                },
+                variables: {
+                    names,
+                    first,
+                    after,
+                },
+            }),
             CreateSearchContext: ({ searchContext, repositories }) => ({
                 createSearchContext: {
                     __typename: 'SearchContext',
@@ -306,22 +304,20 @@ describe('Search contexts', () => {
     test('Edit search context', async () => {
         testContext.overrideGraphQL({
             ...testContextForSearchContexts,
-            RepositoriesByNames: ({ names, first, after }) => {
-                return {
-                    repositories: {
-                        nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
-                        pageInfo: {
-                            endCursor: null,
-                            hasNextPage: true,
-                        },
+            RepositoriesByNames: ({ names, first, after }) => ({
+                repositories: {
+                    nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
+                    pageInfo: {
+                        endCursor: null,
+                        hasNextPage: true,
                     },
-                    variables: {
-                        names,
-                        first,
-                        after,
-                    },
-                }
-            },
+                },
+                variables: {
+                    names,
+                    first,
+                    after,
+                },
+            }),
             UpdateSearchContext: ({ id, searchContext, repositories }) => ({
                 updateSearchContext: {
                     __typename: 'SearchContext',

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -30,7 +30,7 @@ describe('Search contexts', () => {
     })
     after(() => driver?.close())
     let testContext: WebIntegrationTestContext
-    beforeEach(async function () {
+    beforeEach(async function() {
         testContext = await createWebIntegrationTestContext({
             driver,
             currentTest: this.currentTest!,
@@ -142,13 +142,12 @@ describe('Search contexts', () => {
     test('Create static search context', async () => {
         testContext.overrideGraphQL({
             ...testContextForSearchContexts,
-            // TODO: fix this test
             RepositoriesByNames: ({ names, first, after }) => ({
                 repositories: {
                     nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
                     pageInfo: {
                         endCursor: null,
-                        hasNextPage: true,
+                        hasNextPage: false,
                     },
                 },
                 variables: {
@@ -300,7 +299,6 @@ describe('Search contexts', () => {
         await driver.page.waitForSelector('[data-testid="search-contexts-list-page"]')
     })
 
-    // TODO: Fix this test
     test('Edit search context', async () => {
         testContext.overrideGraphQL({
             ...testContextForSearchContexts,
@@ -309,7 +307,7 @@ describe('Search contexts', () => {
                     nodes: names.map((name, index) => ({ id: `index-${index}`, name })),
                     pageInfo: {
                         endCursor: null,
-                        hasNextPage: true,
+                        hasNextPage: false,
                     },
                 },
                 variables: {

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -30,7 +30,7 @@ describe('Search contexts', () => {
     })
     after(() => driver?.close())
     let testContext: WebIntegrationTestContext
-    beforeEach(async function() {
+    beforeEach(async function () {
         testContext = await createWebIntegrationTestContext({
             driver,
             currentTest: this.currentTest!,


### PR DESCRIPTION
This solves [#57932](https://github.com/sourcegraph/sourcegraph/issues/57932). 

A customer reported that search contexts with over a thousand repos were failing when trying to create them. 

The root cause is that the webapp was fetching repositories to validate them, but was not using pagination, and instead tried to get them all in one go. The backend limits the number of results in a page to 1000, even if the client requests more. Now, the web app pages through results.

## Test plan
Create search context exceeding the max number of results. 
Check network responses for the correct output.