### PR TITLE
Surfaces errors in autoindex configuration

### DIFF
--- a/internal/codeintel/autoindexing/transport/graphql/BUILD.bazel
+++ b/internal/codeintel/autoindexing/transport/graphql/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/api",
+        "//internal/codeintel/autoindexing/internal/inference",
         "//internal/codeintel/autoindexing/shared",
         "//internal/codeintel/resolvers",
         "//internal/codeintel/shared/resolvers",

--- a/internal/codeintel/autoindexing/transport/graphql/BUILD.bazel
+++ b/internal/codeintel/autoindexing/transport/graphql/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/api",
-        "//internal/codeintel/autoindexing/internal/inference",
         "//internal/codeintel/autoindexing/shared",
         "//internal/codeintel/resolvers",
         "//internal/codeintel/shared/resolvers",

--- a/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
+++ b/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 
 	"github.com/graph-gophers/graphql-go"
 	"go.opentelemetry.io/otel/attribute"
@@ -14,6 +13,7 @@ import (
 	sharedresolvers "github.com/sourcegraph/sourcegraph/internal/codeintel/shared/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 

--- a/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
+++ b/internal/codeintel/autoindexing/transport/graphql/root_resolver_configuration_repository.go
@@ -114,9 +114,20 @@ func (r *indexConfigurationResolver) InferredConfiguration(ctx context.Context) 
 		}
 	}
 
-	marshaled, err := config.MarshalJSON(config.IndexConfiguration{IndexJobs: result.IndexJobs})
+	var marshaled []byte
 	if err != nil {
-		return nil, err
+		emptyJobs := []config.IndexJob{}
+		json, err := config.MarshalJSON(config.IndexConfiguration{IndexJobs: emptyJobs})
+		if err != nil {
+			return nil, err
+		}
+		marshaled = json
+	} else {
+		json, err := config.MarshalJSON(config.IndexConfiguration{IndexJobs: result.IndexJobs})
+		if err != nil {
+			return nil, err
+		}
+		marshaled = json
 	}
 
 	var indented bytes.Buffer


### PR DESCRIPTION
Fixes #58453

## Test plan

Add the `vitejs/vite` repo to your local sg instance, and view the autoindex configuration page.

After this PR you should see the real error: 
`Error fetching index configuration: Inference limit: requested content for more than 100 (100) files`

instead of a nil pointer exception.

## Implementation notes

I added two commits, but the first is completely overridden by the second. In 67ed1c33e3c589b0a067a5f08be05116eb98a180 I tried to 'interpret' what the code was trying to do in the first place, and return a 'succesful' result even if the evaluation ran into a limit error. That produces very confusing UX though, because now it looks like everything is fine on the configuration page, but there are no build jobs. I think it's better to surface the error in the UI here.

This change leaves things in a bit of an awkward spot. The assignment to `limitErr` is dead code. I don't think the special handling for limit errors make sense here, and it doesn't work anyway (because somewhere on the code path it's not treated different from other errors). I tried ripping it out, but my go-foo isn't quite there yet. I could either open an issue for the follow-up cleanup, or we could try to pair on it @varungandhi-src WDYT?
