### PR TITLE
msp: make monitoring spec optional

### DIFF
--- a/dev/managedservicesplatform/spec/monitoring.go
+++ b/dev/managedservicesplatform/spec/monitoring.go
@@ -16,6 +16,9 @@ type MonitoringSpec struct {
 }
 
 func (s *MonitoringSpec) Validate() []error {
+	if s == nil {
+		return nil
+	}
 	var errs []error
 	errs = append(errs, s.Alerts.Validate()...)
 	return errs

--- a/dev/managedservicesplatform/spec/spec.go
+++ b/dev/managedservicesplatform/spec/spec.go
@@ -25,7 +25,7 @@ type Spec struct {
 	Service      ServiceSpec       `json:"service"`
 	Build        BuildSpec         `json:"build"`
 	Environments []EnvironmentSpec `json:"environments"`
-	Monitoring   MonitoringSpec    `json:"monitoring"`
+	Monitoring   *MonitoringSpec   `json:"monitoring,omitempty"`
 }
 
 // Open a specification file, validate it, unmarshal the data as a MSP spec,
@@ -59,6 +59,10 @@ func parse(data []byte) (*Spec, error) {
 	if err := yaml.Unmarshal(data, &s); err != nil {
 		return nil, err
 	}
+
+	// Assign zero value for top-level monitoring spec for covenience
+	s.Monitoring = &MonitoringSpec{}
+
 	if validationErrs := s.Validate(); len(validationErrs) > 0 {
 		return nil, errors.Append(nil, validationErrs...)
 	}

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -274,7 +274,7 @@ Supports completions on services and environments.`,
 								return errors.Newf("environment %q not found in service spec", targetEnv)
 							}
 
-							if err := syncEnvironmentWorkspaces(c, tfcClient, service.Service, service.Build, *env, service.Monitoring); err != nil {
+							if err := syncEnvironmentWorkspaces(c, tfcClient, service.Service, service.Build, *env, *service.Monitoring); err != nil {
 								return errors.Wrapf(err, "sync env %q", env.ID)
 							}
 						} else {
@@ -282,7 +282,7 @@ Supports completions on services and environments.`,
 								return errors.New("second argument environment ID is required without the '-all' flag")
 							}
 							for _, env := range service.Environments {
-								if err := syncEnvironmentWorkspaces(c, tfcClient, service.Service, service.Build, env, service.Monitoring); err != nil {
+								if err := syncEnvironmentWorkspaces(c, tfcClient, service.Service, service.Build, env, *service.Monitoring); err != nil {
 									return errors.Wrapf(err, "sync env %q", env.ID)
 								}
 							}
@@ -452,7 +452,7 @@ func generateTerraform(serviceID string, opts generateTerraformOptions) error {
 		}
 
 		// Render environment
-		cdktf, err := renderer.RenderEnvironment(service.Service, service.Build, env, service.Monitoring)
+		cdktf, err := renderer.RenderEnvironment(service.Service, service.Build, env, *service.Monitoring)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The top-level spec works if zero value and does not need to be explicitly provided, but right now this causes a JSON schema error if you don't provide `monitoring`. This change makes it optional for the purposes of JSON schema validation.

## Test plan

```
sg msp schema -output='../managed-services/schema/service.schema.json'
```