### PR TITLE
grpc: retry: fork retry package grpc: import fork of go-grpc-middlware/retry package

### DIFF
--- a/internal/grpc/retry/BUILD.bazel
+++ b/internal/grpc/retry/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "retry",
+    srcs = [
+        "backoff.go",
+        "doc.go",
+        "options.go",
+        "retry.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/grpc/retry",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "@com_github_grpc_ecosystem_go_grpc_middleware_v2//metadata",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
+        "@org_golang_x_net//trace",
+    ],
+)
+
+go_test(
+    name = "retry_test",
+    srcs = [
+        "examples_test.go",
+        "retry_test.go",
+    ],
+    embed = [":retry"],
+    deps = [
+        "@com_github_grpc_ecosystem_go_grpc_middleware_v2//testing/testpb",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@com_github_stretchr_testify//suite",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/internal/grpc/retry/backoff.go
+++ b/internal/grpc/retry/backoff.go
@@ -1,0 +1,55 @@
+// Copyright (c) The go-grpc-middleware Authors.
+// Licensed under the Apache License 2.0.
+
+package retry
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+// BackoffLinear is very simple: it waits for a fixed period of time between calls.
+func BackoffLinear(waitBetween time.Duration) BackoffFunc {
+	return func(ctx context.Context, attempt uint) time.Duration {
+		return waitBetween
+	}
+}
+
+// jitterUp adds random jitter to the duration.
+// This adds or subtracts time from the duration within a given jitter fraction.
+// For example for 10s and jitter 0.1, it will return a time within [9s, 11s])
+func jitterUp(duration time.Duration, jitter float64) time.Duration {
+	multiplier := jitter * (rand.Float64()*2 - 1)
+	return time.Duration(float64(duration) * (1 + multiplier))
+}
+
+// exponentBase2 computes 2^(a-1) where a >= 1. If a is 0, the result is 0.
+func exponentBase2(a uint) uint {
+	return (1 << a) >> 1
+}
+
+// BackoffLinearWithJitter waits a set period of time, allowing for jitter (fractional adjustment).
+// For example waitBetween=1s and jitter=0.10 can generate waits between 900ms and 1100ms.
+func BackoffLinearWithJitter(waitBetween time.Duration, jitterFraction float64) BackoffFunc {
+	return func(ctx context.Context, attempt uint) time.Duration {
+		return jitterUp(waitBetween, jitterFraction)
+	}
+}
+
+// BackoffExponential produces increasing intervals for each attempt.
+// The scalar is multiplied times 2 raised to the current attempt. So the first
+// retry with a scalar of 100ms is 100ms, while the 5th attempt would be 1.6s.
+func BackoffExponential(scalar time.Duration) BackoffFunc {
+	return func(ctx context.Context, attempt uint) time.Duration {
+		return scalar * time.Duration(exponentBase2(attempt))
+	}
+}
+
+// BackoffExponentialWithJitter creates an exponential backoff like
+// BackoffExponential does, but adds jitter.
+func BackoffExponentialWithJitter(scalar time.Duration, jitterFraction float64) BackoffFunc {
+	return func(ctx context.Context, attempt uint) time.Duration {
+		return jitterUp(scalar*time.Duration(exponentBase2(attempt)), jitterFraction)
+	}
+}

--- a/internal/grpc/retry/doc.go
+++ b/internal/grpc/retry/doc.go
@@ -1,0 +1,25 @@
+// Copyright (c) The go-grpc-middleware Authors.
+// Licensed under the Apache License 2.0.
+
+/*
+Package retry provides client-side request retry logic for gRPC.
+
+# Client-Side Request Retry Interceptor
+
+It allows for automatic retry, inside the generated gRPC code of requests based on the gRPC status
+of the reply. It supports unary (1:1), and server stream (1:n) requests.
+
+By default the interceptors *are disabled*, preventing accidental use of retries. You can easily
+override the number of retries (setting them to more than 0) with a `grpc.ClientOption`, e.g.:
+
+	myclient.Ping(ctx, goodPing, grpc_retry.WithMax(5))
+
+Other default options are: retry on `ResourceExhausted` and `Unavailable` gRPC codes, use a 50ms
+linear backoff with 10% jitter.
+
+For chained interceptors, the retry interceptor will call every interceptor that follows it
+whenever when a retry happens.
+
+Please see examples for more advanced use.
+*/
+package retry

--- a/internal/grpc/retry/examples_test.go
+++ b/internal/grpc/retry/examples_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) The go-grpc-middleware Authors.
+// Licensed under the Apache License 2.0.
+
+package retry
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+var cc *grpc.ClientConn
+
+// Simple example of using the default interceptor configuration.
+func Example_initialization() {
+	_, _ = grpc.Dial("myservice.example.com",
+		grpc.WithStreamInterceptor(StreamClientInterceptor()),
+		grpc.WithUnaryInterceptor(UnaryClientInterceptor()),
+	)
+}
+
+// Complex example with a 100ms linear backoff interval, and retry only on NotFound and Unavailable.
+func Example_initializationWithOptions() {
+	opts := []CallOption{
+		WithBackoff(BackoffLinear(100 * time.Millisecond)),
+		WithCodes(codes.NotFound, codes.Aborted),
+	}
+	_, _ = grpc.Dial("myservice.example.com",
+		grpc.WithStreamInterceptor(StreamClientInterceptor(opts...)),
+		grpc.WithUnaryInterceptor(UnaryClientInterceptor(opts...)),
+	)
+}
+
+// Example with an exponential backoff starting with 100ms.
+//
+// Each next interval is the previous interval multiplied by 2.
+func Example_initializationWithExponentialBackoff() {
+	opts := []CallOption{
+		WithBackoff(BackoffExponential(100 * time.Millisecond)),
+	}
+	_, _ = grpc.Dial("myservice.example.com",
+		grpc.WithStreamInterceptor(StreamClientInterceptor(opts...)),
+		grpc.WithUnaryInterceptor(UnaryClientInterceptor(opts...)),
+	)
+}
+
+// Simple example of an idempotent `ServerStream` call, that will be retried automatically 3 times.
+func Example_simpleCall() {
+	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+	defer cancel()
+
+	client := testpb.NewTestServiceClient(cc)
+	stream, _ := client.PingList(ctx, &testpb.PingListRequest{}, WithMax(3))
+
+	for {
+		_, err := stream.Recv() // retries happen here
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return
+		}
+	}
+}
+
+// This is an example of an `Unary` call that will also retry on deadlines.
+//
+// Because the passed in context has a `5s` timeout, the whole `Ping` invocation should finish
+// within that time. However, by default all retried calls will use the parent context for their
+// deadlines. This means, that unless you shorten the deadline of each call of the retry, you won't
+// be able to retry the first call at all.
+//
+// `WithPerRetryTimeout` allows you to shorten the deadline of each retry call, allowing you to fit
+// multiple retries in the single parent deadline.
+func ExampleWithPerRetryTimeout() {
+	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	defer cancel()
+
+	client := testpb.NewTestServiceClient(cc)
+	_, _ = client.Ping(
+		ctx,
+		&testpb.PingRequest{},
+		WithMax(3),
+		WithPerRetryTimeout(1*time.Second))
+}
+
+// Scale duration by a factor.
+func scaleDuration(d time.Duration, factor float64) time.Duration {
+	return time.Duration(float64(d) * factor)
+}

