### PR TITLE
bazel: first pass at moving moving logging linting into nogo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -315,6 +315,7 @@ nogo(
             "//dev/linters/gocheckcompilerdirectives",
             "//dev/linters/gocritic",
             "//dev/linters/ineffassign",
+            "//dev/linters/logging",
             "//dev/linters/unparam",
             # Disabled because we currently have a lot of unused code
             # "//dev/linters/unused",

--- a/dev/linters/logging/BUILD.bazel
+++ b/dev/linters/logging/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "logging",
+    srcs = ["logging.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/linters/logging",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//dev/linters/nolint",
+        "@com_github_openpeedeep_depguard_v2//:go_default_library",
+        "@org_golang_x_tools//go/analysis",
+    ],
+)

--- a/dev/linters/logging/logging.go
+++ b/dev/linters/logging/logging.go
@@ -1,0 +1,52 @@
+package logging
+
+import (
+	"fmt"
+
+	"github.com/OpenPeeDeeP/depguard/v2"
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
+)
+
+// This analyzer is modeled after the one in
+// https://sourcegraph.sourcegraph.com/github.com/sourcegraph/sourcegraph@f6ae87add606c65876b87d378929fcb80c3bb493/-/blob/dev/linters/depguard/depguard.go
+// These could potentially be combined into one analyzer.
+var Analyzer *analysis.Analyzer = createAnalyzer()
+
+const USE_LOG_INSTEAD = `use "github.com/sourcegraph/log" instead`
+
+// Deny is a map which contains all the deprecated logging packages
+// The key of the map is the package name that is not allowed - globs can be used as keys.
+// The value of the key is the reason to give as to why the logger is not allowed.
+var Deny = map[string]string{
+	"log$":                              USE_LOG_INSTEAD,
+	"github.com/inconshreveable/log15$": USE_LOG_INSTEAD,
+	"go.uber.org/zap":                   USE_LOG_INSTEAD,
+}
+
+func createAnalyzer() *analysis.Analyzer {
+	settings := &depguard.LinterSettings{
+		"deprecated loggers": &depguard.List{
+			Deny: Deny,
+			Files: []string{
+				// Let everything in dev use whatever they want
+				"!**/dev",
+				// // We allow one usage of a direct zap import here
+				"!**/internal/observation/fields.go",
+				// // Inits old loggers
+				"!**/internal/logging/main.go",
+				// // Dependencies require direct usage of zap
+				"**/cmd/frontend/internal/app/otlpadapter",
+				// // Legacy and special case handling of panics in background routines
+				"**/lib/background/goroutine.go",
+			},
+		},
+	}
+	analyzer, err := depguard.NewAnalyzer(settings)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create deprecated logging analyzer: %v", err))
+	}
+
+	return nolint.Wrap(analyzer)
+}


### PR DESCRIPTION
Adds linting for deprecated logging libraries as a nogo rule. Modeled after https://github.com/sourcegraph/sourcegraph/pull/50585 as it is very similar behavior. So similar in fact that unless there's a good reason, this could just be added to the existing `depguard` rule as another file set.

## Test plan
Performed manual testing by modifying the `Files` argument for each special case to see the rule trigger, as well as adding imports to unmatched files to ensure they failed compilation.