### PR TITLE
sg: add `doctor` command to generate a diagnostics report

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -293,13 +293,14 @@ var sg = &cli.App{
 		msp.Command,
 
 		// Util
-		helpCommand,
-		versionCommand,
-		updateCommand,
-		installCommand,
-		funkyLogoCommand,
 		analyticsCommand,
+		doctorCommand,
+		funkyLogoCommand,
+		helpCommand,
+		installCommand,
 		releaseCommand,
+		updateCommand,
+		versionCommand,
 	},
 	ExitErrHandler: func(cmd *cli.Context, err error) {
 		if err == nil {

--- a/dev/sg/sg_doctor.go
+++ b/dev/sg/sg_doctor.go
@@ -1,13 +1,23 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/urfave/cli/v2"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"gopkg.in/yaml.v3"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/run"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
 var doctorCommand = &cli.Command{
@@ -20,34 +30,136 @@ var doctorCommand = &cli.Command{
 	`,
 	Category: category.Util,
 	Flags: []cli.Flag{
-		&cli.BoolFlag{
+		&cli.PathFlag{
 			Name:    "outputFile",
 			Aliases: []string{"o"},
+			Value:   fmt.Sprintf("sg-doctor-report-%s.md", time.Now().Format("2006-01-02-150405")),
 			Usage:   "write the report to a file with this name",
 		},
 	},
-	Action: doctorAction,
+	Action: runDoctorDiagnostics,
 }
 
 type Diagnostic struct {
-	Name string
-	Cmd string
+	Name string `yaml:"name"`
+	Cmd  string `yaml:"cmd"`
 }
 
-type Diagnostics struct
-	Diagnostic map[string]diagnostic `yaml: ""`
+type Diagnostics struct {
+	Diagnostic map[string][]Diagnostic `yaml:"diagnostics"`
 }
-func doctorAction(cmd *cli.Context) error {
+
+type diagnosticRunner struct {
+	diagnostics *Diagnostics
+	reporter    *std.Output
+}
+
+type DiagnosticResult struct {
+	Diagnostic *Diagnostic
+	Output     string
+	Err        error
+}
+type DiagnosticReport map[string][]*DiagnosticResult
+
+func (r DiagnosticReport) Add(group string, result *DiagnosticResult) {
+	if v, ok := r[group]; !ok {
+		r[group] = []*DiagnosticResult{result}
+	} else {
+		r[group] = append(v, result)
+	}
+}
+
+func runDoctorDiagnostics(cmd *cli.Context) error {
 	repoRoot, err := root.RepositoryRoot()
 	if err != nil {
 		return err
 	}
 	diagnosticsPath := filepath.Join(repoRoot, "sg-doctor.yaml")
-	diags, err := loadDiagnostics(diagnosticsPath)
+	diagnostics, err := loadDiagnostics(diagnosticsPath)
 	if err != nil {
-		return errors.Newf("failed to load diagnostics from %q", diagnosticsPath)
+		return errors.Newf("failed to load diagnostics from %q: %v", diagnosticsPath, err)
 	}
+
+	runner := &diagnosticRunner{
+		diagnostics,
+		std.Out,
+	}
+	report := runner.Run(cmd.Context)
+	err = writeDiagnosticReport(report, cmd.Path("outputFile"))
+	if err != nil {
+		return errors.Wrap(err, "failed to write diagnostic report")
+	}
+
+	std.Out.WriteLine(output.Emoji("📋", "Diagnostic report written to "+cmd.Path("outputFile")))
+
 	return nil
 }
 
+func (d *diagnosticRunner) Run(ctx context.Context) DiagnosticReport {
+	env := os.Environ()
+	report := make(DiagnosticReport)
 
+	d.reporter.WriteLine(output.Emoji("🥼", "Gathering diagnostics"))
+	for group, diagnostics := range d.diagnostics.Diagnostic {
+		blk := d.reporter.Block(output.Emojif("💊", "Running %s diagnostics", group))
+		for _, diagnostic := range diagnostics {
+			pending := blk.Pending(output.Styledf(output.StylePending, "Running %q", diagnostic.Name))
+			out, err := run.BashInRoot(ctx, diagnostic.Cmd, env)
+			diag := diagnostic
+			report.Add(group, &DiagnosticResult{
+				&diag,
+				out,
+				err,
+			})
+			pending.Complete(output.Linef(output.EmojiSuccess, output.StyleSuccess, "Diagnostic %q complete", diagnostic.Name))
+		}
+		blk.Close()
+	}
+
+	d.reporter.WriteLine(output.Emoji("💉", "Gathering of diagnostics complete!"))
+
+	return report
+}
+
+func writeDiagnosticReport(report DiagnosticReport, dst string) error {
+	fd, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	fmt.Fprintf(fd, "# Diagnostic Report\n\n")
+	// General information
+	fmt.Fprintf(fd, "sg commit: %s\n", BuildCommit)
+	fmt.Fprintf(fd, "generated on: %s\n\n", time.Now())
+	// Write out the report
+	titleCaser := cases.Title(language.English)
+	for group, result := range report {
+		fmt.Fprintf(fd, "## %s diagnostics\n\n", titleCaser.String(group))
+		for _, item := range result {
+			cmdLine := fmt.Sprintf("Command: `%s`", item.Diagnostic.Cmd)
+			outputSection := fmt.Sprintf("Output: \n```\n%s\n```\n", item.Output)
+			errSection := fmt.Sprintf("Error: \n```\n%v\n```\n", item.Err)
+			fmt.Fprintf(fd, "### %s\n\n%s\n\n%s\n%s", titleCaser.String(item.Diagnostic.Name), cmdLine, outputSection, errSection)
+		}
+	}
+
+	return nil
+}
+
+func loadDiagnostics(path string) (*Diagnostics, error) {
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var diags Diagnostics
+	dec := yaml.NewDecoder(fd)
+
+	err = dec.Decode(&diags)
+	if err != nil {
+		return nil, err
+	}
+
+	return &diags, nil
+}

--- a/dev/sg/sg_doctor.go
+++ b/dev/sg/sg_doctor.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
+	"github.com/sourcegraph/sourcegraph/dev/sg/root"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var doctorCommand = &cli.Command{
+	Name:  "doctor",
+	Usage: "performs various diagnostics and generates a report",
+	Description: `Runs a series of commands defined in sg-doctor.yaml.
+
+	The output of the commands are stored in a report, which can then be given to a dev-infra team memeber for
+	further diagnosis.
+	`,
+	Category: category.Util,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "outputFile",
+			Aliases: []string{"o"},
+			Usage:   "write the report to a file with this name",
+		},
+	},
+	Action: doctorAction,
+}
+
+type Diagnostic struct {
+	Name string
+	Cmd string
+}
+
+type Diagnostics struct
+	Diagnostic map[string]diagnostic `yaml: ""`
+}
+func doctorAction(cmd *cli.Context) error {
+	repoRoot, err := root.RepositoryRoot()
+	if err != nil {
+		return err
+	}
+	diagnosticsPath := filepath.Join(repoRoot, "sg-doctor.yaml")
+	diags, err := loadDiagnostics(diagnosticsPath)
+	if err != nil {
+		return errors.Newf("failed to load diagnostics from %q", diagnosticsPath)
+	}
+	return nil
+}
+
+

--- a/sg-doctor.yaml
+++ b/sg-doctor.yaml
@@ -1,20 +1,37 @@
 diagnostics:
   general:
-      name: current path
+    - name: current env
+      cmd: env
+    - name: current path
       cmd: pwd
-      name: current commit
+    - name: current branch
       cmd: git rev-parse --abbrev-ref HEAD
+    - cmd: show current commit
+      name: git rev-parse HEAD
+    - name: os kernel
+      cmd: uname -s
   bazel:
-    name: architecture
-      cmd: file -L bazel
-    path:
+    - name: architecture
+      cmd: file -L $(which bazel)
+    - name: where is bazel
       cmd: which bazel
-    info:
+    - name: bazel info
       cmd: bazel info
   go:
-    architecture:
-      cmd: file -L go
-    path:
+    - name: architecture
+      cmd: file -L $(which go)
+    - name: where is go
       cmd: which go
-    version:
+    - name: version of go
       cmd: go version
+  node:
+    - name: architecture
+      cmd: file -L $(which node)
+    - name: where is node
+      cmd: which node
+    - name: version of node
+      cmd: node --version
+    - name: version of pnpm
+      cmd: pnpm --version
+    - name: where is pnpm
+      cmd: which pnpm

--- a/sg-doctor.yaml
+++ b/sg-doctor.yaml
@@ -1,0 +1,20 @@
+diagnostics:
+  general:
+      name: current path
+      cmd: pwd
+      name: current commit
+      cmd: git rev-parse --abbrev-ref HEAD
+  bazel:
+    name: architecture
+      cmd: file -L bazel
+    path:
+      cmd: which bazel
+    info:
+      cmd: bazel info
+  go:
+    architecture:
+      cmd: file -L go
+    path:
+      cmd: which go
+    version:
+      cmd: go version


### PR DESCRIPTION
`sg doctor` runs the diagnostics defined in `sg-doctor.yaml`:
```yaml
diagnostics:
  general:
    - name: current env
      cmd: env
    - name: current path
      cmd: pwd
    - name: current branch
      cmd: git rev-parse --abbrev-ref HEAD
    - cmd: show current commit
      name: git rev-parse HEAD
    - name: os kernel
      cmd: uname -s
  bazel:
    - name: architecture
      cmd: file -L $(which bazel)
    - name: where is bazel
      cmd: which bazel
    - name: bazel info
      cmd: bazel info
  go:
    - name: architecture
      cmd: file -L $(which go)
    - name: where is go
      cmd: which go
    - name: version of go
      cmd: go version
  node:
    - name: architecture
      cmd: file -L $(which node)
    - name: where is node
      cmd: which node
    - name: version of node
      cmd: node --version
    - name: version of pnpm
      cmd: pnpm --version
    - name: where is pnpm
      cmd: which pnpm

```

which produces the following report [sg-doctor-report-2023-12-07-110158.md](https://github.com/sourcegraph/sourcegraph/files/13599892/sg-doctor-report-2023-12-07-110158.md)


I'm not quite convinced at the console output yet so still working on that:
```
go run ./dev/sg doctor
🥼 Gathering diagnostics
💊 Running general diagnostics

✅ Diagnostic "current env" complete
✅ Diagnostic "current path" complete
✅ Diagnostic "current branch" complete
✅ Diagnostic "git rev-parse HEAD" complete
✅ Diagnostic "os kernel" complete

💊 Running bazel diagnostics

✅ Diagnostic "architecture" complete
✅ Diagnostic "where is bazel" complete
✅ Diagnostic "bazel info" complete

💊 Running go diagnostics
✅ Diagnostic "architecture" complete
✅ Diagnostic "where is go" complete
✅ Diagnostic "version of go" complete

💊 Running node diagnostics
✅ Diagnostic "architecture" complete
✅ Diagnostic "where is node" complete
✅ Diagnostic "version of node" complete
✅ Diagnostic "version of pnpm" complete
✅ Diagnostic "where is pnpm" complete

💉 Gathering of diagnostics complete!
📋 Diagnostic report written to sg-doctor-report-2023-12-07-110158.md
```
## Test plan
Tested locally
