### PR TITLE
Search Results: Use new flag for file preview feature

### DIFF
--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -108,7 +108,7 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
     const newSearchUIEnabled = useMemo(() => {
         const settings = settingsCascade.final
         if (!isErrorLike(settings)) {
-            return settings?.experimentalFeatures?.newSearchNavigationUI
+            return settings?.experimentalFeatures?.newSearchResultsUI
         }
         return false
     }, [settingsCascade])


### PR DESCRIPTION
Thanks to @camdencheek for the catch. I forgot to update preview button UI with new feature flag for the search results page

## Test plan
- Check that you can't see preview button when your newSearchResultsUI feature flag is off

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
