### PR TITLE
graphqlbackend: use v2 telemetry for Sourcegraph Operator

### DIFF
--- a/cmd/frontend/internal/app/sign_out.go
+++ b/cmd/frontend/internal/app/sign_out.go
@@ -52,13 +52,13 @@ func serveSignOutHandler(logger log.Logger, db database.DB) http.HandlerFunc {
 		var err error
 		if err = session.InvalidateSessionCurrentUser(w, r, db); err != nil {
 			recordSecurityEvent(r, db, database.SecurityEventNameSignOutFailed, err)
-			recorder.Record(ctx, telemetry.FeatureSignOut, telemetry.ActionFailed, nil)
+			recorder.Record(ctx, "signOut", telemetry.ActionFailed, nil)
 			logger.Error("serveSignOutHandler", log.Error(err))
 		}
 
 		if err = session.SetActor(w, r, nil, 0, time.Time{}); err != nil {
 			recordSecurityEvent(r, db, database.SecurityEventNameSignOutFailed, err)
-			recorder.Record(ctx, telemetry.FeatureSignOut, telemetry.ActionFailed, nil)
+			recorder.Record(ctx, "signOut", telemetry.ActionFailed, nil)
 			logger.Error("serveSignOutHandler", log.Error(err))
 		}
 
@@ -70,7 +70,7 @@ func serveSignOutHandler(logger log.Logger, db database.DB) http.HandlerFunc {
 
 		if err == nil {
 			recordSecurityEvent(r, db, database.SecurityEventNameSignOutSucceeded, nil)
-			recorder.Record(ctx, telemetry.FeatureSignOut, telemetry.ActionSucceeded, nil)
+			recorder.Record(ctx, "signOut", telemetry.ActionSucceeded, nil)
 		}
 
 		http.Redirect(w, r, "/search", http.StatusSeeOther)

--- a/internal/auth/userpasswd/handlers.go
+++ b/internal/auth/userpasswd/handlers.go
@@ -161,7 +161,7 @@ func handleSignUp(logger log.Logger, db database.DB, eventRecorder *telemetry.Ev
 	// New event - we record legacy event manually for now, hence teestore.WithoutV1
 	// TODO: Remove in 5.3
 	events := telemetry.NewBestEffortEventRecorder(logger, eventRecorder)
-	events.Record(teestore.WithoutV1(r.Context()), telemetry.FeatureSignUp, telemetry.ActionSucceeded, &telemetry.EventParameters{
+	events.Record(teestore.WithoutV1(r.Context()), "signUp", telemetry.ActionSucceeded, &telemetry.EventParameters{
 		Metadata: telemetry.EventMetadata{
 			"failIfNewUserIsNotInitialSiteAdmin": telemetry.MetadataBool(failIfNewUserIsNotInitialSiteAdmin),
 		},
@@ -341,7 +341,7 @@ func HandleSignIn(logger log.Logger, db database.DB, store LockoutStore, recorde
 		telemetrySignInResult := telemetry.ActionFailed
 		defer func() {
 			recordSignInSecurityEvent(r, db, &user, &signInResult)
-			events.Record(ctx, telemetry.FeatureSignIn, telemetrySignInResult, nil)
+			events.Record(ctx, "signIn", telemetrySignInResult, nil)
 			checkAccountLockout(store, &user, &signInResult)
 		}()
 

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -9,13 +9,13 @@ import "strings"
 // and preventing strings from being cast to this type.
 type eventFeature string
 
-// All event names in Sourcegraph's Go services.
+// Shared event names in Sourcegraph's backend services.
 const (
 	FeatureExample eventFeature = "exampleFeature"
 
-	FeatureSignIn  eventFeature = "signIn"
-	FeatureSignOut eventFeature = "signOut"
-	FeatureSignUp  eventFeature = "signUp"
+	// FeatureSourcegraphOperator collects all events related to Sourcegraph
+	// Operatores.
+	FeatureSourcegraphOperator eventFeature = "sourcegraphOperator"
 )
 
 // eventAction defines the action associated with an event. Values should


### PR DESCRIPTION
Quick migration since I spotted a lot of these events on my user. I don't think the name of the event is used anywhere else, so these are probably only used for reference today

Also did a bit of cleanup on the slow request logging below to make sure it captures the trace of the request.

## Test plan

CI