### PR TITLE
Speed up some slow DB tests

### DIFF
--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -1692,6 +1692,11 @@ func TestEventLogs_OwnershipFeatureActivity(t *testing.T) {
 		t.Skip()
 	}
 	t.Parallel()
+
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(t))
+	ctx := context.Background()
+
 	for name, testCase := range map[string]struct {
 		now             time.Time
 		events          []*Event
@@ -1908,9 +1913,11 @@ func TestEventLogs_OwnershipFeatureActivity(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			logger := logtest.Scoped(t)
-			db := NewDB(logger, dbtest.NewDB(t))
-			ctx := context.Background()
+			t.Cleanup(func() {
+				_, err := db.ExecContext(ctx, "DELETE FROM event_logs")
+				require.NoError(t, err)
+			})
+
 			for _, e := range testCase.events {
 				//lint:ignore SA1019 existing usage of deprecated functionality.
 				// Use EventRecorder from internal/telemetryrecorder instead.

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1834,16 +1834,15 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	ctx := context.Background()
 
 	clock := timeutil.NewFakeClock(time.Now(), 0)
+	db := NewDB(logger, dbtest.NewDB(t))
 
 	t.Run("no external services", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(t))
 		if err := db.ExternalServices().Upsert(ctx); err != nil {
 			t.Fatalf("Upsert error: %s", err)
 		}
 	})
 
 	t.Run("validation", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(t))
 		store := db.ExternalServices()
 
 		t.Run("config can't be empty", func(t *testing.T) {
@@ -1867,7 +1866,11 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("one external service", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(t))
+		t.Cleanup(func() {
+			_, err := db.ExecContext(ctx, "DELETE FROM external_services")
+			require.NoError(t, err)
+		})
+
 		store := db.ExternalServices()
 
 		svc := typestest.MakeGitLabExternalService()
@@ -1894,7 +1897,11 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("many external services", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(t))
+		t.Cleanup(func() {
+			_, err := db.ExecContext(ctx, "DELETE FROM external_services")
+			require.NoError(t, err)
+		})
+
 		store := db.ExternalServices()
 
 		svcs := typestest.MakeExternalServices()
@@ -1966,7 +1973,11 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("with encryption key", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(t))
+		t.Cleanup(func() {
+			_, err := db.ExecContext(ctx, "DELETE FROM external_services")
+			require.NoError(t, err)
+		})
+
 		store := db.ExternalServices().WithEncryptionKey(et.TestKey{})
 
 		svcs := typestest.MakeExternalServices()
@@ -2049,7 +2060,11 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	})
 
 	t.Run("check code hosts created with many external services", func(t *testing.T) {
-		db := NewDB(logger, dbtest.NewDB(t))
+		t.Cleanup(func() {
+			_, err := db.ExecContext(ctx, "DELETE FROM external_services")
+			require.NoError(t, err)
+		})
+
 		store := db.ExternalServices()
 
 		svcs := typestest.MakeExternalServices()

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -6,34 +6,67 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keegancsmith/sqlf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/log/logtest"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	ff "github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestFeatureFlagStore(t *testing.T) {
-	t.Parallel()
-	t.Run("NewFeatureFlag", testNewFeatureFlagRoundtrip)
-	t.Run("ListFeatureFlags", testListFeatureFlags)
-	t.Run("Overrides", func(t *testing.T) {
-		t.Run("NewOverride", testNewOverrideRoundtrip)
-		t.Run("ListUserOverrides", testListUserOverrides)
-		t.Run("ListOrgOverrides", testListOrgOverrides)
+	logger := logtest.Scoped(t)
+	db := NewDB(logger, dbtest.NewDB(t))
+
+	t.Run("NewFeatureFlag", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		testNewFeatureFlagRoundtrip(t, db)
 	})
-	t.Run("UserFlags", testUserFlags)
-	t.Run("AnonymousUserFlags", testAnonymousUserFlags)
-	t.Run("UserlessFeatureFlags", testUserlessFeatureFlags)
-	t.Run("OrganizationFeatureFlag", testOrgFeatureFlag)
-	t.Run("GetFeatureFlag", testGetFeatureFlag)
-	t.Run("UpdateFeatureFlag", testUpdateFeatureFlag)
+	t.Run("ListFeatureFlags", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		testListFeatureFlags(t, db)
+	})
+	t.Run("Overrides", func(t *testing.T) {
+		t.Run("NewOverride", func(t *testing.T) {
+			t.Cleanup(cleanup(t, db))
+			testNewOverrideRoundtrip(t, db)
+		})
+		t.Run("ListUserOverrides", func(t *testing.T) {
+			t.Cleanup(cleanup(t, db))
+			testListUserOverrides(t, db)
+		})
+		t.Run("ListOrgOverrides", func(t *testing.T) {
+			t.Cleanup(cleanup(t, db))
+			testListOrgOverrides(t, db)
+		})
+	})
+	t.Run("UserFlags", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		testUserFlags(t, db)
+	})
+	t.Run("AnonymousUserFlags", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		testAnonymousUserFlags(t, db)
+	})
+	t.Run("UserlessFeatureFlags", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		testUserlessFeatureFlags(t, db)
+	})
+	t.Run("OrganizationFeatureFlag", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		testOrgFeatureFlag(t, db)
+	})
+	t.Run("GetFeatureFlag", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		testGetFeatureFlag(t, db)
+	})
+	t.Run("UpdateFeatureFlag", func(t *testing.T) {
+		t.Cleanup(cleanup(t, db))
+		testUpdateFeatureFlag(t, db)
+	})
 }
 
 func errorContains(s string) require.ErrorAssertionFunc {
@@ -49,9 +82,9 @@ func cleanup(t *testing.T, db DB) func() {
 			// Retain content on failed tests
 			return
 		}
-		_, err := db.Handle().ExecContext(
+		_, err := db.ExecContext(
 			context.Background(),
-			`truncate feature_flags, feature_flag_overrides, users, orgs, org_members cascade;`,
+			`truncate feature_flag_overrides, feature_flags, users, orgs, org_members, names cascade;`,
 		)
 		require.NoError(t, err)
 	}
@@ -69,11 +102,9 @@ func setupClearRedisCacheTest(t *testing.T, expectedFlagName string) *bool {
 	return &clearRedisCacheCalled
 }
 
-func testNewFeatureFlagRoundtrip(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	flagStore := NewDB(logger, dbtest.NewDB(t)).FeatureFlags()
+func testNewFeatureFlagRoundtrip(t *testing.T, db DB) {
 	ctx := actor.WithInternalActor(context.Background())
+	flagStore := db.FeatureFlags()
 
 	cases := []struct {
 		flag      *ff.FeatureFlag
@@ -126,12 +157,9 @@ func testNewFeatureFlagRoundtrip(t *testing.T) {
 	}
 }
 
-func testListFeatureFlags(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
-	flagStore := &featureFlagStore{Store: basestore.NewWithHandle(db.Handle())}
+func testListFeatureFlags(t *testing.T, db DB) {
 	ctx := actor.WithInternalActor(context.Background())
+	flagStore := db.FeatureFlags()
 
 	flag1 := &ff.FeatureFlag{Name: "bool_true", Bool: &ff.FeatureFlagBool{Value: true}}
 	flag2 := &ff.FeatureFlag{Name: "bool_false", Bool: &ff.FeatureFlagBool{Value: false}}
@@ -145,7 +173,7 @@ func testListFeatureFlags(t *testing.T) {
 	}
 
 	// Deleted flag4
-	err := flagStore.Exec(ctx, sqlf.Sprintf("DELETE FROM feature_flags WHERE flag_name = 'deletable';"))
+	_, err := db.ExecContext(ctx, "DELETE FROM feature_flags WHERE flag_name = 'deletable'")
 	require.NoError(t, err)
 
 	expected := []*ff.FeatureFlag{flag1, flag2, flag3}
@@ -162,13 +190,11 @@ func testListFeatureFlags(t *testing.T) {
 	require.EqualValues(t, res, expected)
 }
 
-func testNewOverrideRoundtrip(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
-	flagStore := db.FeatureFlags()
+func testNewOverrideRoundtrip(t *testing.T, db DB) {
 	users := db.Users()
 	ctx := actor.WithInternalActor(context.Background())
+
+	flagStore := db.FeatureFlags()
 
 	ff1, err := flagStore.CreateBool(ctx, "t", true)
 	require.NoError(t, err)
@@ -212,11 +238,8 @@ func testNewOverrideRoundtrip(t *testing.T) {
 	}
 }
 
-func testListUserOverrides(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
-	flagStore := &featureFlagStore{Store: basestore.NewWithHandle(db.Handle())}
+func testListUserOverrides(t *testing.T, db DB) {
+	flagStore := db.FeatureFlags()
 	users := db.Users()
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -274,7 +297,7 @@ func testListUserOverrides(t *testing.T) {
 		u1 := mkUser("u1")
 		f1 := mkFFBool("f", true)
 		mkOverride(u1.ID, f1.Name, false)
-		err := flagStore.Exec(ctx, sqlf.Sprintf("UPDATE feature_flag_overrides SET deleted_at = now()"))
+		_, err := db.ExecContext(ctx, "UPDATE feature_flag_overrides SET deleted_at = now()")
 		require.NoError(t, err)
 		got, err := flagStore.GetUserOverrides(ctx, u1.ID)
 		require.NoError(t, err)
@@ -292,11 +315,9 @@ func testListUserOverrides(t *testing.T) {
 	})
 }
 
-func testListOrgOverrides(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
-	flagStore := &featureFlagStore{Store: basestore.NewWithHandle(db.Handle())}
+func testListOrgOverrides(t *testing.T, db DB) {
+
+	flagStore := db.FeatureFlags()
 	users := db.Users()
 	orgs := db.Orgs()
 	orgMembers := db.OrgMembers()
@@ -358,7 +379,7 @@ func testListOrgOverrides(t *testing.T) {
 		u1 := mkUser("u", org1.ID)
 		f1 := mkFFBool("f", true)
 		mkOverride(org1.ID, f1.Name, false)
-		err := flagStore.Exec(ctx, sqlf.Sprintf("UPDATE feature_flag_overrides SET deleted_at = now();"))
+		_, err := db.ExecContext(ctx, "UPDATE feature_flag_overrides SET deleted_at = now()")
 		require.NoError(t, err)
 
 		got, err := flagStore.GetOrgOverridesForUser(ctx, u1.ID)
@@ -378,10 +399,7 @@ func testListOrgOverrides(t *testing.T) {
 	})
 }
 
-func testUserFlags(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
+func testUserFlags(t *testing.T, db DB) {
 	flagStore := db.FeatureFlags()
 	users := db.Users()
 	orgs := db.Orgs()
@@ -555,10 +573,8 @@ func testUserFlags(t *testing.T) {
 	})
 }
 
-func testAnonymousUserFlags(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
+func testAnonymousUserFlags(t *testing.T, db DB) {
+
 	flagStore := db.FeatureFlags()
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -600,10 +616,8 @@ func testAnonymousUserFlags(t *testing.T) {
 	// can be defined for an anonymous user.
 }
 
-func testUserlessFeatureFlags(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
+func testUserlessFeatureFlags(t *testing.T, db DB) {
+
 	flagStore := db.FeatureFlags()
 	ctx := actor.WithInternalActor(context.Background())
 
@@ -649,10 +663,8 @@ func testUserlessFeatureFlags(t *testing.T) {
 	})
 }
 
-func testOrgFeatureFlag(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
+func testOrgFeatureFlag(t *testing.T, db DB) {
+
 	flagStore := db.FeatureFlags()
 	orgs := db.Orgs()
 	ctx := actor.WithInternalActor(context.Background())
@@ -725,10 +737,8 @@ func testOrgFeatureFlag(t *testing.T) {
 	})
 }
 
-func testGetFeatureFlag(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
+func testGetFeatureFlag(t *testing.T, db DB) {
+
 	flagStore := db.FeatureFlags()
 	ctx := context.Background()
 	t.Run("no value", func(t *testing.T) {
@@ -752,10 +762,8 @@ func testGetFeatureFlag(t *testing.T) {
 	})
 }
 
-func testUpdateFeatureFlag(t *testing.T) {
-	t.Parallel()
-	logger := logtest.Scoped(t)
-	db := NewDB(logger, dbtest.NewDB(t))
+func testUpdateFeatureFlag(t *testing.T, db DB) {
+
 	flagStore := db.FeatureFlags()
 	ctx := context.Background()
 	t.Run("invalid input", func(t *testing.T) {

--- a/internal/database/outbound_webhook_logs_test.go
+++ b/internal/database/outbound_webhook_logs_test.go
@@ -2,7 +2,9 @@ package database
 
 import (
 	"context"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,7 +265,7 @@ func setupOutboundWebhookTest(t *testing.T, ctx context.Context, db DB, key encr
 	t.Helper()
 
 	userStore := db.Users()
-	user, err := userStore.Create(ctx, NewUser{Username: "test"})
+	user, err := userStore.Create(ctx, NewUser{Username: strconv.Itoa(int(time.Now().UnixMilli()))})
 	require.NoError(t, err)
 
 	webhookStore := db.OutboundWebhooks(key)

--- a/internal/database/outbound_webhooks_test.go
+++ b/internal/database/outbound_webhooks_test.go
@@ -3,7 +3,9 @@ package database
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
@@ -26,7 +28,7 @@ func TestOutboundWebhooks(t *testing.T) {
 
 	runBothEncryptionStates(t, func(t *testing.T, logger log.Logger, db DB, key encryption.Key) {
 		user, err := db.Users().Create(ctx, NewUser{
-			Username: "test",
+			Username: strconv.Itoa(int(time.Now().UnixMilli())),
 		})
 		require.NoError(t, err)
 
@@ -437,14 +439,15 @@ func newTestWebhook(t *testing.T, user *types.User, scopes ...ScopedEventType) *
 func runBothEncryptionStates(t *testing.T, f func(t *testing.T, logger log.Logger, db DB, key encryption.Key)) {
 	t.Helper()
 
-	var key encryption.Key
-
 	logger := logtest.Scoped(t)
 	db := NewDB(logger, dbtest.NewDB(t))
-	t.Run("unencrypted", func(t *testing.T) { f(t, logger, db, key) })
+	t.Run("unencrypted", func(t *testing.T) {
+		t.Cleanup(func() {
+			_, err := db.ExecContext(context.Background(), "DELETE FROM outbound_webhooks CASCADE")
+			require.NoError(t, err)
+		})
+		f(t, logger, db, nil)
+	})
 
-	logger = logtest.Scoped(t)
-	db = NewDB(logger, dbtest.NewDB(t))
-	key = et.ByteaTestKey{}
-	t.Run("encrypted", func(t *testing.T) { f(t, logger, db, key) })
+	t.Run("encrypted", func(t *testing.T) { f(t, logger, db, et.ByteaTestKey{}) })
 }

--- a/internal/database/recent_view_signal.go
+++ b/internal/database/recent_view_signal.go
@@ -125,9 +125,13 @@ const findAncestorPathsFmtstr = `
 // InsertPaths inserts paths and view counts for a given `userID`. This function
 // has a hard limit of 5000 entries per bulk insert. It will issue the len(repoPathIDToCount) % 5000 inserts.
 func (s *recentViewSignalStore) InsertPaths(ctx context.Context, userID int32, repoPathIDToCount map[int]int) error {
+	return s.insertPaths(ctx, userID, repoPathIDToCount, 5000)
+}
+
+func (s *recentViewSignalStore) insertPaths(ctx context.Context, userID int32, repoPathIDToCount map[int]int, maxBatchSize int) error {
 	batchSize := len(repoPathIDToCount)
-	if batchSize > 5000 {
-		batchSize = 5000
+	if batchSize > maxBatchSize {
+		batchSize = maxBatchSize
 	}
 	if batchSize == 0 {
 		return nil


### PR DESCRIPTION
Found this package frustratingly slow, so looked at the worst offenders.

Top 5 before:

```
TestOutboundWebhookJobs,3.61
TestRecentViewSignalStore_InsertPaths_OverBatchSize,4.9
TestFeatureFlagStore,6.28
TestEventLogs_OwnershipFeatureActivity,7.05
TestExternalServicesStore_Upsert,9.72
```

Top 5 after:

```
TestPermsStore_GrantPendingPermissions,2.28
TestExternalServicesStore_DeleteExtServiceWithManyRepos,2.43
TestAccessTokens,2.47
TestWebhookUpdate,2.67
TestFeatureFlagStore,4.95
```



## Test plan

CI still passes.