### PR TITLE
p4: remove skips

### DIFF
--- a/dev/gqltest/external_service_test.go
+++ b/dev/gqltest/external_service_test.go
@@ -162,7 +162,6 @@ func TestExternalService_BitbucketServer(t *testing.T) {
 }
 
 func TestExternalService_Perforce(t *testing.T) {
-	t.Skip("disabled pending p4 trust fix")
 	for _, tc := range []struct {
 		name      string
 		depot     string

--- a/dev/gqltest/sub_repo_permissions_test.go
+++ b/dev/gqltest/sub_repo_permissions_test.go
@@ -21,7 +21,6 @@ const (
 )
 
 func TestSubRepoPermissionsPerforce(t *testing.T) {
-	t.Skip("disabled pending p4 trust fix")
 	checkPerforceEnvironment(t)
 	enableSubRepoPermissions(t)
 	cleanup := createPerforceExternalService(t, testPermsDepot, false)


### PR DESCRIPTION
My 5.2 branch I branched off was dirty when I created https://github.com/sourcegraph/sourcegraph/pull/58805/files and consequently contained two skips had from a previous debugging session.

## Test plan
CI
