### PR TITLE
msp: add 'sg msp logs'

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5243,6 +5243,20 @@ def go_dependencies():
         version = "v0.6.1",
     )
     go_repository(
+        name = "com_github_rickb777_date",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/rickb777/date",
+        sum = "h1:FS47C+yEMgIPE2ZUA67ekpU1CZXMSliHkeB/V+ZFUg4=",
+        version = "v1.14.3",
+    )
+    go_repository(
+        name = "com_github_rickb777_plural",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/rickb777/plural",
+        sum = "h1:4CU5NiUqXSM++2+7JCrX+oguXd2D7RY5O1YisMw1yCI=",
+        version = "v1.2.2",
+    )
+    go_repository(
         name = "com_github_rivo_uniseg",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/rivo/uniseg",
@@ -6125,6 +6139,13 @@ def go_dependencies():
         importpath = "github.com/vultr/govultr/v2",
         sum = "h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=",
         version = "v2.17.2",
+    )
+    go_repository(
+        name = "com_github_vvakame_gcplogurl",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/vvakame/gcplogurl",
+        sum = "h1:dH55ru2OQOIAKjZi5wwXjNnSfN0oXLFYkMQy908s+tU=",
+        version = "v0.2.0",
     )
     go_repository(
         name = "com_github_wk8_go_ordered_map_v2",

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -25,6 +25,7 @@ import (
 const (
 	// TODO: re-export for use, maybe we should lift stack packages out of
 	// internal so that we can share consts, including output names.
+	StackNameProject  = project.StackName
 	StackNameIAM      = iam.StackName
 	StackNameCloudRun = cloudrun.StackName
 )

--- a/dev/sg/msp/BUILD.bazel
+++ b/dev/sg/msp/BUILD.bazel
@@ -24,6 +24,6 @@ go_library(
         "//lib/errors",
         "//lib/output",
         "@com_github_urfave_cli_v2//:cli",
-        "@com_github_vvakame_gcplogurl//:go_default_library",
+        "@com_github_vvakame_gcplogurl//:gcplogurl",
     ],
 )

--- a/dev/sg/msp/BUILD.bazel
+++ b/dev/sg/msp/BUILD.bazel
@@ -24,5 +24,6 @@ go_library(
         "//lib/errors",
         "//lib/output",
         "@com_github_urfave_cli_v2//:cli",
+        "@com_github_vvakame_gcplogurl//:go_default_library",
     ],
 )

--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -32,6 +32,29 @@ func useServiceArgument(c *cli.Context) (*spec.Spec, error) {
 	return spec.Open(serviceSpecPath)
 }
 
