### PR TITLE
cody-gateway: remove SyncOnce, use existing SourceUpdater

### DIFF
--- a/cmd/cody-gateway/internal/actor/actor.go
+++ b/cmd/cody-gateway/internal/actor/actor.go
@@ -198,7 +198,8 @@ func (a *Actor) Limiter(
 		concurrentInterval: limit.ConcurrentRequestsInterval,
 
 		nextLimiter: updateOnErrorLimiter{
-			actor: a,
+			logger: logger.Scoped("updateOnError"),
+			actor:  a,
 
 			nextLimiter: baseLimiter,
 		},

--- a/cmd/cody-gateway/internal/actor/actor.go
+++ b/cmd/cody-gateway/internal/actor/actor.go
@@ -113,10 +113,11 @@ func (a *Actor) Logger(logger log.Logger) log.Logger {
 // does not necessarily occur on every call.
 //
 // If the actor has no source, this is a no-op.
-func (a *Actor) Update(ctx context.Context) {
+func (a *Actor) Update(ctx context.Context) error {
 	if su, ok := a.Source.(SourceUpdater); ok && su != nil {
-		su.Update(ctx, a)
+		return su.Update(ctx, a)
 	}
+	return nil
 }
 
 func (a *Actor) TraceAttributes() []attribute.KeyValue {

--- a/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -60,21 +60,16 @@ func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 	return s.get(ctx, token, false)
 }
 
-func (s *Source) Update(ctx context.Context, act *actor.Actor) {
-	logger := act.Logger(trace.Logger(ctx, s.log))
-
+func (s *Source) Update(ctx context.Context, act *actor.Actor) error {
 	// Update is also called when a user's rate limit is hit, so we don't want
 	// to update every time. We use a shorter interval than the default in
 	// this case.
 	if act.LastUpdated != nil && time.Since(*act.LastUpdated) < 5*time.Minute {
-		logger.Debug("skipping actor update, last updated recently")
-		return
+		return actor.ErrActorRecentlyUpdated{}
 	}
 
 	_, err := s.get(ctx, act.Key, true)
-	if err != nil {
-		logger.Error("failed to update actor")
-	}
+	return err
 }
 
 // fetchAndCache fetches the dotcom user data for the given user token and caches it

--- a/cmd/cody-gateway/internal/actor/limits.go
+++ b/cmd/cody-gateway/internal/actor/limits.go
@@ -154,7 +154,7 @@ func (u updateOnErrorLimiter) TryAcquire(ctx context.Context) (func(context.Cont
 		// Do update transiently, outside request hotpath
 		go func() {
 			if updateErr := u.actor.Update(context.WithoutCancel(ctx)); updateErr != nil &&
-				!errors.Is(updateErr, ErrActorRecentlyUpdated{}) {
+				!IsErrActorRecentlyUpdated(updateErr) {
 				u.logger.Warn("unexpected error updating actor",
 					log.Error(updateErr),
 					log.NamedError("originalError", err))

--- a/cmd/cody-gateway/internal/actor/limits.go
+++ b/cmd/cody-gateway/internal/actor/limits.go
@@ -138,17 +138,28 @@ func (e ErrConcurrencyLimitExceeded) WriteResponse(w http.ResponseWriter) {
 // updateOnErrorLimiter calls Actor.Update if nextLimiter responds with certain
 // access errors.
 type updateOnErrorLimiter struct {
-	actor *Actor
+	logger log.Logger
+	actor  *Actor
 
 	nextLimiter limiter.Limiter
 }
 
 func (u updateOnErrorLimiter) TryAcquire(ctx context.Context) (func(context.Context, int) error, error) {
 	commit, err := u.nextLimiter.TryAcquire(ctx)
+	// If we have an access issue, try to update the actor in case they have
+	// been granted updated access.
 	if errors.As(err, &limiter.NoAccessError{}) || errors.As(err, &limiter.RateLimitExceededError{}) {
 		oteltrace.SpanFromContext(ctx).
 			SetAttributes(attribute.Bool("update-on-error", true))
-		u.actor.Update(ctx) // TODO: run this in goroutine+background context maybe?
+		// Do update transiently, outside request hotpath
+		go func() {
+			if updateErr := u.actor.Update(context.WithoutCancel(ctx)); updateErr != nil &&
+				!errors.Is(updateErr, ErrActorRecentlyUpdated{}) {
+				u.logger.Warn("unexpected error updating actor",
+					log.Error(updateErr),
+					log.NamedError("originalError", err))
+			}
+		}()
 	}
 	return commit, err
 }

--- a/cmd/cody-gateway/internal/actor/limits_test.go
+++ b/cmd/cody-gateway/internal/actor/limits_test.go
@@ -169,8 +169,7 @@ func TestConcurrencyLimiter_TryAcquire(t *testing.T) {
 }
 
 func TestAsErrConcurrencyLimitExceeded(t *testing.T) {
-	var err error
-	err = ErrConcurrencyLimitExceeded{}
+	var err error = ErrConcurrencyLimitExceeded{}
 	assert.True(t, errors.As(err, &ErrConcurrencyLimitExceeded{}))
 	assert.True(t, errors.As(errors.Wrap(err, "foo"), &ErrConcurrencyLimitExceeded{}))
 }

--- a/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
+++ b/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
@@ -116,7 +116,9 @@ func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 func (s *Source) Update(ctx context.Context, act *actor.Actor) error {
 	if time.Since(*act.LastUpdated) < minUpdateInterval {
 		// Last update was too recent - do it later.
-		return actor.ErrActorRecentlyUpdated{}
+		return actor.ErrActorRecentlyUpdated{
+			RetryAt: act.LastUpdated.Add(minUpdateInterval),
+		}
 	}
 
 	_, err := s.fetchAndCache(ctx, act.Key)

--- a/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
+++ b/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
@@ -113,15 +113,14 @@ func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 	return act, nil
 }
 
-func (s *Source) Update(ctx context.Context, actor *actor.Actor) {
-	if time.Since(*actor.LastUpdated) < minUpdateInterval {
+func (s *Source) Update(ctx context.Context, act *actor.Actor) error {
+	if time.Since(*act.LastUpdated) < minUpdateInterval {
 		// Last update was too recent - do it later.
-		return
+		return actor.ErrActorRecentlyUpdated{}
 	}
 
-	if _, err := s.fetchAndCache(ctx, actor.Key); err != nil {
-		sgtrace.Logger(ctx, s.log).Info("failed to update actor", log.Error(err))
-	}
+	_, err := s.fetchAndCache(ctx, act.Key)
+	return err
 }
 
 // Sync retrieves all known actors from this source and updates its cache.

--- a/cmd/cody-gateway/internal/actor/source.go
+++ b/cmd/cody-gateway/internal/actor/source.go
@@ -46,15 +46,19 @@ type Source interface {
 	Get(ctx context.Context, token string) (*Actor, error)
 }
 
+type ErrActorRecentlyUpdated struct{}
+
+func (e ErrActorRecentlyUpdated) Error() string {
+	return "actor already updated recently - try again later"
+}
+
 type SourceUpdater interface {
 	Source
 	// Update updates the given actor's state, though the implementation may
 	// decide not to do so every time.
 	//
-	// We currently don't include an error return in the interface because the
-	// original use case for this was for transient updates when htiting rate
-	// limits - we may want to reconsider this.
-	Update(ctx context.Context, actor *Actor)
+	// Error can be ErrActorRecentlyUpdated if the actor was updated too recently.
+	Update(ctx context.Context, actor *Actor) error
 }
 
 type SourceSyncer interface {

--- a/cmd/cody-gateway/internal/actor/source.go
+++ b/cmd/cody-gateway/internal/actor/source.go
@@ -7,15 +7,13 @@ import (
 
 	"github.com/go-redsync/redsync/v4"
 	"github.com/sourcegraph/conc/pool"
+	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
-
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	sgtrace "github.com/sourcegraph/sourcegraph/internal/trace"

--- a/cmd/cody-gateway/internal/actor/source_test.go
+++ b/cmd/cody-gateway/internal/actor/source_test.go
@@ -168,8 +168,7 @@ func TestSourcesUpdate(t *testing.T) {
 }
 
 func TestIsErrNotFromSource(t *testing.T) {
-	var err error
-	err = ErrNotFromSource{Reason: "foo"}
+	var err error = ErrNotFromSource{Reason: "foo"}
 	assert.True(t, IsErrNotFromSource(err))
 	autogold.Expect("token not from source: foo").Equal(t, err.Error())
 
@@ -179,4 +178,10 @@ func TestIsErrNotFromSource(t *testing.T) {
 
 	err = errors.New("foo")
 	assert.False(t, IsErrNotFromSource(err))
+}
+
+func TestErrActorRecentlyUpdated(t *testing.T) {
+	var err error = ErrActorRecentlyUpdated{RetryAt: time.Now().Add(time.Minute)}
+	assert.True(t, IsErrActorRecentlyUpdated(err))
+	assert.Equal(t, "actor was recently updated - try again in 59s", err.Error())
 }

--- a/cmd/cody-gateway/internal/actor/source_test.go
+++ b/cmd/cody-gateway/internal/actor/source_test.go
@@ -45,8 +45,9 @@ type mockSourceUpdater struct {
 
 var _ SourceUpdater = &mockSourceUpdater{}
 
-func (m *mockSourceUpdater) Update(context.Context, *Actor) {
+func (m *mockSourceUpdater) Update(context.Context, *Actor) error {
 	m.syncCount.Inc()
+	return nil
 }
 
 func TestSourcesWorkers(t *testing.T) {
@@ -153,12 +154,14 @@ func TestSourcesUpdate(t *testing.T) {
 		Key:    "sgd_qweqweqw",
 		Source: &s2, // belongs to s2 source only
 	}
-	act.Update(context.Background())
+	err := act.Update(context.Background())
+	assert.NoError(t, err)
 	assert.Equal(t, int32(0), s1.syncCount.Load())
 	assert.Equal(t, int32(1), s2.syncCount.Load())
 	assert.Equal(t, int32(0), s3.syncCount.Load())
 
-	act.Update(context.Background())
+	err = act.Update(context.Background())
+	assert.NoError(t, err)
 	assert.Equal(t, int32(0), s1.syncCount.Load())
 	assert.Equal(t, int32(2), s2.syncCount.Load())
 	assert.Equal(t, int32(0), s3.syncCount.Load())

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//cmd/cody-gateway/internal/limiter",
         "//cmd/cody-gateway/internal/notify",
         "//cmd/cody-gateway/internal/response",
-        "//internal/authbearer",
         "//internal/codygateway",
         "//internal/completions/types",
         "//internal/trace",

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -3,7 +3,6 @@ package featurelimiter
 import (
 	"context"
 	"encoding/json"
-	"github.com/sourcegraph/sourcegraph/internal/authbearer"
 	"net/http"
 	"strings"
 	"time"
@@ -213,17 +212,7 @@ func ListLimitsHandler(baseLogger log.Logger, redisStore limiter.RedisStore) htt
 func RefreshLimitsHandler(baseLogger log.Logger, sources *actor.Sources) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		act := actor.FromContext(r.Context())
-		logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))
-
-		token, err := authbearer.ExtractBearer(r.Header)
-		if err != nil {
-			response.JSONError(logger, w, http.StatusBadRequest, err)
-		}
-
-		err = sources.SyncOne(r.Context(), token)
-		if err != nil {
-			response.JSONError(logger, w, http.StatusBadRequest, err)
-		}
+		act.Update(r.Context())
 	})
 }
 

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -210,7 +210,7 @@ func ListLimitsHandler(baseLogger log.Logger, redisStore limiter.RedisStore) htt
 	})
 }
 
-func RefreshLimitsHandler(baseLogger log.Logger, sources *actor.Sources) http.Handler {
+func RefreshLimitsHandler(baseLogger log.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		act := actor.FromContext(r.Context())
 

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -216,7 +216,7 @@ func RefreshLimitsHandler(baseLogger log.Logger) http.Handler {
 
 		if err := act.Update(r.Context()); err != nil {
 			logger := act.Logger(trace.Logger(r.Context(), baseLogger))
-			if errors.Is(err, actor.ErrActorRecentlyUpdated{}) {
+			if actor.IsErrActorRecentlyUpdated(err) {
 				response.JSONError(logger, w, http.StatusTooManyRequests, err)
 			} else {
 				response.JSONError(logger, w, http.StatusInternalServerError, err)

--- a/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/handler.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
-
 	"github.com/gorilla/mux"
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -61,7 +59,6 @@ func NewHandler(
 	authr *auth.Authenticator,
 	promptRecorder completions.PromptRecorder,
 	config *Config,
-	sources *actor.Sources,
 ) (http.Handler, error) {
 	// Initialize metrics
 	counter, err := meter.Int64UpDownCounter("cody-gateway.concurrent_upstream_requests",
@@ -227,7 +224,7 @@ func NewHandler(
 			authr.Middleware(
 				requestlogger.Middleware(
 					logger,
-					featurelimiter.RefreshLimitsHandler(logger, sources),
+					featurelimiter.RefreshLimitsHandler(logger),
 				),
 			),
 			otelhttp.WithPublicEndpoint(),

--- a/cmd/cody-gateway/shared/main.go
+++ b/cmd/cody-gateway/shared/main.go
@@ -171,7 +171,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 			FireworksDisableSingleTenant:                config.Fireworks.DisableSingleTenant,
 			EmbeddingsAllowedModels:                     config.AllowedEmbeddingsModels,
 			AutoFlushStreamingResponses:                 config.AutoFlushStreamingResponses,
-		}, sources)
+		})
 	if err != nil {
 		return errors.Wrap(err, "httpapi.NewHandler")
 	}


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/sourcegraph/pull/58732#discussion_r1414348506 as I was reading the code again this morning after looking at some discussions - this change removes the SyncOnce interface and uses our existing SourceUpdater.

There is some more nuance here than I remember, however: `Actor.Update` is also called when a user hits their rate limit. This could be a good thing (poll for update if a user is rate-limited) - if we increase a user's rate limit it will get updated quickly. Because of the above  if the actor was recently updated we no-op and return an error. This could be useful in the general refresh endpoint use case as well, to avoid something repeatedly hitting dotcom in quick succession.

## Test plan

Updated tests assert same behaviour as existing implementation