### PR TITLE
Make sure we test gRPC in CI suites

### DIFF
--- a/dev/run-server-image.sh
+++ b/dev/run-server-image.sh
@@ -8,7 +8,7 @@ PORT=${PORT:-"7080"}
 URL="http://localhost:$PORT"
 DATA=${DATA:-"/tmp/sourcegraph-data"}
 SOURCEGRAPH_LICENSE_GENERATION_KEY=${SOURCEGRAPH_LICENSE_GENERATION_KEY:-""}
-SG_FEATURE_FLAG_GRPC=${SG_FEATURE_FLAG_GRPC:-"false"}
+SG_FEATURE_FLAG_GRPC=${SG_FEATURE_FLAG_GRPC:-"true"}
 DB_STARTUP_TIMEOUT="10s"
 
 echo "--- Checking for existing Sourcegraph instance at $URL"
@@ -20,16 +20,16 @@ fi
 
 # shellcheck disable=SC2153
 case "$CLEAN" in
-"true")
-  clean=y
-  ;;
-"false")
-  clean=n
-  ;;
-*)
-  echo -n "Do you want to delete $DATA and start clean? [Y/n] "
-  read -r clean
-  ;;
+  "true")
+    clean=y
+    ;;
+  "false")
+    clean=n
+    ;;
+  *)
+    echo -n "Do you want to delete $DATA and start clean? [Y/n] "
+    read -r clean
+    ;;
 esac
 
 if [ "$clean" != "n" ] && [ "$clean" != "N" ]; then

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -15,7 +15,7 @@ server_integration_test(
         "//cmd/server:image_tarball",
     ],
     env = {
-        "SG_FEATURE_FLAG_GRPC": "false",
+        "SG_FEATURE_FLAG_GRPC": "true",
         "TEST_USER_EMAIL": "test@sourcegraph.com",
         "TEST_USER_PASSWORD": "supersecurepassword",
         "SOURCEGRAPH_SUDO_TOKEN": "fake-sg-token",
@@ -140,7 +140,7 @@ server_integration_test(
         "//internal/cmd/init-sg",
     ],
     env = {
-        "SG_FEATURE_FLAG_GRPC": "false",
+        "SG_FEATURE_FLAG_GRPC": "true",
         "TEST_USER_EMAIL": "test@sourcegraph.com",
         "TEST_USER_PASSWORD": "supersecurepassword",
         "SOURCEGRAPH_SUDO_USER": "admin",
@@ -225,7 +225,7 @@ server_integration_test(
         ],
     }),
     env = {
-        "SG_FEATURE_FLAG_GRPC": "false",
+        "SG_FEATURE_FLAG_GRPC": "true",
         "TEST_USER_EMAIL": "test@sourcegraph.com",
         "TEST_USER_PASSWORD": "supersecurepassword",
         "SOURCEGRAPH_SUDO_USER": "admin",


### PR DESCRIPTION
Some of the suites weren't yet using gRPC - this PR turns it on so we gain some more confidence before we start dropping HTTP entirely.

## Test plan

See if CI passes.