### PR TITLE
svelte: Fix setting theme from temporary settings

### DIFF
--- a/client/web-sveltekit/src/lib/theme.ts
+++ b/client/web-sveltekit/src/lib/theme.ts
@@ -22,7 +22,7 @@ export const isLightTheme = derived(theme, ($theme, set) => {
     if ($theme === Theme.System) {
         const matchMedia = window.matchMedia('(prefers-color-scheme: light)')
         set(matchMedia.matches)
-        const listener = (event: MediaQueryListEventMap['change']) => {
+        const listener = (event: MediaQueryListEventMap['change']): void => {
             set(event.matches)
         }
         matchMedia.addEventListener('change', listener)
@@ -64,3 +64,24 @@ export const humanTheme = createMappingStore(
         }
     }
 )
+
+/**
+ * Interprets a string as a theme and sets the theme accordingly.
+ */
+export function setThemeFromString(value: string): void {
+    value = value.toLowerCase()
+    switch (value) {
+        case 'light': {
+            theme.set(Theme.Light)
+            break
+        }
+        case 'dark': {
+            theme.set(Theme.Dark)
+            break
+        }
+        case 'system': {
+            theme.set(Theme.System)
+            break
+        }
+    }
+}

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -7,7 +7,7 @@
     import { TemporarySettingsStorage } from '$lib/shared'
     import { isLightTheme, KEY, scrollAll, type SourcegraphContext } from '$lib/stores'
     import { createTemporarySettingsStorage, temporarySetting } from '$lib/temporarySettings'
-    import { humanTheme } from '$lib/theme'
+    import { setThemeFromString } from '$lib/theme'
 
     import Header from './Header.svelte'
 
@@ -18,7 +18,6 @@
     import type { LayoutData, Snapshot } from './$types'
     import { createFeatureFlagStore, fetchEvaluatedFeatureFlags } from '$lib/featureflags'
     import InfoBanner from './InfoBanner.svelte'
-    import { Theme } from '$lib/theme'
 
     export let data: LayoutData
 
@@ -47,7 +46,7 @@
     // on initial page load.
     $: userTheme = temporarySetting('user.themePreference', 'System')
     $: if (!$userTheme.loading && $userTheme.data) {
-        $humanTheme = $userTheme.data
+        setThemeFromString($userTheme.data)
     }
 
     $: if (browser) {


### PR DESCRIPTION
#59086 didn't work properly. Turns out the theme values stored in temporary setting are different from what the prototype expected. It only accidentally worked when I tested it.

This commit introduces a helper method that accepts an arbitrary string value and updates the theme state accordingly, instead of using an arbitrary string value as theme state (ideally TS would have complained about this before but it looks like it didn't).


## Test plan

Go to dotcom, change theme to the different values (system, light, dark). Refresh local dev build (proxies to dotcom) after every change and verify that it applies the set theme.
