### PR TITLE
database: speed up UpdateRepoSizes

### DIFF
--- a/cmd/gitserver/internal/cleanup.go
+++ b/cmd/gitserver/internal/cleanup.go
@@ -624,7 +624,7 @@ func cleanupRepos(
 	}
 
 	if len(repoToSize) > 0 {
-		_, err := db.GitserverRepos().UpdateRepoSizes(ctx, shardID, repoToSize)
+		_, err := db.GitserverRepos().UpdateRepoSizes(ctx, logger, shardID, repoToSize)
 		if err != nil {
 			logger.Error("setting repo sizes", log.Error(err))
 		}

--- a/internal/database/dbmocks/BUILD.bazel
+++ b/internal/database/dbmocks/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//schema",
         "@com_github_google_uuid//:uuid",
         "@com_github_keegancsmith_sqlf//:sqlf",
+        "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_zoekt//:zoekt",
     ],
 )

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -11,9 +11,10 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 
+	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/batch"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -65,7 +66,7 @@ type GitserverRepoStore interface {
 	// counting repos with an associated cloud_default external service.
 	TotalErroredCloudDefaultRepos(ctx context.Context) (int, error)
 	// UpdateRepoSizes sets repo sizes according to input map. Key is repoID, value is repo_size_bytes.
-	UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoName]int64) (int, error)
+	UpdateRepoSizes(ctx context.Context, logger log.Logger, shardID string, repos map[api.RepoName]int64) (int, error)
 	// SetCloningProgress updates a piece of text description from how cloning proceeds.
 	SetCloningProgress(context.Context, api.RepoName, string) error
 	// GetLastSyncOutput returns the last stored output from a repo sync (clone or fetch), or ok: false if
@@ -651,43 +652,49 @@ WHERE repo_id = (SELECT id FROM repo WHERE name = %s)
 	return nil
 }
 
-func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, shardID string, repos map[api.RepoName]int64) (updated int, err error) {
-	// NOTE: We have two args per row, so rows*2 should be less than maximum
-	// Postgres allows.
-	const batchSize = batch.MaxNumPostgresParameters / 2
-	return s.updateRepoSizesWithBatchSize(ctx, repos, batchSize)
+func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, logger log.Logger, shardID string, repos map[api.RepoName]int64) (updated int, err error) {
+	// batchSize is 100 because we started with really large batch sizes (32k)
+	// and noticed that it was really slow in production.
+	// While testing locally, we noticed that even batch sizes of 1000 are slow.
+	const batchSize = 100
+	return s.updateRepoSizesWithBatchSize(ctx, logger, repos, batchSize)
 }
 
