### PR TITLE
graphqlbackend/telemetry: allow client-provided timestamp in events

### DIFF
--- a/cmd/frontend/graphqlbackend/telemetry.go
+++ b/cmd/frontend/graphqlbackend/telemetry.go
@@ -2,6 +2,8 @@ package graphqlbackend
 
 import (
 	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 // TelemetryRootResolver provides TelemetryResolver via field 'telemetry' as
@@ -19,6 +21,7 @@ type RecordEventArgs struct{ Event TelemetryEventInput }
 type RecordEventsArgs struct{ Events []TelemetryEventInput }
 
 type TelemetryEventInput struct {
+	Timestamp         *gqlutil.DateTime                     `json:"timestamp"`
 	Feature           string                                `json:"feature"`
 	Action            string                                `json:"action"`
 	Source            TelemetryEventSourceInput             `json:"source"`

--- a/cmd/frontend/graphqlbackend/telemetry.graphql
+++ b/cmd/frontend/graphqlbackend/telemetry.graphql
@@ -24,6 +24,13 @@ Properties comprising a telemetry V2 event that can be reported by a client.
 """
 input TelemetryEventInput {
     """
+    Timestamp at which the time was recorded. If not provided, a timestamp is
+    generated when the server receives the event, but this does not guarantee
+    consistent ordering or accuracy.
+    """
+    timestamp: DateTime
+
+    """
     Feature associated with the event in camelCase, e.g. 'myFeature'.
 
     Feature names must come from a static set of values in libraries - it is

--- a/cmd/frontend/graphqlbackend/telemetry.graphql
+++ b/cmd/frontend/graphqlbackend/telemetry.graphql
@@ -27,6 +27,8 @@ input TelemetryEventInput {
     Timestamp at which the time was recorded. If not provided, a timestamp is
     generated when the server receives the event, but this does not guarantee
     consistent ordering or accuracy.
+
+    This parameter is only available in Sourcegraph 5.2.5 and later.
     """
     timestamp: DateTime
 

--- a/cmd/frontend/internal/telemetry/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/telemetry/resolvers/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_google_protobuf//types/known/structpb",
+        "@org_golang_google_protobuf//types/known/timestamppb",
     ],
 )
 
@@ -28,6 +29,7 @@ go_test(
     deps = [
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
+        "@com_github_graph_gophers_graphql_go//:graphql-go",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/cmd/frontend/internal/telemetry/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/telemetry/resolvers/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
     deps = [
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
-        "@com_github_graph_gophers_graphql_go//:graphql-go",
+        "//internal/gqlutil",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1"
@@ -23,6 +24,10 @@ func newTelemetryGatewayEvents(
 	gatewayEvents := make([]*telemetrygatewayv1.Event, len(gqlEvents))
 	for i, gqlEvent := range gqlEvents {
 		event := telemetrygatewayv1.NewEventWithDefaults(ctx, now, newUUID)
+
+		if gqlEvent.Timestamp != nil {
+			event.Timestamp = timestamppb.New(gqlEvent.Timestamp.Time)
+		}
 
 		event.Feature = gqlEvent.Feature
 		event.Action = gqlEvent.Action

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/graph-gophers/graphql-go"
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -201,6 +202,28 @@ func TestNewTelemetryGatewayEvents(t *testing.T) {
     }
   },
   "timestamp": "2023-02-24T14:48:30Z"
+}`),
+		},
+		{
+			name: "with custom timestamp",
+			ctx:  context.Background(),
+			event: graphqlbackend.TelemetryEventInput{
+				Timestamp: &graphql.Time{Time: staticTime.Add(48 * time.Hour)},
+				Feature:   "Feature",
+				Action:    "Example",
+			},
+			expect: autogold.Expect(`{
+  "action": "Example",
+  "feature": "Feature",
+  "id": "with custom timestamp",
+  "parameters": {},
+  "source": {
+    "client": {},
+    "server": {
+      "version": "0.0.0+dev"
+    }
+  },
+  "timestamp": "2023-02-26T14:48:30Z"
 }`),
 		},
 	} {

--- a/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
+++ b/cmd/frontend/internal/telemetry/resolvers/telemetrygateway_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/graph-gophers/graphql-go"
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 )
 
 func TestNewTelemetryGatewayEvents(t *testing.T) {
@@ -208,7 +208,7 @@ func TestNewTelemetryGatewayEvents(t *testing.T) {
 			name: "with custom timestamp",
 			ctx:  context.Background(),
 			event: graphqlbackend.TelemetryEventInput{
-				Timestamp: &graphql.Time{Time: staticTime.Add(48 * time.Hour)},
+				Timestamp: &gqlutil.DateTime{Time: staticTime.Add(48 * time.Hour)},
 				Feature:   "Feature",
 				Action:    "Example",
 			},


### PR DESCRIPTION
Generating the timestamp serverside can cause client-generated events to appear out-of-order, and in general will have a gap between when an event actually occurred and the timestamp that gets persisted.

This change only fixes it for V2 telemetry - the V1 `logEvent` mutation doesn't accept a timestamp, and while the V1 `logEvents` GraphQL schema does accept a timestamp, [the resolver input implementation does not use it](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/user_usage_stats.go?L85:1-109:2).

I will update https://github.com/sourcegraph/telemetry after this PR, and add handling to VSCode.

## Test plan

Unit tests