### PR TITLE
bazel: provide p4-fusion via bazel

### DIFF
--- a/cmd/gitserver/README.md
+++ b/cmd/gitserver/README.md
@@ -49,6 +49,10 @@ To use `p4-fusion` while developing Sourcegraph, there are a couple of options.
 
 [Run `gitserver` in a Docker container](https://docs.sourcegraph.com/dev/background-information/sg#run-gitserver-in-a-docker-container). This is the option that gives an experience closest to a deployed Sourcegraph instance, and will work for any platform/OS on which you're developing (running `sg start`).
 
+#### Bazel
+
+Native binaries are provided through Bazel, built via Nix in [our fork of p4-fusion](https://github.com/sourcegraph/p4-fusion/actions/workflows/nix-build-and-upload.yaml). It can be invoked either through `./dev/p4-fusion-dev` or directly with `bazel run //dev/tools:p4-fusion`.
+
 #### Native binary executable
 
 The `p4-fusion` native binary has been built on Linux and macOS, but is untested on Windows.

--- a/dev/p4-fusion-dev
+++ b/dev/p4-fusion-dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# This script is a wrapper around `p4-fusion` to download and run p4-fusion using bazel
+#
+
+# We silence a few things, because the arguments that symbols pass to this script, which are then passed to
+# the bazel run are printed out again by Bazel by default. And they're very long, so much that it hads about
+# 40 lines, adding unecessary noise to the output of `sg start`
+bazel run //dev/tools:p4-fusion --logging=0 --noshow_progress --ui_event_filters=-info,-debug,-stdout -- "$@"

--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -5,6 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 DOCSITE_VERSION = "1.9.4"
 SRC_CLI_VERSION = "5.2.1"
 CTAGS_VERSION = "6.0.0.2783f009"
+P4_FUSION_VERSION = "v1.13.2-sg.04a293a"
 
 SRC_CLI_BUILDFILE = """
 filegroup(
@@ -118,4 +119,25 @@ def tool_deps():
         patch_cmds = GCLOUD_PATCH_CMDS,
         sha256 = "5f9ed1862a82f393be3b16634309e9e8edb6da13a8704952be9c4c59963f9cd4",
         url = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{}-linux-x86_64.tar.gz".format(GCLOUD_VERSION),
+    )
+
+    http_file(
+        name = "p4-fusion-linux-amd64",
+        sha256 = "4c32aa00fa220733faea27a1c6ec4acd0998c1a7f870e08de9947685621f0d06",
+        url = "https://storage.googleapis.com/p4-fusion/x86_64-linux/dist/p4-fusion-{0}".format(P4_FUSION_VERSION),
+        executable = True,
+    )
+
+    http_file(
+        name = "p4-fusion-darwin-amd64",
+        sha256 = "bfa525a8a38d2c2ea205865b1a6d5be0b680e3160a64ba9505953be3294d1b9c",
+        url = "https://storage.googleapis.com/p4-fusion/x86_64-darwin/dist/p4-fusion-{0}".format(P4_FUSION_VERSION),
+        executable = True,
+    )
+
+    http_file(
+        name = "p4-fusion-darwin-arm64",
+        sha256 = "f97942e145902e682a5c1bc2608071a24d17bf943f35faaf18f359cbbaacddcd",
+        url = "https://storage.googleapis.com/p4-fusion/aarch64-darwin/dist/p4-fusion-{0}".format(P4_FUSION_VERSION),
+        executable = True,
     )

--- a/dev/tools/BUILD.bazel
+++ b/dev/tools/BUILD.bazel
@@ -47,3 +47,13 @@ sh_binary(
     }),
     visibility = ["//visibility:public"],
 )
+
+sh_binary(
+    name = "p4-fusion",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin_x86_64": ["@p4-fusion-darwin-amd64//file:downloaded"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["@p4-fusion-darwin-arm64//file:downloaded"],
+        "@bazel_tools//src/conditions:linux_x86_64": ["@p4-fusion-linux-amd64//file:downloaded"],
+    }),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
The only place where we currently use p4-fusion appears to be in integration tests, where the binary is already in the image via Wolfi. All other unit tests just test for expected args/env to p4-fusion if we _were_ to call it\

## Test plan

`./dev/p4-fusion-dev` successfully runs the binary