### PR TITLE
sg rfc: do not include deleted RFCs when querying

### DIFF
--- a/dev/sg/internal/rfc/rfc.go
+++ b/dev/sg/internal/rfc/rfc.go
@@ -339,8 +339,11 @@ func queryRFCs(ctx context.Context, query string, driveSpec DriveSpec, pager fun
 	}
 
 	if query == "" {
-		query = "name contains 'RFC'"
+		query = "name contains 'RFC' and trashed = false"
+	} else {
+		query += " and trashed = false"
 	}
+
 	q := driveSpec.Query(query)
 
 	list := srv.Files.List().


### PR DESCRIPTION
This fixes `sg rfc create` using large numbers.

Erika found out that we base our number on the last number of all RFCs, including deleted ones.

So this fixes the problem by only querying for RFCs that have `trashed=false`.

I confirmed that it works by commenting out the actual code that creates the RFC and only leaving the querying in. Then testing like this:

Before:

        $ go run . rfc create foobar
        [...]
        Last public RFC = 9007
        Checking private RFCs
        Last private RFC = 9005
        nextRfcID: 9008
        ❌ cannot create RFC: thorsten was here
        exit status 1

After:

        $ go run . rfc create foobar
        [...]
        Last public RFC = 871
        Checking private RFCs
        Last private RFC = 872
        nextRfcID: 873
        ❌ cannot create RFC: thorsten was here
        exit status 1

Seems correct.



## Test plan

- See above