### PR TITLE
Turns the `sh_binary` into a `sh_test`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,7 +114,7 @@ http_archive(
 )
 
 # hermetic_cc_toolchain setup ================================
-HERMETIC_CC_TOOLCHAIN_VERSION = "v2.0.0"
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.1.2"
 
 # Please note that we only use hermetic-cc for local development purpose and Nix, at it eases the path to cross-compile
 # so we can produce container images locally on Mac laptops.
@@ -130,7 +130,7 @@ http_archive(
     patches = [
         "//third_party/hermetic_cc:disable_ubsan.patch",
     ],
-    sha256 = "57f03a6c29793e8add7bd64186fc8066d23b5ffd06fe9cc6b0b8c499914d3a65",
+    sha256 = "28fc71b9b3191c312ee83faa1dc65b38eb70c3a57740368f7e7c7a49bedf3106",
     urls = [
         "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
         "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),

--- a/testing/tools/upgradetest/BUILD.bazel
+++ b/testing/tools/upgradetest/BUILD.bazel
@@ -23,23 +23,23 @@ go_binary(
 )
 
 go_cross_binary(
-    name = "upgradetest-darwin-amd64",
-    platform = "@io_bazel_rules_go//go/toolchain:darwin_amd64",
+    name = "upgradetest-darwin-arm64",
+    platform = "@io_bazel_rules_go//go/toolchain:darwin_arm64",
     target = ":go_upgradetest",
     visibility = ["//testing:__pkg__"],
 )
 
-sh_binary(
+sh_test(
     name = "sh_upgradetest",
     srcs = ["test.sh"],
     args = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": [
-            "$(location :upgradetest-darwin-amd64)",
+        "//:darwin_docker_e2e_go": [
+            "$(location :upgradetest-darwin-arm64)",
             "$(location //cmd/migrator:image_tarball)",
             "$(location //cmd/frontend:image_tarball)",
             "$(locations //internal/database:generate_schemas)",
         ],
-        "@bazel_tools//src/conditions:linux_x86_64": [
+        "//conditions:default": [
             "$(location :go_upgradetest)",
             "$(location //cmd/migrator:image_tarball)",
             "$(location //cmd/frontend:image_tarball)",
@@ -47,18 +47,18 @@ sh_binary(
         ],
     }),
     data = select({
-        "@bazel_tools//src/conditions:darwin_x86_64": [
-            ":upgradetest-darwin-amd64",
+        "//:darwin_docker_e2e_go": [
+            ":upgradetest-darwin-arm64",
             "//cmd/frontend:image_tarball",
             "//cmd/migrator:image_tarball",
             "//internal/database:generate_schemas",
         ],
-        "@bazel_tools//src/conditions:linux_x86_64": [
+        "//conditions:default": [
             ":go_upgradetest",
             "//cmd/frontend:image_tarball",
             "//cmd/migrator:image_tarball",
             "//internal/database:generate_schemas",
         ],
     }),
-    # tags = ["requires-network", "no-sandbox"]
+    tags = ["requires-network", "no-sandbox"]
 )


### PR DESCRIPTION
@DaedalusG this PR turns the `sh_binary` into  a `sh_test` and properly fixes the `select` block so we can use this locally (assuming you use your arm laptop). 

I tested it locally, if ran fine, though it failed because of the timeout, which you can adjust on your side. 

I also cherry-picked an update to `hermetic_cc` as the rebase wasn't that trivial and I'll leave you handle that on your side. If you're blocked, please reach out. 

```
bazel test //testing/tools/upgradetest:sh_upgradetest --config darwin-docker
```

## Test plan

Locally tested 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
