### PR TITLE
Additional scope information for each ADO scope section

### DIFF
--- a/doc/admin/external_service/azuredevops.md
+++ b/doc/admin/external_service/azuredevops.md
@@ -19,8 +19,8 @@ To connect Azure DevOps to Sourcegraph, create a personal access token from your
 4. Select the following scopes:
 
    - Code (Read)
-   - Project and Team
-   - User Profile
+   - Project and Team (Read)
+   - User Profile (Read)
 
 Next, configure the code host connection by following the next steps:
 


### PR DESCRIPTION
This change adds more context to each scope option in ADO token creation page. Previously, this wasn't clear to users creating tokens and confused them.



## Test plan
Doc update. Previewed locally.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@doc/ado-scope-update)