### PR TITLE
Sveltekit Prototype: add file icons to svelte prototype

### DIFF
--- a/client/web-sveltekit/src/lib/fileIcons.ts
+++ b/client/web-sveltekit/src/lib/fileIcons.ts
@@ -44,7 +44,7 @@ const YELLOW = 'var(--yellow)'
 const RED = 'var(--red)'
 const GREEN = 'var(--green)'
 const CYAN = 'var(--blue)'
-const DEFAULT_ICON = 'var(--gray-05)'
+const GRAY = 'var(--gray-05)'
 
 enum FileExtension {
     ASSEMBLY = 'asm',
@@ -61,7 +61,6 @@ enum FileExtension {
     CSHARP = 'cs',
     CSS = 'css',
     DART = 'dart',
-    DEFAULT = 'default',
     DOCKERFILE = 'Dockerfile',
     DOCKERIGNORE = 'dockerignore',
     FORTRAN_F = 'f',
@@ -135,7 +134,7 @@ interface FileInfo {
     isTest: boolean
 }
 
-const getColor = (extension: FileExtension) => {
+function getColor(extension: FileExtension) {
     switch (extension) {
         case FileExtension.DOCKERFILE:
         case FileExtension.DOCKERIGNORE:
@@ -175,7 +174,7 @@ const getColor = (extension: FileExtension) => {
             return CYAN
         }
         default: {
-            return DEFAULT_ICON
+            return GRAY
         }
     }
 }
@@ -184,8 +183,7 @@ const getColor = (extension: FileExtension) => {
 // Most programming language Material Design icons will be
 // deprecated very soon, and will not be included in the next release.
 // Additionally, it doesn't have all the icons we need anyway.
-const getIconAttributes = (extension: FileExtension): IconInfo => {
-    const color = getColor(extension)
+function getIcon(extension: FileExtension): string {
     switch (extension) {
         // TODO: Ideally, we would switch to a new icon library
         // so we don't have to default to a general icon
@@ -198,7 +196,6 @@ const getIconAttributes = (extension: FileExtension): IconInfo => {
         case FileExtension.CLOJURE_EDN:
         case FileExtension.CLOJURE_CLJS:
         case FileExtension.DART:
-        case FileExtension.DEFAULT:
         case FileExtension.FORTRAN_F:
         case FileExtension.FORTRAN_FOR:
         case FileExtension.FORTRAN_FTN:
@@ -215,143 +212,135 @@ const getIconAttributes = (extension: FileExtension): IconInfo => {
         case FileExtension.SQL:
         case FileExtension.TEST:
         case FileExtension.ZIG: {
-            return { svgPath: mdiFileCodeOutline, color }
+            return mdiFileCodeOutline
         }
         case FileExtension.BASH:
         case FileExtension.POWERSHELL_PS1:
         case FileExtension.POWERSHELL_PSM1: {
-            return { svgPath: mdiConsole, color }
+            return mdiConsole
         }
         case FileExtension.C: {
-            return { svgPath: mdiLanguageC, color }
+            return mdiLanguageC
         }
         case FileExtension.RUST:
         case FileExtension.TOML: {
-            return { svgPath: mdiLanguageRust, color }
+            return mdiLanguageRust
         }
         case FileExtension.CPP: {
-            return { svgPath: mdiLanguageCpp, color }
+            return mdiLanguageCpp
         }
         case FileExtension.CSHARP: {
-            return { svgPath: mdiLanguageCsharp, color }
+            return mdiLanguageCsharp
         }
         case FileExtension.CSS: {
-            return { svgPath: mdiLanguageCss3, color }
+            return mdiLanguageCss3
         }
         case FileExtension.DOCKERFILE:
         case FileExtension.DOCKERIGNORE: {
-            return { svgPath: mdiDocker, color }
+            return mdiDocker
         }
         case FileExtension.GIF:
         case FileExtension.GIFF: {
-            return { svgPath: mdiFileGifBox, color }
+            return mdiFileGifBox
         }
         case FileExtension.GITIGNORE:
         case FileExtension.GITATTRIBUTES: {
-            return { svgPath: mdiGit, color }
+            return mdiGit
         }
         case FileExtension.GO:
         case FileExtension.GOMOD:
         case FileExtension.GOSUM: {
-            return { svgPath: mdiLanguageGo, color }
+            return mdiLanguageGo
         }
         case FileExtension.GRAPHQL: {
-            return { svgPath: mdiGraphql, color }
+            return mdiGraphql
         }
         case FileExtension.HASKELL: {
-            return { svgPath: mdiLanguageHaskell, color }
+            return mdiLanguageHaskell
         }
         case FileExtension.HTML: {
-            return { svgPath: mdiLanguageHtml5, color }
+            return mdiLanguageHtml5
         }
         case FileExtension.JAVA: {
-            return { svgPath: mdiLanguageJava, color }
+            return mdiLanguageJava
         }
         case FileExtension.JAVASCRIPT: {
-            return { svgPath: mdiLanguageJavascript, color }
+            return mdiLanguageJavascript
         }
         case FileExtension.JPG:
         case FileExtension.JPEG: {
-            return { svgPath: mdiFileJpgBox, color }
+            return mdiFileJpgBox
         }
         case FileExtension.JSON:
         case FileExtension.LOCKFILE: {
-            return { svgPath: mdiCodeJson, color }
+            return mdiCodeJson
         }
         case FileExtension.JSX:
         case FileExtension.TSX: {
-            return { svgPath: mdiReact, color }
+            return mdiReact
         }
         case FileExtension.KOTLIN: {
-            return { svgPath: mdiLanguageKotlin, color }
+            return mdiLanguageKotlin
         }
         case FileExtension.LUA: {
-            return { svgPath: mdiLanguageLua, color }
+            return mdiLanguageLua
         }
         case FileExtension.MARKDOWN:
         case FileExtension.MDX: {
-            return { svgPath: mdiLanguageMarkdown, color }
+            return mdiLanguageMarkdown
         }
         case FileExtension.NCL:
         case FileExtension.NIX: {
-            return { svgPath: mdiNix, color }
+            return mdiNix
         }
         case FileExtension.NPM: {
-            return { svgPath: mdiNpm, color }
+            return mdiNpm
         }
         case FileExtension.PHP: {
-            return { svgPath: mdiLanguagePhp, color }
+            return mdiLanguagePhp
         }
         case FileExtension.PNG: {
-            return { svgPath: mdiFilePngBox, color }
+            return mdiFilePngBox
         }
         case FileExtension.PYTHON: {
-            return { svgPath: mdiLanguagePython, color }
+            return mdiLanguagePython
         }
         case FileExtension.R:
         case FileExtension.R_CAP: {
-            return { svgPath: mdiLanguageR, color }
+            return mdiLanguageR
         }
         case FileExtension.RUBY:
         case FileExtension.GEMFILE: {
-            return { svgPath: mdiLanguageRuby, color }
+            return mdiLanguageRuby
         }
         case FileExtension.SASS: {
-            return { svgPath: mdiSass, color }
+            return mdiSass
         }
         case FileExtension.SVG: {
-            return { svgPath: mdiSvg, color }
+            return mdiSvg
         }
         case FileExtension.SWIFT: {
-            return { svgPath: mdiLanguageSwift, color }
+            return mdiLanguageSwift
         }
         case FileExtension.TYPESCRIPT: {
-            return { svgPath: mdiLanguageTypescript, color }
+            return mdiLanguageTypescript
         }
         case FileExtension.TEXT: {
-            return { svgPath: mdiText, color }
+            return mdiText
         }
         case FileExtension.YAML:
         case FileExtension.YML: {
-            return { svgPath: mdiCog, color }
+            return mdiCog
         }
         default: {
-            return { svgPath: mdiConsole, color }
+            return mdiFileCodeOutline
         }
     }
 }
 
-const getExtension = (file: string): FileExtension => {
-    const ext = file.split('.').at(-1) as FileExtension
-    if (Object.values(FileExtension).includes(ext)) {
-        return ext
-    }
-    return 'default' as FileExtension
-}
-
-export const getFileInfo = (file: string): FileInfo => {
-    const extension = getExtension(file)
-    const icon = FILE_ICONS.get(extension)
+export function getFileInfo(file: string): FileInfo {
+    const extension = file.split('.').at(-1)
+    const icon = FILE_ICONS.get(extension as FileExtension)
 
     if (icon) {
         return {
@@ -363,10 +352,15 @@ export const getFileInfo = (file: string): FileInfo => {
     return {
         icon: {
             svgPath: mdiFileCodeOutline,
-            color: DEFAULT_ICON,
+            color: GRAY,
         },
         isTest: false,
     }
 }
 
-const FILE_ICONS = new Map(Object.values(FileExtension).map(extension => [extension, getIconAttributes(extension)]))
+const FILE_ICONS = new Map(
+    Object.values(FileExtension).map(extension => [
+        extension,
+        { svgPath: getIcon(extension), color: getColor(extension) },
+    ])
+)

--- a/client/web-sveltekit/src/lib/fileIcons.ts
+++ b/client/web-sveltekit/src/lib/fileIcons.ts
@@ -4,6 +4,7 @@ import {
     mdiConsole,
     mdiDocker,
     mdiFileCodeOutline,
+    mdiFileGifBox,
     mdiFileJpgBox,
     mdiFilePngBox,
     mdiGit,
@@ -43,9 +44,9 @@ const YELLOW = 'var(--yellow)'
 const RED = 'var(--red)'
 const GREEN = 'var(--green)'
 const CYAN = 'var(--blue)'
-const DEFAULT_ICON = 'var(--gray-07)'
+const DEFAULT_ICON = 'var(--gray-05)'
 
-export enum FileExtension {
+enum FileExtension {
     ASSEMBLY = 'asm',
     BASH = 'sh',
     BASIC = 'vb',
@@ -124,8 +125,6 @@ export enum FileExtension {
     ZIG = 'zig',
 }
 
-const FILE_ICONS = new Map(Object.values(FileExtension).map(extension => [extension, getIconAttributes(extension)]))
-
 interface IconInfo {
     svgPath: string
     color: string
@@ -138,8 +137,14 @@ interface FileInfo {
 
 const getColor = (extension: FileExtension) => {
     switch (extension) {
+        case FileExtension.DOCKERFILE:
+        case FileExtension.DOCKERIGNORE:
+        case FileExtension.GO:
         case FileExtension.MARKDOWN:
         case FileExtension.MDX:
+        case FileExtension.JSX:
+        case FileExtension.TSX:
+        case FileExtension.TYPESCRIPT:
         case FileExtension.SVG: {
             return BLUE
         }
@@ -159,7 +164,8 @@ const getColor = (extension: FileExtension) => {
         case FileExtension.SASS: {
             return PINK
         }
-        case (FileExtension.JAVASCRIPT, FileExtension.PYTHON): {
+        case FileExtension.JAVASCRIPT:
+        case FileExtension.PYTHON: {
             return YELLOW
         }
         case FileExtension.KOTLIN: {
@@ -236,11 +242,17 @@ const getIconAttributes = (extension: FileExtension): IconInfo => {
         case FileExtension.DOCKERIGNORE: {
             return { svgPath: mdiDocker, color }
         }
+        case FileExtension.GIF:
+        case FileExtension.GIFF: {
+            return { svgPath: mdiFileGifBox, color }
+        }
         case FileExtension.GITIGNORE:
         case FileExtension.GITATTRIBUTES: {
             return { svgPath: mdiGit, color }
         }
-        case FileExtension.GO: {
+        case FileExtension.GO:
+        case FileExtension.GOMOD:
+        case FileExtension.GOSUM: {
             return { svgPath: mdiLanguageGo, color }
         }
         case FileExtension.GRAPHQL: {
@@ -352,3 +364,5 @@ export const getFileInfo = (file: string): FileInfo => {
         isTest: false,
     }
 }
+
+const FILE_ICONS = new Map(Object.values(FileExtension).map(extension => [extension, getIconAttributes(extension)]))

--- a/client/web-sveltekit/src/lib/fileIcons.ts
+++ b/client/web-sveltekit/src/lib/fileIcons.ts
@@ -34,6 +34,7 @@ import {
     mdiSvg,
     mdiText,
 } from '@mdi/js'
+
 import { containsTest } from '$lib/web'
 
 const BLUE = 'var(--blue)'
@@ -123,9 +124,7 @@ export enum FileExtension {
     ZIG = 'zig',
 }
 
-export const FILE_ICONS = new Map(
-    Object.values(FileExtension).map(extension => [extension, getIconAttributes(extension)])
-)
+const FILE_ICONS = new Map(Object.values(FileExtension).map(extension => [extension, getIconAttributes(extension)]))
 
 interface IconInfo {
     svgPath: string
@@ -200,6 +199,8 @@ const getIconAttributes = (extension: FileExtension): IconInfo => {
         case FileExtension.FSHARP:
         case FileExtension.FSI:
         case FileExtension.FSX:
+        case FileExtension.GROOVY:
+        case FileExtension.JULIA:
         case FileExtension.OCAML:
         case FileExtension.PERL:
         case FileExtension.PERL_PM:
@@ -245,9 +246,6 @@ const getIconAttributes = (extension: FileExtension): IconInfo => {
         case FileExtension.GRAPHQL: {
             return { svgPath: mdiGraphql, color }
         }
-        case FileExtension.GROOVY:
-        case FileExtension.JULIA:
-
         case FileExtension.HASKELL: {
             return { svgPath: mdiLanguageHaskell, color }
         }
@@ -289,7 +287,6 @@ const getIconAttributes = (extension: FileExtension): IconInfo => {
         case FileExtension.NPM: {
             return { svgPath: mdiNpm, color }
         }
-
         case FileExtension.PHP: {
             return { svgPath: mdiLanguagePhp, color }
         }
@@ -332,7 +329,7 @@ const getIconAttributes = (extension: FileExtension): IconInfo => {
     }
 }
 
-export const getExtension = (file: string): FileExtension => {
+const getExtension = (file: string): FileExtension => {
     return file.split('.').at(-1) as FileExtension
 }
 

--- a/client/web-sveltekit/src/lib/fileIcons.ts
+++ b/client/web-sveltekit/src/lib/fileIcons.ts
@@ -342,7 +342,11 @@ const getIconAttributes = (extension: FileExtension): IconInfo => {
 }
 
 const getExtension = (file: string): FileExtension => {
-    return file.split('.').at(-1) as FileExtension
+    const ext = file.split('.').at(-1) as FileExtension
+    if (Object.values(FileExtension).includes(ext)) {
+        return ext
+    }
+    return 'default' as FileExtension
 }
 
 export const getFileInfo = (file: string): FileInfo => {

--- a/client/web-sveltekit/src/lib/fileIcons.ts
+++ b/client/web-sveltekit/src/lib/fileIcons.ts
@@ -1,0 +1,357 @@
+import {
+    mdiCodeJson,
+    mdiCog,
+    mdiConsole,
+    mdiDocker,
+    mdiFileCodeOutline,
+    mdiFileJpgBox,
+    mdiFilePngBox,
+    mdiGit,
+    mdiGraphql,
+    mdiLanguageC,
+    mdiLanguageCpp,
+    mdiLanguageCsharp,
+    mdiLanguageCss3,
+    mdiLanguageGo,
+    mdiLanguageHaskell,
+    mdiLanguageHtml5,
+    mdiLanguageJava,
+    mdiLanguageJavascript,
+    mdiLanguageKotlin,
+    mdiLanguageLua,
+    mdiLanguageMarkdown,
+    mdiLanguagePhp,
+    mdiLanguagePython,
+    mdiLanguageR,
+    mdiLanguageRuby,
+    mdiLanguageRust,
+    mdiLanguageSwift,
+    mdiLanguageTypescript,
+    mdiNix,
+    mdiNpm,
+    mdiReact,
+    mdiSass,
+    mdiSvg,
+    mdiText,
+} from '@mdi/js'
+import { containsTest } from '$lib/web'
+
+const BLUE = 'var(--blue)'
+const PINK = 'var(--pink)'
+const YELLOW = 'var(--yellow)'
+const RED = 'var(--red)'
+const GREEN = 'var(--green)'
+const CYAN = 'var(--blue)'
+const DEFAULT_ICON = 'var(--gray-07)'
+
+export enum FileExtension {
+    ASSEMBLY = 'asm',
+    BASH = 'sh',
+    BASIC = 'vb',
+    C = 'c',
+    CLOJURE_CLJ = 'clj',
+    CLOJURE_CLJS = 'cljs',
+    CLOJURE_CLJR = 'cljr',
+    CLOJURE_CLJC = 'cljc',
+    CLOJURE_EDN = 'edn',
+    COFFEE = 'coffee',
+    CPP = 'cc',
+    CSHARP = 'cs',
+    CSS = 'css',
+    DART = 'dart',
+    DEFAULT = 'default',
+    DOCKERFILE = 'Dockerfile',
+    DOCKERIGNORE = 'dockerignore',
+    FORTRAN_F = 'f',
+    FORTRAN_FOR = 'for',
+    FORTRAN_FTN = 'ftn',
+    FSHARP = 'fs',
+    FSI = 'fsi',
+    FSX = 'fsx',
+    GEMFILE = 'Gemfile',
+    GIF = 'gif',
+    GIFF = 'giff',
+    GITIGNORE = 'gitignore',
+    GITATTRIBUTES = 'gitattributes',
+    GO = 'go',
+    GOMOD = 'mod',
+    GOSUM = 'sum',
+    GRAPHQL = 'graphql',
+    GROOVY = 'groovy',
+    HASKELL = 'hs',
+    HTML = 'html',
+    JAVA = 'java',
+    JAVASCRIPT = 'js',
+    JPG = 'jpg',
+    JPEG = 'jpeg',
+    JSON = 'json',
+    JSX = 'jsx',
+    JULIA = 'jl',
+    KOTLIN = 'kt',
+    LOCKFILE = 'lock',
+    LUA = 'lua',
+    MARKDOWN = 'md',
+    MDX = 'mdx',
+    NCL = 'ncl',
+    NIX = 'nix',
+    NPM = 'npmrc',
+    OCAML = 'ml',
+    PHP = 'php',
+    PERL = 'pl',
+    PERL_PM = 'pm',
+    PNG = 'png',
+    POWERSHELL_PS1 = 'ps1',
+    POWERSHELL_PSM1 = 'psm1',
+    PYTHON = 'py',
+    R = 'r',
+    R_CAP = 'R',
+    RUBY = 'rb',
+    RUST = 'rs',
+    SCALA = 'scala',
+    SASS = 'scss',
+    SQL = 'sql',
+    SVELTE = 'svelte',
+    SVG = 'svg',
+    SWIFT = 'swift',
+    TEST = 'test',
+    TOML = 'toml',
+    TYPESCRIPT = 'ts',
+    TSX = 'tsx',
+    TEXT = 'txt',
+    YAML = 'yaml',
+    YML = 'yml',
+    ZIG = 'zig',
+}
+
+export const FILE_ICONS = new Map(
+    Object.values(FileExtension).map(extension => [extension, getIconAttributes(extension)])
+)
+
+interface IconInfo {
+    svgPath: string
+    color: string
+}
+
+interface FileInfo {
+    icon: IconInfo
+    isTest: boolean
+}
+
+const getColor = (extension: FileExtension) => {
+    switch (extension) {
+        case FileExtension.MARKDOWN:
+        case FileExtension.MDX:
+        case FileExtension.SVG: {
+            return BLUE
+        }
+        case FileExtension.GITIGNORE:
+        case FileExtension.GITATTRIBUTES:
+        case FileExtension.HTML:
+        case FileExtension.NPM:
+        case FileExtension.R:
+        case FileExtension.R_CAP:
+        case FileExtension.RUBY:
+        case FileExtension.GEMFILE: {
+            return RED
+        }
+        case FileExtension.GOMOD:
+        case FileExtension.GOSUM:
+        case FileExtension.GRAPHQL:
+        case FileExtension.SASS: {
+            return PINK
+        }
+        case (FileExtension.JAVASCRIPT, FileExtension.PYTHON): {
+            return YELLOW
+        }
+        case FileExtension.KOTLIN: {
+            return GREEN
+        }
+        case FileExtension.PHP: {
+            return CYAN
+        }
+        default: {
+            return DEFAULT_ICON
+        }
+    }
+}
+
+// TODO: Explore other icon libraries or make our own.
+// Most programming language Material Design icons will be
+// deprecated very soon, and will not be included in the next release.
+// Additionally, it doesn't have all the icons we need anyway.
+const getIconAttributes = (extension: FileExtension): IconInfo => {
+    const color = getColor(extension)
+    switch (extension) {
+        // TODO: Ideally, we would switch to a new icon library
+        // so we don't have to default to a general icon
+        // for the languages in the first case block.
+        case FileExtension.ASSEMBLY:
+        case FileExtension.BASIC:
+        case FileExtension.CLOJURE_CLJ:
+        case FileExtension.CLOJURE_CLJC:
+        case FileExtension.CLOJURE_CLJR:
+        case FileExtension.CLOJURE_EDN:
+        case FileExtension.CLOJURE_CLJS:
+        case FileExtension.DART:
+        case FileExtension.DEFAULT:
+        case FileExtension.FORTRAN_F:
+        case FileExtension.FORTRAN_FOR:
+        case FileExtension.FORTRAN_FTN:
+        case FileExtension.FSHARP:
+        case FileExtension.FSI:
+        case FileExtension.FSX:
+        case FileExtension.OCAML:
+        case FileExtension.PERL:
+        case FileExtension.PERL_PM:
+        case FileExtension.SCALA:
+        case FileExtension.SVELTE:
+        case FileExtension.SQL:
+        case FileExtension.TEST:
+        case FileExtension.ZIG: {
+            return { svgPath: mdiFileCodeOutline, color }
+        }
+        case FileExtension.BASH:
+        case FileExtension.POWERSHELL_PS1:
+        case FileExtension.POWERSHELL_PSM1: {
+            return { svgPath: mdiConsole, color }
+        }
+        case FileExtension.C: {
+            return { svgPath: mdiLanguageC, color }
+        }
+        case FileExtension.RUST:
+        case FileExtension.TOML: {
+            return { svgPath: mdiLanguageRust, color }
+        }
+        case FileExtension.CPP: {
+            return { svgPath: mdiLanguageCpp, color }
+        }
+        case FileExtension.CSHARP: {
+            return { svgPath: mdiLanguageCsharp, color }
+        }
+        case FileExtension.CSS: {
+            return { svgPath: mdiLanguageCss3, color }
+        }
+        case FileExtension.DOCKERFILE:
+        case FileExtension.DOCKERIGNORE: {
+            return { svgPath: mdiDocker, color }
+        }
+        case FileExtension.GITIGNORE:
+        case FileExtension.GITATTRIBUTES: {
+            return { svgPath: mdiGit, color }
+        }
+        case FileExtension.GO: {
+            return { svgPath: mdiLanguageGo, color }
+        }
+        case FileExtension.GRAPHQL: {
+            return { svgPath: mdiGraphql, color }
+        }
+        case FileExtension.GROOVY:
+        case FileExtension.JULIA:
+
+        case FileExtension.HASKELL: {
+            return { svgPath: mdiLanguageHaskell, color }
+        }
+        case FileExtension.HTML: {
+            return { svgPath: mdiLanguageHtml5, color }
+        }
+        case FileExtension.JAVA: {
+            return { svgPath: mdiLanguageJava, color }
+        }
+        case FileExtension.JAVASCRIPT: {
+            return { svgPath: mdiLanguageJavascript, color }
+        }
+        case FileExtension.JPG:
+        case FileExtension.JPEG: {
+            return { svgPath: mdiFileJpgBox, color }
+        }
+        case FileExtension.JSON:
+        case FileExtension.LOCKFILE: {
+            return { svgPath: mdiCodeJson, color }
+        }
+        case FileExtension.JSX:
+        case FileExtension.TSX: {
+            return { svgPath: mdiReact, color }
+        }
+        case FileExtension.KOTLIN: {
+            return { svgPath: mdiLanguageKotlin, color }
+        }
+        case FileExtension.LUA: {
+            return { svgPath: mdiLanguageLua, color }
+        }
+        case FileExtension.MARKDOWN:
+        case FileExtension.MDX: {
+            return { svgPath: mdiLanguageMarkdown, color }
+        }
+        case FileExtension.NCL:
+        case FileExtension.NIX: {
+            return { svgPath: mdiNix, color }
+        }
+        case FileExtension.NPM: {
+            return { svgPath: mdiNpm, color }
+        }
+
+        case FileExtension.PHP: {
+            return { svgPath: mdiLanguagePhp, color }
+        }
+        case FileExtension.PNG: {
+            return { svgPath: mdiFilePngBox, color }
+        }
+        case FileExtension.PYTHON: {
+            return { svgPath: mdiLanguagePython, color }
+        }
+        case FileExtension.R:
+        case FileExtension.R_CAP: {
+            return { svgPath: mdiLanguageR, color }
+        }
+        case FileExtension.RUBY:
+        case FileExtension.GEMFILE: {
+            return { svgPath: mdiLanguageRuby, color }
+        }
+        case FileExtension.SASS: {
+            return { svgPath: mdiSass, color }
+        }
+        case FileExtension.SVG: {
+            return { svgPath: mdiSvg, color }
+        }
+        case FileExtension.SWIFT: {
+            return { svgPath: mdiLanguageSwift, color }
+        }
+        case FileExtension.TYPESCRIPT: {
+            return { svgPath: mdiLanguageTypescript, color }
+        }
+        case FileExtension.TEXT: {
+            return { svgPath: mdiText, color }
+        }
+        case FileExtension.YAML:
+        case FileExtension.YML: {
+            return { svgPath: mdiCog, color }
+        }
+        default: {
+            return { svgPath: mdiConsole, color }
+        }
+    }
+}
+
+export const getExtension = (file: string): FileExtension => {
+    return file.split('.').at(-1) as FileExtension
+}
+
+export const getFileInfo = (file: string): FileInfo => {
+    const extension = getExtension(file)
+    const icon = FILE_ICONS.get(extension)
+
+    if (icon) {
+        return {
+            icon,
+            isTest: containsTest(file),
+        }
+    }
+
+    return {
+        icon: {
+            svgPath: mdiFileCodeOutline,
+            color: DEFAULT_ICON,
+        },
+        isTest: false,
+    }
+}

--- a/client/web-sveltekit/src/lib/web.ts
+++ b/client/web-sveltekit/src/lib/web.ts
@@ -29,5 +29,6 @@ export {
 export { isValidLineRange } from '@sourcegraph/web/src/repo/blob/codemirror/utils'
 export { blobPropsFacet } from '@sourcegraph/web/src/repo/blob/codemirror'
 export { defaultSearchModeFromSettings } from '@sourcegraph/web/src/util/settings'
+export { containsTest } from '@sourcegraph/web/src/repo/utils'
 
 export type { FeatureFlagName } from '@sourcegraph/web/src/featureFlags/featureFlags'

--- a/client/web-sveltekit/src/lib/web.ts
+++ b/client/web-sveltekit/src/lib/web.ts
@@ -29,6 +29,6 @@ export {
 export { isValidLineRange } from '@sourcegraph/web/src/repo/blob/codemirror/utils'
 export { blobPropsFacet } from '@sourcegraph/web/src/repo/blob/codemirror'
 export { defaultSearchModeFromSettings } from '@sourcegraph/web/src/util/settings'
-export { containsTest } from '@sourcegraph/web/src/repo/utils'
+export { containsTest } from '@sourcegraph/web/src/repo/fileIcons'
 
 export type { FeatureFlagName } from '@sourcegraph/web/src/featureFlags/featureFlags'

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -20,7 +20,7 @@
     /**
      * Returns the corresponding icon for `entry`
      */
-    function getIconPath(entry: TreeEntryFields, open: boolean) {
+    function getDirectoryIconPath(entry: TreeEntryFields, open: boolean) {
         if (entry === treeRoot) {
             return mdiFolderArrowUpOutline
         }
@@ -124,10 +124,12 @@
                     data-go-up={isRoot ? true : undefined}
                 >
                     {#if entry.isDirectory}
-                        <Icon svgPath={getIconPath(entry, expanded)} inline />
+                        <Icon svgPath={getDirectoryIconPath(entry, expanded)} inline />
                     {:else}
-                        {@const fileInfo = getFileInfo(entry.name)}
-                        <Icon svgPath={fileInfo.icon.svgPath} inline --color={fileInfo.icon.color} />
+                        {@const {
+                            icon: { svgPath, color },
+                        } = getFileInfo(entry.name)}
+                        <Icon {svgPath} inline --color={color} />
                     {/if}
                     {isRoot ? '..' : entry.name}
                 </a>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable />
 
 <script lang="ts">
-    import { mdiFileCodeOutline, mdiFolderArrowUpOutline, mdiFolderOpenOutline, mdiFolderOutline } from '@mdi/js'
+    import { mdiFolderArrowUpOutline, mdiFolderOpenOutline, mdiFolderOutline } from '@mdi/js'
     import { onMount } from 'svelte'
 
     import { afterNavigate, goto } from '$app/navigation'
@@ -11,6 +11,7 @@
     import TreeView, { setTreeContext } from '$lib/TreeView.svelte'
     import { createForwardStore } from '$lib/utils'
     import { replaceRevisionInURL } from '$lib/web'
+    import { getFileInfo } from '$lib/fileIcons'
 
     export let treeProvider: FileTreeProvider
     export let selectedPath: string
@@ -23,10 +24,7 @@
         if (entry === treeRoot) {
             return mdiFolderArrowUpOutline
         }
-        if (entry.isDirectory) {
-            return open ? mdiFolderOpenOutline : mdiFolderOutline
-        }
-        return mdiFileCodeOutline
+        return open ? mdiFolderOpenOutline : mdiFolderOutline
     }
 
     /**
@@ -125,7 +123,12 @@
                     tabindex={-1}
                     data-go-up={isRoot ? true : undefined}
                 >
-                    <Icon svgPath={getIconPath(entry, expanded)} inline />
+                    {#if entry.isDirectory}
+                        <Icon svgPath={getIconPath(entry, expanded)} inline />
+                    {:else}
+                        {@const fileInfo = getFileInfo(entry.name)}
+                        <Icon svgPath={fileInfo.icon.svgPath} inline --color={fileInfo.icon.color} />
+                    {/if}
                     {isRoot ? '..' : entry.name}
                 </a>
             {/if}


### PR DESCRIPTION
This adds file icons to the tree view in the svelte kit prototype.

## Test plan
Manual, visual testing

