### PR TITLE
externalAuthSignup: update v2 events to capture all cases

### DIFF
--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -572,6 +572,8 @@ func TestMetadataOnlyAutomaticallySetOnFirstOccurrence(t *testing.T) {
 	db.GlobalStateFunc.SetDefaultReturn(gss)
 	db.UsersFunc.SetDefaultReturn(users)
 	db.UserExternalAccountsFunc.SetDefaultReturn(externalAccounts)
+	db.EventLogsFunc.SetDefaultReturn(dbmocks.NewMockEventLogStore())
+	db.TelemetryEventsExportQueueFunc.SetDefaultReturn(dbmocks.NewMockTelemetryEventsExportQueueStore())
 
 	// Customers can always set their own display name and avatar URL values, but when
 	// we encounter them via e.g. code host logins, we don't want to override anything


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/sourcegraph/pull/59036 , expanding the new `externalAuthSignup` event coverage for the purposes of a potential SAMS + telemetry V2 demo.
Details in docstrings.

## Test plan

CI