### PR TITLE
svelte: Fix repo sidebar border style

### DIFF
--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -226,7 +226,7 @@
             border-top: 1px solid var(--border-color);
 
             &:first-child {
-                border-bottom: none;
+                border-top: none;
             }
 
             &:last-child {


### PR DESCRIPTION
I had changed the border from bottom to top but forgot to update this rule.


## Test plan

Manual testing
