### PR TITLE
msp: make project_id available in TF variables

### DIFF
--- a/dev/managedservicesplatform/internal/stack/options/googleprovider/google.go
+++ b/dev/managedservicesplatform/internal/stack/options/googleprovider/google.go
@@ -17,6 +17,9 @@ func With(projectID string) stack.NewStackOption {
 		var project *string
 		if projectID != "" {
 			project = pointers.Ptr(projectID)
+			// Make project ID available to custom TF
+			s.Locals().Add("project_id", projectID,
+				"Primary Google Project to use for all GCP resources")
 		}
 		_ = google.NewGoogleProvider(s.Stack, pointers.Ptr("google"), &google.GoogleProviderConfig{
 			Project: project,

--- a/dev/managedservicesplatform/internal/stack/stacks.go
+++ b/dev/managedservicesplatform/internal/stack/stacks.go
@@ -43,6 +43,10 @@ type Stack struct {
 	DynamicVariables TFVars
 }
 
+// Locals allows stack options to add local variables for reference in custom
+// Terraform and outputs.
+func (s Stack) Locals() *StackLocals { return &StackLocals{s} }
+
 // Set collects the stacks that comprise a CDKTF application.
 type Set struct {
 	// app represents a CDKTF application that is comprised of the stacks in


### PR DESCRIPTION
Custom TF might depend on this, and it could also make it easier to collect TF outputs for automation, since now every stack with GCP resources will automatically expose the project ID in `locals.project_id`

## Test plan

https://github.com/sourcegraph/managed-services/actions/runs/7302712634
