### PR TITLE
Gitlab Native integration: Fix code element target selector (#58931)

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/domFunctions.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/domFunctions.ts
@@ -7,8 +7,11 @@ const getSingleFileCodeElementFromLineNumber = (
     line: number,
     part?: DiffPart
 ): HTMLElement | null => codeView.querySelector<HTMLElement>(`#LC${line}`)
+
 export const singleFileDOMFunctions: DOMFunctions = {
-    getCodeElementFromTarget: target => target.closest('span.line'),
+    // We have to support div-like line markup and span-like line markup since
+    // different GitLab versions have different code layout markup.
+    getCodeElementFromTarget: target => target.closest('div.line, span.line'),
     getLineNumberFromCodeElement: codeElement => {
         const line = codeElement.id.replace(/^LC/, '')
         return parseInt(line, 10)


### PR DESCRIPTION
* Fix code element target selector
* Support div and span like lines

(cherry picked from commit 9b829847b91d907e54bbba4347fd03bc3bc7ec52)

## Test plan
- CI is passing

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
