### PR TITLE
search jobs: allow explicit type:file

### DIFF
--- a/internal/search/exhaustive/service/searcher.go
+++ b/internal/search/exhaustive/service/searcher.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -26,10 +27,15 @@ func FromSearchClient(client client.SearchClient) NewSearcher {
 			return nil, err
 		}
 
-		// TODO this hack is an ugly workaround to get the plan and jobs to
-		// get into a shape we like. it will break in bad ways but works for
-		// EAP.
-		q = "type:file index:no " + q
+		// We run queries on searcher only which makes it easier to control limits. Low
+		// latency is not a priority of Search Jobs.
+		q = "index:no " + q
+
+		// TODO this hack is an ugly workaround to limit searches to type:file only.
+		// This is OK for the EAP but we should remove the limitation soon.
+		if strings.Index(q, "type:file") == -1 {
+			q = "type:file " + q
+		}
 
 		inputs, err := client.Plan(
 			ctx,

--- a/internal/search/exhaustive/service/searcher.go
+++ b/internal/search/exhaustive/service/searcher.go
@@ -33,7 +33,7 @@ func FromSearchClient(client client.SearchClient) NewSearcher {
 
 		// TODO this hack is an ugly workaround to limit searches to type:file only.
 		// This is OK for the EAP but we should remove the limitation soon.
-		if strings.Index(q, "type:file") == -1 {
+		if !strings.Contains(q, "type:file") {
 			q = "type:file " + q
 		}
 

--- a/internal/search/exhaustive/service/searcher_test.go
+++ b/internal/search/exhaustive/service/searcher_test.go
@@ -100,6 +100,16 @@ bar2,commitbar0,,1,/bar2@commitbar0/-/blob/?L2
 `),
 	})
 
+	do("explicit type:file", newSearcherTestCase{
+		Query:        "content type:file",
+		WantRefSpecs: "RepositoryRevSpec{1@HEAD} RepositoryRevSpec{2@HEAD} RepositoryRevSpec{3@HEAD}",
+		WantRepoRevs: "RepositoryRevision{1@HEAD} RepositoryRevision{2@HEAD} RepositoryRevision{3@HEAD}",
+		WantCSV: autogold.Expect(`repository,revision,file_path,match_count,first_match_url
+foo1,commitfoo0,,1,/foo1@commitfoo0/-/blob/?L2
+bar2,commitbar0,,1,/bar2@commitbar0/-/blob/?L2
+`),
+	})
+
 	do("repo", newSearcherTestCase{
 		Query:        "repo:foo content",
 		WantRefSpecs: "RepositoryRevSpec{1@HEAD}",
@@ -128,7 +138,7 @@ foo1,commitfoo2,,1,/foo1@commitfoo2/-/blob/?L2
 `),
 	})
 
-	do("globall", newSearcherTestCase{
+	do("global", newSearcherTestCase{
 		Query:        "repo:. rev:*refs/heads/dev* content",
 		WantRefSpecs: "RepositoryRevSpec{1@*refs/heads/dev*} RepositoryRevSpec{2@*refs/heads/dev*} RepositoryRevSpec{3@*refs/heads/dev*}",
 		WantRepoRevs: "RepositoryRevision{1@dev1} RepositoryRevision{1@dev2} RepositoryRevision{2@dev1}",


### PR DESCRIPTION
This fixes a bug which caused search jobs validation to return an error if a user specified an explicit `type:file` filter in the query.

Test plan:
new unit test

