### PR TITLE
fix(sg): start Caddy admin server before `caddy trust`

### DIFF
--- a/dev/caddy.sh
+++ b/dev/caddy.sh
@@ -29,4 +29,6 @@ chmod +x "${target}"
 
 popd >/dev/null
 
-exec "${target}" "$@"
+trap '${target} stop' EXIT SIGINT
+eval "${target} start"
+"${target}" "$@"


### PR DESCRIPTION
This MR addresses #58926.  
The changes ensure the Caddy admin server is running before calling another `caddy [command]`.

I also replaced `exec` with `eval`, as that allowed using `trap` while staying in the current shell session.

<details><summary>Before</summary>

Commit [`57166ea80caa7e2eb7d9c8134b35c47997a0835c`](https://github.com/bevzzz/sourcegraph/commit/57166ea80caa7e2eb7d9c8134b35c47997a0835c)

![before](https://github.com/sourcegraph/sourcegraph/assets/53943884/a20c0af3-4ab3-4a95-a7f1-dee6d17bba17)

</details>


<details><summary>After</summary>

![after](https://github.com/sourcegraph/sourcegraph/assets/53943884/e26d1b44-265f-4976-b96a-65ae2f01b3ea)

</details>

## Test plan

Manually, since most of the logic is still in `caddy.sh` and, as far as I can tell, the script is not used in production.

1. Configure the "initial" state for anyone running `sg setup` for the first time:
- Run  `caddy untrust` to remove the root certificate from your local trust store
- Run ` caddy stop` to make sure the  Caddy admin server is not running (`curl localhost:2019` should exit with `curl: (7) Failed to connect`)

2. Run `sg setup` and wait for Caddy check to fail, then see available fixes `[8]`
3. Opt for automatic resolution `[1]`

The fix should succeed (unlike in the **Before** screen recording).


P.S.: following the [`sg` vision](https://docs.sourcegraph.com/dev/background-information/sg/vision#principles), I also looked into replacing the `caddy.sh` script with a Go equivalent, but did not find a stable public API in the `caddyserver/caddy` package for some commands (e.g. [`caddy trust`](https://sourcegraph.com/github.com/caddyserver/caddy/-/blob/modules/caddypki/command.go?L102) is not exposed and copying  a lot of what looks like internal logic did not feel quite right atm).   
Additionally, there's this ongoing discussion in #25438 about using binaries in `sg`, which might result in an altogether different solution.