### PR TITLE
Treat dotcom-user as dotcom user (duh)

### DIFF
--- a/cmd/cody-gateway/internal/actor/actor.go
+++ b/cmd/cody-gateway/internal/actor/actor.go
@@ -56,7 +56,7 @@ func (a *Actor) GetName() string {
 }
 
 func (a *Actor) GetSource() codygateway.ActorSource {
-	if a.Source == nil {
+	if a == nil || a.Source == nil {
 		return "unknown"
 	}
 	return codygateway.ActorSource(a.Source.Name())

--- a/cmd/cody-gateway/internal/actor/actor.go
+++ b/cmd/cody-gateway/internal/actor/actor.go
@@ -63,8 +63,8 @@ func (a *Actor) GetSource() codygateway.ActorSource {
 }
 
 func (a *Actor) IsDotComActor() bool {
-	// Corresponds to sourcegraph.com subscription ID.
-	return a != nil && a.ID == "d3d2b638-d0a2-4539-a099-b36860b09819"
+	// Corresponds to sourcegraph.com subscription ID, or using a dotcom access token
+	return a != nil && (a.GetSource() == codygateway.ActorSourceProductSubscription && a.ID == "d3d2b638-d0a2-4539-a099-b36860b09819") || a.GetSource() == codygateway.ActorSourceDotcomUser
 }
 
 type contextKey int

--- a/cmd/cody-gateway/internal/actor/actor_test.go
+++ b/cmd/cody-gateway/internal/actor/actor_test.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	"context"
 	"encoding/json"
 	"sort"
 	"testing"
@@ -58,4 +59,49 @@ func TestActor_TraceAttributes(t *testing.T) {
 			tt.wantAttr.Equal(t, string(b))
 		})
 	}
