### PR TITLE
sentry action reporter: set the repo name in the event message

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-go@v4
         with: { go-version: '1.21' }
 
-      - run: './check-pr.sh'
+      - run: exit 1 #'./check-pr.sh'
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
           GITHUB_TOKEN: ${{ secrets.PR_AUDITOR_TOKEN }}
@@ -23,5 +23,5 @@ jobs:
   report_failure:
     needs: check-pr
     if: ${{ failure() }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@wb/actions/set-repo-name-in-msg
     secrets: inherit

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-go@v4
         with: { go-version: '1.21' }
 
-      - run: exit 1 #'./check-pr.sh'
+      - run: './check-pr.sh'
         env:
           GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
           GITHUB_TOKEN: ${{ secrets.PR_AUDITOR_TOKEN }}
@@ -23,5 +23,5 @@ jobs:
   report_failure:
     needs: check-pr
     if: ${{ failure() }}
-    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@wb/actions/set-repo-name-in-msg
+    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
     secrets: inherit

--- a/.github/workflows/report-job-failure.yml
+++ b/.github/workflows/report-job-failure.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Send Sentry event for failed action
         run: |
           npm i -g @sentry/cli
-          sentry-cli send-event -m "A job in the ${{ inputs.workflow_name }} action has failed - see run for exact failure" \
+          sentry-cli send-event -m "A job in the ${{ inputs.workflow_name }} action for the repository '${{ inputs.repo }}' has failed - see run for exact failure" \
             -t "github-action:${{ inputs.workflow_name }}" \
             -t "branch:${{ inputs.branch }}" \
             -t "repository:${{ inputs.repo }}" \


### PR DESCRIPTION
Without the repo name the message is a bit vague

<img width="501" alt="Screenshot 2023-12-21 at 12 29 55" src="https://github.com/sourcegraph/sourcegraph/assets/1001709/57e5f9fc-679d-4488-9cac-67108c9ed30c">

## Test plan
[forced a failure in pr-auditor and ran the action manually](https://github.com/sourcegraph/sourcegraph/actions/runs/7287530980/job/19858354317)
<img width="646" alt="Screenshot 2023-12-21 at 13 28 26" src="https://github.com/sourcegraph/sourcegraph/assets/1001709/9ee2d870-7d4e-472e-8fd7-4e6c8a86cbb6">

