### PR TITLE
bazel: add no-localhost-guard lint to nogo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -318,6 +318,7 @@ nogo(
             "//dev/linters/unparam",
             "//dev/linters/tracinglibraries",
             "//dev/linters/dbconn",
+            "//dev/linters/nolocalhost",
             # Disabled because we currently have a lot of unused code
             # "//dev/linters/unused",
         ] + STATIC_CHECK_ANALYZERS,

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -305,7 +305,7 @@ func shouldPostgresReindex() (shouldReindex bool) {
 	// Check PGHOST variable to see whether it refers to a local address or path
 	// If an external database is used, reindexing can be skipped
 	pgHost := os.Getenv("PGHOST")
-	if !(pgHost == "" || pgHost == "127.0.0.1" || pgHost == "localhost" || string(pgHost[0]) == "/") {
+	if !(pgHost == "" || pgHost == "127.0.0.1" || pgHost == "localhost" || string(pgHost[0]) == "/") { // CI:LOCALHOST_OK
 		fmt.Printf("Using a non-local Postgres database '%s', reindexing not required\n", pgHost)
 		return false
 	}

--- a/dev/check/no-localhost-guard.sh
+++ b/dev/check/no-localhost-guard.sh
@@ -12,7 +12,7 @@ path_filter() {
 }
 
 set +e
-LOCALHOST_MATCHES=$(git grep -e localhost --and -e '^(?!\s*//)' --and --not -e 'CI\:LOCALHOST_OK' -- '*.go' \
+LOCALHOST_MATCHES=$(git grep -n -e localhost --and --not -e '^\s*//' --and --not -e 'CI\:LOCALHOST_OK' -- '*.go' \
   ':(exclude)*_test.go' \
   ':(exclude)cmd/server/shared/nginx.go' \
   ':(exclude)dev/sg/sg_setup.go' \
@@ -36,7 +36,8 @@ https://github.com/sourcegraph/sourcegraph/issues/9129).
 
 If your usage of "localhost" is valid, then either
 1) add the comment "CI:LOCALHOST_OK" to the line where "localhost" occurs, or
-2) add an exclusion clause in the "git grep" command in  no-localhost-guard.sh
+2) add an exclusion clause in the "git grep" command in no-localhost-guard.sh
+   and dev/linters/nolocalhost/nolocalhost.go
 
 EOF
   echo "^^^ +++"

--- a/dev/check/no-localhost-guard.sh
+++ b/dev/check/no-localhost-guard.sh
@@ -18,7 +18,8 @@ LOCALHOST_MATCHES=$(git grep -n -e localhost --and --not -e '^\s*//' --and --not
   ':(exclude)dev/sg/sg_setup.go' \
   ':(exclude)pkg/conf/confdefaults' \
   ':(exclude)schema' \
-  ':(exclude)vendor')
+  ':(exclude)vendor' \
+  ':(exclude)dev/linters/nolocalhost')
 set -e
 
 if [ -n "$LOCALHOST_MATCHES" ]; then

--- a/dev/linters/nolocalhost/BUILD.bazel
+++ b/dev/linters/nolocalhost/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "nolocalhost",
+    srcs = ["nolocalhost.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/linters/nolocalhost",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//dev/linters/nolint",
+        "@com_github_gobwas_glob//:glob",
+        "@org_golang_x_tools//go/analysis",
+    ],
+)

--- a/dev/linters/nolocalhost/nolocalhost.go
+++ b/dev/linters/nolocalhost/nolocalhost.go
@@ -20,6 +20,7 @@ var excludePatterns = []string{
 	"**pkg/conf/confdefaults/**",
 	"**schema**",
 	"**vendor**",
+	"**dev/linters/nolocalhost/**",
 }
 
 var compiledExcludePatterns = make([]glob.Glob, len(excludePatterns))

