### PR TITLE
Chore: disable monitors on dotcom

### DIFF
--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -119,7 +119,12 @@ export const routes: RouteObject[] = [
     },
     {
         path: PageRoutes.CodeMonitoring,
-        element: <LegacyRoute render={props => <GlobalCodeMonitoringArea {...props} />} />,
+        element: (
+            <LegacyRoute
+                render={props => <GlobalCodeMonitoringArea {...props} />}
+                condition={({ isSourcegraphDotCom }) => !isSourcegraphDotCom}
+            />
+        ),
     },
     {
         path: PageRoutes.Insights,

--- a/cmd/frontend/internal/codemonitors/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/codemonitors/resolvers/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/codemonitors/resolvers",
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
+        "//cmd/frontend/envvar",
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
         "//internal/auth",

--- a/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
+++ b/cmd/frontend/internal/codemonitors/resolvers/resolvers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
@@ -657,6 +658,9 @@ func (r *Resolver) withTransact(ctx context.Context, f func(*Resolver) error) er
 
 // isAllowedToEdit checks whether an actor is allowed to edit a given monitor.
 func (r *Resolver) isAllowedToEdit(ctx context.Context, id graphql.ID) error {
+	if envvar.SourcegraphDotComMode() {
+		return errors.New("Code Monitors are disabled on sourcegraph.com")
+	}
 	monitorID, err := unmarshalMonitorID(id)
 	if err != nil {
 		return err
@@ -675,6 +679,9 @@ func (r *Resolver) isAllowedToEdit(ctx context.Context, id graphql.ID) error {
 // - she is a member of the organization which is the owner of the monitor
 // - she is a site-admin
 func (r *Resolver) isAllowedToCreate(ctx context.Context, owner graphql.ID) error {
+	if envvar.SourcegraphDotComMode() {
+		return errors.New("Code Monitors are disabled on sourcegraph.com")
+	}
 	var ownerInt32 int32
 	err := relay.UnmarshalSpec(owner, &ownerInt32)
 	if err != nil {


### PR DESCRIPTION
This removes the code monitors page from sourcegraph.com and adds a check to all code monitor mutations. It still allows code monitor queries because it's cheap to keep read access active via the API, and it lets people still export their monitors if needed.

Part of https://github.com/sourcegraph/sourcegraph/issues/57539

As a followup, I plan to truncate the code monitor execution tables. I will maintain the code monitor definition tables so people can continue to export via the API and they are cheap to keep around.

## Test plan

Tested that `/code-monitors` 404s in dotcom mode, and behaves normally in normal mode. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
