### PR TITLE
buildchecker: send an event to sentry if the action has failed

### DIFF
--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -31,7 +31,11 @@ jobs:
         if: ${{ failure() }}
         run: |
           npm i -g @sentry/cli
-          sentry-cli send-event -m 'buildchecker action failure' -t 'github-action:buildchecker' -a "workflow-run:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          sentry-cli send-event -m 'buildchecker action failure - see run for exact failure' \
+            -t "github-action:$GITHUB_WORKFLOW" \
+            -t "branch:$GITHUB_REF_NAME" \
+            -t "repository:$GITHUB_REPOSITORY" \
+            -t "workflow-run:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DEV_INFRA_DSN }}
           SENTRY_ORG: sourcegraph

--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -19,11 +19,19 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with: { go-version: '1.21' }
+      - uses: mathieu-bour/setup-sentry-cli@v1
+        with:
+          organization: sourcegraph
+          token: 'INSERT-REAL-TOKEN'
+          project: dev-infra
 
-      - run: ./dev/buildchecker/run-check.sh
+      - run: exit 1 #./dev/buildchecker/run-check.sh
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_GITHUB_TOKEN }}
           BUILDKITE_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_BUILDKITE_TOKEN }}
           SLACK_ANNOUNCE_WEBHOOK: ${{ secrets.AUTOBUILDSHERRIF_SLACK_WEBHOOK }}
           SLACK_DEBUG_WEBHOOK: ${{ secrets.AUTOBUILDSHERRIF_SLACK_DEBUG_WEBHOOK }}
           SLACK_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_SLACK_TOKEN }}
+      - name: report failure to sentry
+        if: ${{ failure() }}
+        run: sentry-cli send-event -m 'buildchecker action failure' -t 'github-action:buildchecker' -a "workflow:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -19,12 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with: { go-version: '1.21' }
-      - uses: mathieu-bour/setup-sentry-cli@v1
-        with:
-          organization: sourcegraph
-          token: 'INSERT-REAL-TOKEN'
-          project: dev-infra
-
+      - uses: actions/setup-node@v4
       - run: exit 1 #./dev/buildchecker/run-check.sh
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_GITHUB_TOKEN }}
@@ -34,4 +29,10 @@ jobs:
           SLACK_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_SLACK_TOKEN }}
       - name: report failure to sentry
         if: ${{ failure() }}
-        run: sentry-cli send-event -m 'buildchecker action failure' -t 'github-action:buildchecker' -a "workflow:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        run: |
+          npm i -g @sentry/cli
+          sentry-cli send-event -m 'buildchecker action failure' -t 'github-action:buildchecker' -a "workflow-run:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DEV_INFRA_DSN }}
+          SENTRY_ORG: sourcegraph
+          SENTRY_PROJECT: dev-infra

--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-go@v2
         with: { go-version: '1.21' }
       - uses: actions/setup-node@v4
-      - run: exit 1 #./dev/buildchecker/run-check.sh
+      - run: ./dev/buildchecker/run-check.sh
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_GITHUB_TOKEN }}
           BUILDKITE_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_BUILDKITE_TOKEN }}


### PR DESCRIPTION

<img width="1128" alt="Screenshot 2023-12-18 at 14 51 43" src="https://github.com/sourcegraph/sourcegraph/assets/1001709/f3905fe0-f07b-438e-a1db-2be511c8bf37">

## Test plan
Changed the run to `exit 1` and see that events get sent to sentry
