### PR TITLE
docs: fix up caa records requirement

### DIFF
--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -88,10 +88,9 @@ To verify that your CAA records are set correctly, you can use the following com
 
 ```sh
 dig acme.com caa +short
-dig src.acme.com caa +short
 ```
 
-If the output is empty, you don't have to do anything. If the output is not empty, and it does not contain `letsencrypt.org` and `pki.goog`, you need to add them to your CAA records to the apex domain or your desired subdomain, e.g., `src.acme.com`.
+If the output is empty, you don't have to do anything. If the output is not empty, and it does not contain `letsencrypt.org` and `pki.goog`, you need to add them to your CAA records to the apex domain.
 
 #### Limitations
 


### PR DESCRIPTION
you can't have CAA on `src.acme.com`, cuz it already has a CNAME to cloud-managed domain `acme.sourcegraphcloud.com`. It has to be on the apex domain


## Test plan

docs only

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@michaellzc-patch-3)