### PR TITLE
telemetrygateway: use time-ordered UUID v7 for events

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -2836,8 +2836,8 @@ def go_dependencies():
         name = "com_github_google_uuid",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/google/uuid",
-        sum = "h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=",
-        version = "v1.4.0",
+        sum = "h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=",
+        version = "v1.5.0",
     )
     go_repository(
         name = "com_github_googleapis_enterprise_certificate_proxy",

--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-querystring v1.1.0
-	github.com/google/uuid v1.4.0
+	github.com/google/uuid v1.5.0
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -916,8 +916,8 @@ github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
-github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfFxPRy3Bf7vr3h0cechB90XaQs=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=

--- a/internal/telemetrygateway/v1/event.go
+++ b/internal/telemetrygateway/v1/event.go
@@ -17,7 +17,11 @@ import (
 )
 
 // DefaultEventIDFunc is the default generator for telemetry event IDs.
-var DefaultEventIDFunc = uuid.NewString
+// We currently use V7, which is time-ordered, making them useful for event IDs.
+// https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-03#name-uuid-version-7
+var DefaultEventIDFunc = func() string {
+	return uuid.Must(uuid.NewV7()).String()
+}
 
 // NewEventWithDefaults creates a uniform event with defaults filled in. All
 // constructors making raw events should start with this. In particular, this

--- a/internal/telemetrygateway/v1/event_test.go
+++ b/internal/telemetrygateway/v1/event_test.go
@@ -1,7 +1,7 @@
 package v1_test
 
 import (
-	context "context"
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -18,6 +18,12 @@ import (
 
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1"
 )
+
+func TestDefaultEventIDFunc(t *testing.T) {
+	var id string
+	assert.NotPanics(t, func() { id = telemetrygatewayv1.DefaultEventIDFunc() })
+	assert.NotEmpty(t, id)
+}
 
 func TestNewEventWithDefaults(t *testing.T) {
 	staticTime, err := time.Parse(time.RFC3339, "2023-02-24T14:48:30Z")


### PR DESCRIPTION
This change upgrades `github.com/google/uuid` to use their new implementation of UUID v7, which is a new time-ordered UUID format. This might have benefits because we do potentially large updates/deletes based on the ID (export ack and queue cleanup respectively).

## Test plan

Sanity check test on the new default generator, and monitor post-deploy.