### PR TITLE
svelte: Add more repo navigation entries and make navigation somewhat response

### DIFF
--- a/client/web-sveltekit/.prettierignore
+++ b/client/web-sveltekit/.prettierignore
@@ -13,7 +13,7 @@ pnpm-lock.yaml
 package-lock.json
 yarn.lock
 /static/mockServiceWorker.js
-.gql.d.ts
+*.gql.d.ts
 graphql-operations.ts
 graphql-types.ts
 

--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -8,7 +8,7 @@ import { highlightNode } from '$lib/common'
  * Returns a unique ID to be used with accessible elements.
  * Generates stable IDs in tests.
  */
-export function uniqueID(prefix = '') {
+export function uniqueID(prefix = ''): string {
     if (process.env.VITEST) {
         return `test-${prefix}-123`
     }
@@ -124,6 +124,41 @@ export const restrictToViewport: Action<HTMLElement, { offset?: number }> = (nod
 
         destroy() {
             window.removeEventListener('resize', setMaxHeight)
+        },
+    }
+}
+
+/**
+ * An action to compute the number of elements that fit inside the container.
+ * Only works for static element lists (i.e. the first render should .
+ */
+export const computeFit: Action<HTMLElement> = (
+    node
+): ActionReturn<void, { 'on:fit': (event: CustomEvent<{ itemCount: number }>) => void }> => {
+    // Holds the cumulative width of all elements up to element i.
+    const widths: number[] = [0]
+
+    for (let i = 0; i < node.children.length; i++) {
+        widths[i + 1] = node.children[i].getBoundingClientRect().right
+    }
+
+    function compute(): void {
+        const right = node.getBoundingClientRect().right
+        for (let i = widths.length - 1; i >= 0; i--) {
+            if (widths[i] < right) {
+                node.dispatchEvent(new CustomEvent('fit', { detail: { itemCount: i } }))
+                return
+            }
+        }
+    }
+
+    compute()
+    const observer = new ResizeObserver(compute)
+    observer.observe(node)
+
+    return {
+        destroy() {
+            observer.disconnect()
         },
     }
 }

--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -130,7 +130,11 @@ export const restrictToViewport: Action<HTMLElement, { offset?: number }> = (nod
 
 /**
  * An action to compute the number of elements that fit inside the container.
- * Only works for static element lists (i.e. the first render should .
+ * This works by caching the position of the right hand of each child element,
+ * and then comparing it to the right hand of the container.
+ *
+ * Because of this this action only works for static element lists,
+ * i.e. on initial render the node needs to contain all possible child elements.
  */
 export const computeFit: Action<HTMLElement> = (
     node

--- a/client/web-sveltekit/src/lib/wildcard/menu/Menu.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/menu/Menu.svelte
@@ -22,9 +22,11 @@
 
     interface $$Props extends HTMLButtonAttributes {
         open: Writable<boolean>
+        triggerButtonClass: string
     }
 
     export let open: Writable<boolean>
+    export let triggerButtonClass: string
 
     const {
         elements: { menu, item, trigger, separator },
@@ -35,7 +37,7 @@
     setContext({ item, trigger, separator, builders, open })
 </script>
 
-<button {...$trigger} use:trigger {...$$restProps}>
+<button {...$trigger} use:trigger class={triggerButtonClass} {...$$restProps}>
     <slot name="trigger" />
 </button>
 
@@ -44,18 +46,6 @@
 </div>
 
 <style lang="scss">
-    button {
-        color: var(--icon-color);
-        margin: 0;
-        padding: 0;
-        border: none;
-        background-color: transparent;
-
-        &:hover {
-            text-decoration: none;
-        }
-    }
-
     div,
     div :global([role='menu']) {
         isolation: isolate;

--- a/client/web-sveltekit/src/routes/Header.svelte
+++ b/client/web-sveltekit/src/routes/Header.svelte
@@ -32,7 +32,7 @@
     <a class="logo" href="/search">
         <img src={mark} alt="Sourcegraph" width="25" height="25" />
     </a>
-    <nav class="ml-2">
+    <nav>
         <ul>
             <HeaderNavLink href="/search" svgIconPath={mdiMagnify}>Code search</HeaderNavLink>
             <HeaderNavLink external href="/cody/chat">
@@ -52,7 +52,7 @@
         </ul>
     </nav>
     <Tooltip tooltip="Disable SvelteKit (go to React)">
-        <a class="app-toggle" href={reactURL} data-sveltekit-reload>
+        <a href={reactURL} data-sveltekit-reload>
             <img src={svelteLogoEnabled} alt="Svelte logo" width="20" height="20" />
         </a>
     </Tooltip>
@@ -71,10 +71,11 @@
     header {
         display: flex;
         align-items: center;
-        border-bottom: 1px solid var(--border-color-2);
+        gap: 0.5rem;
         height: var(--navbar-height);
         min-height: 40px;
         padding: 0 0.5rem;
+        border-bottom: 1px solid var(--border-color-2);
         background-color: var(--color-bg-1);
     }
 
@@ -99,6 +100,7 @@
         display: flex;
         align-self: stretch;
         flex: 1;
+        overflow-y: auto;
     }
 
     ul {
@@ -109,9 +111,5 @@
         justify-content: center;
         list-style: none;
         background-size: contain;
-    }
-
-    .app-toggle {
-        margin-right: 1rem;
     }
 </style>

--- a/client/web-sveltekit/src/routes/HeaderNavLink.svelte
+++ b/client/web-sveltekit/src/routes/HeaderNavLink.svelte
@@ -31,6 +31,7 @@
         align-items: stretch;
         border-bottom: 2px solid transparent;
         margin: 0 0.5rem;
+        white-space: nowrap;
 
         &:hover {
             border-color: var(--border-color-2);

--- a/client/web-sveltekit/src/routes/UserMenu.svelte
+++ b/client/web-sveltekit/src/routes/UserMenu.svelte
@@ -4,6 +4,7 @@
     import type { AuthenticatedUser } from '$lib/shared'
     import { humanTheme } from '$lib/theme'
     import { DropdownMenu, MenuLink, MenuRadioGroup, MenuSeparator, Submenu } from '$lib/wildcard'
+    import { getButtonClassName } from '$lib/wildcard/Button'
     import { mdiChevronDown, mdiChevronUp, mdiOpenInNew } from '@mdi/js'
     import { writable } from 'svelte/store'
 
@@ -15,7 +16,11 @@
     $: organizations = authenticatedUser.organizations.nodes
 </script>
 
-<DropdownMenu {open} aria-label="{$open ? 'Close' : 'Open'} user profile menu">
+<DropdownMenu
+    {open}
+    triggerButtonClass={getButtonClassName({ variant: 'icon' })}
+    aria-label="{$open ? 'Close' : 'Open'} user profile menu"
+>
     <svelte:fragment slot="trigger">
         <UserAvatar user={authenticatedUser} />
         <Icon svgPath={$open ? mdiChevronUp : mdiChevronDown} aria-hidden={true} inline />

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/+layout.svelte
@@ -1,24 +1,57 @@
 <script lang="ts">
-    import { mdiAccount, mdiCodeTags, mdiSourceBranch, mdiSourceCommit, mdiSourceRepository, mdiTag } from '@mdi/js'
+    import {
+        mdiAccount,
+        mdiCodeTags,
+        mdiCog,
+        mdiHistory,
+        mdiSourceBranch,
+        mdiSourceCommit,
+        mdiSourceRepository,
+        mdiTag,
+    } from '@mdi/js'
 
     import { page } from '$app/stores'
     import Icon from '$lib/Icon.svelte'
 
     import type { LayoutData } from './$types'
+    import { DropdownMenu, MenuLink } from '$lib/wildcard'
+    import { computeFit } from '$lib/dom'
+    import { writable } from 'svelte/store'
+    import { getButtonClassName } from '@sourcegraph/wildcard'
 
     export let data: LayoutData
 
-    const menu = [
+    const menuOpen = writable(false)
+    const navEntries: { path: string; icon: string; title: string; external?: true }[] = [
+        { path: '', icon: mdiCodeTags, title: 'Code' },
         { path: '/-/commits', icon: mdiSourceCommit, title: 'Commits' },
         { path: '/-/branches', icon: mdiSourceBranch, title: 'Branches' },
         { path: '/-/tags', icon: mdiTag, title: 'Tags' },
         { path: '/-/stats/contributors', icon: mdiAccount, title: 'Contributors' },
-    ] as const
+    ]
+    const menuEntries: { path: string; icon: string; title: string; external?: true }[] = [
+        { path: '/-/compare', icon: mdiHistory, title: 'Compare', external: true },
+        { path: '/-/own', icon: mdiAccount, title: 'Ownership', external: true },
+        { path: '/-/embeddings', icon: '', title: 'Embeddings', external: true },
+        { path: '/-/batch-changes', icon: '', title: 'Batch changes', external: true },
+        { path: '/-/settings', icon: mdiCog, title: 'Settings', external: true },
+    ]
+
+    let visibleNavEntries = navEntries.length
+    $: navEntriesToShow = visibleNavEntries === navEntries.length ? navEntries : navEntries.slice(0, visibleNavEntries)
+    $: overflowMenu = visibleNavEntries !== navEntries.length ? navEntries.slice(visibleNavEntries) : []
+    $: allMenuEntries = [...overflowMenu, ...menuEntries]
 
     function isCodePage(repoURL: string, pathname: string) {
         return (
             pathname === repoURL || pathname.startsWith(`${repoURL}/-/blob`) || pathname.startsWith(`${repoURL}/-/tree`)
         )
+    }
+
+    function isActive(href: string): boolean {
+        return href === data.repoURL
+            ? isCodePage(data.repoURL, $page.url.pathname)
+            : $page.url.pathname.startsWith(href)
     }
 
     $: ({ repoName, displayRepoName } = data)
@@ -28,51 +61,57 @@
     <title>{data.displayRepoName} - Sourcegraph</title>
 </svelte:head>
 
-<div class="header">
-    <nav>
-        <h1><a href="/{repoName}"><Icon svgPath={mdiSourceRepository} inline /> {displayRepoName}</a></h1>
-        <!--
-            TODO: Add back revision
-            {#if revisionLabel}
-                @ <span class="button">{revisionLabel}</span>
-            {/if}
-            -->
-        <ul class="menu">
+<nav>
+    <h1><a href="/{repoName}"><Icon svgPath={mdiSourceRepository} inline /> {displayRepoName}</a></h1>
+    <!--
+        TODO: Add back revision
+        {#if revisionLabel}
+            @ <span class="button">{revisionLabel}</span>
+        {/if}
+        -->
+    <ul use:computeFit on:fit={event => (visibleNavEntries = event.detail.itemCount)}>
+        {#each navEntriesToShow as entry}
+            {@const href = data.repoURL + entry.path}
             <li>
-                <a href={data.repoURL} class:active={isCodePage(data.repoURL, $page.url.pathname)}>
-                    <Icon svgPath={mdiCodeTags} inline /> <span class="ml-1">Code</span>
+                <a {href} class:active={isActive(href)} data-sveltekit-reload={entry.external}>
+                    {#if entry.icon}
+                        <Icon svgPath={entry.icon} inline />
+                    {/if}
+                    <span class="ml-1">{entry.title}</span>
                 </a>
             </li>
-            {#each menu as entry}
-                {@const href = data.repoURL + entry.path}
-                <li>
-                    <a {href} class:active={$page.url.pathname.startsWith(href)}>
-                        <Icon svgPath={entry.icon} inline /> <span class="ml-1">{entry.title}</span>
-                    </a>
-                </li>
-            {/each}
-        </ul>
-    </nav>
-</div>
+        {/each}
+    </ul>
+    <DropdownMenu
+        open={menuOpen}
+        triggerButtonClass={getButtonClassName({ variant: 'secondary', outline: true, size: 'sm' })}
+        aria-label="{$menuOpen ? 'Close' : 'Open'} repo navigation"
+    >
+        <svelte:fragment slot="trigger">&hellip;</svelte:fragment>
+        {#each allMenuEntries as entry}
+            {@const href = data.repoURL + entry.path}
+            <MenuLink {href} data-sveltekit-reload={entry.external}>
+                <span class="overflow-entry" class:active={isActive(href)}>
+                    {#if entry.icon}
+                        <Icon svgPath={entry.icon} inline />
+                    {/if}
+                    <span class="ml-1">{entry.title}</span>
+                </span>
+            </MenuLink>
+        {/each}
+    </DropdownMenu>
+</nav>
 <slot />
 
 <style lang="scss">
-    .header {
-        display: flex;
-        align-items: center;
-        padding: 0.5rem;
-        border-bottom: 1px solid var(--border-color);
-    }
-
-    h1 {
-        margin: 0;
-        margin-right: 1rem;
-        font-size: 1.3rem;
-    }
-
     nav {
         display: flex;
         align-items: center;
+        gap: 0.5rem;
+        overflow: hidden;
+        padding: 0.5rem;
+        border-bottom: 1px solid var(--border-color);
+        flex-shrink: 0;
 
         a {
             color: var(--body-color);
@@ -80,19 +119,28 @@
         }
     }
 
-    ul.menu {
+    h1 {
+        margin: 0;
+        font-size: 1.3rem;
+        white-space: nowrap;
+    }
+
+    ul {
         list-style: none;
         padding: 0;
         margin: 0;
         display: flex;
+        gap: 0.5rem;
+        overflow: hidden;
+        flex: 1;
 
         li a {
             display: flex;
             height: 100%;
             align-items: center;
             padding: 0.25rem 0.5rem;
-            margin: 0 0.25rem;
             border-radius: var(--border-radius);
+            white-space: nowrap;
 
             &:hover {
                 background-color: var(--color-bg-2);
@@ -102,6 +150,17 @@
                 background-color: var(--color-bg-3);
             }
         }
+    }
+
+    .overflow-entry {
+        width: 100%;
+        display: inline-block;
+        padding: 0 0.25rem;
+        border-radius: var(--border-radius);
+    }
+
+    .active {
+        background-color: var(--color-bg-3);
     }
 
     nav {

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -16,5 +16,6 @@ a[data-sveltekit-reload='true'] {
         display: inline-block;
         content: '';
         background-image: url('/react-logo.svg');
+        background-repeat: no-repeat;
     }
 }


### PR DESCRIPTION
Closes #59149

This PR adds more entries to the repo nav bar, all leading to the current web app. I basically copied the same list of links we are showing on the repo page in the current app plus some additional entries (Commits and Contributors; I assume those have been removed because the repo page shows/showed a panel for them? idk)

The navbar felt really crowded, so I put the additional items into a menu. This menu will also hold the navbar items if there is not enough space. We need to make a decision about which items we want to show.

I know the "selected entry" style in the menu is not ideal. While I think in general Svelte's way of handling style is better (it prevents issues with style ordering, which we have right now), it also makes it more difficult to build somewhat styleable component libraries. I'll have to spend more time investigating this. 

The includes some changes to the global navbar to make it work better on narrower screens (I originally wanted to use the same overflow approach, but the global navbar is setup differently, so I couldn't apply it as is).


https://github.com/sourcegraph/sourcegraph/assets/179026/e982a4c7-d5b5-456e-abbc-ffc51fea0446



## Test plan

Manual testing.
