### PR TITLE
Onboarding UI Fixes

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -241,6 +241,7 @@ ts_project(
         "src/cody/isCodyEnabled.tsx",
         "src/cody/management/CodyManagementPage.tsx",
         "src/cody/onboarding/CodyOnboarding.tsx",
+        "src/cody/onboarding/instructions/JetBrains.tsx",
         "src/cody/onboarding/instructions/VsCode.tsx",
         "src/cody/search/CodySearchPage.tsx",
         "src/cody/search/api.ts",

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -24,6 +24,8 @@ interface CodyPlatformCardProps {
     illustration: string
 }
 
+/* eslint-disable  @sourcegraph/sourcegraph/check-help-links */
+
 const onSpeakToAnEngineer = (): void => eventLogger.log(EventName.SPEAK_TO_AN_ENGINEER_CTA)
 const onClickCTAButton = (type: string): void =>
     eventLogger.log('SignupInitiated', { type, source: 'cody-signed-out' }, { type, page: 'cody-signed-out' })

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -18,6 +18,8 @@ type ConversationScope = 'general' | 'repo'
 
 const DEFAULT_VERTICAL_OFFSET = '1rem'
 
+/* eslint-disable  @sourcegraph/sourcegraph/check-help-links */
+
 export const GettingStarted: React.FC<
     Pick<
         CodyChatStore,

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -232,7 +232,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                         <div>
                                             <img
                                                 alt={editor.name}
-                                                src={`https://storage.googleapis.com/sourcegraph-assets/cody-ide-icons/${editor.icon}.png`}
+                                                src={`https://storage.googleapis.com/sourcegraph-assets/ideIcons/ideIcon${editor.icon}.svg`}
                                                 width={34}
                                                 className="mr-2"
                                             />

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -1,7 +1,22 @@
 .modal {
     width: 50rem;
-
+    border-width: 1px;
+    border-image: conic-gradient(rgba(112, 72, 232, 0.7), rgba(74, 193, 232, 0.7), rgba(77, 11, 121, 0.7), rgba(255, 85, 67, 0.7), rgba(112, 72, 232, 0.7)) 1;
 }
+
+
+@media (prefers-color-scheme: dark) {
+    [data-reach-dialog-overlay] {
+        background: linear-gradient(180deg, rgba(17, 20, 27, 0.9) 0%, rgba(13, 16, 25, 0.9) 100%);
+}
+
+@media (prefers-color-scheme: light) {
+    [data-reach-dialog-overlay] {
+        background: linear-gradient(180deg, #FDFCFF 0%, #EFEDF7 100%);
+        opacity:0.9;
+    }
+}
+
 
 
 .release-stage{
@@ -15,6 +30,10 @@
     color: #ffffff;
     padding: 0.25rem 0.675rem;
     border-radius: 50%;
+}
+
+.highlight-step {
+    background: radial-gradient(50% 100% at 50% 100%, var(--gray-08) 0%, transparent 100%)
 }
 
 .instructions-container{
@@ -38,3 +57,4 @@
 .ide-name {
     font-size: 1rem;
 }
+

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -1,21 +1,27 @@
 .modal {
     width: 54rem;
     border-width: 1px;
-    border-image: conic-gradient(rgba(112, 72, 232, 0.2), rgba(74, 193, 232, 0.2), rgba(77, 11, 121, 0.2), rgba(255, 85, 67, 0.2), rgba(112, 72, 232, 0.2)) 1;
+    background-image: repeating-conic-gradient(rgba(112, 72, 232, 0.5) 50%, rgba(0, 203, 236, 0.5) 75%, rgba(161, 18, 255, 0.5) 100%, rgba(255, 85, 67, 0.5) 125%, rgba(112, 72, 232, 0.5) 150%);
+    background-origin: border-box;
+
+    /* to allow a gradient strole, this is actually de color for the background*/
+    box-shadow: inset 0 100vw var(--theme-bg-plain);
 
     /* to let gradient shadow be behind the modal*/
     transform-style: preserve-3d;
+    border: 1px solid transparent;
+    border-radius:6px;
 }
 
 .modal::after{
     content: '';
     position:absolute;
     width: 90%;
-    height:25px;
+    height:45px;
     background: linear-gradient(90deg, #7048E8 0%, #4AC1E8 32.21%, #4D0B79 65.39%, #FF5543 104.43%), #EFF2F5;
-    transform: translateZ(-1px);
+    transform: translateZ(-1px) ;
     filter: blur(30px);
-    opacity: 0.7;
+    opacity: 0.9;
     animation: modal-shadow 6s ease-in-out infinite;
 }
 
@@ -23,15 +29,15 @@
 @keyframes modal-shadow {
     0% {
         transform: translatey(0px) translateZ(-1px);
-        opacity: 0.2;
+        opacity: 0.3;
     }
     50% {
         transform: translatey(-25px) translateZ(-1px);
-        opacity: 0.9;
+        opacity: 0.7;
     }
     100% {
         transform: translatey(0px) translateZ(-1px);
-        opacity: 0.2;
+        opacity: 0.3;
     }
 }
 
@@ -39,17 +45,23 @@
 
 @media (prefers-color-scheme: dark) {
     [data-reach-dialog-overlay] {
-        background: linear-gradient(180deg, rgba(17, 20, 27, 0.95) 0%, rgba(13, 16, 25, 0.92) 100%);
+        background: linear-gradient(180deg, rgba(17, 20, 27, 0.92) 0%, rgba(13, 16, 25, 0.92) 100%);
+        backdrop-filter: blur(7px);
     }
 
     .highlight-step {
-        background: radial-gradient(50% 100% at 50% 100%, var(--gray-09) 0%, transparent 100%)
+        background: radial-gradient(50% 100% at 50% 100%, var(--gray-09) 0%, transparent 100%);
+    }
+
+    .modal {
+        background-image: repeating-conic-gradient(rgba(112, 72, 232, 0.3) 50%, rgba(0, 203, 236, 0.3) 75%, rgba(161, 18, 255, 0.5) 100%, rgba(255, 85, 67, 0.3) 125%, #7048E8 150%);
     }
 }
 
 @media (prefers-color-scheme: light) {
     [data-reach-dialog-overlay] {
-        background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(244, 244, 244, 0.9) 100%);
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(244, 244, 244, 0.9) 100%);
+        backdrop-filter: blur(7px);
     }
 
     .highlight-step {
@@ -100,3 +112,78 @@
     font-size: 1rem;
 }
 
+
+/* Initial welcome*/
+
+.welcome-title {
+    font-size: 2rem;
+    font-weight: 500;
+    letter-spacing: -0.2px;
+}
+
+.welcome-subtitle{
+    font-size: 1.1rem;
+    font-weight: 300;
+}
+
+
+.fade-in {
+    animation: 2.5s fadeInUp;
+}
+
+.fade-first{
+    animation-delay:3s;
+    opacity: 0;
+    /* to keep opacity*/
+    animation-fill-mode: forwards;
+
+}
+
+.fade-second{
+    animation-delay:3.2s;
+    opacity: 0;
+    /* to keep opacity*/
+    animation-fill-mode: forwards;
+
+}
+
+.fade-third{
+    animation-delay:4s;
+    opacity: 0;
+
+    /* to keep opacity*/
+    animation-fill-mode: forwards;
+
+}
+
+.welcome-video {
+    animation: 2.5s moveUp 3s;
+    transform: translateY(70%);
+    animation-fill-mode: forwards;
+}
+
+
+@keyframes moveUp {
+    0% {
+        transform: translateY(70%);
+    }
+    100% {
+        transform: translateY(0%);
+    }
+}
+
+
+@keyframes fadeInUp {
+    0% {
+        transform: translateY(100%);
+        opacity: 0;
+    }
+    100% {
+        transform: translateY(0%);
+        opacity: 1;
+    }
+}
+
+.fadeInUp-animation {
+    animation: 1.5s fadeInUp;
+}

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -1,7 +1,13 @@
 .modal {
     width: 54rem;
     border-width: 1px;
-    background-image: repeating-conic-gradient(rgba(112, 72, 232, 0.5) 50%, rgba(0, 203, 236, 0.5) 75%, rgba(161, 18, 255, 0.5) 100%, rgba(255, 85, 67, 0.5) 125%, rgba(112, 72, 232, 0.5) 150%);
+    background-image: repeating-conic-gradient(
+        rgba(112, 72, 232, 0.5) 50%,
+        rgba(0, 203, 236, 0.5) 75%,
+        rgba(161, 18, 255, 0.5) 100%,
+        rgba(255, 85, 67, 0.5) 125%,
+        rgba(112, 72, 232, 0.5) 150%
+    );
     background-origin: border-box;
 
     /* to allow a gradient strole, this is actually de color for the background*/
@@ -10,38 +16,35 @@
     /* to let gradient shadow be behind the modal*/
     transform-style: preserve-3d;
     border: 1px solid transparent;
-    border-radius:6px;
+    border-radius: 6px;
 }
 
-.modal::after{
+.modal::after {
     content: '';
-    position:absolute;
+    position: absolute;
     width: 90%;
-    height:45px;
-    background: linear-gradient(90deg, #7048E8 0%, #4AC1E8 32.21%, #4D0B79 65.39%, #FF5543 104.43%), #EFF2F5;
-    transform: translateZ(-1px) ;
+    height: 45px;
+    background: linear-gradient(90deg, #7048e8 0%, #4ac1e8 32.21%, #4d0b79 65.39%, #ff5543 104.43%), #eff2f5;
+    transform: translateZ(-1px);
     filter: blur(30px);
     opacity: 0.9;
     animation: modal-shadow 6s ease-in-out infinite;
 }
 
-
 @keyframes modal-shadow {
     0% {
         transform: translatey(0px) translateZ(-1px);
-        opacity: 0.3;
+        opacity: 0.4;
     }
     50% {
         transform: translatey(-25px) translateZ(-1px);
-        opacity: 0.7;
+        opacity: 0.9;
     }
     100% {
         transform: translatey(0px) translateZ(-1px);
-        opacity: 0.3;
+        opacity: 0.4;
     }
 }
-
-
 
 @media (prefers-color-scheme: dark) {
     [data-reach-dialog-overlay] {
@@ -54,7 +57,13 @@
     }
 
     .modal {
-        background-image: repeating-conic-gradient(rgba(112, 72, 232, 0.3) 50%, rgba(0, 203, 236, 0.3) 75%, rgba(161, 18, 255, 0.5) 100%, rgba(255, 85, 67, 0.3) 125%, #7048E8 150%);
+        background-image: repeating-conic-gradient(
+            rgba(112, 72, 232, 0.3) 50%,
+            rgba(0, 203, 236, 0.3) 75%,
+            rgba(161, 18, 255, 0.5) 100%,
+            rgba(255, 85, 67, 0.3) 125%,
+            #7048e8 150%
+        );
     }
 }
 
@@ -65,14 +74,13 @@
     }
 
     .highlight-step {
-        background: radial-gradient(50% 100% at 50% 100%, var(--gray-04) 0%, transparent 100%)
+        background: radial-gradient(50% 100% at 50% 100%, var(--gray-04) 0%, transparent 100%);
     }
 }
 
-.release-stage{
+.release-stage {
     color: var(--gray-07);
 }
-
 
 /*Step section on instructions*/
 .step {
@@ -83,18 +91,15 @@
 }
 
 .ide-grid:hover {
-    background: var(--color-bg-2);
+    background: var(--subtle-bg);
     transition: all 0.25s ease;
 }
 
-
-.instructions-container{
+.instructions-container {
     /*adds vertical scroll to long instructions and prevents "next" and "back buttons" to be under the fold*/
     max-height: 80vh;
     overflow-y: auto;
 }
-
-
 
 .responsive-container {
     @media (--sm-breakpoint-down) {
@@ -112,7 +117,6 @@
     font-size: 1rem;
 }
 
-
 /* Initial welcome*/
 
 .welcome-title {
@@ -121,39 +125,35 @@
     letter-spacing: -0.2px;
 }
 
-.welcome-subtitle{
+.welcome-subtitle {
     font-size: 1.1rem;
     font-weight: 300;
 }
-
 
 .fade-in {
     animation: 2.5s fadeInUp;
 }
 
-.fade-first{
-    animation-delay:3s;
+.fade-first {
+    animation-delay: 3s;
     opacity: 0;
     /* to keep opacity*/
     animation-fill-mode: forwards;
-
 }
 
-.fade-second{
-    animation-delay:3.2s;
+.fade-second {
+    animation-delay: 3.2s;
     opacity: 0;
     /* to keep opacity*/
     animation-fill-mode: forwards;
-
 }
 
-.fade-third{
-    animation-delay:4s;
+.fade-third {
+    animation-delay: 4s;
     opacity: 0;
 
     /* to keep opacity*/
     animation-fill-mode: forwards;
-
 }
 
 .welcome-video {
@@ -161,7 +161,6 @@
     transform: translateY(70%);
     animation-fill-mode: forwards;
 }
-
 
 @keyframes moveUp {
     0% {
@@ -171,7 +170,6 @@
         transform: translateY(0%);
     }
 }
-
 
 @keyframes fadeInUp {
     0% {

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -1,23 +1,42 @@
 .modal {
     width: 50rem;
     border-width: 1px;
-    border-image: conic-gradient(rgba(112, 72, 232, 0.7), rgba(74, 193, 232, 0.7), rgba(77, 11, 121, 0.7), rgba(255, 85, 67, 0.7), rgba(112, 72, 232, 0.7)) 1;
+    border-image: conic-gradient(rgba(112, 72, 232, 0.2), rgba(74, 193, 232, 0.2), rgba(77, 11, 121, 0.2), rgba(255, 85, 67, 0.2), rgba(112, 72, 232, 0.2)) 1;
+
+    /* to let gradient shadow be behind the modal*/
+    transform-style: preserve-3d;
 }
 
+.modal::after{
+    content: '';
+    position:absolute;
+    width: 90%;
+    height:15px;
+    background: linear-gradient(90deg, #7048E8 0%, #4AC1E8 32.21%, #4D0B79 65.39%, #FF5543 104.43%), #EFF2F5;
+    transform: translateZ(-1px);
+    filter: blur(30px);
+    opacity: 0.8;
+}
 
 @media (prefers-color-scheme: dark) {
     [data-reach-dialog-overlay] {
-        background: linear-gradient(180deg, rgba(17, 20, 27, 0.9) 0%, rgba(13, 16, 25, 0.9) 100%);
+        background: linear-gradient(180deg, rgba(17, 20, 27, 0.95) 0%, rgba(13, 16, 25, 0.92) 100%);
+    }
+
+    .highlight-step {
+        background: radial-gradient(50% 100% at 50% 100%, var(--gray-09) 0%, transparent 100%)
+    }
 }
 
 @media (prefers-color-scheme: light) {
     [data-reach-dialog-overlay] {
-        background: linear-gradient(180deg, #FDFCFF 0%, #EFEDF7 100%);
-        opacity:0.9;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 0%, rgba(244, 244, 244, 0.9) 100%);
+    }
+
+    .highlight-step {
+        background: radial-gradient(50% 100% at 50% 100%, var(--gray-04) 0%, transparent 100%)
     }
 }
-
-
 
 .release-stage{
     color: var(--gray-07);
@@ -32,9 +51,7 @@
     border-radius: 50%;
 }
 
-.highlight-step {
-    background: radial-gradient(50% 100% at 50% 100%, var(--gray-08) 0%, transparent 100%)
-}
+
 
 .instructions-container{
     /*adds vertical scroll to long instructions and prevents "next" and "back buttons" to be under the fold*/

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -1,5 +1,5 @@
 .modal {
-    width: 50rem;
+    width: 54rem;
     border-width: 1px;
     border-image: conic-gradient(rgba(112, 72, 232, 0.2), rgba(74, 193, 232, 0.2), rgba(77, 11, 121, 0.2), rgba(255, 85, 67, 0.2), rgba(112, 72, 232, 0.2)) 1;
 
@@ -51,6 +51,10 @@
     border-radius: 50%;
 }
 
+.ide-grid:hover {
+    background: var(--color-bg-2);
+    transition: all 0.25s ease;
+}
 
 
 .instructions-container{

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -1,12 +1,26 @@
 .modal {
     width: 50rem;
+
 }
 
+
+.release-stage{
+    color: var(--gray-07);
+}
+
+
+/*Step section on instructions*/
 .step {
     background: #343a4d;
     color: #ffffff;
     padding: 0.25rem 0.675rem;
     border-radius: 50%;
+}
+
+.instructions-container{
+    /*adds vertical scroll to long instructions and prevents "next" and "back buttons" to be under the fold*/
+    max-height: 80vh;
+    overflow-y: auto;
 }
 
 .responsive-container {

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -1,6 +1,6 @@
 .modal {
     width: 54rem;
-    border-width: 1px;
+    border-radius: 6px;
     background-image: repeating-conic-gradient(
         rgba(112, 72, 232, 0.5) 50%,
         rgba(0, 203, 236, 0.5) 75%,
@@ -10,15 +10,17 @@
     );
     background-origin: border-box;
 
-    /* to allow a gradient strole, this is actually de color for the background*/
+    /* to allow a gradient stroke, this is actually where the color of the background is set*/
     box-shadow: inset 0 100vw var(--theme-bg-plain);
+
+    /* to let the gradient on the background act as a stroke*/
+    border: 1px solid transparent;
 
     /* to let gradient shadow be behind the modal*/
     transform-style: preserve-3d;
-    border: 1px solid transparent;
-    border-radius: 6px;
 }
 
+/* Colorful shadow on the modal*/
 .modal::after {
     content: '';
     position: absolute;

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -11,12 +11,31 @@
     content: '';
     position:absolute;
     width: 90%;
-    height:15px;
+    height:25px;
     background: linear-gradient(90deg, #7048E8 0%, #4AC1E8 32.21%, #4D0B79 65.39%, #FF5543 104.43%), #EFF2F5;
     transform: translateZ(-1px);
     filter: blur(30px);
-    opacity: 0.8;
+    opacity: 0.7;
+    animation: modal-shadow 6s ease-in-out infinite;
 }
+
+
+@keyframes modal-shadow {
+    0% {
+        transform: translatey(0px) translateZ(-1px);
+        opacity: 0.2;
+    }
+    50% {
+        transform: translatey(-25px) translateZ(-1px);
+        opacity: 0.9;
+    }
+    100% {
+        transform: translatey(0px) translateZ(-1px);
+        opacity: 0.2;
+    }
+}
+
+
 
 @media (prefers-color-scheme: dark) {
     [data-reach-dialog-overlay] {

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -10,22 +10,22 @@
     );
     background-origin: border-box;
 
-    /* to allow a gradient stroke, this is actually where the color of the background is set*/
+    /* to allow a gradient stroke, this is actually where the color of the background is set */
     box-shadow: inset 0 100vw var(--theme-bg-plain);
 
-    /* to let the gradient on the background act as a stroke*/
+    /* to let the gradient on the background act as a stroke */
     border: 1px solid transparent;
 
-    /* to let gradient shadow be behind the modal*/
+    /* to let gradient shadow be behind the modal */
     transform-style: preserve-3d;
 }
 
-/* Colorful shadow on the modal*/
+/* Colorful shadow on the modali */
 .modal::after {
     content: '';
     position: absolute;
     width: 90%;
-    height: 45px;
+    height: 2.8125rem;
     background: linear-gradient(90deg, #7048e8 0%, #4ac1e8 32.21%, #4d0b79 65.39%, #ff5543 104.43%), #eff2f5;
     transform: translateZ(-1px);
     filter: blur(30px);
@@ -35,15 +35,15 @@
 
 @keyframes modal-shadow {
     0% {
-        transform: translatey(0px) translateZ(-1px);
+        transform: translateY(0) translateZ(-1px);
         opacity: 0.4;
     }
     50% {
-        transform: translatey(-25px) translateZ(-1px);
+        transform: translateY(-25px) translateZ(-1px);
         opacity: 0.9;
     }
     100% {
-        transform: translatey(0px) translateZ(-1px);
+        transform: translateY(0) translateZ(-1px);
         opacity: 0.4;
     }
 }
@@ -84,7 +84,7 @@
     color: var(--gray-07);
 }
 
-/*Step section on instructions*/
+/* Step section on instructions */
 .step {
     background: #343a4d;
     color: #ffffff;
@@ -98,7 +98,7 @@
 }
 
 .instructions-container {
-    /*adds vertical scroll to long instructions and prevents "next" and "back buttons" to be under the fold*/
+    /* adds vertical scroll to long instructions and prevents "next" and "back buttons" to be under the fold */
     max-height: 80vh;
     overflow-y: auto;
 }
@@ -119,7 +119,7 @@
     font-size: 1rem;
 }
 
-/* Initial welcome*/
+/* Initial welcome */
 
 .welcome-title {
     font-size: 2rem;
@@ -139,14 +139,16 @@
 .fade-first {
     animation-delay: 3s;
     opacity: 0;
-    /* to keep opacity*/
+
+    /* to keep opacity */
     animation-fill-mode: forwards;
 }
 
 .fade-second {
     animation-delay: 3.2s;
     opacity: 0;
-    /* to keep opacity*/
+
+    /* to keep opacity */
     animation-fill-mode: forwards;
 }
 
@@ -154,7 +156,7 @@
     animation-delay: 4s;
     opacity: 0;
 
-    /* to keep opacity*/
+    /* to keep opacity */
     animation-fill-mode: forwards;
 }
 
@@ -184,6 +186,6 @@
     }
 }
 
-.fadeInUp-animation {
+.fade-in-up-animation {
     animation: 1.5s fadeInUp;
 }

--- a/client/web/src/cody/onboarding/CodyOnboarding.module.scss
+++ b/client/web/src/cody/onboarding/CodyOnboarding.module.scss
@@ -63,6 +63,8 @@
     overflow-y: auto;
 }
 
+
+
 .responsive-container {
     @media (--sm-breakpoint-down) {
         flex-direction: column;

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -17,6 +17,7 @@ export interface IEditor {
     icon: string
     name: string
     publisher: string
+    releaseStage: string
     instructions?: React.FC<{ onBack?: () => void; onClose: () => void; showStep?: number }>
 }
 
@@ -26,22 +27,26 @@ export const editorGroups: IEditor[][] = [
             icon: 'VSCode',
             name: 'VS Code',
             publisher: 'Microsoft',
+            releaseStage: 'Stable',
             instructions: VSCodeInstructions,
         },
         {
             icon: 'IntelliJ',
             name: 'IntelliJ IDEA',
             publisher: 'JetBrains',
+            releaseStage: 'Beta',
         },
         {
             icon: 'Neovim',
             name: 'Neovim',
             publisher: 'Neovim Team',
+            releaseStage: 'Experimental',
         },
         {
             icon: 'AndroidStudio',
             name: 'Android Studio',
             publisher: 'Google',
+            releaseStage: 'Beta',
         },
     ],
     [
@@ -49,21 +54,25 @@ export const editorGroups: IEditor[][] = [
             icon: 'PhpStorm',
             name: 'PhpStorm ',
             publisher: 'JetBrains',
+            releaseStage: 'Beta',
         },
         {
             icon: 'PyCharm',
             name: 'PyCharm',
             publisher: 'Jetbrains',
+            releaseStage: 'Beta',
         },
         {
             icon: 'WebStorm',
             name: 'WebStorm',
             publisher: 'JetBrains',
+            releaseStage: 'Beta',
         },
         {
             icon: 'RubyMine',
             name: 'RubyMine',
             publisher: 'JetBrains',
+            releaseStage: 'Beta',
         },
     ],
     [
@@ -71,11 +80,13 @@ export const editorGroups: IEditor[][] = [
             icon: 'GoLand',
             name: 'GoLand',
             publisher: 'JetBrains',
+            releaseStage: 'Beta',
         },
         {
             icon: 'Emacs',
             name: 'Emacs',
             publisher: 'Free Software Foundation',
+            releaseStage: 'Beta',
         },
     ],
 ]
@@ -253,6 +264,7 @@ function EditorStep({
                                             {editor.publisher}
                                         </Text>
                                         <Text className={classNames('mb-0', styles.ideName)}>{editor.name}</Text>
+                                        <h5 className={styles.releaseStage}>{editor.releaseStage}</h5>
                                     </div>
                                 </div>
                             </div>

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -142,7 +142,7 @@ function PurposeStep({ onNext, pro }: { onNext: () => void; pro: boolean }): JSX
         <>
             <div className="border-bottom pb-3 mb-3">
                 <H2 className="mb-1">What are you using Cody for?</H2>
-                <Text className="mb-0" size="small">
+                <Text className="mb-0 text-muted" size="small" >
                     This will allow us to understand our audience better and guide your journey
                 </Text>
             </div>
@@ -214,7 +214,7 @@ function EditorStep({
         <>
             <div className="border-bottom pb-3 mb-3">
                 <H2 className="mb-1">Choose your editor</H2>
-                <Text className="mb-0" size="small">
+                <Text className="mb-0 text-muted" size="small" >
                     Most of Cody experience happens in the IDE. Let's get that set up.
                 </Text>
             </div>

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -229,7 +229,7 @@ function EditorStep({
                         {group.map((editor, index) => (
                             <div
                                 key={index}
-                                className={classNames('d-flex flex-column flex-1 p-3 cursor-pointer', {
+                                className={classNames('d-flex flex-column flex-1 p-3 cursor-pointer', styles.ideGrid, {
                                     'border-left': index !== 0,
                                 })}
                                 role="button"
@@ -250,13 +250,13 @@ function EditorStep({
                                     setEditor(editor)
                                 }}
                             >
-                                <div className="d-flex">
+                                <div className="d-flex align-items-center">
                                     <div>
                                         <img
                                             alt={editor.name}
                                             src={`https://storage.googleapis.com/sourcegraph-assets/cody-ide-icons/${editor.icon}.png`}
                                             width={34}
-                                            className="mr-2"
+                                            className="mr-3"
                                         />
                                     </div>
                                     <div>

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -53,6 +53,7 @@ export const editorGroups: IEditor[][] = [
     ],
     [
         {
+
             icon: 'PhpStorm',
             name: 'PhpStorm ',
             publisher: 'JetBrains',

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -12,6 +12,7 @@ import { CodyColorIcon } from '../chat/CodyPageIcon'
 import { VSCodeInstructions } from './instructions/VsCode'
 
 import styles from './CodyOnboarding.module.scss'
+import {JetBrainsInstructions} from './instructions/JetBrains';
 
 export interface IEditor {
     icon: string
@@ -24,7 +25,7 @@ export interface IEditor {
 export const editorGroups: IEditor[][] = [
     [
         {
-            icon: 'VSCode',
+            icon: 'VsCode',
             name: 'VS Code',
             publisher: 'Microsoft',
             releaseStage: 'Stable',
@@ -35,9 +36,10 @@ export const editorGroups: IEditor[][] = [
             name: 'IntelliJ IDEA',
             publisher: 'JetBrains',
             releaseStage: 'Beta',
+            instructions: JetBrainsInstructions,
         },
         {
-            icon: 'Neovim',
+            icon: 'NeoVim',
             name: 'Neovim',
             publisher: 'Neovim Team',
             releaseStage: 'Experimental',
@@ -86,7 +88,7 @@ export const editorGroups: IEditor[][] = [
             icon: 'Emacs',
             name: 'Emacs',
             publisher: 'Free Software Foundation',
-            releaseStage: 'Beta',
+            releaseStage: 'Coming Soon',
         },
     ],
 ]
@@ -254,7 +256,7 @@ function EditorStep({
                                     <div>
                                         <img
                                             alt={editor.name}
-                                            src={`https://storage.googleapis.com/sourcegraph-assets/cody-ide-icons/${editor.icon}.png`}
+                                            src={`https://storage.googleapis.com/sourcegraph-assets/ideIcons/ideIcon${editor.icon}.svg`}
                                             width={34}
                                             className="mr-3"
                                         />

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -3,16 +3,15 @@ import React, { useState, useEffect } from 'react'
 import classNames from 'classnames'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
-import { Modal, H1, H2, H3, Text, Button, useSearchParameters } from '@sourcegraph/wildcard'
+import { Modal, H5, H2, H3, Text, Button, useSearchParameters } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
-import { CodyColorIcon } from '../chat/CodyPageIcon'
 
+import { JetBrainsInstructions } from './instructions/JetBrains'
 import { VSCodeInstructions } from './instructions/VsCode'
 
 import styles from './CodyOnboarding.module.scss'
-import {JetBrainsInstructions} from './instructions/JetBrains';
 
 export interface IEditor {
     icon: string
@@ -53,7 +52,6 @@ export const editorGroups: IEditor[][] = [
     ],
     [
         {
-
             icon: 'PhpStorm',
             name: 'PhpStorm ',
             publisher: 'JetBrains',
@@ -125,12 +123,21 @@ function WelcomeStep({ onNext, pro }: { onNext: () => void; pro: boolean }): JSX
     }, [pro])
 
     return (
-        <div className="d-flex flex-column align-items-center">
-            <CodyColorIcon width={60} height={60} className="mb-4" />
-            <H1>Welcome {pro ? 'to Cody Pro Trial' : 'to Cody by Sourcegraph!'}</H1>
-            <Text className="mb-4 pb-4">Let's walk through a few quick steps to get you started with Cody.</Text>
-            <Button onClick={onNext} variant="primary" size="sm">
-                Let's Start!
+        <div className={classNames('d-flex flex-column align-items-center p-5')}>
+            <video width="180" className={classNames('mb-5', styles.welcomeVideo)} autoPlay={true} muted={true}>
+                <source src="https://storage.googleapis.com/sourcegraph-assets/codyWelcomeAnim.mp4" type="video/mp4" />
+                Your browser does not support the video tag.
+            </video>
+            <Text className={classNames('mb-4 pb-4', styles.fadeIn, styles.fadeSecond, styles.welcomeSubtitle)}>
+                Ready to breeze through the basics and get comfortable with Cody{pro ? ' to Cody Pro Trial' : ''}?
+            </Text>
+            <Button
+                onClick={onNext}
+                variant="primary"
+                size="lg"
+                className={classNames(styles.fadeIn, styles.fadeThird)}
+            >
+                Sure, let's dive in!
             </Button>
         </div>
     )
@@ -145,7 +152,7 @@ function PurposeStep({ onNext, pro }: { onNext: () => void; pro: boolean }): JSX
         <>
             <div className="border-bottom pb-3 mb-3">
                 <H2 className="mb-1">What are you using Cody for?</H2>
-                <Text className="mb-0 text-muted" size="small" >
+                <Text className="mb-0 text-muted" size="small">
                     This will allow us to understand our audience better and guide your journey
                 </Text>
             </div>
@@ -217,7 +224,7 @@ function EditorStep({
         <>
             <div className="border-bottom pb-3 mb-3">
                 <H2 className="mb-1">Choose your editor</H2>
-                <Text className="mb-0 text-muted" size="small" >
+                <Text className="mb-0 text-muted" size="small">
                     Most of Cody experience happens in the IDE. Let's get that set up.
                 </Text>
             </div>
@@ -267,7 +274,7 @@ function EditorStep({
                                             {editor.publisher}
                                         </Text>
                                         <Text className={classNames('mb-0', styles.ideName)}>{editor.name}</Text>
-                                        <h5 className={styles.releaseStage}>{editor.releaseStage}</h5>
+                                        <H5 className={styles.releaseStage}>{editor.releaseStage}</H5>
                                     </div>
                                 </div>
                             </div>

--- a/client/web/src/cody/onboarding/instructions/JetBrains.tsx
+++ b/client/web/src/cody/onboarding/instructions/JetBrains.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
 
 import classNames from 'classnames'
-import { Link } from 'react-router-dom'
 
-import { H2, Text, Button, ButtonLink } from '@sourcegraph/wildcard'
+import { H2, Text, Button, ButtonLink, Link } from '@sourcegraph/wildcard'
 
 import styles from '../CodyOnboarding.module.scss'
 
@@ -67,7 +66,7 @@ export function JetBrainsInstructions({
                                     </Text>
                                 </div>
                             </div>
-                            <div className="d-flex flex-column justify-content-center align-items-center mt-4"></div>
+                            <div className="d-flex flex-column justify-content-center align-items-center mt-4" />
                             <div className="mt-3 border-bottom">
                                 <div className="d-flex align-items-center">
                                     <div className="mr-1">
@@ -84,7 +83,7 @@ export function JetBrainsInstructions({
                                         </Text>
                                     </div>
                                 </div>
-                                <div className="d-flex flex-column justify-content-center align-items-center mt-4"></div>
+                                <div className="d-flex flex-column justify-content-center align-items-center mt-4" />
                             </div>
                         </div>
                     </div>

--- a/client/web/src/cody/onboarding/instructions/JetBrains.tsx
+++ b/client/web/src/cody/onboarding/instructions/JetBrains.tsx
@@ -5,9 +5,8 @@ import classNames from 'classnames'
 import { H2, Text, Button, ButtonLink } from '@sourcegraph/wildcard'
 
 import styles from '../CodyOnboarding.module.scss'
-import {Link} from 'react-router-dom';
 
-export function VSCodeInstructions({
+export function JetBrainsInstructions({
     onBack,
     onClose,
     showStep,
@@ -23,7 +22,7 @@ export function VSCodeInstructions({
             {step === 0 && (
                 <>
                     <div className="pb-3 border-bottom">
-                        <H2>Setup instructions for VS Code</H2>
+                        <H2>Setup instructions for JetBrains</H2>
                     </div>
 
                     <div className={classNames('pt-3 px-3',styles.instructionsContainer)}>
@@ -129,73 +128,39 @@ export function VSCodeInstructions({
                         <H2>Using Cody on VS Code</H2>
                     </div>
                     <div className="d-flex">
-                        <div className="flex-1 p-3 border-right d-flex flex-column justify-content-center align-items-center">
-                            <Text className="mb-1 w-100" weight="bold">
+                        <div className="flex-1 p-3 border-right">
+                            <Text className="mb-1" weight="bold">
                                 Autocomplete
                             </Text>
-                            <Text className="mb-0 w-100 text-muted" size="small">
+                            <Text className="mb-0 text-muted" size="small">
                                 Cody will autocomplete your code as you type
                             </Text>
-                            <img
-                                alt="Cody Autocomplete"
-                                width="90%"
-                                className={classNames('mt-4', styles.guideIllustration)}
-                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/autoCompleteIllustration.svg"
-                            />
                         </div>
-                        <div className="flex-1 p-3 d-flex flex-column justify-content-center align-items-center">
-                            <Text className="mb-1  w-100" weight="bold">
+                        <div className="flex-1 p-3">
+                            <Text className="mb-1" weight="bold">
                                 Chat
                             </Text>
-                            <Text className="mb-0 text-muted  w-100" size="small">
+                            <Text className="mb-0 text-muted" size="small">
                                 Cody will autocomplete your code as you type
                             </Text>
-                            <img
-                                alt="Cody Chat"
-                                width="80%"
-                                className={classNames('mt-4')}
-                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/chatIllustration.svg"
-                            />
                         </div>
                     </div>
                     <div className="d-flex my-3 py-3 border-top border-bottom">
-                        <div className="flex-1 p-3 border-right d-flex flex-column justify-content-center align-items-center">
-                            <Text className="mb-1  w-100" weight="bold">
-                                Commands
+                        <div className="flex-1 p-3 border-right">
+                            <Text className="mb-1" weight="bold">
+                                Settings
                             </Text>
-                            <Text className="mb-0 text-muted  w-100" size="small">
+                            <Text className="mb-0 text-muted" size="small">
                                 Cody will autocomplete your code as you type
                             </Text>
-                            <img
-                                alt="Cody Commands"
-                                width="80%"
-                                className={classNames('mt-4')}
-                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/commandsIllustration.svg"
-                            />
                         </div>
-                        <div className="flex-1 p-3 d-flex flex-column justify-content-center align-items-center">
-                            <Text className="mb-1  w-100" weight="bold">
+                        <div className="flex-1 p-3">
+                            <Text className="mb-1" weight="bold">
                                 Feedback
                             </Text>
-                            <Text className="mb-0 text-muted w-100" size="small">
+                            <Text className="mb-0 text-muted" size="small">
                                 Cody will autocomplete your code as you type
                             </Text>
-                            <Link to="https://discord.gg/rDPqBejz93" className="d-flex w-100 justify-content-center">
-                            <img
-                                alt="Discord Feedback"
-                                width="50%"
-                                className={classNames('mt-5')}
-                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/discordCTA.svg"
-                            />
-                            </Link>
-                            <Link to="https://github.com/sourcegraph/cody/discussions/new?category=product-feedback" className="d-flex w-100 justify-content-center">
-                                <img
-                                alt="GitHub Feedback"
-                                width="50%"
-                                className={classNames('mt-4')}
-                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/feedbackCTA.svg"
-                                />
-                            </Link>
                         </div>
                     </div>
                     {showStep === undefined ? (

--- a/client/web/src/cody/onboarding/instructions/JetBrains.tsx
+++ b/client/web/src/cody/onboarding/instructions/JetBrains.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 
 import classNames from 'classnames'
+import { Link } from 'react-router-dom'
 
 import { H2, Text, Button, ButtonLink } from '@sourcegraph/wildcard'
 
 import styles from '../CodyOnboarding.module.scss'
-import {Link} from 'react-router-dom';
 
 export function JetBrainsInstructions({
     onBack,
@@ -26,7 +26,7 @@ export function JetBrainsInstructions({
                         <H2>Setup instructions for JetBrains</H2>
                     </div>
 
-                    <div className={classNames('pt-3 px-3',styles.instructionsContainer)}>
+                    <div className={classNames('pt-3 px-3', styles.instructionsContainer)}>
                         <div className={classNames('border-bottom', styles.highlightStep)}>
                             <div className="d-flex align-items-center">
                                 <div className="mr-1">
@@ -37,8 +37,10 @@ export function JetBrainsInstructions({
                                         Open the Plugins Page
                                     </Text>
                                     <Text className="text-muted mb-0" size="small">
-                                        Click the Cog icon in the top right corner of your IDE and select <strong>Plugins</strong>
-                                        Alternatively you can go to the settings option (use ⌘ + , for macOS, or File → Settings for Windows), then select "Plugins" from the menu on the left.
+                                        Click the Cog icon in the top right corner of your IDE and select{' '}
+                                        <strong>Plugins</strong>
+                                        Alternatively you can go to the settings option (use ⌘ + , for macOS, or File →
+                                        Settings for Windows), then select "Plugins" from the menu on the left.
                                     </Text>
                                 </div>
                             </div>
@@ -49,7 +51,6 @@ export function JetBrainsInstructions({
                                 >
                                     Open Marketplace
                                 </ButtonLink>
-
                             </div>
                         </div>
                         <div className="mt-3 border-bottom">
@@ -66,29 +67,26 @@ export function JetBrainsInstructions({
                                     </Text>
                                 </div>
                             </div>
-                            <div className="d-flex flex-column justify-content-center align-items-center mt-4">
-
-                        </div>
-                        <div className="mt-3 border-bottom">
-                            <div className="d-flex align-items-center">
-                                <div className="mr-1">
-                                    <div className={classNames('mr-2', styles.step)}>3</div>
+                            <div className="d-flex flex-column justify-content-center align-items-center mt-4"></div>
+                            <div className="mt-3 border-bottom">
+                                <div className="d-flex align-items-center">
+                                    <div className="mr-1">
+                                        <div className={classNames('mr-2', styles.step)}>3</div>
+                                    </div>
+                                    <div>
+                                        <Text className="mb-1" weight="bold">
+                                            Open the Plugin and Login
+                                        </Text>
+                                        <Text className="text-muted mb-0" size="small">
+                                            Cody will be available on the right side of your IDE. Click the Cody icon to
+                                            open the sidebar and login. Alternatively, you should get a notification
+                                            that you need to login to Cody.
+                                        </Text>
+                                    </div>
                                 </div>
-                                <div>
-                                    <Text className="mb-1" weight="bold">
-                                        Open the Plugin and Login
-                                    </Text>
-                                    <Text className="text-muted mb-0" size="small">
-                                        Cody will be available on the right side of your IDE. Click the Cody icon to open the sidebar and login.
-                                        Alternatively, you should get a notification that you need to login to Cody.
-                                    </Text>
-                                </div>
-                            </div>
-                            <div className="d-flex flex-column justify-content-center align-items-center mt-4">
-
+                                <div className="d-flex flex-column justify-content-center align-items-center mt-4"></div>
                             </div>
                         </div>
-                    </div>
                     </div>
 
                     {showStep === undefined ? (
@@ -174,7 +172,10 @@ export function JetBrainsInstructions({
                                     src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/discordCTA.svg"
                                 />
                             </Link>
-                            <Link to="https://github.com/sourcegraph/cody/discussions/new?category=product-feedback" className="d-flex w-100 justify-content-center">
+                            <Link
+                                to="https://github.com/sourcegraph/cody/discussions/new?category=product-feedback"
+                                className="d-flex w-100 justify-content-center"
+                            >
                                 <img
                                     alt="GitHub Feedback"
                                     width="50%"

--- a/client/web/src/cody/onboarding/instructions/JetBrains.tsx
+++ b/client/web/src/cody/onboarding/instructions/JetBrains.tsx
@@ -123,7 +123,7 @@ export function JetBrainsInstructions({
                             <img
                                 alt="Cody Autocomplete"
                                 width="90%"
-                                className={classNames('mt-4', styles.guideIllustration)}
+                                className="mt-4"
                                 src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/autoCompleteIllustration.svg"
                             />
                         </div>
@@ -137,7 +137,7 @@ export function JetBrainsInstructions({
                             <img
                                 alt="Cody Chat"
                                 width="80%"
-                                className={classNames('mt-4')}
+                                className="mt-4"
                                 src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/chatIllustration.svg"
                             />
                         </div>
@@ -153,7 +153,7 @@ export function JetBrainsInstructions({
                             <img
                                 alt="Cody Commands"
                                 width="80%"
-                                className={classNames('mt-4')}
+                                className="mt-4"
                                 src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/commandsIllustration.svg"
                             />
                         </div>
@@ -168,7 +168,7 @@ export function JetBrainsInstructions({
                                 <img
                                     alt="Discord Feedback"
                                     width="50%"
-                                    className={classNames('mt-5')}
+                                    className="mt-4"
                                     src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/discordCTA.svg"
                                 />
                             </Link>
@@ -179,7 +179,7 @@ export function JetBrainsInstructions({
                                 <img
                                     alt="GitHub Feedback"
                                     width="50%"
-                                    className={classNames('mt-4')}
+                                    className="mt-4"
                                     src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/feedbackCTA.svg"
                                 />
                             </Link>

--- a/client/web/src/cody/onboarding/instructions/JetBrains.tsx
+++ b/client/web/src/cody/onboarding/instructions/JetBrains.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { H2, Text, Button, ButtonLink } from '@sourcegraph/wildcard'
 
 import styles from '../CodyOnboarding.module.scss'
+import {Link} from 'react-router-dom';
 
 export function JetBrainsInstructions({
     onBack,
@@ -33,11 +34,11 @@ export function JetBrainsInstructions({
                                 </div>
                                 <div>
                                     <Text className="mb-1" weight="bold">
-                                        Install Cody
+                                        Open the Plugins Page
                                     </Text>
                                     <Text className="text-muted mb-0" size="small">
-                                        Alternatively, you can reach this page by clicking{' '}
-                                        <strong>View {'>'} Extensions</strong> and searching for <strong>Cody AI</strong>
+                                        Click the Cog icon in the top right corner of your IDE and select <strong>Plugins</strong>
+                                        Alternatively you can go to the settings option (use ⌘ + , for macOS, or File → Settings for Windows), then select "Plugins" from the menu on the left.
                                     </Text>
                                 </div>
                             </div>
@@ -48,12 +49,7 @@ export function JetBrainsInstructions({
                                 >
                                     Open Marketplace
                                 </ButtonLink>
-                                <img
-                                    alt="VS Code Marketplace"
-                                    className="mt-4"
-                                    width="70%"
-                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/__step1.png"
-                                />
+
                             </div>
                         </div>
                         <div className="mt-3 border-bottom">
@@ -63,21 +59,15 @@ export function JetBrainsInstructions({
                                 </div>
                                 <div>
                                     <Text className="mb-1" weight="bold">
-                                        Open Cody from the Sidebar on the Left
+                                        Install the Cody Plugin
                                     </Text>
                                     <Text className="text-muted mb-0" size="small">
-                                        Typically Cody will be the last item in the sidebar
+                                        Type "Cody" in the search bar and install the plugin.
                                     </Text>
                                 </div>
                             </div>
                             <div className="d-flex flex-column justify-content-center align-items-center mt-4">
-                                <img
-                                    alt="VS Code Marketplace"
-                                    className="mt-2"
-                                    width="70%"
-                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/__step2.png"
-                                />
-                            </div>
+
                         </div>
                         <div className="mt-3 border-bottom">
                             <div className="d-flex align-items-center">
@@ -86,22 +76,19 @@ export function JetBrainsInstructions({
                                 </div>
                                 <div>
                                     <Text className="mb-1" weight="bold">
-                                        Login
+                                        Open the Plugin and Login
                                     </Text>
                                     <Text className="text-muted mb-0" size="small">
-                                        Choose the same login method you used when you created your account
+                                        Cody will be available on the right side of your IDE. Click the Cody icon to open the sidebar and login.
+                                        Alternatively, you should get a notification that you need to login to Cody.
                                     </Text>
                                 </div>
                             </div>
                             <div className="d-flex flex-column justify-content-center align-items-center mt-4">
-                                <img
-                                    alt="VS Code Marketplace"
-                                    className="mt-2"
-                                    width="70%"
-                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/__step3.png"
-                                />
+
                             </div>
                         </div>
+                    </div>
                     </div>
 
                     {showStep === undefined ? (
@@ -125,42 +112,76 @@ export function JetBrainsInstructions({
             {step === 1 && (
                 <>
                     <div className="mb-3 pb-3 border-bottom">
-                        <H2>Using Cody on VS Code</H2>
+                        <H2>Cody Features</H2>
                     </div>
                     <div className="d-flex">
-                        <div className="flex-1 p-3 border-right">
-                            <Text className="mb-1" weight="bold">
+                        <div className="flex-1 p-3 border-right d-flex flex-column justify-content-center align-items-center">
+                            <Text className="mb-1 w-100" weight="bold">
                                 Autocomplete
                             </Text>
-                            <Text className="mb-0 text-muted" size="small">
+                            <Text className="mb-0 w-100 text-muted" size="small">
                                 Cody will autocomplete your code as you type
                             </Text>
+                            <img
+                                alt="Cody Autocomplete"
+                                width="90%"
+                                className={classNames('mt-4', styles.guideIllustration)}
+                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/autoCompleteIllustration.svg"
+                            />
                         </div>
-                        <div className="flex-1 p-3">
-                            <Text className="mb-1" weight="bold">
+                        <div className="flex-1 p-3 d-flex flex-column justify-content-center align-items-center">
+                            <Text className="mb-1  w-100" weight="bold">
                                 Chat
                             </Text>
-                            <Text className="mb-0 text-muted" size="small">
+                            <Text className="mb-0 text-muted  w-100" size="small">
                                 Cody will autocomplete your code as you type
                             </Text>
+                            <img
+                                alt="Cody Chat"
+                                width="80%"
+                                className={classNames('mt-4')}
+                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/chatIllustration.svg"
+                            />
                         </div>
                     </div>
                     <div className="d-flex my-3 py-3 border-top border-bottom">
-                        <div className="flex-1 p-3 border-right">
-                            <Text className="mb-1" weight="bold">
-                                Settings
+                        <div className="flex-1 p-3 border-right d-flex flex-column justify-content-center align-items-center">
+                            <Text className="mb-1  w-100" weight="bold">
+                                Commands
                             </Text>
-                            <Text className="mb-0 text-muted" size="small">
+                            <Text className="mb-0 text-muted  w-100" size="small">
                                 Cody will autocomplete your code as you type
                             </Text>
+                            <img
+                                alt="Cody Commands"
+                                width="80%"
+                                className={classNames('mt-4')}
+                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/commandsIllustration.svg"
+                            />
                         </div>
-                        <div className="flex-1 p-3">
-                            <Text className="mb-1" weight="bold">
+                        <div className="flex-1 p-3 d-flex flex-column justify-content-center align-items-center">
+                            <Text className="mb-1  w-100" weight="bold">
                                 Feedback
                             </Text>
-                            <Text className="mb-0 text-muted" size="small">
+                            <Text className="mb-0 text-muted w-100" size="small">
                                 Cody will autocomplete your code as you type
                             </Text>
+                            <Link to="https://discord.gg/rDPqBejz93" className="d-flex w-100 justify-content-center">
+                                <img
+                                    alt="Discord Feedback"
+                                    width="50%"
+                                    className={classNames('mt-5')}
+                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/discordCTA.svg"
+                                />
+                            </Link>
+                            <Link to="https://github.com/sourcegraph/cody/discussions/new?category=product-feedback" className="d-flex w-100 justify-content-center">
+                                <img
+                                    alt="GitHub Feedback"
+                                    width="50%"
+                                    className={classNames('mt-4')}
+                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/feedbackCTA.svg"
+                                />
+                            </Link>
                         </div>
                     </div>
                     {showStep === undefined ? (

--- a/client/web/src/cody/onboarding/instructions/VsCode.tsx
+++ b/client/web/src/cody/onboarding/instructions/VsCode.tsx
@@ -21,12 +21,12 @@ export function VSCodeInstructions({
         <>
             {step === 0 && (
                 <>
-                    <div className="mb-3 pb-3 border-bottom">
+                    <div className="pb-3 border-bottom">
                         <H2>Setup instructions for VS Code</H2>
                     </div>
 
-                    <div className={styles.instructionsContainer}>
-                        <div className="px-3 border-bottom">
+                    <div className={classNames('pt-3 px-3',styles.instructionsContainer)}>
+                        <div className={classNames('border-bottom', styles.highlightStep)}>
                             <div className="d-flex align-items-center">
                                 <div className="mr-1">
                                     <div className={classNames('mr-2', styles.step)}>1</div>
@@ -51,12 +51,12 @@ export function VSCodeInstructions({
                                 <img
                                     alt="VS Code Marketplace"
                                     className="mt-4"
-                                    width="80%"
+                                    width="70%"
                                     src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/__step1.png"
                                 />
                             </div>
                         </div>
-                        <div className="px-3 mt-3 border-bottom">
+                        <div className="mt-3 border-bottom">
                             <div className="d-flex align-items-center">
                                 <div className="mr-1">
                                     <div className={classNames('mr-2', styles.step)}>2</div>
@@ -74,12 +74,12 @@ export function VSCodeInstructions({
                                 <img
                                     alt="VS Code Marketplace"
                                     className="mt-2"
-                                    width="80%"
+                                    width="70%"
                                     src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/__step2.png"
                                 />
                             </div>
                         </div>
-                        <div className="px-3 mt-3 border-bottom">
+                        <div className="mt-3 border-bottom">
                             <div className="d-flex align-items-center">
                                 <div className="mr-1">
                                     <div className={classNames('mr-2', styles.step)}>3</div>
@@ -97,7 +97,7 @@ export function VSCodeInstructions({
                                 <img
                                     alt="VS Code Marketplace"
                                     className="mt-2"
-                                    width="80%"
+                                    width="70%"
                                     src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/__step3.png"
                                 />
                             </div>

--- a/client/web/src/cody/onboarding/instructions/VsCode.tsx
+++ b/client/web/src/cody/onboarding/instructions/VsCode.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
 
 import classNames from 'classnames'
-import { Link } from 'react-router-dom'
 
-import { H2, Text, Button, ButtonLink } from '@sourcegraph/wildcard'
+import { H2, Text, Button, ButtonLink, Link } from '@sourcegraph/wildcard'
 
 import styles from '../CodyOnboarding.module.scss'
 

--- a/client/web/src/cody/onboarding/instructions/VsCode.tsx
+++ b/client/web/src/cody/onboarding/instructions/VsCode.tsx
@@ -141,7 +141,7 @@ export function VSCodeInstructions({
                             <img
                                 alt="Cody Autocomplete"
                                 width="90%"
-                                className={classNames('mt-4', styles.guideIllustration)}
+                                className="mt-4"
                                 src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/autoCompleteIllustration.svg"
                             />
                         </div>
@@ -155,7 +155,7 @@ export function VSCodeInstructions({
                             <img
                                 alt="Cody Chat"
                                 width="80%"
-                                className={classNames('mt-4')}
+                                className="mt-4"
                                 src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/chatIllustration.svg"
                             />
                         </div>
@@ -171,7 +171,7 @@ export function VSCodeInstructions({
                             <img
                                 alt="Cody Commands"
                                 width="80%"
-                                className={classNames('mt-4')}
+                                className="mt-4"
                                 src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/commandsIllustration.svg"
                             />
                         </div>
@@ -186,7 +186,7 @@ export function VSCodeInstructions({
                                 <img
                                     alt="Discord Feedback"
                                     width="50%"
-                                    className={classNames('mt-5')}
+                                    className="mt-4"
                                     src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/discordCTA.svg"
                                 />
                             </Link>
@@ -197,7 +197,7 @@ export function VSCodeInstructions({
                                 <img
                                     alt="GitHub Feedback"
                                     width="50%"
-                                    className={classNames('mt-4')}
+                                    className="mt-4"
                                     src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/feedbackCTA.svg"
                                 />
                             </Link>

--- a/client/web/src/cody/onboarding/instructions/VsCode.tsx
+++ b/client/web/src/cody/onboarding/instructions/VsCode.tsx
@@ -45,7 +45,7 @@ export function VSCodeInstructions({
                             <div className="d-flex flex-column justify-content-center align-items-center mt-4">
                                 <ButtonLink
                                     variant="primary"
-                                    to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai"
+                                    to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai" target="_blank"
                                 >
                                     Open Marketplace
                                 </ButtonLink>

--- a/client/web/src/cody/onboarding/instructions/VsCode.tsx
+++ b/client/web/src/cody/onboarding/instructions/VsCode.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 
 import classNames from 'classnames'
+import { Link } from 'react-router-dom'
 
 import { H2, Text, Button, ButtonLink } from '@sourcegraph/wildcard'
 
 import styles from '../CodyOnboarding.module.scss'
-import {Link} from 'react-router-dom';
 
 export function VSCodeInstructions({
     onBack,
@@ -26,7 +26,7 @@ export function VSCodeInstructions({
                         <H2>Setup instructions for VS Code</H2>
                     </div>
 
-                    <div className={classNames('pt-3 px-3',styles.instructionsContainer)}>
+                    <div className={classNames('pt-3 px-3', styles.instructionsContainer)}>
                         <div className={classNames('border-bottom', styles.highlightStep)}>
                             <div className="d-flex align-items-center">
                                 <div className="mr-1">
@@ -38,14 +38,16 @@ export function VSCodeInstructions({
                                     </Text>
                                     <Text className="text-muted mb-0" size="small">
                                         Alternatively, you can reach this page by clicking{' '}
-                                        <strong>View {'>'} Extensions</strong> and searching for <strong>Cody AI</strong>
+                                        <strong>View {'>'} Extensions</strong> and searching for{' '}
+                                        <strong>Cody AI</strong>
                                     </Text>
                                 </div>
                             </div>
                             <div className="d-flex flex-column justify-content-center align-items-center mt-4">
                                 <ButtonLink
                                     variant="primary"
-                                    to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai" target="_blank"
+                                    to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai"
+                                    target="_blank"
                                 >
                                     Open Marketplace
                                 </ButtonLink>
@@ -181,19 +183,22 @@ export function VSCodeInstructions({
                                 Cody will autocomplete your code as you type
                             </Text>
                             <Link to="https://discord.gg/rDPqBejz93" className="d-flex w-100 justify-content-center">
-                            <img
-                                alt="Discord Feedback"
-                                width="50%"
-                                className={classNames('mt-5')}
-                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/discordCTA.svg"
-                            />
-                            </Link>
-                            <Link to="https://github.com/sourcegraph/cody/discussions/new?category=product-feedback" className="d-flex w-100 justify-content-center">
                                 <img
-                                alt="GitHub Feedback"
-                                width="50%"
-                                className={classNames('mt-4')}
-                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/feedbackCTA.svg"
+                                    alt="Discord Feedback"
+                                    width="50%"
+                                    className={classNames('mt-5')}
+                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/discordCTA.svg"
+                                />
+                            </Link>
+                            <Link
+                                to="https://github.com/sourcegraph/cody/discussions/new?category=product-feedback"
+                                className="d-flex w-100 justify-content-center"
+                            >
+                                <img
+                                    alt="GitHub Feedback"
+                                    width="50%"
+                                    className={classNames('mt-4')}
+                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/feedbackCTA.svg"
                                 />
                             </Link>
                         </div>

--- a/client/web/src/cody/onboarding/instructions/VsCode.tsx
+++ b/client/web/src/cody/onboarding/instructions/VsCode.tsx
@@ -126,7 +126,7 @@ export function VSCodeInstructions({
             {step === 1 && (
                 <>
                     <div className="mb-3 pb-3 border-bottom">
-                        <H2>Using Cody on VS Code</H2>
+                        <H2>Cody Features</H2>
                     </div>
                     <div className="d-flex">
                         <div className="flex-1 p-3 border-right d-flex flex-column justify-content-center align-items-center">

--- a/client/web/src/cody/onboarding/instructions/VsCode.tsx
+++ b/client/web/src/cody/onboarding/instructions/VsCode.tsx
@@ -24,67 +24,86 @@ export function VSCodeInstructions({
                     <div className="mb-3 pb-3 border-bottom">
                         <H2>Setup instructions for VS Code</H2>
                     </div>
-                    <div className="p-3">
-                        <div className="d-flex">
-                            <div>
-                                <div className={classNames('mr-2', styles.step)}>1</div>
+
+                    <div className={styles.instructionsContainer}>
+                        <div className="px-3 border-bottom">
+                            <div className="d-flex align-items-center">
+                                <div className="mr-1">
+                                    <div className={classNames('mr-2', styles.step)}>1</div>
+                                </div>
+                                <div>
+                                    <Text className="mb-1" weight="bold">
+                                        Install Cody
+                                    </Text>
+                                    <Text className="text-muted mb-0" size="small">
+                                        Alternatively, you can reach this page by clicking{' '}
+                                        <strong>View {'>'} Extensions</strong> and searching for <strong>Cody AI</strong>
+                                    </Text>
+                                </div>
                             </div>
-                            <div>
-                                <Text className="mb-1" weight="bold">
-                                    Install Cody
-                                </Text>
-                                <Text className="text-muted mb-0" size="small">
-                                    Alternatively, you can reach this page by clicking{' '}
-                                    <strong>View {'>'} Extensions</strong> and searching for <strong>Cody AI</strong>
-                                </Text>
+                            <div className="d-flex flex-column justify-content-center align-items-center mt-4">
+                                <ButtonLink
+                                    variant="primary"
+                                    to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai"
+                                >
+                                    Open Marketplace
+                                </ButtonLink>
+                                <img
+                                    alt="VS Code Marketplace"
+                                    className="mt-4"
+                                    width="80%"
+                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/__step1.png"
+                                />
                             </div>
                         </div>
-                        <div className="d-flex flex-column justify-content-center align-items-center mt-4">
-                            <ButtonLink
-                                variant="primary"
-                                to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai"
-                            >
-                                Open Marketplace
-                            </ButtonLink>
-                            <img
-                                alt="VS Code Marketplace"
-                                className="mt-4"
-                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/step1.png"
-                            />
+                        <div className="px-3 mt-3 border-bottom">
+                            <div className="d-flex align-items-center">
+                                <div className="mr-1">
+                                    <div className={classNames('mr-2', styles.step)}>2</div>
+                                </div>
+                                <div>
+                                    <Text className="mb-1" weight="bold">
+                                        Open Cody from the Sidebar on the Left
+                                    </Text>
+                                    <Text className="text-muted mb-0" size="small">
+                                        Typically Cody will be the last item in the sidebar
+                                    </Text>
+                                </div>
+                            </div>
+                            <div className="d-flex flex-column justify-content-center align-items-center mt-4">
+                                <img
+                                    alt="VS Code Marketplace"
+                                    className="mt-2"
+                                    width="80%"
+                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/__step2.png"
+                                />
+                            </div>
+                        </div>
+                        <div className="px-3 mt-3 border-bottom">
+                            <div className="d-flex align-items-center">
+                                <div className="mr-1">
+                                    <div className={classNames('mr-2', styles.step)}>3</div>
+                                </div>
+                                <div>
+                                    <Text className="mb-1" weight="bold">
+                                        Login
+                                    </Text>
+                                    <Text className="text-muted mb-0" size="small">
+                                        Choose the same login method you used when you created your account
+                                    </Text>
+                                </div>
+                            </div>
+                            <div className="d-flex flex-column justify-content-center align-items-center mt-4">
+                                <img
+                                    alt="VS Code Marketplace"
+                                    className="mt-2"
+                                    width="80%"
+                                    src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/__step3.png"
+                                />
+                            </div>
                         </div>
                     </div>
-                    <div className="p-3">
-                        <div className="d-flex">
-                            <div>
-                                <div className={classNames('mr-2', styles.step)}>2</div>
-                            </div>
-                            <div>
-                                <Text className="mb-1" weight="bold">
-                                    Open Cody from the Sidebar on the Left
-                                </Text>
-                            </div>
-                        </div>
-                        <div className="d-flex flex-column justify-content-center align-items-center mt-4">
-                            <img
-                                alt="VS Code Marketplace"
-                                className="mt-4"
-                                src="https://storage.googleapis.com/sourcegraph-assets/VSCodeInstructions/step2.png"
-                            />
-                        </div>
-                    </div>
-                    <div className="d-flex p-3 border-bottom">
-                        <div>
-                            <div className={classNames('mr-2', styles.step)}>3</div>
-                        </div>
-                        <div className="mb-4 pb-4">
-                            <Text className="mb-1" weight="bold">
-                                Login
-                            </Text>
-                            <Text className="text-muted mb-0" size="small">
-                                Choose the same login method you used when you created your account
-                            </Text>
-                        </div>
-                    </div>
+
                     {showStep === undefined ? (
                         <div className="mt-3 d-flex justify-content-between">
                             <Button variant="secondary" onClick={onBack} outline={true} size="sm">

--- a/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
+++ b/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
@@ -31,6 +31,8 @@ export interface CodyConfigurationPageProps extends TelemetryProps {
     repo?: { id: string; name: string }
 }
 
+/* eslint-disable  @sourcegraph/sourcegraph/check-help-links */
+
 export const CodyConfigurationPage: FC<CodyConfigurationPageProps> = ({
     authenticatedUser,
     queryPolicies = defaultQueryPolicies,

--- a/client/web/src/get-cody/GetCodyPage.tsx
+++ b/client/web/src/get-cody/GetCodyPage.tsx
@@ -46,6 +46,8 @@ const logEvent = (eventName: string, type?: string, source?: string): void =>
 
 const logPageView = (pageTitle: string): void => eventLogger.logPageView(pageTitle)
 
+/* eslint-disable  @sourcegraph/sourcegraph/check-help-links */
+
 export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authenticatedUser, context }) => {
     const navigate = useNavigate()
     const location = useLocation()

--- a/docsite_run.sh
+++ b/docsite_run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+cd /private/var/tmp/_bazel_danielmarques/2babe0eb2a573a2918fc1ea403c04cde/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/doc/serve.runfiles/__main__ && \
+  exec env \
+    -u JAVA_RUNFILES \
+    -u RUNFILES_DIR \
+    -u RUNFILES_MANIFEST_FILE \
+    -u RUNFILES_MANIFEST_ONLY \
+    -u TEST_SRCDIR \
+    BUILD_WORKING_DIRECTORY=/Users/danielmarques/Documents/GitHub/sourcegraph \
+    BUILD_WORKSPACE_DIRECTORY=/Users/danielmarques/Documents/GitHub/sourcegraph \
+  /private/var/tmp/_bazel_danielmarques/2babe0eb2a573a2918fc1ea403c04cde/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/doc/serve dev/tools/docsite "$@"


### PR DESCRIPTION
1. Adds Video to first step
2. Adds fade-in animation to first step
3. Adds coloured stroke to the modal
4. Makes the overaly bg more opaque
5. Converts all IDE icons to SVGs of the same size
6. Include Release Label on IDE list
7. Adds illustrations to VSCode step
8. Adds illustrations to feature step
9. Adds vertical support for modals with long content

This loom goes over all the changes
https://www.loom.com/share/f81613aecf874d0a9faca779f7d77cc0?sid=ff13e5e0-5aec-4b85-ab72-92e3f4979bdf


## Test plan

Previewed all locally
Mostly CSS and HTML changes

