### PR TITLE
sg msp: add 'sg msp tfc view'

### DIFF
--- a/dev/managedservicesplatform/terraformcloud/terraformcloud.go
+++ b/dev/managedservicesplatform/terraformcloud/terraformcloud.go
@@ -143,6 +143,13 @@ func (w Workspace) URL() string {
 	return fmt.Sprintf("https://%s/app/sourcegraph/workspaces/%s", Hostname, w.Name)
 }
 
+const MSPWorkspaceTag = "msp"
+
+func ServiceWorkspaceTag(svc spec.ServiceSpec) string { return fmt.Sprintf("msp-service-%s", svc.ID) }
+func EnvironmentWorkspaceTag(svc spec.ServiceSpec, env spec.EnvironmentSpec) string {
+	return fmt.Sprintf("msp-env-%s-%s", svc.ID, env.ID)
+}
+
 // SyncWorkspaces is a bit like the Terraform Cloud Terraform provider. We do
 // this directly instead of using the provider to avoid the chicken-and-egg
 // problem of, if Terraform Cloud workspaces provision our resourcs, who provisions
@@ -249,9 +256,9 @@ func (c *Client) SyncWorkspaces(ctx context.Context, svc spec.ServiceSpec, env s
 		}
 
 		wantWorkspaceTags := []*tfe.Tag{
-			{Name: "msp"},
-			{Name: fmt.Sprintf("msp-service-%s", svc.ID)},
-			{Name: fmt.Sprintf("msp-env-%s-%s", svc.ID, env.ID)},
+			{Name: MSPWorkspaceTag},
+			{Name: ServiceWorkspaceTag(svc)},
+			{Name: EnvironmentWorkspaceTag(svc, env)},
 		}
 
 		if existingWorkspace, err := c.client.Workspaces.Read(ctx, c.org, workspaceName); err != nil {

--- a/dev/sg/msp/BUILD.bazel
+++ b/dev/sg/msp/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//dev/managedservicesplatform/spec",
         "//dev/managedservicesplatform/terraformcloud",
         "//dev/sg/internal/category",
+        "//dev/sg/internal/open",
         "//dev/sg/internal/secrets",
         "//dev/sg/internal/std",
         "//dev/sg/msp/example",

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/terraformcloud"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
+	"github.com/sourcegraph/sourcegraph/dev/sg/internal/open"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/secrets"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/msp/example"
@@ -196,6 +197,48 @@ sg msp generate -all <service>
 			Usage:   "Manage Terraform Cloud workspaces for a service",
 			Before:  msprepo.UseManagedServicesRepo,
 			Subcommands: []*cli.Command{
+				{
+					Name:        "view",
+					Usage:       "View MSP Terraform Cloud workspaces",
+					Description: "You may need to request access to the workspaces - see https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform/#terraform-cloud",
+					UsageText: `
+# View all workspaces for all MSP services
+sg msp tfc view
+
+# View all workspaces for all environments for a MSP service
+sg msp tfc view <service>
+
+# View all workspaces for a specific MSP service environment
+sg msp tfc view <service> <environment>
+`,
+					ArgsUsage:    "[service ID] [environment ID]",
+					BashComplete: msprepo.ServicesAndEnvironmentsCompletion(),
+					Action: func(c *cli.Context) error {
+						if c.Args().Len() == 0 {
+							std.Out.WriteNoticef("Opening link to all MSP Terraform Cloud workspaces in browser...")
+							return open.URL(fmt.Sprintf("https://app.terraform.io/app/sourcegraph/workspaces?tag=%s",
+								terraformcloud.MSPWorkspaceTag))
+						}
+
+						service, err := useServiceArgument(c)
+						if err != nil {
+							return err
+						}
+						if c.Args().Len() == 1 {
+							std.Out.WriteNoticef("Opening link to service Terraform Cloud workspaces in browser...")
+							return open.URL(fmt.Sprintf("https://app.terraform.io/app/sourcegraph/workspaces?tag=%s",
+								terraformcloud.ServiceWorkspaceTag(service.Service)))
+						}
+
+						env := service.GetEnvironment(c.Args().Get(1))
+						if env == nil {
+							return errors.Wrapf(err, "environment %q not found", c.Args().Get(1))
+						}
+						std.Out.WriteNoticef("Opening link to service environment Terraform Cloud workspaces in browser...")
+						return open.URL(fmt.Sprintf("https://app.terraform.io/app/sourcegraph/workspaces?tag=%s",
+							terraformcloud.EnvironmentWorkspaceTag(service.Service, *env)))
+					},
+				},
 				{
 					Name:  "sync",
 					Usage: "Create or update all required Terraform Cloud workspaces for an environment",


### PR DESCRIPTION
Convenience helper for opening workspaces in browser. I'm hoping to expand `sg msp` with more commands to view resources in GCP console and stuff.

## Test plan

```
sg msp tfc view  
sg msp tfc view msp-testbed
sg msp tfc view msp-testbed test
```