### PR TITLE
cody-gateway: add trace_id to metadata

### DIFF
--- a/cmd/cody-gateway/internal/events/events.go
+++ b/cmd/cody-gateway/internal/events/events.go
@@ -106,6 +106,9 @@ func (l *bigQueryLogger) LogEvent(spanCtx context.Context, event Event) (err err
 	// HACK: Inject Sourcegraph actor that is held in the span context
 	event.Metadata["sg.actor"] = sgactor.FromContext(spanCtx)
 
+	// Inject trace metadata
+	event.Metadata["trace_id"] = oteltrace.SpanContextFromContext(spanCtx).TraceID().String()
+
 	metadata, err := json.Marshal(event.Metadata)
 	if err != nil {
 		return errors.Wrap(err, "marshaling metadata")


### PR DESCRIPTION
Could be useful for deriving retry information from specific events.

## Test plan

n/a