### PR TITLE
ci: add --force-rebuild to chromatic if a build is retried

### DIFF
--- a/dev/ci/internal/ci/operations.go
+++ b/dev/ci/internal/ci/operations.go
@@ -182,7 +182,7 @@ func clientChromaticTests(opts CoreTestOperationsOptions) operations.Operation {
 		}
 
 		// Upload storybook to Chromatic
-		chromaticCommand := "pnpm chromatic --exit-zero-on-changes --exit-once-uploaded"
+		chromaticCommand := "./dev/ci/run-chromatic.sh --exit-zero-on-changes --exit-once-uploaded"
 		if opts.ChromaticShouldAutoAccept {
 			chromaticCommand += " --auto-accept-changes"
 		} else {

--- a/dev/ci/run-chromatic.sh
+++ b/dev/ci/run-chromatic.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+ARGS=("$@")
+
+if [[ ${BUILDKITE_RETRY_COUNT:-0} == 1 ]]; then
+  ARGS=("${ARGS[@]}" "--force-rebuild")
+fi
+
+pnpm chromatic ${ARGS[*]}


### PR DESCRIPTION
Add the `--force-rebuild` flag if the step retried so taht we don't get errors like https://buildkite.com/sourcegraph/sourcegraph/builds/254585#018c662d-4bd3-4a8d-9a71-3b45bd10f54d/159-215

## Test plan
Tested locally
