### PR TITLE
janitor: improve repo size update perf from 5.5sec to 200ms

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -654,10 +654,12 @@ WHERE repo_id = (SELECT id FROM repo WHERE name = %s)
 
 func (s *gitserverRepoStore) UpdateRepoSizes(ctx context.Context, logger log.Logger, shardID string, repos map[api.RepoName]int64) (updated int, err error) {
 	logger = logger.Scoped("gitserverRepoStore.UpdateRepoSizes")
-	// batchSize is 100 because we started with really large batch sizes (32k)
+	// batchSize is 200 because we started with really large batch sizes (32k)
 	// and noticed that it was really slow in production.
-	// While testing locally, we noticed that even batch sizes of 1000 are slow.
-	const batchSize = 100
+	//
+	// As of today (13 Dec 2023) updating 200 rows (with all of them having new
+	// values) on sourcegraph.com takes ~800ms.
+	const batchSize = 200
 	return s.updateRepoSizesWithBatchSize(ctx, logger, repos, batchSize)
 }
 

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -672,7 +672,7 @@ func (s *gitserverRepoStore) updateRepoSizesWithBatchSize(ctx context.Context, l
 	for repo, size := range repos {
 		start := time.Now()
 
-		queries[currentCount] = sqlf.Sprintf("(%s::text, %s::bigint)", repo, size)
+		queries[currentCount] = sqlf.Sprintf("(%s::citext, %s::bigint)", repo, size)
 
 		currentCount += 1
 


### PR DESCRIPTION
While inspecting this query in production we noticed that it didn't use the `repo.name` index. Changing the cast from `::text` to `::citext` makes it use the index.

With a representative query on sourcegraph.com, we go from

    before: 5.5sec with batch size 100

to

    after: 194ms with batch size 100



## Test plan

Run the following on the production DB:

```sql
WITH update_data AS (
	SELECT * FROM (VALUES
		-- (<repo_name>, <repo_size_bytes>),
        ('github.com/jawah/niquests'::citext, 13812962::bigint),
        ('github.com/calebyhan/population_cities'::citext, 31575::bigint),
        ('github.com/jeroenouw/AngularIonic'::citext, 2208211::bigint),
        ('github.com/elysium-suite/sarpedon'::citext, 384235::bigint),
        ('github.com/zhangtaii/douban.fm'::citext, 951327::bigint),
        ('github.com/lildinti/pygubu-examples'::citext, 0::bigint),
        ('github.com/burlizzi/qiwen'::citext, 437163210::bigint),
        ('github.com/jishanshaikh4/lila-local'::citext, 335807138::bigint),
        ('github.com/mbcastro/multikernel'::citext, 26858348::bigint),
        ('github.com/linghao58456/autoVue'::citext, 35845505::bigint),
        ('github.com/FHSWar/classicSort'::citext, 1341732::bigint),
        ('github.com/xupingxie/mnni-rom'::citext, 28560129::bigint),
        ('github.com/ashishvermarox/ELK-Infra-using-terraform'::citext, 52842::bigint),
        ('github.com/wbillingsley/demo-typescript-canvas-d3'::citext, 37547::bigint),
        ('github.com/WebBluetoothCG/WebBluetoothCG.github.io'::citext, 31768::bigint),
        ('github.com/195779/graduationDesign'::citext, 110578552::bigint),
        ('github.com/jenskreidler/database-rider'::citext, 4820237::bigint),
        ('gitlab.com/dirodriguezm/nuxt-clean-architecture'::citext, 234583::bigint),
        ('github.com/livelace/logrus'::citext, 1089899::bigint),
        ('github.com/lightningMan/MyBatisCodeHelper'::citext, 13330629::bigint),
        ('github.com/Walk119/jsonschema2json'::citext, 31318::bigint),
        ('github.com/danielmahetotkassa/SpringMail'::citext, 77700::bigint),
        ('github.com/VPagani/monkey'::citext, 130224::bigint),
        ('github.com/ByteStorage/contrast-benchmark'::citext, 63321::bigint),
        ('github.com/jweidley/Junos-Audit'::citext, 72725::bigint),
        ('github.com/thecaliskan/laravel-tdk'::citext, 41247::bigint),
        ('github.com/Isaque96/NewProject-ASP.NetCoreMVC'::citext, 785845::bigint),
        ('github.com/jiangweike/chineseSort'::citext, 161766::bigint),
        ('github.com/IronetIvan/T06_ViewPager_Android'::citext, 167312::bigint),
        ('github.com/Maitri-13/Implementation-and-Analysis-of-Adaptive-Histogram-Equalization'::citext, 26536537::bigint),
        ('github.com/aifly/couplet'::citext, 4787515::bigint),
        ('github.com/AHG-BSCS/Console-Point-of-Sales'::citext, 13402075::bigint),
        ('github.com/hailiang194/curl_cmake_example'::citext, 29951::bigint),
        ('github.com/aeternity/aepp-calldata-js'::citext, 6548819::bigint),
        ('github.com/me0w00f/SimpleTools'::citext, 74907::bigint),
        ('github.com/wanhaozhou/ADA-Project'::citext, 860944::bigint),
        ('github.com/leduss/portofolio'::citext, 0::bigint),
        ('github.com/meizucustoms/umkdtimg'::citext, 32918::bigint),
        ('github.com/fivecells/ourbank'::citext, 25747691::bigint),
        ('github.com/hesta-io/Zhir-Bootcamp'::citext, 41005512::bigint),
        ('github.com/revolutree/etherglass'::citext, 113361::bigint),
        ('github.com/EOE0102/Kemono2'::citext, 1018934::bigint),
        ('github.com/shinokada/statsfig'::citext, 0::bigint),
        ('github.com/tehtnaz/Shoukaku'::citext, 0::bigint),
        ('github.com/qinguangming1999/SRINet'::citext, 7404695::bigint),
        ('github.com/macalimlim/haskell-programming-from-first-principles'::citext, 153251::bigint),
        ('github.com/AhnSinYong/jjan_front_renewal'::citext, 20504820::bigint),
        ('github.com/XutaxKamay/scgen'::citext, 69767::bigint),
        ('github.com/LogicDancing/market-breadth'::citext, 4063332::bigint),
        ('github.com/lakhanp1/fungal_resources'::citext, 207284756::bigint),
        ('gitlab.com/austreelis/buffed'::citext, 404302::bigint),
        ('github.com/yunus/Hostapd-with-WebID'::citext, 9867168::bigint),
        ('github.com/SmuSmu/OpAgent'::citext, 310779::bigint),
        ('github.com/karlhorky/create-react-app'::citext, 18842968::bigint),
        ('github.com/Parneet-Raghuvanshi/MarketWatch'::citext, 6155635::bigint),
        ('github.com/ThanhPhamC/MD4_project'::citext, 129538::bigint),
        ('github.com/mikesimb/AICommand'::citext, 68381::bigint),
        ('github.com/chengh1356/changeFilesName'::citext, 68132::bigint),
        ('github.com/cmcmillan/HTMLtoRST'::citext, 1257950::bigint),
        ('github.com/himanshugoel2797/libVHL'::citext, 45066::bigint),
        ('github.com/glzjin/SSPanel-Uim'::citext, 75934763::bigint),
        ('github.com/jcomeauictx/wbr1310'::citext, 136491273::bigint),
        ('github.com/PrimarySite/drf-deny-allow-pc'::citext, 227931::bigint),
        ('github.com/ChiLoneYu/ACAD-Extensions'::citext, 9876919::bigint),
        ('github.com/paullewallencom/ceph-978-1-7883-9106-1'::citext, 26449::bigint),
        ('github.com/tamhinsf/Slurm4Azure'::citext, 83203::bigint),
        ('github.com/sempuki/code'::citext, 9827370::bigint),
        ('github.com/sunplus-plus1/sp_buildroot'::citext, 106981::bigint),
        ('github.com/cemian/react-iztro'::citext, 0::bigint),
        ('gitlab.com/aleixq/apptitle-plasmoid'::citext, 57073::bigint),
        ('github.com/ggxchain/cita-trie'::citext, 159523::bigint),
        ('github.com/Boosmith/trelloid'::citext, 1278275::bigint),
        ('github.com/s3bash/factorio-cheat-sheet'::citext, 22209542::bigint),
        ('github.com/medipolchain/MedipolDAO-Authentication'::citext, 35098::bigint),
        ('github.com/yxtwang/eladmin'::citext, 7940472::bigint),
        ('github.com/sangpham27/cdond-c3-projectstarter'::citext, 6527204::bigint),
        ('github.com/xuyudong666/MakeMoney'::citext, 47497::bigint),
        ('github.com/wisdom2050/wisdom-server'::citext, 11268318::bigint),
        ('github.com/LifeofAGeek/DUCS'::citext, 7808241::bigint),
        ('github.com/DisorganizedWizardry/TrueNAS-smartctl'::citext, 142126::bigint),
        ('github.com/yuriyvyatkin/ajs-hw-6.2-destructuring'::citext, 323870::bigint),
        ('github.com/AlessandroRestagno/Capstone-Project-SDC-Term3-P3-Udacity'::citext, 204772602::bigint),
        ('github.com/CyJaySong/dio'::citext, 3760515::bigint),
        ('github.com/tongtongstudio/ide-eval-resetter'::citext, 112383::bigint),
        ('github.com/devguii/sistema-contas-digitais-BTG'::citext, 447420::bigint),
        ('github.com/nakulkundaliya/react-native-instagram-gallery-view'::citext, 402284::bigint),
        ('github.com/shentu/shentu.github.io'::citext, 750424::bigint),
        ('github.com/MarcellGranat/ujdemografiaiprogram'::citext, 14788009::bigint),
        ('github.com/tylerwei/monitor'::citext, 26849::bigint),
        ('github.com/AvulaRanjan/SpringBoot-Oath2'::citext, 18999383::bigint),
        ('github.com/luffy0223/flink'::citext, 444143732::bigint),
        ('github.com/Dulpyanghaobo/wxcloudrun-springboot'::citext, 120545::bigint),
        ('github.com/czqhurricnae/EasyOCR'::citext, 165607503::bigint),
        ('github.com/rmeira/php7.4-fpm-alpine-nginx'::citext, 75125::bigint),
        ('gitlab.com/soapbox-pub/proxy-worker'::citext, 110589::bigint),
        ('github.com/ashutosh16/api'::citext, 12661486::bigint),
        ('github.com/WangYihang/rug'::citext, 49261::bigint),
        ('gitlab.com/holomedia/holoslides'::citext, 88739750::bigint),
        ('github.com/egeulgen/Bioinformatics_Stronghold'::citext, 506300::bigint),
        ('github.com/KleKwi/zsh-ssh'::citext, 76709::bigint)
	) AS tmp(repo_name, repo_size_bytes)
)
UPDATE gitserver_repos AS gr
SET
    repo_size_bytes = update_data.repo_size_bytes,
	updated_at = NOW()
FROM repo r
JOIN update_data on update_data.repo_name = r.name
WHERE
	r.id = gr.repo_id
AND
	update_data.repo_size_bytes IS DISTINCT FROM gr.repo_size_bytes;
```