### PR TITLE
release: remove manual migration bazel output generation func

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -82,7 +82,6 @@ import {
     validateNoReleaseBlockers,
     verifyWithInput,
     type ReleaseTag,
-    updateMigratorBazelOuts,
     getContainerRegistryCredential,
 } from './util'
 
@@ -731,7 +730,6 @@ cc @${release.captainGitHubUsername}
                                 ? `comby -in-place 'const minimumUpgradeableVersion = ":[1]"' 'const minimumUpgradeableVersion = "${release.version.version}"' dev/ci/internal/ci/*.go`
                                 : 'echo "Skipping minimumUpgradeableVersion bump on patch release"',
                             updateUpgradeGuides(release.previous.version, release.version.version),
-                            updateMigratorBazelOuts(release.version.version),
                         ],
                         ...prBodyAndDraftState(
                             ((): string[] => {

--- a/dev/release/src/util.ts
+++ b/dev/release/src/util.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, writeFileSync, createReadStream } from 'fs'
+import { readdirSync, readFileSync, writeFileSync } from 'fs'
 import * as path from 'path'
 import * as readline from 'readline'
 
@@ -289,48 +289,6 @@ export const updateUpgradeGuides = (previous: string, next: string): EditFunc =>
         }
     }
 }
-
-export const updateMigratorBazelOuts =
-    (version: string): EditFunc =>
-    (directory: string): void => {
-        const newEntries = `        "schema-descriptions/v${version}-internal_database_schema.codeinsights.json",
-        "schema-descriptions/v${version}-internal_database_schema.codeintel.json",
-        "schema-descriptions/v${version}-internal_database_schema.json",`
-        const filePath = `${directory}/cmd/migrator/BUILD.bazel`
-
-        let inGenrule = false
-        let inOuts = false
-        const result: string[] = []
-
-        const rls = readline.createInterface({
-            input: createReadStream(filePath),
-            output: process.stdout,
-            terminal: false,
-        })
-
-        rls.on('line', line => {
-            if (line.includes('genrule(')) {
-                inGenrule = true
-            }
-
-            if (inGenrule && line.includes('outs = [')) {
-                inOuts = true
-            }
-
-            if (inGenrule && inOuts && line.includes('],')) {
-                inOuts = false
-                inGenrule = false
-                line = `${newEntries}\n${line}`
-            }
-
-            result.push(line)
-        })
-
-        rls.on('close', () => {
-            writeFileSync(filePath, result.join('\n'))
-            console.log(`${filePath} updated successfully.`)
-        })
-    }
 
 export async function retryInput(
     prompt: string,


### PR DESCRIPTION
Since the introduction of [#57591](https://github.com/sourcegraph/sourcegraph/pull/57591) we do not need to manually populate the bazel output anymore.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
If the `5.2.4` release goes on fine. We should be good.