--- a/internal/grpc/retry/options.go
+++ b/internal/grpc/retry/options.go
@@ -1,0 +1,139 @@
+// Copyright (c) The go-grpc-middleware Authors.
+// Licensed under the Apache License 2.0.
+
+package retry
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+var (
+	// DefaultRetriableCodes is a set of well known types gRPC codes that should be retri-able.
+	//
+	// `ResourceExhausted` means that the user quota, e.g. per-RPC limits, have been reached.
+	// `Unavailable` means that system is currently unavailable and the client should retry again.
+	DefaultRetriableCodes = []codes.Code{codes.ResourceExhausted, codes.Unavailable}
+
+	defaultOptions = &options{
+		max:            0, // disabled
+		perCallTimeout: 0, // disabled
+		includeHeader:  true,
+		codes:          DefaultRetriableCodes,
+		backoffFunc:    BackoffLinearWithJitter(50*time.Millisecond /*jitter*/, 0.10),
+		onRetryCallback: OnRetryCallback(func(ctx context.Context, attempt uint, err error) {
+			logTrace(ctx, "grpc_retry attempt: %d, backoff for %v", attempt, err)
+		}),
+	}
+)
+
+// BackoffFunc denotes a family of functions that control the backoff duration between call retries.
+//
+// They are called with an identifier of the attempt, and should return a time the system client should
+// hold off for. If the time returned is longer than the `context.Context.Deadline` of the request
+// the deadline of the request takes precedence and the wait will be interrupted before proceeding
+// with the next iteration. The context can be used to extract request scoped metadata and context values.
+type BackoffFunc func(ctx context.Context, attempt uint) time.Duration
+
+// OnRetryCallback is the type of function called when a retry occurs.
+type OnRetryCallback func(ctx context.Context, attempt uint, err error)
+
+// Disable disables the retry behaviour on this call, or this interceptor.
+//
+// Its semantically the same to `WithMax`
+func Disable() CallOption {
+	return WithMax(0)
+}
+
+// WithMax sets the maximum number of retries on this call, or this interceptor.
+func WithMax(maxRetries uint) CallOption {
+	return CallOption{applyFunc: func(o *options) {
+		o.max = maxRetries
+	}}
+}
+
+// WithBackoff sets the `BackoffFunc` used to control time between retries.
+func WithBackoff(bf BackoffFunc) CallOption {
+	return CallOption{applyFunc: func(o *options) {
+		o.backoffFunc = bf
+	}}
+}
+
+// WithOnRetryCallback sets the callback to use when a retry occurs.
+//
+// By default, when no callback function provided, we will just print a log to trace
+func WithOnRetryCallback(fn OnRetryCallback) CallOption {
+	return CallOption{applyFunc: func(o *options) {
+		o.onRetryCallback = fn
+	}}
+}
+
+// WithCodes sets which codes should be retried.
+//
+// Please *use with care*, as you may be retrying non-idempotent calls.
+//
+// You cannot automatically retry on Cancelled and Deadline, please use `WithPerRetryTimeout` for these.
+func WithCodes(retryCodes ...codes.Code) CallOption {
+	return CallOption{applyFunc: func(o *options) {
+		o.codes = retryCodes
+	}}
+}
+
+// WithPerRetryTimeout sets the RPC timeout per call (including initial call) on this call, or this interceptor.
+//
+// The context.Deadline of the call takes precedence and sets the maximum time the whole invocation
+// will take, but WithPerRetryTimeout can be used to limit the RPC time per each call.
+//
+// For example, with context.Deadline = now + 10s, and WithPerRetryTimeout(3 * time.Seconds), each
+// of the retry calls (including the initial one) will have a deadline of now + 3s.
+//
+// A value of 0 disables the timeout overrides completely and returns to each retry call using the
+// parent `context.Deadline`.
+//
+// Note that when this is enabled, any DeadlineExceeded errors that are propagated up will be retried.
+func WithPerRetryTimeout(timeout time.Duration) CallOption {
+	return CallOption{applyFunc: func(o *options) {
+		o.perCallTimeout = timeout
+	}}
+}
+
+type options struct {
+	max             uint
+	perCallTimeout  time.Duration
+	includeHeader   bool
+	codes           []codes.Code
+	backoffFunc     BackoffFunc
+	onRetryCallback OnRetryCallback
+}
+
+// CallOption is a grpc.CallOption that is local to grpc_retry.
+type CallOption struct {
+	grpc.EmptyCallOption // make sure we implement private after() and before() fields so we don't panic.
+	applyFunc            func(opt *options)
+}
+
+func reuseOrNewWithCallOptions(opt *options, callOptions []CallOption) *options {
+	if len(callOptions) == 0 {
+		return opt
+	}
+	optCopy := &options{}
+	*optCopy = *opt
+	for _, f := range callOptions {
+		f.applyFunc(optCopy)
+	}
+	return optCopy
+}
+
+func filterCallOptions(callOptions []grpc.CallOption) (grpcOptions []grpc.CallOption, retryOptions []CallOption) {
+	for _, opt := range callOptions {
+		if co, ok := opt.(CallOption); ok {
+			retryOptions = append(retryOptions, co)
+		} else {
+			grpcOptions = append(grpcOptions, opt)
+		}
+	}
+	return grpcOptions, retryOptions
+}

