### PR TITLE
Web: remove aggregableBadge from `ChunkMatch` and `LineMatch`

### DIFF
--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -7,7 +7,6 @@ import type { Observable } from 'rxjs'
 
 import { isErrorLike, pluralize } from '@sourcegraph/common'
 import type { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
-import type { AggregableBadge } from '@sourcegraph/shared/src/codeintel/legacy-extensions/api'
 import { LineRanking } from '@sourcegraph/shared/src/components/ranking/LineRanking'
 import type { MatchItem } from '@sourcegraph/shared/src/components/ranking/PerFileResultRanking'
 import { ZoektRanking } from '@sourcegraph/shared/src/components/ranking/ZoektRanking'
@@ -19,7 +18,7 @@ import {
 } from '@sourcegraph/shared/src/search/stream'
 import { isSettingsValid, type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Icon, Badge } from '@sourcegraph/wildcard'
+import { Icon } from '@sourcegraph/wildcard'
 
 import { CopyPathAction } from './CopyPathAction'
 import { FileMatchChildren } from './FileMatchChildren'
@@ -141,7 +140,6 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
                       content: match.content,
                       startLine: match.contentStart.line,
                       endLine: match.ranges.at(-1)!.end.line,
-                      aggregableBadges: match.aggregableBadges,
                   })) ||
                   result.lineMatches?.map(match => ({
                       highlightRanges: match.offsetAndLengths.map(offsetAndLength => ({
@@ -153,7 +151,6 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
                       content: match.line,
                       startLine: match.lineNumber,
                       endLine: match.lineNumber,
-                      aggregableBadges: match.aggregableBadges,
                   })) ||
                   []
                 : [],
@@ -191,24 +188,6 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
         }
     }, [collapsible, expanded])
 
-    const description =
-        items.length > 0 ? (
-            <>
-                {aggregateBadges(items).map(badge => (
-                    <Badge
-                        key={badge.text}
-                        href={badge.linkURL}
-                        tooltip={badge.hoverMessage}
-                        variant="secondary"
-                        small={true}
-                        className="text-muted text-uppercase file-match__badge"
-                    >
-                        {badge.text}
-                    </Badge>
-                ))}
-            </>
-        ) : undefined
-
     const title = (
         <>
             <span className="d-flex align-items-center">
@@ -231,7 +210,6 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
                     telemetryService={telemetryService}
                 />
             </span>
-            {description && <span className={classNames('ml-2', styles.headerDescription)}>{description}</span>}
         </>
     )
 
@@ -306,13 +284,4 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
             </div>
         </ResultContainer>
     )
-}
-
-function aggregateBadges(items: MatchItem[]): AggregableBadge[] {
-    const aggregatedBadges = new Map<string, AggregableBadge>()
-    for (const badge of items.flatMap(item => item.aggregableBadges || [])) {
-        aggregatedBadges.set(badge.text, badge)
-    }
-
-    return [...aggregatedBadges.values()].sort((a, b) => a.text.localeCompare(b.text))
 }

--- a/client/shared/src/components/ranking/PerFileResultRanking.ts
+++ b/client/shared/src/components/ranking/PerFileResultRanking.ts
@@ -1,5 +1,3 @@
-import type { AggregableBadge, Badge as ExtensionBadgeType } from '../../codeintel/legacy-extensions/api'
-
 /**
  * Interface for different ranking algorithms that determine how to display search results in the client.
  *
@@ -21,7 +19,7 @@ export interface RankingResult {
     grouped: MatchGroup[]
 }
 
-export interface MatchItem extends ExtensionBadgeType {
+export interface MatchItem {
     highlightRanges: {
         startLine: number
         startCharacter: number
@@ -40,7 +38,6 @@ export interface MatchItem extends ExtensionBadgeType {
      * The 0-based line number where the matched content ends.
      */
     endLine: number
-    aggregableBadges?: AggregableBadge[]
 }
 
 /**

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -12,7 +12,6 @@ import { defaultIfEmpty, map, materialize, scan, switchMap } from 'rxjs/operator
 
 import { asError, type ErrorLike, isErrorLike } from '@sourcegraph/common'
 
-import type { AggregableBadge } from '../codeintel/legacy-extensions/api'
 import type { SearchPatternType, SymbolKind } from '../graphql-operations'
 
 import { SearchMode } from './searchQueryState'
@@ -94,14 +93,12 @@ export interface LineMatch {
     line: string
     lineNumber: number
     offsetAndLengths: number[][]
-    aggregableBadges?: AggregableBadge[]
 }
 
 interface ChunkMatch {
     content: string
     contentStart: Location
     ranges: Range[]
-    aggregableBadges?: AggregableBadge[]
 }
 
 export interface SymbolMatch {

--- a/client/web-sveltekit/src/lib/search/utils.ts
+++ b/client/web-sveltekit/src/lib/search/utils.ts
@@ -28,8 +28,7 @@ export function resultToMatchItems(result: ContentMatch): MatchItem[] {
               })),
               content: match.content,
               startLine: match.contentStart.line,
-              endLine: match.ranges.at(-1).end.line,
-              aggregableBadges: match.aggregableBadges,
+              endLine: match.ranges.at(-1)?.end.line ?? match.contentStart.line,
           })) ||
               result.lineMatches?.map(match => ({
                   highlightRanges: match.offsetAndLengths.map(offsetAndLength => ({
@@ -41,7 +40,6 @@ export function resultToMatchItems(result: ContentMatch): MatchItem[] {
                   content: match.line,
                   startLine: match.lineNumber,
                   endLine: match.lineNumber,
-                  aggregableBadges: match.aggregableBadges,
               })) ||
               []
         : []


### PR DESCRIPTION
This removes a field that is never set on `ChunkMatch` and `LineMatch`. These types should match the definitions on the backend. Looking at the git history, it looks like this hasn't been functional in a long time. `AggregableBadge` _is_ still used in some code intel hover code because it used to be an extension point.

## Test plan

The type system will catch most obvious errors here. I also did a bit of manual clicking to make sure nothing unexpected broke. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
