### PR TITLE
ci: permit changes to doc/cloud/*

### DIFF
--- a/dev/sg/linters/doc_changes.go
+++ b/dev/sg/linters/doc_changes.go
@@ -2,6 +2,7 @@ package linters
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/sourcegraph/run"
@@ -10,6 +11,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+var (
+	allowDocChangesPrefixAllowlist = []string{
+		"doc/cloud/",
+	}
 )
 
 func docChangesLint() *linter {
@@ -24,6 +31,12 @@ func docChangesLint() *linter {
 		}
 		diffset := make(map[string]struct{}, len(diff))
 		for filename := range diff {
+			// ignore exceptions
+			if slices.ContainsFunc(allowDocChangesPrefixAllowlist, func(s string) bool {
+				return strings.HasPrefix(filename, s)
+			}) {
+				continue
+			}
 			diffset[filename] = struct{}{}
 		}
 

--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -110,7 +110,7 @@ If you have specific requirements for the region, please reach out to your Sourc
 
 More details about the locations and data storage can be found in [our handbook](https://handbook.sourcegraph.com/departments/cloud/technical-docs/multi-region/)
 
-### Private Connectivit (test remote later)
+### Private Connectivity
 
 Sourcegraph Cloud can connect to resources that are publically accessible or protected by IP-based firewall rules out-of-the-box. Sourcegraph can provide static IP addresses for customers to add to their firewall allowlist. Please let your account team know.
 

--- a/doc/cloud/index.md
+++ b/doc/cloud/index.md
@@ -110,7 +110,7 @@ If you have specific requirements for the region, please reach out to your Sourc
 
 More details about the locations and data storage can be found in [our handbook](https://handbook.sourcegraph.com/departments/cloud/technical-docs/multi-region/)
 
-### Private Connectivity
+### Private Connectivit (test remote later)
 
 Sourcegraph Cloud can connect to resources that are publically accessible or protected by IP-based firewall rules out-of-the-box. Sourcegraph can provide static IP addresses for customers to add to their firewall allowlist. Please let your account team know.
 


### PR DESCRIPTION
In https://github.com/sourcegraph/sourcegraph/pull/59114, we started blocking all changes to docs v1.

After discussing with @MaedahBatool @eshamow, we decided to permit changes to Cloud docs until docs v1 can be sunset to avoid showing outdated content to Cloud customers.

## Test plan

CI should pass