### PR TITLE
msp: fixed-length operator access account ID, restrict service ID lengths

### DIFF
--- a/dev/managedservicesplatform/internal/stack/iam/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/iam/BUILD.bazel
@@ -7,10 +7,12 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack/iam",
     visibility = ["//dev/managedservicesplatform:__subpackages__"],
     deps = [
+        "//dev/managedservicesplatform/internal/resource/random",
         "//dev/managedservicesplatform/internal/resource/serviceaccount",
         "//dev/managedservicesplatform/internal/resourceid",
         "//dev/managedservicesplatform/internal/stack",
         "//dev/managedservicesplatform/internal/stack/options/googleprovider",
+        "//dev/managedservicesplatform/internal/stack/options/randomprovider",
         "//dev/managedservicesplatform/spec",
         "//lib/errors",
         "//lib/pointers",

--- a/dev/managedservicesplatform/spec/service.go
+++ b/dev/managedservicesplatform/spec/service.go
@@ -9,10 +9,10 @@ import (
 
 type ServiceSpec struct {
 	// ID is an all-lowercase, hyphen-delimited identifier for the service,
-	// e.g. "cody-gateway".
+	// e.g. "cody-gateway". It MUST be at most 20 characters long.
 	ID string `json:"id"`
 	// Name is an optional human-readable display name for the service,
-	// e.g. "Cody Gateway"
+	// e.g. "Cody Gateway".
 	Name *string `json:"name"`
 	// Owners denotes the teams or individuals primarily responsible for the
 	// service.
@@ -37,6 +37,10 @@ type ServiceSpec struct {
 
 func (s ServiceSpec) Validate() []error {
 	var errs []error
+
+	if len(s.ID) > 20 {
+		errs = append(errs, errors.New("id must be at most 20 characters"))
+	}
 
 	if s.ProjectIDSuffixLength != nil && *s.ProjectIDSuffixLength < 4 {
 		errs = append(errs, errors.New("projectIDSuffixLength must be >= 4"))


### PR DESCRIPTION
Using service name in the account ID results in IDs that are too long for the operator access SA added in #59105 - this change uses a randomized name with fixed length. This fits the use case as well, since these operator accounts should only be used by MSP tooling.

To prevent future issues, there is now a check restricting the service ID length. We have 1 service exceeding this length - I am working to migrate that first.

## Test plan

n/a