### PR TITLE
[Backport 5.2] telemetrygateway: use time-ordered UUID v7 for events (#59016)

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -3231,8 +3231,8 @@ def go_dependencies():
         name = "com_github_google_uuid",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/google/uuid",
-        sum = "h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=",
-        version = "v1.3.1",
+        sum = "h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=",
+        version = "v1.5.0",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -123,7 +123,7 @@ require (
 	github.com/google/go-github/v31 v31.0.0
 	github.com/google/go-github/v43 v43.0.0
 	github.com/google/go-querystring v1.1.0
-	github.com/google/uuid v1.3.1
+	github.com/google/uuid v1.5.0
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/schema v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1173,8 +1173,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
-github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/enterprise-certificate-proxy v0.2.5 h1:UR4rDjcgpgEnqpIEvkiqTYKBCKLNmlge2eVjoZfySzM=

--- a/internal/telemetrygateway/v1/event.go
+++ b/internal/telemetrygateway/v1/event.go
@@ -17,7 +17,11 @@ import (
 )
 
 // DefaultEventIDFunc is the default generator for telemetry event IDs.
-var DefaultEventIDFunc = uuid.NewString
+// We currently use V7, which is time-ordered, making them useful for event IDs.
+// https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-03#name-uuid-version-7
+var DefaultEventIDFunc = func() string {
+	return uuid.Must(uuid.NewV7()).String()
+}
 
 // NewEventWithDefaults creates a uniform event with defaults filled in. All
 // constructors making raw events should start with this. In particular, this

--- a/internal/telemetrygateway/v1/event_test.go
+++ b/internal/telemetrygateway/v1/event_test.go
@@ -1,7 +1,7 @@
 package v1_test
 
 import (
-	context "context"
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -18,6 +18,12 @@ import (
 
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1"
 )
+
+func TestDefaultEventIDFunc(t *testing.T) {
+	var id string
+	assert.NotPanics(t, func() { id = telemetrygatewayv1.DefaultEventIDFunc() })
+	assert.NotEmpty(t, id)
+}
 
 func TestNewEventWithDefaults(t *testing.T) {
 	staticTime, err := time.Parse(time.RFC3339, "2023-02-24T14:48:30Z")


### PR DESCRIPTION
This change upgrades github.com/google/uuid to use their new implementation of UUID v7, which is a new time-ordered UUID format. This might have benefits because we do potentially large updates/deletes based on the ID (export ack and queue cleanup respectively).

(cherry picked from commit da5694f6974794432047819eeb77d8c74bff2e50 #59016)

## Test plan

CI, and I've seen some non-scientifically-visible improvements corresponding to when this was rolled out to dotcom, with a slight drop in export durations, queue cleanup times, and time to collect metrics about the backlog:

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/6ad66591-f722-4b7a-aa97-0bb598a96371)
