### PR TITLE
cleanup: Simplify some of the ref panel code

### DIFF
--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -264,6 +264,19 @@ const SearchTokenFindingReferencesList: React.FunctionComponent<
 
 const SHOW_SPINNER_DELAY_MS = 100
 
+const useSpinner = (loading: boolean): boolean => {
+    // We only show the inline loading message if loading takes longer than
+    // SHOW_SPINNER_DELAY_MS milliseconds.
+    const [canShowSpinner, setCanShowSpinner] = useState(false)
+    useEffect(() => {
+        const handle = setTimeout(() => setCanShowSpinner(loading), SHOW_SPINNER_DELAY_MS)
+        // In case the component un-mounts before
+        return () => clearTimeout(handle)
+        // Make sure this effect only runs once
+    }, [loading])
+    return canShowSpinner
+}
+
 const ReferencesList: React.FunctionComponent<
     React.PropsWithChildren<
         ReferencesPanelPropsWithToken & {
@@ -323,15 +336,7 @@ const ReferencesList: React.FunctionComponent<
         getSetting,
     })
 
-    // We only show the inline loading message if loading takes longer than
-    // SHOW_SPINNER_DELAY_MS milliseconds.
-    const [canShowSpinner, setCanShowSpinner] = useState(false)
-    useEffect(() => {
-        const handle = setTimeout(() => setCanShowSpinner(loading), SHOW_SPINNER_DELAY_MS)
-        // In case the component un-mounts before
-        return () => clearTimeout(handle)
-        // Make sure this effect only runs once
-    }, [loading])
+    const showSpinner = useSpinner(loading)
 
     // The "active URL" is the URL of the highlighted line number in SideBlob,
     // which also influences which item gets highlighted inside
@@ -425,8 +430,8 @@ const ReferencesList: React.FunctionComponent<
                     <small>
                         <Icon
                             aria-hidden={true}
-                            as={canShowSpinner ? LoadingSpinner : undefined}
-                            svgPath={!canShowSpinner ? mdiFilterOutline : undefined}
+                            as={showSpinner ? LoadingSpinner : undefined}
+                            svgPath={!showSpinner ? mdiFilterOutline : undefined}
                             size="md"
                             className={styles.filterIcon}
                         />

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -381,10 +381,6 @@ const ReferencesList: React.FunctionComponent<
         navigate(url)
     }
 
-    const navigateToUrl = (url: string): void => {
-        navigate(url)
-    }
-
     const [collapsed, setCollapsed] = useSessionStorage<Record<string, boolean>>(
         'sideblob-collapse-state-' + sessionStorageKeyFromToken(props.token),
         props.collapsedState
@@ -453,7 +449,6 @@ const ReferencesList: React.FunctionComponent<
                         loadingMore={false}
                         filter={debouncedFilter}
                         activeURL={activeURL || ''}
-                        navigateToUrl={navigateToUrl}
                         isActiveLocation={isActiveLocation}
                         setActiveLocation={setActiveLocation}
                         handleOpenChange={handleOpenChange}
@@ -468,7 +463,6 @@ const ReferencesList: React.FunctionComponent<
                         loadingMore={fetchMoreReferencesLoading}
                         filter={debouncedFilter}
                         activeURL={activeURL || ''}
-                        navigateToUrl={navigateToUrl}
                         setActiveLocation={setActiveLocation}
                         isActiveLocation={isActiveLocation}
                         handleOpenChange={handleOpenChange}
@@ -485,7 +479,6 @@ const ReferencesList: React.FunctionComponent<
                         filter={debouncedFilter}
                         isActiveLocation={isActiveLocation}
                         activeURL={activeURL || ''}
-                        navigateToUrl={navigateToUrl}
                         handleOpenChange={handleOpenChange}
                         isOpen={isOpen}
                     />
@@ -500,7 +493,6 @@ const ReferencesList: React.FunctionComponent<
                         filter={debouncedFilter}
                         isActiveLocation={isActiveLocation}
                         activeURL={activeURL || ''}
-                        navigateToUrl={navigateToUrl}
                         handleOpenChange={handleOpenChange}
                         isOpen={isOpen}
                     />
@@ -531,7 +523,7 @@ const ReferencesList: React.FunctionComponent<
                                     to={activeURL}
                                     onClick={event => {
                                         event.preventDefault()
-                                        navigateToUrl(activeURL)
+                                        navigate(activeURL)
                                     }}
                                     className={styles.sideBlobFilename}
                                 >
@@ -572,7 +564,6 @@ interface CollapsibleLocationListProps
     hasMore: boolean
     fetchMore?: () => void
     loadingMore: boolean
-    navigateToUrl: (url: string) => void
     activeURL: string
 }
 
