### PR TITLE
grpc: retry: add sourcegraph tracing support

### DIFF
--- a/internal/grpc/defaults/BUILD.bazel
+++ b/internal/grpc/defaults/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//internal/ttlcache",
         "//lib/errors",
         "@com_github_grpc_ecosystem_go_grpc_middleware_providers_prometheus//:prometheus",
-        "@com_github_grpc_ecosystem_go_grpc_middleware_v2//interceptors/retry",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc//:otelgrpc",

--- a/internal/grpc/defaults/defaults.go
+++ b/internal/grpc/defaults/defaults.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
-	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/grpc/retry"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
@@ -78,27 +78,27 @@ func defaultDialOptions(logger log.Logger, creds credentials.TransportCredential
 	out := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithChainStreamInterceptor(
-			retry.StreamClientInterceptor(),
-			metrics.StreamClientInterceptor(),
-			messagesize.StreamClientInterceptor,
 			propagator.StreamClientPropagator(actor.ActorPropagator{}),
 			propagator.StreamClientPropagator(policy.ShouldTracePropagator{}),
 			propagator.StreamClientPropagator(requestclient.Propagator{}),
 			propagator.StreamClientPropagator(requestinteraction.Propagator{}),
 			otelgrpc.StreamClientInterceptor(),
+			retry.StreamClientInterceptor(logger),
+			metrics.StreamClientInterceptor(),
+			messagesize.StreamClientInterceptor,
 			internalerrs.PrometheusStreamClientInterceptor,
 			internalerrs.LoggingStreamClientInterceptor(logger),
 			contextconv.StreamClientInterceptor,
 		),
 		grpc.WithChainUnaryInterceptor(
-			retry.UnaryClientInterceptor(),
-			metrics.UnaryClientInterceptor(),
-			messagesize.UnaryClientInterceptor,
 			propagator.UnaryClientPropagator(actor.ActorPropagator{}),
 			propagator.UnaryClientPropagator(policy.ShouldTracePropagator{}),
 			propagator.UnaryClientPropagator(requestclient.Propagator{}),
 			propagator.UnaryClientPropagator(requestinteraction.Propagator{}),
 			otelgrpc.UnaryClientInterceptor(),
+			retry.UnaryClientInterceptor(logger),
+			metrics.UnaryClientInterceptor(),
+			messagesize.UnaryClientInterceptor,
 			internalerrs.PrometheusUnaryClientInterceptor,
 			internalerrs.LoggingUnaryClientInterceptor(logger),
 			contextconv.UnaryClientInterceptor,

--- a/internal/grpc/retry/BUILD.bazel
+++ b/internal/grpc/retry/BUILD.bazel
@@ -12,12 +12,15 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/grpc/retry",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/grpc/grpcutil",
+        "//internal/trace",
         "@com_github_grpc_ecosystem_go_grpc_middleware_v2//metadata",
+        "@com_github_sourcegraph_log//:log",
+        "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
-        "@org_golang_x_net//trace",
     ],
 )
 
