### PR TITLE
msp: Add alerts if Redis is configured

### DIFF
--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     visibility = ["//dev/managedservicesplatform:__subpackages__"],
     deps = [
         "//dev/managedservicesplatform/internal/resourceid",
-        "//dev/managedservicesplatform/spec",
         "//lib/errors",
         "//lib/pointers",
         "@com_github_aws_constructs_go_constructs_v10//:constructs",

--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy_test.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy_test.go
@@ -18,7 +18,7 @@ func TestBuildFilter(t *testing.T) {
 			name: "Service Metric",
 			config: Config{
 				ServiceName: "my-service-name",
-				ServiceKind: "service",
+				ServiceKind: CloudRunService,
 				ThresholdAggregation: &ThresholdAggregation{
 					Filters: map[string]string{
 						"metric.type": "run.googleapis.com/container/startup_latencies",
@@ -31,7 +31,7 @@ func TestBuildFilter(t *testing.T) {
 			name: "Job Metric",
 			config: Config{
 				ServiceName: "my-job-name",
-				ServiceKind: "job",
+				ServiceKind: CloudRunJob,
 				ThresholdAggregation: &ThresholdAggregation{
 					Filters: map[string]string{
 						"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",

--- a/dev/managedservicesplatform/internal/resource/redis/redis.go
+++ b/dev/managedservicesplatform/internal/resource/redis/redis.go
@@ -15,6 +15,7 @@ import (
 )
 
 type Output struct {
+	ID          *string
 	Endpoint    string
 	Certificate gsmsecret.Output
 }
@@ -64,5 +65,6 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 		Endpoint: fmt.Sprintf("rediss://:%s@%s:%v",
 			*redis.AuthString(), *redis.Host(), *redis.Port()),
 		Certificate: *redisCACert,
+		ID:          redis.Id(),
 	}, nil
 }

--- a/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
@@ -37,7 +37,7 @@ import (
 )
 
 type CrossStackOutput struct {
-	RedisID *string
+	RedisInstanceID *string
 }
 
 type Variables struct {
@@ -146,7 +146,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 	// redisInstance is only created and non-nil if Redis is configured for the
 	// environment.
 	// If Redis is configured, populate cross-stack output with Redis ID.
-	var redisID *string
+	var redisInstanceID *string
 	if vars.Environment.Resources != nil && vars.Environment.Resources.Redis != nil {
 		redisInstance, err := redis.New(stack,
 			resourceid.New("redis"),
@@ -160,7 +160,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 			return nil, errors.Wrap(err, "failed to render Redis instance")
 		}
 
-		redisID = redisInstance.ID
+		redisInstanceID = redisInstance.ID
 
 		// Configure endpoint string.
 		cloudRunBuilder.AddEnv("REDIS_ENDPOINT", redisInstance.Endpoint)
@@ -267,7 +267,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 	locals.Add("image_tag", imageTag.StringValue,
 		"Resolved tag of service image to deploy")
 	return &CrossStackOutput{
-		RedisID: redisID,
+		RedisInstanceID: redisInstanceID,
 	}, nil
 }
 

--- a/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
@@ -36,7 +36,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
-type CrossStackOutput struct{}
+type CrossStackOutput struct {
+	RedisID *string
+}
 
 type Variables struct {
 	ProjectID                      string
@@ -143,6 +145,8 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 
 	// redisInstance is only created and non-nil if Redis is configured for the
 	// environment.
+	// If Redis is configured, populate cross-stack output with Redis ID.
+	var redisID *string
 	if vars.Environment.Resources != nil && vars.Environment.Resources.Redis != nil {
 		redisInstance, err := redis.New(stack,
 			resourceid.New("redis"),
@@ -155,6 +159,8 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to render Redis instance")
 		}
+
+		redisID = redisInstance.ID
 
 		// Configure endpoint string.
 		cloudRunBuilder.AddEnv("REDIS_ENDPOINT", redisInstance.Endpoint)
@@ -260,7 +266,9 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 	// Collect outputs
 	locals.Add("image_tag", imageTag.StringValue,
 		"Resolved tag of service image to deploy")
-	return &CrossStackOutput{}, nil
+	return &CrossStackOutput{
+		RedisID: redisID,
+	}, nil
 }
 
 type envVariablesData struct {

--- a/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
@@ -56,6 +56,9 @@ type Variables struct {
 	Service    spec.ServiceSpec
 	Monitoring spec.MonitoringSpec
 	MaxCount   *int
+
+	// If Redis is enabled we configure alerts for it
+	RedisID *string
 }
 
 const StackName = "monitoring"
@@ -67,38 +70,47 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	}
 
 	id := resourceid.New("monitoring")
-	err = commonAlerts(stack, id, vars)
+	err = commonAlerts(stack, id.Group("common"), vars)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create common alerts")
 	}
 
 	switch pointers.Deref(vars.Service.Kind, spec.ServiceKindService) {
 	case spec.ServiceKindService:
-		err = serviceAlerts(stack, id, vars)
-		if err != nil {
+		if err = serviceAlerts(stack, id.Group("service"), vars); err != nil {
 			return nil, errors.Wrap(err, "failed to create service alerts")
 		}
 
 		if vars.Monitoring.Alerts.ResponseCodeRatios != nil {
-			err = responseCodeMetrics(stack, id, vars)
-		}
-
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create response code metrics")
+			if err = responseCodeMetrics(stack, id.Group("response-code"), vars); err != nil {
+				return nil, errors.Wrap(err, "failed to create response code metrics")
+			}
 		}
 	case spec.ServiceKindJob:
-		err = jobAlerts(stack, id, vars)
-		if err != nil {
+		if err = jobAlerts(stack, id.Group("job"), vars); err != nil {
 			return nil, errors.Wrap(err, "failed to create job alerts")
 		}
 	default:
 		return nil, errors.New("unknown service kind")
 	}
 
+	if vars.RedisID != nil {
+		if err = redisAlerts(stack, id.Group("redis"), vars); err != nil {
+			return nil, errors.Wrap(err, "failed to create redis alerts")
+		}
+	}
+
 	return &CrossStackOutput{}, nil
 }
 
 func commonAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
+	// Convert a spec.ServiceKind into a monitoringalertpolicy.ServiceKind
+	serviceKind := monitoringalertpolicy.CloudRunService
+	kind := pointers.Deref(vars.Service.Kind, "service")
+	if kind == spec.ServiceKindJob {
+		serviceKind = monitoringalertpolicy.CloudRunJob
+	}
+
 	for _, config := range []monitoringalertpolicy.Config{
 		{
 			ID:          "cpu",
@@ -140,9 +152,8 @@ func commonAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) 
 
 		config.ProjectID = vars.ProjectID
 		config.ServiceName = vars.Service.ID
-		config.ServiceKind = pointers.Deref(vars.Service.Kind, "service")
-		_, err := monitoringalertpolicy.New(stack, id, &config)
-		if err != nil {
+		config.ServiceKind = serviceKind
+		if _, err := monitoringalertpolicy.New(stack, id, &config); err != nil {
 			return err
 		}
 	}
@@ -153,21 +164,20 @@ func commonAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) 
 func serviceAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
 	// Only provision if MaxCount is specified above 5
 	if pointers.Deref(vars.MaxCount, 0) > 5 {
-		_, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
+		if _, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
 			ID:          "instance_count",
 			Name:        "Container Instance Count",
 			Description: pointers.Ptr("There are a lot of Cloud Run instances running - we may need to increase per-instance requests make make sure we won't hit the configured max instance count"),
 			ProjectID:   vars.ProjectID,
 			ServiceName: vars.Service.ID,
-			ServiceKind: spec.ServiceKindService,
+			ServiceKind: monitoringalertpolicy.CloudRunService,
 			ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
 				Filters: map[string]string{"metric.type": "run.googleapis.com/container/instance_count"},
 				Aligner: monitoringalertpolicy.MonitoringAlignMax,
 				Reducer: monitoringalertpolicy.MonitoringReduceMax,
 				Period:  "60s",
 			},
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}
@@ -176,26 +186,25 @@ func serviceAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables)
 
 func jobAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
 	// Alert whenever a Cloud Run Job fails
-	_, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
+	if _, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
 		ID:          "job_failures",
 		Name:        "Cloud Run Job Failures",
 		Description: pointers.Ptr("Failed executions of Cloud Run Job"),
 		ProjectID:   vars.ProjectID,
 		ServiceName: vars.Service.ID,
-		ServiceKind: spec.ServiceKindJob,
+		ServiceKind: monitoringalertpolicy.CloudRunJob,
 		ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
 			Filters: map[string]string{
 				"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
 				"metric.labels.result": "failed",
 			},
-			GroupByField: "metric.label.result",
-			Aligner:      monitoringalertpolicy.MonitoringAlignCount,
-			Reducer:      monitoringalertpolicy.MonitoringReduceSum,
-			Period:       "60s",
-			Threshold:    0,
+			GroupByFields: []string{"metric.label.result"},
+			Aligner:       monitoringalertpolicy.MonitoringAlignCount,
+			Reducer:       monitoringalertpolicy.MonitoringReduceSum,
+			Period:        "60s",
+			Threshold:     0,
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -205,12 +214,12 @@ func jobAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) err
 func responseCodeMetrics(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
 	for _, config := range vars.Monitoring.Alerts.ResponseCodeRatios {
 
-		_, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
+		if _, err := monitoringalertpolicy.New(stack, id, &monitoringalertpolicy.Config{
 			ID:          config.ID,
 			ProjectID:   vars.ProjectID,
 			Name:        config.Name,
 			ServiceName: vars.Service.ID,
-			ServiceKind: spec.ServiceKindService,
+			ServiceKind: monitoringalertpolicy.CloudRunService,
 			ResponseCodeMetric: &monitoringalertpolicy.ResponseCodeMetric{
 				Code:         config.Code,
 				CodeClass:    config.CodeClass,
@@ -218,8 +227,59 @@ func responseCodeMetrics(stack cdktf.TerraformStack, id resourceid.ID, vars Vari
 				Ratio:        config.Ratio,
 				Duration:     config.Duration,
 			},
-		})
-		if err != nil {
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func redisAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) error {
+	for _, config := range []monitoringalertpolicy.Config{
+		{
+			ID:          "memory",
+			Name:        "Cloud Redis - System Memory Utilization",
+			Description: pointers.Ptr("This alert fires if the system memory utilization is above the set threshold. The utilization is measured on a scale of 0 to 1."),
+			ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
+				Filters:   map[string]string{"metric.type": "redis.googleapis.com/stats/memory/system_memory_usage_ratio"},
+				Aligner:   monitoringalertpolicy.MonitoringAlignMean,
+				Reducer:   monitoringalertpolicy.MonitoringReduceNone,
+				Period:    "300s",
+				Threshold: 0.8,
+			},
+		},
+		{
+			ID:          "cpu",
+			Name:        "Cloud Redis - System CPU Utilization",
+			Description: pointers.Ptr("This alert fires if the Redis Engine CPU Utilization goes above the set threshold. The utilization is measured on a scale of 0 to 1."),
+			ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
+				Filters:       map[string]string{"metric.type": "redis.googleapis.com/stats/cpu_utilization_main_thread"},
+				GroupByFields: []string{"resource.label.instance_id", "resource.label.node_id"},
+				Aligner:       monitoringalertpolicy.MonitoringAlignRate,
+				Reducer:       monitoringalertpolicy.MonitoringReduceSum,
+				Period:        "300s",
+				Threshold:     0.9,
+			},
+		},
+		{
+			ID:          "failover",
+			Name:        "Cloud Redis - Standard Instance Failover",
+			Description: pointers.Ptr("This alert fires if failover occurs for a standard tier instance."),
+			ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
+				Filters:       map[string]string{"metric.type": "redis.googleapis.com/stats/cpu_utilization_main_thread"},
+				GroupByFields: []string{"resource.label.instance_id", "resource.label.node_id"},
+				Aligner:       monitoringalertpolicy.MonitoringAlignStddev,
+				Reducer:       monitoringalertpolicy.MonitoringReduceNone,
+				Period:        "300s",
+				Threshold:     0,
+			},
+		},
+	} {
+		config.ProjectID = vars.ProjectID
+		config.ServiceName = *vars.RedisID
+		config.ServiceKind = monitoringalertpolicy.CloudRedis
+		if _, err := monitoringalertpolicy.New(stack, id, &config); err != nil {
 			return err
 		}
 	}

--- a/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
@@ -58,7 +58,7 @@ type Variables struct {
 	MaxCount   *int
 
 	// If Redis is enabled we configure alerts for it
-	RedisID *string
+	RedisInstanceID *string
 }
 
 const StackName = "monitoring"
@@ -94,7 +94,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 		return nil, errors.New("unknown service kind")
 	}
 
-	if vars.RedisID != nil {
+	if vars.RedisInstanceID != nil {
 		if err = redisAlerts(stack, id.Group("redis"), vars); err != nil {
 			return nil, errors.Wrap(err, "failed to create redis alerts")
 		}
@@ -277,7 +277,7 @@ func redisAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) e
 		},
 	} {
 		config.ProjectID = vars.ProjectID
-		config.ServiceName = *vars.RedisID
+		config.ServiceName = *vars.RedisInstanceID
 		config.ServiceKind = monitoringalertpolicy.CloudRedis
 		if _, err := monitoringalertpolicy.New(stack, id, &config); err != nil {
 			return err

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -108,7 +108,7 @@ func (r *Renderer) RenderEnvironment(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create IAM stack")
 	}
-	if _, err := cloudrun.NewStack(stacks, cloudrun.Variables{
+	cloudrunOutput, err := cloudrun.NewStack(stacks, cloudrun.Variables{
 		ProjectID:                      *projectOutput.Project.ProjectId(),
 		CloudRunWorkloadServiceAccount: iamOutput.CloudRunWorkloadServiceAccount,
 
@@ -117,7 +117,8 @@ func (r *Renderer) RenderEnvironment(
 		Environment: env,
 
 		StableGenerate: r.StableGenerate,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, errors.Wrap(err, "failed to create cloudrun stack")
 	}
 
@@ -131,6 +132,7 @@ func (r *Renderer) RenderEnvironment(
 			}
 			return nil
 		}(),
+		RedisID: cloudrunOutput.RedisID,
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to create monitoring stack")
 	}

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -132,7 +132,7 @@ func (r *Renderer) RenderEnvironment(
 			}
 			return nil
 		}(),
-		RedisID: cloudrunOutput.RedisID,
+		RedisInstanceID: cloudrunOutput.RedisInstanceID,
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to create monitoring stack")
 	}

--- a/dev/managedservicesplatform/spec/monitoring.go
+++ b/dev/managedservicesplatform/spec/monitoring.go
@@ -38,7 +38,16 @@ type ResponseCodeRatioSpec struct {
 
 func (s *MonitoringAlertsSpec) Validate() []error {
 	var errs []error
+	// Use map to contain seen IDs to ensure uniqueness
+	ids := make(map[string]struct{})
 	for _, r := range s.ResponseCodeRatios {
+		if r.ID == "" {
+			errs = append(errs, errors.New("responseCodeRatios[].id is required and cannot be empty"))
+		}
+		if _, ok := ids[r.ID]; ok {
+			errs = append(errs, errors.Newf("response code alert IDs must be unique, found duplicate ID: %s", r.ID))
+		}
+		ids[r.ID] = struct{}{}
 		errs = append(errs, r.Validate()...)
 	}
 	return errs

--- a/lib/pointers/ptr.go
+++ b/lib/pointers/ptr.go
@@ -53,3 +53,13 @@ func Float64[T numberType](v T) *float64 {
 func Stringf(format string, a ...any) *string {
 	return Ptr(fmt.Sprintf(format, a...))
 }
+
+// Slice takes a slice of values and turns it into a slice of pointers.
+func Slice[S []V, V any](s S) []*V {
+	slice := make([]*V, len(s))
+	for i, v := range s {
+		v := v // copy
+		slice[i] = &v
+	}
+	return slice
+}

--- a/lib/pointers/ptr_test.go
+++ b/lib/pointers/ptr_test.go
@@ -203,3 +203,11 @@ func TestDeref(t *testing.T) {
 		runDerefTest(t, tc)
 	}
 }
+
+func TestSlice(t *testing.T) {
+	values := []string{"1", "2", "3"}
+	pointified := Slice(values)
+	for i, p := range pointified {
+		assert.Equal(t, values[i], *p)
+	}
+}


### PR DESCRIPTION
Part of 
- https://github.com/sourcegraph/sourcegraph/pull/58816

Adds monitoring alert policies for Redis based on [alerts_redis.tf](https://sourcegraph.sourcegraph.com/github.com/sourcegraph/infrastructure/-/blob/cody-gateway/modules/monitoring/alerts_redis.tf) from Cody Gateway
Redis ID is referenced using a cross stack output. Example here from the generated output `resource.labels.redis_instance_id = \"${data.terraform_remote_state.cross-stack-reference-input-cloudrun.outputs.cross-stack-output-google_redis_instanceredis-instanceid}\"`

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
CI + viewing generated terraform cdtkf - has not been tested live