### PR TITLE
oidc: store access token into auth_data

### DIFF
--- a/cmd/frontend/internal/auth/openidconnect/BUILD.bazel
+++ b/cmd/frontend/internal/auth/openidconnect/BUILD.bazel
@@ -66,5 +66,6 @@ go_test(
         "@com_github_coreos_go_oidc//:go-oidc",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_oauth2//:oauth2",
     ],
 )

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -329,7 +329,7 @@ func AuthCallback(db database.DB, r *http.Request, usernamePrefix string, getPro
 		return c.Value
 	}
 	anonymousId, _ := cookie.AnonymousUID(r)
-	newUserCreated, actor, safeErrMsg, err := getOrCreateUser(r.Context(), db, p, idToken, userInfo, &claims, usernamePrefix, anonymousId, getCookie("sourcegraphSourceUrl"), getCookie("sourcegraphRecentSourceUrl"))
+	newUserCreated, actor, safeErrMsg, err := getOrCreateUser(r.Context(), db, p, oauth2Token, idToken, userInfo, &claims, usernamePrefix, anonymousId, getCookie("sourcegraphSourceUrl"), getCookie("sourcegraphRecentSourceUrl"))
 	if err != nil {
 		return nil,
 			safeErrMsg,

--- a/cmd/frontend/internal/auth/openidconnect/user_test.go
+++ b/cmd/frontend/internal/auth/openidconnect/user_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/coreos/go-oidc"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
@@ -67,6 +68,7 @@ func TestAllowSignup(t *testing.T) {
 				context.Background(),
 				dbmocks.NewStrictMockDB(),
 				p,
+				&oauth2.Token{},
 				&oidc.IDToken{},
 				&oidc.UserInfo{
 					Email:         "foo@bar.com",


### PR DESCRIPTION
We haven't been storing token info into the `user_external_accounts.auth_data` column, which might be an oversight. We need to store the token info for SAMS (and Cody Gateway later on), so need to fix it now.

## Test plan

CI and tested e2e (local credentials):

<img width="608" alt="CleanShot 2023-12-06 at 17 52 21@2x" src="https://github.com/sourcegraph/sourcegraph/assets/2946214/b59f6bb4-91e8-457e-89ba-811e8a9ded13">
