### PR TITLE
pubsub: add narrower TopicPublisher interface, ensure Stop in telemetry-gateway

### DIFF
--- a/cmd/telemetry-gateway/internal/events/events.go
+++ b/cmd/telemetry-gateway/internal/events/events.go
@@ -15,12 +15,12 @@ import (
 )
 
 type Publisher struct {
-	topic pubsub.TopicClient
+	topic pubsub.TopicPublisher
 
 	metadataJSON json.RawMessage
 }
 
-func NewPublisherForStream(eventsTopic pubsub.TopicClient, metadata *telemetrygatewayv1.RecordEventsRequestMetadata) (*Publisher, error) {
+func NewPublisherForStream(eventsTopic pubsub.TopicPublisher, metadata *telemetrygatewayv1.RecordEventsRequestMetadata) (*Publisher, error) {
 	metadataJSON, err := protojson.Marshal(metadata)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshaling metadata")

--- a/cmd/telemetry-gateway/internal/server/server.go
+++ b/cmd/telemetry-gateway/internal/server/server.go
@@ -22,7 +22,7 @@ import (
 
 type Server struct {
 	logger      log.Logger
-	eventsTopic pubsub.TopicClient
+	eventsTopic pubsub.TopicPublisher
 
 	recordEventsMetrics recordEventsMetrics
 
@@ -32,7 +32,7 @@ type Server struct {
 
 var _ telemetrygatewayv1.TelemeteryGatewayServiceServer = (*Server)(nil)
 
-func New(logger log.Logger, eventsTopic pubsub.TopicClient) (*Server, error) {
+func New(logger log.Logger, eventsTopic pubsub.TopicPublisher) (*Server, error) {
 	m, err := newRecordEventsMetrics()
 	if err != nil {
 		return nil, err

--- a/cmd/telemetry-gateway/service/service.go
+++ b/cmd/telemetry-gateway/service/service.go
@@ -87,7 +87,10 @@ func (Service) Initialize(ctx context.Context, logger log.Logger, contract runti
 		),
 		background.CallbackRoutine{
 			// No Start - serving is handled by httpserver
-			StopFunc: func() { grpcServer.GracefulStop() },
+			StopFunc: func() {
+				grpcServer.GracefulStop()
+				eventsTopic.Stop()
+			},
 		},
 	}, nil
 }

--- a/internal/pubsub/topic.go
+++ b/internal/pubsub/topic.go
@@ -16,8 +16,20 @@ import (
 
 // TopicClient is a Pub/Sub client that bound to a topic.
 type TopicClient interface {
+	// TopicPublisher is the interface most callsites will use, which only
+	// includes publishing entrypoints. When propagating TopicClient as a
+	// dependency, prefer to use the smaller TopicPublisher interface.
+	TopicPublisher
+
 	// Ping checks if the connection to the topic is valid.
 	Ping(ctx context.Context) error
+	// Stop stops the topic publishing channel. The client should not be used after
+	// calling Stop.
+	Stop()
+}
+
+// TopicPublisher is a Pub/Sub publisher bound to a topic.
+type TopicPublisher interface {
 	// Publish publishes messages and waits for all the results synchronously.
 	// It returns the first error encountered or nil if all succeeded. To collect
 	// individual errors, call Publish with only 1 message, or use PublishMessage.
@@ -25,9 +37,6 @@ type TopicClient interface {
 	// PublishMessage publishes a single message with attributes and waits for
 	// the result synchronously.
 	PublishMessage(ctx context.Context, message []byte, attributes map[string]string) error
-	// Stop stops the topic publishing channel. The client should not be used after
-	// calling Stop.
-	Stop()
 }
 
 var (

--- a/internal/updatecheck/handler.go
+++ b/internal/updatecheck/handler.go
@@ -94,7 +94,7 @@ type Meter struct {
 
 // Handle handles the ping requests and responds with information about software
 // updates for Sourcegraph.
-func Handle(logger log.Logger, pubsubClient pubsub.TopicClient, meter *Meter, w http.ResponseWriter, r *http.Request) {
+func Handle(logger log.Logger, pubsubClient pubsub.TopicPublisher, meter *Meter, w http.ResponseWriter, r *http.Request) {
 	meter.RequestCounter.Add(r.Context(), 1)
 
 	pr, err := readPingRequest(r)
@@ -396,7 +396,7 @@ type pingPayload struct {
 	RepoMetadataUsage             json.RawMessage `json:"repo_metadata_usage"`
 }
 
-func logPing(logger log.Logger, pubsubClient pubsub.TopicClient, meter *Meter, r *http.Request, pr *pingRequest, hasUpdate bool) {
+func logPing(logger log.Logger, pubsubClient pubsub.TopicPublisher, meter *Meter, r *http.Request, pr *pingRequest, hasUpdate bool) {
 	logger = logger.Scoped("logPing")
 	defer func() {
 		if err := recover(); err != nil {


### PR DESCRIPTION
We currently don't call `Stop` on the pub/sub client, which is pretty important because I think it actually does buffering by default: https://sourcegraph.com/github.com/googleapis/google-cloud-go@6eb769621618a965abeabf11e6315bdb8be9b050/-/blob/pubsub/topic.go?L122-137

This change adds a `TopicPublisher` interface with write-only methods so that we don't accidentally Stop the client at callsites, and adds a Stop to telemetry-gateway. I'll follow up with another change to update Pings to the MSP runtime and apply a Stop there as well

## Test plan

CI