### PR TITLE
svelte: Show commit info next to tree entries on tree page

### DIFF
--- a/client/web-sveltekit/src/lib/Timestamp.svelte
+++ b/client/web-sveltekit/src/lib/Timestamp.svelte
@@ -24,20 +24,22 @@
     export let date: Date | string
 
     /** Use exact timestamps (i.e. omit "less than", "about", etc.) */
-    export let strict: boolean | undefined = undefined
+    export let strict: boolean = false
 
     /** Show absolute timestamp and show relative timestamp in label*/
-    export let showAbsolute: boolean | undefined = undefined
+    export let showAbsolute: boolean = false
 
-    /** Show an appropriate suffix, e.g. 'ago' */
-    export let addSuffix: boolean = true
+    /** Hide suffix (e.g. ago) */
+    export let hideSuffix: boolean = false
 
     /** Show time in UTC */
     export let utc: boolean | undefined = undefined
 
     $: dateObj = typeof date === 'string' ? new Date(date) : date
     $: formattedDate = formatDate(dateObj, { utc })
-    $: relativeDate = (strict ? formatDistanceStrict : formatDistance)(dateObj, $currentDate, { addSuffix })
+    $: relativeDate = (strict ? formatDistanceStrict : formatDistance)(dateObj, $currentDate, {
+        addSuffix: !hideSuffix,
+    })
 </script>
 
 <Tooltip tooltip={showAbsolute ? relativeDate : formattedDate}>

