### PR TITLE
Gitlab Native integration: Fix code element target selector

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/domFunctions.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/domFunctions.ts
@@ -9,7 +9,9 @@ const getSingleFileCodeElementFromLineNumber = (
 ): HTMLElement | null => codeView.querySelector<HTMLElement>(`#LC${line}`)
 
 export const singleFileDOMFunctions: DOMFunctions = {
-    getCodeElementFromTarget: target => target.closest('div.line'),
+    // We have to support div-like line markup and span-like line markup since
+    // different GitLab versions have different code layout markup.
+    getCodeElementFromTarget: target => target.closest('div.line, span.line'),
     getLineNumberFromCodeElement: codeElement => {
         const line = codeElement.id.replace(/^LC/, '')
         return parseInt(line, 10)

--- a/client/browser/src/shared/code-hosts/gitlab/domFunctions.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/domFunctions.ts
@@ -7,8 +7,9 @@ const getSingleFileCodeElementFromLineNumber = (
     line: number,
     part?: DiffPart
 ): HTMLElement | null => codeView.querySelector<HTMLElement>(`#LC${line}`)
+
 export const singleFileDOMFunctions: DOMFunctions = {
-    getCodeElementFromTarget: target => target.closest('span.line'),
+    getCodeElementFromTarget: target => target.closest('div.line'),
     getLineNumberFromCodeElement: codeElement => {
         const line = codeElement.id.replace(/^LC/, '')
         return parseInt(line, 10)


### PR DESCRIPTION
Thanks to @taras-yemets this PR fixes code target selector since Gitlab changed their markup about code blocks recently. 

## Test plan
- Check that code intel tooltip shows up in Gitlab code view

