### PR TITLE
Apply model list for users with overrides

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -261,8 +261,13 @@ func getCompletionsRateLimit(ctx context.Context, db database.DB, userID int32, 
 	// If there's no override, check the self-serve limits.
 	cfg := conf.GetCompletionsConfig(conf.Get().SiteConfig())
 	intervalSeconds := oneDayInSeconds
-	// Default to the pre-PLG model list for now.
-	models := allowedModels(scope, false, false)
+	// We may not update the limit, but we should check the models
+	user, err := db.Users().GetByID(ctx, userID)
+	if err != nil {
+		return licensing.CodyGatewayRateLimit{}, graphqlbackend.CodyGatewayRateLimitSourcePlan, err
+	}
+	isProUser := user.CodyProEnabledAt != nil
+	models := allowedModels(scope, isCodyProEnabled, isProUser)
 	if limit == nil && cfg != nil && isCodyProEnabled {
 		source = graphqlbackend.CodyGatewayRateLimitSourcePlan
 		user, err := db.Users().GetByID(ctx, userID)


### PR DESCRIPTION
For users with quota overrides, we should still use their Cody-pro limits
## Test plan

- tested locally
- curl correctly refreshes limits
