### PR TITLE
Disable chromatic again

### DIFF
--- a/dev/ci/internal/ci/operations.go
+++ b/dev/ci/internal/ci/operations.go
@@ -173,27 +173,28 @@ func addJetBrainsUnitTests(pipeline *bk.Pipeline) {
 
 func clientChromaticTests(opts CoreTestOperationsOptions) operations.Operation {
 	return func(pipeline *bk.Pipeline) {
-		stepOpts := []bk.StepOpt{
-			withPnpmCache(),
-			bk.AutomaticRetry(3),
-			bk.Cmd("./dev/ci/pnpm-install-with-retry.sh"),
-			bk.Cmd("pnpm run generate"),
-			bk.Env("MINIFY", "1"),
-		}
-
-		// Upload storybook to Chromatic
-		chromaticCommand := "pnpm chromatic --exit-zero-on-changes --exit-once-uploaded"
-		if opts.ChromaticShouldAutoAccept {
-			chromaticCommand += " --auto-accept-changes"
-		} else {
-			// Unless we plan on automatically accepting these changes, we only run this
-			// step on ready-for-review pull requests.
-			stepOpts = append(stepOpts, bk.IfReadyForReview(opts.ForceReadyForReview))
-			chromaticCommand += " | ./dev/ci/post-chromatic.sh"
-		}
-
-		pipeline.AddStep(":chromatic: Upload Storybook to Chromatic",
-			append(stepOpts, bk.Cmd(chromaticCommand))...)
+		// stepOpts := []bk.StepOpt{
+		// 	withPnpmCache(),
+		// 	bk.AutomaticRetry(3),
+		// 	bk.Cmd("./dev/ci/pnpm-install-with-retry.sh"),
+		// 	bk.Cmd("pnpm run generate"),
+		// 	bk.Env("MINIFY", "1"),
+		// }
+		//
+		// // Upload storybook to Chromatic
+		// chromaticCommand := "pnpm chromatic --exit-zero-on-changes --exit-once-uploaded"
+		// if opts.ChromaticShouldAutoAccept {
+		// 	chromaticCommand += " --auto-accept-changes"
+		// } else {
+		// 	// Unless we plan on automatically accepting these changes, we only run this
+		// 	// step on ready-for-review pull requests.
+		// 	stepOpts = append(stepOpts, bk.IfReadyForReview(opts.ForceReadyForReview))
+		// 	chromaticCommand += " | ./dev/ci/post-chromatic.sh"
+		// }
+		//
+		// TODO(burmudar): reenable chromatic
+		// pipeline.AddStep(":chromatic: Upload Storybook to Chromatic",
+		// 	append(stepOpts, bk.Cmd(chromaticCommand))...)
 	}
 }
 


### PR DESCRIPTION
Revert "Revert - disable chromatic (#58841)"

This reverts commit 53bcd31b1ffea2b4ca9b2c04424b5dc486877052.

## Test plan
None - Disabling a step
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
