### PR TITLE
Flush for code completions only

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -375,7 +375,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 			// if this is a streaming request, we want to flush ourselves instead of leaving that to the http.Server
 			// (so events are sent to the client as soon as possible)
 			var responseWriter io.Writer = w
-			if autoFlushStreamingResponses && body.ShouldStream() {
+			if autoFlushStreamingResponses && body.ShouldStream() && feature == codygateway.FeatureCodeCompletions {
 				if fw, err := response.NewAutoFlushingWriter(w); err == nil {
 					responseWriter = fw
 				} else {


### PR DESCRIPTION
This PR changes the new autoflushing code to only perform our aggressive flushing for code-completions, which:

- have far lower latency (lower chance of interrupts)
- return smaller responses
- have lower cost of retries (if we get an error)
- make it easier to gracefully handle errors (are used to populate cache, not directly returned to the user)

This code is off-by-default, I intend to enable it later today and watch https://cloudlogging.app.goo.gl/ozyEAoy1PsmBAPU19 for errors.

## Test plan

- locally tested