### PR TITLE
Use clear map function from go 1.21

### DIFF
--- a/internal/authz/providers/perforce/protects.go
+++ b/internal/authz/providers/perforce/protects.go
@@ -503,9 +503,7 @@ func allUsersScanner(ctx context.Context, p *Provider, users map[string]struct{}
 				switch line.entityType {
 				case "user":
 					if line.name == "*" {
-						for u := range users {
-							delete(users, u)
-						}
+						clear(users)
 					} else {
 						delete(users, line.name)
 					}


### PR DESCRIPTION
A tiny change to use the new `clear` function in go 1.21 instead of deleting
each entry manually. This was the only place I saw where we could use it.

## Test plan

Covered by existing tests