### PR TITLE
Fix logic for when to show add access token button

### DIFF
--- a/client/web/src/site-admin/SiteAdminTokensPage.tsx
+++ b/client/web/src/site-admin/SiteAdminTokensPage.tsx
@@ -4,7 +4,7 @@ import { mdiPlus } from '@mdi/js'
 import { Subject } from 'rxjs'
 
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Button, ButtonLink, Container, Icon, PageHeader } from '@sourcegraph/wildcard'
+import { Button, ButtonLink, Container, Icon, PageHeader, Tooltip } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../auth'
 import { FilteredConnection } from '../components/FilteredConnection'
@@ -51,18 +51,15 @@ export const SiteAdminTokensPage: React.FunctionComponent<React.PropsWithChildre
                                 className="ml-2"
                                 to={`${authenticatedUser.settingsURL!}/tokens/new`}
                             >
-                                <Icon aria-hidden={true} svgPath={mdiPlus} /> Generate access token
+                                <Icon aria-hidden={true} svgPath={mdiPlus} /> Generate new token
                             </ButtonLink>
                         )}
                         {!accessTokensEnabled && (
-                            <Button
-                                variant="primary"
-                                title="Access token creation is disabled in site configuration"
-                                className="ml-2"
-                                disabled={true}
-                            >
-                                <Icon aria-hidden={true} svgPath={mdiPlus} /> Generate access token
-                            </Button>
+                            <Tooltip content="Access token creation is disabled in site configuration">
+                                <Button variant="primary" className="ml-2" disabled={true}>
+                                    <Icon aria-hidden={true} svgPath={mdiPlus} /> Generate new token
+                                </Button>
+                            </Tooltip>
                         )}
                     </>
                 }

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
@@ -6,7 +6,7 @@ import { map } from 'rxjs/operators'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Container, PageHeader, Button, Link, Icon, Text } from '@sourcegraph/wildcard'
+import { Container, PageHeader, Button, Icon, Text, ButtonLink, Tooltip } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import { FilteredConnection } from '../../../components/FilteredConnection'
@@ -73,6 +73,9 @@ export const UserSettingsTokensPage: React.FunctionComponent<React.PropsWithChil
     )
 
     const siteAdminViewingOtherUser = authenticatedUser && authenticatedUser.id !== user.id
+    const accessTokensEnabled =
+        (authenticatedUser.siteAdmin && window.context.accessTokensAllow === 'site-admin-create') ||
+        (!siteAdminViewingOtherUser && window.context.accessTokensAllow === 'all-users-create')
 
     return (
         <div className="user-settings-tokens-page">
@@ -82,11 +85,26 @@ export const UserSettingsTokensPage: React.FunctionComponent<React.PropsWithChil
                 path={[{ text: 'Access tokens' }]}
                 description="Access tokens may be used to access the Sourcegraph API."
                 actions={
-                    !siteAdminViewingOtherUser && (
-                        <Button to="new" variant="primary" as={Link}>
-                            <Icon role="img" aria-hidden={true} svgPath={mdiPlus} /> Generate new token
-                        </Button>
-                    )
+                    <>
+                        {accessTokensEnabled && (
+                            <ButtonLink variant="primary" className="ml-2" to="new">
+                                <Icon aria-hidden={true} svgPath={mdiPlus} /> Generate new token
+                            </ButtonLink>
+                        )}
+                        {!accessTokensEnabled && (
+                            <Tooltip
+                                content={
+                                    siteAdminViewingOtherUser
+                                        ? 'Access token creation for other users is disabled in site configuration'
+                                        : 'Access token creation is disabled in site configuration'
+                                }
+                            >
+                                <Button variant="primary" className="ml-2" disabled={true}>
+                                    <Icon aria-hidden={true} svgPath={mdiPlus} /> Generate new token
+                                </Button>
+                            </Tooltip>
+                        )}
+                    </>
                 }
                 className="mb-3"
             />


### PR DESCRIPTION
The previous logic didn't account for the allow-site-admin state so we never displayed the button in that case. This PR fixes that.

I want to reconsider these three options in the future and see if we couldn't replace it with RBAC instead, but for now this seems like the most straightforward way to improvement.

## Test plan

Manually tested all the states.