### PR TITLE
msp/iam: grant external secret to workload SA, not Cloud Run identity

### DIFF
--- a/dev/managedservicesplatform/internal/stack/iam/iam.go
+++ b/dev/managedservicesplatform/internal/stack/iam/iam.go
@@ -154,7 +154,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 					Project:  &p.projectID,
 					SecretId: &p.secretID,
 					Role:     pointers.Ptr("roles/secretmanager.secretAccessor"),
-					Member:   identityMember,
+					Member:   &workloadServiceAccount.Member,
 				})
 		}
 


### PR DESCRIPTION
Looks like the one that needs it is the SA, not the Cloud Run identity:

```
Error: Error waiting to create Service: Error waiting for Creating Service: Error code 13, message: Revision 'sams-00001-8m6' is not ready and cannot serve traffic. spec.template.spec.containers[0].env[12].value_from.secret_key_ref.name: Permission denied on secret: projects/sourcegraph-dev/secrets/SAMS_GITHUB_CLIENT_SECRET/versions/latest for Revision service account sams-sa@sams-dev-bfec.iam.gserviceaccount.com.
```

## Test plan

Was able to successfully start revision with https://github.com/sourcegraph/managed-services/commit/56af2255a5928c60cd8a24aa7cfd3f42ed120c7f