### PR TITLE
Update the webhook endpoint for the multiple license keys check

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
@@ -77,7 +77,7 @@ func sendSlackMessage(logger log.Logger, license *dbLicense, siteID string) {
 		return
 	}
 
-	client := slack.New(dotcom.SlackLicenseExpirationWebhook)
+	client := slack.New(dotcom.SlackLicenseAnomallyWebhook)
 	err = client.Post(context.Background(), &slack.Payload{
 		Text: fmt.Sprintf(multipleInstancesSameKeySlackFmt, externalURL.String(), url.QueryEscape(license.ProductSubscriptionID), url.QueryEscape(license.ID), license.ID, *license.SiteID, siteID),
 	})


### PR DESCRIPTION
Just updates the duplicate license keys check so that it doesn't spam the #licenses Slack channel

## Test plan

N/A webhook endpoint update

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
