### PR TITLE
repo statistics: coalesce when compacting table

### DIFF
--- a/internal/database/repo_statistics.go
+++ b/internal/database/repo_statistics.go
@@ -108,13 +108,13 @@ WITH deleted AS (
 )
 INSERT INTO repo_statistics (total, soft_deleted, not_cloned, cloning, cloned, failed_fetch, corrupted)
 SELECT
-	SUM(total),
-	SUM(soft_deleted),
-	SUM(not_cloned),
-	SUM(cloning),
-	SUM(cloned),
-	SUM(failed_fetch),
-	SUM(corrupted)
+	COALESCE(SUM(total), 0),
+	COALESCE(SUM(soft_deleted), 0),
+	COALESCE(SUM(not_cloned), 0),
+	COALESCE(SUM(cloning), 0),
+	COALESCE(SUM(cloned), 0),
+	COALESCE(SUM(failed_fetch), 0),
+	COALESCE(SUM(corrupted), 0)
 FROM deleted;
 `
 

--- a/internal/database/repo_statistics_test.go
+++ b/internal/database/repo_statistics_test.go
@@ -419,6 +419,15 @@ func TestRepoStatistics_Compaction(t *testing.T) {
 	ctx := context.Background()
 	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
 
+	// Empty table, should work, even though we should always have a row in
+	// there with 0 values.
+	if err := s.Exec(ctx, sqlf.Sprintf("DELETE FROM repo_statistics")); err != nil {
+		t.Fatalf("failed to query repo name: %s", err)
+	}
+	if err := s.CompactRepoStatistics(ctx); err != nil {
+		t.Fatalf("CompactRepoStatistics failed: %s", err)
+	}
+
 	shards := []string{
 		"shard-1",
 		"shard-2",
@@ -496,6 +505,15 @@ func TestGitserverReposStatistics_Compaction(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 	s := &repoStatisticsStore{Store: basestore.NewWithHandle(db.Handle())}
+
+	// Empty table, should work, even though we should always have a row in
+	// there with 0 values.
+	if err := s.Exec(ctx, sqlf.Sprintf("DELETE FROM gitserver_repos_statistics")); err != nil {
+		t.Fatalf("failed to query repo name: %s", err)
+	}
+	if err := s.CompactGitserverReposStatistics(ctx); err != nil {
+		t.Fatalf("CompactGitserverReposStatistics failed: %s", err)
+	}
 
 	shards := []string{
 		"shard-1",


### PR DESCRIPTION
This is an edge case, because we should always have `0` values in the table, but maybe sometimes we don't due to manual editing or something. So let's be on the safe side.

## Test plan

- Manual testing of both queries in SQL console
- Unit tests