### PR TITLE
sg: add 'sg msp postgresql connect'

### DIFF
--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -22,6 +22,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
 )
 
+const (
+	// TODO: re-export for use, maybe we should lift stack packages out of
+	// internal so that we can share consts, including output names.
+	StackNameIAM      = iam.StackName
+	StackNameCloudRun = cloudrun.StackName
+)
+
 type TerraformCloudOptions struct {
 	// Enabled will render all stacks to use a Terraform CLoud workspace as its
 	// Terraform state backend with the following format as the workspace name

--- a/dev/managedservicesplatform/terraformcloud/BUILD.bazel
+++ b/dev/managedservicesplatform/terraformcloud/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "terraformcloud",
-    srcs = ["terraformcloud.go"],
+    srcs = [
+        "runs.go",
+        "terraformcloud.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/terraformcloud",
     visibility = ["//visibility:public"],
     deps = [

--- a/dev/managedservicesplatform/terraformcloud/runs.go
+++ b/dev/managedservicesplatform/terraformcloud/runs.go
@@ -1,0 +1,62 @@
+package terraformcloud
+
+import (
+	"context"
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type RunsClient struct {
+	client *tfe.Client
+	org    string
+}
+
+func NewRunsClient(accessToken string) (*RunsClient, error) {
+	c, err := tfe.NewClient(&tfe.Config{
+		Token: accessToken,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &RunsClient{
+		org:    Organization,
+		client: c,
+	}, nil
+}
+
+type Outputs []*tfe.StateVersionOutput
+
+func (o Outputs) Find(name string) (*tfe.StateVersionOutput, error) {
+	// In stacks we prefix all output IDs with 'output-'.
+	key := fmt.Sprintf("output-%s", name)
+	for _, output := range o {
+		if output.Name == key {
+			return output, nil
+		}
+	}
+	return nil, errors.Newf("output %q not found, available: %+v", key, o.Names())
+}
+
+func (o Outputs) Names() []string {
+	var names []string
+	for _, output := range o {
+		names = append(names, output.Name)
+	}
+	return names
+}
+
+func (c *RunsClient) GetOutputs(ctx context.Context, workspaceName string) (Outputs, error) {
+	ws, err := c.client.Workspaces.Read(ctx, c.org, workspaceName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "get workspace %q", workspaceName)
+	}
+	outputs, err := c.client.StateVersionOutputs.ReadCurrent(ctx, ws.ID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "get current outputs for workspace ID %q", ws.ID)
+	}
+	// We  don't need pagination for now, we have very few outputs
+	return outputs.Items, nil
+}

--- a/dev/managedservicesplatform/terraformcloud/terraformcloud.go
+++ b/dev/managedservicesplatform/terraformcloud/terraformcloud.go
@@ -341,19 +341,6 @@ func (c *Client) DeleteWorkspaces(ctx context.Context, svc spec.ServiceSpec, env
 	return errs
 }
 
-func (c *Client) GetOutputs(ctx context.Context, workspaceName string) ([]*tfe.StateVersionOutput, error) {
-	ws, err := c.client.Workspaces.Read(ctx, c.org, workspaceName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "get workspace %q", workspaceName)
-	}
-	outputs, err := c.client.StateVersionOutputs.ReadCurrent(ctx, ws.ID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "get current outputs for workspace ID %q", ws.ID)
-	}
-	// We  don't need pagination for now, we have very few outputs
-	return outputs.Items, nil
-}
-
 func (c *Client) ensureAccessForTeam(ctx context.Context, project *tfe.Project, currentTeams *tfe.TeamProjectAccessList, teamID string) error {
 	var existingAccessID string
 	for _, a := range currentTeams.Items {

--- a/dev/sg/cloudsqlproxy/BUILD.bazel
+++ b/dev/sg/cloudsqlproxy/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "cloudsqlproxy",
+    srcs = [
+        "binary.go",
+        "cloudsqlproxy.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/sg/cloudsqlproxy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//dev/sg/internal/std",
+        "//lib/errors",
+        "//lib/output",
+        "@com_github_sourcegraph_run//:run",
+    ],
+)

--- a/dev/sg/cloudsqlproxy/binary.go
+++ b/dev/sg/cloudsqlproxy/binary.go
@@ -14,7 +14,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
-const CloudSQLProxyVersion = "2.1.1"
+// CloudSQLProxyVersion can be found from https://github.com/GoogleCloudPlatform/cloud-sql-proxy/releases
+const CloudSQLProxyVersion = "2.8.1"
 
 // Init configures the cloud-sql-proxy binary for the current platform
 // optionally downloading if requested

--- a/dev/sg/cloudsqlproxy/binary.go
+++ b/dev/sg/cloudsqlproxy/binary.go
@@ -1,0 +1,90 @@
+// Initially copy-pasta from https://github.com/sourcegraph/controller/blob/main/internal/cloudsqlproxy/gen.go
+package cloudsqlproxy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/output"
+)
+
+const CloudSQLProxyVersion = "2.1.1"
+
+// Init configures the cloud-sql-proxy binary for the current platform
+// optionally downloading if requested
+func Init(download bool) error {
+	if download {
+		err := Download()
+		if err != nil {
+			return err
+		}
+	}
+
+	cloudSQLProxyPath, err := Path()
+	if err != nil {
+		return errors.Wrap(err, "failed to get path for current platform")
+	}
+	_, err = os.Stat(cloudSQLProxyPath)
+	if err != nil && os.IsNotExist(err) {
+		std.Out.WriteWarningf("cloud-sql-proxy binary not found at %q. try running again with '-download' flag",
+			cloudSQLProxyPath)
+		return errors.Wrapf(err, "failed to find binary")
+	} else if err != nil {
+		return errors.Wrapf(err, "failed to read %s binary", cloudSQLProxyPath)
+	}
+	return nil
+}
+
+// Path returns the path to the cloud-sql-proxy binary.
+func Path() (string, error) {
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get user cache dir")
+	}
+
+	appCacheDir := filepath.Join(userCacheDir, "sourcegraph", "bin", "cloud-sql-proxy", CloudSQLProxyVersion)
+	if err := os.MkdirAll(appCacheDir, 0755); err != nil {
+		return "", errors.Wrap(err, "failed to create application cache dir")
+	}
+
+	cloudSQLProxyPath := filepath.Join(appCacheDir, "cloud-sql-proxy")
+
+	return cloudSQLProxyPath, nil
+}
+
+func Download() error {
+	url := fmt.Sprintf("https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v%s/cloud-sql-proxy.%s.%s",
+		CloudSQLProxyVersion, runtime.GOOS, runtime.GOARCH)
+	pending := std.Out.Pending(output.Styledf(output.StylePending,
+		"Downloading cloud-sql-proxy binary for current platform (goos: %s, goarch: %s, url: %s)",
+		runtime.GOOS, runtime.GOARCH, url))
+	resp, err := http.Get(url)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return errors.Wrapf(err,
+			"failed to download cloud-sql-proxy binary for OS: %s, Arch: %s",
+			runtime.GOOS, runtime.GOARCH)
+	}
+	defer resp.Body.Close()
+	d, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read response for current platform")
+	}
+	path, err := Path()
+	if err != nil {
+		return errors.Wrap(err, "failed to get path for current platform")
+	}
+	pending.Updatef("Saving cloud-sql-proxy binary to %q", path)
+	err = os.WriteFile(path, d, 0755)
+	if err != nil {
+		return errors.Wrap(err, "failed to write cloud-sql-proxy binary")
+	}
+	pending.Complete(output.Emojif(output.EmojiSuccess,
+		"cloud-sql-proxy binary saved to %q", path))
+	return nil
+}

