### PR TITLE
svelte: Fix bazel build to include React logo

### DIFF
--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -16,6 +16,7 @@ SRCS = [
     ".prettierignore",
     ".env",
     ".env.dotcom",
+    "static/react-logo.svg",
     "//client/wildcard:sass-breakpoints",
     "//client/wildcard:global-style-sources",
     "//client/web/dist/img:copy",


### PR DESCRIPTION
In the prototype "external" links are marked with a React logo to make it clear that these links makes you leave the prototype. This currently doesn't work on S2 because the React logo wasn't included in the list of source files for bazel.



## Test plan

I don't have a good way to test this locally, but it's safe because it's a non-code change.