### PR TITLE
grpc: searcher: zoekt-webserver support automatic retries

### DIFF
--- a/internal/search/backend/BUILD.bazel
+++ b/internal/search/backend/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "index_options.go",
         "indexers.go",
         "metered_searcher.go",
+        "retry.go",
         "zoekt.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/search/backend",

--- a/internal/search/backend/retry.go
+++ b/internal/search/backend/retry.go
@@ -1,0 +1,37 @@
+package backend
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
+	proto "github.com/sourcegraph/zoekt/grpc/protos/zoekt/webserver/v1"
+	"google.golang.org/grpc"
+)
+
+// automaticRetryClient is a convenience wrapper around a base proto.WebserverServiceClient that automatically retries
+// idempotent ("safe") methods in accordance to the policy defined in internal/grpc/defaults.RetryPolicy.
+//
+// Read the implementation of this type for more details are automatically retried (and why).
+//
+// Callers are free to override the default retry behavior by proving their own grpc.CallOptions when invoking the RPC.
+// (example: providing retry.WithMax(0) will disable retries even when invoking StreamSearch - which is idempotent).
+type automaticRetryClient struct {
+	base proto.WebserverServiceClient
+}
+
+func (a *automaticRetryClient) Search(ctx context.Context, in *proto.SearchRequest, opts ...grpc.CallOption) (*proto.SearchResponse, error) {
+	opts = append(defaults.RetryPolicy, opts...)
+	return a.base.Search(ctx, in, opts...)
+}
+
+func (a *automaticRetryClient) StreamSearch(ctx context.Context, in *proto.StreamSearchRequest, opts ...grpc.CallOption) (proto.WebserverService_StreamSearchClient, error) {
+	opts = append(defaults.RetryPolicy, opts...)
+	return a.base.StreamSearch(ctx, in, opts...)
+}
+
+func (a *automaticRetryClient) List(ctx context.Context, in *proto.ListRequest, opts ...grpc.CallOption) (*proto.ListResponse, error) {
+	opts = append(defaults.RetryPolicy, opts...)
+	return a.base.List(ctx, in, opts...)
+}
+
+var _ proto.WebserverServiceClient = &automaticRetryClient{}

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -120,9 +120,11 @@ func ZoektDialGRPC(endpoint string) zoekt.Streamer {
 		log.Scoped("zoekt"),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxRecvMsgSize)),
 	)
+
+	client := &automaticRetryClient{base: proto.NewWebserverServiceClient(conn)}
 	return NewMeteredSearcher(endpoint, &zoektGRPCClient{
 		endpoint: endpoint,
-		client:   proto.NewWebserverServiceClient(conn),
+		client:   client,
 		dialErr:  err,
 	})
 }


### PR DESCRIPTION
This PR adds support for automatic retries in the `zoekt-webserver` grpc client that `searcher` uses.

---

I wrapped the basic zoekt-webserver grpc client with an "automaticRetryClient" that uses the default retry policy that was defined in https://github.com/sourcegraph/sourcegraph/pull/59095. See that PR for more details. All the methods don't have any side effects, so they're all capable of being retried. 

Note that for ServerStreaming methods like StreamSearch and List, the retry logic will only automatically retry if we haven't received any messages back from the server yet. 

After we receive a single message, we can't know whether or not the caller has consumed the message yet (e.x: started consuming the search results from `StreamSearch` and displaying them in the WebUI) and can tolerate receiving old messages, duplicated messages, etc. If we get an error after this point, we'll fail the RPC immediately and bubble up the underlying error to the caller. Only the caller would know the semantics of how it's consuming the stream to know how to proceed. 

## Test plan

CI
