### PR TITLE
dev: revert to old search mode for local dev environment

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -11,8 +11,5 @@
   },
   "search.repositoryGroups": {
     "test": ["github.com/gorilla/mux", "github.com/gorilla/pat"]
-  },
-  // team search platform: This enables the experimental "precise (NEW)" search mode by default
-  "search.defaultMode": "precise",
-  "search.defaultPatternType": "newStandardRC1"
+  }
 }


### PR DESCRIPTION
This reverts the default from loveable search to smart search for the local dev environment. This is mainly to disentangle our protoype running on S2 from everyone's dev experience.

Devs who want to use loveable search locally, can set the feature flag "search-new-keyword".

## Test plan
- ran a local instance and confirmed that the default is now "smart search".