### PR TITLE
msp: add monitoring stack

### DIFF
--- a/dev/managedservicesplatform/BUILD.bazel
+++ b/dev/managedservicesplatform/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//dev/managedservicesplatform/internal/stack",
         "//dev/managedservicesplatform/internal/stack/cloudrun",
         "//dev/managedservicesplatform/internal/stack/iam",
+        "//dev/managedservicesplatform/internal/stack/monitoring",
         "//dev/managedservicesplatform/internal/stack/options/terraformversion",
         "//dev/managedservicesplatform/internal/stack/options/tfcbackend",
         "//dev/managedservicesplatform/internal/stack/project",

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//dev/managedservicesplatform:__subpackages__"],
     deps = [
         "//dev/managedservicesplatform/internal/resourceid",
+        "//dev/managedservicesplatform/spec",
         "//lib/pointers",
         "@com_github_aws_constructs_go_constructs_v10//:constructs",
         "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//monitoringalertpolicy",

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     visibility = ["//dev/managedservicesplatform:__subpackages__"],
     deps = [
         "//dev/managedservicesplatform/internal/resourceid",
-        "//dev/managedservicesplatform/spec",
         "//lib/errors",
         "//lib/pointers",
         "@com_github_aws_constructs_go_constructs_v10//:constructs",

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//dev/managedservicesplatform/internal/resourceid",
         "//dev/managedservicesplatform/spec",
+        "//lib/errors",
         "//lib/pointers",
         "@com_github_aws_constructs_go_constructs_v10//:constructs",
         "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//monitoringalertpolicy",

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//dev:go_defs.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "monitoringalertpolicy",
+    srcs = ["monitoringalertpolicy.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/monitoringalertpolicy",
+    visibility = ["//dev/managedservicesplatform:__subpackages__"],
+    deps = [
+        "//dev/managedservicesplatform/internal/resourceid",
+        "//lib/pointers",
+        "@com_github_aws_constructs_go_constructs_v10//:constructs",
+        "@com_github_sourcegraph_managed_services_platform_cdktf_gen_google//monitoringalertpolicy",
+    ],
+)
+
+go_test(
+    name = "monitoringalertpolicy_test",
+    srcs = ["monitoringalertpolicy_test.go"],
+    embed = [":monitoringalertpolicy"],
+    deps = [
+        "//lib/pointers",
+        "@com_github_hexops_autogold_v2//:autogold",
+    ],
+)

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
@@ -211,8 +211,8 @@ func buildFilter(config *Config) string {
 		filters = append(filters, fmt.Sprintf(`%s = "%s"`, key, val))
 	}
 
-	// Sort to ensure stable output for testing
-	// This code runs so infreuqently that sort performance is not a concern and there are only a couple elements
+	// Sort to ensure stable output for testing, because
+	// config.ThresholdAggregation.Filters is a map.
 	sort.Strings(filters)
 
 	if config.ServiceKind == spec.ServiceKindService {

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
@@ -82,7 +82,7 @@ type ThresholdAggregation struct {
 	Duration     string
 }
 
-// ResponseCodeMetric for alerting when the numer of a certain response code exceeds a threshold
+// ResponseCodeMetric for alerting when the number of a certain response code exceeds a threshold
 //
 // Must specify either `Code` (e.g. 404) or `CodeClass` (e.g. 4xx)
 //

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
@@ -274,11 +274,12 @@ func responseCodeMetric(scope constructs.Construct, id resourceid.ID, config *Co
 func responseCodeBuilder(config *Config) string {
 	var builder strings.Builder
 
-	builder.WriteString("fetch cloud_run_revision\n")
-	builder.WriteString("| metric 'run.googleapis.com/request_count'\n")
-	builder.WriteString("| group_by 15s, [value_request_count_aggregate: aggregate(value.request_count)]\n")
-	builder.WriteString("| every 15s\n")
-	builder.WriteString("| {\n")
+	builder.WriteString(`fetch cloud_run_revision
+| metric 'run.googleapis.com/request_count'
+| group_by 15s, [value_request_count_aggregate: aggregate(value.request_count)]
+| every 15s
+| {
+`)
 	if config.ResponseCodeMetric.CodeClass != nil {
 		builder.WriteString("  group_by [metric.response_code, metric.response_code_class],\n")
 	} else {
@@ -295,11 +296,12 @@ func responseCodeBuilder(config *Config) string {
 			builder.WriteString(fmt.Sprintf("  | filter (metric.response_code != '%s')\n", code))
 		}
 	}
-	builder.WriteString("; group_by [],\n")
-	builder.WriteString("  [value_request_count_aggregate_aggregate: aggregate(value_request_count_aggregate)]\n")
-	builder.WriteString("}\n")
-	builder.WriteString("| join\n")
-	builder.WriteString("| value [response_code_ratio: val(0) / val(1)]\n")
+	builder.WriteString(`; group_by [],
+  [value_request_count_aggregate_aggregate: aggregate(value_request_count_aggregate)]
+}
+| join
+| value [response_code_ratio: val(0) / val(1)]
+`)
 	builder.WriteString(fmt.Sprintf("| condition gt(val(), %s)\n", strconv.FormatFloat(config.ResponseCodeMetric.Ratio, 'f', -1, 64)))
 	return builder.String()
 }

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
@@ -1,11 +1,12 @@
 package monitoringalertpolicy
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringalertpolicy"
@@ -148,7 +149,7 @@ func thresholdAggregation(scope constructs.Construct, id resourceid.ID, config *
 	} else if config.ServiceKind == spec.ServiceKindJob {
 		// No default for this
 	} else {
-		return nil, fmt.Errorf("invalid service kind %q", config.ServiceKind)
+		return nil, errors.Newf("invalid service kind %q", config.ServiceKind)
 	}
 
 	if config.ThresholdAggregation.Comparison == "" {

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
@@ -218,11 +218,15 @@ func buildFilter(config *Config) string {
 	sort.Strings(filters)
 
 	if config.ServiceKind == spec.ServiceKindService {
-		filters = append(filters, `resource.type = "cloud_run_revision"`)
-		filters = append(filters, fmt.Sprintf(`resource.labels.service_name = "%s"`, config.ServiceName))
+		filters = append(filters,
+			`resource.type = "cloud_run_revision"`,
+			fmt.Sprintf(`resource.labels.service_name = "%s"`, config.ServiceName),
+		)
 	} else if config.ServiceKind == spec.ServiceKindJob {
-		filters = append(filters, `resource.type = "cloud_run_job"`)
-		filters = append(filters, fmt.Sprintf(`resource.labels.job_name = "%s"`, config.ServiceName))
+		filters = append(filters,
+			`resource.type = "cloud_run_job"`,
+			fmt.Sprintf(`resource.labels.job_name = "%s"`, config.ServiceName),
+		)
 	}
 
 	return strings.Join(filters, " AND ")

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
@@ -71,6 +71,8 @@ const (
 // Must specify a `metric.type` filter. Additional filters are optional.
 //
 // All filters are joined with ` AND `
+//
+// `GroupByField` is an optional field for Jobs for specifying the time series aggregation target label
 type ThresholdAggregation struct {
 	Filters      map[string]string
 	GroupByField string

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
@@ -1,0 +1,298 @@
+package monitoringalertpolicy
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/aws/constructs-go/constructs/v10"
+	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringalertpolicy"
+
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+type Aligner string
+
+const (
+	MonitoringAlignNone          Aligner = "ALIGN_NONE"
+	MonitoringAlignDelta         Aligner = "ALIGN_DELTA"
+	MonitoringAlignRate          Aligner = "ALIGN_RATE"
+	MonitoringAlignInterpolate   Aligner = "ALIGN_INTERPOLATE"
+	MonitoringAlignNextOrder     Aligner = "ALIGN_NEXT_ORDER"
+	MonitoringAlignMin           Aligner = "ALIGN_MIN"
+	MonitoringAlignMax           Aligner = "ALIGN_MAX"
+	MonitoringAlignMean          Aligner = "ALIGN_MEAN"
+	MonitoringAlignCount         Aligner = "ALIGN_COUNT"
+	MonitoringAlignSum           Aligner = "ALIGN_SUM"
+	MonitoringAlignStddev        Aligner = "ALIGN_STDDEV"
+	MonitoringAlignCountTrue     Aligner = "ALIGN_COUNT_TRUE"
+	MonitoringAlignCountFalse    Aligner = "ALIGN_COUNT_FALSE"
+	MonitoringAlignFractionTrue  Aligner = "ALIGN_FRACTION_TRUE"
+	MonitoringAlignPercentile99  Aligner = "ALIGN_PERCENTILE_99"
+	MonitoringAlignPercentile95  Aligner = "ALIGN_PERCENTILE_95"
+	MonitoringAlignPercentile50  Aligner = "ALIGN_PERCENTILE_50"
+	MonitoringAlignPercentile05  Aligner = "ALIGN_PERCENTILE_05"
+	MonitoringAlignPercentChange Aligner = "ALIGN_PERCENT_CHANGE"
+)
+
+type Reducer string
+
+const (
+	MonitoringReduceNone         Reducer = "REDUCE_NONE"
+	MonitoringReduceMean         Reducer = "REDUCE_MEAN"
+	MonitoringReduceMin          Reducer = "REDUCE_MIN"
+	MonitoringReduceMax          Reducer = "REDUCE_MAX"
+	MonitoringReduceSum          Reducer = "REDUCE_SUM"
+	MonitoringReduceStddev       Reducer = "REDUCE_STDDEV"
+	MonitoringReduceCount        Reducer = "REDUCE_COUNT"
+	MonitoringReduceCountTrue    Reducer = "REDUCE_COUNT_TRUE"
+	MonitoringReduceCountFalse   Reducer = "REDUCE_COUNT_FALSE"
+	MonitoringReduceFractionTrue Reducer = "REDUCE_FRACTION_TRUE"
+	MonitoringReducePercentile99 Reducer = "REDUCE_PERCENTILE_99"
+	MonitoringReducePercentile95 Reducer = "REDUCE_PERCENTILE_95"
+	MonitoringReducePercentile50 Reducer = "REDUCE_PERCENTILE_50"
+	MonitoringReducePercentile05 Reducer = "REDUCE_PERCENTILE_05"
+)
+
+type Comparison string
+
+const (
+	ComparisonGT Comparison = "COMPARISON_GT"
+	ComparisonLT Comparison = "COMPARISON_LT"
+)
+
+// ThresholdAggregation for alerting when a metric exceeds a defined threshold
+//
+// Must specify a `metric.type` filter. Additional filters are optional.
+//
+// All filters are joined with ` AND `
+type ThresholdAggregation struct {
+	Filters      map[string]string
+	GroupByField string
+	Comparison   Comparison
+	Aligner      Aligner
+	Reducer      Reducer
+	Period       string
+	Threshold    float64
+	Duration     string
+}
+
+// ResponseCodeMetric for alerting when the numer of a certain response code exceeds a threshold
+//
+// Must specify either `Code` (e.g. 404) or `CodeClass` (e.g. 4xx)
+//
+// `ExcludeCodes` allows filtering out specific response codes from the `CodeClass`
+type ResponseCodeMetric struct {
+	Code         *int
+	CodeClass    *string
+	ExcludeCodes []string
+	Ratio        float64
+	Duration     *string
+}
+
+// Config for a Monitoring Alert Policy
+// Must define either `ThresholdAggregation` or `ResponseCodeMetric`
+type Config struct {
+	// A unique identifier
+	ID          string
+	Name        string
+	Description *string
+	ProjectID   string
+	// Name of the service/job to filter the alert on
+	ServiceName string
+	ServiceKind spec.ServiceKind
+
+	ThresholdAggregation *ThresholdAggregation
+	ResponseCodeMetric   *ResponseCodeMetric
+}
+
+type Output struct {
+}
+
+func New(scope constructs.Construct, id resourceid.ID, config *Config) (*Output, error) {
+	if config.ThresholdAggregation == nil && config.ResponseCodeMetric == nil {
+		return nil, errors.New("Must provide either SingleMetric or ResponseCodeMetric config")
+	}
+
+	if config.ThresholdAggregation != nil && config.ResponseCodeMetric != nil {
+		return nil, errors.New("Must provide either SingleMetric or ResponseCodeMetric config, not both")
+	}
+
+	if config.ThresholdAggregation != nil {
+		if config.ServiceKind == spec.ServiceKindService && config.ThresholdAggregation.GroupByField != "" {
+			return nil, errors.New("Specifying GroupByField is invalid for Cloud Run Services as the default `resource.label.revision_name` is enforced")
+		}
+
+		if len(config.ThresholdAggregation.Filters) == 0 {
+			return nil, errors.New("must specify at least one filter for threshold aggregation")
+		}
+
+		if _, ok := config.ThresholdAggregation.Filters["metric.type"]; !ok {
+			return nil, errors.New("must specify filter for `metric.type`")
+		}
+		return thresholdAggregation(scope, id, config)
+	}
+	return responseCodeMetric(scope, id, config)
+}
+
+// threshholdAggregation defines a monitoring alert policy based on a single metric threshold
+func thresholdAggregation(scope constructs.Construct, id resourceid.ID, config *Config) (*Output, error) {
+	// Set some defaults
+	if config.ServiceKind == spec.ServiceKindService {
+		// For Cloud Run Services we need to group by the revision_name
+		config.ThresholdAggregation.GroupByField = "resource.label.revision_name"
+	} else if config.ServiceKind == spec.ServiceKindJob {
+		// No default for this
+	} else {
+		return nil, fmt.Errorf("invalid service kind %q", config.ServiceKind)
+	}
+
+	if config.ThresholdAggregation.Comparison == "" {
+		config.ThresholdAggregation.Comparison = ComparisonGT
+	}
+
+	if config.ThresholdAggregation.Duration == "" {
+		config.ThresholdAggregation.Duration = "0s"
+	}
+
+	// Optional on Jobs
+	var group_by *[]*string
+	if config.ThresholdAggregation.GroupByField != "" {
+		group_by = pointers.Ptr([]*string{pointers.Ptr(config.ThresholdAggregation.GroupByField)})
+	}
+
+	_ = monitoringalertpolicy.NewMonitoringAlertPolicy(scope,
+		id.TerraformID(config.ID), &monitoringalertpolicy.MonitoringAlertPolicyConfig{
+			Project:     pointers.Ptr(config.ProjectID),
+			DisplayName: pointers.Ptr(config.Name),
+			Documentation: &monitoringalertpolicy.MonitoringAlertPolicyDocumentation{
+				Content:  config.Description,
+				MimeType: pointers.Ptr("text/markdown"),
+			},
+			Combiner: pointers.Ptr("OR"),
+			Conditions: []monitoringalertpolicy.MonitoringAlertPolicyConditions{
+				{
+					DisplayName: pointers.Ptr(config.Name),
+					ConditionThreshold: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThreshold{
+						Aggregations: []monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdAggregations{
+							{
+								AlignmentPeriod:    pointers.Ptr(config.ThresholdAggregation.Period),
+								PerSeriesAligner:   pointers.Ptr(string(config.ThresholdAggregation.Aligner)),
+								CrossSeriesReducer: pointers.Ptr(string(config.ThresholdAggregation.Reducer)),
+								GroupByFields:      group_by,
+							},
+						},
+						Comparison:     pointers.Ptr(string(config.ThresholdAggregation.Comparison)),
+						Duration:       pointers.Ptr(config.ThresholdAggregation.Duration),
+						Filter:         pointers.Ptr(filter(config)),
+						ThresholdValue: pointers.Float64(config.ThresholdAggregation.Threshold),
+						Trigger: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
+							Count: pointers.Float64(1),
+						},
+					},
+				},
+			},
+			AlertStrategy: &monitoringalertpolicy.MonitoringAlertPolicyAlertStrategy{
+				AutoClose: pointers.Ptr("604800s"),
+			},
+		})
+	return &Output{}, nil
+}
+
+// filter creates the Filter string for a ThresholdAggregation monitoring alert policy
+func filter(config *Config) string {
+	filters := make([]string, 0)
+	for key, val := range config.ThresholdAggregation.Filters {
+		filters = append(filters, fmt.Sprintf(`%s = "%s"`, key, val))
+	}
+
+	// Sort to ensure stable output for testing
+	// This code runs so infreuqently that sort performance is not a concern and there are only a couple elements
+	sort.Strings(filters)
+
+	if config.ServiceKind == spec.ServiceKindService {
+		filters = append(filters, `resource.type = "cloud_run_revision"`)
+		filters = append(filters, fmt.Sprintf(`resource.labels.service_name = "%s"`, config.ServiceName))
+	} else if config.ServiceKind == spec.ServiceKindJob {
+		filters = append(filters, `resource.type = "cloud_run_job"`)
+		filters = append(filters, fmt.Sprintf(`resource.labels.job_name = "%s"`, config.ServiceName))
+	}
+
+	return strings.Join(filters, " AND ")
+}
+
+// responseCodeMetric defines the MonitoringAlertPolicy for response code metrics
+// Supports a single Code e.g. 404 or an entire Code Class e.g. 4xx
+// Optionally when using a Code Class, codes to exclude can be defined
+func responseCodeMetric(scope constructs.Construct, id resourceid.ID, config *Config) (*Output, error) {
+	query := responseCodeBuilder(config)
+
+	if config.ResponseCodeMetric.Duration == nil {
+		config.ResponseCodeMetric.Duration = pointers.Ptr("60s")
+	}
+
+	_ = monitoringalertpolicy.NewMonitoringAlertPolicy(scope,
+		id.TerraformID(config.ID), &monitoringalertpolicy.MonitoringAlertPolicyConfig{
+			Project:     pointers.Ptr(config.ProjectID),
+			DisplayName: pointers.Ptr(fmt.Sprintf("High Ratio of %s Responses", config.Name)),
+			Documentation: &monitoringalertpolicy.MonitoringAlertPolicyDocumentation{
+				Content:  config.Description,
+				MimeType: pointers.Ptr("text/markdown"),
+			},
+			Combiner: pointers.Ptr("OR"),
+			Conditions: []monitoringalertpolicy.MonitoringAlertPolicyConditions{
+				{
+					DisplayName: pointers.Ptr(fmt.Sprintf("High Ratio of %s Responses", config.Name)),
+					ConditionMonitoringQueryLanguage: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionMonitoringQueryLanguage{
+						Query:    pointers.Ptr(query),
+						Duration: config.ResponseCodeMetric.Duration,
+						Trigger: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionMonitoringQueryLanguageTrigger{
+							Count: pointers.Float64(1),
+						},
+					},
+				},
+			},
+			AlertStrategy: &monitoringalertpolicy.MonitoringAlertPolicyAlertStrategy{
+				AutoClose: pointers.Ptr("604800s"),
+			},
+		})
+	return &Output{}, nil
+}
+
+// responseCodeBuilder builds the MQL for a response code metric alert
+func responseCodeBuilder(config *Config) string {
+	var builder strings.Builder
+
+	builder.WriteString("fetch cloud_run_revision\n")
+	builder.WriteString("| metric 'run.googleapis.com/request_count'\n")
+	builder.WriteString("| group_by 15s, [value_request_count_aggregate: aggregate(value.request_count)]\n")
+	builder.WriteString("| every 15s\n")
+	builder.WriteString("| {\n")
+	if config.ResponseCodeMetric.CodeClass != nil {
+		builder.WriteString("  group_by [metric.response_code, metric.response_code_class],\n")
+	} else {
+		builder.WriteString("  group_by [metric.response_code],\n")
+	}
+	builder.WriteString("  [response_code_count_aggregate: aggregate(value_request_count_aggregate)]\n")
+	if config.ResponseCodeMetric.Code != nil {
+		builder.WriteString(fmt.Sprintf("  | filter (metric.response_code = '%d')\n", *config.ResponseCodeMetric.Code))
+	} else {
+		builder.WriteString(fmt.Sprintf("  | filter (metric.response_code_class = '%s')\n", *config.ResponseCodeMetric.CodeClass))
+	}
+	if config.ResponseCodeMetric.ExcludeCodes != nil && len(config.ResponseCodeMetric.ExcludeCodes) > 0 {
+		for _, code := range config.ResponseCodeMetric.ExcludeCodes {
+			builder.WriteString(fmt.Sprintf("  | filter (metric.response_code != '%s')\n", code))
+		}
+	}
+	builder.WriteString("; group_by [],\n")
+	builder.WriteString("  [value_request_count_aggregate_aggregate: aggregate(value_request_count_aggregate)]\n")
+	builder.WriteString("}\n")
+	builder.WriteString("| join\n")
+	builder.WriteString("| value [response_code_ratio: val(0) / val(1)]\n")
+	builder.WriteString(fmt.Sprintf("| condition gt(val(), %s)\n", strconv.FormatFloat(config.ResponseCodeMetric.Ratio, 'f', -1, 64)))
+	return builder.String()
+}

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
@@ -189,7 +189,7 @@ func thresholdAggregation(scope constructs.Construct, id resourceid.ID, config *
 						},
 						Comparison:     pointers.Ptr(string(config.ThresholdAggregation.Comparison)),
 						Duration:       pointers.Ptr(config.ThresholdAggregation.Duration),
-						Filter:         pointers.Ptr(filter(config)),
+						Filter:         pointers.Ptr(buildFilter(config)),
 						ThresholdValue: pointers.Float64(config.ThresholdAggregation.Threshold),
 						Trigger: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
 							Count: pointers.Float64(1),
@@ -204,8 +204,8 @@ func thresholdAggregation(scope constructs.Construct, id resourceid.ID, config *
 	return &Output{}, nil
 }
 
-// filter creates the Filter string for a ThresholdAggregation monitoring alert policy
-func filter(config *Config) string {
+// buildFilter creates the Filter string for a ThresholdAggregation monitoring alert policy
+func buildFilter(config *Config) string {
 	filters := make([]string, 0)
 	for key, val := range config.ThresholdAggregation.Filters {
 		filters = append(filters, fmt.Sprintf(`%s = "%s"`, key, val))

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy_test.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
-func TestFilter(t *testing.T) {
+func TestBuildFilter(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		config Config
@@ -43,7 +43,7 @@ func TestFilter(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := filter(&tc.config)
+			got := buildFilter(&tc.config)
 			tc.want.Equal(t, got)
 		})
 	}

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy_test.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy_test.go
@@ -1,0 +1,136 @@
+package monitoringalertpolicy
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func TestFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config Config
+		want   autogold.Value
+	}{
+		{
+			name: "Service Metric",
+			config: Config{
+				ServiceName: "my-service-name",
+				ServiceKind: "service",
+				ThresholdAggregation: &ThresholdAggregation{
+					Filters: map[string]string{
+						"metric.type": "run.googleapis.com/container/startup_latencies",
+					},
+				},
+			},
+			want: autogold.Expect(`metric.type = "run.googleapis.com/container/startup_latencies" AND resource.type = "cloud_run_revision" AND resource.labels.service_name = "my-service-name"`),
+		},
+		{
+			name: "Job Metric",
+			config: Config{
+				ServiceName: "my-job-name",
+				ServiceKind: "job",
+				ThresholdAggregation: &ThresholdAggregation{
+					Filters: map[string]string{
+						"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
+						"metric.labels.result": "failed",
+					},
+				},
+			},
+			want: autogold.Expect(`metric.labels.result = "failed" AND metric.type = "run.googleapis.com/job/completed_task_attempt_count" AND resource.type = "cloud_run_job" AND resource.labels.job_name = "my-job-name"`),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filter(&tc.config)
+			tc.want.Equal(t, got)
+		})
+	}
+}
+
+func TestResponseCodeBuilder(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ResponseCodeMetric
+		want autogold.Value
+	}{
+		{
+			name: "Single Response Code",
+			ResponseCodeMetric: ResponseCodeMetric{
+				Code:  pointers.Ptr(404),
+				Ratio: 0.1,
+			},
+			want: autogold.Expect(`fetch cloud_run_revision
+| metric 'run.googleapis.com/request_count'
+| group_by 15s, [value_request_count_aggregate: aggregate(value.request_count)]
+| every 15s
+| {
+  group_by [metric.response_code],
+  [response_code_count_aggregate: aggregate(value_request_count_aggregate)]
+  | filter (metric.response_code = '404')
+; group_by [],
+  [value_request_count_aggregate_aggregate: aggregate(value_request_count_aggregate)]
+}
+| join
+| value [response_code_ratio: val(0) / val(1)]
+| condition gt(val(), 0.1)
+`),
+		},
+		{
+			name: "Response Code Class",
+			ResponseCodeMetric: ResponseCodeMetric{
+				CodeClass: pointers.Ptr("4xx"),
+				Ratio:     0.4,
+			},
+			want: autogold.Expect(`fetch cloud_run_revision
+| metric 'run.googleapis.com/request_count'
+| group_by 15s, [value_request_count_aggregate: aggregate(value.request_count)]
+| every 15s
+| {
+  group_by [metric.response_code, metric.response_code_class],
+  [response_code_count_aggregate: aggregate(value_request_count_aggregate)]
+  | filter (metric.response_code_class = '4xx')
+; group_by [],
+  [value_request_count_aggregate_aggregate: aggregate(value_request_count_aggregate)]
+}
+| join
+| value [response_code_ratio: val(0) / val(1)]
+| condition gt(val(), 0.4)
+`),
+		},
+		{
+			name: "Response Code Class + Exclude",
+			ResponseCodeMetric: ResponseCodeMetric{
+				CodeClass:    pointers.Ptr("4xx"),
+				ExcludeCodes: []string{"404", "429"},
+				Ratio:        0.8,
+			},
+			want: autogold.Expect(`fetch cloud_run_revision
+| metric 'run.googleapis.com/request_count'
+| group_by 15s, [value_request_count_aggregate: aggregate(value.request_count)]
+| every 15s
+| {
+  group_by [metric.response_code, metric.response_code_class],
+  [response_code_count_aggregate: aggregate(value_request_count_aggregate)]
+  | filter (metric.response_code_class = '4xx')
+  | filter (metric.response_code != '404')
+  | filter (metric.response_code != '429')
+; group_by [],
+  [value_request_count_aggregate_aggregate: aggregate(value_request_count_aggregate)]
+}
+| join
+| value [response_code_ratio: val(0) / val(1)]
+| condition gt(val(), 0.8)
+`),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := responseCodeBuilder(&Config{
+				ServiceName:        "test-service",
+				ResponseCodeMetric: &tc.ResponseCodeMetric,
+			})
+			tc.want.Equal(t, got)
+		})
+	}
+}

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy_test.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy_test.go
@@ -18,7 +18,7 @@ func TestBuildFilter(t *testing.T) {
 			name: "Service Metric",
 			config: Config{
 				ServiceName: "my-service-name",
-				ServiceKind: "service",
+				ServiceKind: CloudRunService,
 				ThresholdAggregation: &ThresholdAggregation{
 					Filters: map[string]string{
 						"metric.type": "run.googleapis.com/container/startup_latencies",
@@ -31,7 +31,7 @@ func TestBuildFilter(t *testing.T) {
 			name: "Job Metric",
 			config: Config{
 				ServiceName: "my-job-name",
-				ServiceKind: "job",
+				ServiceKind: CloudRunJob,
 				ThresholdAggregation: &ThresholdAggregation{
 					Filters: map[string]string{
 						"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",

--- a/dev/managedservicesplatform/internal/resource/redis/redis.go
+++ b/dev/managedservicesplatform/internal/resource/redis/redis.go
@@ -15,6 +15,7 @@ import (
 )
 
 type Output struct {
+	ID          *string
 	Endpoint    string
 	Certificate gsmsecret.Output
 }
@@ -64,5 +65,6 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 		Endpoint: fmt.Sprintf("rediss://:%s@%s:%v",
 			*redis.AuthString(), *redis.Host(), *redis.Port()),
 		Certificate: *redisCACert,
+		ID:          redis.Id(),
 	}, nil
 }

--- a/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
@@ -36,7 +36,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
-type CrossStackOutput struct{}
+type CrossStackOutput struct {
+	RedisInstanceID *string
+}
 
 type Variables struct {
 	ProjectID                      string
@@ -143,6 +145,8 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 
 	// redisInstance is only created and non-nil if Redis is configured for the
 	// environment.
+	// If Redis is configured, populate cross-stack output with Redis ID.
+	var redisInstanceID *string
 	if vars.Environment.Resources != nil && vars.Environment.Resources.Redis != nil {
 		redisInstance, err := redis.New(stack,
 			resourceid.New("redis"),
@@ -155,6 +159,8 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render Redis instance")
 		}
+
+		redisInstanceID = redisInstance.ID
 
 		// Configure endpoint string.
 		cloudRunBuilder.AddEnv("REDIS_ENDPOINT", redisInstance.Endpoint)
@@ -260,7 +266,9 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 	// Collect outputs
 	locals.Add("image_tag", imageTag.StringValue,
 		"Resolved tag of service image to deploy")
-	return &CrossStackOutput{}, nil
+	return &CrossStackOutput{
+		RedisInstanceID: redisInstanceID,
+	}, nil
 }
 
 type envVariablesData struct {

--- a/dev/managedservicesplatform/internal/stack/monitoring/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/monitoring/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "monitoring",
+    srcs = ["monitoring.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack/monitoring",
+    visibility = ["//dev/managedservicesplatform:__subpackages__"],
+    deps = [
+        "//dev/managedservicesplatform/internal/resource/monitoringalertpolicy",
+        "//dev/managedservicesplatform/internal/resourceid",
+        "//dev/managedservicesplatform/internal/stack",
+        "//dev/managedservicesplatform/internal/stack/options/googleprovider",
+        "//dev/managedservicesplatform/spec",
+        "//lib/pointers",
+        "@com_github_hashicorp_terraform_cdk_go_cdktf//:cdktf",
+    ],
+)

--- a/dev/managedservicesplatform/internal/stack/monitoring/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/monitoring/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//dev/managedservicesplatform/internal/stack",
         "//dev/managedservicesplatform/internal/stack/options/googleprovider",
         "//dev/managedservicesplatform/spec",
+        "//lib/errors",
         "//lib/pointers",
         "@com_github_hashicorp_terraform_cdk_go_cdktf//:cdktf",
     ],

--- a/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
@@ -1,8 +1,6 @@
 package monitoring
 
 import (
-	"errors"
-
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/monitoringalertpolicy"
@@ -10,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack/options/googleprovider"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 

--- a/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
@@ -1,0 +1,229 @@
+package monitoring
+
+import (
+	"errors"
+
+	"github.com/hashicorp/terraform-cdk-go/cdktf"
+
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/monitoringalertpolicy"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack/options/googleprovider"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// Common
+// - Container (8)
+//    - run.googleapis.com/container/billable_instance_time
+//    - run.googleapis.com/container/cpu/allocation_time
+//    * run.googleapis.com/container/cpu/utilizations
+//    - run.googleapis.com/container/memory/allocation_time
+//    * run.googleapis.com/container/memory/utilizations
+//    * run.googleapis.com/container/startup_latencies
+//    - run.googleapis.com/container/network/received_bytes_count
+//    - run.googleapis.com/container/network/sent_bytes_count
+// - Log-based metrics (2)
+//    - logging.googleapis.com/byte_count
+//    - logging.googleapis.com/log_entry_count
+// Cloud Run Job
+// - Job (4)
+//    - run.googleapis.com/job/completed_execution_count
+//    * run.googleapis.com/job/completed_task_attempt_count
+//    - run.googleapis.com/job/running_executions
+//    - run.googleapis.com/job/running_task_attempts
+// Cloud Run Service
+// - Container (9)
+//    - run.googleapis.com/container/completed_probe_attempt_count
+//    - run.googleapis.com/container/completed_probe_count
+//    - run.googleapis.com/container/probe_attempt_latencies
+//    - run.googleapis.com/container/probe_latencies
+//    * run.googleapis.com/container/instance_count
+//    - run.googleapis.com/container/max_request_concurrencies
+//    - run.googleapis.com/container/cpu/usage
+//    - run.googleapis.com/container/containers
+//    - run.googleapis.com/container/memory/usage
+// - Request_count (1)
+//    - run.googleapis.com/request_count
+// - Request_latencies (1)
+//    * run.googleapis.com/request_latencies
+// - Pending_queue (1)
+//    - run.googleapis.com/pending_queue/pending_requests
+
+type CrossStackOutput struct{}
+
+type Variables struct {
+	ProjectID  string
+	Service    spec.ServiceSpec
+	Monitoring spec.MonitoringSpec
+	MaxCount   int
+}
+
+const StackName = "monitoring"
+
+func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
+	stack, _, err := stacks.New(StackName, googleprovider.With(vars.ProjectID))
+	if err != nil {
+		return nil, err
+	}
+
+	id := resourceid.New("monitoring")
+	err = commonAlerts(stack, id, vars)
+	if err != nil {
+		return nil, err
+	}
+
+	switch pointers.Deref(vars.Service.Kind, spec.ServiceKindService) {
+	case spec.ServiceKindService:
+		err = serviceAlerts(stack, id, vars)
+		if err != nil {
+			return nil, err
+		}
+
+		if vars.Monitoring.Alerts.ResponseCodeRatios != nil {
+			err = responseCodeMetrics(stack, id, vars)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	case spec.ServiceKindJob:
+		err = jobAlerts(stack, id, vars)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.New("unknown service kind")
+	}
+
+	return &CrossStackOutput{}, nil
+}
+
+func commonAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
+	for _, config := range []monitoringalertpolicy.Config{
+		{
+			ID:          "cpu",
+			Name:        "High Container CPU Utilization",
+			Description: pointers.Ptr("High CPU Usage - it may be neccessaru to reduce load or increase CPU allocation"),
+			ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
+				Filters:   map[string]string{"metric.type": "run.googleapis.com/container/cpu/utilizations"},
+				Aligner:   monitoringalertpolicy.MonitoringAlignPercentile99,
+				Reducer:   monitoringalertpolicy.MonitoringReduceMax,
+				Period:    "300s",
+				Threshold: 0.8,
+			},
+		},
+		{
+			ID:          "memory",
+			Name:        "High Container Memory Utilization",
+			Description: pointers.Ptr("High Memory Usage - it may be neccessary to reduce load or increase memory allocation"),
+			ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
+				Filters:   map[string]string{"metric.type": "run.googleapis.com/container/memory/utilizations"},
+				Aligner:   monitoringalertpolicy.MonitoringAlignPercentile99,
+				Reducer:   monitoringalertpolicy.MonitoringReduceMax,
+				Period:    "300s",
+				Threshold: 0.8,
+			},
+		},
+		{
+			ID:          "startup",
+			Name:        "Container Startup Latency",
+			Description: pointers.Ptr("Instance is taking a long time to start up - something may be blocking startup"),
+			ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
+				Filters:   map[string]string{"metric.type": "run.googleapis.com/container/startup_latencies"},
+				Aligner:   monitoringalertpolicy.MonitoringAlignPercentile99,
+				Reducer:   monitoringalertpolicy.MonitoringReduceMax,
+				Period:    "60s",
+				Threshold: 10000,
+			},
+		},
+	} {
+
+		config.ProjectID = vars.ProjectID
+		config.ServiceName = vars.Service.ID
+		config.ServiceKind = pointers.Deref(vars.Service.Kind, "service")
+		_, err := monitoringalertpolicy.New(stack, id, &config)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func serviceAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
+	// Only provision if we have a limit above 5 set
+	if vars.MaxCount > 5 {
+		_, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
+			ID:          "instance_count",
+			Name:        "Container Instance Count",
+			Description: pointers.Ptr("There are a lot of Cloud Run instances running - we may need to increase per-instance requests make make sure we won't hit the configured max instance count"),
+			ProjectID:   vars.ProjectID,
+			ServiceName: vars.Service.ID,
+			ServiceKind: spec.ServiceKindService,
+			ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
+				Filters: map[string]string{"metric.type": "run.googleapis.com/container/instance_count"},
+				Aligner: monitoringalertpolicy.MonitoringAlignMax,
+				Reducer: monitoringalertpolicy.MonitoringReduceMax,
+				Period:  "60s",
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func jobAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
+	// Alert whenever a Cloud Run Job fails
+	_, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
+		ID:          "job_failures",
+		Name:        "Cloud Run Job Failures",
+		Description: pointers.Ptr("Failed executions of Cloud Run Job"),
+		ProjectID:   vars.ProjectID,
+		ServiceName: vars.Service.ID,
+		ServiceKind: spec.ServiceKindJob,
+		ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
+			Filters: map[string]string{
+				"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
+				"metric.labels.result": "failed",
+			},
+			GroupByField: "metric.label.result",
+			Aligner:      monitoringalertpolicy.MonitoringAlignCount,
+			Reducer:      monitoringalertpolicy.MonitoringReduceSum,
+			Period:       "60s",
+			Threshold:    0,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func responseCodeMetrics(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
+	for _, config := range vars.Monitoring.Alerts.ResponseCodeRatios {
+
+		_, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
+			ID:          config.ID,
+			ProjectID:   vars.ProjectID,
+			Name:        config.Name,
+			ServiceName: vars.Service.ID,
+			ServiceKind: spec.ServiceKindService,
+			ResponseCodeMetric: &monitoringalertpolicy.ResponseCodeMetric{
+				Code:         config.Code,
+				CodeClass:    config.CodeClass,
+				ExcludeCodes: config.ExcludeCodes,
+				Ratio:        config.Ratio,
+				Duration:     config.Duration,
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
@@ -55,7 +55,7 @@ type Variables struct {
 	ProjectID  string
 	Service    spec.ServiceSpec
 	Monitoring spec.MonitoringSpec
-	MaxCount   int
+	MaxCount   *int
 }
 
 const StackName = "monitoring"
@@ -151,8 +151,8 @@ func commonAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) 
 }
 
 func serviceAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
-	// Only provision if we have a limit above 5 set
-	if vars.MaxCount > 5 {
+	// Only provision if MaxCount is specified above 5
+	if pointers.Deref(vars.MaxCount, 0) > 5 {
 		_, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
 			ID:          "instance_count",
 			Name:        "Container Instance Count",

--- a/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
@@ -69,14 +69,14 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	id := resourceid.New("monitoring")
 	err = commonAlerts(stack, id, vars)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to create common alerts")
 	}
 
 	switch pointers.Deref(vars.Service.Kind, spec.ServiceKindService) {
 	case spec.ServiceKindService:
 		err = serviceAlerts(stack, id, vars)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to create service alerts")
 		}
 
 		if vars.Monitoring.Alerts.ResponseCodeRatios != nil {
@@ -84,12 +84,12 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 		}
 
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to create response code metrics")
 		}
 	case spec.ServiceKindJob:
 		err = jobAlerts(stack, id, vars)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to create job alerts")
 		}
 	default:
 		return nil, errors.New("unknown service kind")

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -121,16 +121,16 @@ func (r *Renderer) RenderEnvironment(
 		return nil, errors.Wrap(err, "failed to create cloudrun stack")
 	}
 
-	// We only create the instance_count alert when MaxCount > 5 so default to 0 if unspecified
-	maxCount := 0
-	if env.Instances.Scaling != nil {
-		maxCount = pointers.Deref(env.Instances.Scaling.MaxCount, 0)
-	}
 	if _, err := monitoring.NewStack(stacks, monitoring.Variables{
 		ProjectID:  *projectOutput.Project.ProjectId(),
 		Service:    svc,
 		Monitoring: monitoringSpec,
-		MaxCount:   maxCount,
+		MaxCount: func() *int {
+			if env.Instances.Scaling != nil {
+				return env.Instances.Scaling.MaxCount
+			}
+			return nil
+		}(),
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to create monitoring stack")
 	}

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -54,7 +54,7 @@ func (r *Renderer) RenderEnvironment(
 	svc spec.ServiceSpec,
 	build spec.BuildSpec,
 	env spec.EnvironmentSpec,
-	mntrng spec.MonitoringSpec,
+	monitoringSpec spec.MonitoringSpec,
 ) (*CDKTF, error) {
 	terraformVersion := terraform.Version
 	stackSetOptions := []stack.NewStackOption{
@@ -129,7 +129,7 @@ func (r *Renderer) RenderEnvironment(
 	if _, err := monitoring.NewStack(stacks, monitoring.Variables{
 		ProjectID:  *projectOutput.Project.ProjectId(),
 		Service:    svc,
-		Monitoring: mntrng,
+		Monitoring: monitoringSpec,
 		MaxCount:   maxCount,
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to create monitoring stack")

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -108,7 +108,7 @@ func (r *Renderer) RenderEnvironment(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create IAM stack")
 	}
-	if _, err := cloudrun.NewStack(stacks, cloudrun.Variables{
+	cloudrunOutput, err := cloudrun.NewStack(stacks, cloudrun.Variables{
 		ProjectID:                      *projectOutput.Project.ProjectId(),
 		CloudRunWorkloadServiceAccount: iamOutput.CloudRunWorkloadServiceAccount,
 
@@ -117,7 +117,8 @@ func (r *Renderer) RenderEnvironment(
 		Environment: env,
 
 		StableGenerate: r.StableGenerate,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, errors.Wrap(err, "failed to create cloudrun stack")
 	}
 
@@ -131,6 +132,7 @@ func (r *Renderer) RenderEnvironment(
 			}
 			return nil
 		}(),
+		RedisInstanceID: cloudrunOutput.RedisInstanceID,
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to create monitoring stack")
 	}

--- a/dev/managedservicesplatform/spec/BUILD.bazel
+++ b/dev/managedservicesplatform/spec/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "build.go",
         "environment.go",
+        "monitoring.go",
         "service.go",
         "spec.go",
     ],

--- a/dev/managedservicesplatform/spec/monitoring.go
+++ b/dev/managedservicesplatform/spec/monitoring.go
@@ -1,8 +1,9 @@
 package spec
 
 import (
-	"regexp"
 	"time"
+
+	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )

--- a/dev/managedservicesplatform/spec/monitoring.go
+++ b/dev/managedservicesplatform/spec/monitoring.go
@@ -1,0 +1,85 @@
+package spec
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var codeClassPattern = regexp.MustCompile(`\dx+`)
+
+type MonitoringSpec struct {
+	// Alerts is a list of alert configurations for the deployment
+	Alerts MonitoringAlertsSpec `json:"alerts"`
+}
+
+func (s *MonitoringSpec) Validate() []error {
+	var errs []error
+	errs = append(errs, s.Alerts.Validate()...)
+	return errs
+}
+
+type MonitoringAlertsSpec struct {
+	ResponseCodeRatios []ResponseCodeRatioSpec `json:"responseCodeRatios"`
+}
+
+type ResponseCodeRatioSpec struct {
+	ID           string   `json:"id"`
+	Name         string   `json:"name"`
+	Description  *string  `json:"description,omitempty"`
+	Code         *int     `json:"code,omitempty"`
+	CodeClass    *string  `json:"codeClass,omitempty"`
+	ExcludeCodes []string `json:"excludeCodes,omitempty"`
+	Duration     *string  `json:"duration,omitempty"`
+	Ratio        float64  `json:"ratio"`
+}
+
+func (s *MonitoringAlertsSpec) Validate() []error {
+	var errs []error
+	for _, r := range s.ResponseCodeRatios {
+		errs = append(errs, r.Validate()...)
+	}
+	return errs
+}
+
+func (r *ResponseCodeRatioSpec) Validate() []error {
+	var errs []error
+
+	if r.ID == "" {
+		errs = append(errs, errors.New("responseCodeRatios[].id is required"))
+	}
+
+	if r.Name == "" {
+		errs = append(errs, errors.New("responseCodeRatios[].name is required"))
+	}
+
+	if r.Ratio < 0 || r.Ratio > 1 {
+		errs = append(errs, errors.New("responseCodeRatios[].ratio must be between 0 and 1"))
+	}
+
+	if r.CodeClass != nil && r.Code != nil {
+		errs = append(errs, errors.New("only one of responseCodeRatios[].code or responseCodeRatios[].codeClass should be specified"))
+	}
+
+	if r.Code != nil && *r.Code <= 0 {
+		errs = append(errs, errors.New("responseCodeRatios[].code must be positive"))
+	}
+
+	if r.CodeClass != nil {
+		if !codeClassPattern.MatchString(*r.CodeClass) {
+			errs = append(errs, errors.New("responseCodeRatios[].codeClass must match the format NXX (e.g. 4xx, 5xx)"))
+		}
+	}
+
+	if r.Duration != nil {
+		duration, err := time.ParseDuration(*r.Duration)
+		if err != nil {
+			errs = append(errs, errors.New("responseCodeRatios[].duration must be in the format of XXs"))
+		} else if duration%time.Minute != 0 {
+			errs = append(errs, errors.New("responseCodeRatios[].duration must be a multiple of 60s"))
+		}
+	}
+
+	return errs
+}

--- a/dev/managedservicesplatform/spec/monitoring.go
+++ b/dev/managedservicesplatform/spec/monitoring.go
@@ -38,7 +38,16 @@ type ResponseCodeRatioSpec struct {
 
 func (s *MonitoringAlertsSpec) Validate() []error {
 	var errs []error
+	// Use map to contain seen IDs to ensure uniqueness
+	ids := make(map[string]struct{})
 	for _, r := range s.ResponseCodeRatios {
+		if r.ID == "" {
+			errs = append(errs, errors.New("responseCodeRatios[].id is required and cannot be empty"))
+		}
+		if _, ok := ids[r.ID]; ok {
+			errs = append(errs, errors.Newf("response code alert IDs must be unique, found duplicate ID: %s", r.ID))
+		}
+		ids[r.ID] = struct{}{}
 		errs = append(errs, r.Validate()...)
 	}
 	return errs

--- a/dev/managedservicesplatform/spec/monitoring.go
+++ b/dev/managedservicesplatform/spec/monitoring.go
@@ -69,14 +69,14 @@ func (r *ResponseCodeRatioSpec) Validate() []error {
 
 	if r.CodeClass != nil {
 		if !codeClassPattern.MatchString(*r.CodeClass) {
-			errs = append(errs, errors.New("responseCodeRatios[].codeClass must match the format NXX (e.g. 4xx, 5xx)"))
+			errs = append(errs, errors.New("responseCodeRatios[].codeClass must match the format Nxx (e.g. 4xx, 5xx)"))
 		}
 	}
 
 	if r.Duration != nil {
 		duration, err := time.ParseDuration(*r.Duration)
 		if err != nil {
-			errs = append(errs, errors.New("responseCodeRatios[].duration must be in the format of XXs"))
+			errs = append(errs, errors.Wrap(err, "responseCodeRatios[].duration must be in the format of XXs"))
 		} else if duration%time.Minute != 0 {
 			errs = append(errs, errors.New("responseCodeRatios[].duration must be a multiple of 60s"))
 		}

--- a/dev/managedservicesplatform/spec/spec.go
+++ b/dev/managedservicesplatform/spec/spec.go
@@ -25,6 +25,7 @@ type Spec struct {
 	Service      ServiceSpec       `json:"service"`
 	Build        BuildSpec         `json:"build"`
 	Environments []EnvironmentSpec `json:"environments"`
+	Monitoring   MonitoringSpec    `json:"monitoring"`
 }
 
 // Open a specification file, validate it, unmarshal the data as a MSP spec,
@@ -83,6 +84,7 @@ func (s Spec) Validate() []error {
 	for _, env := range s.Environments {
 		errs = append(errs, env.Validate()...)
 	}
+	errs = append(errs, s.Monitoring.Validate()...)
 	return errs
 }
 

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -274,7 +274,7 @@ Supports completions on services and environments.`,
 								return errors.Newf("environment %q not found in service spec", targetEnv)
 							}
 
-							if err := syncEnvironmentWorkspaces(c, tfcClient, service.Service, service.Build, *env); err != nil {
+							if err := syncEnvironmentWorkspaces(c, tfcClient, service.Service, service.Build, *env, service.Monitoring); err != nil {
 								return errors.Wrapf(err, "sync env %q", env.ID)
 							}
 						} else {
@@ -282,7 +282,7 @@ Supports completions on services and environments.`,
 								return errors.New("second argument environment ID is required without the '-all' flag")
 							}
 							for _, env := range service.Environments {
-								if err := syncEnvironmentWorkspaces(c, tfcClient, service.Service, service.Build, env); err != nil {
+								if err := syncEnvironmentWorkspaces(c, tfcClient, service.Service, service.Build, env, service.Monitoring); err != nil {
 									return errors.Wrapf(err, "sync env %q", env.ID)
 								}
 							}
@@ -323,7 +323,7 @@ Supports completions on services and environments.`,
 	}
 }
 
-func syncEnvironmentWorkspaces(c *cli.Context, tfc *terraformcloud.Client, service spec.ServiceSpec, build spec.BuildSpec, env spec.EnvironmentSpec) error {
+func syncEnvironmentWorkspaces(c *cli.Context, tfc *terraformcloud.Client, service spec.ServiceSpec, build spec.BuildSpec, env spec.EnvironmentSpec, monitoring spec.MonitoringSpec) error {
 	if os.TempDir() == "" {
 		return errors.New("no temp dir available")
 	}
@@ -341,7 +341,7 @@ func syncEnvironmentWorkspaces(c *cli.Context, tfc *terraformcloud.Client, servi
 	renderPending := std.Out.Pending(output.Styledf(output.StylePending,
 		"[%s] Rendering required Terraform Cloud workspaces for environment %q",
 		service.ID, env.ID))
-	cdktf, err := renderer.RenderEnvironment(service, build, env)
+	cdktf, err := renderer.RenderEnvironment(service, build, env, monitoring)
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func generateTerraform(serviceID string, opts generateTerraformOptions) error {
 		}
 
 		// Render environment
-		cdktf, err := renderer.RenderEnvironment(service.Service, service.Build, env)
+		cdktf, err := renderer.RenderEnvironment(service.Service, service.Build, env, service.Monitoring)
 		if err != nil {
 			return err
 		}

--- a/lib/pointers/ptr.go
+++ b/lib/pointers/ptr.go
@@ -53,3 +53,13 @@ func Float64[T numberType](v T) *float64 {
 func Stringf(format string, a ...any) *string {
 	return Ptr(fmt.Sprintf(format, a...))
 }
+
+// Slice takes a slice of values and turns it into a slice of pointers.
+func Slice[S []V, V any](s S) []*V {
+	slice := make([]*V, len(s))
+	for i, v := range s {
+		v := v // copy
+		slice[i] = &v
+	}
+	return slice
+}

--- a/lib/pointers/ptr_test.go
+++ b/lib/pointers/ptr_test.go
@@ -203,3 +203,11 @@ func TestDeref(t *testing.T) {
 		runDerefTest(t, tc)
 	}
 }
+
+func TestSlice(t *testing.T) {
+	values := []string{"1", "2", "3"}
+	pointified := Slice(values)
+	for i, p := range pointified {
+		assert.Equal(t, values[i], *p)
+	}
+}


### PR DESCRIPTION
Add monitoring stack to MSP

Includes alerts based on those defined in cody gateway [alerts_cloudrun.tf](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/infrastructure/-/blob/cody-gateway/modules/monitoring/alerts_cloudrun.tf)

Closes https://github.com/sourcegraph/sourcegraph/issues/56876

## Test plan
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
- Deployed to a msp-testbed GCP project observed alert policies in place
- eyeballed the cdktf matches alerts in [alerts_cloudrun.tf](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/infrastructure/-/blob/cody-gateway/modules/monitoring/alerts_cloudrun.tf)