--- a/client/web-sveltekit/src/lib/Timestamp.test.ts
+++ b/client/web-sveltekit/src/lib/Timestamp.test.ts
@@ -11,7 +11,7 @@ import { useFakeTimers, useRealTimers } from '$mocks'
 import Timestamp from './Timestamp.svelte'
 
 describe('Timestamp.svelte', () => {
-    function renderTimestamp(options?: Partial<ComponentProps<Timestamp>>) {
+    function renderTimestamp(options?: Partial<ComponentProps<Timestamp>>): void {
         const date = faker.date.recent()
         render(Timestamp, { date, ...options })
     }
@@ -31,16 +31,16 @@ describe('Timestamp.svelte', () => {
         const element = screen.getByTestId('timestamp')
         expect(element.textContent).toMatchInlineSnapshot('"less than a minute ago"')
 
-        // Advance timer by 42 minutes
-        await vi.advanceTimersByTimeAsync(42 * 60 * 1000)
-        expect(element.textContent).toMatchInlineSnapshot('"42 minutes ago"')
+        // Advance timer by 9 minutes
+        await vi.advanceTimersByTimeAsync(9 * 60 * 1000)
+        expect(element.textContent).toMatchInlineSnapshot('"9 minutes ago"')
 
         useRealTimers()
     })
 
-    test.each([{}, { addSuffix: false }, { strict: true }, { addSuffix: false, strict: true }, { showAbsolute: true }])(
+    test.each([{}, { hideSuffix: true }, { strict: true }, { hideSuffix: true, strict: true }, { showAbsolute: true }])(
         'props: %o',
-        (_, options) => {
+        options => {
             useFakeTimers()
 
             renderTimestamp(options)

--- a/client/web-sveltekit/src/lib/__snapshots__/Timestamp.test.ts.snap
+++ b/client/web-sveltekit/src/lib/__snapshots__/Timestamp.test.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Timestamp.svelte > props: { addSuffix: false } 1`] = `"about 23 hours ago"`;
+exports[`Timestamp.svelte > props: { hideSuffix: true } 1`] = `"about 23 hours"`;
 
-exports[`Timestamp.svelte > props: { addSuffix: false, strict: true } 1`] = `"about 23 hours ago"`;
+exports[`Timestamp.svelte > props: { hideSuffix: true, strict: true } 1`] = `"23 hours"`;
 
-exports[`Timestamp.svelte > props: { showAbsolute: true } 1`] = `"about 23 hours ago"`;
+exports[`Timestamp.svelte > props: { showAbsolute: true } 1`] = `"2021-05-23 12:57:34 PM"`;
 
-exports[`Timestamp.svelte > props: { strict: true } 1`] = `"about 23 hours ago"`;
+exports[`Timestamp.svelte > props: { strict: true } 1`] = `"23 hours ago"`;
 
 exports[`Timestamp.svelte > props: {} 1`] = `"about 23 hours ago"`;

--- a/client/web-sveltekit/src/lib/graphql/apollo.ts
+++ b/client/web-sveltekit/src/lib/graphql/apollo.ts
@@ -72,6 +72,9 @@ export const getGraphQLClient = once(async (): Promise<GraphQLClient> => {
                 merge: true,
             },
         },
+        possibleTypes: {
+            TreeEntry: ['GitTree', 'GitBlob'],
+        },
     })
 
     // TODO: Persist data locally after figuring out how to determine user authentication state

--- a/client/web-sveltekit/src/lib/repo/FileTable.gql
+++ b/client/web-sveltekit/src/lib/repo/FileTable.gql
@@ -1,0 +1,16 @@
+fragment TreeEntryWithCommitInfo on TreeEntry {
+    canonicalURL
+    history(first: 1) {
+        nodes {
+            canonicalURL
+            commit {
+                id
+                canonicalURL
+                subject
+                author {
+                    date
+                }
+            }
+        }
+    }
+}

--- a/client/web-sveltekit/src/lib/repo/FileTable.svelte
+++ b/client/web-sveltekit/src/lib/repo/FileTable.svelte
@@ -2,21 +2,51 @@
     import { mdiFileDocumentOutline, mdiFolderOutline } from '@mdi/js'
 
     import Icon from '$lib/Icon.svelte'
-    import type { TreeEntryFields } from './api/tree'
+    import type { TreeEntry, TreeEntryWithCommitInfo } from './FileTable.gql'
     import { replaceRevisionInURL } from '$lib/web'
+    import Timestamp from '$lib/Timestamp.svelte'
 
-    export let entries: TreeEntryFields[]
+    export let entries: TreeEntry[]
+    export let commitInfo: TreeEntryWithCommitInfo[]
     export let revision: string
+
+    $: commitInfoByPath = new Map(commitInfo.map(entry => [entry.canonicalURL, entry]))
+    $: hasCommitInfo = commitInfo.length > 0
 </script>
 
-<table>
+<table class:hasCommitInfo>
+    <thead>
+        <tr>
+            <th class="file-name">Name</th>
+            {#if hasCommitInfo}
+                <th class="commit-message">Last commit message</th>
+                <th class="commit-date">Last commit date</th>
+            {/if}
+        </tr>
+    </thead>
     <tbody>
         {#each entries as entry}
             <tr>
-                <td>
+                <td class="file-name">
                     <Icon svgPath={entry.isDirectory ? mdiFolderOutline : mdiFileDocumentOutline} inline />
                     <a href={replaceRevisionInURL(entry.canonicalURL, revision)}>{entry.name}</a>
                 </td>
+                {#if hasCommitInfo}
+                    {@const commit = commitInfoByPath.get(entry.canonicalURL)?.history.nodes[0]?.commit}
+                    {#if commit}
+                        <td class="commit-message">
+                            <a href={commit.canonicalURL}>{commit.subject}</a>
+                        </td>
+                        <td class="commit-date">
+                            <a href={commit.canonicalURL}>
+                                <Timestamp date={commit.author.date} strict />
+                            </a>
+                        </td>
+                    {:else}
+                        <td></td>
+                        <td></td>
+                    {/if}
+                {/if}
             </tr>
         {/each}
     </tbody>
@@ -25,23 +55,46 @@
 <style lang="scss">
     table {
         width: 100%;
+        table-layout: fixed;
+    }
+
+    th {
+        background-color: var(--body-bg);
+        border-bottom: 1px solid var(--border-color);
+        padding: 0.25rem 0.5rem;
+        font-weight: normal;
     }
 
     td {
         background-color: var(--color-bg-1);
         border-bottom: 1px solid var(--border-color);
         padding: 0.25rem 0.5rem;
+    }
 
-        &:hover {
-            background-color: var(--color-bg-2);
+    th,
+    td {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+        box-sizing: content-box;
+    }
+
+    .commit-message,
+    .commit-date {
+        a {
+            color: var(--text-muted);
         }
     }
 
-    a {
-        color: var(--body-color);
-
-        &:hover {
-            color: var(--link-color);
+    .hasCommitInfo {
+        .file-name {
+            width: 30%;
         }
+    }
+
+    .commit-date {
+        width: 120px;
+        text-align: right;
     }
 </style>

--- a/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
+++ b/client/web-sveltekit/src/lib/repo/HistoryPanel.svelte
@@ -87,7 +87,7 @@
                         {commit.subject}
                     {/if}
                 </td>
-                <td><Timestamp date={new Date(commit.author.date)} /></td>
+                <td><Timestamp date={new Date(commit.author.date)} strict /></td>
                 <td><a href={commit.canonicalURL}>{commit.abbreviatedOID}</a></td>
                 <td>
                     {#if selected}

--- a/client/web-sveltekit/src/lib/repo/api/tree.ts
+++ b/client/web-sveltekit/src/lib/repo/api/tree.ts
@@ -9,7 +9,6 @@ const MAX_FILE_TREE_ENTRIES = 1000
 const treeEntriesQuery = gql`
     query TreeEntries($repoID: ID!, $commitID: String!, $filePath: String!, $first: Int) {
         node(id: $repoID) {
-            __typename
             id
             ... on Repository {
                 commit(rev: $commitID) {
@@ -21,44 +20,19 @@ const treeEntriesQuery = gql`
 
     fragment GitCommitFieldsWithTree on GitCommit {
         id
-        oid
-        abbreviatedOID
-        author {
-            ...UserFields
-        }
-        committer {
-            ...UserFields
-        }
-        subject
-
         tree(path: $filePath) {
             canonicalURL
             isRoot
             name
             path
             isDirectory
-            submodule {
-                commit
-            }
             entries(first: $first) {
                 canonicalURL
                 name
                 path
                 isDirectory
-                submodule {
-                    commit
-                }
             }
         }
-    }
-
-    fragment UserFields on Signature {
-        person {
-            name
-            displayName
-            avatarURL
-        }
-        date
     }
 `
 
@@ -129,15 +103,15 @@ interface FileTreeProviderArgs {
 export class FileTreeProvider implements TreeProvider<FileTreeNodeValue> {
     constructor(private args: FileTreeProviderArgs) {}
 
-    getRoot(): FileTreeNodeValue {
+    public getRoot(): FileTreeNodeValue {
         return this.args.root
     }
 
-    getRepoID(): Scalars['ID']['input'] {
+    public getRepoID(): Scalars['ID']['input'] {
         return this.args.repoID
     }
 
-    getEntries(): FileTreeNodeValue[] {
+    public getEntries(): FileTreeNodeValue[] {
         if (this.args.parent || this.args.root.isRoot) {
             return this.args.values
         }
@@ -145,7 +119,7 @@ export class FileTreeProvider implements TreeProvider<FileTreeNodeValue> {
         return [this.args.root, ...this.args.values]
     }
 
-    async fetchChildren(entry: FileTreeNodeValue): Promise<FileTreeProvider> {
+    public async fetchChildren(entry: FileTreeNodeValue): Promise<FileTreeProvider> {
         if (!this.isExpandable(entry)) {
             // This should never happen because the caller should only call fetchChildren
             // for entries where isExpandable returns true
@@ -160,7 +134,7 @@ export class FileTreeProvider implements TreeProvider<FileTreeNodeValue> {
         })
     }
 
-    async fetchParent(): Promise<FileTreeProvider> {
+    public async fetchParent(): Promise<FileTreeProvider> {
         const parentPath = dirname(this.args.root.path)
         return this.args.loader({
             repoID: this.args.repoID,
@@ -169,15 +143,15 @@ export class FileTreeProvider implements TreeProvider<FileTreeNodeValue> {
         })
     }
 
-    getNodeID(entry: FileTreeNodeValue): string {
+    public getNodeID(entry: FileTreeNodeValue): string {
         return entry === NODE_LIMIT ? 'node-limit' : entry.path
     }
 
-    isExpandable(entry: FileTreeNodeValue): entry is ExpandableFileTreeNodeValues {
+    public isExpandable(entry: FileTreeNodeValue): entry is ExpandableFileTreeNodeValues {
         return entry !== NODE_LIMIT && entry !== this.args.root && entry.isDirectory
     }
 
-    isSelectable(entry: FileTreeNodeValue): boolean {
+    public isSelectable(entry: FileTreeNodeValue): boolean {
         return entry !== NODE_LIMIT
     }
 }

--- a/client/web-sveltekit/src/lib/repo/tree.ts
+++ b/client/web-sveltekit/src/lib/repo/tree.ts
@@ -1,5 +1,8 @@
-import type { TreeEntryFields } from './api/tree'
+interface Entry {
+    isDirectory: boolean
+    name: string
+}
 
-export function findReadme(entries: TreeEntryFields[]): TreeEntryFields | null {
+export function findReadme<T extends Entry>(entries: T[]): T | null {
     return entries.find(entry => !entry.isDirectory && /^readme($|\.)/i.test(entry.name)) ?? null
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.svelte
@@ -6,6 +6,7 @@
     import FileHeader from '$lib/repo/FileHeader.svelte'
     import Permalink from '$lib/repo/Permalink.svelte'
     import { createPromiseStore } from '$lib/utils'
+    import type { TreeWithCommitInfo } from './page.gql'
 
     import FileDiff from '../../../../-/commit/[...revspec]/FileDiff.svelte'
 
@@ -15,11 +16,14 @@
     export let data: PageData
 
     const { value: tree, set: setTree } = createPromiseStore<PageData['deferred']['treeEntries']>()
+    const { value: commitInfo, set: setCommitInfo } = createPromiseStore<Promise<TreeWithCommitInfo | null>>()
     const { value: readme, set: setReadme } = createPromiseStore<PageData['deferred']['readme']>()
 
     $: setTree(data.deferred.treeEntries)
+    $: setCommitInfo(data.deferred.commitInfo)
     $: setReadme(data.deferred.readme)
     $: entries = $tree?.entries ?? []
+    $: entriesWithCommitInfo = $commitInfo?.entries ?? []
 </script>
 
 <svelte:head>
@@ -43,7 +47,7 @@
             {/each}
         {/await}
     {:else}
-        <FileTable revision={data.revision ?? ''} {entries} />
+        <FileTable revision={data.revision ?? ''} {entries} commitInfo={entriesWithCommitInfo} />
     {/if}
     {#if $readme}
         <h4 class="header">

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.ts
@@ -4,10 +4,11 @@ import { fetchTreeEntries } from '$lib/repo/api/tree'
 import { findReadme } from '$lib/repo/tree'
 
 import type { PageLoad } from './$types'
+import { TreeEntriesCommitInfo } from './page.gql'
 
 export const load: PageLoad = async ({ params, parent, url }) => {
     const revisionToCompare = url.searchParams.get('rev')
-    const { resolvedRevision } = await parent()
+    const { resolvedRevision, graphqlClient } = await parent()
 
     const treeEntries = fetchTreeEntries({
         repoID: resolvedRevision.repo.id,
@@ -23,6 +24,22 @@ export const load: PageLoad = async ({ params, parent, url }) => {
         filePath: params.path,
         deferred: {
             treeEntries,
+            commitInfo: graphqlClient
+                .query({
+                    query: TreeEntriesCommitInfo,
+                    variables: {
+                        repoID: resolvedRevision.repo.id,
+                        commitID: resolvedRevision.commitID,
+                        filePath: params.path,
+                        first: null,
+                    },
+                })
+                .then(result => {
+                    if (result.data.node?.__typename !== 'Repository') {
+                        throw new Error('Unable to load repository')
+                    }
+                    return result.data.node.commit?.tree ?? null
+                }),
             readme: treeEntries.then(result => {
                 if (!result) {
                     return null

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/page.gql
@@ -1,0 +1,23 @@
+#import "$lib/repo/FileTable.gql"
+
+fragment TreeWithCommitInfo on GitTree {
+    canonicalURL
+    entries(first: $first) {
+        ...TreeEntryWithCommitInfo
+    }
+}
+
+query TreeEntriesCommitInfo($repoID: ID!, $commitID: String!, $filePath: String!, $first: Int) {
+    node(id: $repoID) {
+        __typename
+        id
+        ... on Repository {
+            commit(rev: $commitID) {
+                id
+                tree(path: $filePath) {
+                    ...TreeWithCommitInfo
+                }
+            }
+        }
+    }
+}

--- a/client/web-sveltekit/src/stories/TimestampExample.svelte
+++ b/client/web-sveltekit/src/stories/TimestampExample.svelte
@@ -6,11 +6,11 @@
     const date = faker.date.recent()
     const cases: [string, Partial<ComponentProps<Timestamp>>][] = [
         ['default', {}],
-        ['no ago', { addSuffix: false }],
+        ['with ago', { hideSuffix: true }],
         ['strict', { strict: true }],
         ['utc', { utc: true }],
         ['absolute', { showAbsolute: true }],
-        ['no ago, strict', { addSuffix: false, strict: true }],
+        ['with ago, strict', { hideSuffix: true, strict: true }],
         ['absolute, utc', { showAbsolute: true, utc: true }],
     ]
 </script>


### PR DESCRIPTION
This commit builds on #58847 (which enables a new way of working with GraphQL). I initially also changed the loader to query for the list of files directly instead of using `fetchTreeEntries`, but the same function is used by the file tree sidebar, which, thanks to caching, ensures that we have to fetch this data only once. I'd still like to refactor this at some point and make it so that data dependencies are declared next to the components that need them, but that should be done in a separate PR/commit.

This commit also changes the prop of the Timestamp component, because props that default to `false` are easier to work with. This also uncovered an issue with the test setup.

![2023-12-08_21-21](https://github.com/sourcegraph/sourcegraph/assets/179026/65b411e4-f185-435b-9319-701d9276a225)


## Test plan

Manual testing
