### PR TITLE
errored repos syncer: do not try to sync blocked repos

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -165,6 +165,7 @@ JOIN external_service_repos esr ON gr.repo_id = esr.repo_id
 JOIN external_services es on esr.external_service_id = es.id
 WHERE
 	gr.last_error != ''
+	AND r.blocked IS NULL
 	AND r.deleted_at IS NULL
 	AND es.cloud_default IS TRUE
 `
@@ -183,6 +184,7 @@ JOIN external_service_repos esr ON repo.id = esr.repo_id
 JOIN external_services es on esr.external_service_id = es.id
 WHERE
 	gr.last_error != ''
+	AND repo.blocked IS NULL
 	AND repo.deleted_at IS NULL
 	AND es.cloud_default IS TRUE
 `


### PR DESCRIPTION
This syncer tries to sync repos that have an error, but it also tries to sync *blocked* repos which would always fail to sync. Unnecessary work.


## Test plan

- Unit tests
- Confirmation in production by looking at logs