### PR TITLE
OpenAI: lower max chat token defaults

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -1078,7 +1078,7 @@ func defaultMaxPromptTokens(provider conftypes.CompletionsProviderName, model st
 	case conftypes.CompletionsProviderNameAzureOpenAI:
 		// We cannot know based on the model name what model is actually used,
 		// this is a sane default for GPT in general.
-		return 8_000
+		return 7_500
 	case conftypes.CompletionsProviderNameAWSBedrock:
 		if strings.HasPrefix(model, "anthropic.") {
 			return anthropicDefaultMaxPromptTokens(strings.TrimPrefix(model, "anthropic."))
@@ -1108,7 +1108,7 @@ func anthropicDefaultMaxPromptTokens(model string) int {
 func openaiDefaultMaxPromptTokens(model string) int {
 	switch model {
 	case "gpt-4":
-		return 8_000
+		return 7_500
 	case "gpt-4-32k":
 		return 32_000
 	case "gpt-3.5-turbo", "gpt-3.5-turbo-instruct", "gpt-4-1106-preview":

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -465,7 +465,7 @@ func TestGetCompletionsConfig(t *testing.T) {
 			},
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "gpt-4",
-				ChatModelMaxTokens:       8000,
+				ChatModelMaxTokens:       7500,
 				FastChatModel:            "gpt-3.5-turbo",
 				FastChatModelMaxTokens:   4000,
 				CompletionModel:          "gpt-3.5-turbo-instruct",
@@ -491,11 +491,11 @@ func TestGetCompletionsConfig(t *testing.T) {
 			},
 			wantConfig: &conftypes.CompletionsConfig{
 				ChatModel:                "gpt4-deployment",
-				ChatModelMaxTokens:       8000,
+				ChatModelMaxTokens:       7500,
 				FastChatModel:            "gpt35-turbo-deployment",
-				FastChatModelMaxTokens:   8000,
+				FastChatModelMaxTokens:   7500,
 				CompletionModel:          "gpt35-turbo-deployment",
-				CompletionModelMaxTokens: 8000,
+				CompletionModelMaxTokens: 7500,
 				AccessToken:              "asdf",
 				Provider:                 "azure-openai",
 				Endpoint:                 "https://acmecorp.openai.azure.com",


### PR DESCRIPTION
There have been several reports of Azure OpenAI chat requests exceeding the token limit, this lowers the default for Azure and OpenAI GPT-4 to allow for a little more margin of error with token estimation.
## Test plan
unit tests updated

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