--- a/internal/grpc/retry/retry.go
+++ b/internal/grpc/retry/retry.go
@@ -1,0 +1,319 @@
+// Copyright (c) The go-grpc-middleware Authors.
+// Licensed under the Apache License 2.0.
+
+package retry
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/metadata"
+	"golang.org/x/net/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcMetadata "google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	AttemptMetadataKey = "x-retry-attempt"
+)
+
+// UnaryClientInterceptor returns a new retrying unary client interceptor.
+//
+// The default configuration of the interceptor is to not retry *at all*. This behaviour can be
+// changed through options (e.g. WithMax) on creation of the interceptor or on call (through grpc.CallOptions).
+func UnaryClientInterceptor(optFuncs ...CallOption) grpc.UnaryClientInterceptor {
+	intOpts := reuseOrNewWithCallOptions(defaultOptions, optFuncs)
+	return func(parentCtx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		grpcOpts, retryOpts := filterCallOptions(opts)
+		callOpts := reuseOrNewWithCallOptions(intOpts, retryOpts)
+		// short circuit for simplicity, and avoiding allocations.
+		if callOpts.max == 0 {
+			return invoker(parentCtx, method, req, reply, cc, grpcOpts...)
+		}
+		var lastErr error
+		for attempt := uint(0); attempt < callOpts.max; attempt++ {
+			if err := waitRetryBackoff(attempt, parentCtx, callOpts); err != nil {
+				return err
+			}
+			callCtx, cancel := perCallContext(parentCtx, callOpts, attempt)
+			defer cancel() // Clean up potential resources.
+			lastErr = invoker(callCtx, method, req, reply, cc, grpcOpts...)
+			// TODO(mwitkow): Maybe dial and transport errors should be retriable?
+			if lastErr == nil {
+				return nil
+			}
+			callOpts.onRetryCallback(parentCtx, attempt, lastErr)
+			if isContextError(lastErr) {
+				if parentCtx.Err() != nil {
+					logTrace(parentCtx, "grpc_retry attempt: %d, parent context error: %v", attempt, parentCtx.Err())
+					// its the parent context deadline or cancellation.
+					return lastErr
+				} else if callOpts.perCallTimeout != 0 {
+					// We have set a perCallTimeout in the retry middleware, which would result in a context error if
+					// the deadline was exceeded, in which case try again.
+					logTrace(parentCtx, "grpc_retry attempt: %d, context error from retry call", attempt)
+					continue
+				}
+			}
+			if !isRetriable(lastErr, callOpts) {
+				return lastErr
+			}
+		}
+		return lastErr
+	}
+}
+
+// StreamClientInterceptor returns a new retrying stream client interceptor for server side streaming calls.
+//
+// The default configuration of the interceptor is to not retry *at all*. This behaviour can be
+// changed through options (e.g. WithMax) on creation of the interceptor or on call (through grpc.CallOptions).
+//
+// Retry logic is available *only for ServerStreams*, i.e. 1:n streams, as the internal logic needs
+// to buffer the messages sent by the client. If retry is enabled on any other streams (ClientStreams,
+// BidiStreams), the retry interceptor will fail the call.
+func StreamClientInterceptor(optFuncs ...CallOption) grpc.StreamClientInterceptor {
+	intOpts := reuseOrNewWithCallOptions(defaultOptions, optFuncs)
+	return func(parentCtx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		grpcOpts, retryOpts := filterCallOptions(opts)
+		callOpts := reuseOrNewWithCallOptions(intOpts, retryOpts)
+		// short circuit for simplicity, and avoiding allocations.
+		if callOpts.max == 0 {
+			return streamer(parentCtx, desc, cc, method, grpcOpts...)
+		}
+		if desc.ClientStreams {
+			return nil, status.Error(codes.Unimplemented, "grpc_retry: cannot retry on ClientStreams, set grpc_retry.Disable()")
+		}
+
+		var lastErr error
+		for attempt := uint(0); attempt < callOpts.max; attempt++ {
+			if err := waitRetryBackoff(attempt, parentCtx, callOpts); err != nil {
+				return nil, err
+			}
+			var newStreamer grpc.ClientStream
+			newStreamer, lastErr = streamer(parentCtx, desc, cc, method, grpcOpts...)
+			if lastErr == nil {
+				retryingStreamer := &serverStreamingRetryingStream{
+					ClientStream: newStreamer,
+					callOpts:     callOpts,
+					parentCtx:    parentCtx,
+					streamerCall: func(ctx context.Context) (grpc.ClientStream, error) {
+						return streamer(ctx, desc, cc, method, grpcOpts...)
+					},
+				}
+				return retryingStreamer, nil
+			}
+			callOpts.onRetryCallback(parentCtx, attempt, lastErr)
+			if isContextError(lastErr) {
+				if parentCtx.Err() != nil {
+					logTrace(parentCtx, "grpc_retry attempt: %d, parent context error: %v", attempt, parentCtx.Err())
+					// its the parent context deadline or cancellation.
+					return nil, lastErr
+				} else if callOpts.perCallTimeout != 0 {
+					// We have set a perCallTimeout in the retry middleware, which would result in a context error if
+					// the deadline was exceeded, in which case try again.
+					logTrace(parentCtx, "grpc_retry attempt: %d, context error from retry call", attempt)
+					continue
+				}
+			}
+			if !isRetriable(lastErr, callOpts) {
+				return nil, lastErr
+			}
+		}
+		return nil, lastErr
+	}
+}
+
+// type serverStreamingRetryingStream is the implementation of grpc.ClientStream that acts as a
+// proxy to the underlying call. If any of the RecvMsg() calls fail, it will try to reestablish
+// a new ClientStream according to the retry policy.
+type serverStreamingRetryingStream struct {
+	grpc.ClientStream
+	bufferedSends []any // single message that the client can sen
+	wasClosedSend bool  // indicates that CloseSend was closed
+	parentCtx     context.Context
+	callOpts      *options
+	streamerCall  func(ctx context.Context) (grpc.ClientStream, error)
+	mu            sync.RWMutex
+}
+
+func (s *serverStreamingRetryingStream) setStream(clientStream grpc.ClientStream) {
+	s.mu.Lock()
+	s.ClientStream = clientStream
+	s.mu.Unlock()
+}
+
+func (s *serverStreamingRetryingStream) getStream() grpc.ClientStream {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.ClientStream
+}
+
+func (s *serverStreamingRetryingStream) SendMsg(m any) error {
+	s.mu.Lock()
+	s.bufferedSends = append(s.bufferedSends, m)
+	s.mu.Unlock()
+	return s.getStream().SendMsg(m)
+}
+
+func (s *serverStreamingRetryingStream) CloseSend() error {
+	s.mu.Lock()
+	s.wasClosedSend = true
+	s.mu.Unlock()
+	return s.getStream().CloseSend()
+}
+
+func (s *serverStreamingRetryingStream) Header() (grpcMetadata.MD, error) {
+	return s.getStream().Header()
+}
+
+func (s *serverStreamingRetryingStream) Trailer() grpcMetadata.MD {
+	return s.getStream().Trailer()
+}
+
+func (s *serverStreamingRetryingStream) RecvMsg(m any) error {
+	attemptRetry, lastErr := s.receiveMsgAndIndicateRetry(m)
+	if !attemptRetry {
+		return lastErr // success or hard failure
+	}
+	// We start off from attempt 1, because zeroth was already made on normal SendMsg().
+	for attempt := uint(1); attempt < s.callOpts.max; attempt++ {
+		if err := waitRetryBackoff(attempt, s.parentCtx, s.callOpts); err != nil {
+			return err
+		}
+		s.callOpts.onRetryCallback(s.parentCtx, attempt, lastErr)
+		newStream, err := s.reestablishStreamAndResendBuffer(s.parentCtx)
+		if err != nil {
+			// Retry dial and transport errors of establishing stream as grpc doesn't retry.
+			if isRetriable(err, s.callOpts) {
+				continue
+			}
+			return err
+		}
+
+		s.setStream(newStream)
+		attemptRetry, lastErr = s.receiveMsgAndIndicateRetry(m)
+
+		if !attemptRetry {
+			return lastErr
+		}
+	}
+	return lastErr
+}
+
+func (s *serverStreamingRetryingStream) receiveMsgAndIndicateRetry(m any) (bool, error) {
+	err := s.getStream().RecvMsg(m)
+	if err == nil || err == io.EOF {
+		return false, err
+	}
+	if isContextError(err) {
+		if s.parentCtx.Err() != nil {
+			logTrace(s.parentCtx, "grpc_retry parent context error: %v", s.parentCtx.Err())
+			return false, err
+		} else if s.callOpts.perCallTimeout != 0 {
+			// We have set a perCallTimeout in the retry middleware, which would result in a context error if
+			// the deadline was exceeded, in which case try again.
+			logTrace(s.parentCtx, "grpc_retry context error from retry call")
+			return true, err
+		}
+	}
+	return isRetriable(err, s.callOpts), err
+}
+
+func (s *serverStreamingRetryingStream) reestablishStreamAndResendBuffer(callCtx context.Context) (grpc.ClientStream, error) {
+	s.mu.RLock()
+	bufferedSends := s.bufferedSends
+	s.mu.RUnlock()
+	newStream, err := s.streamerCall(callCtx)
+	if err != nil {
+		logTrace(callCtx, "grpc_retry failed redialing new stream: %v", err)
+		return nil, err
+	}
+	for _, msg := range bufferedSends {
+		if err := newStream.SendMsg(msg); err != nil {
+			logTrace(callCtx, "grpc_retry failed resending message: %v", err)
+			return nil, err
+		}
+	}
+	if err := newStream.CloseSend(); err != nil {
+		logTrace(callCtx, "grpc_retry failed CloseSend on new stream %v", err)
+		return nil, err
+	}
+	return newStream, nil
+}
+
+func waitRetryBackoff(attempt uint, parentCtx context.Context, callOpts *options) error {
+	var waitTime time.Duration = 0
+	if attempt > 0 {
+		waitTime = callOpts.backoffFunc(parentCtx, attempt)
+	}
+	if waitTime > 0 {
+		logTrace(parentCtx, "grpc_retry attempt: %d, backoff for %v", attempt, waitTime)
+		timer := time.NewTimer(waitTime)
+		select {
+		case <-parentCtx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return contextErrToGrpcErr(parentCtx.Err())
+		case <-timer.C:
+		}
+	}
+	return nil
+}
+
+func isRetriable(err error, callOpts *options) bool {
+	errCode := status.Code(err)
+	if isContextError(err) {
+		// context errors are not retriable based on user settings.
+		return false
+	}
+	for _, code := range callOpts.codes {
+		if code == errCode {
+			return true
+		}
+	}
+	return false
+}
+
+func isContextError(err error) bool {
+	code := status.Code(err)
+	return code == codes.DeadlineExceeded || code == codes.Canceled
+}
+
+func perCallContext(parentCtx context.Context, callOpts *options, attempt uint) (context.Context, context.CancelFunc) {
+	cancel := context.CancelFunc(func() {})
+
+	ctx := parentCtx
+	if callOpts.perCallTimeout != 0 {
+		ctx, cancel = context.WithTimeout(ctx, callOpts.perCallTimeout)
+	}
+	if attempt > 0 && callOpts.includeHeader {
+		mdClone := metadata.ExtractOutgoing(ctx).Clone().Set(AttemptMetadataKey, fmt.Sprintf("%d", attempt))
+		ctx = mdClone.ToOutgoing(ctx)
+	}
+	return ctx, cancel
+}
+
+func contextErrToGrpcErr(err error) error {
+	switch err {
+	case context.DeadlineExceeded:
+		return status.Error(codes.DeadlineExceeded, err.Error())
+	case context.Canceled:
+		return status.Error(codes.Canceled, err.Error())
+	default:
+		return status.Error(codes.Unknown, err.Error())
+	}
+}
+
+func logTrace(ctx context.Context, format string, a ...any) {
+	tr, ok := trace.FromContext(ctx)
+	if !ok {
+		return
+	}
+	tr.LazyPrintf(format, a...)
+}

