### PR TITLE
chore: Ignore bazel in search and quick-open vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,8 @@
     "**/.cache": true,
     "**/.nyc_output": true,
     "doc/_resources/assets": true,
-    "**/.eslintcache": true
+    "**/.eslintcache": true,
+    "bazel*/**": true
   },
   "files.exclude": {
     "**/*.scss.d.ts": true
@@ -23,11 +24,15 @@
   },
   "json.schemas": [
     {
-      "fileMatch": ["dev/critical-config.json"],
+      "fileMatch": [
+        "dev/critical-config.json"
+      ],
       "url": "/schema/critical/critical.schema.json"
     },
     {
-      "fileMatch": ["dev/site-config.json"],
+      "fileMatch": [
+        "dev/site-config.json"
+      ],
       "url": "/schema/site.schema.json"
     }
   ],
@@ -46,11 +51,21 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.packageManager": "pnpm",
   "eslint.lintTask.enable": false,
-  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
   "editor.codeActionsOnSave": {},
   "eslint.codeActionsOnSave.mode": "problems",
-  "eslint.options": { "cache": true },
-  "eslint.workingDirectories": ["./dev/release", "./client/*"],
+  "eslint.options": {
+    "cache": true
+  },
+  "eslint.workingDirectories": [
+    "./dev/release",
+    "./client/*"
+  ],
   "go.lintTool": "golangci-lint",
   "shellformat.flag": "-i 2 -ci",
   "vscode-graphql.useSchemaFileDefinitions": true,
@@ -70,5 +85,8 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "cody.codebase": "github.com/sourcegraph/sourcegraph",
-  "rust-analyzer.linkedProjects": ["docker-images/syntax-highlighter/Cargo.toml", "src-tauri/Cargo.toml"]
+  "rust-analyzer.linkedProjects": [
+    "docker-images/syntax-highlighter/Cargo.toml",
+    "src-tauri/Cargo.toml"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,15 +24,11 @@
   },
   "json.schemas": [
     {
-      "fileMatch": [
-        "dev/critical-config.json"
-      ],
+      "fileMatch": ["dev/critical-config.json"],
       "url": "/schema/critical/critical.schema.json"
     },
     {
-      "fileMatch": [
-        "dev/site-config.json"
-      ],
+      "fileMatch": ["dev/site-config.json"],
       "url": "/schema/site.schema.json"
     }
   ],
@@ -51,21 +47,13 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.packageManager": "pnpm",
   "eslint.lintTask.enable": false,
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "editor.codeActionsOnSave": {},
   "eslint.codeActionsOnSave.mode": "problems",
   "eslint.options": {
     "cache": true
   },
-  "eslint.workingDirectories": [
-    "./dev/release",
-    "./client/*"
-  ],
+  "eslint.workingDirectories": ["./dev/release", "./client/*"],
   "go.lintTool": "golangci-lint",
   "shellformat.flag": "-i 2 -ci",
   "vscode-graphql.useSchemaFileDefinitions": true,
@@ -85,8 +73,5 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "cody.codebase": "github.com/sourcegraph/sourcegraph",
-  "rust-analyzer.linkedProjects": [
-    "docker-images/syntax-highlighter/Cargo.toml",
-    "src-tauri/Cargo.toml"
-  ]
+  "rust-analyzer.linkedProjects": ["docker-images/syntax-highlighter/Cargo.toml", "src-tauri/Cargo.toml"]
 }


### PR DESCRIPTION
Nice to have, prevents search results in VS Code from being clogged with Bazel generated files 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
Tested in VS code UI
