### PR TITLE
search: expose GitHub/GitLab topics in UI

### DIFF
--- a/client/branded/src/search-ui/components/RepoSearchResult.tsx
+++ b/client/branded/src/search-ui/components/RepoSearchResult.tsx
@@ -75,17 +75,16 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
 
     const showExtraInfo = result.archived || result.fork || result.private
 
-    const metadataTags = !metadata
-        ? []
-        : Object.entries(metadata).map(([key, value]) =>
-              metadataToTag({ key, value }, queryState, false, buildSearchURLQueryFromQueryState)
-          )
+    const tags = [
+        ...(metadata
+            ? Object.entries(metadata).map(([key, value]) =>
+                  metadataToTag({ key, value }, queryState, false, buildSearchURLQueryFromQueryState)
+              )
+            : []),
+        ...(topics ? topics.map(topic => topicToTag(topic, queryState, false, buildSearchURLQueryFromQueryState)) : []),
+    ]
 
-    const topicTags = !topics
-        ? []
-        : topics.map(topic => topicToTag(topic, queryState, false, buildSearchURLQueryFromQueryState))
-
-    const showRepoMetadata = enableRepositoryMetadata && (metadataTags.length > 0 || topicTags.length > 0)
+    const showRepoMetadata = enableRepositoryMetadata && tags.length > 0
 
     return (
         <ResultContainer
@@ -147,7 +146,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
                     )}
                     {showRepoMetadata && (
                         <div className="d-flex">
-                            <TagList tags={[...metadataTags, ...topicTags]} />
+                            <TagList tags={tags} />
                         </div>
                     )}
                 </div>

--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -160,6 +160,7 @@ export interface RepositoryMatch {
     branches?: string[]
     descriptionMatches?: Range[]
     metadata?: Record<string, string | undefined>
+    topics?: string[]
 }
 
 export type OwnerMatch = PersonMatch | TeamMatch

--- a/client/web/src/integration/commit-page.test.ts
+++ b/client/web/src/integration/commit-page.test.ts
@@ -302,6 +302,7 @@ describe('RepositoryCommitPage', () => {
                 changelist: null,
                 isFork: false,
                 metadata: [],
+                topics: [],
             },
         }),
     }

--- a/client/web/src/integration/graphQlResponseHelpers.ts
+++ b/client/web/src/integration/graphQlResponseHelpers.ts
@@ -103,6 +103,7 @@ export const createResolveRepoRevisionResult = (treeUrl: string, oid = '1'.repea
         changelist: null,
         isFork: false,
         metadata: [],
+        topics: [],
     },
 })
 
