### PR TITLE
Admin: avoid false impression that Zoekt is indexing

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -191,7 +191,7 @@ const TextSearchIndexedReference: React.FunctionComponent<
     return (
         <li className={styles.ref}>
             {showWarning ? (
-                <Tooltip content="Indexing has been delayed for over 8 hours. Please check logs for the indexed search service.">
+                <Tooltip content="Indexing has been delayed for over 8 hours. Please check the Zoekt indexserver logs.">
                     <Icon className={classNames(styles.refIcon)} svgPath={mdiAlert} aria-hidden={true} />
                 </Tooltip>
             ) : (

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -185,13 +185,13 @@ const TextSearchIndexedReference: React.FunctionComponent<
 > = ({ repo, indexedRef, lastIndexed }) => {
     const isCurrent = indexedRef.indexed && indexedRef.current
 
-    const indexingDelay = !indexedRef.current && lastIndexed && Date.now() - new Date(lastIndexed).getTime()
-    const showWarning = indexingDelay && indexingDelay > largeIndexingDelayMs
+    const lastIndexTime = !indexedRef.current && lastIndexed && new Date(lastIndexed).getTime()
+    const indexingDelayed = lastIndexTime && (Date.now() - lastIndexTime) > largeIndexingDelayMs
 
     return (
         <li className={styles.ref}>
-            {showWarning ? (
-                <Tooltip content="Indexing has been delayed for over 8 hours. Please check the Zoekt indexserver logs.">
+            {indexingDelayed ? (
+                <Tooltip content="Indexing hasn't completed for over 8 hours, which usually indicates an error. Please check the Zoekt indexserver logs.">
                     <Icon className={classNames(styles.refIcon)} svgPath={mdiAlert} aria-hidden={true} />
                 </Tooltip>
             ) : (
@@ -207,7 +207,7 @@ const TextSearchIndexedReference: React.FunctionComponent<
             &nbsp;&mdash;&nbsp;
             {indexedRef.indexed ? (
                 <span>
-                    {indexedRef.current ? 'up to date.' : 'queued for indexing.'}
+                    {indexedRef.current ? 'up to date.' : (indexingDelayed ? 'indexing is delayed.' : 'queued for indexing.')}
                     {' Last indexing job ran at '}
                     <Code>
                         <LinkOrSpan

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -186,7 +186,7 @@ const TextSearchIndexedReference: React.FunctionComponent<
     const isCurrent = indexedRef.indexed && indexedRef.current
 
     const lastIndexTime = !indexedRef.current && lastIndexed && new Date(lastIndexed).getTime()
-    const indexingDelayed = lastIndexTime && (Date.now() - lastIndexTime) > largeIndexingDelayMs
+    const indexingDelayed = lastIndexTime && Date.now() - lastIndexTime > largeIndexingDelayMs
 
     return (
         <li className={styles.ref}>
@@ -207,7 +207,11 @@ const TextSearchIndexedReference: React.FunctionComponent<
             &nbsp;&mdash;&nbsp;
             {indexedRef.indexed ? (
                 <span>
-                    {indexedRef.current ? 'up to date.' : (indexingDelayed ? 'indexing is delayed.' : 'queued for indexing.')}
+                    {indexedRef.current
+                        ? 'up to date.'
+                        : indexingDelayed
+                        ? 'indexing is delayed.'
+                        : 'queued for indexing.'}
                     {' Last indexing job ran at '}
                     <Code>
                         <LinkOrSpan


### PR DESCRIPTION
Previously, when an index is not up-to-date, we'd always claim that we're
actively indexing the repo. This is misleading, because indexing indexing could
be stuck or failing.

Now, we remove the loading spinner and just say the repo is "queued for
indexing". If the index is out-of-date and it's been more than 8 hours since
the last successful job, then we also show a warning tooltip.

Addresses #57337

## Test plan

Lots of manual testing.
