### PR TITLE
telemetry-gateway: add attributes to pubsub events

### DIFF
--- a/cmd/telemetry-gateway/internal/events/BUILD.bazel
+++ b/cmd/telemetry-gateway/internal/events/BUILD.bazel
@@ -23,5 +23,6 @@ go_test(
         "//internal/pubsub/pubsubtest",
         "//internal/telemetrygateway/v1:telemetrygateway",
         "@com_github_stretchr_testify//require",
+        "@tools_gotest//assert",
     ],
 )

--- a/cmd/telemetry-gateway/internal/events/events.go
+++ b/cmd/telemetry-gateway/internal/events/events.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -62,7 +63,12 @@ func (p *Publisher) Publish(ctx context.Context, events []*telemetrygatewayv1.Ev
 
 			// Publish a single message in each callback to manage concurrency
 			// ourselves, and
-			if err := p.topic.Publish(ctx, payload); err != nil {
+			if err := p.topic.PublishMessage(ctx, payload, map[string]string{
+				"event.feature": event.Feature,
+				"event.action":  event.Action,
+				"event.hasPrivateMetadata": strconv.FormatBool(
+					event.GetParameters().GetPrivateMetadata() != nil),
+			}); err != nil {
 				return errors.Wrap(err, "publishing event")
 			}
 

--- a/cmd/telemetry-gateway/internal/events/events_test.go
+++ b/cmd/telemetry-gateway/internal/events/events_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 
 	"github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/events"
 	"github.com/sourcegraph/sourcegraph/internal/pubsub/pubsubtest"
@@ -34,7 +35,9 @@ func TestPublish(t *testing.T) {
 	events := make([]*telemetrygatewayv1.Event, 100)
 	for i := range events {
 		events[i] = &telemetrygatewayv1.Event{
-			Id: strconv.Itoa(i),
+			Id:      strconv.Itoa(i),
+			Feature: t.Name(),
+			Action:  strconv.Itoa(i),
 		}
 	}
 
@@ -63,11 +66,14 @@ func TestPublish(t *testing.T) {
 	// Collect all the messages we published
 	for _, m := range memTopic.Messages {
 		var payload map[string]json.RawMessage
-		require.NoError(t, json.Unmarshal(m, &payload))
+		require.NoError(t, json.Unmarshal(m.Data, &payload))
 
 		var event telemetrygatewayv1.Event
 		require.NoError(t, json.Unmarshal(payload["event"], &event))
 		publishedEvents[event.GetId()] = true
+
+		assert.Equal(t, event.Feature, m.Attributes["event.feature"])
+		assert.Equal(t, event.Action, m.Attributes["event.action"])
 	}
 
 	// Make our assertions - all events should be have results or be published

--- a/internal/pubsub/pubsubtest/pubsubtest.go
+++ b/internal/pubsub/pubsubtest/pubsubtest.go
@@ -9,17 +9,22 @@ import (
 
 var _ pubsub.TopicClient = (*MemoryTopicClient)(nil)
 
+type PublishedMessage struct {
+	Data       []byte
+	Attributes map[string]string
+}
+
 // NewMemoryTopicClient creates a no-op Pub/Sub client does nothing but save
 // published messages to an internal slice. Publish is concurrency-safe, but
 // reading Messages is not.
 func NewMemoryTopicClient() *MemoryTopicClient {
-	return &MemoryTopicClient{Messages: [][]byte{}}
+	return &MemoryTopicClient{Messages: []PublishedMessage{}}
 }
 
 type MemoryTopicClient struct {
 	mux            sync.Mutex
 	PrePublishHook func()
-	Messages       [][]byte
+	Messages       []PublishedMessage
 }
 
 func (c *MemoryTopicClient) Publish(ctx context.Context, messages ...[]byte) error {
@@ -27,7 +32,19 @@ func (c *MemoryTopicClient) Publish(ctx context.Context, messages ...[]byte) err
 		c.PrePublishHook()
 	}
 	c.mux.Lock()
-	c.Messages = append(c.Messages, messages...)
+	for _, m := range messages {
+		c.Messages = append(c.Messages, PublishedMessage{Data: m})
+	}
+	c.mux.Unlock()
+	return nil
+}
+
+func (c *MemoryTopicClient) PublishMessage(ctx context.Context, message []byte, attributes map[string]string) error {
+	if c.PrePublishHook != nil {
+		c.PrePublishHook()
+	}
+	c.mux.Lock()
+	c.Messages = append(c.Messages, PublishedMessage{Data: message, Attributes: attributes})
 	c.mux.Unlock()
 	return nil
 }


### PR DESCRIPTION
This might make it easier to the team to work with the incoming data, and could be useful for some degree of tagging.

## Test plan

Unit tests