### PR TITLE
Cody: Azure OpenAI allow authentication requests to use a proxy

### DIFF
--- a/doc/cody/core-concepts/embeddings/index.md
+++ b/doc/cody/core-concepts/embeddings/index.md
@@ -112,7 +112,7 @@ For the access token, you can either:
 
 - As of 5.2.4 the access token can be left empty and it will rely on Environmental, Workload Identity or Managed Identity credentials configured for the `frontend` service
 - Set it to `<API_KEY>` if directly configuring the credentials using the API key specified in the Azure portal
-
+- If Azure Authentication requests require a proxy the environment variable `CODY_AZURE_AUTH_PROXY` can be specified to a proxy URL
 
 <br>
 

--- a/doc/cody/core-concepts/embeddings/index.md
+++ b/doc/cody/core-concepts/embeddings/index.md
@@ -112,7 +112,7 @@ For the access token, you can either:
 
 - As of 5.2.4 the access token can be left empty and it will rely on Environmental, Workload Identity or Managed Identity credentials configured for the `frontend` service
 - Set it to `<API_KEY>` if directly configuring the credentials using the API key specified in the Azure portal
-- If Azure Authentication requests require a proxy the environment variable `CODY_AZURE_AUTH_PROXY` can be specified to a proxy URL
+- If Azure Authentication requests require a proxy the environment variable `CODY_AZURE_OPENAI_IDENTITY_HTTP_PROXY` can be specified to a proxy URL
 
 <br>
 

--- a/doc/cody/overview/enable-cody-enterprise.md
+++ b/doc/cody/overview/enable-cody-enterprise.md
@@ -304,7 +304,7 @@ For the access token, you can either:
 
 - As of 5.2.4 the access token can be left empty and it will rely on Environmental, Workload Identity or Managed Identity credentials configured for the `frontend` and `worker` services
 - Set it to `<API_KEY>` if directly configuring the credentials using the API key specified in the Azure portal
-- If Azure Authentication requests require a proxy the environment variable `CODY_AZURE_AUTH_PROXY` can be specified to a proxy URL
+- If Azure Authentication requests require a proxy the environment variable `CODY_AZURE_OPENAI_IDENTITY_HTTP_PROXY` can be specified to a proxy URL
 
 
 ### Anthropic Claude through AWS Bedrock

--- a/doc/cody/overview/enable-cody-enterprise.md
+++ b/doc/cody/overview/enable-cody-enterprise.md
@@ -304,6 +304,7 @@ For the access token, you can either:
 
 - As of 5.2.4 the access token can be left empty and it will rely on Environmental, Workload Identity or Managed Identity credentials configured for the `frontend` and `worker` services
 - Set it to `<API_KEY>` if directly configuring the credentials using the API key specified in the Azure portal
+- If Azure Authentication requests require a proxy the environment variable `CODY_AZURE_AUTH_PROXY` can be specified to a proxy URL
 
 
 ### Anthropic Claude through AWS Bedrock

--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -65,6 +65,7 @@ func GetAPIClient(endpoint, accessToken string) (CompletionsClient, error) {
 		if credErr != nil {
 			return nil, credErr
 		}
+		apiClient.endpoint = endpoint
 		apiClient.client, err = azopenai.NewClient(endpoint, credential, nil)
 	}
 	return apiClient.client, err

--- a/internal/completions/client/azureopenai/openai.go
+++ b/internal/completions/client/azureopenai/openai.go
@@ -16,7 +16,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var authProxyURL = os.Getenv("CODY_AZURE_AUTH_PROXY")
+// HTTP proxy value to be used for id token requests to Azure
+// This value will only used when using an access token is not provided
+// and it will only apply to requests made to the Azure authentication endpoint
+// not other requests such as to the OpenAI API
+var authProxyURL = os.Getenv("CODY_AZURE_OPENAI_IDENTITY_HTTP_PROXY")
 
 // We want to reuse the client because when using the DefaultAzureCredential
 // it will acquire a short lived token and reusing the client

--- a/internal/embeddings/embed/client/azureopenai/BUILD.bazel
+++ b/internal/embeddings/embed/client/azureopenai/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//internal/embeddings/embed/client/modeltransformations",
         "//lib/errors",
         "@com_github_azure_azure_sdk_for_go_sdk_ai_azopenai//:azopenai",
+        "@com_github_azure_azure_sdk_for_go_sdk_azcore//:azcore",
         "@com_github_azure_azure_sdk_for_go_sdk_azidentity//:azidentity",
     ],
 )

