### PR TITLE
SSC: Handle returnTo params on /cody/manage

### DIFF
--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -114,9 +114,11 @@ export function CodyOnboarding({
 
     const navigate = useNavigate()
 
-    if (completed && !showEditorStep && returnToURL) {
-        navigate(returnToURL)
-    }
+    useEffect(() => {
+        if (completed && !showEditorStep && returnToURL) {
+            navigate(returnToURL)
+        }
+    }, [completed, returnToURL, navigate, showEditorStep])
 
     if (!showEditorStep && (completed || step === -1 || step > 1)) {
         return null

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -115,10 +115,14 @@ export function CodyOnboarding({
     const navigate = useNavigate()
 
     useEffect(() => {
-        if (completed && !showEditorStep && returnToURL) {
+        if (completed && returnToURL) {
             navigate(returnToURL)
         }
-    }, [completed, returnToURL, navigate, showEditorStep])
+    }, [completed, returnToURL, navigate])
+
+    if (completed && returnToURL) {
+        return null
+    }
 
     if (!showEditorStep && (completed || step === -1 || step > 1)) {
         return null

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import classNames from 'classnames'
+import { useNavigate } from 'react-router-dom'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
-import { Modal, H5, H2, Text, Button, useSearchParameters } from '@sourcegraph/wildcard'
+import { Button, H2, H5, Modal, Text, useSearchParameters } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
 import { HubSpotForm } from '../../marketing/components/HubSpotForm'
@@ -101,7 +102,7 @@ export function CodyOnboarding({
     authenticatedUser: AuthenticatedUser | null
 }): JSX.Element | null {
     const [showEditorStep, setShowEditorStep] = useState(false)
-    const [completed = true, setOnboardingCompleted] = useTemporarySetting('cody.onboarding.completed', false)
+    const [completed = false, setOnboardingCompleted] = useTemporarySetting('cody.onboarding.completed', false)
     // steps start from 0
     const [step = -1, setOnboardingStep] = useTemporarySetting('cody.onboarding.step', 0)
 
@@ -109,6 +110,13 @@ export function CodyOnboarding({
 
     const parameters = useSearchParameters()
     const enrollPro = parameters.get('pro') === 'true'
+    const returnToURL = parameters.get('returnTo')
+
+    const navigate = useNavigate()
+
+    if (completed && !showEditorStep && returnToURL) {
+        navigate(returnToURL)
+    }
 
     if (!showEditorStep && (completed || step === -1 || step > 1)) {
         return null


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/cody/issues/2054

It was a small change, after all.

## Test plan

Watch me test it in this [3-min Loom](https://www.loom.com/share/66611ce7d82043669ef06d597876784f?sid=6be701b9-23ac-4a6e-b20d-e5d47255aeda)

I tested:
- If `/cody/manage` gets a `returnTo` parameter, it correctly goes through the onboarding process, then redirects to the desired page
- If it doesn't get the new param, it won't do a redirect