--- a/dev/linters/nolocalhost/nolocalhost.go
+++ b/dev/linters/nolocalhost/nolocalhost.go
@@ -1,0 +1,87 @@
+package nolocalhost
+
+import (
+	"go/ast"
+	"go/token"
+	"slices"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+
+	"github.com/gobwas/glob"
+
+	"github.com/sourcegraph/sourcegraph/dev/linters/nolint"
+)
+
+var excludePatterns = []string{
+	"**_test.go",
+	"**cmd/server/shared/nginx.go",
+	"**dev/sg/sg_setup.go",
+	"**pkg/conf/confdefaults/**",
+	"**schema**",
+	"**vendor**",
+}
+
+var compiledExcludePatterns = make([]glob.Glob, len(excludePatterns))
+
+func init() {
+	for i, p := range excludePatterns {
+		compiledExcludePatterns[i] = glob.MustCompile(p, '/')
+	}
+}
+
+// We generally prefer to use "127.0.0.1" instead of "localhost", because
+// the Go DNS resolver fails to resolve "localhost" correctly in some
+// situations (see https://github.com/sourcegraph/issues/issues/34 and
+// https://github.com/sourcegraph/sourcegraph/issues/9129).
+
+// If your usage of "localhost" is valid, then either
+// 1) add the comment "CI:LOCALHOST_OK" to the line where "localhost" occurs, or
+// 2) add an exclusion clause in the "git grep" command here and in no-localhost-guard.sh
+//
+// Ideally we would use nolint instead of CI:LOCALHOST_OK, but git grep (in the original script)
+// can't handle checking the line before for nolint.
+var Analyzer = nolint.Wrap(&analysis.Analyzer{
+	Name: "nolocalhost",
+	Doc:  "Disallow using 'localhost', preferring '127.0.0.1'. Adapted from ./dev/check/no-localhost-guard.sh",
+	Run:  run,
+})
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, f := range pass.Files {
+		if !slices.ContainsFunc(compiledExcludePatterns, func(g glob.Glob) bool {
+			return g.Match(pass.Fset.Position(f.Package).Filename)
+		}) {
+			v := &visitor{pass: pass}
+			ast.Walk(v, f)
+			// Not every comment is available when walking the AST, so instead we search in (*ast.File).Comments.
+			for _, candidate := range v.candidates {
+				hasOkComment := slices.ContainsFunc(f.Comments, func(cg *ast.CommentGroup) bool {
+					return pass.Fset.Position(cg.Pos()).Line == pass.Fset.Position(candidate.Pos()).Line && strings.Contains(cg.Text(), "CI:LOCALHOST_OK")
+				})
+				if !hasOkComment {
+					pass.ReportRangef(candidate, "disallowed instance of 'localhost'")
+				}
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+type visitor struct {
+	pass       *analysis.Pass
+	candidates []*ast.BasicLit
+}
+
+var _ (ast.Visitor) = &visitor{}
+
+func (v *visitor) Visit(node ast.Node) (w ast.Visitor) {
+	switch n := node.(type) {
+	case *ast.BasicLit:
+		if n.Kind == token.STRING && strings.Contains(n.Value, "localhost") {
+			v.candidates = append(v.candidates, n)
+		}
+	}
+	return v
+}

--- a/dev/linters/nolocalhost/nolocalhost.go
+++ b/dev/linters/nolocalhost/nolocalhost.go
@@ -60,7 +60,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 					return pass.Fset.Position(cg.Pos()).Line == pass.Fset.Position(candidate.Pos()).Line && strings.Contains(cg.Text(), "CI:LOCALHOST_OK")
 				})
 				if !hasOkComment {
-					pass.ReportRangef(candidate, "disallowed instance of 'localhost'")
+					pass.ReportRangef(candidate, "disallowed instance of 'localhost', please use '127.0.0.1' instead or suffix the line with '// CI:LOCALHOST_OK'")
 				}
 			}
 		}

--- a/dev/sg/internal/rfc/rfc.go
+++ b/dev/sg/internal/rfc/rfc.go
@@ -185,7 +185,7 @@ func handleAuthResponse() (*url.URL, chan string, chan error, error) {
 	startAuthHandlerServer(socket, AuthEndpoint, codeReceiver, errorReceiver)
 
 	redirectUrl := url.URL{
-		Host:   net.JoinHostPort("localhost", strconv.Itoa(socket.Addr().(*net.TCPAddr).Port)),
+		Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(socket.Addr().(*net.TCPAddr).Port)),
 		Path:   AuthEndpoint,
 		Scheme: "http",
 	}