--- a/internal/grpc/retry/retry_test.go
+++ b/internal/grpc/retry/retry_test.go
@@ -1,0 +1,398 @@
+// Copyright (c) The go-grpc-middleware Authors.
+// Licensed under the Apache License 2.0.
+
+package retry
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	retriableErrors = []codes.Code{codes.Unavailable, codes.DataLoss}
+	noSleep         = 0 * time.Second
+	retryTimeout    = 50 * time.Millisecond
+)
+
+type failingService struct {
+	testpb.TestServiceServer
+	mu sync.Mutex
+
+	reqCounter uint
+	reqModulo  uint
+	reqSleep   time.Duration
+	reqError   codes.Code
+}
+
+func (s *failingService) resetFailingConfiguration(modulo uint, errorCode codes.Code, sleepTime time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.reqCounter = 0
+	s.reqModulo = modulo
+	s.reqError = errorCode
+	s.reqSleep = sleepTime
+}
+
+func (s *failingService) requestCount() uint {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.reqCounter
+}
+
+func (s *failingService) maybeFailRequest() error {
+	s.mu.Lock()
+	s.reqCounter += 1
+	reqModulo := s.reqModulo
+	reqCounter := s.reqCounter
+	reqSleep := s.reqSleep
+	reqError := s.reqError
+	s.mu.Unlock()
+	if (reqModulo > 0) && (reqCounter%reqModulo == 0) {
+		return nil
+	}
+	time.Sleep(reqSleep)
+	return status.Error(reqError, "maybeFailRequest: failing it")
+}
+
+func (s *failingService) Ping(ctx context.Context, ping *testpb.PingRequest) (*testpb.PingResponse, error) {
+	if err := s.maybeFailRequest(); err != nil {
+		return nil, err
+	}
+	return s.TestServiceServer.Ping(ctx, ping)
+}
+
+func (s *failingService) PingList(ping *testpb.PingListRequest, stream testpb.TestService_PingListServer) error {
+	if err := s.maybeFailRequest(); err != nil {
+		return err
+	}
+	return s.TestServiceServer.PingList(ping, stream)
+}
+
+func (s *failingService) PingStream(stream testpb.TestService_PingStreamServer) error {
+	if err := s.maybeFailRequest(); err != nil {
+		return err
+	}
+	return s.TestServiceServer.PingStream(stream)
+}
+
+func TestRetrySuite(t *testing.T) {
+	service := &failingService{
+		TestServiceServer: &testpb.TestPingService{},
+	}
+	unaryInterceptor := UnaryClientInterceptor(
+		WithCodes(retriableErrors...),
+		WithMax(3),
+		WithBackoff(BackoffLinear(retryTimeout)),
+	)
+	streamInterceptor := StreamClientInterceptor(
+		WithCodes(retriableErrors...),
+		WithMax(3),
+		WithBackoff(BackoffLinear(retryTimeout)),
+	)
+	s := &RetrySuite{
+		srv: service,
+		InterceptorTestSuite: &testpb.InterceptorTestSuite{
+			TestService: service,
+			ClientOpts: []grpc.DialOption{
+				grpc.WithStreamInterceptor(streamInterceptor),
+				grpc.WithUnaryInterceptor(unaryInterceptor),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+type RetrySuite struct {
+	*testpb.InterceptorTestSuite
+	srv *failingService
+}
+
+func (s *RetrySuite) SetupTest() {
+	s.srv.resetFailingConfiguration( /* don't fail */ 0, codes.OK, noSleep)
+}
+
+func (s *RetrySuite) TestUnary_FailsOnNonRetriableError() {
+	s.srv.resetFailingConfiguration(5, codes.Internal, noSleep)
+	_, err := s.Client.Ping(s.SimpleCtx(), testpb.GoodPing)
+	require.Error(s.T(), err, "error must occur from the failing service")
+	require.Equal(s.T(), codes.Internal, status.Code(err), "failure code must come from retrier")
+	require.EqualValues(s.T(), 1, s.srv.requestCount(), "one request should have been made")
+}
+
+func (s *RetrySuite) TestUnary_FailsOnNonRetriableContextError() {
+	s.srv.resetFailingConfiguration(5, codes.Canceled, noSleep)
+	_, err := s.Client.Ping(s.SimpleCtx(), testpb.GoodPing)
+	require.Error(s.T(), err, "error must occur from the failing service")
+	require.Equal(s.T(), codes.Canceled, status.Code(err), "failure code must come from retrier")
+	require.EqualValues(s.T(), 1, s.srv.requestCount(), "one request should have been made")
+}
+
+func (s *RetrySuite) TestCallOptionsDontPanicWithoutInterceptor() {
+	// Fix for https://github.com/grpc-ecosystem/go-grpc-middleware/issues/37
+	// If this code doesn't panic, that's good.
+	s.srv.resetFailingConfiguration(100, codes.DataLoss, noSleep) // doesn't matter all requests should fail
+	nonMiddlewareClient := s.NewClient()
+	_, err := nonMiddlewareClient.Ping(s.SimpleCtx(), testpb.GoodPing,
+		WithMax(5),
+		WithBackoff(BackoffLinear(1*time.Millisecond)),
+		WithCodes(codes.DataLoss),
+		WithPerRetryTimeout(1*time.Millisecond),
+	)
+	require.Error(s.T(), err)
+}
+
+func (s *RetrySuite) TestServerStream_FailsOnNonRetriableError() {
+	s.srv.resetFailingConfiguration(5, codes.Internal, noSleep)
+	stream, err := s.Client.PingList(s.SimpleCtx(), testpb.GoodPingList)
+	require.NoError(s.T(), err, "should not fail on establishing the stream")
+	_, err = stream.Recv()
+	require.Error(s.T(), err, "error must occur from the failing service")
+	require.Equal(s.T(), codes.Internal, status.Code(err), "failure code must come from retrier")
+}
+
+func (s *RetrySuite) TestUnary_SucceedsOnRetriableError() {
+	s.srv.resetFailingConfiguration(3, codes.DataLoss, noSleep) // see retriable_errors
+	out, err := s.Client.Ping(s.SimpleCtx(), testpb.GoodPing)
+	require.NoError(s.T(), err, "the third invocation should succeed")
+	require.NotNil(s.T(), out, "Pong must be not nil")
+	require.EqualValues(s.T(), 3, s.srv.requestCount(), "three requests should have been made")
+}
+
+func (s *RetrySuite) TestUnary_OverrideFromDialOpts() {
+	s.srv.resetFailingConfiguration(5, codes.ResourceExhausted, noSleep) // default is 3 and retriable_errors
+	out, err := s.Client.Ping(s.SimpleCtx(), testpb.GoodPing, WithCodes(codes.ResourceExhausted), WithMax(5))
+	require.NoError(s.T(), err, "the fifth invocation should succeed")
+	require.NotNil(s.T(), out, "Pong must be not nil")
+	require.EqualValues(s.T(), 5, s.srv.requestCount(), "five requests should have been made")
+}
+
+func (s *RetrySuite) TestUnary_OnRetryCallbackCalled() {
+	retryCallbackCount := 0
+
+	s.srv.resetFailingConfiguration(3, codes.Unavailable, noSleep) // see retriable_errors
+	out, err := s.Client.Ping(s.SimpleCtx(), testpb.GoodPing,
+		WithOnRetryCallback(func(ctx context.Context, attempt uint, err error) {
+			retryCallbackCount++
+		}),
+	)
+
+	require.NoError(s.T(), err, "the third invocation should succeed")
+	require.NotNil(s.T(), out, "Pong must be not nil")
+	require.EqualValues(s.T(), 2, retryCallbackCount, "two retry callbacks should be called")
+}
+
+func (s *RetrySuite) TestServerStream_SucceedsOnRetriableError() {
+	s.srv.resetFailingConfiguration(3, codes.DataLoss, noSleep) // see retriable_errors
+	stream, err := s.Client.PingList(s.SimpleCtx(), testpb.GoodPingList)
+	require.NoError(s.T(), err, "establishing the connection must always succeed")
+	s.assertPingListWasCorrect(stream)
+	require.EqualValues(s.T(), 3, s.srv.requestCount(), "three requests should have been made")
+}
+
+func (s *RetrySuite) TestServerStream_OverrideFromContext() {
+	s.srv.resetFailingConfiguration(5, codes.ResourceExhausted, noSleep) // default is 3 and retriable_errors
+	stream, err := s.Client.PingList(s.SimpleCtx(), testpb.GoodPingList, WithCodes(codes.ResourceExhausted), WithMax(5))
+	require.NoError(s.T(), err, "establishing the connection must always succeed")
+	s.assertPingListWasCorrect(stream)
+	require.EqualValues(s.T(), 5, s.srv.requestCount(), "three requests should have been made")
+}
+
+func (s *RetrySuite) TestServerStream_OnRetryCallbackCalled() {
+	retryCallbackCount := 0
+
+	s.srv.resetFailingConfiguration(3, codes.Unavailable, noSleep) // see retriable_errors
+	stream, err := s.Client.PingList(s.SimpleCtx(), testpb.GoodPingList,
+		WithOnRetryCallback(func(ctx context.Context, attempt uint, err error) {
+			retryCallbackCount++
+		}),
+	)
+
+	require.NoError(s.T(), err, "establishing the connection must always succeed")
+	s.assertPingListWasCorrect(stream)
+	require.EqualValues(s.T(), 2, retryCallbackCount, "two retry callbacks should be called")
+}
+
+func (s *RetrySuite) TestServerStream_CallFailsOnOutOfRetries() {
+	restarted := s.RestartServer(3 * retryTimeout)
+	_, err := s.Client.PingList(s.SimpleCtx(), testpb.GoodPingList)
+
+	require.Error(s.T(), err, "establishing the connection should not succeed")
+	assert.Equal(s.T(), codes.Unavailable, status.Code(err))
+
+	<-restarted
+}
+
+func (s *RetrySuite) TestServerStream_CallFailsOnDeadlineExceeded() {
+	restarted := s.RestartServer(3 * retryTimeout)
+	ctx, cancel := context.WithTimeout(context.TODO(), retryTimeout)
+	defer cancel()
+	_, err := s.Client.PingList(ctx, testpb.GoodPingList)
+
+	require.Error(s.T(), err, "establishing the connection should not succeed")
+	assert.Equal(s.T(), codes.DeadlineExceeded, status.Code(err))
+
+	<-restarted
+}
+
+func (s *RetrySuite) TestServerStream_CallRetrySucceeds() {
+	restarted := s.RestartServer(retryTimeout)
+
+	_, err := s.Client.PingList(s.SimpleCtx(), testpb.GoodPingList,
+		WithMax(40),
+	)
+
+	assert.NoError(s.T(), err, "establishing the connection should succeed")
+	<-restarted
+}
+
+func (s *RetrySuite) assertPingListWasCorrect(stream testpb.TestService_PingListClient) {
+	count := 0
+	for {
+		pong, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "no errors during receive on client side")
+		require.NotNil(s.T(), pong, "received values must not be nil")
+		require.Equal(s.T(), testpb.GoodPingList.Value, pong.Value, "the returned pong contained the outgoing ping")
+		count += 1
+	}
+	require.EqualValues(s.T(), testpb.ListResponseCount, count, "should have received all ping items")
+}
+
+type trackedInterceptor struct {
+	called int
+}
+
+func (ti *trackedInterceptor) UnaryClientInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	ti.called++
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+func (ti *trackedInterceptor) StreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	ti.called++
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
+func TestChainedRetrySuite(t *testing.T) {
+	service := &failingService{
+		TestServiceServer: &testpb.TestPingService{},
+	}
+	preRetryInterceptor := &trackedInterceptor{}
+	postRetryInterceptor := &trackedInterceptor{}
+	s := &ChainedRetrySuite{
+		srv:                  service,
+		preRetryInterceptor:  preRetryInterceptor,
+		postRetryInterceptor: postRetryInterceptor,
+		InterceptorTestSuite: &testpb.InterceptorTestSuite{
+			TestService: service,
+			ClientOpts: []grpc.DialOption{
+				grpc.WithChainUnaryInterceptor(
+					preRetryInterceptor.UnaryClientInterceptor,
+					UnaryClientInterceptor(),
+					postRetryInterceptor.UnaryClientInterceptor,
+				),
+				grpc.WithChainStreamInterceptor(
+					preRetryInterceptor.StreamClientInterceptor,
+					StreamClientInterceptor(),
+					postRetryInterceptor.StreamClientInterceptor,
+				),
+			},
+		},
+	}
+	suite.Run(t, s)
+}
+
+type ChainedRetrySuite struct {
+	*testpb.InterceptorTestSuite
+	srv                  *failingService
+	preRetryInterceptor  *trackedInterceptor
+	postRetryInterceptor *trackedInterceptor
+}
+
+func (s *ChainedRetrySuite) SetupTest() {
+	s.srv.resetFailingConfiguration( /* don't fail */ 0, codes.OK, noSleep)
+	s.preRetryInterceptor.called = 0
+	s.postRetryInterceptor.called = 0
+}
+
+func (s *ChainedRetrySuite) TestUnaryWithChainedInterceptors_NoFailure() {
+	_, err := s.Client.Ping(s.SimpleCtx(), testpb.GoodPing, WithMax(2))
+	require.NoError(s.T(), err, "the invocation should succeed")
+	require.EqualValues(s.T(), 1, s.srv.requestCount(), "one request should have been made")
+	require.EqualValues(s.T(), 1, s.preRetryInterceptor.called, "pre-retry interceptor should be called once")
+	require.EqualValues(s.T(), 1, s.postRetryInterceptor.called, "post-retry interceptor should be called once")
+}
+
+func (s *ChainedRetrySuite) TestUnaryWithChainedInterceptors_WithRetry() {
+	s.srv.resetFailingConfiguration(2, codes.Unavailable, noSleep)
+	_, err := s.Client.Ping(s.SimpleCtx(), testpb.GoodPing, WithMax(2))
+	require.NoError(s.T(), err, "the second invocation should succeed")
+	require.EqualValues(s.T(), 2, s.srv.requestCount(), "two requests should have been made")
+	require.EqualValues(s.T(), 1, s.preRetryInterceptor.called, "pre-retry interceptor should be called once")
+	require.EqualValues(s.T(), 2, s.postRetryInterceptor.called, "post-retry interceptor should be called twice")
+}
+
+func (s *ChainedRetrySuite) TestStreamWithChainedInterceptors_NoFailure() {
+	stream, err := s.Client.PingList(s.SimpleCtx(), testpb.GoodPingList, WithMax(2))
+	require.NoError(s.T(), err, "the invocation should succeed")
+	_, err = stream.Recv()
+	require.NoError(s.T(), err, "the Recv should succeed")
+	require.EqualValues(s.T(), 1, s.srv.requestCount(), "one request should have been made")
+	require.EqualValues(s.T(), 1, s.preRetryInterceptor.called, "pre-retry interceptor should be called once")
+	require.EqualValues(s.T(), 1, s.postRetryInterceptor.called, "post-retry interceptor should be called once")
+}
+
+func (s *ChainedRetrySuite) TestStreamWithChainedInterceptors_WithRetry() {
+	s.srv.resetFailingConfiguration(2, codes.Unavailable, noSleep)
+	stream, err := s.Client.PingList(s.SimpleCtx(), testpb.GoodPingList, WithMax(2))
+	require.NoError(s.T(), err, "the second invocation should succeed")
+	_, err = stream.Recv()
+	require.NoError(s.T(), err, "the Recv should succeed")
+	require.EqualValues(s.T(), 2, s.srv.requestCount(), "two requests should have been made")
+	require.EqualValues(s.T(), 1, s.preRetryInterceptor.called, "pre-retry interceptor should be called once")
+	require.EqualValues(s.T(), 2, s.postRetryInterceptor.called, "post-retry interceptor should be called twice")
+}
+
+func TestJitterUp(t *testing.T) {
+	// Arguments to jitterup.
+	duration := 10 * time.Second
+	variance := 0.10
+
+	// Bound to check.
+	max := 11000 * time.Millisecond
+	min := 9000 * time.Millisecond
+	high := scaleDuration(max, 0.98)
+	low := scaleDuration(min, 1.02)
+
+	highCount := 0
+	lowCount := 0
+
+	for i := 0; i < 1000; i++ {
+		out := jitterUp(duration, variance)
+		assert.True(t, out <= max, "value %s must be <= %s", out, max)
+		assert.True(t, out >= min, "value %s must be >= %s", out, min)
+
+		if out > high {
+			highCount++
+		}
+		if out < low {
+			lowCount++
+		}
+	}
+
+	assert.True(t, highCount != 0, "at least one sample should reach to >%s", high)
+	assert.True(t, lowCount != 0, "at least one sample should to <%s", low)
+}


### PR DESCRIPTION
The package has some issues (the retry logic for client stream is flawed). I'm adding a copy of this to our repository for future edits.

See the discussion in https://github.com/sourcegraph/sourcegraph/pull/59145

## Test plan

The existing test suite from the copied project is now running in CI.