### PR TITLE
buildtracker: ignore inprogress jobs when determining final status

### DIFF
--- a/dev/build-tracker/notify/slack.go
+++ b/dev/build-tracker/notify/slack.go
@@ -54,6 +54,7 @@ type BuildNotification struct {
 	BuildStatus        string
 	Fixed              []JobLine
 	Failed             []JobLine
+	InProgress         []JobLine
 }
 
 type JobLine interface {


### PR DESCRIPTION
The build can be finished and have failing jobs but a late job can come in and make the build "not be finished", which is a problem since we don't get a notification for the late job finishing, which leads to the job perpetually being in in-progress.

We do not count in-progress jobs anymore because this can lead to invalid build states even though the build is finished

## Test plan
Added unit tests

Reproduce the problem
```
go test ./...
?       github.com/sourcegraph/sourcegraph/dev/build-tracker/config     [no test files]
?       github.com/sourcegraph/sourcegraph/dev/build-tracker/util       [no test files]
--- FAIL: TestToBuildNotification (0.00s)
    --- FAIL: TestToBuildNotification/Finished_build,_with_2_failed_jobs_and_then_a_late_in_progress_job (0.00s)
        main_test.go:156: got 2, wanted 3 for failed jobs in BuildNotification
        main_test.go:159: got InProgress, wanted Failed for Build Status in Notification
FAIL
FAIL    github.com/sourcegraph/sourcegraph/dev/build-tracker    0.705s
ok      github.com/sourcegraph/sourcegraph/dev/build-tracker/build      (cached)
ok      github.com/sourcegraph/sourcegraph/dev/build-tracker/notify     (cached)
```

With the fix of this PR
```
go test ./...
?       github.com/sourcegraph/sourcegraph/dev/build-tracker/config     [no test files]
?       github.com/sourcegraph/sourcegraph/dev/build-tracker/util       [no test files]
ok      github.com/sourcegraph/sourcegraph/dev/build-tracker    1.119s
ok      github.com/sourcegraph/sourcegraph/dev/build-tracker/build      (cached)
ok      github.com/sourcegraph/sourcegraph/dev/build-tracker/notify     (cached)
```
