### PR TITLE
bzl: fix repo name for executor-vm

### DIFF
--- a/docker-images/executor-vm/BUILD.bazel
+++ b/docker-images/executor-vm/BUILD.bazel
@@ -10,11 +10,11 @@ oci_image(
 oci_tarball(
     name = "image_tarball",
     image = ":image",
-    repo_tags = ["executor_vm:candidate"],
+    repo_tags = ["executor-vm:candidate"],
 )
 
 oci_push(
     name = "candidate_push",
     image = ":image",
-    repository = image_repository("executor_vm"),
+    repository = image_repository("executor-vm"),
 )


### PR DESCRIPTION
We spotted a typo with @burmudar that was real hard to catch during a review. It has no incidence on the final image name that gets pushed, but during the build, it's incorrect. 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
