### PR TITLE
Add URL param checking to all event types, not just page view events

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -165,9 +165,21 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         if (window.context?.userAgentIsBot || !eventLabel) {
             return
         }
+
+        this.logInternal(eventLabel, eventProperties, publicArgument)
+
+        // Use flag to ensure URL query params are only stripped once
+        if (!this.hasStrippedQueryParameters) {
+            handleQueryEvents(window.location.href)
+            this.hasStrippedQueryParameters = true
+        }
+    }
+
+    public logInternal(eventLabel: string, eventProperties?: any, publicArgument?: any): void {
         serverAdmin.trackAction(eventLabel, eventProperties, publicArgument)
         this.logToConsole(eventLabel, eventProperties, publicArgument)
     }
+
 
     private logToConsole(eventLabel: string, eventProperties?: any, publicArgument?: any): void {
         if (debugEventLoggingEnabled()) {
@@ -241,12 +253,12 @@ function handleQueryEvents(url: string): void {
     const parsedUrl = new URL(url)
     if (parsedUrl.searchParams.has('signup')) {
         const args = { serviceType: parsedUrl.searchParams.get('signup') || '' }
-        eventLogger.log('web:auth:signUpCompleted', args, args)
+        eventLogger.logInternal('web:auth:signUpCompleted', args, args)
     }
 
     if (parsedUrl.searchParams.has('signin')) {
         const args = { serviceType: parsedUrl.searchParams.get('signin') || '' }
-        eventLogger.log('web:auth:signInCompleted', args, args)
+        eventLogger.logInternal('web:auth:signInCompleted', args, args)
     }
 
     stripURLParameters(url, ['utm_campaign', 'utm_source', 'utm_medium', 'signup', 'signin'])

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -180,7 +180,6 @@ export class EventLogger implements TelemetryService, SharedEventLogger {
         this.logToConsole(eventLabel, eventProperties, publicArgument)
     }
 
-
     private logToConsole(eventLabel: string, eventProperties?: any, publicArgument?: any): void {
         if (debugEventLoggingEnabled()) {
             logger.debug('%cEVENT %s', 'color: #aaa', eventLabel, eventProperties, publicArgument)


### PR DESCRIPTION
Currently we only [log post-auth events from the frontend](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@fe5f100efdb631a53c0ea104af72224ec718ff88/-/blob/client/web/src/tracking/eventLogger.ts?L240-253) when a view event is called. However, we recently discovered that some pages have been added that don't call view events (e.g. [here's an example of "fixing" one](https://github.com/sourcegraph/sourcegraph/pull/57957)).

This PR makes it so that any logged events trigger the appropriate checks.

## Test plan

Tested locally