### PR TITLE
nix: empty out before writing to it .bazelrc-nix

### DIFF
--- a/dev/nix/shell-hook.sh
+++ b/dev/nix/shell-hook.sh
@@ -18,6 +18,9 @@ export SRC_DEV_EXCEPT="${SRC_DEV_EXCEPT:-postgres_exporter}"
 
 popd >/dev/null || exit
 
+# Empty out .bazelrc-nix
+echo -n > .bazelrc-nix
+
 # Use a hermetic and non-host CC compiler on NixOS.
 if [ -f /etc/NIXOS ]; then
   cat <<EOF > .bazelrc-nix


### PR DESCRIPTION
Currently on non-nixos hosts we will append to .bazelrc-nix everytime the shell hook runs. This leads to the file growing quite large, I am unsure on the impact on bazel. This was an accidental regression when we removed bazel from the nix darwin environment.

Test Plan: ran nix develop and I didn't have duplicated lines.