### PR TITLE
msp: fixup default bigquery dataset ID

### DIFF
--- a/dev/managedservicesplatform/internal/resource/bigquery/bigquery.go
+++ b/dev/managedservicesplatform/internal/resource/bigquery/bigquery.go
@@ -1,6 +1,8 @@
 package bigquery
 
 import (
+	"strings"
+
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
 
@@ -37,10 +39,13 @@ type Config struct {
 // New creates a BigQuery dataset and all configured tables.
 func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, error) {
 	var (
-		datasetID = pointers.Deref(config.Spec.DatasetID, config.ServiceID)
-		projectID = pointers.Deref(config.Spec.ProjectID, config.DefaultProjectID)
-		location  = pointers.Deref(config.Spec.Location, "US")
-		labels    = map[string]*string{
+		datasetID = pointers.Deref(config.Spec.DatasetID,
+			// Dataset IDs must be alphanumeric (plus underscores)
+			strings.ReplaceAll(config.ServiceID, "-", "_"))
+		projectID = pointers.Deref(config.Spec.ProjectID,
+			config.DefaultProjectID)
+		location = pointers.Deref(config.Spec.Location, "US")
+		labels   = map[string]*string{
 			"service": &config.ServiceID,
 		}
 	)

--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -388,6 +388,8 @@ type EnvironmentResourceBigQueryDatasetSpec struct {
 
 	// DatasetID, if provided, configures a custom dataset ID to place all tables
 	// into. By default, we use the service ID as the dataset ID.
+	//
+	// Dataset IDs must be alphanumeric (plus underscores).
 	DatasetID *string `json:"datasetID,omitempty"`
 	// ProjectID can be used to specify a separate project ID from the service's
 	// project for BigQuery resources. If not provided, resources are created


### PR DESCRIPTION
Dashes are not allowed in dataset ID, since we use it in service IDs we cannot use it as-is for dataset IDs. We had a fix for this in Cody Gateway TF but I forgot to port it

## Test plan

https://github.com/sourcegraph/managed-services/commit/c761f01422b7e3b90d2f5a615a904085bd6c0dad fixed my workspace