### PR TITLE
gitserver repos: do not log corruption from wrong shard

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -593,7 +593,6 @@ func (s *gitserverRepoStore) LogCorruption(ctx context.Context, name api.RepoNam
 	res, err := s.ExecResult(ctx, sqlf.Sprintf(`
 UPDATE gitserver_repos as gtr
 SET
-	shard_id = %s,
 	corrupted_at = NOW(),
 	-- prepend the json and then ensure we only keep 10 items in the resulting json array
 	corruption_logs = (SELECT jsonb_path_query_array(%s||gtr.corruption_logs, '$[0 to 9]')),
@@ -601,7 +600,9 @@ SET
 WHERE
 	repo_id = (SELECT id FROM repo WHERE name = %s)
 AND
-	corrupted_at IS NULL`, shardID, rawLog, name))
+	(shard_id = %s OR shard_id = '')
+AND
+	corrupted_at IS NULL`, rawLog, name, shardID))
 	if err != nil {
 		return errors.Wrapf(err, "logging repo corruption")
 	}

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -623,7 +623,7 @@ func TestRepos_List_OnlyCorrupted(t *testing.T) {
 	assertCount(t, ReposListOptions{}, 1)
 	assertCount(t, ReposListOptions{OnlyCorrupted: true}, 0)
 
-	logCorruption(t, db, repo.Name, "", "some corruption")
+	logCorruption(t, db, repo.Name, shardID, "some corruption")
 	assertCount(t, ReposListOptions{OnlyCorrupted: true}, 1)
 	assertCount(t, ReposListOptions{}, 1)
 }


### PR DESCRIPTION
So previously this would log corruption errors even if the repo was on a different shard than the one this method is called on.

This change makes it only log if the repo is on the local shard.

## Test plan

- NA