### PR TITLE
Recreate repo statistics every Sunday morning

### DIFF
--- a/cmd/worker/internal/repostatistics/BUILD.bazel
+++ b/cmd/worker/internal/repostatistics/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "repostatistics",
-    srcs = ["compactor.go"],
+    srcs = [
+        "compactor.go",
+        "resetter.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/worker/internal/repostatistics",
     visibility = ["//cmd/worker:__subpackages__"],
     deps = [

--- a/cmd/worker/internal/repostatistics/BUILD.bazel
+++ b/cmd/worker/internal/repostatistics/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//internal/goroutine",
         "//internal/observation",
         "//lib/errors",
+        "@com_github_jackc_pgconn//:pgconn",
         "@com_github_sourcegraph_log//:log",
     ],
 )

--- a/cmd/worker/internal/repostatistics/resetter.go
+++ b/cmd/worker/internal/repostatistics/resetter.go
@@ -1,0 +1,84 @@
+package repostatistics
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/job"
+	workerdb "github.com/sourcegraph/sourcegraph/cmd/worker/shared/init/db"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// resetter is a worker responsible for deleting all rows in
+// `repo_statistics`/`gitserver_repos_statistics` and recreating their value.
+//
+// This is done because sometimes the statistics might get out of sync
+// (possibly due to people modifying the `repo` table by hand)
+type resetter struct{}
+
+func NewResetter() job.Job {
+	return &resetter{}
+}
+
+func (j *resetter) Description() string {
+	return ""
+}
+
+func (j *resetter) Config() []env.Config {
+	return nil
+}
+
+func (j *resetter) Routines(_ context.Context, observationCtx *observation.Context) ([]goroutine.BackgroundRoutine, error) {
+	db, err := workerdb.InitDB(observationCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	return []goroutine.BackgroundRoutine{
+		goroutine.NewPeriodicGoroutine(
+			context.Background(),
+			&resetterHandler{
+				store:  db.RepoStatistics(),
+				logger: observationCtx.Logger,
+			},
+			goroutine.WithName("repomgmt.statistics-resetter"),
+			goroutine.WithDescription("resets repo statistics"),
+			goroutine.WithInterval(30*time.Minute),
+		),
+	}, nil
+}
+
+type resetterHandler struct {
+	store  database.RepoStatisticsStore
+	logger log.Logger
+}
+
+var _ goroutine.Handler = &resetterHandler{}
+
+func (h *resetterHandler) Handle(ctx context.Context) error {
+	// We only run this handler once a week, Sunday morning between 2:00 and
+	// 2:30 UTC, because it might run for 2-3 minutes.
+	now := time.Now().UTC()
+	isSunday := now.Weekday() == time.Sunday
+	isBetween2And230 := now.Hour() == 2 && now.Minute() < 30
+
+	if !isSunday || !isBetween2And230 {
+		h.logger.Debug("Skipping deleting and recreating statistics; not Sunday between 2-2:30 UTC")
+		return nil
+	}
+
+	// It's Sunday and between 2:00 and 2:30 AM UTC
+	h.logger.Info("Deleting and recreating repo statistics")
+
+	// We use a 5 minute timeout here to prevent the table lock from taking
+	// down the instance.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	return h.store.DeleteAndRecreateStatistics(ctx)
+}

--- a/cmd/worker/internal/repostatistics/resetter.go
+++ b/cmd/worker/internal/repostatistics/resetter.go
@@ -65,9 +65,11 @@ var _ goroutine.Handler = &resetterHandler{}
 func (h *resetterHandler) Handle(ctx context.Context) error {
 	// We only run this handler once a week, Sunday morning between 2:00 and
 	// 2:30 UTC, because it might run for 2-3 minutes.
+	//
+	// TODO: we temporarily run this on Monday, 10 UTC, to see how it behaves
 	now := time.Now().UTC()
-	isSunday := now.Weekday() == time.Sunday
-	isBetween2And230 := now.Hour() == 2 && now.Minute() < 30
+	isSunday := now.Weekday() == time.Monday
+	isBetween2And230 := now.Hour() == 10 && now.Minute() < 30
 
 	if !isSunday || !isBetween2And230 {
 		h.logger.Debug("Skipping deleting and recreating statistics; not Sunday between 2-2:30 UTC")

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -77,6 +77,7 @@ func LoadConfig(registerEnterpriseMigrators oobmigration.RegisterMigratorsFunc) 
 		"gitserver-metrics":                     gitserver.NewMetricsJob(),
 		"record-encrypter":                      encryption.NewRecordEncrypterJob(),
 		"repo-statistics-compactor":             repostatistics.NewCompactor(),
+		"repo-statistics-resetter":              repostatistics.NewResetter(),
 		"zoekt-repos-updater":                   zoektrepos.NewUpdater(),
 		"outbound-webhook-sender":               outboundwebhooks.NewSender(),
 		"license-check":                         licensecheck.NewJob(),

--- a/doc/admin/workers.md
+++ b/doc/admin/workers.md
@@ -136,7 +136,15 @@ This job dispatches HTTP requests for outbound webhooks and periodically removes
 
 #### `repo-statistics-compactor`
 
-This job periodically cleans up the `repo_statistics` table by rolling up all rows into a single row.
+This job periodically cleans up the `repo_statistics` and `gitserver_repos_statistics` tables by rolling up all rows into a single row.
+
+#### `repo-statistics-resetter`
+
+This job cleans up and recreates the `repo_statistics`/`gitserver_repos_statistics` table.
+
+**Attention:** it requires exclusive locks on the `repo` and `gitserver_repos`, which means it might take 3-4 minutes to run if the instance is very busy.
+
+It's only running on Sunday mornings at ~2am UTC.
 
 #### `record-encrypter`
 

--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -59657,6 +59657,10 @@ type MockRepoStatisticsStore struct {
 	// CompactRepoStatisticsFunc is an instance of a mock function object
 	// controlling the behavior of the method CompactRepoStatistics.
 	CompactRepoStatisticsFunc *RepoStatisticsStoreCompactRepoStatisticsFunc
+	// DeleteAndRecreateStatisticsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// DeleteAndRecreateStatistics.
+	DeleteAndRecreateStatisticsFunc *RepoStatisticsStoreDeleteAndRecreateStatisticsFunc
 	// GetGitserverReposStatisticsFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// GetGitserverReposStatistics.
@@ -59686,6 +59690,11 @@ func NewMockRepoStatisticsStore() *MockRepoStatisticsStore {
 			},
 		},
 		CompactRepoStatisticsFunc: &RepoStatisticsStoreCompactRepoStatisticsFunc{
+			defaultHook: func(context.Context) (r0 error) {
+				return
+			},
+		},
+		DeleteAndRecreateStatisticsFunc: &RepoStatisticsStoreDeleteAndRecreateStatisticsFunc{
 			defaultHook: func(context.Context) (r0 error) {
 				return
 			},
@@ -59733,6 +59742,11 @@ func NewStrictMockRepoStatisticsStore() *MockRepoStatisticsStore {
 				panic("unexpected invocation of MockRepoStatisticsStore.CompactRepoStatistics")
 			},
 		},
+		DeleteAndRecreateStatisticsFunc: &RepoStatisticsStoreDeleteAndRecreateStatisticsFunc{
+			defaultHook: func(context.Context) error {
+				panic("unexpected invocation of MockRepoStatisticsStore.DeleteAndRecreateStatistics")
+			},
+		},
 		GetGitserverReposStatisticsFunc: &RepoStatisticsStoreGetGitserverReposStatisticsFunc{
 			defaultHook: func(context.Context) ([]database.GitserverReposStatistic, error) {
 				panic("unexpected invocation of MockRepoStatisticsStore.GetGitserverReposStatistics")
@@ -59771,6 +59785,9 @@ func NewMockRepoStatisticsStoreFrom(i database.RepoStatisticsStore) *MockRepoSta
 		},
 		CompactRepoStatisticsFunc: &RepoStatisticsStoreCompactRepoStatisticsFunc{
 			defaultHook: i.CompactRepoStatistics,
+		},
+		DeleteAndRecreateStatisticsFunc: &RepoStatisticsStoreDeleteAndRecreateStatisticsFunc{
+			defaultHook: i.DeleteAndRecreateStatistics,
 		},
 		GetGitserverReposStatisticsFunc: &RepoStatisticsStoreGetGitserverReposStatisticsFunc{
 			defaultHook: i.GetGitserverReposStatistics,
@@ -59999,6 +60016,112 @@ func (c RepoStatisticsStoreCompactRepoStatisticsFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c RepoStatisticsStoreCompactRepoStatisticsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0}
+}
+
+// RepoStatisticsStoreDeleteAndRecreateStatisticsFunc describes the behavior
+// when the DeleteAndRecreateStatistics method of the parent
+// MockRepoStatisticsStore instance is invoked.
+type RepoStatisticsStoreDeleteAndRecreateStatisticsFunc struct {
+	defaultHook func(context.Context) error
+	hooks       []func(context.Context) error
+	history     []RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall
+	mutex       sync.Mutex
+}
+
+// DeleteAndRecreateStatistics delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockRepoStatisticsStore) DeleteAndRecreateStatistics(v0 context.Context) error {
+	r0 := m.DeleteAndRecreateStatisticsFunc.nextHook()(v0)
+	m.DeleteAndRecreateStatisticsFunc.appendCall(RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall{v0, r0})
+	return r0
+}
+
+// SetDefaultHook sets function that is called when the
+// DeleteAndRecreateStatistics method of the parent MockRepoStatisticsStore
+// instance is invoked and the hook queue is empty.
+func (f *RepoStatisticsStoreDeleteAndRecreateStatisticsFunc) SetDefaultHook(hook func(context.Context) error) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// DeleteAndRecreateStatistics method of the parent MockRepoStatisticsStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *RepoStatisticsStoreDeleteAndRecreateStatisticsFunc) PushHook(hook func(context.Context) error) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *RepoStatisticsStoreDeleteAndRecreateStatisticsFunc) SetDefaultReturn(r0 error) {
+	f.SetDefaultHook(func(context.Context) error {
+		return r0
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *RepoStatisticsStoreDeleteAndRecreateStatisticsFunc) PushReturn(r0 error) {
+	f.PushHook(func(context.Context) error {
+		return r0
+	})
+}
+
+func (f *RepoStatisticsStoreDeleteAndRecreateStatisticsFunc) nextHook() func(context.Context) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *RepoStatisticsStoreDeleteAndRecreateStatisticsFunc) appendCall(r0 RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall objects describing
+// the invocations of this function.
+func (f *RepoStatisticsStoreDeleteAndRecreateStatisticsFunc) History() []RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall {
+	f.mutex.Lock()
+	history := make([]RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall is an object that
+// describes an invocation of method DeleteAndRecreateStatistics on an
+// instance of MockRepoStatisticsStore.
+type RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c RepoStatisticsStoreDeleteAndRecreateStatisticsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 

--- a/internal/database/repo_statistics.go
+++ b/internal/database/repo_statistics.go
@@ -43,6 +43,7 @@ type RepoStatisticsStore interface {
 	CompactRepoStatistics(ctx context.Context) error
 	GetGitserverReposStatistics(ctx context.Context) ([]GitserverReposStatistic, error)
 	CompactGitserverReposStatistics(ctx context.Context) error
+	DeleteAndRecreateStatistics(ctx context.Context) error
 }
 
 // repoStatisticsStore is responsible for data stored in the repo_statistics
@@ -161,6 +162,76 @@ SELECT
 	SUM(failed_fetch) AS failed_fetch,
 	SUM(corrupted) AS corrupted
 FROM gitserver_repos_statistics
+GROUP BY shard_id
+`
+
+func (s *repoStatisticsStore) DeleteAndRecreateStatistics(ctx context.Context) (err error) {
+	tx, err := s.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	// First lock repo, since we have triggers that write repo and cause updates on
+	// gitserver_repos but not the other way around.
+	if err := tx.Exec(ctx, sqlf.Sprintf(`LOCK repo IN EXCLUSIVE MODE`)); err != nil {
+		return err
+	}
+	// Then lock gitserver_repos
+	if err := tx.Exec(ctx, sqlf.Sprintf(`LOCK gitserver_repos IN EXCLUSIVE MODE`)); err != nil {
+		return err
+	}
+
+	// Delete old state in repo_statistics/gitserver_repo_statistics (we can't
+	// update the state, since this is an append-only table).
+	if err := tx.Exec(ctx, sqlf.Sprintf(`DELETE FROM repo_statistics`)); err != nil {
+		return err
+	}
+	if err := tx.Exec(ctx, sqlf.Sprintf(`DELETE FROM gitserver_repos_statistics`)); err != nil {
+		return err
+	}
+
+	// Insert new total counts in repo_statistics
+	if err := tx.Exec(ctx, sqlf.Sprintf(recreateRepoStatisticsStateQuery)); err != nil {
+		return err
+	}
+	// Insert new total counts in gitserver_repos_statistics
+	if err := tx.Exec(ctx, sqlf.Sprintf(recreateGitserverReposStatisticsQuery)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const recreateRepoStatisticsStateQuery = `
+INSERT INTO repo_statistics (total, soft_deleted, not_cloned, cloning, cloned, failed_fetch, corrupted)
+SELECT
+  COUNT(*) AS total,
+  (SELECT COUNT(*) FROM repo WHERE deleted_at is NOT NULL AND blocked IS NULL) AS soft_deleted,
+  COUNT(*) FILTER(WHERE gitserver_repos.clone_status = 'not_cloned') AS not_cloned,
+  COUNT(*) FILTER(WHERE gitserver_repos.clone_status = 'cloning') AS cloning,
+  COUNT(*) FILTER(WHERE gitserver_repos.clone_status = 'cloned') AS cloned,
+  COUNT(*) FILTER(WHERE gitserver_repos.last_error IS NOT NULL) AS failed_fetch,
+  COUNT(*) FILTER(WHERE gitserver_repos.corrupted_at IS NOT NULL) AS corrupted
+FROM repo
+JOIN gitserver_repos ON gitserver_repos.repo_id = repo.id
+WHERE
+  repo.deleted_at is NULL AND repo.blocked IS NULL
+`
+
+const recreateGitserverReposStatisticsQuery = `
+INSERT INTO
+  gitserver_repos_statistics (shard_id, total, not_cloned, cloning, cloned, failed_fetch, corrupted)
+SELECT
+  shard_id,
+  COUNT(*) AS total,
+  COUNT(*) FILTER(WHERE clone_status = 'not_cloned') AS not_cloned,
+  COUNT(*) FILTER(WHERE clone_status = 'cloning') AS cloning,
+  COUNT(*) FILTER(WHERE clone_status = 'cloned') AS cloned,
+  COUNT(*) FILTER(WHERE last_error IS NOT NULL) AS failed_fetch,
+  COUNT(*) FILTER(WHERE corrupted_at IS NOT NULL) AS corrupted
+FROM
+  gitserver_repos
 GROUP BY shard_id
 `
 

--- a/internal/database/repo_statistics_test.go
+++ b/internal/database/repo_statistics_test.go
@@ -577,6 +577,10 @@ func TestReposStatisticsStore_DeleteAndRecreateStatistics(t *testing.T) {
 	ctx := context.Background()
 	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
 
+	// Safety check: make sure it works with empty table
+	err := s.DeleteAndRecreateStatistics(ctx)
+	require.NoError(t, err)
+
 	shards := []string{
 		"shard-1",
 		"shard-2",
@@ -618,7 +622,7 @@ func TestReposStatisticsStore_DeleteAndRecreateStatistics(t *testing.T) {
 	assertRepoStatistics(t, ctx, s, wantRepoStatistics, wantGitserverReposStatistics)
 
 	// Now delete and recreate
-	err := s.DeleteAndRecreateStatistics(ctx)
+	err = s.DeleteAndRecreateStatistics(ctx)
 	require.NoError(t, err)
 
 	// Should be the same, except the empty shard is gone

--- a/internal/database/repo_statistics_test.go
+++ b/internal/database/repo_statistics_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -564,6 +565,69 @@ func TestGitserverReposStatistics_Compaction(t *testing.T) {
 	if count != wantCount {
 		t.Fatalf("wrong statistics count. have=%d, want=%d", count, wantCount)
 	}
+}
+
+func TestReposStatisticsStore_DeleteAndRecreateStatistics(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(t))
+	ctx := context.Background()
+	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
+
+	shards := []string{
+		"shard-1",
+		"shard-2",
+		"shard-3",
+	}
+	repos := types.Repos{
+		&types.Repo{Name: "repo1"},
+		&types.Repo{Name: "repo2"},
+		&types.Repo{Name: "repo3"},
+		&types.Repo{Name: "repo4"},
+		&types.Repo{Name: "repo5"},
+		&types.Repo{Name: "repo6"},
+	}
+
+	// Trigger 21 insertions into gitserver_repos_statistics table:
+	// 6 repos added: 6 rows
+	createTestRepos(ctx, t, db, repos)
+	// 6 clone status changes and shard assignments: 12 rows
+	setCloneStatus(t, db, repos[0].Name, shards[0], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[1].Name, shards[0], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[2].Name, shards[1], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[3].Name, shards[1], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[4].Name, shards[2], types.CloneStatusCloning)
+	setCloneStatus(t, db, repos[5].Name, shards[2], types.CloneStatusCloning)
+	// 2 errors: 2 rows
+	setLastError(t, db, repos[0].Name, shards[0], "internet broke repo-1")
+	setLastError(t, db, repos[4].Name, shards[2], "internet broke repo-5")
+	// 1 corruption: 1 row
+	logCorruption(t, db, repos[2].Name, shards[1], "runaway corruption repo-3")
+
+	// Safety check that the counts are right:
+	wantRepoStatistics := RepoStatistics{Total: 6, Cloning: 6, FailedFetch: 2, Corrupted: 1}
+	wantGitserverReposStatistics := []GitserverReposStatistic{
+		{ShardID: ""},
+		{ShardID: shards[0], Total: 2, Cloning: 2, FailedFetch: 1},
+		{ShardID: shards[1], Total: 2, Cloning: 2, FailedFetch: 0, Corrupted: 1},
+		{ShardID: shards[2], Total: 2, Cloning: 2, FailedFetch: 1},
+	}
+	assertRepoStatistics(t, ctx, s, wantRepoStatistics, wantGitserverReposStatistics)
+
+	// Now delete and recreate
+	err := s.DeleteAndRecreateStatistics(ctx)
+	require.NoError(t, err)
+
+	// Should be the same, except the empty shard is gone
+	wantGitserverReposStatistics = []GitserverReposStatistic{
+		{ShardID: shards[0], Total: 2, Cloning: 2, FailedFetch: 1},
+		{ShardID: shards[1], Total: 2, Cloning: 2, FailedFetch: 0, Corrupted: 1},
+		{ShardID: shards[2], Total: 2, Cloning: 2, FailedFetch: 1},
+	}
+	assertRepoStatistics(t, ctx, s, wantRepoStatistics, wantGitserverReposStatistics)
 }
 
 func queryRepoName(t *testing.T, ctx context.Context, s *repoStatisticsStore, repoID api.RepoID) api.RepoName {


### PR DESCRIPTION
We've noticed over the past year that sometimes there can be drift in the `repo_statistics` and `gitserver_repo_statistics` tables. We still don't know why, our strongest hypothesis is that it's because someone hand-modifies the `repo` table.

In any case: it doesn't hurt to make the statistics self-repairing.

The only downside is that the worker requires an exclusive lock on the `repo` and `gitserver_repos` tables, which are some of our busiest tables.

That's why we only run it when the instance is presumably _not_ busy and we also use a 5min timeout.

## Test plan

- Unit tests
- Manually ran the worker every 1s to make sure it doesn't run

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@mrn/recreate-repo-statistics)