### PR TITLE
eventlogs: use real deprecation warnings

### DIFF
--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -46,11 +46,19 @@ type EventLogStore interface {
 	// AggregatedSearchEvents calculates SearchAggregatedEvent for each every unique event type related to search.
 	AggregatedSearchEvents(ctx context.Context, now time.Time) ([]types.SearchAggregatedEvent, error)
 
-	// BulkInsert inserts a set of events.
+	// BulkInsert should only be used in internal/telemetry/teestore.
+	// BulkInsert does NOT respect context cancellation, as it is assumed that
+	// we never drop events once we attempt to store it.
 	//
-	// It does NOT respect context cancellation, as it is assumed that we never
-	// drop events once we attempt to queue it for export.
+	// Deprecated: Use EventRecorder from internal/telemetryrecorder instead.
+	// Learn more: https://docs.sourcegraph.com/dev/background-information/telemetry
 	BulkInsert(ctx context.Context, events []*Event) error
+
+	// Insert is a legacy mechanism for inserting a single event.
+	//
+	// Deprecated: Use EventRecorder from internal/telemetryrecorder instead.
+	// Learn more: https://docs.sourcegraph.com/dev/background-information/telemetry
+	Insert(ctx context.Context, e *Event) error
 
 	// CodeIntelligenceCrossRepositoryWAUs returns the WAU (current week) with any (precise or search-based) cross-repository code intelligence event.
 	CodeIntelligenceCrossRepositoryWAUs(ctx context.Context) (int, error)
@@ -119,9 +127,6 @@ type EventLogStore interface {
 
 	// CountUsersWithSetting returns the number of users wtih the given temporary setting set to the given value.
 	CountUsersWithSetting(ctx context.Context, setting string, value any) (int, error)
-
-	// ❗ DEPRECATED: Use event recorders from internal/telemetryrecorder instead.
-	Insert(ctx context.Context, e *Event) error
 
 	// LatestPing returns the most recently recorded ping event.
 	LatestPing(ctx context.Context) (*Event, error)

--- a/internal/telemetry/teestore/teestore.go
+++ b/internal/telemetry/teestore/teestore.go
@@ -49,6 +49,7 @@ func (s *Store) StoreEvents(ctx context.Context, events []*telemetrygatewayv1.Ev
 	})
 	if !shouldDisableV1(ctx) {
 		wg.Go(func() error {
+			//lint:ignore SA1019 we translate the new format into the existing store for local reference.
 			err := s.eventLogs.BulkInsert(ctx, toEventLogs(time.Now, events))
 			counterV1Events.
 				WithLabelValues(strconv.FormatBool(err != nil)).

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -107,14 +107,16 @@ func LogBackendEvent(db database.DB, userID int32, deviceID, eventName string, a
 
 // LogEvent logs an event.
 //
-// ❗ DEPRECATED: Use event recorders from internal/telemetryrecorder instead.
+// Deprecated: Use EventRecorder from internal/telemetryrecorder instead.
+// Learn more: https://docs.sourcegraph.com/dev/background-information/telemetry
 func LogEvent(ctx context.Context, db database.DB, args Event) error {
 	return LogEvents(ctx, db, []Event{args})
 }
 
 // LogEvents logs a batch of events.
 //
-// ❗ DEPRECATED: Use event recorders from internal/telemetryrecorder instead.
+// Deprecated: Use EventRecorder from internal/telemetryrecorder instead.
+// Learn more: https://docs.sourcegraph.com/dev/background-information/telemetry
 func LogEvents(ctx context.Context, db database.DB, events []Event) error {
 	if !conf.EventLoggingEnabled() {
 		return nil


### PR DESCRIPTION

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
