### PR TITLE
database: simplify test helper

### DIFF
--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -437,10 +437,7 @@ func TestGitserverReposGetByID(t *testing.T) {
 	ctx := context.Background()
 
 	// Create one test repo
-	_, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:          "github.com/sourcegraph/repo",
-		RepoSizeBytes: 100,
-	})
+	_, gitserverRepo := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo")
 
 	// GetByID should now work
 	fromDB, err := db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID)
@@ -463,10 +460,7 @@ func TestGitserverReposGetByName(t *testing.T) {
 	ctx := context.Background()
 
 	// Create one test repo
-	repo, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:          "github.com/sourcegraph/repo",
-		RepoSizeBytes: 100,
-	})
+	repo, gitserverRepo := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo")
 
 	// GetByName should now work
 	fromDB, err := db.GitserverRepos().GetByName(ctx, repo.Name)
@@ -495,9 +489,7 @@ func TestGitserverReposGetByNames(t *testing.T) {
 	gitserverRepos := make([]*types.GitserverRepo, 5)
 	for i := 0; i < len(repoNames); i++ {
 		repoName := fmt.Sprintf("github.com/sourcegraph/repo%d", i)
-		repo, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name: api.RepoName(repoName),
-		})
+		repo, gitserverRepo := createTestRepo(ctx, t, db, api.RepoName(repoName))
 		repoNames[i] = repo.Name
 		gitserverRepos[i] = gitserverRepo
 	}
@@ -530,11 +522,7 @@ func TestSetCloneStatus(t *testing.T) {
 	ctx := context.Background()
 
 	// Create one test repo
-	repo, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:          "github.com/sourcegraph/repo",
-		RepoSizeBytes: 100,
-		CloneStatus:   types.CloneStatusNotCloned,
-	})
+	repo, gitserverRepo := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo")
 
 	// Set cloned
 	setGitserverRepoCloneStatus(t, db, repo.Name, types.CloneStatusCloned)
@@ -598,11 +586,7 @@ func TestCloningProgress(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Default", func(t *testing.T) {
-		repo, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name:          "github.com/sourcegraph/defaultcloningprogress",
-			RepoSizeBytes: 100,
-			CloneStatus:   types.CloneStatusNotCloned,
-		})
+		repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/defaultcloningprogress")
 		gotRepo, err := db.GitserverRepos().GetByName(ctx, repo.Name)
 		if err != nil {
 			t.Fatalf("GetByName: %s", err)
@@ -613,11 +597,7 @@ func TestCloningProgress(t *testing.T) {
 	})
 
 	t.Run("Set", func(t *testing.T) {
-		repo, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name:          "github.com/sourcegraph/updatedcloningprogress",
-			RepoSizeBytes: 100,
-			CloneStatus:   types.CloneStatusNotCloned,
-		})
+		repo, gitserverRepo := createTestRepo(ctx, t, db, "github.com/sourcegraph/updatedcloningprogress")
 
 		gitserverRepo.CloningProgress = "Receiving objects: 97% (97/100)"
 		if err := db.GitserverRepos().SetCloningProgress(ctx, repo.Name, gitserverRepo.CloningProgress); err != nil {
@@ -643,11 +623,7 @@ func TestLogCorruption(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("log repo corruption sets corrupted_at time", func(t *testing.T) {
-		repo, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name:          "github.com/sourcegraph/repo1",
-			RepoSizeBytes: 100,
-			CloneStatus:   types.CloneStatusNotCloned,
-		})
+		repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo1")
 		logRepoCorruption(t, db, repo.Name, "test")
 
 		fromDB, err := db.GitserverRepos().GetByID(ctx, repo.ID)
@@ -670,11 +646,7 @@ func TestLogCorruption(t *testing.T) {
 		}
 	})
 	t.Run("setting clone status clears corruptedAt time", func(t *testing.T) {
-		repo, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name:          "github.com/sourcegraph/repo2",
-			RepoSizeBytes: 100,
-			CloneStatus:   types.CloneStatusNotCloned,
-		})
+		repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo2")
 		logRepoCorruption(t, db, repo.Name, "test 2")
 
 		setGitserverRepoCloneStatus(t, db, repo.Name, types.CloneStatusCloned)
@@ -688,11 +660,7 @@ func TestLogCorruption(t *testing.T) {
 		}
 	})
 	t.Run("setting last error does not clear corruptedAt time", func(t *testing.T) {
-		repo, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name:          "github.com/sourcegraph/repo3",
-			RepoSizeBytes: 100,
-			CloneStatus:   types.CloneStatusNotCloned,
-		})
+		repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo3")
 		logRepoCorruption(t, db, repo.Name, "test 3")
 
 		setGitserverRepoLastChanged(t, db, repo.Name, time.Now())
