### PR TITLE
cody-gateway: For streaming requests, flush response after every write

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//internal/conf/conftypes",
         "//internal/httpcli",
         "//internal/requestclient",
+        "//internal/search/streaming/http",
         "//internal/trace",
         "//lib/errors",
         "@com_github_grafana_regexp//:regexp",

--- a/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//internal/conf/conftypes",
         "//internal/httpcli",
         "//internal/requestclient",
-        "//internal/search/streaming/http",
         "//internal/trace",
         "//lib/errors",
         "@com_github_grafana_regexp//:regexp",

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"io"
 	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 
 	"github.com/grafana/regexp"
 

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -174,6 +174,7 @@ func NewAnthropicHandler(
 				r.Header.Set("X-API-Key", accessToken)
 				r.Header.Set("anthropic-version", "2023-01-01")
 			},
+			forwardResponse: defaultForwardResponse[anthropicRequest],
 			parseResponseAndUsage: func(logger log.Logger, reqBody anthropicRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
 				// First, extract prompt usage details from the request.
 				promptUsage.characters = len(reqBody.Prompt)

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -111,6 +111,7 @@ func NewAnthropicHandler(
 	promptRecorder PromptRecorder,
 	allowedPromptPatterns []string,
 	requestBlockingEnabled bool,
+	autoFlushStreamingResponses bool,
 ) (http.Handler, error) {
 	// Tokenizer only needs to be initialized once, and can be shared globally.
 	anthropicTokenizer, err := tokenizer.NewAnthropicClaudeTokenizer()
@@ -245,6 +246,7 @@ func NewAnthropicHandler(
 		// able to circumvent concurrents limits without raising an error to the
 		// user.
 		2, // seconds
+		autoFlushStreamingResponses,
 	), nil
 }
 

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -174,7 +174,6 @@ func NewAnthropicHandler(
 				r.Header.Set("X-API-Key", accessToken)
 				r.Header.Set("anthropic-version", "2023-01-01")
 			},
-			forwardResponse: defaultForwardResponse[anthropicRequest],
 			parseResponseAndUsage: func(logger log.Logger, reqBody anthropicRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
 				// First, extract prompt usage details from the request.
 				promptUsage.characters = len(reqBody.Prompt)
@@ -262,6 +261,10 @@ type anthropicRequest struct {
 
 	// Use (*anthropicRequest).GetTokenCount()
 	promptTokens *anthropicTokenCount
+}
+
+func (ar anthropicRequest) ShouldStream() bool {
+	return ar.Stream
 }
 
 func (ar anthropicRequest) GetModel() string {

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -32,6 +32,7 @@ func NewFireworksHandler(
 	allowedModels []string,
 	logSelfServeCodeCompletionRequests bool,
 	disableSingleTenant bool,
+	autoFlushStreamingResponses bool,
 ) http.Handler {
 	return makeUpstreamHandler(
 		baseLogger,
@@ -165,6 +166,7 @@ func NewFireworksHandler(
 		// Setting to a valuer higher than SRC_HTTP_CLI_EXTERNAL_RETRY_AFTER_MAX_DURATION to not
 		// do any retries
 		30, // seconds
+		autoFlushStreamingResponses,
 	)
 }
 

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/events"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/limiter"
@@ -14,8 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"io"
-	"net/http"
 )
 
 const fireworksAPIURL = "https://api.fireworks.ai/inference/v1/completions"

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -32,6 +32,7 @@ func NewOpenAIHandler(
 	accessToken string,
 	orgID string,
 	allowedModels []string,
+	autoFlushStreamingResponses bool,
 ) http.Handler {
 	return makeUpstreamHandler(
 		baseLogger,
@@ -135,6 +136,7 @@ func NewOpenAIHandler(
 		// clients from retrying at all since retries are probably not going to
 		// help in a minute-long rate limit window.
 		30, // seconds
+		autoFlushStreamingResponses,
 	)
 }
 

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"io"
 	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 
 	"github.com/sourcegraph/log"
 

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -69,7 +69,6 @@ func NewOpenAIHandler(
 					r.Header.Set("OpenAI-Organization", orgID)
 				}
 			},
-			forwardResponse: defaultForwardResponse[openaiRequest],
 			parseResponseAndUsage: func(logger log.Logger, body openaiRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
 				// First, extract prompt usage details from the request.
 				for _, m := range body.Messages {
@@ -157,6 +156,10 @@ type openaiRequest struct {
 	FrequencyPenalty float32                `json:"frequency_penalty,omitempty"`
 	LogitBias        map[string]float32     `json:"logit_bias,omitempty"`
 	User             string                 `json:"user,omitempty"`
+}
+
+func (r openaiRequest) ShouldStream() bool {
+	return r.Stream
 }
 
 func (r openaiRequest) GetModel() string {

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -69,6 +69,7 @@ func NewOpenAIHandler(
 					r.Header.Set("OpenAI-Organization", orgID)
 				}
 			},
+			forwardResponse: defaultForwardResponse[openaiRequest],
 			parseResponseAndUsage: func(logger log.Logger, body openaiRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
 				// First, extract prompt usage details from the request.
 				for _, m := range body.Messages {

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -377,7 +377,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
-			fmt.Println("Response written after()", time.Since(start))
+
 			if upstreamStatusCode >= 200 && upstreamStatusCode < 300 {
 				// Pass reader to response transformer to capture token counts.
 				promptUsage, completionUsage = methods.parseResponseAndUsage(logger, body, &responseBuf)

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -98,6 +98,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 	// limit events in case a retry-after is not provided by the upstream
 	// response.
 	defaultRetryAfterSeconds int,
+	autoFlushStreamingResponses bool,
 ) http.Handler {
 	baseLogger = baseLogger.Scoped(upstreamName).
 		With(log.String("upstream.url", upstreamAPIURL))
@@ -374,7 +375,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 			// if this is a streaming request, we want to flush ourselves instead of leaving that to the http.Server
 			// (so events are sent to the client as soon as possible)
 			var responseWriter io.Writer = w
-			if body.ShouldStream() {
+			if autoFlushStreamingResponses && body.ShouldStream() {
 				if fw, err := response.NewAutoFlushingWriter(w); err == nil {
 					responseWriter = fw
 				} else {

--- a/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/handler.go
@@ -2,8 +2,9 @@ package httpapi
 
 import (
 	"context"
-	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/log"
@@ -40,6 +41,7 @@ type Config struct {
 	FireworksAllowedModels                      []string
 	FireworksLogSelfServeCodeCompletionRequests bool
 	EmbeddingsAllowedModels                     []string
+	AutoFlushStreamingResponses                 bool
 }
 
 var meter = otel.GetMeterProvider().Meter("cody-gateway/internal/httpapi")
@@ -88,6 +90,7 @@ func NewHandler(
 			promptRecorder,
 			config.AnthropicAllowedPromptPatterns,
 			config.AnthropicRequestBlockingEnabled,
+			config.AutoFlushStreamingResponses,
 		)
 		if err != nil {
 			return nil, errors.Wrap(err, "init Anthropic handler")
@@ -127,6 +130,7 @@ func NewHandler(
 								config.OpenAIAccessToken,
 								config.OpenAIOrgID,
 								config.OpenAIAllowedModels,
+								config.AutoFlushStreamingResponses,
 							),
 						),
 					),
@@ -195,6 +199,7 @@ func NewHandler(
 								config.FireworksAllowedModels,
 								config.FireworksLogSelfServeCodeCompletionRequests,
 								config.FireworksDisableSingleTenant,
+								config.AutoFlushStreamingResponses,
 							),
 						),
 					),

--- a/cmd/cody-gateway/internal/response/BUILD.bazel
+++ b/cmd/cody-gateway/internal/response/BUILD.bazel
@@ -6,7 +6,10 @@ go_library(
     srcs = ["response.go"],
     importpath = "github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/response",
     visibility = ["//cmd/cody-gateway:__subpackages__"],
-    deps = ["@com_github_sourcegraph_log//:log"],
+    deps = [
+        "//lib/errors",
+        "@com_github_sourcegraph_log//:log",
+    ],
 )
 
 go_test(

--- a/cmd/cody-gateway/internal/response/response.go
+++ b/cmd/cody-gateway/internal/response/response.go
@@ -2,6 +2,8 @@ package response
 
 import (
 	"encoding/json"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"io"
 	"net/http"
 
 	"github.com/sourcegraph/log"
@@ -100,4 +102,32 @@ func (e HTTPStatusCodeError) HTTPStatusCode() int { return e.status }
 
 func (e HTTPStatusCodeError) IsCustom() (originalCode int, isCustom bool) {
 	return e.originalStatus, e.custom
+}
+
+type autoFlusher struct {
+	rw      http.ResponseWriter
+	flusher http.Flusher
+}
+
+var _ io.Writer = autoFlusher{}
+
+// NewAutoFlushingWriter returns an io.Writer that will flush after every Write()
+// call. It will return an error if the response writer doesn't implement the Flusher interface.
+func NewAutoFlushingWriter(w http.ResponseWriter) (io.Writer, error) {
+	if flusher, ok := w.(http.Flusher); !ok {
+		return nil, errors.Newf("can't flush response using", w)
+	} else {
+		return autoFlusher{
+			rw: w, flusher: flusher,
+		}, nil
+	}
+}
+
+func (a autoFlusher) Write(p []byte) (n int, err error) {
+	n, err = a.rw.Write(p)
+	if err != nil {
+		return 0, err
+	}
+	a.flusher.Flush()
+	return n, nil
 }

--- a/cmd/cody-gateway/internal/response/response.go
+++ b/cmd/cody-gateway/internal/response/response.go
@@ -2,9 +2,10 @@ package response
 
 import (
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"io"
 	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/log"
 )

--- a/cmd/cody-gateway/internal/response/response.go
+++ b/cmd/cody-gateway/internal/response/response.go
@@ -116,7 +116,7 @@ var _ io.Writer = autoFlusher{}
 // call. It will return an error if the response writer doesn't implement the Flusher interface.
 func NewAutoFlushingWriter(w http.ResponseWriter) (io.Writer, error) {
 	if flusher, ok := w.(http.Flusher); !ok {
-		return nil, errors.Newf("can't flush response using", w)
+		return nil, errors.Newf("can't flush response using %v as it doesn't implement http.Flusher", w)
 	} else {
 		return autoFlusher{
 			rw: w, flusher: flusher,

--- a/cmd/cody-gateway/internal/response/response_test.go
+++ b/cmd/cody-gateway/internal/response/response_test.go
@@ -1,10 +1,11 @@
 package response
 
 import (
-	"github.com/sourcegraph/log/logtest"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/sourcegraph/log/logtest"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cmd/cody-gateway/internal/response/response_test.go
+++ b/cmd/cody-gateway/internal/response/response_test.go
@@ -35,3 +35,42 @@ func TestStatusHeaderRecorder(t *testing.T) {
 		assert.Equal(t, "foo", underlying.Body.String())
 	})
 }
+
+func TestAutoFlusher_Write(t *testing.T) {
+	rw := &responseWriterMock{}
+
+	writer, err := NewAutoFlushingWriter(rw)
+	assert.NoError(t, err)
+
+	_, err = writer.Write([]byte("data"))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, rw.flushCalledTimes)
+	assert.Equal(t, []byte("data"), rw.written)
+	_, err = writer.Write([]byte("value"))
+	assert.NoError(t, err)
+	assert.Equal(t, 2, rw.flushCalledTimes)
+	assert.Equal(t, []byte("datavalue"), rw.written)
+}
+
+type responseWriterMock struct {
+	written          []byte
+	flushCalledTimes int
+}
+
+var _ http.Flusher = &responseWriterMock{}
+var _ http.ResponseWriter = &responseWriterMock{}
+
+func (m *responseWriterMock) Flush() {
+	m.flushCalledTimes += 1
+}
+
+func (m *responseWriterMock) Write(p []byte) (int, error) {
+	m.written = append(m.written, p...)
+	return len(p), nil
+}
+func (m *responseWriterMock) Header() http.Header {
+	return nil
+}
+
+func (m *responseWriterMock) WriteHeader(_ int) {
+}

--- a/cmd/cody-gateway/shared/config.go
+++ b/cmd/cody-gateway/shared/config.go
@@ -66,8 +66,9 @@ type Config struct {
 
 	OpenTelemetry OpenTelemetryConfig
 
-	ActorConcurrencyLimit codygateway.ActorConcurrencyLimitConfig
-	ActorRateLimitNotify  codygateway.ActorRateLimitNotifyConfig
+	ActorConcurrencyLimit       codygateway.ActorConcurrencyLimitConfig
+	ActorRateLimitNotify        codygateway.ActorRateLimitNotifyConfig
+	AutoFlushStreamingResponses bool
 }
 
 type OpenTelemetryConfig struct {
@@ -184,6 +185,7 @@ func (c *Config) Load() {
 	c.ActorConcurrencyLimit.Interval = c.GetInterval("CODY_GATEWAY_ACTOR_CONCURRENCY_LIMIT_INTERVAL", "10s", "The interval at which to check the concurrent requests limit from an actor.")
 
 	c.ActorRateLimitNotify.SlackWebhookURL = c.GetOptional("CODY_GATEWAY_ACTOR_RATE_LIMIT_NOTIFY_SLACK_WEBHOOK_URL", "The Slack webhook URL to send notifications to.")
+	c.AutoFlushStreamingResponses = c.GetBool("CODY_GATEWAY_AUTO_FLUSH_STREAMING_RESPONSES", "false", "Whether we should flush streaming responses after every write.")
 }
 
 // splitMaybe splits on commas, but only returns at least one element if the input

--- a/cmd/cody-gateway/shared/main.go
+++ b/cmd/cody-gateway/shared/main.go
@@ -170,6 +170,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 			FireworksLogSelfServeCodeCompletionRequests: config.Fireworks.LogSelfServeCodeCompletionRequests,
 			FireworksDisableSingleTenant:                config.Fireworks.DisableSingleTenant,
 			EmbeddingsAllowedModels:                     config.AllowedEmbeddingsModels,
+			AutoFlushStreamingResponses:                 config.AutoFlushStreamingResponses,
 		}, sources)
 	if err != nil {
 		return errors.Wrap(err, "httpapi.NewHandler")

--- a/internal/completions/client/fireworks/fireworks.go
+++ b/internal/completions/client/fireworks/fireworks.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"net/http"
-	"strings"
-
 	"github.com/sourcegraph/sourcegraph/internal/completions/types"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"net/http"
+	"strings"
 )
 
 func NewClient(cli httpcli.Doer, endpoint, accessToken string) types.CompletionsClient {


### PR DESCRIPTION
For streaming requests, we don't want to buffer responses, but instead send the data to the client as soon as possible - see [Slack](https://sourcegraph.slack.com/archives/C05AGQYD528/p1701791953787829) and this issue https://github.com/sourcegraph/cody/issues/2180. This PR detects streaming requests (from all providers) and automatically flushes the response after every write.

Improvement can be observed using this https://sourcegraph.slack.com/archives/C05AGQYD528/p1702287275092429?thread_ts=1701791953.787829&cid=C05AGQYD528.
From local tests, this cuts time-to-first-event from ~1s to ~300ms (Fireworks Starcoder, measured client side). 
## Test plan

- tested locally
- unit tests