### PR TITLE
Do not add code-exploration team label to PRs

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -1,9 +1,3 @@
-team/code-exploration:
-  - '@umpox'
-  - '@valerybugakov'
-  - '@lrhacker'
-  - '@philipp-spiess'
-
 team/source:
   - '@ryphil'
   - '@mrnugget'


### PR DESCRIPTION
This team doesn't exist anymore



## Test plan

Trivial change, not touching any app code. 