--- a/dev/sg/internal/rfc/rfc_test.go
+++ b/dev/sg/internal/rfc/rfc_test.go
@@ -108,8 +108,8 @@ func TestHandleAuthResponse(t *testing.T) {
 
 	// Check redirect URL is properly formed
 	host, port, _ := net.SplitHostPort(redirectUrl.Host)
-	if redirectUrl.Scheme != "http" || host != "localhost" || port == "0" {
-		t.Errorf("Expected redirect URL to be http://localhost, got %s", redirectUrl.String())
+	if redirectUrl.Scheme != "http" || host != "127.0.0.1" || port == "0" {
+		t.Errorf("Expected redirect URL to be http://127.0.0.1, got %s", redirectUrl.String())
 	}
 
 	const fakeAuthCode = "XXXYYYZZZ"
@@ -148,7 +148,8 @@ func (th *mockConfig) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) s
 }
 
 func (th *mockConfig) Exchange(ctx context.Context, code string,
-	opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	opts ...oauth2.AuthCodeOption,
+) (*oauth2.Token, error) {
 	if code != th.code {
 		return nil, fmt.Errorf("Code mismatch. Wanted '%s' but got '%s", th.code, code)
 	}

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -37,8 +37,8 @@ var Targets = []Target{
 		Description: "Check go code for linting errors, forbidden imports, generated files, etc",
 		Checks: []*linter{
 			goGenerateLinter,
-			goDBConnImport,
-			noLocalHost,
+			onlyLocal(goDBConnImport),
+			onlyLocal(noLocalHost),
 			lintGoDirectives(),
 			lintLoggingLibraries(),
 			onlyLocal(lintTracingLibraries()),

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -103,8 +103,8 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 
 				outputPath := msprepo.ServiceYAMLPath(c.Args().First())
 
-				_ = os.MkdirAll(filepath.Dir(outputPath), 0755)
-				if err := os.WriteFile(outputPath, exampleSpec, 0644); err != nil {
+				_ = os.MkdirAll(filepath.Dir(outputPath), 0o755)
+				if err := os.WriteFile(outputPath, exampleSpec, 0o644); err != nil {
 					return err
 				}
 
@@ -324,7 +324,7 @@ full access, use the '-write-access' flag.
 							saUsername := strings.ReplaceAll(serviceAccountEmail,
 								".gserviceaccount.com", "")
 							if err := std.Out.WriteCode("bash",
-								fmt.Sprintf(`psql -U %s -d %s -h localhost -p %d`,
+								fmt.Sprintf(`psql -U %s -d %s -h 127.0.0.1 -p %d`,
 									saUsername,
 									db,
 									proxyPort)); err != nil {
@@ -486,7 +486,7 @@ Supports completions on services and environments.`,
 				}
 				if output := c.String("output"); output != "" {
 					_ = os.Remove(output)
-					if err := os.WriteFile(output, jsonSchema, 0644); err != nil {
+					if err := os.WriteFile(output, jsonSchema, 0o644); err != nil {
 						return err
 					}
 					std.Out.WriteSuccessf("Rendered service spec JSON schema in %s", output)

--- a/dev/sg/sg_embeddings_qa.go
+++ b/dev/sg/sg_embeddings_qa.go
@@ -16,7 +16,7 @@ var contextCommand = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "url",
-			Value:   "http://localhost:9991/search",
+			Value:   "http://127.0.0.1:9991/search",
 			Aliases: []string{"u"},
 			Usage:   "Run the evaluation against this endpoint",
 		},

--- a/internal/grpc/example/client/main.go
+++ b/internal/grpc/example/client/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	// The defaults.Dial function is a helper function that sets up a gRPC connection with good defaults, including a few monitoring and tracing middlewares.
 	// See internal/grpc/defaults/defaults.go for more information.
-	conn, err := defaults.Dial("localhost:50051", logger)
+	conn, err := defaults.Dial("127.0.0.1:50051", logger)
 	if err != nil {
 		logger.Fatal("Failed to connect", log.Error(err))
 	}

--- a/internal/webhooks/outbound/outbound.go
+++ b/internal/webhooks/outbound/outbound.go
@@ -71,7 +71,7 @@ func (m *mockResolver) LookupHost(hostname string) ([]string, error) {
 	switch hostname {
 	case "sourcegraph.local":
 		return []string{"127.0.0.1"}, nil
-	case "localhost":
+	case "localhost": // (CI:LOCALHOST_OK)
 		return []string{"127.0.0.1"}, nil
 	case "sourcegraph.com":
 		return []string{"1.2.3.4"}, nil


### PR DESCRIPTION
Also fixes all the violations that snuck past due to https://github.com/sourcegraph/sourcegraph/pull/46202 confusingly breaking the `git grep` call :thinking: 

## Test plan

Tested with various combinations of [the following line](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@main/-/blob/internal/conf/computed.go?L300)