@@ -622,7 +613,6 @@ const CollapsibleLocationList: React.FunctionComponent<
                                     isActiveLocation={props.isActiveLocation}
                                     setActiveLocation={props.setActiveLocation}
                                     filter={props.filter}
-                                    navigateToUrl={props.navigateToUrl}
                                     handleOpenChange={(id, isOpen) => props.handleOpenChange(props.name + id, isOpen)}
                                     isOpen={id => props.isOpen(props.name + id)}
                                     fetchHighlightedFileLineRanges={props.fetchHighlightedFileLineRanges}
@@ -691,7 +681,6 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
             SearchTokenProps &
             HighlightedFileLineRangesProps & {
                 filter: string | undefined
-                navigateToUrl: (url: string) => void
                 locations: LocationsGroupedByRepo
                 openByDefault: boolean
                 activeURL: string
@@ -701,7 +690,6 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
     locations,
     isActiveLocation,
     setActiveLocation,
-    navigateToUrl,
     filter,
     openByDefault,
     isOpen,
@@ -744,7 +732,6 @@ const CollapsibleRepoLocationGroup: React.FunctionComponent<
                             filter={filter}
                             handleOpenChange={(id, isOpen) => handleOpenChange(repoName + id, isOpen)}
                             isOpen={id => isOpen(repoName + id)}
-                            navigateToUrl={navigateToUrl}
                             fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
                         />
                     ))}
@@ -763,7 +750,6 @@ const CollapsibleLocationGroup: React.FunctionComponent<
                 repoName: string
                 group: LocationsGroupedByFile
                 filter: string | undefined
-                navigateToUrl: (url: string) => void
                 activeURL: string
             }
     >
@@ -776,7 +762,6 @@ const CollapsibleLocationGroup: React.FunctionComponent<
     isOpen,
     handleOpenChange,
     fetchHighlightedFileLineRanges,
-    navigateToUrl,
 }) => {
     // On the first load, update the scroll position towards the active
     // location.  Without this behavior, the scroll position points at the top
@@ -836,6 +821,7 @@ const CollapsibleLocationGroup: React.FunctionComponent<
     }
 
     const open = isOpen(group.path) ?? true
+    const navigate = useNavigate()
 
     return (
         <Collapse isOpen={open} onOpenChange={isOpen => handleOpenChange(group.path, isOpen)}>
@@ -905,14 +891,14 @@ const CollapsibleLocationGroup: React.FunctionComponent<
 
                                     event.preventDefault()
                                     if (isActive) {
-                                        navigateToUrl(locationToUrl(reference))
+                                        navigate(locationToUrl(reference))
                                     } else {
                                         setActiveLocation(reference)
                                     }
                                 }
                                 const doubleClickReference = (event: MouseEvent<HTMLElement>): void => {
                                     event.preventDefault()
-                                    navigateToUrl(locationToUrl(reference))
+                                    navigate(locationToUrl(reference))
                                 }
 
                                 return (

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -333,11 +333,6 @@ const ReferencesList: React.FunctionComponent<
         // Make sure this effect only runs once
     }, [loading])
 
-    const references = data?.references.nodes ?? LocationsGroup.empty
-    const definitions = data?.definitions.nodes ?? LocationsGroup.empty
-    const implementations = data?.implementations.nodes ?? LocationsGroup.empty
-    const prototypes = data?.prototypes.nodes ?? LocationsGroup.empty
-
     // The "active URL" is the URL of the highlighted line number in SideBlob,
     // which also influences which item gets highlighted inside
     // CollapsibleLocationList. This URL is persisted to session storage so that
@@ -372,18 +367,6 @@ const ReferencesList: React.FunctionComponent<
             false
         return result
     }
