### PR TITLE
Revert "Code Navigation: tokens highlight immediately on hover"

### DIFF
--- a/client/branded/src/search-ui/input/codemirror/token-info.ts
+++ b/client/branded/src/search-ui/input/codemirror/token-info.ts
@@ -86,7 +86,7 @@ export function tokenInfo(): Extension {
                 effect.is(setHighlighedTokenPosition)
             )
             if (effect) {
-                position = effect.value
+                position = effect?.value
             }
             if (position !== null) {
                 // Mapping the position might not be necessary since we clear

--- a/client/wildcard/src/global-styles/highlight.scss
+++ b/client/wildcard/src/global-styles/highlight.scss
@@ -556,21 +556,6 @@
         color: var(--hl-pink);
     }
 
-    // The following hl-typed-* that have associated tooltips.
-    // This ensures that tokens highlight before tooltip is available.
-    .hl-typed-Identifier:hover,
-    .hl-typed-IdentifierParameter:hover,
-    .hl-typed-IdentifierAttribute:hover,
-    .hl-typed-IdentifierType:hover,
-    .hl-typed-IdentifierFunction:hover,
-    .hl-typed-IdentifierModule:hover,
-    .hl-typed-IdentifierFunctionDefinition:hover,
-    .hl-typed-IdentifierNamespace:hover,
-    .hl-typed-IdentifierConstant:hover,
-    .hl-typed-IdentifierBuiltin:hover {
-        background-color: var(--mark-bg);
-    }
-
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995
     // .hl-typed-RegexEscape {
     // }
@@ -991,21 +976,6 @@
     }
     .hl-typed-IdentifierAttribute {
         color: var(--hl-purple);
-    }
-
-    // The following hl-typed-* that have associated tooltips.
-    // This ensures that tokens highlight before tooltip is available.
-    .hl-typed-Identifier:hover,
-    .hl-typed-IdentifierAttribute:hover,
-    .hl-typed-IdentifierBuiltin:hover,
-    .hl-typed-IdentifierConstant:hover,
-    .hl-typed-IdentifierFunction:hover,
-    .hl-typed-IdentifierFunctionDefinition:hover,
-    .hl-typed-IdentifierModule:hover,
-    .hl-typed-IdentifierNamespace:hover,
-    .hl-typed-IdentifierParameter:hover,
-    .hl-typed-IdentifierType:hover {
-        background-color: var(--mark-bg);
     }
 
     // TODO: Followup for https://github.com/sourcegraph/sourcegraph/issues/30995


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#58384

This caused some drastic UI issues with search results and certain file types.

## Test plan
Tested that the behavior has been returned to the original state, where tokens are only highlighted when the info for the hovercards is populated.
