### PR TITLE
Docs: fix batch changes settings names

### DIFF
--- a/doc/batch_changes/explanations/permissions_in_batch_changes.md
+++ b/doc/batch_changes/explanations/permissions_in_batch_changes.md
@@ -79,8 +79,8 @@ If you are not permitted to view a repository on Sourcegraph, then you won't be 
 
 ## Disabling Batch Changes
 
-A site admin can disable Batch Changes for the entire site by setting the [site configuration](../../../admin/config/site_config.md) property `"batch-changes.enabled"` to `false`. <!--- TODO:check --->
+A site admin can disable Batch Changes for the entire site by setting the [site configuration](../../../admin/config/site_config.md) property `"batchChanges.enabled"` to `false`. <!--- TODO:check --->
 
 ## Disabling Batch Changes for non-site-admin users
 
-A site admin can disable batch changes for normal users by setting the [site configuration](../../../admin/config/site_config.md) property `"batch-changes.restrictToAdmins"` to `true`. <!--- TODO:check --->
+A site admin can disable batch changes for normal users by setting the [site configuration](../../../admin/config/site_config.md) property `"batchChanges.restrictToAdmins"` to `true`. <!--- TODO:check --->


### PR DESCRIPTION
Just a couple of settings that were [cased incorrectly](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@4df3edf5ae0f17c702485455a7bf71fb86f0c9be/-/blob/schema/site.schema.json?L594-594).

## Test plan

N/A

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@cc/fix-batch-changes-docs)