### PR TITLE
search: support glob syntax for repo and file filters

### DIFF
--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -20,6 +20,7 @@ const (
 	IsAlias
 	Standard
 	QuotesAsLiterals
+	GlobFilters
 )
 
 var allLabels = map[labels]string{

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -881,7 +881,7 @@ func (p *parser) ParseParameter(label labels) (Parameter, bool, error) {
 		return Parameter{}, false, err
 	}
 
-	if label.IsSet(GlobFilters) {
+	if label.IsSet(GlobFilters) && !parsedLabels.IsSet(IsPredicate) {
 		switch field {
 		case "r", "repo", "f", "file":
 			value = globToRegex(value)

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -852,3 +852,115 @@ func TestParseNewStandard(t *testing.T) {
 		autogold.ExpectFile(t, autogold.Raw(test(`"foo \"bar\""`)))
 	})
 }
+
+func TestGlobToRegex(t *testing.T) {
+	type value struct {
+		Result       string
+		ResultLabels string
+		ResultRange  string
+	}
+
+	test := func(input string) value {
+		parser := &parser{buf: []byte(input), heuristics: parensAsPatterns | allowDanglingParens}
+		result, err := parser.parseLeaves(Standard | Literal | GlobFilters)
+		if err != nil {
+			t.Fatal(fmt.Sprintf("Unexpected error: %s", err))
+		}
+		resultNode := result[0]
+		got, _ := json.Marshal(resultNode)
+
+		var gotRange string
+		switch n := resultNode.(type) {
+		case Pattern:
+			gotRange = n.Annotation.Range.String()
+		case Parameter:
+			gotRange = n.Annotation.Range.String()
+		}
+
+		var gotLabels string
+		if _, ok := resultNode.(Pattern); ok {
+			gotLabels = labelsToString([]Node{resultNode})
+		}
+
+		return value{
+			Result:       string(got),
+			ResultLabels: gotLabels,
+			ResultRange:  gotRange,
+		}
+	}
+
+	autogold.Expect(value{
+		Result:      `{"field":"f","value":"^$","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":2}}`,
+	}).Equal(t, test(`f:`))
+	autogold.Expect(value{
+		Result:      `{"field":"f","value":"^ $","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":5}}`,
+	}).Equal(t, test(`f:" "`))
+	autogold.Expect(value{
+		Result:      `{"field":"f","value":" $","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}`,
+	}).Equal(t, test(`f:"* "`))
+	autogold.Expect(value{
+		Result:      `{"field":"f","value":"^ ","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}`,
+	}).Equal(t, test(`f:" *"`))
+	autogold.Expect(value{
+		Result:      `{"field":"f","value":" ","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":7}}`,
+	}).Equal(t, test(`f:"* *"`))
+	autogold.Expect(value{
+		Result:      `{"field":"f","value":"^foo bar$","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":11}}`,
+	}).Equal(t, test(`f:"foo bar"`))
+	autogold.Expect(value{
+		Result:      `{"field":"r","value":".*","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}`,
+	}).Equal(t, test(`r:*`))
+	autogold.Expect(value{
+		Result:      `{"field":"repo","value":".*","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}`,
+	}).Equal(t, test(`repo:*`))
+	autogold.Expect(value{
+		Result:      `{"field":"f","value":".*","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}`,
+	}).Equal(t, test(`f:*`))
+	autogold.Expect(value{
+		Result:      `{"field":"file","value":".*","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}`,
+	}).Equal(t, test(`file:*`))
+	autogold.Expect(value{
+		Result:      `{"field":"repo","value":"^sourcegraph$","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":16}}`,
+	}).Equal(t, test(`repo:sourcegraph`))
+	autogold.Expect(value{
+		Result:      `{"field":"repo","value":"^github\\.com/","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":17}}`,
+	}).Equal(t, test(`repo:github.com/*`))
+	autogold.Expect(value{
+		Result:      `{"field":"repo","value":"/sourcegraph$","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":18}}`,
+	}).Equal(t, test(`repo:*/sourcegraph`))
+	autogold.Expect(value{
+		Result:      `{"field":"file","value":"^README\\.md$","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
+	}).Equal(t, test(`file:README.md`))
+	autogold.Expect(value{
+		Result:      `{"field":"file","value":"^client/README\\.md$","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":21}}`,
+	}).Equal(t, test(`file:client/README.md`))
+	autogold.Expect(value{
+		Result:      `{"field":"file","value":"/Dockerfile$","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":17}}`,
+	}).Equal(t, test(`file:*/Dockerfile`))
+	autogold.Expect(value{
+		Result:      `{"field":"file","value":"\\.go$","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":9}}`,
+	}).Equal(t, test(`file:*.go`))
+	autogold.Expect(value{
+		Result:      `{"field":"file","value":"^src/","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":10}}`,
+	}).Equal(t, test(`file:src/*`))
+	autogold.Expect(value{Result: `{"Kind":1,"Operands":[{"field":"context","value":"global","negated":false},{"field":"repo","value":"/sourcegraph$","negated":false},{"field":"f","value":"\\.md$","negated":false},{"value":"zoekt","negated":false}],"Annotation":{"labels":0,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}}}`}).Equal(t, test(`context:global repo:*/sourcegraph zoekt f:*.md`))
+	autogold.Expect(value{Result: `{"Kind":1,"Operands":[{"field":"f","value":"_test\\.go$","negated":true},{"field":"f","value":"search.*\\.go$","negated":false}],"Annotation":{"labels":0,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}}}`}).Equal(t, test(`-f:*_test.go f:*search*.go`))
+}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -963,4 +963,23 @@ func TestGlobToRegex(t *testing.T) {
 	}).Equal(t, test(`file:src/*`))
 	autogold.Expect(value{Result: `{"Kind":1,"Operands":[{"field":"context","value":"global","negated":false},{"field":"repo","value":"/sourcegraph$","negated":false},{"field":"f","value":"\\.md$","negated":false},{"value":"zoekt","negated":false}],"Annotation":{"labels":0,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}}}`}).Equal(t, test(`context:global repo:*/sourcegraph zoekt f:*.md`))
 	autogold.Expect(value{Result: `{"Kind":1,"Operands":[{"field":"f","value":"_test\\.go$","negated":true},{"field":"f","value":"search.*\\.go$","negated":false}],"Annotation":{"labels":0,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}}}`}).Equal(t, test(`-f:*_test.go f:*search*.go`))
+	// Make sure we don't convert predicates to regex patterns
+	autogold.Expect(value{
+		Result:      `{"field":"r","value":"has.meta(language)","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":20}}`,
+	}).Equal(t, test(`r:has.meta(language)`))
+	autogold.Expect(value{
+		Result:      `{"field":"r","value":"has.file(go.mod)","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":18}}`,
+	}).Equal(t, test(`r:has.file(go.mod)`))
+	autogold.Expect(value{
+		Result:      `{"field":"r","value":"has.content(apple)","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":20}}`,
+	}).Equal(t, test(`r:has.content(apple)`))
+	autogold.Expect(value{
+		Result:      `{"field":"f","value":"has.content(apple)","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":20}}`,
+	}).Equal(t, test(`f:has.content(apple)`))
+	autogold.Expect(value{
+		Result: `{"Kind":1,"Operands":[{"field":"r","value":"go$","negated":false},{"field":"r","value":"has.topic(language)","negated":false}],"Annotation":{"labels":0,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}}}`}).Equal(t, test(`r:*go r:has.topic(language)`))
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -28,7 +28,7 @@ func TestSubstituteAliases(t *testing.T) {
 	autogold.Expect(`[{"field":"file","value":"foo","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":8}}}]`).
 		Equal(t, test("path:foo", SearchTypeLiteral))
 
-	autogold.Expect(`[{"and":[{"field":"repo","value":"repo","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}},{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":7},"end":{"line":0,"column":10}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":11},"end":{"line":0,"column":14}}}]}]`).
+	autogold.Expect(`[{"and":[{"field":"repo","value":"^repo$","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}},{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":7},"end":{"line":0,"column":10}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":11},"end":{"line":0,"column":14}}}]}]`).
 		Equal(t, test("r:repo foo bar", SearchTypeNewStandardRC1))
 
 	autogold.Expect(`[{"and":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":4},"end":{"line":0,"column":7}}},{"value":"bas","negated":false,"labels":["Regexp"],"range":{"start":{"line":0,"column":8},"end":{"line":0,"column":13}}}]}]`).


### PR DESCRIPTION
Relates to https://github.com/sourcegraph/sourcegraph/issues/58815
Ported directly from https://github.com/sourcegraph/sourcegraph/pull/58849/

We add support for glob syntax to file and repo filters.

Notes:
- `f:` matches nothing. I think this is less surprising than our [current behavior](https://sourcegraph.com/search?q=context:global+f:&patternType=standard&sm=1)
- `*` matches any sequence of characters, including `/`
- No other special characters are supported

Test plan:
- new unit tests
