### PR TITLE
msp/runtime: clarify what Healthy should indicate

### DIFF
--- a/lib/managedservicesplatform/runtime/contract.go
+++ b/lib/managedservicesplatform/runtime/contract.go
@@ -83,12 +83,20 @@ type HandlerRegisterer interface {
 
 type ServiceState interface {
 	// Healthy should return nil if the service is healthy, or an error with
-	// detailed diagnostics if the service is not healthy. The query parameter
-	// provides the URL query parameters the healtcheck was called with, to
-	// implement different "degrees" of healtchecks.
+	// detailed diagnostics if the service is not healthy. In general:
 	//
-	// The default MSP healthchecks are called without any query parameters, and
-	// should be implemented such that they can evaluate quickly.
+	// - A healthy state indicates that the service is ready to serve traffic
+	//   and do work.
+	// - An unhealthy state indicates that the previous revision should continue
+	//   to serve traffic.
+	//
+	// Healthy should be implemented with the above considerations in mind.
+	//
+	// The query parameter provides the URL query parameters the healtcheck was
+	// called with, to implement different "degrees" of healtchecks that can be
+	// used by a human operator. The default MSP healthchecks are called without
+	// any query parameters, and should be implemented such that they can
+	// evaluate quickly.
 	//
 	// Healthy is only called if the correct service secret is provided.
 	Healthy(ctx context.Context, query url.Values) error


### PR DESCRIPTION
Update docstring to try to guide how Healthy should be implemented

## Test plan

n/a