### PR TITLE
Rg/fix response flushing

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -138,7 +138,7 @@ func HandleFeature(
 			return
 		}
 
-		responseRecorder := response.NewStatusHeaderRecorder(w)
+		responseRecorder := response.NewStatusHeaderRecorder(w, logger)
 		next.ServeHTTP(responseRecorder, r)
 
 		// If response is healthy, consume the rate limit

--- a/cmd/cody-gateway/internal/httpapi/requestlogger/requestlogger.go
+++ b/cmd/cody-gateway/internal/httpapi/requestlogger/requestlogger.go
@@ -18,7 +18,7 @@ func Middleware(logger log.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
-		response := response.NewStatusHeaderRecorder(w)
+		response := response.NewStatusHeaderRecorder(w, logger)
 		next.ServeHTTP(response, r)
 
 		ctx := r.Context()

--- a/cmd/cody-gateway/internal/response/response_test.go
+++ b/cmd/cody-gateway/internal/response/response_test.go
@@ -1,6 +1,7 @@
 package response
 
 import (
+	"github.com/sourcegraph/log/logtest"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,9 +10,11 @@ import (
 )
 
 func TestStatusHeaderRecorder(t *testing.T) {
+	logger := logtest.Scoped(t)
+
 	t.Run("WriteHeader", func(t *testing.T) {
 		underlying := httptest.NewRecorder()
-		recorder := NewStatusHeaderRecorder(underlying)
+		recorder := NewStatusHeaderRecorder(underlying, logger)
 
 		var w http.ResponseWriter = recorder
 		w.WriteHeader(http.StatusTeapot)
@@ -22,7 +25,7 @@ func TestStatusHeaderRecorder(t *testing.T) {
 
 	t.Run("implicit WriteHeader", func(t *testing.T) {
 		underlying := httptest.NewRecorder()
-		recorder := NewStatusHeaderRecorder(underlying)
+		recorder := NewStatusHeaderRecorder(underlying, logger)
 
 		var w http.ResponseWriter = recorder
 		w.Write([]byte("foo")) // should implicitly write header


### PR DESCRIPTION
Implement response flushing in StatusHeaderRecorder - until now, we embedded a ResponseWriter, but didn't implement Flusher, so our own code or [stdlib](https://tip.golang.org/doc/go1.20#http_responsecontroller) couldn't flush responses.
## Test plan

- unit tests
- tested locally