### PR TITLE
svelte: Fix local build

### DIFF
--- a/client/web-sveltekit/vite.config.ts
+++ b/client/web-sveltekit/vite.config.ts
@@ -164,6 +164,21 @@ export default defineConfig(({ mode }) => {
             },
         },
 
+        resolve: {
+            alias: [
+                // Unclear why Vite fails. It claims that index.esm.js doesn't have this export (it does).
+                // Rewriting this to index.js fixes the issue. Error:
+                // import { CiWarning, CiSettings, CiTextAlignLeft } from "react-icons/ci/index.esm.js";
+                //                     ^^^^^^^^^^
+                // SyntaxError: Named export 'CiSettings' not found. The requested module 'react-icons/ci/index.esm.js'
+                // is a CommonJS module, which may not support all module.exports as named exports.
+                {
+                    find: /^react-icons\/(.+)$/,
+                    replacement: 'react-icons/$1/index.js',
+                }
+            ],
+        },
+
         optimizeDeps: {
             exclude: [
                 // Without addings this Vite throws an error

--- a/client/web-sveltekit/vite.config.ts
+++ b/client/web-sveltekit/vite.config.ts
@@ -175,7 +175,7 @@ export default defineConfig(({ mode }) => {
                 {
                     find: /^react-icons\/(.+)$/,
                     replacement: 'react-icons/$1/index.js',
-                }
+                },
             ],
         },
 


### PR DESCRIPTION
I don't know if this is only an issue for me, but I'm not able to run `pnpm build` locally anymore. The build fails with the error mentioned in the comment. Hover seeing that CI is green for other PRs and SvelteKit is deployed to S2 successfully, I don't really know why this is happening.
This change fixes it though.

## Test plan

`pnpm build` runs locally without issue.