### PR TITLE
SSC: Hook up exempted users with cody-pro FF

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -278,7 +278,6 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (n
 	// Enable the cody-pro feature flag for new users who are on the "exempted from the minimum external account age" list
 	dc := conf.Get().Dotcom
 	verifiedEmails, err := db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{UserID: userID, OnlyVerified: true})
-	fmt.Println("XXX verifiedEmails", verifiedEmails, dc, err)
 	if dc != nil && err == nil {
 		exempted := false
 		for _, exemptedEmail := range dc.MinimumExternalAccountAgeExemptList {
@@ -292,7 +291,6 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (n
 				break
 			}
 		}
-		fmt.Println("XXX exempted", exempted)
 		if exempted {
 			_, err = db.FeatureFlags().CreateOverride(context.Background(), &featureflag.Override{FlagName: "cody-pro", Value: true, UserID: &userID})
 			if err != nil {

--- a/cmd/frontend/internal/auth/oauth/BUILD.bazel
+++ b/cmd/frontend/internal/auth/oauth/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//internal/extsvc/bitbucketcloud",
         "//internal/extsvc/github",
         "//internal/extsvc/gitlab",
-        "//internal/featureflag",
         "//internal/httpcli",
         "//internal/trace",
         "//lib/errors",

--- a/cmd/frontend/internal/auth/oauth/BUILD.bazel
+++ b/cmd/frontend/internal/auth/oauth/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//internal/extsvc/bitbucketcloud",
         "//internal/extsvc/github",
         "//internal/extsvc/gitlab",
+        "//internal/featureflag",
         "//internal/httpcli",
         "//internal/trace",
         "//lib/errors",

--- a/cmd/frontend/internal/auth/oauth/session.go
+++ b/cmd/frontend/internal/auth/oauth/session.go
@@ -138,7 +138,7 @@ func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, ses
 		if newUserCreated {
 			dc := conf.Get().Dotcom
 			verifiedEmails, err := db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: true})
-			if dc != nil && err != nil && dc.MinimumExternalAccountAge > 0 {
+			if dc != nil && err != nil {
 				exempted := false
 				for _, exemptedEmail := range dc.MinimumExternalAccountAgeExemptList {
 					for _, verifiedEmail := range verifiedEmails {
@@ -153,6 +153,10 @@ func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, ses
 				}
 				if exempted {
 					_, err = db.FeatureFlags().CreateOverride(context.Background(), &featureflag.Override{FlagName: "cody-pro", Value: true, UserID: &user.ID})
+					if err != nil {
+						logger.Error("failed to create feature flag override", log.Error(err))
+						// Don't fail, though.
+					}
 				}
 			}
 		}

--- a/cmd/frontend/internal/auth/oauth/session.go
+++ b/cmd/frontend/internal/auth/oauth/session.go
@@ -3,8 +3,6 @@ package oauth
 import (
 	"context"
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"net/http"
 	"time"
 
@@ -132,33 +130,6 @@ func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, ses
 			logger.Error("OAuth failed: could not initiate session.", log.Error(err))
 			http.Error(w, fmt.Sprintf("Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: %s", err.Error()), http.StatusInternalServerError)
 			return
-		}
-
-		// Enable the cody-pro feature flag for new users who are on the "exempted from the minimum external account age" list
-		if newUserCreated {
-			dc := conf.Get().Dotcom
-			verifiedEmails, err := db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: true})
-			if dc != nil && err != nil {
-				exempted := false
-				for _, exemptedEmail := range dc.MinimumExternalAccountAgeExemptList {
-					for _, verifiedEmail := range verifiedEmails {
-						if verifiedEmail.Email == exemptedEmail {
-							exempted = true
-							break
-						}
-					}
-					if exempted {
-						break
-					}
-				}
-				if exempted {
-					_, err = db.FeatureFlags().CreateOverride(context.Background(), &featureflag.Override{FlagName: "cody-pro", Value: true, UserID: &user.ID})
-					if err != nil {
-						logger.Error("failed to create feature flag override", log.Error(err))
-						// Don't fail, though.
-					}
-				}
-			}
 		}
 
 		db.SecurityEventLogs().LogEvent(ctx, &database.SecurityEvent{

--- a/cmd/frontend/internal/auth/oauth/session.go
+++ b/cmd/frontend/internal/auth/oauth/session.go
@@ -134,7 +134,7 @@ func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, ses
 			return
 		}
 
-		// If the user is new, check if they should be exempted from the minimum external account age
+		// Enable the cody-pro feature flag for new users who are on the "exempted from the minimum external account age" list
 		if newUserCreated {
 			dc := conf.Get().Dotcom
 			verifiedEmails, err := db.UserEmails().ListByUser(ctx, database.UserEmailsListOptions{UserID: user.ID, OnlyVerified: true})

--- a/cmd/frontend/internal/auth/oauth/session.go
+++ b/cmd/frontend/internal/auth/oauth/session.go
@@ -125,7 +125,7 @@ func SessionIssuer(logger log.Logger, db database.DB, s SessionIssuerHelper, ses
 			return
 		}
 
-		// Since we obtained a valid user from the OAuth token, we consider the GitHub login successful at this point
+		// Since we obtained a valid user from the OAuth token, we consider the login successful at this point
 		ctx, err = session.SetActorFromUser(ctx, w, r, user, expiryDuration)
 		if err != nil {
 			span.SetError(err)


### PR DESCRIPTION
We have a few test users whom we want to make Cody PLG users automatically. This PR does that.

## Test plan

Tested this:
- ✅ Created a new user through OpenID Connect. If the user was on `MinimumExternalAccountAgeExemptList` then they got `cody-pro` as a feature flag.
- ✅ Otherwise, they didn't get the feature flag.
- ✅ If the `MinimumExternalAccountAgeExemptList` config item doesn't exist, it still works