### PR TITLE
SSC: Fix Cody Web

### DIFF
--- a/internal/accesstoken/personal_access_token.go
+++ b/internal/accesstoken/personal_access_token.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// personalAccessTokenPrefix is the token prefix for Sourcegraph personal access tokens. Its purpose
+// PersonalAccessTokenPrefix is the token prefix for Sourcegraph personal access tokens. Its purpose
 // is to make it easier to identify that a given string (in a file, document, etc.) is a secret
 // Sourcegraph personal access token (vs. some arbitrary high-entropy hex-encoded value).
 const PersonalAccessTokenPrefix = "sgp_"
@@ -21,7 +21,7 @@ const InstanceIdentifierHmacKey = "instance_identifier_hmac_key" // Public as we
 
 var personalAccessTokenRegex = lazyregexp.New("^(?:sgp_|sgph_)?(?:[a-fA-F0-9]{16}_|local_)?([a-fA-F0-9]{40})$")
 
-// ParseAccessToken parses a personal access token to remove prefixes and extract the <token> that is stored in the database
+// ParsePersonalAccessToken parses a personal access token to remove prefixes and extract the <token> that is stored in the database
 // Personal access tokens can take several forms:
 //   - <token>
 //   - sgp_<token>

--- a/internal/completions/httpapi/BUILD.bazel
+++ b/internal/completions/httpapi/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//internal/conf/conftypes",
         "//internal/database",
         "//internal/featureflag",
+        "//internal/hashutil",
         "//internal/honey",
         "//internal/redispool",
         "//internal/requestclient",

