### PR TITLE
auth: allow exempted list from the minimumExternalAccountAge

### DIFF
--- a/cmd/frontend/internal/auth/gitlaboauth/session.go
+++ b/cmd/frontend/internal/auth/gitlaboauth/session.go
@@ -50,12 +50,16 @@ func (s *sessionIssuerHelper) GetOrCreateUser(ctx context.Context, token *oauth2
 	}
 
 	dc := conf.Get().Dotcom
-
 	if dc != nil && dc.MinimumExternalAccountAge > 0 {
-
+		exempted := false
+		for _, exemptedEmail := range dc.MinimumExternalAccountAgeExemptList {
+			if exemptedEmail == gUser.Email {
+				exempted = true
+				break
+			}
+		}
 		earliestValidCreationDate := time.Now().Add(time.Duration(-dc.MinimumExternalAccountAge) * 24 * time.Hour)
-
-		if gUser.CreatedAt.After(earliestValidCreationDate) {
+		if !exempted && gUser.CreatedAt.After(earliestValidCreationDate) {
 			return false, nil, fmt.Sprintf("User account was created less than %d days ago", dc.MinimumExternalAccountAge), errors.New("user account too new")
 		}
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -654,6 +654,8 @@ type Dotcom struct {
 	CodyGateway *CodyGateway `json:"codyGateway,omitempty"`
 	// MinimumExternalAccountAge description: The minimum amount of days a Github or GitLab account must exist, before being allowed on Sourcegraph.com.
 	MinimumExternalAccountAge int `json:"minimumExternalAccountAge,omitempty"`
+	// MinimumExternalAccountAgeExemptList description: A list of email addresses that are allowed to be exempted from the minimumExternalAccountAge requirement.
+	MinimumExternalAccountAgeExemptList []string `json:"minimumExternalAccountAgeExemptList,omitempty"`
 	// SlackLicenseAnomallyWebhook description: Slack webhook for when there is an anomaly detected with license key usage.
 	SlackLicenseAnomallyWebhook string `json:"slackLicenseAnomallyWebhook,omitempty"`
 	// SlackLicenseExpirationWebhook description: Slack webhook for upcoming license expiration notifications.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1993,6 +1993,13 @@
           "type": "integer",
           "default": 0
         },
+        "minimumExternalAccountAgeExemptList": {
+          "description": "A list of email addresses that are allowed to be exempted from the minimumExternalAccountAge requirement.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "app.notifications": {
           "description": "Notifications to display in the Sourcegraph app.",
           "type": "array",


### PR DESCRIPTION
Needed for PLG QA, see https://docs.google.com/document/d/1all3z8dPs52amhNs3m4O1Lu7V6VsCaU7jXovprte-EE/edit?disco=AAABAHybed8

## Test plan

1. Setting `dotcom.minimumExternalAccountAge` to `36500`
	<img width="643" alt="CleanShot 2023-12-04 at 18 54 05@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/127587b3-0a67-41c9-aaaf-078a5d85d9fd">
1. Adding my primary email on both GitHub.com and GitLab.com to `dotocm.minimumExternalAccountAgeExemptList`, authenticated successfully.