@@ -706,11 +674,7 @@ func TestLogCorruption(t *testing.T) {
 		}
 	})
 	t.Run("setting clone status clears corruptedAt time", func(t *testing.T) {
-		repo, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name:          "github.com/sourcegraph/repo4",
-			RepoSizeBytes: 100,
-			CloneStatus:   types.CloneStatusNotCloned,
-		})
+		repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo4")
 		logRepoCorruption(t, db, repo.Name, "test 3")
 
 		setGitserverRepoLastError(t, db, repo.Name, "This is a TEST ERAWR")
@@ -724,11 +688,7 @@ func TestLogCorruption(t *testing.T) {
 		}
 	})
 	t.Run("consecutive corruption logs appends", func(t *testing.T) {
-		repo, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name:          "github.com/sourcegraph/repo5",
-			RepoSizeBytes: 100,
-			CloneStatus:   types.CloneStatusNotCloned,
-		})
+		repo, gitserverRepo := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo5")
 		for i := 0; i < 12; i++ {
 			logRepoCorruption(t, db, repo.Name, fmt.Sprintf("test %d", i))
 			// We set the Clone status so that the 'corrupted_at' time gets cleared
@@ -763,11 +723,7 @@ func TestLogCorruption(t *testing.T) {
 
 	})
 	t.Run("large reason gets truncated", func(t *testing.T) {
-		repo, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name:          "github.com/sourcegraph/repo6",
-			RepoSizeBytes: 100,
-			CloneStatus:   types.CloneStatusNotCloned,
-		})
+		repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo6")
 
 		largeReason := make([]byte, MaxReasonSizeInMB*2)
 		for i := 0; i < len(largeReason); i++ {
@@ -787,9 +743,7 @@ func TestLogCorruption(t *testing.T) {
 	})
 	t.Run("logging corruption from wrong shard does not log corruption", func(t *testing.T) {
 		// Create repo
-		repo, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{
-			Name: "github.com/sourcegraph/repo7",
-		})
+		repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo7")
 
 		// Mark it as cloned on shard-1
 		err := db.GitserverRepos().SetCloneStatus(ctx, repo.Name, types.CloneStatusCloned, "shard-1")
@@ -820,11 +774,7 @@ func TestSetLastError(t *testing.T) {
 	ctx := context.Background()
 
 	// Create one test repo
-	repo, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:          "github.com/sourcegraph/repo",
-		CloneStatus:   types.CloneStatusNotCloned,
-		RepoSizeBytes: 100,
-	})
+	repo, gitserverRepo := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo")
 
 	// Set error.
 	//
@@ -899,10 +849,7 @@ func TestSetRepoSize(t *testing.T) {
 	ctx := context.Background()
 
 	// Create one test repo
-	repo, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:          "github.com/sourcegraph/repo",
-		RepoSizeBytes: 100,
-	})
+	repo, gitserverRepo := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo")
 
 	// Set repo size
 	err := db.GitserverRepos().SetRepoSize(ctx, repo.Name, 200, "")
@@ -976,11 +923,7 @@ func TestGitserverRepo_Update(t *testing.T) {
 	ctx := context.Background()
 
 	// Create one test repo
-	repo, gitserverRepo := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:          "github.com/sourcegraph/repo",
-		CloneStatus:   types.CloneStatusNotCloned,
-		RepoSizeBytes: 100,
-	})
+	repo, gitserverRepo := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo")
 
 	// Change clone status
 	gitserverRepo.CloneStatus = types.CloneStatusCloned
@@ -1040,16 +983,8 @@ func TestGitserverRepoUpdateMany(t *testing.T) {
 	ctx := context.Background()
 
 	// Create two test repos
-	repo1, gitserverRepo1 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:          "github.com/sourcegraph/repo1",
-		CloneStatus:   types.CloneStatusNotCloned,
-		RepoSizeBytes: 100,
-	})
-	repo2, gitserverRepo2 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name:          "github.com/sourcegraph/repo2",
-		CloneStatus:   types.CloneStatusNotCloned,
-		RepoSizeBytes: 100,
-	})
+	repo1, gitserverRepo1 := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo1")
+	repo2, gitserverRepo2 := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo2")
 
 	// Change their clone statuses
 	gitserverRepo1.CloneStatus = types.CloneStatusCloned
@@ -1103,17 +1038,9 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := context.Background()
 
