### PR TITLE
bazel: nicer error message for forbidigo patterns

### DIFF
--- a/dev/linters/forbidigo/forbidigo.go
+++ b/dev/linters/forbidigo/forbidigo.go
@@ -1,6 +1,7 @@
 package forbidigo
 
 import (
+	"fmt"
 	"go/ast"
 
 	"github.com/ashanbrown/forbidigo/forbidigo"
@@ -13,9 +14,11 @@ import (
 // Analyzer is the analyzer nogo should use
 var Analyzer = nolint.Wrap(analyzer.NewAnalyzer())
 
-// defaultPatterns the patterns forbigigo should ban if they match
+// defaultPatterns the patterns forbigigo should ban if they match.
+// JSON based off the pattern struct:
+// https://sourcegraph.com/github.com/ashanbrown/forbidigo@57bf5a72a4f5c3c28dce5a8aebb37a9be36bece7/-/blob/forbidigo/patterns.go?L13-29
 var defaultPatterns = []string{
-	"^fmt\\.Errorf$", // Use errors.Newf instead
+	fmt.Sprintf(`{"p":"^fmt\\.Errorf$", "msg": "%s should be used instead"}`, "`errors.Newf`"),
 }
 
 var config = struct {


### PR DESCRIPTION
New output: `dev/linters/dbconn/dbconn.go:83:16: use of fmt.Errorf forbidden because “errors.Newf should be used instead” (forbidigo)`
Previous output: `dev/linters/dbconn/dbconn.go:83:16: use of fmt.Errorf forbidden by pattern ^fmt\.Errorf$ (forbidigo)`

## Test plan

Used `fmt.Errorf` in //dev/linters/dbconn` and ran bazel build on it