### PR TITLE
bazel: set retry flakes to 3

### DIFF
--- a/.aspect/bazelrc/ci.bazelrc
+++ b/.aspect/bazelrc/ci.bazelrc
@@ -16,7 +16,7 @@ test --test_timeout_filters=-eternal
 # is more likely to get fixed.
 # Note that when passing after the first attempt, Bazel will give a special "FLAKY" status.
 # Docs: https://bazel.build/docs/user-manual#flaky-test-attempts
-test --flaky_test_attempts=3
+test --flaky_test_attempts=2
 
 # Announce all announces command options read from the bazelrc file(s) when starting up at the
 # beginning of each Bazel invocation. This is very useful on CI to be able to inspect what Bazel rc

--- a/.aspect/bazelrc/ci.bazelrc
+++ b/.aspect/bazelrc/ci.bazelrc
@@ -16,7 +16,7 @@ test --test_timeout_filters=-eternal
 # is more likely to get fixed.
 # Note that when passing after the first attempt, Bazel will give a special "FLAKY" status.
 # Docs: https://bazel.build/docs/user-manual#flaky-test-attempts
-test --flaky_test_attempts=2
+test --flaky_test_attempts=3
 
 # Announce all announces command options read from the bazelrc file(s) when starting up at the
 # beginning of each Bazel invocation. This is very useful on CI to be able to inspect what Bazel rc

--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -49,3 +49,8 @@ common --test_env=DOCKER_HOST
 
 # Used by migration rules
 common --action_env=PGUSER=postgres
+
+# This overrides the same flag set in ci.bazelrc. Note that if for some reason this bazelrc is loaded before ci.bazelrc,
+# then the ci.bazelrc will override this one.
+test --flaky_test_attempts=2
+


### PR DESCRIPTION
This is more a change for Aspect Workflows, considering we auto retry steps on Buildkite in our normal pipeline - we increase the flake retry attempts so that Aspect (but really Bazel) also retries a little bit more 
## Test plan
CI