### PR TITLE
SSC: Allow only one LLM for Free users

### DIFF
--- a/internal/completions/httpapi/chat.go
+++ b/internal/completions/httpapi/chat.go
@@ -2,6 +2,8 @@ package httpapi
 
 import (
 	"context"
+	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"net/http"
 
 	"github.com/sourcegraph/log"
@@ -27,8 +29,15 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 		types.CompletionsFeatureChat,
 		rl,
 		"chat",
-		func(_ context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
-			if isAllowedCustomChatModel(requestParams.Model) {
+		func(ctx context.Context, requestParams types.CodyCompletionRequestParameters, c *conftypes.CompletionsConfig) (string, error) {
+			actor := sgactor.FromContext(ctx)
+			user, err := actor.User(ctx, db.Users())
+			if err != nil {
+				return "", err
+			}
+			isCodyProEnabled := featureflag.FromContext(ctx).GetBoolOr("cody-pro", false)
+			isProUser := user.CodyProEnabledAt != nil
+			if isAllowedCustomChatModel(requestParams.Model, isProUser || !isCodyProEnabled) {
 				return requestParams.Model, nil
 			}
 			// No user defined models for now.
@@ -42,20 +51,26 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 
 // We only allow dotcom clients to select a custom chat model and maintain an allowlist for which
 // custom values we support
-func isAllowedCustomChatModel(model string) bool {
+func isAllowedCustomChatModel(model string, isProUser bool) bool {
 	if !(envvar.SourcegraphDotComMode()) {
 		return false
 	}
 
-	switch model {
-	case "anthropic/claude-2",
-		"anthropic/claude-2.0",
-		"anthropic/claude-2.1",
-		"anthropic/claude-instant-1.2-cyan",
-		"anthropic/claude-instant-1.2",
-		"openai/gpt-3.5-turbo",
-		"openai/gpt-4-1106-preview":
-		return true
+	if isProUser {
+		switch model {
+		case "anthropic/claude-2",
+			"anthropic/claude-2.0",
+			"anthropic/claude-2.1",
+			"anthropic/claude-instant-1.2-cyan",
+			"anthropic/claude-instant-1.2",
+			"openai/gpt-3.5-turbo",
+			"openai/gpt-4-1106-preview":
+			return true
+		}
+	} else {
+		if model == "anthropic/claude-2.0" {
+			return true
+		}
 	}
 
 	return false


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/sourcegraph/issues/58753

New behavior:
- Allows only `anthropic/claude-2.0` for Cody PLG Free users.
- Allows all models (no change) for Cody PLG Pro users
- No change for non-Cody PLG users
- No change for enterprise instances

## Test plan

- Tested with a Free plan and got restricted for `anthropic/claude-2.1`
- Tested with a Pro plan and got through for `anthropic/claude-2.1`