-
-    // If props.jumpToFirst is true and we finished loading (and have
-    // definitions) we select the first definition. We set it as activeLocation
-    // and push it to the blobMemoryHistory so the code blob is open.
-    useEffect(() => {
-        if (props.jumpToFirst) {
-            const firstDef = definitions.first
-            if (firstDef) {
-                setActiveLocation(firstDef)
-            }
-        }
-    }, [setActiveLocation, props.jumpToFirst, definitions.first, setActiveURL])
 
     const onBlobNav = (url: string): void => {
         // Store the URL that the user promoted even if no definition/reference
@@ -420,6 +403,20 @@ const ReferencesList: React.FunctionComponent<
     if (!data) {
         return <>Nothing found</>
     }
+
+    const definitions = data.definitions.nodes
+
+    // If props.jumpToFirst is true and we finished loading (and have
+    // definitions) we select the first definition. We set it as activeLocation
+    // and push it to the blobMemoryHistory so the code blob is open.
+    useEffect(() => {
+        if (props.jumpToFirst) {
+            const firstDef = definitions.first
+            if (firstDef) {
+                setActiveLocation(firstDef)
+            }
+        }
+    }, [setActiveLocation, props.jumpToFirst, definitions.first])
 
     return (
         <div className={classNames('align-items-stretch', styles.panel)}>
@@ -460,7 +457,7 @@ const ReferencesList: React.FunctionComponent<
                     <CollapsibleLocationList
                         {...props}
                         name="references"
-                        locationsGroup={references}
+                        locationsGroup={data.references.nodes}
                         hasMore={referencesHasNextPage}
                         fetchMore={fetchMoreReferences}
                         loadingMore={fetchMoreReferencesLoading}
@@ -475,7 +472,7 @@ const ReferencesList: React.FunctionComponent<
                     <CollapsibleLocationList
                         {...props}
                         name="implementations"
-                        locationsGroup={implementations}
+                        locationsGroup={data.implementations.nodes}
                         hasMore={implementationsHasNextPage}
                         fetchMore={fetchMoreImplementations}
                         loadingMore={fetchMoreImplementationsLoading}
@@ -490,7 +487,7 @@ const ReferencesList: React.FunctionComponent<
                     <CollapsibleLocationList
                         {...props}
                         name="prototypes"
-                        locationsGroup={prototypes}
+                        locationsGroup={data.prototypes.nodes}
                         hasMore={prototypesHasNextPage}
                         fetchMore={fetchMorePrototypes}
                         loadingMore={fetchMorePrototypesLoading}

--- a/client/web/src/codeintel/ReferencesPanel.tsx
+++ b/client/web/src/codeintel/ReferencesPanel.tsx
@@ -359,6 +359,19 @@ const ReferencesList: React.FunctionComponent<
         [setActiveURL]
     )
 
+    const definitions = data?.definitions.nodes
+    // If props.jumpToFirst is true and we finished loading (and have
+    // definitions) we select the first definition. We set it as activeLocation
+    // and push it to the blobMemoryHistory so the code blob is open.
+    useEffect(() => {
+        if (props.jumpToFirst) {
+            const firstDef = definitions?.first
+            if (firstDef) {
+                setActiveLocation(firstDef)
+            }
+        }
+    }, [setActiveLocation, props.jumpToFirst, definitions?.first])
+
     const sideblob = useMemo(() => parseSideBlobProps(activeURL), [activeURL])
 
     const isActiveLocation = (location: Location): boolean => {
@@ -405,20 +418,6 @@ const ReferencesList: React.FunctionComponent<
         return <>Nothing found</>
     }
 
-    const definitions = data.definitions.nodes
-
-    // If props.jumpToFirst is true and we finished loading (and have
-    // definitions) we select the first definition. We set it as activeLocation
-    // and push it to the blobMemoryHistory so the code blob is open.
-    useEffect(() => {
-        if (props.jumpToFirst) {
-            const firstDef = definitions.first
-            if (firstDef) {
-                setActiveLocation(firstDef)
-            }
-        }
-    }, [setActiveLocation, props.jumpToFirst, definitions.first])
-
     return (
         <div className={classNames('align-items-stretch', styles.panel)}>
             <div className={classNames('px-0', styles.leftSubPanel)}>
@@ -444,7 +443,7 @@ const ReferencesList: React.FunctionComponent<
                     <CollapsibleLocationList
                         {...props}
                         name="definitions"
-                        locationsGroup={definitions}
+                        locationsGroup={data.definitions.nodes}
                         hasMore={false}
                         loadingMore={false}
                         filter={debouncedFilter}


### PR DESCRIPTION
As I was changing the code to use the code intel API,
figured that I might as well simplify a few small things
that I noticed were off.

Does not affect any functionality

## Test plan

Tested with `sg start web-standalone`