### PR TITLE
[Backport 5.2] Embeddings: avoid constantly rerunning job if it failed

### DIFF
--- a/cmd/frontend/internal/app/resolvers/app.go
+++ b/cmd/frontend/internal/app/resolvers/app.go
@@ -110,7 +110,7 @@ func (r *appResolver) SetupNewAppRepositoriesForEmbedding(ctx context.Context, a
 					r.logger.Debug("Checking repo")
 					branch, _, err := r.gitClient.GetDefaultBranch(ctx, repoName, true)
 					if err == nil && branch != "" {
-						if err := embeddings.ScheduleRepositoriesForEmbedding(
+						if err := embeddings.ScheduleRepositories(
 							ctx,
 							[]api.RepoName{repoName},
 							false,

--- a/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -148,7 +148,7 @@ func (r *Resolver) ScheduleRepositoriesForEmbedding(ctx context.Context, args gr
 	}
 	forceReschedule := args.Force != nil && *args.Force
 
-	err = embeddings.ScheduleRepositoriesForEmbedding(
+	err = embeddings.ScheduleRepositories(
 		ctx,
 		repoNames,
 		forceReschedule,

--- a/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
+++ b/enterprise/cmd/worker/internal/embeddings/repo/scheduler.go
@@ -57,23 +57,13 @@ func newRepoEmbeddingScheduler(
 				return err
 			}
 
-			// get repo names from embeddable repos
 			var repoIDs []api.RepoID
 			for _, embeddable := range embeddableRepos {
 				repoIDs = append(repoIDs, embeddable.ID)
 			}
-			repos, err := db.Repos().GetByIDs(ctx, repoIDs...)
-			if err != nil {
-				return err
-			}
-			var repoNames []api.RepoName
-			for _, r := range repos {
-				repoNames = append(repoNames, r.Name)
-			}
 
-			return embeddings.ScheduleRepositoriesForEmbedding(ctx,
-				repoNames,
-				false, // Automatically scheduled jobs never force a full reindex
+			return embeddings.ScheduleRepositoriesForPolicy(ctx,
+				repoIDs,
 				db,
 				repoEmbeddingJobsStore,
 				gitserverClient)

--- a/internal/embeddings/background/repo/types.go
+++ b/internal/embeddings/background/repo/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/executor"
 )
@@ -37,12 +38,12 @@ func (j *RepoEmbeddingJob) RecordUID() string {
 }
 
 func (j *RepoEmbeddingJob) IsRepoEmbeddingJobScheduledOrCompleted() bool {
-	return j != nil && (j.State == "completed" || j.State == "processing" || j.State == "queued")
+	return j.State == "completed" || j.State == "processing" || j.State == "queued"
 }
 
 // EmptyRepoEmbeddingJob returns true if this job completed with an empty revision value and final state of failed
 func (j *RepoEmbeddingJob) EmptyRepoEmbeddingJob() bool {
-	return j != nil && j.State == "failed" && j.Revision == ""
+	return j.State == "failed" && j.Revision == ""
 }
 
 type EmbedRepoStats struct {

--- a/internal/embeddings/background/repo/types.go
+++ b/internal/embeddings/background/repo/types.go
@@ -41,11 +41,6 @@ func (j *RepoEmbeddingJob) IsRepoEmbeddingJobScheduledOrCompleted() bool {
 	return j.State == "completed" || j.State == "processing" || j.State == "queued"
 }
 
-// EmptyRepoEmbeddingJob returns true if this job completed with an empty revision value and final state of failed
-func (j *RepoEmbeddingJob) EmptyRepoEmbeddingJob() bool {
-	return j.State == "failed" && j.Revision == ""
-}
-
 type EmbedRepoStats struct {
 	CodeIndexStats EmbedFilesStats
 	TextIndexStats EmbedFilesStats

--- a/internal/embeddings/schedule.go
+++ b/internal/embeddings/schedule.go
@@ -9,14 +9,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
-func ScheduleRepositoriesForEmbedding(
+func ScheduleRepositories(
 	ctx context.Context,
 	repoNames []api.RepoName,
 	forceReschedule bool,
 	db database.DB,
 	repoEmbeddingJobsStore repo.RepoEmbeddingJobsStore,
 	gitserverClient gitserver.Client,
-) error {
+) (err error) {
 	tx, err := repoEmbeddingJobsStore.Transact(ctx)
 	if err != nil {
 		return err
@@ -25,36 +25,73 @@ func ScheduleRepositoriesForEmbedding(
 
 	repoStore := db.Repos()
 	for _, repoName := range repoNames {
-		// Scope the iteration to an anonymous function, so we can capture all errors and properly rollback tx in defer above.
-		err = func() error {
-			r, err := repoStore.GetByName(ctx, repoName)
-			if err != nil {
-				return nil
-			}
-
-			refName, latestRevision, err := gitserverClient.GetDefaultBranch(ctx, r.Name, false)
-			// enqueue with an empty revision and let handler determine whether job can execute
-			if err != nil || refName == "" {
-				latestRevision = ""
-			}
-
-			// Skip creating a repo embedding job for a repo at revision, if there already exists
-			// an identical job that has been completed, or is scheduled to run (processing or queued).
-			if !forceReschedule {
-				job, _ := tx.GetLastRepoEmbeddingJobForRevision(ctx, r.ID, latestRevision)
-
-				// if job previously failed then only resubmit if revision is non-empty
-				if job.IsRepoEmbeddingJobScheduledOrCompleted() || job.EmptyRepoEmbeddingJob() {
-					return nil
-				}
-			}
-
-			_, err = tx.CreateRepoEmbeddingJob(ctx, r.ID, latestRevision)
+		r, err := repoStore.GetByName(ctx, repoName)
+		if err != nil {
 			return err
-		}()
+		}
+
+		refName, latestRevision, err := gitserverClient.GetDefaultBranch(ctx, r.Name, false)
+		if err != nil || refName == "" {
+			return err
+		}
+
+		if !forceReschedule {
+			job, _ := tx.GetLastRepoEmbeddingJobForRevision(ctx, r.ID, latestRevision)
+			if job != nil && isScheduledOrCompleted(job) {
+				continue
+			}
+		}
+
+		_, err = tx.CreateRepoEmbeddingJob(ctx, r.ID, latestRevision)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func ScheduleRepositoriesForPolicy(
+	ctx context.Context,
+	repoIDs []api.RepoID,
+	db database.DB,
+	repoEmbeddingJobsStore repo.RepoEmbeddingJobsStore,
+	gitserverClient gitserver.Client,
+) (err error) {
+	tx, err := repoEmbeddingJobsStore.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	repoStore := db.Repos()
+	repos, err := repoStore.ListMinimalRepos(ctx, database.ReposListOptions{IDs: repoIDs})
+	if err != nil {
+		return err
+	}
+
+	for _, r := range repos {
+		refName, latestRevision, err := gitserverClient.GetDefaultBranch(ctx, r.Name, false)
+		// enqueue with an empty revision and let handler determine whether job can execute
+		if err != nil || refName == "" {
+			latestRevision = ""
+		}
+
+		job, _ := tx.GetLastRepoEmbeddingJobForRevision(ctx, r.ID, latestRevision)
+		if job != nil && isScheduledOrCompleted(job) {
+			continue
+		}
+
+		_, err = tx.CreateRepoEmbeddingJob(ctx, r.ID, latestRevision)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// We skip creating a repo embedding job for a repo at revision if there already exists
+// an identical job that has been completed, or is scheduled to run (processing or queued).
+// In the case that a repo is empty, a job is considered "completed" even if it failed.
+func isScheduledOrCompleted(job *repo.RepoEmbeddingJob) bool {
+	return job.IsRepoEmbeddingJobScheduledOrCompleted() || job.EmptyRepoEmbeddingJob()
 }

--- a/internal/embeddings/schedule_test.go
+++ b/internal/embeddings/schedule_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func TestScheduleRepositoriesForEmbedding(t *testing.T) {
+func TestScheduleRepositories(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
@@ -38,21 +38,52 @@ func TestScheduleRepositoriesForEmbedding(t *testing.T) {
 
 	// By default, we shouldn't schedule a new job for the same revision
 	repoNames := []api.RepoName{"github.com/sourcegraph/sourcegraph"}
-	err = ScheduleRepositoriesForEmbedding(ctx, repoNames, false, db, store, gitserverClient)
+	err = ScheduleRepositories(ctx, repoNames, false, db, store, gitserverClient)
 	require.NoError(t, err)
 	count, err := store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 
 	// With the 'force' argument, a new job will be scheduled anyways
-	err = ScheduleRepositoriesForEmbedding(ctx, repoNames, true, db, store, gitserverClient)
+	err = ScheduleRepositories(ctx, repoNames, true, db, store, gitserverClient)
 	require.NoError(t, err)
 	count, err = store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
 	require.NoError(t, err)
 	require.Equal(t, 2, count)
 }
 
-func TestScheduleRepositoriesForEmbeddingRepoNotFound(t *testing.T) {
+func TestScheduleMultipleReposForPolicy(t *testing.T) {
+	t.Parallel()
+
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(t))
+	repoStore := db.Repos()
+
+	createdRepo := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}
+	createdRepo2 := &types.Repo{Name: "github.com/sourcegraph/zoekt", URI: "github.com/sourcegraph/zoekt", ExternalRepo: api.ExternalRepoSpec{}}
+	err := repoStore.Create(ctx, createdRepo, createdRepo2)
+	require.NoError(t, err)
+
+	// Create a repo embedding job.
+	store := repo.NewRepoEmbeddingJobsStore(db)
+	_, err = store.CreateRepoEmbeddingJob(ctx, createdRepo.ID, "coffee")
+	require.NoError(t, err)
+
+	gitserverClient := gitserver.NewMockClient()
+	gitserverClient.GetDefaultBranchFunc.SetDefaultReturn("main", "coffee", nil)
+
+	// We should only schedule a new job for the 'zoekt' repo
+	repoIDs := []api.RepoID{createdRepo.ID, createdRepo2.ID}
+	err = ScheduleRepositoriesForPolicy(ctx, repoIDs, db, store, gitserverClient)
+	require.NoError(t, err)
+
+	count, err := store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+}
+
+func TestScheduleRepositoriesRepoNotFound(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
@@ -70,8 +101,37 @@ func TestScheduleRepositoriesForEmbeddingRepoNotFound(t *testing.T) {
 	gitserverClient := gitserver.NewMockClient()
 	gitserverClient.GetDefaultBranchFunc.PushReturn("main", "sgrevision", nil)
 
-	repoNames := []api.RepoName{"github.com/repo/notfound", "github.com/sourcegraph/sourcegraph"}
-	err = ScheduleRepositoriesForEmbedding(ctx, repoNames, false, db, store, gitserverClient)
+	repoNames := []api.RepoName{"github.com/sourcegraph/sourcegraph", "github.com/repo/notfound"}
+	err = ScheduleRepositories(ctx, repoNames, false, db, store, gitserverClient)
+	require.Error(t, err, database.RepoNotFoundErr{})
+
+	pattern := "github.com/sourcegraph/sourcegraph"
+	first := 10
+	jobs, err := store.ListRepoEmbeddingJobs(ctx, repo.ListOpts{PaginationArgs: &database.PaginationArgs{First: &first, OrderBy: database.OrderBy{{Field: "id"}}, Ascending: true}, Query: &pattern})
+	require.NoError(t, err)
+	require.Nil(t, jobs)
+}
+
+func TestScheduleRepositoriesForPolicyRepoNotFound(t *testing.T) {
+	t.Parallel()
+
+	logger := logtest.Scoped(t)
+	ctx := context.Background()
+	db := database.NewDB(logger, dbtest.NewDB(t))
+	repoStore := db.Repos()
+
+	createdRepo0 := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}
+	err := repoStore.Create(ctx, createdRepo0)
+	require.NoError(t, err)
+
+	// Create a repo embedding job.
+	store := repo.NewRepoEmbeddingJobsStore(db)
+
+	gitserverClient := gitserver.NewMockClient()
+	gitserverClient.GetDefaultBranchFunc.PushReturn("main", "sgrevision", nil)
+
+	repoIDs := []api.RepoID{api.RepoID(234), createdRepo0.ID} // Include one non-existent ID
+	err = ScheduleRepositoriesForPolicy(ctx, repoIDs, db, store, gitserverClient)
 	require.NoError(t, err)
 	count, err := store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
 	require.NoError(t, err)
@@ -84,7 +144,7 @@ func TestScheduleRepositoriesForEmbeddingRepoNotFound(t *testing.T) {
 	require.Equal(t, "queued", jobs[0].State)
 }
 
-func TestScheduleRepositoriesForEmbeddingInvalidDefaultBranch(t *testing.T) {
+func TestScheduleRepositoriesInvalidDefaultBranch(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
@@ -102,8 +162,8 @@ func TestScheduleRepositoriesForEmbeddingInvalidDefaultBranch(t *testing.T) {
 	gitserverClient := gitserver.NewMockClient()
 	gitserverClient.GetDefaultBranchFunc.PushReturn("", "sgrevision", nil)
 
-	repoNames := []api.RepoName{"github.com/sourcegraph/sourcegraph"}
-	err = ScheduleRepositoriesForEmbedding(ctx, repoNames, false, db, store, gitserverClient)
+	repoIDs := []api.RepoID{createdRepo0.ID}
+	err = ScheduleRepositoriesForPolicy(ctx, repoIDs, db, store, gitserverClient)
 	require.NoError(t, err)
 	count, err := store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
 	require.NoError(t, err)
@@ -116,7 +176,7 @@ func TestScheduleRepositoriesForEmbeddingInvalidDefaultBranch(t *testing.T) {
 	require.Equal(t, "queued", jobs[0].State)
 }
 
-func TestScheduleRepositoriesForEmbeddingFailed(t *testing.T) {
+func TestScheduleRepositoriesFailed(t *testing.T) {
 	t.Parallel()
 
 	logger := logtest.Scoped(t)
@@ -139,8 +199,8 @@ func TestScheduleRepositoriesForEmbeddingFailed(t *testing.T) {
 	gitserverClient.GetDefaultBranchFunc.PushReturn("", "sgrevision", nil)
 	gitserverClient.GetDefaultBranchFunc.PushReturn("main", "zoektrevision", nil)
 
-	repoNames := []api.RepoName{"github.com/sourcegraph/sourcegraph", "github.com/sourcegraph/zoekt"}
-	err = ScheduleRepositoriesForEmbedding(ctx, repoNames, false, db, store, gitserverClient)
+	repoIDs := []api.RepoID{createdRepo0.ID, createdRepo1.ID}
+	err = ScheduleRepositoriesForPolicy(ctx, repoIDs, db, store, gitserverClient)
 	require.NoError(t, err)
 	count, err := store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
 	require.NoError(t, err)
@@ -169,7 +229,7 @@ func TestScheduleRepositoriesForEmbeddingFailed(t *testing.T) {
 	gitserverClient.GetDefaultBranchFunc.PushReturn("", "sgrevision", nil)
 	gitserverClient.GetDefaultBranchFunc.PushReturn("main", "zoektrevision", nil)
 
-	err = ScheduleRepositoriesForEmbedding(ctx, repoNames, false, db, store, gitserverClient)
+	err = ScheduleRepositoriesForPolicy(ctx, repoIDs, db, store, gitserverClient)
 	require.NoError(t, err)
 	count, err = store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
 	require.NoError(t, err)
@@ -180,7 +240,7 @@ func TestScheduleRepositoriesForEmbeddingFailed(t *testing.T) {
 	gitserverClient.GetDefaultBranchFunc.PushReturn("main", "sgrevision", nil)
 	gitserverClient.GetDefaultBranchFunc.PushReturn("main", "zoektrevision", nil)
 
-	err = ScheduleRepositoriesForEmbedding(ctx, repoNames, false, db, store, gitserverClient)
+	err = ScheduleRepositoriesForPolicy(ctx, repoIDs, db, store, gitserverClient)
 	require.NoError(t, err)
 	count, err = store.CountRepoEmbeddingJobs(ctx, repo.ListOpts{})
 	require.NoError(t, err)

--- a/internal/embeddings/schedule_test.go
+++ b/internal/embeddings/schedule_test.go
@@ -57,7 +57,7 @@ func TestScheduleMultipleReposForPolicy(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(t))
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	repoStore := db.Repos()
 
 	createdRepo := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}
@@ -117,7 +117,7 @@ func TestScheduleRepositoriesForPolicyRepoNotFound(t *testing.T) {
 
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-	db := database.NewDB(logger, dbtest.NewDB(t))
+	db := database.NewDB(logger, dbtest.NewDB(logger, t))
 	repoStore := db.Repos()
 
 	createdRepo0 := &types.Repo{Name: "github.com/sourcegraph/sourcegraph", URI: "github.com/sourcegraph/sourcegraph", ExternalRepo: api.ExternalRepoSpec{}}


### PR DESCRIPTION
This PR backports a fix to embeddings, plus an earlier refactor that it's based on:
* https://github.com/sourcegraph/sourcegraph/pull/58980
* https://github.com/sourcegraph/sourcegraph/pull/58787

## Test plan

Modified unit tests