### PR TITLE
search: don't convert rev to regex for kw search

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -899,6 +899,14 @@ func (p *parser) ParseParameter(label labels) (Parameter, bool, error) {
 var regexSpecialCharacter = regexp.MustCompile(`[\$\(\)\*\+\.\?\[\\\]\^\{\|\}]`)
 
 func globToRegex(glob string) string {
+	// Split off the revision, if any.
+	var rev string
+	i := strings.Index(glob, "@")
+	if i != -1 {
+		rev = glob[i+1:]
+		glob = glob[:i]
+	}
+
 	// First, we escape all the regex special characters.
 	r := regexSpecialCharacter.ReplaceAllStringFunc(glob, func(match string) string {
 		if match == "*" {
@@ -923,6 +931,10 @@ func globToRegex(glob string) string {
 		r = strings.TrimSuffix(r, ".*")
 	} else {
 		r = r + "$"
+	}
+
+	if rev != "" {
+		r = r + "@" + rev
 	}
 
 	return r

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -982,4 +982,16 @@ func TestGlobToRegex(t *testing.T) {
 	}).Equal(t, test(`f:has.content(apple)`))
 	autogold.Expect(value{
 		Result: `{"Kind":1,"Operands":[{"field":"r","value":"go$","negated":false},{"field":"r","value":"has.topic(language)","negated":false}],"Annotation":{"labels":0,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}}}`}).Equal(t, test(`r:*go r:has.topic(language)`))
+	autogold.Expect(value{
+		Result:      `{"field":"r","value":"^sourcegraph$@ae3f1c","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":20}}`,
+	}).Equal(t, test(`r:sourcegraph@ae3f1c`))
+	autogold.Expect(value{
+		Result:      `{"field":"r","value":"^sourcegraph$@main","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":18}}`,
+	}).Equal(t, test(`r:sourcegraph@main`))
+	autogold.Expect(value{
+		Result:      `{"field":"r","value":"sourcegraph$@*refs/heads*","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":27}}`,
+	}).Equal(t, test(`r:*sourcegraph@*refs/heads*`))
 }


### PR DESCRIPTION
Relates to #58815 

This fixes a bug I found during manual testing. We didn't split off the revision before converting glob to regex.

<img width="1708" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/e08eb6b5-333a-4b1e-ac7d-116485bfbbc3">


Test plan:
New unit tests