### PR TITLE
statistics resetter: run on Sunday, between 2 and 2:30am

### DIFF
--- a/cmd/worker/internal/repostatistics/resetter.go
+++ b/cmd/worker/internal/repostatistics/resetter.go
@@ -65,11 +65,9 @@ var _ goroutine.Handler = &resetterHandler{}
 func (h *resetterHandler) Handle(ctx context.Context) error {
 	// We only run this handler once a week, Sunday morning between 2:00 and
 	// 2:30 UTC, because it might run for 2-3 minutes.
-	//
-	// TODO: We're trying to run this on Tuesday 10-10:30am UTC, for testing purposes
 	now := time.Now().UTC()
-	isSunday := now.Weekday() == time.Tuesday
-	isBetween2And230 := now.Hour() == 10 && now.Minute() < 30
+	isSunday := now.Weekday() == time.Sunday
+	isBetween2And230 := now.Hour() == 2 && now.Minute() < 30
 
 	if !isSunday || !isBetween2And230 {
 		h.logger.Debug("Skipping deleting and recreating statistics; not Sunday between 2-2:30 UTC")


### PR DESCRIPTION
Final test was successful: resetter ran on sourcegraph.com and took 1min.

Logging was also helpful.

So this is the production-ready version.

## Test plan

- N/A