### PR TITLE
Rewrite ST models to MT equivalents

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/handler.go
@@ -36,6 +36,7 @@ type Config struct {
 	OpenAIOrgID                                 string
 	OpenAIAllowedModels                         []string
 	FireworksAccessToken                        string
+	FireworksDisableSingleTenant                bool
 	FireworksAllowedModels                      []string
 	FireworksLogSelfServeCodeCompletionRequests bool
 	EmbeddingsAllowedModels                     []string
@@ -193,6 +194,7 @@ func NewHandler(
 								config.FireworksAccessToken,
 								config.FireworksAllowedModels,
 								config.FireworksLogSelfServeCodeCompletionRequests,
+								config.FireworksDisableSingleTenant,
 							),
 						),
 					),

--- a/cmd/cody-gateway/shared/config.go
+++ b/cmd/cody-gateway/shared/config.go
@@ -45,6 +45,7 @@ type Config struct {
 		AllowedModels                      []string
 		AccessToken                        string
 		LogSelfServeCodeCompletionRequests bool
+		DisableSingleTenant                bool
 	}
 
 	AllowedEmbeddingsModels []string
@@ -148,6 +149,7 @@ func (c *Config) Load() {
 		}, ","),
 		"Fireworks models that can be used."))
 	c.Fireworks.LogSelfServeCodeCompletionRequests = c.GetBool("CODY_GATEWAY_FIREWORKS_LOG_SELF_SERVE_COMPLETION_REQUESTS", "false", "Whether we should log self-serve code completion requests.")
+	c.Fireworks.DisableSingleTenant = c.GetBool("CODY_GATEWAY_FIREWORKS_DISABLE_SINGLE_TENANT", "false", "Whether we should disable single tenant models for Fireworks.")
 	if c.Fireworks.AccessToken != "" && len(c.Fireworks.AllowedModels) == 0 {
 		c.AddError(errors.New("must provide allowed models for Fireworks"))
 	}

--- a/cmd/cody-gateway/shared/main.go
+++ b/cmd/cody-gateway/shared/main.go
@@ -168,6 +168,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 			FireworksAccessToken:                        config.Fireworks.AccessToken,
 			FireworksAllowedModels:                      config.Fireworks.AllowedModels,
 			FireworksLogSelfServeCodeCompletionRequests: config.Fireworks.LogSelfServeCodeCompletionRequests,
+			FireworksDisableSingleTenant:                config.Fireworks.DisableSingleTenant,
 			EmbeddingsAllowedModels:                     config.AllowedEmbeddingsModels,
 		}, sources)
 	if err != nil {


### PR DESCRIPTION
Some [traffic is still hitting](https://redash.sgdev.org/queries/226/source#445) the ST environment, despite the relevant [feature flag](https://sourcegraph.com/site-admin/feature-flags/configuration/cody-autocomplete-default-starcoder-hybrid-sourcegraph) being ramped down to 0 (likely due to a delay in feature flag propagation on the client side) - this PR adds a mechanism that forwards requests sent to ST models to hit the MT ones. 

Off by default, so should be safe to roll out.

## Test plan

- tested locally