### PR TITLE
grpc: create stub retry utilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -262,6 +262,7 @@ require (
 	github.com/google/go-github/v48 v48.2.0
 	github.com/google/go-github/v55 v55.0.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0-rc.0
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0
 	github.com/hashicorp/cronexpr v1.1.1
 	github.com/hashicorp/go-tfe v1.32.1
 	github.com/hashicorp/terraform-cdk-go/cdktf v0.17.3
@@ -328,7 +329,6 @@ require (
 	github.com/gosimple/slug v1.12.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/grafana-tools/sdk v0.0.0-20220919052116-6562121319fc // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/internal/grpc/defaults/BUILD.bazel
+++ b/internal/grpc/defaults/BUILD.bazel
@@ -6,11 +6,13 @@ go_library(
     srcs = [
         "cache.go",
         "defaults.go",
+        "retry.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/grpc/defaults",
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/actor",
+        "//internal/env",
         "//internal/grpc",
         "//internal/grpc/contextconv",
         "//internal/grpc/internalerrs",
@@ -22,11 +24,13 @@ go_library(
         "//internal/ttlcache",
         "//lib/errors",
         "@com_github_grpc_ecosystem_go_grpc_middleware_providers_prometheus//:prometheus",
+        "@com_github_grpc_ecosystem_go_grpc_middleware_v2//interceptors/retry",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc//:otelgrpc",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials",
         "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//reflection",
@@ -35,9 +39,13 @@ go_library(
 
 go_test(
     name = "defaults_test",
-    srcs = ["cache_test.go"],
+    srcs = [
+        "cache_test.go",
+        "retry_test.go",
+    ],
     embed = [":defaults"],
     deps = [
+        "//lib/errors",
         "@com_github_google_go_cmp//cmp",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",

--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -77,6 +78,7 @@ func defaultDialOptions(logger log.Logger, creds credentials.TransportCredential
 	out := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithChainStreamInterceptor(
+			retry.StreamClientInterceptor(),
 			metrics.StreamClientInterceptor(),
 			messagesize.StreamClientInterceptor,
 			propagator.StreamClientPropagator(actor.ActorPropagator{}),
@@ -89,6 +91,7 @@ func defaultDialOptions(logger log.Logger, creds credentials.TransportCredential
 			contextconv.StreamClientInterceptor,
 		),
 		grpc.WithChainUnaryInterceptor(
+			retry.UnaryClientInterceptor(),
 			metrics.UnaryClientInterceptor(),
 			messagesize.UnaryClientInterceptor,
 			propagator.UnaryClientPropagator(actor.ActorPropagator{}),

--- a/internal/grpc/defaults/retry.go
+++ b/internal/grpc/defaults/retry.go
@@ -1,0 +1,86 @@
+package defaults
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+var (
+	internalRetryDelayBase, _   = time.ParseDuration(env.Get("SRC_GRPC_RETRY_DELAY_BASE", "50ms", "Base retry delay duration for internal GRPC requests"))
+	internalRetryMaxAttempts, _ = strconv.Atoi(env.Get("SRC_GRPC_RETRY_MAX_ATTEMPTS", "20", "Max retry attempts for internal GRPC requests"))
+	internalRetryMaxDuration, _ = time.ParseDuration(env.Get("SRC_GRPC_RETRY_MAX_DURATION", "3s", "Max retry duration for internal GRPC requests"))
+)
+
+// RetryPolicy is the default retry policy for internal GRPC requests.
+//
+// The retry policy will trigger on Unavailable and ResourceExhausted status errors, and will retry up to 20 times using an
+// exponential backoff policy with a maximum duration of 3s in between retries.
+//
+// Only Unary (1:1) and ServerStreaming (1:N) requests are retried. All other types of requests will immediately
+// return an Unimplemented status error. It's up to the caller to manually retry these requests.
+//
+// These defaults can be overridden with the following environment variables:
+// - SRC_GRPC_RETRY_DELAY_BASE: Base retry delay duration for internal GRPC requests
+// - SRC_GRPC_RETRY_MAX_ATTEMPTS: Max retry attempts for internal GRPC requests
+// - SRC_GRPC_RETRY_MAX_DURATION: Max retry duration for internal GRPC requests
+var RetryPolicy = []grpc.CallOption{
+	retry.WithCodes(codes.Unavailable, codes.ResourceExhausted),
+
+	// Together with the default options, the maximum delay will behave like this:
+	// Retry# Delay
+	// 1	0.05s
+	// 2	0.1s
+	// 3	0.2s
+	// 4	0.4s
+	// 5	0.8s
+	// 6	1.6s
+	// 7	3.0s
+	// 8	3.0s
+	// ...
+	// 20	3.0s
+	retry.WithMax(uint(internalRetryMaxAttempts)),
+	retry.WithBackoff(fullJitter(internalRetryDelayBase, internalRetryMaxDuration)),
+}
+
+// fullJitter returns a retry.BackOff function that generates
+// a random backoff duration in the range [base, min(base*2^attempt, max)).
+//
+// base and max must both be >= 0, and max must be greater than base. If any of these
+// conditions are not met, this function panics.
+//
+// See the full jitter algorithm described here:
+// http://www.awsarchitectureblog.com/2015/03/backoff.html
+func fullJitter(base, max time.Duration) retry.BackoffFunc {
+	if base < 0 {
+		panic(fmt.Sprintf("base must be >= 0, got %v", base))
+	}
+
+	if base >= max {
+		panic(fmt.Sprintf("max must be > base, got base=%v and max=%v", base, max))
+	}
+
+	return func(ctx context.Context, attempt uint) time.Duration {
+		if attempt <= 1 {
+			return base // save some CPU cycles
+		}
+
+		// Note: "attempt" is always > 0, so this is safe
+		multiplier := (1 << attempt) >> 1 // powers of 2: 1, 2, 4, 8
+
+		upperLimit := base * time.Duration(multiplier) // base * 2^attempt
+		if !(base < upperLimit && upperLimit <= max) { // handle underflow, overflow, or something greater than our specified max
+			upperLimit = max
+		}
+
+		jitter := time.Duration(rand.Int63n(int64(upperLimit - base)))
+		return base + jitter
+	}
+}

--- a/internal/grpc/defaults/retry_test.go
+++ b/internal/grpc/defaults/retry_test.go
@@ -1,0 +1,54 @@
+package defaults
+
+import (
+	"context"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+func TestFuzzFullJitter(t *testing.T) {
+	var jitterErr error
+
+	err := quick.Check(func(base, max time.Duration) bool {
+
+		if base < 0 {
+			base = -base // base must be non-negative
+		}
+
+		if base == 0 {
+			base = 1 // ensure base is at least 1
+		}
+
+		if max < 0 {
+			max = -max // max must be non-negative
+		}
+
+		if max == 0 {
+			max = 1 // ensure max is at least 1
+		}
+
+		if base >= max {
+			max = base + 1 // pad max to be greater than base if needed
+		}
+
+		backoffFunc := fullJitter(base, max)
+
+		for attempt := 1; attempt <= 10000; attempt++ {
+			delay := backoffFunc(context.Background(), uint(attempt))
+
+			if !(base <= delay && delay < max) {
+				jitterErr = errors.Newf("FullJitter(base=%s, max=%s)'s delay (%s) for attempt # %d is not in the range [base=%s, max=%s)", base, max, delay, attempt, base, max)
+				return false
+			}
+		}
+
+		return true
+	}, nil)
+	if err != nil {
+		t.Error(jitterErr)
+	}
+
+}


### PR DESCRIPTION
This PR adds a basic configuration for enabling retries with gRPC  for certain RPC types. 

The description for `defaults.RetryPolicy` is probably the most important thing to read:

```go
// RetryPolicy is the default retry policy for internal GRPC requests.
//
// The retry policy will trigger on Unavailable and ResourceExhausted status errors, and will retry up to 20 times using an
// exponential backoff policy with a maximum duration of 3s in between retries.
//
// Only Unary (1:1) and ServerStreaming (1:N) requests are retried. All other types of requests will immediately
// return an Unimplemented status error. It's up to the caller to manually retry these requests.
//
// These defaults can be overridden with the following environment variables:
// - SRC_GRPC_RETRY_DELAY_BASE: Base retry delay duration for internal GRPC requests
// - SRC_GRPC_RETRY_MAX_ATTEMPTS: Max retry attempts for internal GRPC requests
// - SRC_GRPC_RETRY_MAX_DURATION: Max retry duration for internal GRPC requests
var RetryPolicy = []grpc.CallOption{
	retry.WithCodes(codes.Unavailable, codes.ResourceExhausted),
	// Together with the default options, the maximum delay will behave like this:
	// Retry# Delay
	// 1	0.05s
	// 2	0.1s
	// 3	0.2s
	// 4	0.4s
	// 5	0.8s
	// 6	1.6s
	// 7	3.0s
	// 8	3.0s
	// ...
	// 20	3.0s
	retry.WithMax(uint(internalRetryMaxAttempts)),
	retry.WithBackoff(fullJitter(internalRetryDelayBase, internalRetryMaxDuration)),
}
```

This is off by default for all services (since this logic doesn't work with RPCS or might not be desirable as the default behavior if you don't know whether or not your method is idempotent).

 The upstack PRs selectively enable this logic for appropriate RPCs (see those PRs for the exact semantics). 

## Test plan

CI