--- a/internal/completions/httpapi/chat.go
+++ b/internal/completions/httpapi/chat.go
@@ -22,6 +22,7 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 	return newCompletionsHandler(
 		logger,
 		db.Users(),
+		db.AccessTokens(),
 		telemetryrecorder.New(db),
 		types.CompletionsFeatureChat,
 		rl,

--- a/internal/completions/httpapi/codecompletion.go
+++ b/internal/completions/httpapi/codecompletion.go
@@ -22,6 +22,7 @@ func NewCodeCompletionsHandler(logger log.Logger, db database.DB) http.Handler {
 	return newCompletionsHandler(
 		logger,
 		db.Users(),
+		db.AccessTokens(),
 		telemetryrecorder.New(db),
 		types.CompletionsFeatureCode,
 		rl,

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -16,9 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/hashutil"
-	"net/http"
-	"strconv"
-	"time"
 
 	"github.com/sourcegraph/log"
 

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -93,6 +93,7 @@ func newCompletionsHandler(
 		isDotcom := envvar.SourcegraphDotComMode()
 		isProviderCodyGateway := completionsConfig.Provider == conftypes.CompletionsProviderNameSourcegraph
 		if isCodyProEnabled && isDotcom && isProviderCodyGateway {
+			// Note: if we have no Authorization header, that's fine too, this will return an error
 			apiToken, _, err := authz.ParseAuthorizationHeader(r.Header.Get("Authorization"))
 			if err != nil {
 				// No actor either, so we fail.

--- a/internal/database/access_tokens_test.go
+++ b/internal/database/access_tokens_test.go
@@ -531,9 +531,9 @@ func testAccessTokens_tokenSHA256Hash(t *testing.T) {
 		wantError bool
 	}{
 		{name: "old prefix-less format", token: "0123456789012345678901234567890123456789"},
-		{name: "old prefix format", token: "sgp_01234567890123456789" + "01234567890123456789"},
-		{name: "new local identifier format", token: "sgp_local_01234567890123456789" + "01234567890123456789"},
-		{name: "new identifier format", token: "sgp_abcdef0123456789_01234567890123456789" + "01234567890123456789"},
+		{name: "old prefix format", token: "sgp_0123456789012345678901234567890123456789"},
+		{name: "new local identifier format", token: "sgp_local_0123456789012345678901234567890123456789"},
+		{name: "new identifier format", token: "sgp_abcdef0123456789_0123456789012345678901234567890123456789"},
 		{name: "empty", token: "", wantError: true},
 		{name: "invalid", token: "×", wantError: true},
 		{name: "invalid", token: "xxx", wantError: true},

--- a/internal/database/access_tokens_test.go
+++ b/internal/database/access_tokens_test.go
@@ -36,6 +36,7 @@ func TestAccessTokens(t *testing.T) {
 		t.Run("testAccessTokens_Lookup", testAccessTokens_Lookup)
 		t.Run("testAccessToken_Lookup_deletedUser", testAccessTokens_Lookup_deletedUser)
 		t.Run("testAccessTokens_tokenSHA256Hash", testAccessTokens_tokenSHA256Hash)
+		t.Run("testAccessTokens_GetOrCreateInternalToken", testAccessTokens_GetOrCreateInternalToken)
 	})
 
 	// Don't run parallel as it's mocking an expired license
@@ -530,9 +531,9 @@ func testAccessTokens_tokenSHA256Hash(t *testing.T) {
 		wantError bool
 	}{
 		{name: "old prefix-less format", token: "0123456789012345678901234567890123456789"},
-		{name: "old prefix format", token: "sgp_0123456789012345678901234567890123456789"},
-		{name: "new local identifier format", token: "sgp_local_0123456789012345678901234567890123456789"},
-		{name: "new identifier format", token: "sgp_abcdef0123456789_0123456789012345678901234567890123456789"},
+		{name: "old prefix format", token: "sgp_01234567890123456789" + "01234567890123456789"},
+		{name: "new local identifier format", token: "sgp_local_01234567890123456789" + "01234567890123456789"},
+		{name: "new identifier format", token: "sgp_abcdef0123456789_01234567890123456789" + "01234567890123456789"},
 		{name: "empty", token: "", wantError: true},
 		{name: "invalid", token: "×", wantError: true},
 		{name: "invalid", token: "xxx", wantError: true},
@@ -551,4 +552,39 @@ func testAccessTokens_tokenSHA256Hash(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testAccessTokens_GetOrCreateInternalToken(t *testing.T) {
+	db := NewDB(logtest.Scoped(t), dbtest.NewDB(t))
+	ctx := context.Background()
+
+	t.Run("can create and retrieve tokens", func(t *testing.T) {
+		u, err := db.Users().Create(ctx, NewUser{Email: "a@test.com", Username: "a", EmailIsVerified: true})
+		assert.NoError(t, err)
+
+		// Create token automatically
+		sha256, err := db.AccessTokens().GetOrCreateInternalToken(ctx, u.ID, []string{"a"})
+		assert.NoError(t, err)
+		assert.NotEmpty(t, sha256)
+
+		// Retrieve same token again
+		sha256Again, err := db.AccessTokens().GetOrCreateInternalToken(ctx, u.ID, []string{"a"})
+		assert.NoError(t, err)
+		assert.Equal(t, sha256, sha256Again)
+	})
+
+	t.Run("can create and retrieve tokens", func(t *testing.T) {
+		u, err := db.Users().Create(ctx, NewUser{Email: "b@test.com", Username: "b", EmailIsVerified: true})
+		assert.NoError(t, err)
+
+		// Create token manually
+		_, token, err := db.AccessTokens().CreateInternal(ctx, u.ID, []string{"a"}, "n0", u.ID)
+		assert.NoError(t, err)
+		hashedToken, err := tokenSHA256Hash(token)
+
+		// Get token and compare it
+		sha256, err := db.AccessTokens().GetOrCreateInternalToken(ctx, u.ID, []string{"a"})
+		assert.NoError(t, err)
+		assert.Equal(t, hashedToken, sha256)
+	})
 }

--- a/internal/database/access_tokens_test.go
+++ b/internal/database/access_tokens_test.go
@@ -581,6 +581,7 @@ func testAccessTokens_GetOrCreateInternalToken(t *testing.T) {
 		_, token, err := db.AccessTokens().CreateInternal(ctx, u.ID, []string{"a"}, "n0", u.ID)
 		assert.NoError(t, err)
 		hashedToken, err := tokenSHA256Hash(token)
+		assert.NoError(t, err)
 
 		// Get token and compare it
 		sha256, err := db.AccessTokens().GetOrCreateInternalToken(ctx, u.ID, []string{"a"})

--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -1193,6 +1193,9 @@ type MockAccessTokenStore struct {
 	// GetByTokenFunc is an instance of a mock function object controlling
 	// the behavior of the method GetByToken.
 	GetByTokenFunc *AccessTokenStoreGetByTokenFunc
+	// GetOrCreateInternalTokenFunc is an instance of a mock function object
+	// controlling the behavior of the method GetOrCreateInternalToken.
+	GetOrCreateInternalTokenFunc *AccessTokenStoreGetOrCreateInternalTokenFunc
 	// HandleFunc is an instance of a mock function object controlling the
 	// behavior of the method Handle.
 	HandleFunc *AccessTokenStoreHandleFunc
@@ -1250,6 +1253,11 @@ func NewMockAccessTokenStore() *MockAccessTokenStore {
 		},
 		GetByTokenFunc: &AccessTokenStoreGetByTokenFunc{
 			defaultHook: func(context.Context, string) (r0 *database.AccessToken, r1 error) {
+				return
+			},
+		},
+		GetOrCreateInternalTokenFunc: &AccessTokenStoreGetOrCreateInternalTokenFunc{
+			defaultHook: func(context.Context, int32, []string) (r0 []byte, r1 error) {
 				return
 			},
 		},
@@ -1325,6 +1333,11 @@ func NewStrictMockAccessTokenStore() *MockAccessTokenStore {
 				panic("unexpected invocation of MockAccessTokenStore.GetByToken")
 			},
 		},
+		GetOrCreateInternalTokenFunc: &AccessTokenStoreGetOrCreateInternalTokenFunc{
+			defaultHook: func(context.Context, int32, []string) ([]byte, error) {
+				panic("unexpected invocation of MockAccessTokenStore.GetOrCreateInternalToken")
+			},
+		},
 		HandleFunc: &AccessTokenStoreHandleFunc{
 			defaultHook: func() basestore.TransactableHandle {
 				panic("unexpected invocation of MockAccessTokenStore.Handle")
@@ -1383,6 +1396,9 @@ func NewMockAccessTokenStoreFrom(i database.AccessTokenStore) *MockAccessTokenSt
 		},
 		GetByTokenFunc: &AccessTokenStoreGetByTokenFunc{
 			defaultHook: i.GetByToken,
+		},
+		GetOrCreateInternalTokenFunc: &AccessTokenStoreGetOrCreateInternalTokenFunc{
+			defaultHook: i.GetOrCreateInternalToken,
 		},
 		HandleFunc: &AccessTokenStoreHandleFunc{
 			defaultHook: i.Handle,
@@ -2180,6 +2196,121 @@ func (c AccessTokenStoreGetByTokenFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c AccessTokenStoreGetByTokenFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// AccessTokenStoreGetOrCreateInternalTokenFunc describes the behavior when
+// the GetOrCreateInternalToken method of the parent MockAccessTokenStore
+// instance is invoked.
+type AccessTokenStoreGetOrCreateInternalTokenFunc struct {
+	defaultHook func(context.Context, int32, []string) ([]byte, error)
+	hooks       []func(context.Context, int32, []string) ([]byte, error)
+	history     []AccessTokenStoreGetOrCreateInternalTokenFuncCall
+	mutex       sync.Mutex
+}
+
+// GetOrCreateInternalToken delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockAccessTokenStore) GetOrCreateInternalToken(v0 context.Context, v1 int32, v2 []string) ([]byte, error) {
+	r0, r1 := m.GetOrCreateInternalTokenFunc.nextHook()(v0, v1, v2)
+	m.GetOrCreateInternalTokenFunc.appendCall(AccessTokenStoreGetOrCreateInternalTokenFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetOrCreateInternalToken method of the parent MockAccessTokenStore
+// instance is invoked and the hook queue is empty.
+func (f *AccessTokenStoreGetOrCreateInternalTokenFunc) SetDefaultHook(hook func(context.Context, int32, []string) ([]byte, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetOrCreateInternalToken method of the parent MockAccessTokenStore
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *AccessTokenStoreGetOrCreateInternalTokenFunc) PushHook(hook func(context.Context, int32, []string) ([]byte, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *AccessTokenStoreGetOrCreateInternalTokenFunc) SetDefaultReturn(r0 []byte, r1 error) {
+	f.SetDefaultHook(func(context.Context, int32, []string) ([]byte, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *AccessTokenStoreGetOrCreateInternalTokenFunc) PushReturn(r0 []byte, r1 error) {
+	f.PushHook(func(context.Context, int32, []string) ([]byte, error) {
+		return r0, r1
+	})
+}
+
+func (f *AccessTokenStoreGetOrCreateInternalTokenFunc) nextHook() func(context.Context, int32, []string) ([]byte, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *AccessTokenStoreGetOrCreateInternalTokenFunc) appendCall(r0 AccessTokenStoreGetOrCreateInternalTokenFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// AccessTokenStoreGetOrCreateInternalTokenFuncCall objects describing the
+// invocations of this function.
+func (f *AccessTokenStoreGetOrCreateInternalTokenFunc) History() []AccessTokenStoreGetOrCreateInternalTokenFuncCall {
+	f.mutex.Lock()
+	history := make([]AccessTokenStoreGetOrCreateInternalTokenFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// AccessTokenStoreGetOrCreateInternalTokenFuncCall is an object that
+// describes an invocation of method GetOrCreateInternalToken on an instance
+// of MockAccessTokenStore.
+type AccessTokenStoreGetOrCreateInternalTokenFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int32
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 []string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []byte
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c AccessTokenStoreGetOrCreateInternalTokenFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c AccessTokenStoreGetOrCreateInternalTokenFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/58572

Our plan to use internal access tokens worked!
I found no way to get the SHA256-hashed token value from the DB, so I created a new function to get it.
I tested the new function to make sure it works. 

## Test plan

Tested it in two ways:
1. With Cody Web locally: I could repro the problem before this change, and not after. 🎉 
2. In the API console with the query
```
query CodyGatewayAccess {
  completions(input: {messages: [{speaker:HUMAN, text:"hi\n\nAssistant:"}], temperature:1,maxTokensToSample: 2, topK: 1, topP: 1}) {}
}
```

Btw, it's an additional win that the API console works again!
