### PR TITLE
search: use literal suggestions for keyword search

### DIFF
--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -121,12 +121,14 @@
     let suggestionsPaddingTop = 0
     let suggestionsUI: Extension = []
 
-    $: regularExpressionEnabled = $queryState.patternType === SearchPatternType.regexp
-    $: structuralEnabled = $queryState.patternType === SearchPatternType.structural
+    $: patternType = $queryState.patternType
+    $: regularExpressionEnabled = patternType === SearchPatternType.regexp
+    $: structuralEnabled = patternType === SearchPatternType.structural
     $: extension = [
         suggestions({
             id: popoverID,
             source: createSuggestionsSource({
+                valueType: patternType === SearchPatternType.newStandardRC1 ? 'glob' : 'regex',
                 graphqlQuery,
                 authenticatedUser: $user,
                 isSourcegraphDotCom: false,

--- a/client/web/src/search/input/V2SearchInput.tsx
+++ b/client/web/src/search/input/V2SearchInput.tsx
@@ -141,7 +141,7 @@ export const V2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = ({
     const suggestionSource = useMemo(
         () =>
             createSuggestionsSource({
-                valueType: inputProps.patternType == SearchPatternType.newStandardRC1 ? 'glob' : 'regex',
+                valueType: inputProps.patternType === SearchPatternType.newStandardRC1 ? 'glob' : 'regex',
                 graphqlQuery<T, V extends Record<string, any>>(query: string, variables: V): Promise<T> {
                     return client.query<T, V>({ query: getDocumentNode(query), variables }).then(result => result.data)
                 },

--- a/client/web/src/search/input/V2SearchInput.tsx
+++ b/client/web/src/search/input/V2SearchInput.tsx
@@ -19,6 +19,7 @@ import {
     type CodeMirrorQueryInputWrapperProps,
 } from '@sourcegraph/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper'
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import type { SearchContextProps, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { FILTERS, FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { resolveFilterMemoized } from '@sourcegraph/shared/src/search/query/utils'
@@ -140,13 +141,14 @@ export const V2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = ({
     const suggestionSource = useMemo(
         () =>
             createSuggestionsSource({
+                valueType: inputProps.patternType == SearchPatternType.newStandardRC1 ? 'glob' : 'regex',
                 graphqlQuery<T, V extends Record<string, any>>(query: string, variables: V): Promise<T> {
                     return client.query<T, V>({ query: getDocumentNode(query), variables }).then(result => result.data)
                 },
                 authenticatedUser,
                 isSourcegraphDotCom,
             }),
-        [client, authenticatedUser, isSourcegraphDotCom]
+        [client, authenticatedUser, isSourcegraphDotCom, inputProps.patternType]
     )
 
     const extensions = useMemo(

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -201,8 +201,13 @@ interface CodeSymbol {
 /**
  * Converts a Repo value to a suggestion.
  */
-function toRepoSuggestion(result: FzfResultItem<Repo>, from: number, to?: number): Option {
-    const option = toRepoCompletion(result, from, to, 'repo:')
+function toRepoSuggestion(
+    result: FzfResultItem<Repo>,
+    config: SuggestionsSourceConfig,
+    from: number,
+    to?: number
+): Option {
+    const option = toRepoCompletion(result, config, from, to, 'repo:')
     option.render = RenderAs.FILTER
     return option
 }
@@ -212,6 +217,7 @@ function toRepoSuggestion(result: FzfResultItem<Repo>, from: number, to?: number
  */
 function toRepoCompletion(
     { item, positions }: FzfResultItem<Repo>,
+    config: SuggestionsSourceConfig,
     from: number,
     to?: number,
     valuePrefix = ''
@@ -226,7 +232,7 @@ function toRepoCompletion(
         kind: 'repo',
         action: {
             type: 'completion',
-            insertValue: valuePrefix + regexInsertText(item.name) + ' ',
+            insertValue: valuePrefix + (config.valueType == 'regex' ? regexInsertText(item.name) : item.name) + ' ',
             from,
             to,
         },
@@ -289,6 +295,7 @@ function toFilterCompletion(label: string, description: string | undefined, from
  */
 function toFileCompletion(
     { item, positions }: FzfResultItem<File>,
+    config: SuggestionsSourceConfig,
     from: number,
     to?: number,
     valuePrefix = ''
@@ -303,7 +310,8 @@ function toFileCompletion(
         kind: 'file',
         action: {
             type: 'completion',
-            insertValue: valuePrefix + regexInsertText(item.path) + ' ',
+            insertValue:
+                valuePrefix + (config.valueType == 'regex' ? regexInsertText(item.path) + ' ' : item.path) + ' ',
             from,
             to,
         },
@@ -313,8 +321,13 @@ function toFileCompletion(
 /**
  * Converts a File value to a (jump) target suggestion.
  */
-function toFileSuggestion(result: FzfResultItem<File>, from: number, to?: number): Option {
-    const option = toFileCompletion(result, from, to, 'file:')
+function toFileSuggestion(
+    result: FzfResultItem<File>,
+    config: SuggestionsSourceConfig,
+    from: number,
+    to?: number
+): Option {
+    const option = toFileCompletion(result, config, from, to, 'file:')
     option.render = RenderAs.FILTER
     return option
 }
@@ -499,7 +512,7 @@ const contextActions: Group = {
  * Returns static and dynamic completion suggestions for filters when completing
  * a filter value.
  */
-function filterValueSuggestions(caches: Caches): InternalSource {
+function filterValueSuggestions(caches: Caches, config: SuggestionsSourceConfig): InternalSource {
     return ({ token, parsedQuery, position }) => {
         if (token?.type !== 'filter') {
             return null
@@ -531,7 +544,7 @@ function filterValueSuggestions(caches: Caches): InternalSource {
                                             ? ALL_FILTER_VALUE_LIST_SIZE
                                             : MULTIPLE_FILTER_VALUE_LIST_SIZE
                                     )
-                                    .map(item => toRepoCompletion(item, from, to)),
+                                    .map(item => toRepoCompletion(item, config, from, to)),
                             },
                         ]
 
@@ -562,7 +575,7 @@ function filterValueSuggestions(caches: Caches): InternalSource {
                                     predicates.length === 0
                                         ? ALL_FILTER_VALUE_LIST_SIZE
                                         : MULTIPLE_FILTER_VALUE_LIST_SIZE,
-                                    item => toFileCompletion(item, from, to)
+                                    item => toFileCompletion(item, config, from, to)
                                 ),
                             },
                         ]
@@ -733,7 +746,7 @@ function staticFilterPredicateOptions(type: 'repo' | 'file', filter: Filter, fro
  * Returns repository (jump) target suggestions matching the term at the cursor,
  * but only if the query doesn't already contain a 'repo:' filter.
  */
-function repoSuggestions(cache: Caches['repo']): InternalSource {
+function repoSuggestions(cache: Caches['repo'], config: SuggestionsSourceConfig): InternalSource {
     return ({ token, tokens, parsedQuery, position }) => {
         const showRepoSuggestions =
             token?.type === 'pattern' &&
@@ -749,7 +762,7 @@ function repoSuggestions(cache: Caches['repo']): InternalSource {
                     title: 'Repositories',
                     options: results
                         .slice(0, DEFAULT_SUGGESTIONS_LIST_SIZE)
-                        .map(result => toRepoSuggestion(result, token.range.start)),
+                        .map(result => toRepoSuggestion(result, config, token.range.start)),
                 },
             ],
             parsedQuery,
@@ -763,13 +776,13 @@ function repoSuggestions(cache: Caches['repo']): InternalSource {
  * but only if the query contains suitable filters. On dotcom we only show file
  * suggestions if the query contains at least one context: or repo: filter.
  */
-function fileSuggestions(cache: Caches['file'], isSourcegraphDotCom?: boolean): InternalSource {
+function fileSuggestions(cache: Caches['file'], config: SuggestionsSourceConfig): InternalSource {
     return ({ token, tokens, parsedQuery, position }) => {
         // Only show file suggestions on dotcom if the query contains at least
         // one context: filter that is not 'global', or a repo: filter.
         const showFileSuggestions =
             token?.type === 'pattern' &&
-            (!isSourcegraphDotCom ||
+            (!config.isSourcegraphDotCom ||
                 tokens.some(token => {
                     if (token.type !== 'filter') {
                         return false
@@ -790,7 +803,7 @@ function fileSuggestions(cache: Caches['file'], isSourcegraphDotCom?: boolean): 
                 {
                     title: 'Files',
                     options: limitUniqueOptions(results, DEFAULT_SUGGESTIONS_HIGH_PRI_LIST_SIZE, result =>
-                        toFileSuggestion(result, token.range.start)
+                        toFileSuggestion(result, config, token.range.start)
                     ),
                 },
             ],
@@ -870,6 +883,7 @@ export interface SuggestionsSourceConfig {
     graphqlQuery: <T, V extends Record<string, any>>(query: string, variables: V) => Promise<T>
     authenticatedUser?: AuthenticatedUser | null
     isSourcegraphDotCom?: boolean
+    valueType: 'regex' | 'glob'
 }
 
 let sharedCaches: Caches | null = null
@@ -1062,10 +1076,10 @@ export const createSuggestionsSource = (config: SuggestionsSourceConfig): Source
 
     const sources: InternalSource[] = [
         defaultSuggestions,
-        filterValueSuggestions(caches),
+        filterValueSuggestions(caches, config),
         filterSuggestions,
-        repoSuggestions(caches.repo),
-        fileSuggestions(caches.file, config.isSourcegraphDotCom),
+        repoSuggestions(caches.repo, config),
+        fileSuggestions(caches.file, config),
         symbolSuggestions(caches.symbol),
     ]
 

--- a/client/web/src/search/input/suggestions.ts
+++ b/client/web/src/search/input/suggestions.ts
@@ -232,7 +232,7 @@ function toRepoCompletion(
         kind: 'repo',
         action: {
             type: 'completion',
-            insertValue: valuePrefix + (config.valueType == 'regex' ? regexInsertText(item.name) : item.name) + ' ',
+            insertValue: valuePrefix + (config.valueType === 'regex' ? regexInsertText(item.name) : item.name) + ' ',
             from,
             to,
         },
@@ -311,7 +311,7 @@ function toFileCompletion(
         action: {
             type: 'completion',
             insertValue:
-                valuePrefix + (config.valueType == 'regex' ? regexInsertText(item.path) + ' ' : item.path) + ' ',
+                valuePrefix + (config.valueType === 'regex' ? regexInsertText(item.path) + ' ' : item.path) + ' ',
             from,
             to,
         },


### PR DESCRIPTION
This updates suggestions to insert literals instead of regex-escaped values for repo and file filters.

![Kapture 2023-12-20 at 14 50 13](https://github.com/sourcegraph/sourcegraph/assets/26413131/75decaaf-f526-457f-a026-5d39c0418aa7)

## Test plan
CI