-func (s *gitserverRepoStore) updateRepoSizesWithBatchSize(ctx context.Context, repos map[api.RepoName]int64, batchSize int) (updated int, err error) {
-	tx, err := s.Store.Transact(ctx)
-	if err != nil {
-		return 0, err
-	}
-	defer func() { err = tx.Done(err) }()
-
+func (s *gitserverRepoStore) updateRepoSizesWithBatchSize(ctx context.Context, logger log.Logger, repos map[api.RepoName]int64, batchSize int) (updated int, err error) {
 	queries := make([]*sqlf.Query, batchSize)
+
+	logger.Info("Updating repository sizes", log.Int("count", len(repos)), log.Int("batchSize", batchSize))
 
 	left := len(repos)
 	currentCount := 0
 	updatedRows := 0
 	for repo, size := range repos {
+		start := time.Now()
+
 		queries[currentCount] = sqlf.Sprintf("(%s::text, %s::bigint)", repo, size)
 
 		currentCount += 1
 
 		if currentCount == batchSize || currentCount == left {
+			logger.Info("Updating batch of repository sizes", log.Int("left", left))
+
 			// IMPORTANT: we only take the elements of batch up to currentCount
 			q := sqlf.Sprintf(updateRepoSizesQueryFmtstr, sqlf.Join(queries[:currentCount], ","))
-			res, err := tx.ExecResult(ctx, q)
+			res, err := s.ExecResult(ctx, q)
 			if err != nil {
-				return 0, err
+				logger.Info("Failed to update batch", log.Error(err))
+				return updatedRows, err
 			}
 
 			rowsAffected, err := res.RowsAffected()
 			if err != nil {
-				return 0, err
+				logger.Info("Failed to read updated rows", log.Error(err))
+				return updatedRows, err
 			}
 			updatedRows += int(rowsAffected)
+
+			duration := time.Since(start)
+			logger.Info("Done", log.Duration("duration", duration), log.Int("rowsAffected", int(rowsAffected)))
 
 			left -= currentCount
 			currentCount = 0
@@ -703,24 +710,17 @@ WITH update_data AS (
 		-- (<repo_name>, <repo_size_bytes>),
 		%s
 	) AS tmp(repo_name, repo_size_bytes)
-),
-locked_data AS (
-	SELECT update_data.*, gr.repo_id
-	FROM update_data
-	JOIN gitserver_repos gr ON gr.repo_id = (SELECT r.id FROM repo r WHERE r.name = update_data.repo_name)
-	WHERE
-		update_data.repo_size_bytes IS DISTINCT FROM gr.repo_size_bytes
-	ORDER BY gr.repo_id ASC
-	FOR UPDATE OF gr
 )
-
 UPDATE gitserver_repos AS gr
 SET
-    repo_size_bytes = locked_data.repo_size_bytes,
+    repo_size_bytes = update_data.repo_size_bytes,
 	updated_at = NOW()
-FROM locked_data
+FROM repo r
+INNER JOIN update_data on update_data.repo_name = r.name
 WHERE
-	locked_data.repo_id = gr.repo_id
+	r.id = gr.repo_id
+AND
+	update_data.repo_size_bytes IS DISTINCT FROM gr.repo_size_bytes
 `
 
 // sanitizeToUTF8 will remove any null character terminated string. The null character can be

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -653,6 +653,7 @@ WHERE repo_id = (SELECT id FROM repo WHERE name = %s)
 }
 
 func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, logger log.Logger, shardID string, repos map[api.RepoName]int64) (updated int, err error) {
+	logger = logger.Scoped("gitserverRepoStore.UpdateRepoSizes")
 	// batchSize is 100 because we started with really large batch sizes (32k)
 	// and noticed that it was really slow in production.
 	// While testing locally, we noticed that even batch sizes of 1000 are slow.
@@ -694,7 +695,7 @@ func (s *gitserverRepoStore) updateRepoSizesWithBatchSize(ctx context.Context, l
 			updatedRows += int(rowsAffected)
 
 			duration := time.Since(start)
-			logger.Info("Done", log.Duration("duration", duration), log.Int("rowsAffected", int(rowsAffected)))
+			logger.Info("Batch updated", log.Duration("duration", duration), log.Int("rowsAffected", int(rowsAffected)))
 
 			left -= currentCount
 			currentCount = 0


### PR DESCRIPTION
Noticed as part of #wg-cheaper-sourcegraph that the calls to UpdateRepoSizes on sourcegraph.com would never, ever return. Instead the goroutine would get stuck, somehow connection between client and DB would get lost, DB would think client is still there, and the whole thing might have locked rows, and it all became a big disaster.

Digging into this I found that even locally, I could never get the test to update, say, 100k repos with the given batch size. It would time out after 10min.

So what I was to

1. Remove the transaction and the locking -- we update two fields anywhere, that aren't updated by anything else (and in the case of `updated_at` it doesn't matter)
2. Reduce the batch size drastically
3. Add a test to play around with large repo sizes
4. Add a logger

When running the test with 20k repos, I noticed the following:

    Batch size 100: test takes 35s
    Batch size 1000: test takes 64s

Then, with 5k repos, I played with the batch size some more and found:

    Batch size 100: one batch takes ~50ms to update.
    Batch size 500: one batch takes ~650ms to update.

So let's go with 100.

On sourcegraph.com, we right now have 770k repos per shard. That means we end up with 7.700 batches. That should take ~6-7min.

That's still better than one continuous query that never finishes.


## Test plan

- Unit test