### PR TITLE
search jobs: handle unknown users

### DIFF
--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -354,7 +354,7 @@ const SearchJob: FC<SearchJobProps> = props => {
             {withCreatorColumn && (
                 <span className={styles.jobCreator}>
                     <UserAvatar user={job.creator!} className={styles.jobAvatar} />
-                    {job.creator?.displayName ?? job.creator?.username}
+                    {job.creator?.displayName ?? job.creator?.username ?? 'UNKNOWN'}
                 </span>
             )}
 

--- a/cmd/frontend/internal/search/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/search/resolvers/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//cmd/frontend/graphqlbackend/graphqlutil",
         "//internal/conf",
         "//internal/database",
+        "//internal/errcode",
         "//internal/gqlutil",
         "//internal/search/exhaustive/service",
         "//internal/search/exhaustive/store",


### PR DESCRIPTION
This fixes a bug where the search jobs page wouldn't render if a user was missing. The reason was that we returned an error if a user was missing, instead of nil, so we rendered that error instead.

Test plan:
I ran a search job locally, deleted the user afterwards and verified that the page renders as exepected.

<img width="1261" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/a73fbdb8-ebf4-48b7-8840-0645e20b08f7">
