### PR TITLE
wolfi: add redis cli to server image

### DIFF
--- a/wolfi-images/redis.yaml
+++ b/wolfi-images/redis.yaml
@@ -8,6 +8,7 @@ contents:
 
     # redis packages
     - redis-6.2
+    - redis-cli-6.2
 
 accounts:
   groups:

--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -29,6 +29,7 @@ contents:
     - prometheus
     - prometheus-alertmanager
     - redis-6.2
+    - redis-cli-6.2
     - sqlite-libs
     - su-exec
 


### PR DESCRIPTION
`redis-cli` package was missing from image
## Test plan
`sg wolfi image server` + ` docker run -it --entrypoint /bin/sh sourcegraph-wolfi/server-base:latest-amd64 redis-cli -h`
