### PR TITLE
msp: fix incorrect redis filter resource descriptor

### DIFF
--- a/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/monitoringalertpolicy/monitoringalertpolicy.go
@@ -232,7 +232,7 @@ func buildFilter(config *Config) string {
 	case CloudRedis:
 		filters = append(filters,
 			`resource.type = "redis_instance"`,
-			fmt.Sprintf(`resource.labels.redis_instance_id = "%s"`, config.ServiceName),
+			fmt.Sprintf(`resource.labels.instance_id = "%s"`, config.ServiceName),
 		)
 	}
 


### PR DESCRIPTION
Quick fix to the redis monitoring
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
CI
Checked the generated output is updated
Clickops in GCP to see the generated output matches GCP code