### PR TITLE
Code Navigation: collapses folder when clicked

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarFileTree.tsx
@@ -472,9 +472,7 @@ function renderNode({
             onClick={event => {
                 event.preventDefault()
                 handleSelect(event)
-                // When clicking on a non-expanded folder, we want to navigate
-                // to it _and_ expand it.
-                if (isBranch && !isExpanded) {
+                if (isBranch) {
                     handleExpand(event)
                 }
             }}


### PR DESCRIPTION
Previously, folders in the file tree could only be expanded by clicking the file container, but not collapsed. The file tree has now been updated so that folders can be both expanded and collapsed by clicking the file container.

## Test plan
Manual testing
1. Ran local instance and clicked multiple folders at various levels of the file tree
2. Make sure once the state of the folder is expanded, it will collapse when clicked again.
3. Ensure the icon still changes
4. Ensure the collapsing functionality does not slow down tree performance (tested in a very large repo)
5. Test multiple repos on local instance.
