### PR TITLE
Allow refreshing usage limits for dotcom users

### DIFF
--- a/cmd/cody-gateway/internal/actor/source_test.go
+++ b/cmd/cody-gateway/internal/actor/source_test.go
@@ -26,7 +26,13 @@ type mockSourceSyncer struct {
 	syncCount atomic.Int32
 }
 
+type mockSourceSingleSyncer struct {
+	mockSourceSyncer
+}
+
 var _ SourceSyncer = &mockSourceSyncer{}
+
+var _ SourceSingleSyncer = &mockSourceSingleSyncer{}
 
 func (m *mockSourceSyncer) Name() string { return "mock" }
 
@@ -37,6 +43,11 @@ func (m *mockSourceSyncer) Get(context.Context, string) (*Actor, error) {
 func (m *mockSourceSyncer) Sync(context.Context) (int, error) {
 	m.syncCount.Inc()
 	return 10, nil
+}
+
+func (m *mockSourceSingleSyncer) SyncOne(_ context.Context, _ string) error {
+	m.syncCount.Inc()
+	return nil
 }
 
 func TestSourcesWorkers(t *testing.T) {
@@ -131,6 +142,26 @@ func TestSourcesSyncAll(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), s1.syncCount.Load())
 	assert.Equal(t, int32(2), s2.syncCount.Load())
+}
+
+func TestSourcesSyncOne(t *testing.T) {
+	t.Parallel()
+
+	var s1 mockSourceSyncer
+	var s2 mockSourceSingleSyncer
+	var s3 mockSourceSingleSyncer
+	sources := NewSources(&s1, &s2, &s3)
+	err := sources.SyncOne(context.Background(), "sgd_qweqweqw")
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), s1.syncCount.Load())
+	assert.Equal(t, int32(1), s2.syncCount.Load())
+	assert.Equal(t, int32(0), s3.syncCount.Load())
+
+	err = sources.SyncOne(context.Background(), "sgd_qweqweqw")
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), s1.syncCount.Load())
+	assert.Equal(t, int32(2), s2.syncCount.Load())
+	assert.Equal(t, int32(0), s3.syncCount.Load())
 }
 
 func TestIsErrNotFromSource(t *testing.T) {

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//cmd/cody-gateway/internal/limiter",
         "//cmd/cody-gateway/internal/notify",
         "//cmd/cody-gateway/internal/response",
+        "//internal/authbearer",
         "//internal/codygateway",
         "//internal/completions/types",
         "//internal/trace",

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -210,7 +210,7 @@ func ListLimitsHandler(baseLogger log.Logger, redisStore limiter.RedisStore) htt
 	})
 }
 
-func RefreshLimitsHandler(baseLogger log.Logger, eventLogger events.Logger, redisStore limiter.RedisStore, sources *actor.Sources) http.Handler {
+func RefreshLimitsHandler(baseLogger log.Logger, sources *actor.Sources) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		act := actor.FromContext(r.Context())
 		logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -214,10 +214,12 @@ func RefreshLimitsHandler(baseLogger log.Logger, sources *actor.Sources) http.Ha
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		act := actor.FromContext(r.Context())
 		logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))
+
 		token, err := authbearer.ExtractBearer(r.Header)
 		if err != nil {
 			response.JSONError(logger, w, http.StatusBadRequest, err)
 		}
