### PR TITLE
Code Navigation: add 'ago' back to timestamps

### DIFF
--- a/client/web/src/repo/tree/TreePagePanels.tsx
+++ b/client/web/src/repo/tree/TreePagePanels.tsx
@@ -227,11 +227,7 @@ export const FilesCard: FC<FilePanelProps> = ({ entries, historyEntries, classNa
                                         </span>
                                     </td>
                                     <td className={classNames(styles.commitDate, 'text-muted')}>
-                                        <Timestamp
-                                            noAbout={true}
-                                            noAgo={true}
-                                            date={getCommitDate(fileHistoryByPath[entry.path])}
-                                        />
+                                        <Timestamp noAbout={true} date={getCommitDate(fileHistoryByPath[entry.path])} />
                                     </td>
                                 </>
                             )}

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//cmd/cody-gateway/internal/limiter",
         "//cmd/cody-gateway/internal/notify",
         "//cmd/cody-gateway/internal/response",
-        "//internal/authbearer",
         "//internal/codygateway",
         "//internal/completions/types",
         "//internal/trace",

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//cmd/cody-gateway/internal/limiter",
         "//cmd/cody-gateway/internal/notify",
         "//cmd/cody-gateway/internal/response",
+        "//internal/authbearer",
         "//internal/codygateway",
         "//internal/completions/types",
         "//internal/trace",


### PR DESCRIPTION
Adds 'ago' back to timestamps in the 'last updated' column of the TreePanel. 

## Test plan
Manual testing/CI passing