### PR TITLE
gRPC: remove duplicate implementation

### DIFF
--- a/internal/search/searcher/search.go
+++ b/internal/search/searcher/search.go
@@ -199,16 +199,6 @@ func (s *TextSearchJob) searchFilesInRepo(
 		return false, err
 	}
 
-	if conf.IsGRPCEnabled(ctx) {
-		onMatches := func(searcherMatch *proto.FileMatch) {
-			stream.Send(streaming.SearchEvent{
-				Results: []result.Match{convertProtoMatch(repo, commit, &rev, searcherMatch, s.PathRegexps)},
-			})
-		}
-
-		return SearchGRPC(ctx, searcherURLs, searcherGRPCConnectionCache, gitserverRepo, repo.ID, rev, commit, index, info, fetchTimeout, s.Features, onMatches)
-	}
-
 	onMatches := func(searcherMatches []*protocol.FileMatch) {
 		stream.Send(streaming.SearchEvent{
 			Results: convertMatches(repo, commit, &rev, searcherMatches, s.PathRegexps),


### PR DESCRIPTION
This block duplicates the logic further down. It doesn't cause any problems because it makes the `IsGRPCEnabled` check below it redundant, but it's just unnecessary duplication.

## Test plan

CI.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
