### PR TITLE
Fix new flag for file preview feature/global navigation search box

### DIFF
--- a/client/branded/src/search-ui/components/FilePathSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FilePathSearchResult.tsx
@@ -37,7 +37,7 @@ export const FilePathSearchResult: React.FunctionComponent<FilePathSearchResult 
     const newSearchUIEnabled = useMemo(() => {
         const settings = settingsCascade.final
         if (!isErrorLike(settings)) {
-            return settings?.experimentalFeatures?.newSearchNavigationUI
+            return settings?.experimentalFeatures?.newSearchResultsUI
         }
         return false
     }, [settingsCascade])

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -184,6 +184,12 @@ const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
     const navigate = useNavigate()
     const location = useLocation()
 
+    // If the feature-flag "search-new-keyword" is set, we allow the user to
+    // choose between precise (legacy), precise (new), and smart search.  This
+    // is only temporary for internal testing.  The goal is to make the new
+    // precise search the default.
+    const [showExtendedPicker] = useFeatureFlag('search-new-keyword')
+
     const [isFocused, setFocused] = useState(false)
     const { searchMode, queryState, searchPatternType, searchCaseSensitivity, setQueryState, submitSearch } =
         useNavbarQueryState(selectQueryState, shallow)
@@ -240,6 +246,7 @@ const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
                     setCaseSensitivity={setSearchCaseSensitivity}
                     setSearchMode={setSearchMode}
                     submitSearch={submitSearchOnChange}
+                    showExtendedPicker={showExtendedPicker}
                 />
             </LazyV2SearchInput>
 


### PR DESCRIPTION
So there are a few problems with new search results UI and global navigation UI feature flags
- In new navigation the new search mode picker is missing (this PR fixes)
- When we released file preview feature behind navigation flag we had to change it to newSearchResultUI feature flag, when I updated it I forgot about one place, so I fixed it here too

## Test plan
- Check that new navigation search box has new search modes picker
- Check that file preview feature is available only when `newSearchResultsUI` is enabled 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
