### PR TITLE
update logging to include public_args

### DIFF
--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -186,7 +186,11 @@ function WelcomeStep({ onNext, pro }: { onNext: () => void; pro: boolean }): JSX
     const [show, setShow] = useState(false)
     const isLightTheme = useIsLightTheme()
     useEffect(() => {
-        eventLogger.log(EventName.CODY_ONBOARDING_WELCOME_VIEWED, { tier: pro ? 'pro' : 'free' })
+        eventLogger.log(
+            EventName.CODY_ONBOARDING_WELCOME_VIEWED,
+            { tier: pro ? 'pro' : 'free' },
+            { tier: pro ? 'pro' : 'free' }
+        )
     }, [pro])
 
     useEffect(() => {
@@ -244,7 +248,11 @@ function PurposeStep({
     const [useCase, setUseCase] = useState<'work' | 'personal' | null>(null)
 
     useEffect(() => {
-        eventLogger.log(EventName.CODY_ONBOARDING_PURPOSE_VIEWED, { tier: pro ? 'pro' : 'free' })
+        eventLogger.log(
+            EventName.CODY_ONBOARDING_PURPOSE_VIEWED,
+            { tier: pro ? 'pro' : 'free' },
+            { tier: pro ? 'pro' : 'free' }
+        )
     }, [pro])
 
     const primaryEmail = authenticatedUser.emails.find(email => email.isPrimary)?.email
@@ -289,7 +297,7 @@ function PurposeStep({
                     formId="85548efc-a879-4553-9ef0-a8da8fdcf541"
                     onFormSubmitted={() => {
                         if (useCase) {
-                            eventLogger.log(EventName.CODY_ONBOARDING_PURPOSE_SELECTED, { useCase })
+                            eventLogger.log(EventName.CODY_ONBOARDING_PURPOSE_SELECTED, { useCase }, { useCase })
                         }
                         onNext()
                     }}
@@ -305,7 +313,11 @@ function PurposeStep({
 
 function EditorStep({ onCompleted, pro }: { onCompleted: () => void; pro: boolean }): JSX.Element {
     useEffect(() => {
-        eventLogger.log(EventName.CODY_ONBOARDING_CHOOSE_EDITOR_VIEWED, { tier: pro ? 'pro' : 'free' })
+        eventLogger.log(
+            EventName.CODY_ONBOARDING_CHOOSE_EDITOR_VIEWED,
+            { tier: pro ? 'pro' : 'free' },
+            { tier: pro ? 'pro' : 'free' }
+        )
     }, [pro])
 
     const [editor, setEditor] = useState<null | IEditor>(null)
@@ -345,16 +357,30 @@ function EditorStep({ onCompleted, pro }: { onCompleted: () => void; pro: boolea
                                 onKeyDown={() => {
                                     setEditor(editor)
 
-                                    eventLogger.log(EventName.CODY_ONBOARDING_CHOOSE_EDITOR_SELECTED, {
-                                        tier: pro ? 'pro' : 'free',
-                                        editor,
-                                    })
+                                    eventLogger.log(
+                                        EventName.CODY_ONBOARDING_CHOOSE_EDITOR_SELECTED,
+                                        {
+                                            tier: pro ? 'pro' : 'free',
+                                            editor,
+                                        },
+                                        {
+                                            tier: pro ? 'pro' : 'free',
+                                            editor,
+                                        }
+                                    )
                                 }}
                                 onClick={() => {
-                                    eventLogger.log(EventName.CODY_ONBOARDING_CHOOSE_EDITOR_SELECTED, {
-                                        tier: pro ? 'pro' : 'free',
-                                        editor,
-                                    })
+                                    eventLogger.log(
+                                        EventName.CODY_ONBOARDING_CHOOSE_EDITOR_SELECTED,
+                                        {
+                                            tier: pro ? 'pro' : 'free',
+                                            editor,
+                                        },
+                                        {
+                                            tier: pro ? 'pro' : 'free',
+                                            editor,
+                                        }
+                                    )
                                     setEditor(editor)
                                 }}
                             >
@@ -391,7 +417,11 @@ function EditorStep({ onCompleted, pro }: { onCompleted: () => void; pro: boolea
                     size="small"
                     onClick={() => {
                         onCompleted()
-                        eventLogger.log(EventName.CODY_ONBOARDING_CHOOSE_EDITOR_SKIPPED, { tier: pro ? 'pro' : 'free' })
+                        eventLogger.log(
+                            EventName.CODY_ONBOARDING_CHOOSE_EDITOR_SKIPPED,
+                            { tier: pro ? 'pro' : 'free' },
+                            { tier: pro ? 'pro' : 'free' }
+                        )
                     }}
                 >
                     Skip for now

--- a/client/web/src/cody/subscription/CancelProModal.tsx
+++ b/client/web/src/cody/subscription/CancelProModal.tsx
@@ -52,9 +52,15 @@ export function CancelProModal({
                         <Button
                             variant="secondary"
                             onClick={() => {
-                                eventLogger.log(EventName.CODY_SUBSCRIPTION_PLAN_CONFIRMED, {
-                                    tier: 'free',
-                                })
+                                eventLogger.log(
+                                    EventName.CODY_SUBSCRIPTION_PLAN_CONFIRMED,
+                                    {
+                                        tier: 'free',
+                                    },
+                                    {
+                                        tier: 'free',
+                                    }
+                                )
 
                                 changeCodyPlan({ variables: { pro: false, id: authenticatedUser.id } })
                             }}

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -49,7 +49,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
     const utm_source = parameters.get('utm_source')
 
     useEffect(() => {
-        eventLogger.log(EventName.CODY_SUBSCRIPTION_PAGE_VIEWED, { utm_source })
+        eventLogger.log(EventName.CODY_SUBSCRIPTION_PAGE_VIEWED, { utm_source }, { utm_source })
     }, [utm_source])
 
     const { data } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
@@ -199,9 +199,15 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                             className="mb-0 text-muted d-inline cursor-pointer"
                                             size="small"
                                             onClick={() => {
-                                                eventLogger.log(EventName.CODY_SUBSCRIPTION_PLAN_CLICKED, {
-                                                    tier: 'free',
-                                                })
+                                                eventLogger.log(
+                                                    EventName.CODY_SUBSCRIPTION_PLAN_CLICKED,
+                                                    {
+                                                        tier: 'free',
+                                                    },
+                                                    {
+                                                        tier: 'free',
+                                                    }
+                                                )
                                                 setShowCancelPro(true)
                                             }}
                                         >
@@ -213,7 +219,11 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         className="flex-1"
                                         variant="primary"
                                         onClick={() => {
-                                            eventLogger.log(EventName.CODY_SUBSCRIPTION_PLAN_CLICKED, { tier: 'pro' })
+                                            eventLogger.log(
+                                                EventName.CODY_SUBSCRIPTION_PLAN_CLICKED,
+                                                { tier: 'pro' },
+                                                { tier: 'pro' }
+                                            )
                                             setShowUpgradeToPro(true)
                                         }}
                                     >
@@ -329,7 +339,11 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                 to="https://sourcegraph.com/contact/request-info?utm_source=cody_subscription_page"
                                 target="_blank"
                                 onClick={() => {
-                                    eventLogger.log(EventName.CODY_SUBSCRIPTION_PLAN_CLICKED, { tier: 'enterprise' })
+                                    eventLogger.log(
+                                        EventName.CODY_SUBSCRIPTION_PLAN_CLICKED,
+                                        { tier: 'enterprise' },
+                                        { tier: 'enterprise' }
+                                    )
                                 }}
                             >
                                 Contact sales

--- a/client/web/src/cody/subscription/UpgradeToProModal.tsx
+++ b/client/web/src/cody/subscription/UpgradeToProModal.tsx
@@ -148,9 +148,15 @@ export function UpgradeToProModal({
                                 <Button
                                     variant="primary"
                                     onClick={() => {
-                                        eventLogger.log(EventName.CODY_SUBSCRIPTION_PLAN_CONFIRMED, {
-                                            tier: 'pro',
-                                        })
+                                        eventLogger.log(
+                                            EventName.CODY_SUBSCRIPTION_PLAN_CONFIRMED,
+                                            {
+                                                tier: 'pro',
+                                            },
+                                            {
+                                                tier: 'pro',
+                                            }
+                                        )
 
                                         changeCodyPlan({ variables: { pro: true, id: authenticatedUser.id } })
                                     }}


### PR DESCRIPTION
For Cody GA some web events have been added and they are only logging metadata to `event_properties` and not `public_arguments`. This PR fixes that and ensures the analytics team is able to receive the event metadata.
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 


These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
simple change, not touching any logic.
ensure `sg start` runs
