### PR TITLE
msp: fix tfc workspace sync on services with private images

### DIFF
--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -44,6 +44,8 @@ func syncEnvironmentWorkspaces(c *cli.Context, tfc *terraformcloud.Client, servi
 		TFC: managedservicesplatform.TerraformCloudOptions{
 			Enabled: true, // required to generate all workspaces
 		},
+		// Avoid external resource access
+		StableGenerate: true,
 	}
 	defer os.RemoveAll(renderer.OutputDir)
 


### PR DESCRIPTION
We generate all stacks to get a list of stacks for which we need TFC workspaces - we need to do this in "stable mode" to avoid image access on subscription types (same thing we do for CI)

## Test plan

n/a
