### PR TITLE
telemetry-gateway: bump default stream publish concurrency to 250, make configurable

### DIFF
--- a/cmd/telemetry-gateway/internal/events/events_test.go
+++ b/cmd/telemetry-gateway/internal/events/events_test.go
@@ -29,10 +29,13 @@ func TestPublish(t *testing.T) {
 		}
 	}
 
-	publisher, err := events.NewPublisherForStream(memTopic, &telemetrygatewayv1.RecordEventsRequestMetadata{})
+	const concurrency = 50
+	publisher, err := events.NewPublisherForStream(memTopic, &telemetrygatewayv1.RecordEventsRequestMetadata{}, events.PublishStreamOptions{
+		ConcurrencyLimit: concurrency,
+	})
 	require.NoError(t, err)
 
-	events := make([]*telemetrygatewayv1.Event, 100)
+	events := make([]*telemetrygatewayv1.Event, concurrency)
 	for i := range events {
 		events[i] = &telemetrygatewayv1.Event{
 			Id:      strconv.Itoa(i),

--- a/cmd/telemetry-gateway/internal/server/server.go
+++ b/cmd/telemetry-gateway/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 type Server struct {
 	logger      log.Logger
 	eventsTopic pubsub.TopicPublisher
+	publishOpts events.PublishStreamOptions
 
 	recordEventsMetrics recordEventsMetrics
 
@@ -32,7 +33,7 @@ type Server struct {
 
 var _ telemetrygatewayv1.TelemeteryGatewayServiceServer = (*Server)(nil)
 
-func New(logger log.Logger, eventsTopic pubsub.TopicPublisher) (*Server, error) {
+func New(logger log.Logger, eventsTopic pubsub.TopicPublisher, publishOpts events.PublishStreamOptions) (*Server, error) {
 	m, err := newRecordEventsMetrics()
 	if err != nil {
 		return nil, err
@@ -41,6 +42,7 @@ func New(logger log.Logger, eventsTopic pubsub.TopicPublisher) (*Server, error) 
 	return &Server{
 		logger:      logger.Scoped("server"),
 		eventsTopic: eventsTopic,
+		publishOpts: publishOpts,
 
 		recordEventsMetrics: m,
 	}, nil
@@ -107,7 +109,7 @@ func (s *Server) RecordEvents(stream telemetrygatewayv1.TelemeteryGatewayService
 			}
 
 			// Set up a publisher with the provided metadata
-			publisher, err = events.NewPublisherForStream(s.eventsTopic, metadata)
+			publisher, err = events.NewPublisherForStream(s.eventsTopic, metadata, s.publishOpts)
 			if err != nil {
 				return status.Errorf(codes.Internal, "failed to create publisher: %v", err)
 			}

--- a/cmd/telemetry-gateway/service/BUILD.bazel
+++ b/cmd/telemetry-gateway/service/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/service",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/telemetry-gateway/internal/events",
         "//cmd/telemetry-gateway/internal/server",
         "//internal/debugserver",
         "//internal/grpc",

--- a/cmd/telemetry-gateway/service/BUILD.bazel
+++ b/cmd/telemetry-gateway/service/BUILD.bazel
@@ -1,32 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "shared",
-    srcs = [
-        "config.go",
-        "service.go",
-    ],
-    importpath = "github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/shared",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//cmd/telemetry-gateway/internal/server",
-        "//internal/debugserver",
-        "//internal/grpc",
-        "//internal/grpc/defaults",
-        "//internal/httpserver",
-        "//internal/pubsub",
-        "//internal/telemetrygateway/v1:telemetrygateway",
-        "//internal/trace/policy",
-        "//internal/version",
-        "//lib/background",
-        "//lib/errors",
-        "//lib/managedservicesplatform/runtime",
-        "@com_github_sourcegraph_log//:log",
-        "@org_golang_google_grpc//:go_default_library",
-    ],
-)
-
-go_library(
     name = "service",
     srcs = [
         "config.go",

--- a/cmd/telemetry-gateway/service/config.go
+++ b/cmd/telemetry-gateway/service/config.go
@@ -11,6 +11,8 @@ type Config struct {
 			ProjectID *string
 			TopicID   *string
 		}
+
+		StreamPublishConcurrency int
 	}
 }
 
@@ -21,4 +23,6 @@ func (c *Config) Load(env *runtime.Env) {
 		"The project ID for the Pub/Sub.")
 	c.Events.PubSub.TopicID = env.GetOptional("TELEMETRY_GATEWAY_EVENTS_PUBSUB_TOPIC_ID",
 		"The topic ID for the Pub/Sub.")
+	c.Events.StreamPublishConcurrency = env.GetInt("TELEMETRY_GATEWAY_EVENTS_STREAM_PUBLISH_CONCURRENCY", "250",
+		"Per-stream concurrent publishing limit.")
 }

--- a/cmd/telemetry-gateway/service/service.go
+++ b/cmd/telemetry-gateway/service/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime"
 
+	"github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/events"
 	"github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/server"
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1"
 )
@@ -53,7 +54,12 @@ func (Service) Initialize(ctx context.Context, logger log.Logger, contract runti
 	// TODO(@bobheadxi): Maybe don't use defaults.NewServer, which is geared
 	// towards in-Sourcegraph services.
 	grpcServer := defaults.NewServer(logger)
-	telemetryGatewayServer, err := server.New(logger, eventsTopic)
+	telemetryGatewayServer, err := server.New(
+		logger,
+		eventsTopic,
+		events.PublishStreamOptions{
+			ConcurrencyLimit: config.Events.StreamPublishConcurrency,
+		})
 	if err != nil {
 		return nil, errors.Wrap(err, "init telemetry gateway server")
 	}


### PR DESCRIPTION
In dotcom, each export job is now taking a pretty long time (https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/18312), and part of that might be because we are not very fast at doing these exports in Telemetry Gateway, with a concurrent publish limit of 100, when payloads in a stream are regularly several times that.

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/f69dd71c-3498-4876-a8c6-bd0297eee1d1)

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/6a962c93-d3f3-4d23-a5f0-afc6dc5f61c3)

This change increases the default from 100 to 250, and also makes it configurable via env var so we can change it more easily. Resource utilization on Telemetry Gateway is _very_ low, so this should be safe on our end - if it causes issues with Pub/Sub (unlikely) we'll get Sentry alerts.

## Test plan

CI