@@ -134,6 +135,7 @@ export const createResolveCloningRepoRevisionResult = (
         changelist: null,
         isFork: false,
         metadata: [],
+        topics: [],
     },
     errors: [
         {

--- a/client/web/src/repo/backend.ts
+++ b/client/web/src/repo/backend.ts
@@ -58,6 +58,7 @@ export const repositoryFragment = gql`
             key
             value
         }
+        topics
     }
 `
 

--- a/client/web/src/repo/tree/TreePage.test.tsx
+++ b/client/web/src/repo/tree/TreePage.test.tsx
@@ -34,6 +34,7 @@ describe('TreePage', () => {
             abbrevName: 'def-branch-abbr',
         },
         metadata: [],
+        topics: [],
     })
 
     const treePagePropsDefaults = (repositoryFields: RepositoryFields): Props => ({

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -110,6 +110,7 @@ export const treePageRepositoryFragment = gql`
             key
             value
         }
+        topics
         sourceType
     }
 `

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -4,7 +4,7 @@ import { mdiCog, mdiFileOutline, mdiGlasses, mdiInformationOutline } from '@mdi/
 import classNames from 'classnames'
 import { escapeRegExp } from 'lodash'
 
-import { RepoMetadata } from '@sourcegraph/branded'
+import { metadataToTag, TagList, topicToTag } from '@sourcegraph/branded'
 import { encodeURIPathComponent, numberWithCommas, pluralize } from '@sourcegraph/common'
 import { gql, useQuery } from '@sourcegraph/http-client'
 import { TeamAvatar } from '@sourcegraph/shared/src/components/TeamAvatar'
@@ -82,14 +82,27 @@ const ExtraInfoSection: React.FC<{
 }> = ({ repo, className, hasWritePermissions }) => {
     const [enableRepositoryMetadata] = useFeatureFlag('repository-metadata', true)
 
-    const metadataItems = useMemo(() => repo.metadata.map(({ key, value }) => ({ key, value })) || [], [repo.metadata])
     const queryState = useNavbarQueryState(state => state.queryState)
+
+    const metadataTags = useMemo(
+        () => repo.metadata.map(item => metadataToTag(item, queryState, true, buildSearchURLQueryFromQueryState)),
+        [repo.metadata, queryState]
+    )
+
+    const topicTags = useMemo(
+        () => repo.topics.map(topic => topicToTag(topic, queryState, true, buildSearchURLQueryFromQueryState)),
+        [repo.topics, queryState]
+    )
 
     return (
         <Card className={className}>
             <ExtraInfoSectionItem>
                 <ExtraInfoSectionItemHeader title="Description" tooltip="Synchronized from the code host" />
                 {repo.description && <Text>{repo.description}</Text>}
+            </ExtraInfoSectionItem>
+            <ExtraInfoSectionItem>
+                <ExtraInfoSectionItemHeader title="Topics" tooltip={<>Topics synced from GitHub or GitLab</>} />
+                {topicTags ? <TagList tags={topicTags} /> : <Text className="text-muted">None</Text>}
             </ExtraInfoSectionItem>
             {enableRepositoryMetadata && (
                 <ExtraInfoSectionItem>
@@ -122,16 +135,7 @@ const ExtraInfoSection: React.FC<{
                             </Tooltip>
                         )}
                     </ExtraInfoSectionItemHeader>
-                    {metadataItems.length ? (
-                        <RepoMetadata
-                            items={metadataItems}
-                            queryState={queryState}
-                            queryBuildOptions={{ omitRepoFilter: true }}
-                            buildSearchURLQueryFromQueryState={buildSearchURLQueryFromQueryState}
-                        />
-                    ) : (
-                        <Text className="text-muted">None</Text>
-                    )}
+                    {metadataTags.length ? <TagList tags={metadataTags} /> : <Text className="text-muted">None</Text>}
                 </ExtraInfoSectionItem>
             )}
         </Card>

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -100,7 +100,7 @@ const ExtraInfoSection: React.FC<{
                 <ExtraInfoSectionItemHeader title="Description" tooltip="Synchronized from the code host" />
                 {repo.description && <Text>{repo.description}</Text>}
             </ExtraInfoSectionItem>
-            {/*Not all code hosts support the concept of "topics", hence we only show topics if we have them*/}
+            {/* Not all code hosts support the concept of "topics", hence we only show topics if we have them */}
             {topicTags.length > 0 && (
                 <ExtraInfoSectionItem>
                     <ExtraInfoSectionItemHeader title="Topics" tooltip={<>Topics synced from the code host</>} />

--- a/client/web/src/repo/tree/TreePageContent.tsx
+++ b/client/web/src/repo/tree/TreePageContent.tsx
@@ -100,10 +100,13 @@ const ExtraInfoSection: React.FC<{
                 <ExtraInfoSectionItemHeader title="Description" tooltip="Synchronized from the code host" />
                 {repo.description && <Text>{repo.description}</Text>}
             </ExtraInfoSectionItem>
-            <ExtraInfoSectionItem>
-                <ExtraInfoSectionItemHeader title="Topics" tooltip={<>Topics synced from GitHub or GitLab</>} />
-                {topicTags ? <TagList tags={topicTags} /> : <Text className="text-muted">None</Text>}
-            </ExtraInfoSectionItem>
+            {/*Not all code hosts support the concept of "topics", hence we only show topics if we have them*/}
+            {topicTags.length > 0 && (
+                <ExtraInfoSectionItem>
+                    <ExtraInfoSectionItemHeader title="Topics" tooltip={<>Topics synced from the code host</>} />
+                    <TagList tags={topicTags} />
+                </ExtraInfoSectionItem>
+            )}
             {enableRepositoryMetadata && (
                 <ExtraInfoSectionItem>
                     <ExtraInfoSectionItemHeader

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -497,6 +497,7 @@ go_test(
         "//internal/extsvc",
         "//internal/extsvc/gerrit",
         "//internal/extsvc/github",
+        "//internal/extsvc/gitlab",
         "//internal/featureflag",
         "//internal/fileutil",
         "//internal/gitserver",

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -541,6 +541,7 @@ go_test(
         "@com_github_golang_jwt_jwt_v4//:jwt",
         "@com_github_google_go_cmp//cmp",
         "@com_github_google_go_cmp//cmp/cmpopts",
+        "@com_github_grafana_regexp//:regexp",
         "@com_github_graph_gophers_graphql_go//:graphql-go",
         "@com_github_graph_gophers_graphql_go//errors",
         "@com_github_graph_gophers_graphql_go//relay",

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -497,7 +497,6 @@ go_test(
         "//internal/extsvc",
         "//internal/extsvc/gerrit",
         "//internal/extsvc/github",
-        "//internal/extsvc/gitlab",
         "//internal/featureflag",
         "//internal/fileutil",
         "//internal/gitserver",

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -216,7 +216,7 @@ func TestResolverTo(t *testing.T) {
 		typ := reflect.TypeOf(r)
 		t.Run(typ.Name(), func(t *testing.T) {
 			for i := 0; i < typ.NumMethod(); i++ {
-				if name := typ.Method(i).Name; strings.HasPrefix(name, "To") {
+				if name := typ.Method(i).Name; strings.HasPrefix(name, "To") && name != "Topics" {
 					reflect.ValueOf(r).MethodByName(name).Call(nil)
 				}
 			}

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -12,10 +12,10 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"strings"
 	"sync/atomic"
 	"testing"
 
+	"github.com/grafana/regexp"
 	"github.com/inconshreveable/log15"
 	sglog "github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
@@ -212,11 +212,14 @@ func TestResolverTo(t *testing.T) {
 		&settingsSubjectResolver{},
 		&statusMessageResolver{db: db},
 	}
+
+	re := regexp.MustCompile("To[A-Z]")
+
 	for _, r := range resolvers {
 		typ := reflect.TypeOf(r)
 		t.Run(typ.Name(), func(t *testing.T) {
 			for i := 0; i < typ.NumMethod(); i++ {
-				if name := typ.Method(i).Name; strings.HasPrefix(name, "To") && name != "Topics" {
+				if name := typ.Method(i).Name; re.MatchString(name) {
 					reflect.ValueOf(r).MethodByName(name).Call(nil)
 				}
 			}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -489,7 +489,7 @@ func (r *RepositoryResolver) Topics(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	return database.GetTopics(repo.Metadata), nil
+	return repo.Topics, nil
 }
 
 func (r *RepositoryResolver) hydrate(ctx context.Context) error {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -483,6 +483,15 @@ func (r *RepositoryResolver) Metadata(ctx context.Context) ([]KeyValuePair, erro
 	return kvps, nil
 }
 
+func (r *RepositoryResolver) Topics(ctx context.Context) ([]string, error) {
+	repo, err := r.repo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return database.GetTopics(repo.Metadata), nil
+}
+
 func (r *RepositoryResolver) hydrate(ctx context.Context) error {
 	r.hydration.Do(func() {
 		// Repositories with an empty creation date were created using RepoName.ToRepo(),

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -12,9 +13,13 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
@@ -278,4 +283,88 @@ func TestRepository_DefaultBranch(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRepositoryTopics tests whether repo metadata is correctly unmarshalled.
+func TestRepositoryTopics(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := dbmocks.NewMockDBFrom(database.NewDB(logger, dbtest.NewDB(t)))
+
+	testCases := []struct {
+		name      string
+		typesRepo *types.Repo
+		metadata  any
+	}{
+		{
+			name: "GitLab",
+			typesRepo: &types.Repo{
+				Name: api.RepoName("gitlab_repo"),
+				ExternalRepo: api.ExternalRepoSpec{
+					ServiceType: extsvc.TypeGitLab,
+				},
+			},
+			metadata: &gitlab.Project{Topics: []string{"gitlab_topic1", "gitlab_topic2"}},
+		},
+		{
+			name: "GitHub",
+			typesRepo: &types.Repo{
+				Name: api.RepoName("github_repo"),
+				ExternalRepo: api.ExternalRepoSpec{
+					ServiceType: extsvc.TypeGitHub,
+				},
+			},
+			metadata: &github.Repository{
+				RepositoryTopics: github.RepositoryTopics{
+					Nodes: []github.RepositoryTopic{
+						{
+							Topic: github.Topic{
+								Name: "github_topic1",
+							},
+						},
+						{
+							Topic: github.Topic{
+								Name: "github_topic2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(tt.metadata)
+			require.NoError(t, err)
+			tt.typesRepo.Metadata = b
+
+			err = db.Repos().Create(ctx, tt.typesRepo)
+			require.NoError(t, err)
+
+			repo, err := db.Repos().GetByName(ctx, tt.typesRepo.Name)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.metadata, repo.Metadata)
+		})
+	}
+}
+
+func TestRepositoryNoMetadata(t *testing.T) {
+	ctx := context.Background()
+	logger := logtest.Scoped(t)
+	db := dbmocks.NewMockDBFrom(database.NewDB(logger, dbtest.NewDB(t)))
+
+	err := db.Repos().Create(ctx, &types.Repo{
+		Name: "github_repo",
+		ExternalRepo: api.ExternalRepoSpec{
+			ServiceType: extsvc.TypeGitHub,
+		},
+	})
+	require.NoError(t, err)
+
+	repo, err := db.Repos().GetByName(ctx, "github_repo")
+	require.NoError(t, err)
+
+	require.Equal(t, &github.Repository{}, repo.Metadata)
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3956,6 +3956,11 @@ type Repository implements Node & GenericSearchResultInterface {
     metadata: [KeyValuePair!]!
 
     """
+    A list of GitHub or GitLab topics associated with the repo.
+    """
+    topics: [String!]!
+
+    """
     The size of repo when cloned on disk
     """
     diskSizeBytes: BigInt

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -461,6 +461,7 @@ func fromRepository(rm *result.RepoMatch, repoCache map[api.RepoID]*types.Search
 		repoEvent.Archived = r.Archived
 		repoEvent.Private = r.Private
 		repoEvent.Metadata = r.KeyValuePairs
+		repoEvent.Topics = r.Topics
 	}
 
 	return repoEvent

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -1337,6 +1337,9 @@ func TestRepos_List_topics(t *testing.T) {
 					ghr.RepositoryTopics.Nodes = append(ghr.RepositoryTopics.Nodes, github.RepositoryTopic{
 						Topic: github.Topic{Name: topic},
 					})
+					// In production, topics are only set on read. Here we add them manually to be
+					// able to compare them with the repos returned by the db.
+					r.Topics = append(r.Topics, topic)
 				}
 			}
 		}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -109,6 +109,7 @@ type EventRepoMatch struct {
 	Archived           bool               `json:"archived,omitempty"`
 	Private            bool               `json:"private,omitempty"`
 	Metadata           map[string]*string `json:"metadata,omitempty"`
+	Topics             []string           `json:"topics,omitempty"`
 }
 
 func (e *EventRepoMatch) eventMatch() {}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"reflect"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 
 	"github.com/google/uuid"
 
@@ -83,6 +84,8 @@ type Repo struct {
 	Blocked *RepoBlock `json:",omitempty"`
 	// KeyValuePairs is the set of key-value pairs associated with the repo
 	KeyValuePairs map[string]*string `json:",omitempty"`
+	// Topics synced from GitHub or GitLab
+	Topics []string
 }
 
 func (r *Repo) IDName() RepoIDName {
@@ -132,7 +135,7 @@ type SearchedRepo struct {
 	LastFetched *time.Time
 	// A set of key-value pairs associated with the repo
 	KeyValuePairs map[string]*string
-	// Topics contains the topics synced from GitHub or GitLab.
+	// Topics synced from GitHub or GitLab
 	Topics []string
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -132,6 +132,8 @@ type SearchedRepo struct {
 	LastFetched *time.Time
 	// A set of key-value pairs associated with the repo
 	KeyValuePairs map[string]*string
+	// Topics contains the topics synced from GitHub or GitLab.
+	Topics []string
 }
 
 // RepoBlock contains data about a repo that has been blocked. Blocked repos aren't returned by store methods by default.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -85,7 +85,7 @@ type Repo struct {
 	// KeyValuePairs is the set of key-value pairs associated with the repo
 	KeyValuePairs map[string]*string `json:",omitempty"`
 	// Topics synced from GitHub or GitLab
-	Topics []string
+	Topics []string `json:",omitempty"`
 }
 
 func (r *Repo) IDName() RepoIDName {


### PR DESCRIPTION
Currently, we sync topics from GitHub and GitLab and it is possible to
filter repositories by their topics with the `repo:has.topic` filter.

However, unlike user-added metadata, the synced topics are not visible in the UI,
neither for repo matches nor on the repo tree page. This means it is impossible 
for users to figure out which topics they can filter by.

With this PR we display topics, such as "language" or "golang", in addition to 
metadata (EG `fruit:banana`) for repo matches and on the repo tree page (see screenshots).

**Search results**
<img width="891" alt="Screenshot 2023-12-15 at 12 44 54" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/88c49a90-95eb-44fc-8c2c-158d635e07dc">

**Repository tree page (right panel)**
<img width="1239" alt="Screenshot 2023-12-15 at 12 45 03" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/a7b7d0ce-7de2-4fac-926b-3a4339599a6c">

## Test plan

Note: Our search language distinguishes between user provided metadata (has.meta) and automatically synced metadata (has.topic). 

- manual testing
  - I checked that clicking on a "topic" badge adds a "has.topic" filter, while clicking on a "metadata" badge add a "has.meta" filter
  - Adding and deleting metadata works like before
  - Topics and metadata are sorted alphabetically
  - Results without metadata or topics are displayed correctly
- added new unit test