--- a/dev/sg/cloudsqlproxy/cloudsqlproxy.go
+++ b/dev/sg/cloudsqlproxy/cloudsqlproxy.go
@@ -1,0 +1,74 @@
+// Initially copy-pasta from https://github.com/sourcegraph/controller/blob/main/internal/cloudsqlproxy/proxy.go
+package cloudsqlproxy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sourcegraph/run"
+
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// CloudSQLProxy is a cloud-sql-proxy instance
+//
+// It uses the identity of the service account to connect to the database
+// and the proxy can handle the authentication for the database and refresh
+// the credentials as needed.
+type CloudSQLProxy struct {
+	Token                     string
+	DBInstanceConnectionName  string
+	ImpersonateServiceAccount string
+	Port                      int
+}
+
+func NewCloudSQLProxy(dbConnection string, iamUserEmail string, port int) (*CloudSQLProxy, error) {
+	return &CloudSQLProxy{
+		DBInstanceConnectionName:  dbConnection,
+		ImpersonateServiceAccount: iamUserEmail,
+		Port:                      port,
+	}, nil
+}
+
+func (p *CloudSQLProxy) Start(ctx context.Context, timeoutSeconds int) error {
+	bin, err := Path()
+	if err != nil {
+		return errors.Wrap(err, "failed to get path to the cloud-sql-proxy binary")
+	}
+
+	proxyCmd := fmt.Sprintf("%s -i -p %d --impersonate-service-account=%s  %s",
+		bin, p.Port, p.ImpersonateServiceAccount, p.DBInstanceConnectionName)
+
+	if timeoutSeconds > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithCancel(ctx)
+		defer cancel()
+
+		std.Out.WriteWarningf("The current session will terminate in %d seconds. Use '-session.timeout' to increase the session duration.",
+			timeoutSeconds)
+		time.AfterFunc(time.Duration(timeoutSeconds)*time.Second, func() {
+			select {
+			case <-ctx.Done():
+				return // nothing to do
+			default:
+				std.Out.WriteAlertf("The current session has timed out after %d seconds and will be terminated.",
+					timeoutSeconds)
+				cancel()
+			}
+		})
+	}
+
+	err = run.Cmd(ctx, proxyCmd).Run().StreamLines(func(line string) {
+		std.Out.Write("  [cloud-sql-proxy] " + line)
+	})
+	if err != nil {
+		if ctx.Err() == context.Canceled {
+			return nil
+		}
+		return errors.Wrap(err, "failed to start cloud-sql-proxy")
+	}
+
+	return nil
+}

