### PR TITLE
[Backport 5.2] Admin: improve search indexing page

### DIFF
--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -190,31 +190,32 @@ const TextSearchIndexedReference: React.FunctionComponent<
             />
             <LinkOrSpan to={indexedRef.ref.url}>
                 <Code weight="bold">{indexedRef.ref.displayName}</Code>
-            </LinkOrSpan>{' '}
+            </LinkOrSpan>
+            &nbsp;&mdash;&nbsp;
             {indexedRef.indexed ? (
                 <span>
-                    &nbsp;&mdash; indexed at{' '}
+                    {indexedRef.current ? 'up to date.' : 'index update in progress.'}
+                    {' Last indexing job ran at '}
                     <Code>
                         <LinkOrSpan
                             to={indexedRef.indexedCommit?.commit ? indexedRef.indexedCommit.commit.url : repo.url}
                         >
                             {indexedRef.indexedCommit!.abbreviatedOID}
                         </LinkOrSpan>
-                    </Code>{' '}
-                    {indexedRef.current ? '(up to date)' : '(index update in progress)'}
+                    </Code>
                     {indexedRef.skippedIndexed && Number(indexedRef.skippedIndexed.count) > 0 ? (
                         <span>
-                            .&nbsp;
+                            {', with '}
                             <Link to={'/search?q=' + encodeURIComponent(indexedRef.skippedIndexed.query)}>
-                                {indexedRef.skippedIndexed.count}{' '}
-                                {pluralize('file', Number(indexedRef.skippedIndexed.count))} skipped during indexing
+                                {indexedRef.skippedIndexed.count} skipped{' '}
+                                {pluralize('file', Number(indexedRef.skippedIndexed.count))}
                             </Link>
                             .
                         </span>
                     ) : null}
                 </span>
             ) : (
-                <span>&nbsp;&mdash; initial indexing in progress</span>
+                <span>initial indexing in progress.</span>
             )}
         </li>
     )

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { mdiCheckCircle } from '@mdi/js'
+import { mdiAlert, mdiCheckCircle, mdiClockOutline } from '@mdi/js'
 import classNames from 'classnames'
 import prettyBytes from 'pretty-bytes'
 import { type Observable, Subject, Subscription } from 'rxjs'
@@ -17,6 +17,7 @@ import {
     Link,
     Alert,
     Icon,
+    Tooltip,
     Code,
     H3,
     ErrorAlert,
@@ -172,29 +173,45 @@ const Reindex: React.FunctionComponent<React.PropsWithChildren<{ id: Scalars['ID
     )
 }
 
+// If there's an indexing delay of more than 8 hours, we warn about it
+const largeIndexingDelayMs = 8 * 60 * 60 * 1000
+
 const TextSearchIndexedReference: React.FunctionComponent<
     React.PropsWithChildren<{
         repo: SettingsAreaRepositoryFields
         indexedRef: NonNullable<RepositoryTextSearchIndex>['refs'][number]
+        lastIndexed: string | undefined
     }>
-> = ({ repo, indexedRef }) => {
+> = ({ repo, indexedRef, lastIndexed }) => {
     const isCurrent = indexedRef.indexed && indexedRef.current
+
+    const lastIndexTime = !indexedRef.current && lastIndexed && new Date(lastIndexed).getTime()
+    const indexingDelayed = lastIndexTime && Date.now() - lastIndexTime > largeIndexingDelayMs
 
     return (
         <li className={styles.ref}>
-            <Icon
-                className={classNames(styles.refIcon, isCurrent && styles.refIconCurrent)}
-                svgPath={isCurrent ? mdiCheckCircle : undefined}
-                as={!isCurrent ? LoadingSpinner : undefined}
-                aria-hidden={true}
-            />
+            {indexingDelayed ? (
+                <Tooltip content="Indexing hasn't completed for over 8 hours, which usually indicates an error. Please check the Zoekt indexserver logs.">
+                    <Icon className={classNames(styles.refIcon)} svgPath={mdiAlert} aria-hidden={true} />
+                </Tooltip>
+            ) : (
+                <Icon
+                    className={classNames(styles.refIcon, isCurrent && styles.refIconCurrent)}
+                    svgPath={isCurrent ? mdiCheckCircle : mdiClockOutline}
+                    aria-hidden={true}
+                />
+            )}
             <LinkOrSpan to={indexedRef.ref.url}>
                 <Code weight="bold">{indexedRef.ref.displayName}</Code>
             </LinkOrSpan>
             &nbsp;&mdash;&nbsp;
             {indexedRef.indexed ? (
                 <span>
-                    {indexedRef.current ? 'up to date.' : 'index update in progress.'}
+                    {indexedRef.current
+                        ? 'up to date.'
+                        : indexingDelayed
+                        ? 'indexing is delayed.'
+                        : 'queued for indexing.'}
                     {' Last indexing job ran at '}
                     <Code>
                         <LinkOrSpan
@@ -215,7 +232,7 @@ const TextSearchIndexedReference: React.FunctionComponent<
                     ) : null}
                 </span>
             ) : (
-                <span>initial indexing in progress.</span>
+                <span>queued for initial indexing.</span>
             )}
         </li>
     )
@@ -292,6 +309,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                                                 key={index}
                                                 repo={this.props.repo}
                                                 indexedRef={reference}
+                                                lastIndexed={this.state.textSearchIndex?.status?.updatedAt}
                                             />
                                         ))}
                                     </ul>

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -224,22 +224,20 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                                 <MenuItem
                                     as={Button}
                                     disabled={!repoClonedAndHealthy(node)}
