### PR TITLE
Guard repo code-intel page on Dotcom

### DIFF
--- a/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
@@ -68,7 +68,7 @@ export const codeIntelAreaRoutes: readonly CodeIntelAreaRoute[] = [
     {
         path: '/dashboard',
         render: props => <RepoDashboardPage {...props} />,
-        condition: context => context.authenticatedUser !== null,
+        condition: context => Boolean(context.authenticatedUser?.siteAdmin),
     },
 
     // Precise index routes

--- a/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
@@ -68,6 +68,7 @@ export const codeIntelAreaRoutes: readonly CodeIntelAreaRoute[] = [
     {
         path: '/dashboard',
         render: props => <RepoDashboardPage {...props} />,
+        condition: context => context.authenticatedUser !== null,
     },
 
     // Precise index routes

--- a/internal/codeintel/uploads/transport/graphql/root_resolver_coverage.go
+++ b/internal/codeintel/uploads/transport/graphql/root_resolver_coverage.go
@@ -40,6 +40,11 @@ func (r *rootResolver) RepositorySummary(ctx context.Context, repoID graphql.ID)
 	}})
 	endObservation.OnCancel(ctx, 1, observation.Args{})
 
+	// 🚨 SECURITY: Only site admins can access repository summary
+	if err := r.siteAdminChecker.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	id, err := resolverstubs.UnmarshalID[int](repoID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
[Slack Thread](https://sourcegraph.slack.com/archives/C07KZF47K/p1703102588008859)

## Test plan

* Start your sourcegraph instance with Dotcom configuration. `sg start dotcom`
* Navigate to the code intel dashboard of any repo: `https://sourcegraph.test:3443/github.com/sourcegraph/sourcegraph/-/code-graph/dashboard`
* You should get a 404 page.

### Screenshots

* Before adding the guard on the client side and added the backend guard.
![CleanShot 2023-12-20 at 22 09 57](https://github.com/sourcegraph/sourcegraph/assets/25608335/858fcc85-a43c-44e1-ad90-c9bdefb9b2c1)

* With both guards (Client & Backend)
![CleanShot 2023-12-20 at 22 10 36](https://github.com/sourcegraph/sourcegraph/assets/25608335/f5249e2f-d6d3-42bb-aa97-a92f39e524a7)
