### PR TITLE
gomod: Bump Zoekt to remove shard logging

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5722,8 +5722,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:nhxLVoE/muGcygm76NwutJC4fQ1IVgkNXY7xOLGnDI8=",
-        version = "v0.0.0-20231129132138-0d03621d45a3",
+        sum = "h1:ODktEWcIYRQHQjbg8X9rZAYcgYuSASZ0nn7nz4MNgS4=",
+        version = "v0.0.0-20231206165318-7b678e15c348",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -569,7 +569,7 @@ require (
 	github.com/sourcegraph/managed-services-platform-cdktf/gen/postgresql v0.0.0-20231121191755-214be625af21
 	github.com/sourcegraph/mountinfo v0.0.0-20231018142932-e00da332dac5
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20231129132138-0d03621d45a3
+	github.com/sourcegraph/zoekt v0.0.0-20231206165318-7b678e15c348
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1665,8 +1665,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20231129132138-0d03621d45a3 h1:nhxLVoE/muGcygm76NwutJC4fQ1IVgkNXY7xOLGnDI8=
-github.com/sourcegraph/zoekt v0.0.0-20231129132138-0d03621d45a3/go.mod h1:bWvtH95V0T8hHKS3wWyo5aYDXiDKlObq5kC7nltqXqk=
+github.com/sourcegraph/zoekt v0.0.0-20231206165318-7b678e15c348 h1:ODktEWcIYRQHQjbg8X9rZAYcgYuSASZ0nn7nz4MNgS4=
+github.com/sourcegraph/zoekt v0.0.0-20231206165318-7b678e15c348/go.mod h1:DA42q8CujJGj9zLcJfgvVV3VI6rykt/VrjkLaGdmNp4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This bumps Zoekt to pick up a fix to remove shard logging, which showed up as a
major memory contributor in profiles.

https://github.com/sourcegraph/zoekt/compare/0d03621d45a3...7b678e15c348

- https://github.com/sourcegraph/zoekt/commit/51fc9db12f all: remove detailed debug file logging
- https://github.com/sourcegraph/zoekt/commit/7b678e15c3 Indexing: clean up ctags parser wrapper

## Test plan

Zoekt and Sourcegraph CI