### PR TITLE
Fix top_p type for Fireworks

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -161,7 +161,7 @@ type fireworksRequest struct {
 	Model       string   `json:"model"`
 	MaxTokens   int32    `json:"max_tokens,omitempty"`
 	Temperature float32  `json:"temperature,omitempty"`
-	TopP        int32    `json:"top_p,omitempty"`
+	TopP        float32  `json:"top_p,omitempty"`
 	N           int32    `json:"n,omitempty"`
 	Stream      bool     `json:"stream,omitempty"`
 	Echo        bool     `json:"echo,omitempty"`

--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -132,7 +132,7 @@ func (c *fireworksClient) makeRequest(ctx context.Context, requestParams types.C
 	payload := fireworksRequest{
 		Model:       requestParams.Model,
 		Temperature: requestParams.Temperature,
-		TopP:        int32(requestParams.TopP),
+		TopP:        requestParams.TopP,
 		N:           1,
 		Stream:      stream,
 		MaxTokens:   int32(requestParams.MaxTokensToSample),
@@ -173,7 +173,7 @@ type fireworksRequest struct {
 	Model       string   `json:"model"`
 	MaxTokens   int32    `json:"max_tokens,omitempty"`
 	Temperature float32  `json:"temperature,omitempty"`
-	TopP        int32    `json:"top_p,omitempty"`
+	TopP        float32  `json:"top_p,omitempty"`
 	N           int32    `json:"n,omitempty"`
 	Stream      bool     `json:"stream,omitempty"`
 	Echo        bool     `json:"echo,omitempty"`


### PR DESCRIPTION
Top_p is a number (i.e. a float) in Fireworks API spec, but we used int32 to represent it. This didn't throw errors because we converted it here, but resulted in all requests using a value of 0 (instead of what was passed).
## Test plan

- tested locally
- tests should pass