### PR TITLE
sg generate: report duration for bazel step

### DIFF
--- a/dev/sg/generates.go
+++ b/dev/sg/generates.go
@@ -47,11 +47,7 @@ var allGenerateTargets = generateTargets{
 }
 
 func generateBazelRunner(ctx context.Context, args []string) *generate.Report {
-	if report := generate.RunScript("bazel run //dev:write_all_generated")(ctx, args); report.Err != nil {
-		return report
-	}
-
-	return &generate.Report{}
+	return generate.RunScript("bazel run //dev:write_all_generated")(ctx, args)
 }
 
 func generateGoRunner(ctx context.Context, args []string) *generate.Report {


### PR DESCRIPTION
Previously it would always report 0s for Bazel, even though it takes way longer than that (and many more cores :P).

This change returns the report as-is which means the duration reporting is correct.


## Test plan

- Run `go run ./dev/sg generate` and see `✅ Target "bazel" done (116s)`
