### PR TITLE
Searcher: factor out structural search logic

### DIFF
--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -210,7 +210,7 @@ func benchSearchRegex(b *testing.B, p *protocol.Request) {
 	}
 
 	ctx := context.Background()
-	path, err := githubStore.PrepareZip(ctx, p.Repo, p.Commit)
+	path, err := githubStore.PrepareZip(ctx, p.Repo, p.Commit, nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/cmd/searcher/internal/search/store.go
+++ b/cmd/searcher/internal/search/store.go
@@ -139,12 +139,9 @@ func (s *Store) Start() {
 
 // PrepareZip returns the path to a local zip archive of repo at commit.
 // It will first consult the local cache, otherwise will fetch from the network.
-func (s *Store) PrepareZip(ctx context.Context, repo api.RepoName, commit api.CommitID) (path string, err error) {
-	return s.PrepareZipPaths(ctx, repo, commit, nil)
-}
-
-func (s *Store) PrepareZipPaths(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (path string, err error) {
-	tr, ctx := trace.New(ctx, "ArchiveStore.PrepareZipPaths")
+// If paths is non-empty, the archive will only contain files from paths.
+func (s *Store) PrepareZip(ctx context.Context, repo api.RepoName, commit api.CommitID, paths []string) (path string, err error) {
+	tr, ctx := trace.New(ctx, "ArchiveStore.PrepareZip")
 	defer tr.EndWithErr(&err)
 
 	var cacheHit bool

--- a/cmd/searcher/internal/search/store_test.go
+++ b/cmd/searcher/internal/search/store_test.go
@@ -49,7 +49,7 @@ func TestPrepareZip(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		go func() {
 			<-startPrepareZip
-			_, err := s.PrepareZip(context.Background(), wantRepo, wantCommit)
+			_, err := s.PrepareZip(context.Background(), wantRepo, wantCommit, nil)
 			prepareZipErr <- err
 		}()
 	}
@@ -83,7 +83,7 @@ func TestPrepareZip(t *testing.T) {
 	if !onDisk {
 		t.Fatal("timed out waiting for items to appear in cache at", s.Path)
 	}
-	_, err := s.PrepareZip(context.Background(), wantRepo, wantCommit)
+	_, err := s.PrepareZip(context.Background(), wantRepo, wantCommit, nil)
 	if err != nil {
 		t.Fatal("expected PrepareZip to succeed:", err)
 	}
@@ -95,7 +95,7 @@ func TestPrepareZip_fetchTarFail(t *testing.T) {
 	s.FetchTar = func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 		return nil, fetchErr
 	}
-	_, err := s.PrepareZip(context.Background(), "foo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	_, err := s.PrepareZip(context.Background(), "foo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", nil)
 	if !errors.Is(err, fetchErr) {
 		t.Fatalf("expected PrepareZip to fail with %v, failed with %v", fetchErr, err)
 	}
@@ -109,7 +109,7 @@ func TestPrepareZip_fetchTarReaderErr(t *testing.T) {
 		w.CloseWithError(fetchErr)
 		return r, nil
 	}
-	_, err := s.PrepareZip(context.Background(), "foo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	_, err := s.PrepareZip(context.Background(), "foo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", nil)
 	if !errors.Is(err, fetchErr) {
 		t.Fatalf("expected PrepareZip to fail with %v, failed with %v", fetchErr, err)
 	}
@@ -128,7 +128,7 @@ func TestPrepareZip_errHeader(t *testing.T) {
 		}
 		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 	}
-	_, err := s.PrepareZip(context.Background(), "foo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	_, err := s.PrepareZip(context.Background(), "foo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", nil)
 	if have, want := errors.Cause(err).Error(), tar.ErrHeader.Error(); have != want {
 		t.Fatalf("expected PrepareZip to fail with tar.ErrHeader, failed with %v", err)
 	}

--- a/cmd/searcher/internal/search/zipcache_test.go
+++ b/cmd/searcher/internal/search/zipcache_test.go
@@ -19,7 +19,7 @@ func TestZipCacheDelete(t *testing.T) {
 	}
 
 	// Grab a zip.
-	path, err := s.PrepareZip(context.Background(), "somerepo", "0123456789012345678901234567890123456789")
+	path, err := s.PrepareZip(context.Background(), "somerepo", "0123456789012345678901234567890123456789", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Searcher's entrypoint method handles delegating to standard unindexed search
vs. structural search. This change consolidates the structural search logic to
make this method easier to follow

Specific changes:
* Create new function `Service.getZipFile`
* Consolidate structural search logic
* Remove redundant method `Store.PrepareZip`

## Test plan

Refactor is covered by existing unit tests