### PR TITLE
dev/sg/autocomplete: sync completion scripts from upstream

### DIFF
--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -240,16 +239,13 @@ func categoryAdditionalSGConfiguration() category {
 					}
 					shell := usershell.ShellType(ctx)
 					autocompletePath := usershell.AutocompleteScriptPath(sgHome, shell)
-					completionScript, err := os.Open(autocompletePath)
+					completionScript, err := os.ReadFile(autocompletePath)
 					if err != nil {
 						return errors.Wrapf(err, "autocomplete script for shell %s not found", shell)
 					}
-					if completionScriptContents, err := io.ReadAll(completionScript); err != nil {
-						return errors.Wrapf(err, "could not check autocomplete script for shell %s", shell)
-					} else {
-						if string(completionScriptContents) != usershell.AutocompleteScripts[shell] {
-							return errors.Wrapf(err, "autocomplete script for shell %s is not up to date", shell)
-						}
+
+					if string(completionScript) != usershell.AutocompleteScripts[shell] {
+						return errors.Wrapf(err, "autocomplete script for shell %s is not up to date", shell)
 					}
 
 					shellConfig := usershell.ShellConfigPath(ctx)

--- a/dev/sg/dependencies/shared.go
+++ b/dev/sg/dependencies/shared.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -239,8 +240,16 @@ func categoryAdditionalSGConfiguration() category {
 					}
 					shell := usershell.ShellType(ctx)
 					autocompletePath := usershell.AutocompleteScriptPath(sgHome, shell)
-					if _, err := os.Stat(autocompletePath); err != nil {
+					completionScript, err := os.Open(autocompletePath)
+					if err != nil {
 						return errors.Wrapf(err, "autocomplete script for shell %s not found", shell)
+					}
+					if completionScriptContents, err := io.ReadAll(completionScript); err != nil {
+						return errors.Wrapf(err, "could not check autocomplete script for shell %s", shell)
+					} else {
+						if string(completionScriptContents) != usershell.AutocompleteScripts[shell] {
+							return errors.Wrapf(err, "autocomplete script for shell %s is not up to date", shell)
+						}
 					}
 
 					shellConfig := usershell.ShellConfigPath(ctx)

--- a/dev/sg/internal/usershell/autocomplete/README.md
+++ b/dev/sg/internal/usershell/autocomplete/README.md
@@ -1,3 +1,3 @@
 # autocomplete scripts
 
-Autocomplete scripts are sourced from [`urfave/cli/autocomplete`](https://github.com/urfave/cli/tree/master/autocomplete).
+Autocomplete scripts are sourced from [`urfave/cli/autocomplete`](https://github.com/urfave/cli/tree/main/autocomplete).

--- a/dev/sg/internal/usershell/autocomplete/bash_autocomplete
+++ b/dev/sg/internal/usershell/autocomplete/bash_autocomplete
@@ -2,16 +2,30 @@
 
 : ${PROG:=$(basename ${BASH_SOURCE})}
 
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+_cli_init_completion() {
+  COMPREPLY=()
+  _get_comp_words_by_ref "$@" cur prev words cword
+}
+
 _cli_bash_autocomplete() {
   if [[ "${COMP_WORDS[0]}" != "source" ]]; then
-    local cur opts base
+    local cur opts base words
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    if [[ "$cur" == "-"* ]]; then
-      opts=$(${COMP_WORDS[@]:0:$COMP_CWORD} ${cur} --generate-bash-completion)
+    if declare -F _init_completion >/dev/null 2>&1; then
+      _init_completion -n "=:" || return
     else
-      opts=$(${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion)
+      _cli_init_completion -n "=:" || return
     fi
+    words=("${words[@]:0:$cword}")
+    if [[ "$cur" == "-"* ]]; then
+      requestComp="${words[*]} ${cur} --generate-bash-completion"
+    else
+      requestComp="${words[*]} --generate-bash-completion"
+    fi
+    opts=$(eval "${requestComp}" 2>/dev/null)
     COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
     return 0
   fi

--- a/dev/sg/internal/usershell/autocomplete/zsh_autocomplete
+++ b/dev/sg/internal/usershell/autocomplete/zsh_autocomplete
@@ -1,16 +1,13 @@
 #compdef $PROG
 
-_CLI_ZSH_AUTOCOMPLETE_HACK=1
-
 _cli_zsh_autocomplete() {
-
   local -a opts
   local cur
   cur=${words[-1]}
   if [[ "$cur" == "-"* ]]; then
-    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-bash-completion)}")
   else
-    opts=("${(@f)$(_CLI_ZSH_AUTOCOMPLETE_HACK=1 ${words[@]:0:#words[@]-1} --generate-bash-completion)}")
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-bash-completion)}")
   fi
 
   if [[ "${opts[1]}" != "" ]]; then
@@ -18,8 +15,6 @@ _cli_zsh_autocomplete() {
   else
     _files
   fi
-
-  return
 }
 
 compdef _cli_zsh_autocomplete $PROG


### PR DESCRIPTION
Still trying to figure out if https://github.com/urfave/cli/issues/1822 is caused by us, I notice our completion script has fallen out of sync with upstream.

## Test plan

```
sg setup
```

play around with new completions
```
sg setup # should show completions up-to-date
```