+}
+
+type mockSource struct {
+	name codygateway.ActorSource
+}
+
+func (m mockSource) Name() string {
+	return string(m.name)
+}
+
+func (m mockSource) Get(_ context.Context, _ string) (*Actor, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+var _ Source = mockSource{}
+
+func TestIsDotComActor(t *testing.T) {
+	t.Run("true for dotcom subscription", func(t *testing.T) {
+		actor := &Actor{
+			ID:     "d3d2b638-d0a2-4539-a099-b36860b09819",
+			Source: mockSource{name: codygateway.ActorSourceProductSubscription},
+		}
+		require.True(t, actor.IsDotComActor())
+	})
+
+	t.Run("true for dotcom user", func(t *testing.T) {
+		actor := &Actor{
+			Source: mockSource{codygateway.ActorSourceDotcomUser},
+		}
+		require.True(t, actor.IsDotComActor())
+	})
+
+	t.Run("false for other subscription", func(t *testing.T) {
+		actor := &Actor{
+			ID:     "other-sub-id",
+			Source: mockSource{codygateway.ActorSourceProductSubscription},
+		}
+		require.False(t, actor.IsDotComActor())
+	})
+
+	t.Run("false for nil", func(t *testing.T) {
+		var actor *Actor = nil
+		require.False(t, actor.IsDotComActor())
+	})
 }

--- a/cmd/cody-gateway/internal/actor/actor_test.go
+++ b/cmd/cody-gateway/internal/actor/actor_test.go
@@ -1,7 +1,6 @@
 package actor
 
 import (
-	"context"
 	"encoding/json"
 	"sort"
 	"testing"
@@ -61,33 +60,18 @@ func TestActor_TraceAttributes(t *testing.T) {
 	}
 }
 
-type mockSource struct {
-	name codygateway.ActorSource
-}
-
-func (m mockSource) Name() string {
-	return string(m.name)
-}
-
-func (m mockSource) Get(_ context.Context, _ string) (*Actor, error) {
-	// TODO implement me
-	panic("implement me")
-}
-
-var _ Source = mockSource{}
-
 func TestIsDotComActor(t *testing.T) {
 	t.Run("true for dotcom subscription", func(t *testing.T) {
 		actor := &Actor{
 			ID:     "d3d2b638-d0a2-4539-a099-b36860b09819",
-			Source: mockSource{name: codygateway.ActorSourceProductSubscription},
+			Source: FakeSource{codygateway.ActorSourceProductSubscription},
 		}
 		require.True(t, actor.IsDotComActor())
 	})
 
 	t.Run("true for dotcom user", func(t *testing.T) {
 		actor := &Actor{
-			Source: mockSource{codygateway.ActorSourceDotcomUser},
+			Source: FakeSource{codygateway.ActorSourceDotcomUser},
 		}
 		require.True(t, actor.IsDotComActor())
 	})
@@ -95,7 +79,7 @@ func TestIsDotComActor(t *testing.T) {
 	t.Run("false for other subscription", func(t *testing.T) {
 		actor := &Actor{
 			ID:     "other-sub-id",
-			Source: mockSource{codygateway.ActorSourceProductSubscription},
+			Source: FakeSource{codygateway.ActorSourceProductSubscription},
 		}
 		require.False(t, actor.IsDotComActor())
 	})

--- a/cmd/cody-gateway/internal/actor/source.go
+++ b/cmd/cody-gateway/internal/actor/source.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-redsync/redsync/v4"
 	"github.com/sourcegraph/conc/pool"
+	"github.com/sourcegraph/sourcegraph/internal/codygateway"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -327,3 +328,18 @@ func (s *sourcesSyncHandler) Handle(ctx context.Context) (err error) {
 	handleLogger.Info("Running sources sync")
 	return s.sources.SyncAll(ctx, handleLogger)
 }
+
+type FakeSource struct {
+	SourceName codygateway.ActorSource
+}
+
+func (m FakeSource) Name() string {
+	return string(m.SourceName)
+}
+
+func (m FakeSource) Get(_ context.Context, _ string) (*Actor, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+var _ Source = FakeSource{}

--- a/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     deps = [
         "//cmd/cody-gateway/internal/actor",
         "//cmd/cody-gateway/internal/tokenizer",
+        "//internal/codygateway",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//assert",

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/grafana/regexp"
+	"github.com/sourcegraph/sourcegraph/internal/codygateway"
 
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
@@ -119,29 +120,30 @@ func TestAnthropicRequestGetPromptTokenCount(t *testing.T) {
 
 func TestActor_IsDotComActor(t *testing.T) {
 	t.Run("with dotcom actor", func(t *testing.T) {
-		actor := &actor.Actor{
-			ID: "d3d2b638-d0a2-4539-a099-b36860b09819",
+		act := &actor.Actor{
+			ID:     "d3d2b638-d0a2-4539-a099-b36860b09819",
+			Source: actor.FakeSource{codygateway.ActorSourceProductSubscription},
 		}
 
-		isDotCom := actor.IsDotComActor()
+		isDotCom := act.IsDotComActor()
 
 		require.True(t, isDotCom)
 	})
 
 	t.Run("with nondotcom actor", func(t *testing.T) {
-		actor := &actor.Actor{
+		act := &actor.Actor{
 			ID: "NOT_DOTCOM",
 		}
 
-		isDotCom := actor.IsDotComActor()
+		isDotCom := act.IsDotComActor()
 
 		require.False(t, isDotCom)
 	})
 
 	t.Run("with nil actor", func(t *testing.T) {
-		var actor *actor.Actor = nil
+		var act *actor.Actor = nil
 
-		isDotCom := actor.IsDotComActor()
+		isDotCom := act.IsDotComActor()
 
 		require.False(t, isDotCom)
 	})


### PR DESCRIPTION
Historically, we never saw meaningful abuse from Cody App users, but now that PLG users use `dotcom-user` by default, we need abuse tooling to work for this too.

## Test plan

- tested locally
- also unit tests
