### PR TITLE
search: respect patternType when navigating to search results

### DIFF
--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -12,7 +12,6 @@ import React, {
 } from 'react'
 
 import classNames from 'classnames'
-import { escapeRegExp } from 'lodash'
 import { createPortal } from 'react-dom'
 import { type Location, useLocation, Route, Routes } from 'react-router-dom'
 import { NEVER, of } from 'rxjs'
@@ -32,7 +31,6 @@ import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/cont
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import type { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import { EditorHint, type SearchContextProps } from '@sourcegraph/shared/src/search'
-import { escapeSpaces } from '@sourcegraph/shared/src/search/query/filters'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
@@ -52,7 +50,7 @@ import type { ExternalLinkFields, RepositoryFields } from '../graphql-operations
 import type { CodeInsightsProps } from '../insights/types'
 import type { NotebookProps } from '../notebooks'
 import type { OwnConfigProps } from '../own/OwnConfigProps'
-import { searchQueryForRepoRevision, type SearchStreamingProps } from '../search'
+import { searchQueryForRepoRevision, fileFilterForFilePath, type SearchStreamingProps } from '../search'
 import { useV2QueryInput } from '../search/useV2QueryInput'
 import { useNavbarQueryState } from '../stores'
 import { EventName } from '../util/constants'
@@ -407,16 +405,17 @@ const RepoUserContainer: FC<RepoUserContainerProps> = ({
         [enableV2QueryInput, selectedSearchContextSpec]
     )
     const onNavbarQueryChange = useNavbarQueryState(state => state.setQueryState)
+    const patternType = useNavbarQueryState.getState().searchPatternType
     useEffect(() => {
-        let query = queryPrefix + searchQueryForRepoRevision(repoName, revision)
+        let query = queryPrefix + searchQueryForRepoRevision(repoName, revision, patternType)
         if (filePath) {
-            query = `${query.trimEnd()} file:${escapeSpaces('^' + escapeRegExp(filePath))}`
+            query = `${query.trimEnd()} ${fileFilterForFilePath(filePath, patternType)}`
         }
         onNavbarQueryChange({
             query,
             hint: EditorHint.Blur,
         })
-    }, [revision, filePath, repoName, onNavbarQueryChange, queryPrefix])
+    }, [revision, filePath, repoName, onNavbarQueryChange, queryPrefix, patternType])
 
     const isError = isErrorLike(repoOrError) || isErrorLike(resolvedRevisionOrError)
 

--- a/client/web/src/search/index.ts
+++ b/client/web/src/search/index.ts
@@ -148,8 +148,22 @@ export function repoFilterForRepoRevision(repoName: string, revision?: string): 
     return `${escapeSpaces(`^${escapeRegExp(repoName)}$${revision ? `@${abbreviateOID(revision)}` : ''}`)}`
 }
 
-export function searchQueryForRepoRevision(repoName: string, revision?: string): string {
+export function searchQueryForRepoRevision(
+    repoName: string,
+    revision?: string,
+    patternType?: SearchPatternType
+): string {
+    if (patternType === SearchPatternType.newStandardRC1) {
+        return `repo:${repoName}${revision ? `@${abbreviateOID(revision)}` : ''}`
+    }
     return `repo:${repoFilterForRepoRevision(repoName, revision)} `
+}
+
+export function fileFilterForFilePath(filePath: string, patternType?: SearchPatternType): string {
+    if (patternType === SearchPatternType.newStandardRC1) {
+        return `file:${filePath}`
+    }
+    return `file:${escapeSpaces('^' + escapeRegExp(filePath))}`
 }
 
 function abbreviateOID(oid: string): string {


### PR DESCRIPTION
When a user clicks on a search result we navigate to the file and set the repo and file filters in the query input. However, this was hardcoded to use regex syntax. With this change we respect the patternType.

## Test plan
CI

