### PR TITLE
msp/cloudflare: add comment and tags for identifiability

### DIFF
--- a/dev/managedservicesplatform/internal/resource/cloudflare/cloudflare.go
+++ b/dev/managedservicesplatform/internal/resource/cloudflare/cloudflare.go
@@ -46,6 +46,8 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 			Type:    pointers.Ptr("A"),
 			Value:   config.Target.ExternalAddress.Address(),
 			Proxied: pointers.Ptr(config.Spec.Proxied),
+			Comment: pointers.Ptr("Managed Services Platform service"),
+			Tags:    pointers.Ptr(pointers.Slice([]string{"msp"})),
 		})
 	return &Output{}, nil
 }


### PR DESCRIPTION
There are a _lot_ of records and stuff in Cloudflare - this makes it easier to identify which ones are managed by MSP.

## Test plan

n/a