### PR TITLE
SSC: Re-enable dotcom rate limits

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -191,8 +191,8 @@ func (r codyUserGatewayAccessResolver) EmbeddingsRateLimit(ctx context.Context) 
 }
 
 func getEmbeddingsRateLimit(ctx context.Context, db database.DB, userID int32) (licensing.CodyGatewayRateLimit, error) {
-	// Hard-coded defaults: 200M tokens for life
-	limit := int64(20 * tokensPerDollar)
+	// Hard-coded defaults: 280M tokens for life
+	limit := int64(280 * tokensPerDollar)
 	intervalSeconds := int32(math.MaxInt32)
 
 	// Apply self-serve limits if available


### PR DESCRIPTION
- This PR reverts https://github.com/sourcegraph/sourcegraph/pull/58957 and bumps the hard-coded embeddings limit slightly.

## Test plan

This just reverts a PR.