### PR TITLE
nix: update flake for clang 16 and assert typescript 5.3.2

### DIFF
--- a/dev/nix/nodejs.nix
+++ b/dev/nix/nodejs.nix
@@ -15,7 +15,7 @@ pkgs.nodejs_20.overrideAttrs (oldAttrs: {
     };
     # fetching typescript 5.2.2 from npm registry results in an archive with a missing package-lock.json, which nix
     # refuses to build without. We can generate this lock file with `npm install --package-lock-only` but at the time I didn't
-    # want to vendor the file. Fortunately, nixpkgs-unstable has typescript at 5.2.2
-    typescript = assert typescript.version == "5.2.2"; typescript;
+    # want to vendor the file. Fortunately, nixpkgs-unstable has typescript at 5.3.2
+    typescript = assert typescript.version == "5.3.2"; typescript;
   });
 })

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698553279,
-        "narHash": "sha256-T/9P8yBSLcqo/v+FTOBK+0rjzjPMctVymZydbvR/Fak=",
+        "lastModified": 1701336116,
+        "narHash": "sha256-kEmpezCR/FpITc6yMbAh4WrOCiT2zg5pSjnKrq51h5Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90e85bc7c1a6fc0760a94ace129d3a1c61c3d035",
+        "rev": "f5c27c6136db4d76c30e533c20517df6864c46ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update flake so that we can use clang 16 on darwin
## Test plan
* nix develop
```
clang --version
clang version 16.0.6
Target: arm64-apple-darwin
Thread model: posix
InstalledDir: /nix/store/a5v30qll5i02vr9y97bk1rdx3mm6kvlm-clang-16.0.6/bin
```