+// useServiceAndEnvironmentArguments retrieves the service and environment specs
+// corresponding to the first and second arguments respectively. It should only
+// be used if both arguments are required.
+func useServiceAndEnvironmentArguments(c *cli.Context) (*spec.Spec, *spec.EnvironmentSpec, error) {
+	svc, err := useServiceArgument(c)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	environmentID := c.Args().Get(1)
+	if environmentID == "" {
+		return svc, nil, errors.New("second argument <environment ID> is required")
+	}
+
+	env := svc.GetEnvironment(environmentID)
+	if env == nil {
+		return svc, nil, errors.Newf("environment %q not found in service spec, available environments: %+v",
+			environmentID, svc.ListEnvironmentIDs())
+	}
+
+	return svc, env, nil
+}
+
 func getTFCRunsClient(c *cli.Context) (*terraformcloud.RunsClient, error) {
 	secretStore, err := secrets.FromContext(c.Context)
 	if err != nil {

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -208,13 +208,9 @@ sg msp generate -all <service>
 			},
 			BashComplete: msprepo.ServicesAndEnvironmentsCompletion(),
 			Action: func(c *cli.Context) error {
-				service, err := useServiceArgument(c)
+				service, env, err := useServiceAndEnvironmentArguments(c)
 				if err != nil {
 					return err
-				}
-				env := service.GetEnvironment(c.Args().Get(1))
-				if env == nil {
-					return errors.Errorf("environment %q not found", c.Args().Get(1))
 				}
 
 				tfcClient, err := getTFCRunsClient(c)
@@ -234,9 +230,10 @@ sg msp generate -all <service>
 
 				switch component := c.String("component"); component {
 				case "service":
+					std.Out.WriteNoticef("Opening link to service logs in browser...")
 					return open.URL((&gcplogurl.Explorer{
 						ProjectID: projectID.Value.(string),
-						Query:     gcplogurl.Query(`resource.type = "cloud_run_revision"`),
+						Query:     gcplogurl.Query(`resource.type = "cloud_run_revision" jsonPayload.InstrumentationScope != ""`),
 						SummaryFields: &gcplogurl.SummaryFields{
 							Fields: []string{
 								// fields from structured logs by sourcegraph/log
@@ -297,13 +294,9 @@ full access, use the '-write-access' flag.
 					},
 					BashComplete: msprepo.ServicesAndEnvironmentsCompletion(),
 					Action: func(c *cli.Context) error {
-						service, err := useServiceArgument(c)
+						service, env, err := useServiceAndEnvironmentArguments(c)
 						if err != nil {
 							return err
-						}
-						env := service.GetEnvironment(c.Args().Get(1))
-						if env == nil {
-							return errors.Errorf("environment %q not found", c.Args().Get(1))
 						}
 						if env.Resources.PostgreSQL == nil {
 							return errors.New("no postgresql instance provisioned")

--- a/go.mod
+++ b/go.mod
@@ -279,6 +279,7 @@ require (
 	github.com/sourcegraph/managed-services-platform-cdktf/gen/tfe v0.0.0-20231218231056-4749baca142f
 	github.com/sourcegraph/sourcegraph/lib/managedservicesplatform v0.0.0-00010101000000-000000000000
 	github.com/vektah/gqlparser/v2 v2.4.5
+	github.com/vvakame/gcplogurl v0.2.0
 	go.opentelemetry.io/collector/config/confighttp v0.81.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.81.0
 	go.opentelemetry.io/collector/config/configtls v0.81.0
@@ -358,6 +359,8 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
 	github.com/prometheus/prometheus v0.40.5 // indirect
+	github.com/rickb777/date v1.14.3 // indirect
+	github.com/rickb777/plural v1.2.2 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.5 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1535,6 +1535,10 @@ github.com/redis/go-redis/v9 v9.0.2/go.mod h1:/xDTe9EF1LM61hek62Poq2nzQSGj0xSrEt
 github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
+github.com/rickb777/date v1.14.3 h1:FS47C+yEMgIPE2ZUA67ekpU1CZXMSliHkeB/V+ZFUg4=
+github.com/rickb777/date v1.14.3/go.mod h1:mes+vf4wqTD6l4zgZh4Z5TQkrLA57dpuzEGVeTk/XSc=
+github.com/rickb777/plural v1.2.2 h1:4CU5NiUqXSM++2+7JCrX+oguXd2D7RY5O1YisMw1yCI=
+github.com/rickb777/plural v1.2.2/go.mod h1:xyHbelv4YvJE51gjMnHvk+U2e9zIysg6lTnSQK8XUYA=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
@@ -1756,6 +1760,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/vvakame/gcplogurl v0.2.0 h1:dH55ru2OQOIAKjZi5wwXjNnSfN0oXLFYkMQy908s+tU=
+github.com/vvakame/gcplogurl v0.2.0/go.mod h1:CFjKFlur6M+/2DoGZL67O1FqZxB42jiqCyl4cXAmjOU=
 github.com/wk8/go-ordered-map/v2 v2.1.5 h1:jLbYIFyWQMUwHLO20cImlCRBoNc5lp0nmE2dvwcxc7k=
 github.com/wk8/go-ordered-map/v2 v2.1.5/go.mod h1:9Xvgm2mV2kSq2SAm0Y608tBmu8akTzI7c2bz7/G7ZN4=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=


### PR DESCRIPTION
Jump to a tidy view of service logs (assuming `sourcegraph/log`) in browser quickly.

## Test plan

```
sg msp logs sams dev
```

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/7cfd8290-aaf9-4589-9935-e71f7aa904f6)
