### PR TITLE
client: Avoid complex tokenization in ref panel code

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
+++ b/client/shared/src/codeintel/legacy-extensions/language-specs/languages.ts
@@ -377,6 +377,8 @@ const zigSpec: LanguageSpec = {
  *
  * The set of languages come from https://madnight.github.io/githut/#/pull_requests/2018/4 (with additions)
  * The language names come from https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers.
+ *
+ * @deprecated See FIXME(id: language-detection)
  */
 export const languageSpecs: LanguageSpec[] = [
     apexSpec,
@@ -425,6 +427,8 @@ export const languageSpecs: LanguageSpec[] = [
 /**
  * Returns the language spec with the given language identifier. If no language
  * matches is configured with the given identifier an error is thrown.
+ *
+ * @deprecated See FIXME(id: language-detection)
  */
 export function findLanguageSpec(languageID: string): LanguageSpec | undefined {
     return languageSpecs.find(spec => spec.languageID === languageID || spec.additionalLanguages?.includes(languageID))

--- a/client/shared/src/languages.ts
+++ b/client/shared/src/languages.ts
@@ -3,9 +3,22 @@ import { basename } from 'path'
 /** The LSP mode used for plain text files and all other unrecognized files. */
 const PLAINTEXT_MODE = 'plaintext'
 
+// FIXME(id: language-detection)
+//
+// For correctness, we should do language detection on the server
+// and use the inferred language on the client instead of incorrectly
+// doing language detection on the client using incomplete information
+// like file extensions.
+//
+// For example, MATLAB and Objective-C both use the '.m' file extension.
+//
+// See https://github.com/sourcegraph/sourcegraph/issues/56376
+
 /**
  * getModeFromPath returns the LSP mode for the provided file path. If the file path does not correspond to any
  * known mode, 'plaintext' is returned.
+ *
+ * DO NOT introduce new usages of this API. See FIXME(id: language-detection).
  */
 export function getModeFromPath(path: string): string {
     const fileName = basename(path)

--- a/client/shared/src/languages.ts
+++ b/client/shared/src/languages.ts
@@ -18,7 +18,7 @@ const PLAINTEXT_MODE = 'plaintext'
  * getModeFromPath returns the LSP mode for the provided file path. If the file path does not correspond to any
  * known mode, 'plaintext' is returned.
  *
- * DO NOT introduce new usages of this API. See FIXME(id: language-detection).
+ * @deprecated See FIXME(id: language-detection).
  */
 export function getModeFromPath(path: string): string {
     const fileName = basename(path)
@@ -32,6 +32,8 @@ export function getModeFromPath(path: string): string {
  * provided file name (e.g. "dockerfile")
  *
  * Cherry picked from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
+ *
+ * @deprecated See FIXME(id: language-detection)
  */
 function getModeFromExactFilename(fileName: string): string | undefined {
     switch (fileName.toLowerCase()) {
@@ -56,6 +58,8 @@ function getModeFromExactFilename(fileName: string): string | undefined {
  *
  * Cherry picked from https://github.com/isagalaev/highlight.js/tree/master/src/languages
  * and https://github.com/github/linguist/blob/master/lib/linguist/languages.yml.
+ *
+ * @deprecated See FIXME(id: language-detection)
  */
 function getModeFromExtension(extension: string): string | undefined {
     switch (extension.toLowerCase()) {

--- a/client/web/src/codeintel/token.ts
+++ b/client/web/src/codeintel/token.ts
@@ -38,7 +38,7 @@ export function findSearchToken(args: {
     // In the common case, when 'Find references' is triggered through
     // the blob view, the 'end' parameter will be provided.
     if (args.end) {
-        return line.slice(args.start.character, args.end.character + 1)
+        return line.slice(args.start.character, args.end.character)
     }
 
     // For old URLs, have a fallback where we attempt to detect identifier

--- a/client/web/src/codeintel/token.ts
+++ b/client/web/src/codeintel/token.ts
@@ -1,12 +1,3 @@
-/* eslint-disable jsdoc/check-param-names */
-import { flatten } from 'lodash'
-
-import type { BlockCommentStyle } from '@sourcegraph/shared/src/codeintel/legacy-extensions/language-specs/language-spec'
-import { Position, SyntaxKind } from '@sourcegraph/shared/src/codeintel/scip'
-
-import { syntaxHighlight } from '../repo/blob/codemirror/highlight'
-import { getBlobEditView } from '../repo/blob/use-blob-store'
-
 /**
  * The default regex for characters allowed in an identifier. It works well for
  * C-like languages (C/C++, C#, Java, etc.) but not for languages that allow
@@ -14,245 +5,53 @@ import { getBlobEditView } from '../repo/blob/use-blob-store'
  */
 const DEFAULT_IDENT_CHAR_PATTERN = /\w/
 
+export interface ZeroBasedPosition {
+    line: number
+    character: number
+}
+
 /**
- * Extract the token that occurs on the given line at the given position. This will
- * scan the line around the current hover position trying to return the maximal set
- * of characters that appear like a symbol given the identifier pattern.
+ * Extract the token from [start, end) if 'end' is provided, else attempt
+ * to extract a token from 'start' based on common identifier characters,
+ * without any language-specific heuristics.
  *
- * @param args Parameter bag.
+ * If a string is returned, it is guaranteed to be non-empty.
  */
-export function findSearchToken({
-    text,
-    position,
-    lineRegexes,
-    blockCommentStyles,
-    identCharPattern = DEFAULT_IDENT_CHAR_PATTERN,
-}: {
+export function findSearchToken(args: {
     /** The text of the current document. */
     text: string
-    /** The current hover position. */
-    position: { line: number; character: number }
-    /** The patterns that identify line comments. */
-    lineRegexes: RegExp[]
-    /** The patterns that identify block comments. */
-    blockCommentStyles: BlockCommentStyle[]
-    /** The pattern that identifies identifiers in this language. */
-    identCharPattern?: RegExp
-}): { searchToken: string; isString: boolean; isComment: boolean } | undefined {
-    const lines = text.split('\n')
-    const line = lines[position.line]
-    if (line === undefined) {
-        // Weird case where the position is bogus relative to the text
+    start: ZeroBasedPosition
+    end?: ZeroBasedPosition
+}): string | undefined {
+    const lines = args.text.split('\n')
+    if (
+        args.start.line < 0 ||
+        args.start.character < 0 ||
+        args.start.line >= lines.length ||
+        (args.end && (args.end.line !== args.start.line || args.end.character <= args.start.character))
+    ) {
         return undefined
     }
 
-    const view = getBlobEditView()
-    if (view !== null) {
-        const occurrences = view.state.facet(syntaxHighlight).occurrences
-        for (const occurrence of occurrences) {
-            if (
-                occurrence.range.isSingleLine() &&
-                occurrence.range.contains(new Position(position.line, position.character))
-            ) {
-                const text = line.slice(occurrence.range.start.character, occurrence.range.end.character)
-                return {
-                    searchToken: text,
-                    isString: occurrence.kind === SyntaxKind.StringLiteral,
-                    isComment: occurrence.kind === SyntaxKind.Comment,
-                }
-            }
-        }
+    const line = lines[args.start.line]
+
+    // In the common case, when 'Find references' is triggered through
+    // the blob view, the 'end' parameter will be provided.
+    if (args.end) {
+        return line.slice(args.start.character, args.end.character + 1)
     }
 
-    // Scan from the current hover position to the right while the characters
-    // still match the identifier pattern. If no characters match the pattern
-    // then we default to the end of the line.
+    // For old URLs, have a fallback where we attempt to detect identifier
+    // boundaries in a best-effort fashion.
 
     let end = line.length
-    for (let index = position.character; index < line.length; index++) {
-        if (!identCharPattern.test(line[index])) {
+    const start = args.start.character
+    for (let index = start; index < line.length; index++) {
+        if (!DEFAULT_IDENT_CHAR_PATTERN.test(line[index])) {
             end = index
             break
         }
     }
 
-    // Scan from the current hover position to the left while the characters
-    // still match the identifier pattern. If no characters match the pattern
-    // then we default to the start of the line.
-
-    let start = 0
-    for (let index = position.character; index >= 0; index--) {
-        if (!identCharPattern.test(line[index])) {
-            start = index + 1
-            break
-        }
-    }
-
-    if (start >= end) {
-        return undefined
-    }
-
-    return {
-        searchToken: line.slice(start, end),
-        isString: isInsideString({ line: lines[position.line], start, end }),
-        isComment: isInsideComment({ lines, position, start, end, lineRegexes, blockCommentStyles }),
-    }
-}
-
-/**
- * Determine if the identifier matched on the given line occurs within a string.
- *
- * @param args Parameter bag.
- */
-function isInsideString({
-    line,
-    start,
-    end,
-}: {
-    /** The line containing the identifier */
-    line: string
-    /** The offset of the identifier in the target line. */
-    start: number
-    /** The offset and length of the identifier in the target line. */
-    end: number
-}): boolean {
-    return checkMatchIntersection([...line.matchAll(/'.*?'|".*?"/gs)], { start, end })
-}
-
-/**
- * Determine if the identifier matched on the given line occurs within a comment
- * defined by the given line comment and block comment regular expressions.
- *
- * @param args Parameter bag.
- */
-function isInsideComment({
-    lines,
-    position,
-    start,
-    end,
-    blockCommentStyles,
-    lineRegexes,
-}: {
-    /** The text of the current document split into lines. */
-    lines: string[]
-    /** The current hover position. */
-    position: { line: number }
-    /** The offset of the identifier in the target line. */
-    start: number
-    /** The offset and length of the identifier in the target line. */
-    end: number
-    /** The patterns that identify line comments. */
-    lineRegexes: RegExp[]
-    /** The patterns that identify block comments. */
-    blockCommentStyles: BlockCommentStyle[]
-}): boolean {
-    const line = lines[position.line]
-
-    if (
-        isInsideLineComment({ line, start, lineRegexes }) ||
-        isInsideBlockComment({ lines, position, start, end, blockCommentStyles })
-    ) {
-        const searchToken = lines[position.line].slice(start, end)
-
-        const blessedPatterns = [
-            // looks like a function call
-            new RegExp(`${searchToken}\\(`),
-            // looks like a field projection
-            new RegExp(`\\.${searchToken}`),
-        ]
-
-        return !blessedPatterns.some(pattern => pattern.test(line))
-    }
-
-    return false
-}
-
-/**
- * Determine if the identifier matched on the given line occurs within a comment
- * defined by the given line comment regular expressions.
- *
- * @param args Parameter bag.
- */
-function isInsideLineComment({
-    line,
-    start,
-    lineRegexes,
-}: {
-    /** The line containing the identifier */
-    line: string
-    /** The index where the identifier occurs on the line. */
-    start: number
-    /** The patterns that identify line comments. */
-    lineRegexes: RegExp[]
-}): boolean {
-    // Determine if the token occurs after a comment on the same line
-    return lineRegexes.some(lineRegex => {
-        const match = line.match(lineRegex)
-        if (!match) {
-            return false
-        }
-
-        return match?.index !== undefined && match.index < start
-    })
-}
-
-/**
- * How many lines of context to capture on each side of a identifier when checking
- * whether or not the user is within a comment. A value of 50 will search over 101
- * lines in total.
- */
-const LINES_OF_CONTEXT = 50
-
-/**
- * Determine if the identifier matched on the given line occurs within a comment
- * defined by the given line block comment style.
- *
- * @param args Parameter bag.
- */
-function isInsideBlockComment({
-    lines,
-    position,
-    start,
-    end,
-    blockCommentStyles,
-}: {
-    /** The text of the current document split into lines. */
-    lines: string[]
-    /** The current hover position. */
-    position: { line: number }
-    /** The offset of the identifier in the target line. */
-    start: number
-    /** The offset and length of the identifier in the target line. */
-    end: number
-    /** The patterns that identify block comments. */
-    blockCommentStyles: BlockCommentStyle[]
-}): boolean {
-    const line = lines[position.line]
-    const linesBefore = lines.slice(Math.max(position.line - LINES_OF_CONTEXT, 0), position.line)
-    const linesAfter = lines.slice(position.line + 1, position.line + LINES_OF_CONTEXT + 1)
-
-    // Search over multiple lines of text covering our identifier
-    const context = flatten([linesBefore, [line], linesAfter]).join('\n')
-
-    // Determine how many characters in the context we skip before landing on our line
-    const offset = linesBefore.reduce((accumulator, line) => accumulator + line.length, 0) + linesBefore.length
-
-    // Match all commented blocks in the given block of text. We know
-    // the range of the target identifier in this text: if it's covered
-    // in a match's range then it is nested inside of a comment.
-    return blockCommentStyles.some(block =>
-        checkMatchIntersection(
-            [...context.matchAll(new RegExp(`${block.startRegex.source}.*?${block.endRegex.source}`, 'gs'))],
-            { start: start + offset, end: end + offset }
-        )
-    )
-}
-
-/**
- * Determine if any of the matches in the given array cover the given range.
- */
-function checkMatchIntersection(matches: RegExpMatchArray[], range: { start: number; end: number }): boolean {
-    return matches.some(
-        match => match.index !== undefined && match.index <= range.start && match.index + match[0].length >= range.end
-    )
+    return line.slice(start, end)
 }

--- a/client/web/src/codeintel/useCodeIntel.ts
+++ b/client/web/src/codeintel/useCodeIntel.ts
@@ -50,7 +50,7 @@ export interface UseCodeIntelParameters {
     searchToken: string
     fileContent: string
 
-    spec: LanguageSpec
+    spec: LanguageSpec | undefined
 
     isFork: boolean
     isArchived: boolean

--- a/client/web/src/enterprise/codeintel/searchBased.ts
+++ b/client/web/src/enterprise/codeintel/searchBased.ts
@@ -242,7 +242,7 @@ export function isSourcegraphDotCom(): boolean {
  * @param result The search result.
  */
 export function isExternalPrivateSymbol(
-    spec: LanguageSpec,
+    spec: LanguageSpec | undefined,
     path: string,
     { fileLocal, file, symbolKind }: Result
 ): boolean {
@@ -250,7 +250,7 @@ export function isExternalPrivateSymbol(
     // doesn't let us treat that way.
     // See https://github.com/universal-ctags/ctags/issues/1844
 
-    if (spec.languageID === 'java' && symbolKind === 'ENUMMEMBER') {
+    if (spec && spec.languageID === 'java' && symbolKind === 'ENUMMEMBER') {
         return false
     }
 


### PR DESCRIPTION
Previously, we relied on detecting the language from file paths,
then using various regexes associated with the language to identify
token boundaries. However, the code mirror blob view always provides
a full token range, which can be used directly, instead of attempting
to recompute the token boundaries.

For older URLs, we fallback to simple identifiers, which should
work for the vast majority of languages and identifiers.

We cannot yet remove the language detection here because the file
extensions associated with the language are later used for search-based
code navigation.

This patch also makes the language spec optional for search-based
code intel, as we do not have a solution to #56376 which would
guarantee that we always have a language available. If a language
is not available, search-based code intel falls back to searching
other files with the same extension as a best effort guess.

Fixes https://github.com/sourcegraph/sourcegraph/issues/58548

## Test plan

Locally tested for MATLAB code. The ref panel shows up correctly,
unlike the error earlier in #58548

![CleanShot 2023-12-13 at 15 25 17@2x](https://github.com/sourcegraph/sourcegraph/assets/93103176/b1feb315-d467-4b62-addf-84d050e9422b)