@@ -30,6 +33,8 @@ go_test(
     embed = [":retry"],
     deps = [
         "@com_github_grpc_ecosystem_go_grpc_middleware_v2//testing/testpb",
+        "@com_github_sourcegraph_log//:log",
+        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@com_github_stretchr_testify//suite",

--- a/internal/grpc/retry/examples_test.go
+++ b/internal/grpc/retry/examples_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/testing/testpb"
+	logger "github.com/sourcegraph/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
@@ -18,8 +19,8 @@ var cc *grpc.ClientConn
 // Simple example of using the default interceptor configuration.
 func Example_initialization() {
 	_, _ = grpc.Dial("myservice.example.com",
-		grpc.WithStreamInterceptor(StreamClientInterceptor()),
-		grpc.WithUnaryInterceptor(UnaryClientInterceptor()),
+		grpc.WithStreamInterceptor(StreamClientInterceptor(logger.NoOp())),
+		grpc.WithUnaryInterceptor(UnaryClientInterceptor(logger.NoOp())),
 	)
 }
 
@@ -30,8 +31,8 @@ func Example_initializationWithOptions() {
 		WithCodes(codes.NotFound, codes.Aborted),
 	}
 	_, _ = grpc.Dial("myservice.example.com",
-		grpc.WithStreamInterceptor(StreamClientInterceptor(opts...)),
-		grpc.WithUnaryInterceptor(UnaryClientInterceptor(opts...)),
+		grpc.WithStreamInterceptor(StreamClientInterceptor(logger.NoOp(), opts...)),
+		grpc.WithUnaryInterceptor(UnaryClientInterceptor(logger.NoOp(), opts...)),
 	)
 }
 
@@ -43,8 +44,8 @@ func Example_initializationWithExponentialBackoff() {
 		WithBackoff(BackoffExponential(100 * time.Millisecond)),
 	}
 	_, _ = grpc.Dial("myservice.example.com",
-		grpc.WithStreamInterceptor(StreamClientInterceptor(opts...)),
-		grpc.WithUnaryInterceptor(UnaryClientInterceptor(opts...)),
+		grpc.WithStreamInterceptor(StreamClientInterceptor(logger.NoOp(), opts...)),
+		grpc.WithUnaryInterceptor(UnaryClientInterceptor(logger.NoOp(), opts...)),
 	)
 }
 

--- a/internal/grpc/retry/options.go
+++ b/internal/grpc/retry/options.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
@@ -25,7 +26,7 @@ var (
 		codes:          DefaultRetriableCodes,
 		backoffFunc:    BackoffLinearWithJitter(50*time.Millisecond /*jitter*/, 0.10),
 		onRetryCallback: OnRetryCallback(func(ctx context.Context, attempt uint, err error) {
-			logTrace(ctx, "grpc_retry attempt: %d, backoff for %v", attempt, err)
+			logTrace(ctx, "grpc_retry attempting backing off due to error", attribute.Int("attempt", int(attempt)), attribute.String("error", err.Error()))
 		}),
 	}
 )


### PR DESCRIPTION
This tweaks our forked [grpc retry](https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware/retry) package to support traces in a similar manner to our internal httpcli logic. 

When reviewing this PR, I'd recommend comparing this against the logic in `internal/httpcli` to see if it's to your liking: https://github.com/sourcegraph/sourcegraph/blob/023e96c2fc25ced65c528be2474b5fd1f9a34792/internal/httpcli/client.go#L582-L631

## Test plan

1. (pre-requisite) I checked out https://github.com/sourcegraph/sourcegraph/pull/59136 (`12-20-grpc_frontend_configuration_support_automatic_retries_GetConfig_is_idempotent_`) that is the PR that has retries hooked up for all services.

2.  In `sg.config.yaml`, I commented out the entry that starts one of the gitserver instances when running `sg start`.

```patch
diff --git a/sg.config.yaml b/sg.config.yaml
index 312e5ebfbdc..eb0eef61193 100644
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1106,7 +1106,7 @@ commandsets:
       - repo-updater
       - web
       - gitserver-0
-      - gitserver-1
+#      - gitserver-1
       - searcher
       - caddy
       - symbols
```

3. I then ran `sg start` and `sg start monitoring` to start jaeger.

4. I executed the following search query with tracing enabled: https://sourcegraph.test:3443/search?q=context:global+type:diff+test+timeout:2m+count:all&patternType=standard&sm=1&trace=1&groupBy=repo


This produces a trace with entries that look like the following

<img width="1713" alt="Screenshot 2023-12-21 at 4 32 42 PM" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/ec7e2c48-602c-4537-b27a-e9490105b384">

You can see the full trace here: [gh_trace.json](https://github.com/sourcegraph/sourcegraph/files/13747118/gh_trace.json)


