### PR TITLE
SSC: Add redirect from /post-sign-up to /cody/manage for users with the cody-pro feature flag

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -115,6 +115,8 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
 
     const newSearchNavigation = useExperimentalFeatures<boolean>(features => features.newSearchNavigationUI ?? false)
     const [enableContrastCompliantSyntaxHighlighting] = useFeatureFlag('contrast-compliant-syntax-highlighting')
+    // Start with `true` to avoid redirecting before having a chance to check the real value of the flag.
+    const [isCodyProEnabled] = useFeatureFlag('cody-pro', true)
 
     const { theme } = useTheme()
     const showHelpShortcut = useKeyboardShortcut('keyboardShortcutsHelp')
@@ -205,6 +207,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
 
     if (
         props.isSourcegraphDotCom &&
+        !isCodyProEnabled &&
         props.authenticatedUser &&
         !props.authenticatedUser.completedPostSignup &&
         !isPostSignUpPage

--- a/client/web/src/auth/PostSignUpPage.tsx
+++ b/client/web/src/auth/PostSignUpPage.tsx
@@ -7,6 +7,7 @@ import { Page } from '../components/Page'
 import { PageTitle } from '../components/PageTitle'
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 import { CodySurveyToast } from '../marketing/toast/CodySurveyToast'
+import { PageRoutes } from '../routes.constants'
 import { eventLogger } from '../tracking/eventLogger'
 
 import { getReturnTo } from './SignInSignUpCommon'
@@ -26,10 +27,19 @@ const PostSignUp: React.FunctionComponent<PostSignUpPageProps> = ({ authenticate
     const containsExperimentFlagParam = searchParameters.has('experiment_flag')
     const shouldRedirect = !containsExperimentFlagParam && authenticatedUser.completedPostSignup
     const [showQualificationSurvey, status] = useFeatureFlag('signup-survey-enabled')
+    const [isCodyProEnabled] = useFeatureFlag('cody-pro', false)
+    const returnTo = getReturnTo(location)
+
+    // Redirects Cody PLG users without asking
+    if (isCodyProEnabled) {
+        const params = new URLSearchParams()
+        params.set('returnTo', returnTo)
+        const navigateTo = PageRoutes.CodyManagement + '?' + params.toString()
+        return <Navigate to={navigateTo.toString()} replace={true} />
+    }
 
     // Redirects if the experiment flag is not provided and if the user has completed the post-signup flow.
     if (shouldRedirect) {
-        const returnTo = getReturnTo(location)
         return <Navigate to={returnTo} replace={true} />
     }
 

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
@@ -5,6 +5,7 @@ import { Navigate, Route, Routes } from 'react-router-dom'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { NotFoundPage } from '../../../components/HeroPage'
+import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import type { CreateAccessTokenResult } from '../../../graphql-operations'
 import { PageRoutes } from '../../../routes.constants'
 import type { UserSettingsAreaRouteContext } from '../UserSettingsArea'
@@ -20,12 +21,19 @@ interface Props extends Pick<UserSettingsAreaRouteContext, 'user' | 'authenticat
 
 export const UserSettingsTokensArea: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
     const [newToken, setNewToken] = useState<CreateAccessTokenResult['createAccessToken'] | undefined>()
+    // Start with `true` to avoid redirecting before having a chance to check the real value of the flag.
+    const [isCodyProEnabled] = useFeatureFlag('cody-pro', true)
 
     const onDidPresentNewToken = useCallback(() => {
         setNewToken(undefined)
     }, [])
 
-    if (props.isSourcegraphDotCom && props.authenticatedUser && !props.authenticatedUser.completedPostSignup) {
+    if (
+        props.isSourcegraphDotCom &&
+        !isCodyProEnabled &&
+        props.authenticatedUser &&
+        !props.authenticatedUser.completedPostSignup
+    ) {
         const returnTo = window.location.href
         const params = new URLSearchParams()
         params.set('returnTo', returnTo)


### PR DESCRIPTION
- This PR accompanies https://github.com/sourcegraph/sourcegraph/pull/58854 in solving https://github.com/sourcegraph/cody/issues/2054

I did two things:
- Add an "IF cody-pro feature flag is on THEN redirect /post-sign-up to /cody/manage"
- IF cody-pro feature flag is on THEN don't redirect other pages to /post-sign-up.

I recommend [this Loom recording](https://www.loom.com/share/eaa6c32fa0114321a482846676664bef) to
- @chenkc805 to verify if the behavior is as expected
- the reviewer because I also go though the code

## Test plan

Tested it in the [Loom](https://www.loom.com/share/eaa6c32fa0114321a482846676664bef)