### PR TITLE
telemetry-gateway: try to record cancel cause if one is provided

### DIFF
--- a/cmd/telemetry-gateway/internal/events/events.go
+++ b/cmd/telemetry-gateway/internal/events/events.go
@@ -69,6 +69,10 @@ func (p *Publisher) Publish(ctx context.Context, events []*telemetrygatewayv1.Ev
 				"event.hasPrivateMetadata": strconv.FormatBool(
 					event.GetParameters().GetPrivateMetadata() != nil),
 			}); err != nil {
+				// Try to record the cancel cause in case one is recorded.
+				if cancelCause := context.Cause(ctx); cancelCause != nil {
+					return errors.Wrap(err, "interrupted event publish")
+				}
 				return errors.Wrap(err, "publishing event")
 			}
 


### PR DESCRIPTION
Just in case we can get more details from error reports like https://sourcegraph.slack.com/archives/C05V6JS7QKB/p1702496634429589

## Test plan

CI