-                                    onSelect={() => navigate(`/${node.name}/-/embeddings/configuration`)}
+                                    onSelect={() => navigate(`/${node.name}/-/settings/index`)}
                                     className="p-2"
                                 >
                                     <Icon aria-hidden={true} svgPath={mdiVectorPolyline} className="mr-1" />
-                                    Embeddings policies
+                                    Search indexing
                                 </MenuItem>
                                 <MenuItem
                                     as={Button}
                                     disabled={!repoClonedAndHealthy(node)}
-                                    onSelect={() =>
-                                        navigate(`/site-admin/embeddings?query=${encodeURIComponent(node.name)}`)
-                                    }
+                                    onSelect={() => navigate(`/${node.name}/-/embeddings/configuration`)}
                                     className="p-2"
                                 >
                                     <Icon aria-hidden={true} svgPath={mdiVectorPolyline} className="mr-1" />
-                                    Embeddings jobs
+                                    Embeddings
                                 </MenuItem>
                                 <MenuItem
                                     as={Button}

--- a/client/web/src/site-admin/RepositoryNode.tsx
+++ b/client/web/src/site-admin/RepositoryNode.tsx
@@ -12,6 +12,7 @@ import {
     mdiSecurity,
     mdiVectorPolyline,
     mdiListStatus,
+    mdiSearchWeb,
 } from '@mdi/js'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
@@ -227,7 +228,7 @@ export const RepositoryNode: React.FunctionComponent<React.PropsWithChildren<Rep
                                     onSelect={() => navigate(`/${node.name}/-/settings/index`)}
                                     className="p-2"
                                 >
-                                    <Icon aria-hidden={true} svgPath={mdiVectorPolyline} className="mr-1" />
+                                    <Icon aria-hidden={true} svgPath={mdiSearchWeb} className="mr-1" />
                                     Search indexing
                                 </MenuItem>
                                 <MenuItem


### PR DESCRIPTION
This PR backports these changes related to the search indexing admin experience:
* https://github.com/sourcegraph/sourcegraph/pull/58061
* https://github.com/sourcegraph/sourcegraph/pull/58415
* https://github.com/sourcegraph/sourcegraph/pull/57903
* https://github.com/sourcegraph/sourcegraph/pull/58793

## Test plan

 CI and manual testing
