### PR TITLE
Embeddings: fail job immediately if rate limited exceeded

### DIFF
--- a/cmd/worker/internal/embeddings/repo/scheduler.go
+++ b/cmd/worker/internal/embeddings/repo/scheduler.go
@@ -73,6 +73,6 @@ func newRepoEmbeddingScheduler(
 		enqueueActive,
 		goroutine.WithName("repoEmbeddingSchedulerJob"),
 		goroutine.WithDescription("resolves embedding policies and schedules jobs to embed repos"),
-		goroutine.WithInterval(5*time.Minute),
+		goroutine.WithInterval(15*time.Minute),
 	)
 }

--- a/doc/cody/core-concepts/embeddings/configure-embeddings.md
+++ b/doc/cody/core-concepts/embeddings/configure-embeddings.md
@@ -57,7 +57,7 @@ as embedding all repositories without discrimination can consume significant res
 
 ### Lifecycle of an embeddings policy
 
-Every 5 minutes, a worker process checks the embeddings policies and resolves them into a list of repositories to index.
+Every 15 minutes, a worker process checks the embeddings policies and resolves them into a list of repositories to index.
 
 Another worker then creates a new index job for each repository and queues it for processing.
 A repository cannot be queued for processing if:


### PR DESCRIPTION
Usually, during an embeddings job we allow 10% of embedding requests to fail,
simply skipping over failed chunks. If a customer has hit their rate limits,
this means we might continually send a huge number of embedding requests that
we know will immediately fail. With this change, we immediately fail a job if
the rate limit is exceeded.

It also increases the amount of time between attempting to run a job to 15
minutes. This won't make a big difference to user experience, since by default
embeddings jobs aren't allowed to be scheduled within 24h of the last run. But
it helps prevent jobs from continuously being scheduled then failing.

This change is unlikely to have a user-facing impact, but just helps cut down
on noise in logs and excessive requests to Cody Gateway.

## Test plan

Added new unit test

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@jtibs/embeddings)