### PR TITLE
Bypass the access token auth handler for license checks

### DIFF
--- a/cmd/frontend/internal/httpapi/BUILD.bazel
+++ b/cmd/frontend/internal/httpapi/BUILD.bazel
@@ -99,6 +99,7 @@ go_test(
     deps = [
         "//cmd/frontend/backend",
         "//cmd/frontend/enterprise",
+        "//cmd/frontend/envvar",
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
         "//internal/api",

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -38,6 +38,13 @@ func AccessTokenAuthMiddleware(db database.DB, baseLogger log.Logger, next http.
 			return
 		}
 
+		// The license check handler uses a Bearer token and request body which
+		// is checked in `productsubscription/license_check_handler.go`
+		if strings.HasPrefix(r.URL.Path, "/.api/license/check") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		logger := trace.Logger(r.Context(), baseLogger)
 
 		w.Header().Add("Vary", "Authorization")

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -40,7 +40,7 @@ func AccessTokenAuthMiddleware(db database.DB, baseLogger log.Logger, next http.
 
 		// The license check handler uses a Bearer token and request body which
 		// is checked in `productsubscription/license_check_handler.go`
-		if strings.HasPrefix(r.URL.Path, "/.api/license/check") {
+		if envvar.SourcegraphDotComMode() && strings.HasPrefix(r.URL.Path, "/.api/license/check") {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -78,7 +78,7 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 		})
 	}
 
-	t.Run("license check bypasses handler", func(t *testing.T) {
+	t.Run("license check bypasses handler in dotcom mode", func(t *testing.T) {
 		currMode := envvar.SourcegraphDotComMode()
 		envvar.MockSourcegraphDotComMode(true)
 		t.Cleanup(func() {

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -76,6 +77,18 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 			checkHTTPResponse(t, db, req, http.StatusUnauthorized, "Invalid Authorization header.\n")
 		})
 	}
+
+	t.Run("license check bypasses handler", func(t *testing.T) {
+		currMode := envvar.SourcegraphDotComMode()
+		envvar.MockSourcegraphDotComMode(true)
+		t.Cleanup(func() {
+			envvar.MockSourcegraphDotComMode(currMode)
+		})
+
+		req, _ := http.NewRequest("GET", "/.api/license/check", nil)
+		req.Header.Set("Authorization", "Bearer sometoken")
+		checkHTTPResponse(t, db, req, http.StatusOK, "no user")
+	})
 
 	t.Run("valid header with invalid token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/", nil)


### PR DESCRIPTION
#57160 introduced a regression where requests to `/.api/license/check` all started failing with `401 Unauthorized`. License checks have been failing since 4 October. We never noticed because we disabled any consequences of license checks failing, but we would like these checks to succeed so that we can use the events produced by the checks to detect when licenses are used by multiple instances.

This PR adds a bypass to this handler, similar to the bypass for `/.api/scim/v2`, so that the license check handler checks the authentication instead.

## Test plan

Added unit test

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
