### PR TITLE
search.latencies: record fromSessionCookie in attributes

### DIFF
--- a/internal/actor/actor.go
+++ b/internal/actor/actor.go
@@ -41,8 +41,9 @@ type Actor struct {
 	SourcegraphOperator bool `json:",omitempty"`
 
 	// FromSessionCookie is whether a session cookie was used to authenticate the actor. It is used
-	// to selectively display a logout link. (If the actor wasn't authenticated with a session
-	// cookie, logout would be ineffective.)
+	// to selectively display a logout link (if the actor wasn't authenticated with a session
+	// cookie, logout would be ineffective), and for use in telemetry to indicate if a user
+	// might have come from a web browser (likely cookie) or directly via the API.
 	FromSessionCookie bool `json:"-"`
 
 	// user is populated lazily by (*Actor).User()

--- a/internal/auth/userpasswd/handlers.go
+++ b/internal/auth/userpasswd/handlers.go
@@ -139,7 +139,7 @@ func handleSignUp(logger log.Logger, db database.DB, eventRecorder *telemetry.Ev
 	events := telemetry.NewBestEffortEventRecorder(logger, eventRecorder)
 	events.Record(teestore.WithoutV1(r.Context()), telemetry.FeatureSignUp, telemetry.ActionSucceeded, &telemetry.EventParameters{
 		Metadata: telemetry.EventMetadata{
-			"failIfNewUserIsNotInitialSiteAdmin": telemetry.MetadataBool(failIfNewUserIsNotInitialSiteAdmin),
+			"failIfNewUserIsNotInitialSiteAdmin": telemetry.Bool(failIfNewUserIsNotInitialSiteAdmin),
 		},
 	})
 	// Legacy event

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -152,7 +152,8 @@ func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, durat
 				Metadata: telemetry.EventMetadata{
 					"durationMs": telemetry.Number(duration.Milliseconds()),
 					// TODO: Maybe make FromSessionCookie a first-class data
-					// point in (telemetrygateway.proto).EventUser
+					// point in (telemetrygateway.proto).EventUser if more use
+					// cases surface.
 					"actor.fromSessionCookie": telemetry.Bool(a.FromSessionCookie),
 				},
 			})

--- a/internal/search/job/jobutil/log_job.go
+++ b/internal/search/job/jobutil/log_job.go
@@ -150,7 +150,10 @@ func (l *LogJob) logEvent(ctx context.Context, clients job.RuntimeClients, durat
 			// New event
 			events.Record(ctx, "search.latencies", telemetry.Action(types[0]), &telemetry.EventParameters{
 				Metadata: telemetry.EventMetadata{
-					"durationMs": float64(duration.Milliseconds()),
+					"durationMs": telemetry.Number(duration.Milliseconds()),
+					// TODO: Maybe make FromSessionCookie a first-class data
+					// point in (telemetrygateway.proto).EventUser
+					"actor.fromSessionCookie": telemetry.Bool(a.FromSessionCookie),
 				},
 			})
 			// Legacy event

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -17,13 +17,20 @@ type constString string
 // Keys must be const strings.
 type EventMetadata map[constString]float64
 
-// MetadataBool returns 1 for true and 0 for false, for use in EventMetadata's
-// restricted int64 values.
-func MetadataBool(value bool) float64 {
+// Bool returns 1 for true and 0 for false, for use in EventMetadata values.
+func Bool(value bool) float64 {
 	if value {
 		return 1 // true
 	}
-	return 0 // 0
+	return 0 // false
+}
+
+// Number casts the value as a float64, for use in EventMetadata values.
+func Number[T interface {
+	~float32 | ~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}](value T) float64 {
+	return float64(value)
 }
 
 // EventBillingMetadata records metadata that attributes the event to product


### PR DESCRIPTION
https://sourcegraph.slack.com/archives/CN4FC7XT4/p1701348599252859 - this might help us guess if a search usage is from a web app or not

## Test plan

CI