--- a/internal/embeddings/embed/client/azureopenai/client.go
+++ b/internal/embeddings/embed/client/azureopenai/client.go
@@ -19,7 +19,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-var authProxyURL = os.Getenv("CODY_AZURE_AUTH_PROXY")
+// HTTP proxy value to be used for id token requests to Azure
+// This value will only used when using an access token is not provided
+// and it will only apply to requests made to the Azure authentication endpoint
+// not other requests such as to the OpenAI API
+var authProxyURL = os.Getenv("CODY_AZURE_OPENAI_IDENTITY_HTTP_PROXY")
 
 // We want to reuse the client because when using the DefaultAzureCredential
 // it will acquire a short lived token and reusing the client

--- a/internal/embeddings/embed/client/azureopenai/client.go
+++ b/internal/embeddings/embed/client/azureopenai/client.go
@@ -3,10 +3,14 @@ package azureopenai
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -14,6 +18,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/embeddings/embed/client/modeltransformations"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+var authProxyURL = os.Getenv("CODY_AZURE_AUTH_PROXY")
 
 // We want to reuse the client because when using the DefaultAzureCredential
 // it will acquire a short lived token and reusing the client
@@ -51,13 +57,38 @@ func GetAPIClient(endpoint, accessToken string) (EmbeddingsClient, error) {
 		}
 		apiClient.client, err = azopenai.NewClientWithKeyCredential(endpoint, credential, nil)
 	} else {
-		credential, credErr := azidentity.NewDefaultAzureCredential(nil)
+		var opts *azidentity.DefaultAzureCredentialOptions
+		opts, err = getCredentialOptions()
+		if err != nil {
+			return nil, err
+		}
+		credential, credErr := azidentity.NewDefaultAzureCredential(opts)
 		if credErr != nil {
 			return nil, credErr
 		}
+		apiClient.endpoint = endpoint
 		apiClient.client, err = azopenai.NewClient(endpoint, credential, nil)
 	}
 	return apiClient.client, err
+
+}
+
+func getCredentialOptions() (*azidentity.DefaultAzureCredentialOptions, error) {
+	// if there is no proxy we don't need any options
+	if authProxyURL == "" {
+		return nil, nil
+	}
+
+	proxyUrl, err := url.Parse(authProxyURL)
+	if err != nil {
+		return nil, err
+	}
+	proxiedClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)}}
+	return &azidentity.DefaultAzureCredentialOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: proxiedClient,
+		},
+	}, nil
 
 }
 


### PR DESCRIPTION
Because Azure get token requests are sent to `login.microsoftonline.com` sometimes it is required to direct the request through a proxy, however if not all outgoing requests can be directed though the proxy it is not possible to use standard proxy environment variables.

This adds the `CODY_AZURE_OPENAI_IDENTITY_HTTP_PROXY` environment variable for this specific purpose.  If set the credential requests will use a separate http.Client with the proxy specified.

resolves https://github.com/sourcegraph/sourcegraph/issues/58827

## Test plan
Created an Azure SPN with cert
Created a local proxy 
az logout -- to ensure that i'm not getting credentials from az
export CODY_AZURE_OPENAI_IDENTITY_HTTP_PROXY=localhost:29100
set azure environment credential env variables
start proxy
sg start
```
2023/12/08 14:32:41 [001] INFO: Running 0 CONNECT handlers
2023/12/08 14:32:41 [001] INFO: Accepting CONNECT to login.microsoftonline.com:443   <---- worker embeddings 
2023/12/08 14:32:57 [002] INFO: Running 0 CONNECT handlers
2023/12/08 14:32:57 [002] INFO: Accepting CONNECT to login.microsoftonline.com:443  <---- frontend embeddings (search)
2023/12/08 14:32:57 [003] INFO: Running 0 CONNECT handlers
2023/12/08 14:32:57 [003] INFO: Accepting CONNECT to login.microsoftonline.com:443  <---- frontend completions
```
verified 3 connections though proxy to authenticate each client

shutdown proxy and verified error
```
Request failed: DefaultAzureCredential: failed to acquire a token. Attempted credentials: ClientCertificateCredential: unable to resolve an endpoint: server response error: Get "https://login.microsoftonline.com/....": proxyconnect tcp: dial tcp 127.0.0.1:29100: connect: connection refused
```

unset CODY_AZURE_OPENAI_IDENTITY_HTTP_PROXY
no proxy running
Verified chat & embeddings work

restarted proxy 
unset CODY_AZURE_OPENAI_IDENTITY_HTTP_PROXY
Verified chat & embeddings work
verified no requests logged to proxy


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@cw/azure-proxy)