### PR TITLE
sg msp: add workaround to retain stable resourceid

### DIFF
--- a/dev/managedservicesplatform/internal/stack/project/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/project/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//dev/managedservicesplatform/internal/resourceid",
         "//dev/managedservicesplatform/internal/stack",
         "//dev/managedservicesplatform/internal/stack/options/googleprovider",
-        "//dev/managedservicesplatform/internal/stack/options/randomprovider",
         "//dev/managedservicesplatform/spec",
         "//lib/pointers",
         "@com_github_aws_jsii_runtime_go//:jsii-runtime-go",


### PR DESCRIPTION
I forgot to push this change to my previous PR, https://github.com/sourcegraph/sourcegraph/pull/59220

## Test plan

n/a