### PR TITLE
dev: make issue tracker only crawl open tracking issues

### DIFF
--- a/internal/cmd/tracking-issue/api.go
+++ b/internal/cmd/tracking-issue/api.go
@@ -13,7 +13,7 @@ import (
 // ListTrackingIssues returns all issues with the `tracking` label (and at least one other label)
 // in the given organization.
 func ListTrackingIssues(ctx context.Context, cli *graphql.Client, org string) ([]*Issue, error) {
-	issues, _, err := LoadIssues(ctx, cli, []string{fmt.Sprintf("org:%q label:tracking", org)})
+	issues, _, err := LoadIssues(ctx, cli, []string{fmt.Sprintf("org:%q label:tracking is:open", org)})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue Tracking GHA has been broken for a while, this PR fixes it. Basically, we were crawling closed issues and one of them was breaking the label identifying function. We don't care about closed tracking issue anyway, so let's just skip them entirely. 

## Test plan

Run the issue tracker locally and it completed (failed on not being able to update issues but that's expected). 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
