### PR TITLE
Use document element for class theme in code hosts integrations

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -727,8 +727,8 @@ export async function handleCodeHost({
     // Handle theming
     subscriptions.add(
         (codeHost.isLightTheme ?? of(true)).subscribe(isLightTheme => {
-            document.body.classList.toggle('theme-light', isLightTheme)
-            document.body.classList.toggle('theme-dark', !isLightTheme)
+            document.documentElement.classList.toggle('theme-light', isLightTheme)
+            document.documentElement.classList.toggle('theme-dark', !isLightTheme)
         })
     )
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/23251

I think this problem has been with us since the very beginning of native code integration and browser extension development. This may became even worse since we switched from Webpack to esbuild where we include all possible code host styles in one bundle (meaning that we still load GitHub-related styles even if we're in GitLab integration). 

Overall, the current state is 
- In this PR we use just a hot fix way and use the most top level HTML element to assign css tokens and colors (this gives us ability to not native styles and keep cascade specificity lower than native styles)
- Possible we could use here `@layer` cascade at-rule, but at the moment our CSS token system structure just ins't ready for this change and this could lead to some regressions in the main application. 
- Ideally, we should assign CSS tokens only on nodes where we actually render something Sourcegraph specific, like code-intel tooltip or "open in Sourcegraph" button. But again, this would require to change our global css tokens in our wildcard, so we skip this option for now but should take this option as a main one if we would return to our browser extension development in future.
- We still do have `.hljs` css global classes in the bundle, but since Gitlab increase cascade specificity on their side this is kind of fixed but this is where we could use `@layers` approach IMO)


## Test plan
- Check gitlab with enabled browser extension in different themes, check that code editor and general UI has native gitlab styles.

## Note after merging this
- Don't forget to run publish script as soon as this change is merged.
