### PR TITLE
svelte: Initialize theme with user configured value

### DIFF
--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -6,7 +6,8 @@
     import { isErrorLike } from '$lib/common'
     import { TemporarySettingsStorage } from '$lib/shared'
     import { isLightTheme, KEY, scrollAll, type SourcegraphContext } from '$lib/stores'
-    import { createTemporarySettingsStorage } from '$lib/temporarySettings'
+    import { createTemporarySettingsStorage, temporarySetting } from '$lib/temporarySettings'
+    import { humanTheme } from '$lib/theme'
 
     import Header from './Header.svelte'
 
@@ -17,6 +18,7 @@
     import type { LayoutData, Snapshot } from './$types'
     import { createFeatureFlagStore, fetchEvaluatedFeatureFlags } from '$lib/featureflags'
     import InfoBanner from './InfoBanner.svelte'
+    import { Theme } from '$lib/theme'
 
     export let data: LayoutData
 
@@ -39,6 +41,14 @@
     // Update stores when data changes
     $: $user = data.user ?? null
     $: $settings = isErrorLike(data.settings) ? null : data.settings.final
+
+    // Set initial, user configured theme
+    // TODO: This should be send be server in the HTML so that we don't flash the wrong theme
+    // on initial page load.
+    $: userTheme = temporarySetting('user.themePreference', 'System')
+    $: if (!$userTheme.loading && $userTheme.data) {
+        $humanTheme = $userTheme.data
+    }
 
     $: if (browser) {
         document.documentElement.classList.toggle('theme-light', $isLightTheme)


### PR DESCRIPTION
Before this commit the theme was always initialized as 'system'. This loads the configured theme from temporary settings. There will be a flash of the wrong theme on load, but that's not avoidable atm.



## Test plan

Manual testing.
