### PR TITLE
sg: add config to run backend-integration tests locally

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1607,6 +1607,29 @@ tests:
     cmd: go test
     defaultArgs: ./...
 
+  bazel-backend-integration:
+    cmd: |
+      export GHE_GITHUB_TOKEN=$(gcloud secrets versions access latest --secret=GHE_GITHUB_TOKEN --quiet --project=sourcegraph-ci)
+      export GH_TOKEN=$(gcloud secrets versions access latest --secret=GITHUB_TOKEN --quiet --project=sourcegraph-ci)
+
+      export BITBUCKET_SERVER_USERNAME=$(gcloud secrets versions access latest --secret=BITBUCKET_SERVER_USERNAME --quiet --project=sourcegraph-ci)
+      export BITBUCKET_SERVER_TOKEN=$(gcloud secrets versions access latest --secret=BITBUCKET_SERVER_TOKEN --quiet --project=sourcegraph-ci)
+      export BITBUCKET_SERVER_URL=$(gcloud secrets versions access latest --secret=BITBUCKET_SERVER_URL --quiet --project=sourcegraph-ci)
+
+      export PERFORCE_PASSWORD=$(gcloud secrets versions access latest --secret=PERFORCE_PASSWORD --quiet --project=sourcegraph-ci)
+      export PERFORCE_USER=$(gcloud secrets versions access latest --secret=PERFORCE_USER --quiet --project=sourcegraph-ci)
+      export PERFORCE_PORT=$(gcloud secrets versions access latest --secret=PERFORCE_PORT --quiet --project=sourcegraph-ci)
+
+      export SOURCEGRAPH_LICENSE_KEY=$(gcloud secrets versions access latest --secret=SOURCEGRAPH_LICENSE_KEY --quiet --project=sourcegraph-ci)
+      export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(gcloud secrets versions access latest --secret=SOURCEGRAPH_LICENSE_GENERATION_KEY --quiet --project=sourcegraph-ci)
+
+      if [[ $(uname) == "Darwin" ]]; then
+        BAZEL_FLAGS=("--config darwin-docker")
+      else
+        BAZEL_FLAGS=()
+      fi
+      bazel test //testing:backend_integration_test ${BAZEL_FLAGS[*]} --verbose_failures --sandbox_debug
+
   bazel-e2e:
     cmd: |
       export GHE_GITHUB_TOKEN=$(gcloud secrets versions access latest --secret=GHE_GITHUB_TOKEN --quiet --project=sourcegraph-ci)

--- a/testing/tools/integration_runner.sh
+++ b/testing/tools/integration_runner.sh
@@ -59,7 +59,18 @@ function generate_unique_container_name() {
   local prefix="$1"
   prefix="$1"
   local ident
-  ident="$(openssl rand -hex 12)"
+
+  # try generate a unique identifier with openssl otherwise fallback to dd and hexdump
+  if command -v openssl &> /dev/null; then
+    ident="$(openssl rand -hex 12)"
+  elif command -v hexdump &> /dev/null; then
+    ident="$(dd if=/dev/urandom bs=12 count=1 2>/dev/null | hexdump -e '24/1 "%02x"')"
+  else
+    echo "⚠️ Missing openssl or hexdump. Unable to generate unique id"
+    echo "👉 Aborting."
+    exit 1
+  fi
+
   echo "$prefix-$ident"
 }
 


### PR DESCRIPTION
Additionally, when generating unique ids in integration tests fallback to hexdump if openssl is not available

## Test plan
Tested locally
```
<snip>
if [[ $(uname) == "Darwin" ]]; then
  BAZEL_FLAGS=("--config darwin-docker")
else
  BAZEL_FLAGS=()
fi
bazel test //testing:backend_integration_test ${BAZEL_FLAGS[*]} --verbose_failures --sandbox_debug  in "/Users/william/code/sourcegraph"...
INFO: Analyzed target //testing:backend_integration_test (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
[1 / 2] Testing //testing:backend_integration_test; 662s darwin-sandbox