### PR TITLE
github-actions: report run failures to sentry

### DIFF
--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -57,3 +57,17 @@ jobs:
         token: ${{ secrets.GH_REPO_TOKEN }}
         pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
         merge-method: squash
+
+    - name: report failure to sentry
+      if: ${{ failure() }}
+      run: |
+        npm i -g @sentry/cli
+        sentry-cli send-event -m "$GITHUB_WORKFLOW action failure - see run for exact failure" \
+          -t "github-action:$GITHUB_WORKFLOW" \
+          -t "branch:$GITHUB_REF_NAME" \
+          -t "repository:$GITHUB_REPOSITORY" \
+          -t "workflow-run:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+      env:
+        SENTRY_DSN: ${{ secrets.SENTRY_DEV_INFRA_DSN }}
+        SENTRY_ORG: sourcegraph
+        SENTRY_PROJECT: dev-infra

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -20,3 +20,16 @@ jobs:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
           GITHUB_TOKEN: ${{ secrets.PR_AUDITOR_TOKEN }}
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      - name: report failure to sentry
+        if: ${{ failure() }}
+        run: |
+          npm i -g @sentry/cli
+          sentry-cli send-event -m "$GITHUB_WORKFLOW action failure - see run for exact failure" \
+            -t "github-action:$GITHUB_WORKFLOW" \
+            -t "branch:$GITHUB_REF_NAME" \
+            -t "repository:$GITHUB_REPOSITORY" \
+            -t "workflow-run:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DEV_INFRA_DSN }}
+          SENTRY_ORG: sourcegraph
+          SENTRY_PROJECT: dev-infra

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -125,3 +125,17 @@ jobs:
         env:
           repo: sourcegraph/sg
           GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}
+
+      - name: report failure to sentry
+        if: ${{ failure() }}
+        run: |
+          npm i -g @sentry/cli
+          sentry-cli send-event -m "$GITHUB_WORKFLOW action failure - see run for exact failure" \
+            -t "github-action:$GITHUB_WORKFLOW" \
+            -t "branch:$GITHUB_REF_NAME" \
+            -t "repository:$GITHUB_REPOSITORY" \
+            -t "workflow-run:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DEV_INFRA_DSN }}
+          SENTRY_ORG: sourcegraph
+          SENTRY_PROJECT: dev-infra

--- a/.github/workflows/tracking-issue.yml
+++ b/.github/workflows/tracking-issue.yml
@@ -10,3 +10,17 @@ jobs:
       - uses: docker://sourcegraph/tracking-issue:latest
         env:
           GITHUB_TOKEN: ${{ secrets.TRACKING_ISSUE_SYNCER_TOKEN_DEVX_BOT }}
+      - name: report failure to sentry
+        if: ${{ failure() }}
+        run: |
+          npm i -g @sentry/cli
+          sentry-cli send-event -m "$GITHUB_WORKFLOW action failure - see run for exact failure" \
+            -t "github-action:$GITHUB_WORKFLOW" \
+            -t "branch:$GITHUB_REF_NAME" \
+            -t "repository:$GITHUB_REPOSITORY" \
+            -t "workflow-run:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DEV_INFRA_DSN }}
+          SENTRY_ORG: sourcegraph
+          SENTRY_PROJECT: dev-infra
+

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -122,3 +122,16 @@ jobs:
           path: './dist/'
           destination: 'universal_ctags/x86_64-linux'
           glob: 'universal-ctags-*'
+      - name: report failure to sentry
+        if: ${{ failure() }}
+        run: |
+          npm i -g @sentry/cli
+          sentry-cli send-event -m "$GITHUB_WORKFLOW action failure - see run for exact failure" \
+            -t "github-action:$GITHUB_WORKFLOW" \
+            -t "branch:$GITHUB_REF_NAME" \
+            -t "repository:$GITHUB_REPOSITORY" \
+            -t "workflow-run:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DEV_INFRA_DSN }}
+          SENTRY_ORG: sourcegraph
+          SENTRY_PROJECT: dev-infra


### PR DESCRIPTION
For all actions owned by dev-infra, if the action fails send an event to sentry
## Test plan
Have to manually test it, but the step is copied from 
- https://github.com/sourcegraph/sourcegraph/pull/59059
### Manual run
- [ ] pr-auditor
- [ ] license-update
- [ ] tracking-issue
- [ ] universal-ctags
- [ ] sg-binary-release