-	repo1, gitserverRepo1 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name: "github.com/sourcegraph/repo1",
-	})
-
-	repo2, gitserverRepo2 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name: "github.com/sourcegraph/repo2",
-	})
-
-	repo3, gitserverRepo3 := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name: "github.com/sourcegraph/repo3",
-	})
+	repo1, gitserverRepo1 := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo1")
+	repo2, gitserverRepo2 := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo2")
+	repo3, gitserverRepo3 := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo3")
 
 	// Setting repo sizes in DB
 	sizes := map[api.RepoName]int64{
@@ -1194,10 +1121,10 @@ func TestGitserverUpdateRepoSizes(t *testing.T) {
 	}
 }
 
-func createTestRepo(ctx context.Context, t *testing.T, db DB, payload *createTestRepoPayload) (*types.Repo, *types.GitserverRepo) {
+func createTestRepo(ctx context.Context, t *testing.T, db DB, name api.RepoName) (*types.Repo, *types.GitserverRepo) {
 	t.Helper()
 
-	repo := &types.Repo{Name: payload.Name, URI: payload.URI, Fork: payload.Fork}
+	repo := &types.Repo{Name: name}
 
 	// Create Repo
 	err := db.Repos().Create(ctx, repo)
@@ -1221,25 +1148,6 @@ func createTestRepo(ctx context.Context, t *testing.T, db DB, payload *createTes
 	}
 
 	return repo, gitserverRepo
-}
-
-type createTestRepoPayload struct {
-	// Repo related properties
-
-	// Name is the name for this repository (e.g., "github.com/user/repo"). It
-	// is the same as URI, unless the user configures a non-default
-	// repositoryPathPattern.
-	//
-	// Previously, this was called RepoURI.
-	Name api.RepoName
-	URI  string
-	Fork bool
-
-	// Gitserver related properties
-
-	// Size of the repository in bytes.
-	RepoSizeBytes int64
-	CloneStatus   types.CloneStatus
 }
 
 func createTestRepos(ctx context.Context, t *testing.T, db DB, repos types.Repos) {
@@ -1288,9 +1196,7 @@ func TestGitserverRepos_GetGitserverGitDirSize(t *testing.T) {
 	assertSize(0)
 
 	// Create one test repo.
-	repo, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name: "github.com/sourcegraph/repo",
-	})
+	repo, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo")
 
 	// Now, we should see an uncloned test repo that takes no space.
 	assertSize(0)
@@ -1302,9 +1208,7 @@ func TestGitserverRepos_GetGitserverGitDirSize(t *testing.T) {
 	assertSize(200)
 
 	// Now add a second repo to make sure it aggregates properly.
-	repo2, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{
-		Name: "github.com/sourcegraph/repo2",
-	})
+	repo2, _ := createTestRepo(ctx, t, db, "github.com/sourcegraph/repo2")
 	require.NoError(t, db.GitserverRepos().SetRepoSize(ctx, repo2.Name, 500, "test-gitserver"))
 
 	// 200 from the first repo and another 500 from the newly created repo.

--- a/internal/database/zoekt_repos_test.go
+++ b/internal/database/zoekt_repos_test.go
@@ -28,9 +28,9 @@ func TestZoektRepos_GetZoektRepo(t *testing.T) {
 	ctx := context.Background()
 	s := &zoektReposStore{Store: basestore.NewWithHandle(db.Handle())}
 
-	repo1, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{Name: "repo1"})
-	repo2, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{Name: "repo2"})
-	repo3, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{Name: "repo3"})
+	repo1, _ := createTestRepo(ctx, t, db, "repo1")
+	repo2, _ := createTestRepo(ctx, t, db, "repo2")
+	repo3, _ := createTestRepo(ctx, t, db, "repo3")
 
 	assertZoektRepos(t, ctx, s, map[api.RepoID]*ZoektRepo{
 		repo1.ID: {RepoID: repo1.ID, IndexStatus: "not_indexed", Branches: []zoekt.RepositoryBranch{}},
@@ -56,7 +56,7 @@ func TestZoektRepos_UpdateIndexStatuses(t *testing.T) {
 		"repo2",
 		"repo3",
 	} {
-		r, _ := createTestRepo(ctx, t, db, &createTestRepoPayload{Name: name})
+		r, _ := createTestRepo(ctx, t, db, name)
 		repos = append(repos, types.MinimalRepo{ID: r.ID, Name: r.Name})
 	}
 


### PR DESCRIPTION
We bumped into this earlier. Turns out this helper was a "would be nice" approach that didn't pan out. Instead of changing all of the tests to follow this approach, I decided to simplify and reduce the things that aren't needed because it makes maintenance easier.

## Test plan

NA