### PR TITLE
bazel: fix nogo matchers and ensuing violations

### DIFF
--- a/cmd/frontend/backend/external_services.go
+++ b/cmd/frontend/backend/external_services.go
@@ -72,10 +72,10 @@ func (e *externalServices) ValidateConnection(ctx context.Context, svc *types.Ex
 		return err
 	}
 
-	return externalServiceValidate(ctx, svc, genericSrc)
+	return externalServiceValidate(ctx, genericSrc)
 }
 
-func externalServiceValidate(ctx context.Context, es *types.ExternalService, src internalrepos.Source) error {
+func externalServiceValidate(ctx context.Context, src internalrepos.Source) error {
 	if v, ok := src.(internalrepos.UserSource); ok {
 		return v.ValidateAuthenticator(ctx)
 	}

--- a/cmd/frontend/backend/external_services_test.go
+++ b/cmd/frontend/backend/external_services_test.go
@@ -230,7 +230,7 @@ func TestExternalServiceValidate(t *testing.T) {
 			return nil
 		},
 	}
-	err := externalServiceValidate(ctx, &types.ExternalService{}, src)
+	err := externalServiceValidate(ctx, src)
 	if err != nil {
 		t.Errorf("expected nil, got %v", err)
 	}

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -592,9 +592,7 @@ func (e *externalServiceStore) Create(ctx context.Context, confGet func() *conf.
 	}
 
 	// Ensure the calculated fields in the external service are up to date.
-	if err := e.recalculateFields(es, string(normalized)); err != nil {
-		return err
-	}
+	e.recalculateFields(es, string(normalized))
 
 	encryptedConfig, keyID, err := es.Config.Encrypt(ctx, e.getEncryptionKey())
 	if err != nil {
@@ -691,9 +689,7 @@ func (e *externalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 			s.Config.Set(rawConfig)
 		}
 
-		if err := e.recalculateFields(s, string(normalized)); err != nil {
-			return err
-		}
+		e.recalculateFields(s, string(normalized))
 
 		chID, err := ensureCodeHost(ctx, tx, s.Kind, string(normalized))
 		if err != nil {
@@ -1737,7 +1733,7 @@ func calcUnrestricted(config string) bool {
 // recalculateFields updates the value of the external service fields that are
 // calculated depending on the external service configuration, namely
 // `Unrestricted` and `HasWebhooks`.
-func (e *externalServiceStore) recalculateFields(es *types.ExternalService, rawConfig string) error {
+func (e *externalServiceStore) recalculateFields(es *types.ExternalService, rawConfig string) {
 	es.Unrestricted = calcUnrestricted(rawConfig)
 
 	hasWebhooks := false
@@ -1750,8 +1746,6 @@ func (e *externalServiceStore) recalculateFields(es *types.ExternalService, rawC
 		e.logger.Warn("cannot parse external service configuration as JSON", log.Error(err), log.Int64("id", es.ID))
 	}
 	es.HasWebhooks = &hasWebhooks
-
-	return nil
 }
 
 func ensureCodeHost(ctx context.Context, tx *externalServiceStore, kind string, config string) (codeHostID int32, _ error) {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -2542,7 +2542,7 @@ func TestExternalServiceStore_recalculateFields(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			require.NoError(t, e.recalculateFields(es, rawConfig))
+			e.recalculateFields(es, rawConfig)
 
 			require.Equal(t, es.Unrestricted, tc.expectUnrestricted)
 		})

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -2,54 +2,53 @@
   "_base": {
     "description": "Base config which all analyzers will inherit, unless a specific config is given",
     "exclude_files": {
-      "rules_go.*/*": "ignore rules_go working directory",
-      "external/*": "no need to vet third party code",
-      "schema/schema.go": "ignore generated code",
+      "rules_go.*/.*": "ignore rules_go working directory",
+      "external/.*": "no need to vet third party code",
+      "schema/schema\\.go$": "ignore generated code",
       ".*_generated\\.go$": "ignore generated code",
       ".*_pb\\.go$": "ignore protobuff generated code",
-      "docker-images/*": "ignore all code under docker-images",
-      "main.go": "ignore main",
+      "docker-images/.*": "ignore all code under docker-images",
+      "main\\.go$": "ignore main",
       ".*_test\\.go$": "ignore test code",
-      "internal/batches/testing/*": "ignore batches testing code",
-      "internal/gitserver/mock.go": "ignore deprecation warning of P4Exec",
+      "internal/batches/testing/.*": "ignore batches testing code",
+      "internal/gitserver/mock\\.go$": "ignore deprecation warning of P4Exec",
       "internal/database/dbmocks": "ignore generated database mocks"
     }
   },
   "bodyclose": {
     "exclude_files": {
-      "external/*": "no need to vet third party code",
+      "external/.*": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
       ".*_pb\\.go$": "ignore protobuff generated code",
-      ".*_test\\.go": "exclude bodyclose lint from tests because leaking connections in tests is a non issue",
-      "internal/extsvc/": "ignore temporarily",
-      "cmd/frontend/internal/gosrc/import_path.go": "temp ignore till we support nolint: comment"
+      ".*_test\\.go$": "exclude bodyclose lint from tests because leaking connections in tests is a non issue",
+      "internal/extsvc/": "ignore temporarily"
     }
   },
   "forbidigo": {
     "exclude_files": {
-      "rules_go.*/*": "ignore rules_go working directory",
+      "rules_go.*/.*": "ignore rules_go working directory",
       "external/": "no need to vet third party code",
-      "schema/schema.go": "ignore generated code",
-      "errors/cockroach.go": "ignore generated code",
+      "schema/schema\\.go": "ignore generated code",
+      "errors/cockroach\\.go": "ignore generated code",
       ".*_test\\.go$": "ignore test code",
       ".*_generated\\.go$": "ignore generated code",
       ".*_pb\\.go$": "ignore protobuff generated code",
-      "main.go": "ignore main files"
+      "main\\.go$": "ignore main files"
     }
   },
   "ineffassign": {
     "exclude_files": {
-      "external/*": "no need to vet third party code",
+      "external/.*": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
       ".*_pb\\.go$": "ignore protobuff generated code",
-      "dev/buildchecker/slack.go": "ignore false positive"
+      "dev/buildchecker/slack\\.go$": "ignore false positive"
     }
   },
   "exportloopref": {
     "exclude_files": {
-      "lib/batches/env/var.go": "false positive",
-      "rules_go.*/*": "ignore rules_go working directory",
-      "external/*": "no need to vet third party code",
+      "lib/batches/env/var\\.go$": "false positive",
+      "rules_go.*/.*": "ignore rules_go working directory",
+      "external/.*": "no need to vet third party code",
       ".*_generated\\.go$": "ignore generated code",
       ".*_pb\\.go$": "ignore protobuff generated code"
     }


### PR DESCRIPTION
Regex vs glob shenanigans

## Test plan

`bazel build $(bazel query 'kind("go_binary", //...)'`
