### PR TITLE
bump go version in buildchecker

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
-        with: { go-version: '1.19' }
+        with: { go-version: '1.21' }
 
       - run: ./dev/buildchecker/run-week-history.sh
         env:

--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
-        with: { go-version: '1.19' }
+        with: { go-version: '1.21' }
 
       - run: ./dev/buildchecker/run-check.sh
         env:


### PR DESCRIPTION
buildchecker now requires Go 1.21 due to changes in a dependency, but this was never reflected in the Go version used by the workflow file, hence it has been failing for some time now

## Test plan

Tested using `act workflow_dispatch -W .github/workflows/buildchecker.yml` 