+
 		err = sources.SyncOne(r.Context(), token)
 		if err != nil {
 			response.JSONError(logger, w, http.StatusBadRequest, err)

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -3,6 +3,7 @@ package featurelimiter
 import (
 	"context"
 	"encoding/json"
+	"github.com/sourcegraph/sourcegraph/internal/authbearer"
 	"net/http"
 	"strings"
 	"time"
@@ -71,7 +72,7 @@ func extractFeature(r *http.Request) (codygateway.Feature, error) {
 	return codygateway.Feature(feature), nil
 }
 
-// Handle uses a predefined feature to determine the appropriate per-feature
+// HandleFeature uses a predefined feature to determine the appropriate per-feature
 // rate limits applied for an actor.
 func HandleFeature(
 	baseLogger log.Logger,
@@ -154,7 +155,7 @@ func HandleFeature(
 }
 
 // ListLimitsHandler returns a map of all features and their current rate limit usages.
-func ListLimitsHandler(baseLogger log.Logger, eventLogger events.Logger, redisStore limiter.RedisStore) http.Handler {
+func ListLimitsHandler(baseLogger log.Logger, redisStore limiter.RedisStore) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		act := actor.FromContext(r.Context())
 		logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))
@@ -164,7 +165,7 @@ func ListLimitsHandler(baseLogger log.Logger, eventLogger events.Logger, redisSt
 		// Iterate over all features.
 		for _, f := range codygateway.AllFeatures {
 			// Get the limiter, but don't log any rate limit events, the only limits enforced
-			// here are concurrency limits and we should not care about those.
+			// here are concurrency limits, and we should not care about those.
 			l, ok := act.Limiter(logger, redisStore, f, noopRateLimitNotifier)
 			if !ok {
 				response.JSONError(logger, w, http.StatusForbidden, errors.Newf("no access to feature %s", f))
@@ -209,6 +210,21 @@ func ListLimitsHandler(baseLogger log.Logger, eventLogger events.Logger, redisSt
 	})
 }
 
+func RefreshLimitsHandler(baseLogger log.Logger, eventLogger events.Logger, redisStore limiter.RedisStore, sources *actor.Sources) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		act := actor.FromContext(r.Context())
+		logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))
+		token, err := authbearer.ExtractBearer(r.Header)
+		if err != nil {
+			response.JSONError(logger, w, http.StatusBadRequest, err)
+		}
+		err = sources.SyncOne(r.Context(), token)
+		if err != nil {
+			response.JSONError(logger, w, http.StatusBadRequest, err)
+		}
+	})
+}
+
 type listLimitElement struct {
 	Limit         int64      `json:"limit"`
 	Interval      string     `json:"interval"`
@@ -217,6 +233,6 @@ type listLimitElement struct {
 	AllowedModels []string   `json:"allowedModels"`
 }
 
-func noopRateLimitNotifier(ctx context.Context, actor codygateway.Actor, feature codygateway.Feature, usageRatio float32, ttl time.Duration) {
+func noopRateLimitNotifier(_ context.Context, _ codygateway.Actor, _ codygateway.Feature, _ float32, _ time.Duration) {
 	// nothing
 }

--- a/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/handler.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"context"
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -57,6 +58,7 @@ func NewHandler(
 	authr *auth.Authenticator,
 	promptRecorder completions.PromptRecorder,
 	config *Config,
+	sources *actor.Sources,
 ) (http.Handler, error) {
 	// Initialize metrics
 	counter, err := meter.Int64UpDownCounter("cody-gateway.concurrent_upstream_requests",
@@ -199,14 +201,25 @@ func NewHandler(
 			),
 		)
 	}
-
+	// Register a route where actors can refresh their rate limit state.
+	v1router.Path("/limits/refresh").Methods(http.MethodPost).Handler(
+		instrumentation.HTTPMiddleware("v1.limits",
+			authr.Middleware(
+				requestlogger.Middleware(
+					logger,
+					featurelimiter.RefreshLimitsHandler(logger, eventLogger, rs, sources),
+				),
+			),
+			otelhttp.WithPublicEndpoint(),
+		),
+	)
 	// Register a route where actors can retrieve their current rate limit state.
 	v1router.Path("/limits").Methods(http.MethodGet).Handler(
 		instrumentation.HTTPMiddleware("v1.limits",
 			authr.Middleware(
 				requestlogger.Middleware(
 					logger,
-					featurelimiter.ListLimitsHandler(logger, eventLogger, rs),
+					featurelimiter.ListLimitsHandler(logger, rs),
 				),
 			),
 			otelhttp.WithPublicEndpoint(),

--- a/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/handler.go
@@ -201,18 +201,7 @@ func NewHandler(
 			),
 		)
 	}
-	// Register a route where actors can refresh their rate limit state.
-	v1router.Path("/limits/refresh").Methods(http.MethodPost).Handler(
-		instrumentation.HTTPMiddleware("v1.limits",
-			authr.Middleware(
-				requestlogger.Middleware(
-					logger,
-					featurelimiter.RefreshLimitsHandler(logger, eventLogger, rs, sources),
-				),
-			),
-			otelhttp.WithPublicEndpoint(),
-		),
-	)
+
 	// Register a route where actors can retrieve their current rate limit state.
 	v1router.Path("/limits").Methods(http.MethodGet).Handler(
 		instrumentation.HTTPMiddleware("v1.limits",
@@ -225,7 +214,18 @@ func NewHandler(
 			otelhttp.WithPublicEndpoint(),
 		),
 	)
-
+	// Register a route where actors can refresh their rate limit state.
+	v1router.Path("/limits/refresh").Methods(http.MethodPost).Handler(
+		instrumentation.HTTPMiddleware("v1.limits",
+			authr.Middleware(
+				requestlogger.Middleware(
+					logger,
+					featurelimiter.RefreshLimitsHandler(logger, sources),
+				),
+			),
+			otelhttp.WithPublicEndpoint(),
+		),
+	)
 	return r, nil
 }
 

--- a/cmd/cody-gateway/shared/main.go
+++ b/cmd/cody-gateway/shared/main.go
@@ -169,7 +169,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 			FireworksAllowedModels:                      config.Fireworks.AllowedModels,
 			FireworksLogSelfServeCodeCompletionRequests: config.Fireworks.LogSelfServeCodeCompletionRequests,
 			EmbeddingsAllowedModels:                     config.AllowedEmbeddingsModels,
-		})
+		}, sources)
 	if err != nil {
 		return errors.Wrap(err, "httpapi.NewHandler")
 	}


### PR DESCRIPTION
This PR adds a `/v1/limits/refresh` API endpoint to Cody Gateway, allowing an authenticated user to trigger a refresh of their limit (bypassing the Cody Gateway cache), [context](https://sourcegraph.slack.com/archives/C05SZB829D0/p1701364254661389?thread_ts=1701187278.753019&cid=C05SZB829D0). This endpoint:

- doesn't accept any parameters or return any values
- blocks until the refresh is complete
- replaces a cached value with a newly read value 
-- in case of errors, the cached value is not updated

This is currently only implemented for sourcegraph.com users using a `dotcom-user` Source (i.e. not Product Subscriptions). 

As a [follow-up](https://github.com/sourcegraph/sourcegraph/issues/58734) we should make sure people don't use it to refresh the token "too often" (making sourcegraph.com do more work). 
## Test plan

- some unit tests + tested locally (this relies on integration of multiple system, and is not trivally unit testable)