--- a/dev/sg/msp/BUILD.bazel
+++ b/dev/sg/msp/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//dev/managedservicesplatform/googlesecretsmanager",
         "//dev/managedservicesplatform/spec",
         "//dev/managedservicesplatform/terraformcloud",
+        "//dev/sg/cloudsqlproxy",
         "//dev/sg/internal/category",
         "//dev/sg/internal/secrets",
         "//dev/sg/internal/std",

--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -18,6 +18,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/output"
 )
 
+// useServiceArgument retrieves the service spec corresponding to the first
+// argument.
+func useServiceArgument(c *cli.Context) (*spec.Spec, error) {
+	serviceID := c.Args().First()
+	if serviceID == "" {
+		return nil, errors.New("argument service is required")
+	}
+	serviceSpecPath := msprepo.ServiceYAMLPath(serviceID)
+
+	return spec.Open(serviceSpecPath)
+}
+
 func syncEnvironmentWorkspaces(c *cli.Context, tfc *terraformcloud.Client, service spec.ServiceSpec, build spec.BuildSpec, env spec.EnvironmentSpec, monitoring spec.MonitoringSpec) error {
 	if os.TempDir() == "" {
 		return errors.New("no temp dir available")

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -2,14 +2,17 @@
 package msp
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/googlesecretsmanager"
-	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/terraformcloud"
+	"github.com/sourcegraph/sourcegraph/dev/sg/cloudsqlproxy"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
@@ -191,6 +194,138 @@ sg msp generate -all <service>
 			},
 		},
 		{
+			Name:    "postgresql",
+			Aliases: []string{"pg"},
+			Usage:   "Interact with PostgreSQL instances provisioned by MSP",
+			Before:  msprepo.UseManagedServicesRepo,
+			Subcommands: []*cli.Command{
+				{
+					Name:  "connect",
+					Usage: "Connect to the PostgreSQL instance using psql",
+					Flags: []cli.Flag{
+						&cli.IntFlag{
+							Name:  "port",
+							Value: 5433,
+							Usage: "Port to use for the cloud-sql-proxy",
+						},
+						&cli.BoolFlag{
+							Name:  "download",
+							Usage: "Install or update the cloud-sql-proxy",
+						},
+						&cli.BoolFlag{
+							Name:  "write-access",
+							Usage: "Connect to the database with write access",
+						},
+						// db proxy provides privileged access to the database,
+						// so we want to avoid having it dangling around for too long unattended
+						&cli.IntFlag{
+							Name:  "session.timeout",
+							Usage: "Timeout for the proxy session in seconds - 0 means no timeout",
+							Value: 300,
+						},
+					},
+					BashComplete: msprepo.ServicesAndEnvironmentsCompletion(),
+					Action: func(c *cli.Context) error {
+						service, err := useServiceArgument(c)
+						if err != nil {
+							return err
+						}
+						env := service.GetEnvironment(c.Args().Get(1))
+						if env == nil {
+							return errors.Errorf("environment %q not found", c.Args().Get(1))
+						}
+						if env.Resources.PostgreSQL == nil {
+							return errors.New("no postgresql instance provisioned")
+						}
+
+						err = cloudsqlproxy.Init(c.Bool("download"))
+						if err != nil {
+							return err
+						}
+
+						secretStore, err := secrets.FromContext(c.Context)
+						if err != nil {
+							return err
+						}
+
+						// We use a team token to get workspace details
+						tfcMSPAccessToken, err := secretStore.GetExternal(c.Context, secrets.ExternalSecret{
+							Name:    googlesecretsmanager.SecretTFCMSPTeamToken,
+							Project: googlesecretsmanager.ProjectID,
+						})
+						if err != nil {
+							return errors.Wrap(err, "get TFC OAuth client ID")
+						}
+						tfcClient, err := terraformcloud.NewRunsClient(tfcMSPAccessToken)
+						if err != nil {
+							return errors.Wrap(err, "init Terraform Cloud client")
+						}
+
+						iamOutputs, err := tfcClient.GetOutputs(c.Context,
+							terraformcloud.WorkspaceName(service.Service, *env,
+								managedservicesplatform.StackNameIAM))
+						if err != nil {
+							return errors.Wrap(err, "get IAM outputs")
+						}
+						var serviceAccountEmail string
+						if c.Bool("write-access") {
+							// Use the workload identity if all access is requested
+							workloadSA, err := iamOutputs.Find("cloud_run_service_account")
+							if err != nil {
+								return errors.Wrap(err, "find IAM output")
+							}
+							serviceAccountEmail = workloadSA.Value.(string)
+						} else {
+							// Otherwise, use the operator access account which
+							// is a bit more limited.
+							operatorAccessSA, err := iamOutputs.Find("operator_access_service_account")
+							if err != nil {
+								return errors.Wrap(err, "find IAM output")
+							}
+							serviceAccountEmail = operatorAccessSA.Value.(string)
+						}
+
+						cloudRunOutputs, err := tfcClient.GetOutputs(c.Context,
+							terraformcloud.WorkspaceName(service.Service, *env,
+								managedservicesplatform.StackNameCloudRun))
+						if err != nil {
+							return errors.Wrap(err, "get Cloud Run outputs")
+						}
+						connectionName, err := cloudRunOutputs.Find("cloudsql_connection_name")
+						if err != nil {
+							return errors.Wrap(err, "find Cloud Run output")
+						}
+
+						proxyPort := c.Int("port")
+						proxy, err := cloudsqlproxy.NewCloudSQLProxy(
+							connectionName.Value.(string),
+							serviceAccountEmail,
+							proxyPort)
+						if err != nil {
+							return err
+						}
+
+						for _, db := range env.Resources.PostgreSQL.Databases {
+							std.Out.WriteNoticef("Use this command to connect to database %q:", db)
+
+							saUsername := strings.ReplaceAll(serviceAccountEmail,
+								".gserviceaccount.com", "")
+							if err := std.Out.WriteCode("bash",
+								fmt.Sprintf(`psql -U %s -d %s -h localhost -p %d`,
+									saUsername,
+									db,
+									proxyPort)); err != nil {
+								return errors.Wrapf(err, "write command for db %q", db)
+							}
+						}
+
+						// Run proxy until stopped
+						return proxy.Start(c.Context, c.Int("session.timeout"))
+					},
+				},
+			},
+		},
+		{
 			Name:    "terraform-cloud",
 			Aliases: []string{"tfc"},
 			Usage:   "Manage Terraform Cloud workspaces for a service",
@@ -222,13 +357,7 @@ Supports completions on services and environments.`,
 					},
 					BashComplete: msprepo.ServicesAndEnvironmentsCompletion(),
 					Action: func(c *cli.Context) error {
-						serviceID := c.Args().First()
-						if serviceID == "" {
-							return errors.New("argument service is required")
-						}
-						serviceSpecPath := msprepo.ServiceYAMLPath(serviceID)
-
-						service, err := spec.Open(serviceSpecPath)
+						service, err := useServiceArgument(c)
 						if err != nil {
 							return err
 						}

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -201,7 +201,19 @@ sg msp generate -all <service>
 			Subcommands: []*cli.Command{
 				{
 					Name:  "connect",
-					Usage: "Connect to the PostgreSQL instance using psql",
+					Usage: "Connect to the PostgreSQL instance",
+					Description: `
+This command runs 'cloud-sql-proxy' authenticated against the specified MSP
+service environment, and provides 'psql' commands for interacting with the
+database through the proxy.
+
+If this is your first time using this command, include the '-download' flag to
+install 'cloud-sql-proxy'.
+
+By default, you will only have 'SELECT' privileges through the connection - for
+full access, use the '-write-access' flag.
+`,
+					ArgsUsage: "<service ID> <environment ID>",
 					Flags: []cli.Flag{
 						&cli.IntFlag{
 							Name:  "port",
@@ -214,7 +226,7 @@ sg msp generate -all <service>
 						},
 						&cli.BoolFlag{
 							Name:  "write-access",
-							Usage: "Connect to the database with write access",
+							Usage: "Connect to the database with write access - by default, only select access is granted.",
 						},
 						// db proxy provides privileged access to the database,
 						// so we want to avoid having it dangling around for too long unattended


### PR DESCRIPTION
This change introduces an `mi2`-like experience for interacting with MSP databases. By default we use the new readonly-SA introduced in https://github.com/sourcegraph/sourcegraph/pull/59105, otherwise with the `--write-access` flag you can connect as the same user as the Cloud Run workload, which gives a lot more permissions.

An alias, `sg msp pg connect`, is available for those less inclined to type out the entire `postgresql` subcommand name.

Closes https://github.com/sourcegraph/managed-services/issues/207

## Test plan

Applied to `msp-testbed`, which has a PG instance and provisioned tables.
Try both service accounts:

```
sg msp pg connect --write-access msp-testbed test
sg msp pg connect msp-testbed test 
```

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/c75bcb8c-5f7d-4f3b-90ec-9effb3306ba9)

With both of the above:

```
primary=> select * from users;
 id | created_at | updated_at | deleted_at | external_id | name | avatar_url 
----+------------+------------+------------+-------------+------+------------
(0 rows)
```