### PR TITLE
Enterprise: disable enterprise embeddings  by default

### DIFF
--- a/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
+++ b/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
@@ -262,3 +262,37 @@ func (r *repoEmbeddingJobStatsResolver) FilesSkipped() int32 {
 	}
 	return int32(skipped)
 }
+
+func NewEmptyRepoEmbeddingJobsResolver(
+	args graphqlbackend.ListRepoEmbeddingJobsArgs,
+) (*graphqlutil.ConnectionResolver[graphqlbackend.RepoEmbeddingJobResolver], error) {
+	opts := &graphqlutil.ConnectionResolverOptions{}
+	return graphqlutil.NewConnectionResolver[graphqlbackend.RepoEmbeddingJobResolver](&emptyEmbeddingJobStore{}, &args.ConnectionResolverArgs, opts)
+}
+
+type emptyEmbeddingJobStore struct{}
+
+func (s *emptyEmbeddingJobStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]graphqlbackend.RepoEmbeddingJobResolver, error) {
+	return []graphqlbackend.RepoEmbeddingJobResolver{}, nil
+}
+func (s *emptyEmbeddingJobStore) ComputeTotal(ctx context.Context) (int32, error) {
+	return 0, nil
+}
+func (s *emptyEmbeddingJobStore) MarshalCursor(node graphqlbackend.RepoEmbeddingJobResolver, _ database.OrderBy) (*string, error) {
+	return nil, nil
+}
+
+func (s *emptyEmbeddingJobStore) UnmarshalCursor(cursor string, _ database.OrderBy) ([]any, error) {
+	return nil, nil
+}
+func (r *emptyEmbeddingJobStore) Nodes() []graphqlbackend.RepoEmbeddingJobResolver {
+	return []graphqlbackend.RepoEmbeddingJobResolver{}
+}
+
+func (r *emptyEmbeddingJobStore) TotalCount() int32 {
+	return 0
+}
+
+func (r *emptyEmbeddingJobStore) PageInfo() *graphqlutil.PageInfo {
+	return &graphqlutil.PageInfo{}
+}

--- a/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
@@ -44,7 +44,8 @@ func TestDBPaginationWithRepoFilter(t *testing.T) {
 			CodyEnabled: pointers.Ptr(true),
 			LicenseKey:  "foobar",
 			Embeddings: &schema.Embeddings{
-				Provider: "sourcegraph",
+				Provider:           "sourcegraph",
+				EnterpriseOverride: pointers.Ptr(true),
 			},
 		},
 	})

--- a/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
@@ -75,6 +75,9 @@ func TestEmbeddingSearchResolver(t *testing.T) {
 		SiteConfiguration: schema.SiteConfiguration{
 			CodyEnabled: pointers.Ptr(true),
 			LicenseKey:  "asdf",
+			Embeddings: &schema.Embeddings{
+				EnterpriseOverride: pointers.Ptr(true),
+			},
 		},
 	})
 

--- a/cmd/worker/internal/embeddings/repo/handler.go
+++ b/cmd/worker/internal/embeddings/repo/handler.go
@@ -56,7 +56,8 @@ var splitOptions = codeintelContext.SplitOptions{
 func (h *handler) Handle(ctx context.Context, logger log.Logger, record *bgrepo.RepoEmbeddingJob) (err error) {
 	embeddingsConfig := conf.GetEmbeddingsConfig(conf.Get().SiteConfig())
 	if embeddingsConfig == nil {
-		return errors.New("embeddings are not configured or disabled")
+		logger.Info("embeddings are not configured or disabled")
+		return nil
 	}
 
 	ctx = featureflag.WithFlags(ctx, h.db.FeatureFlags())

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -799,7 +799,6 @@ const embeddingsMaxFileSizeBytes = 1000000
 // GetEmbeddingsConfig evaluates a complete embeddings configuration based on
 // site configuration. The configuration may be nil if completions is disabled.
 func GetEmbeddingsConfig(siteConfig schema.SiteConfiguration) *conftypes.EmbeddingsConfig {
-
 	// If cody is disabled, don't use embeddings.
 	if !codyEnabled(siteConfig) {
 		return nil

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/cronexpr"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
@@ -804,9 +803,9 @@ func GetEmbeddingsConfig(siteConfig schema.SiteConfiguration) *conftypes.Embeddi
 		return nil
 	}
 
-	// Enterprise should default to no embeddings
-	// This is a escape hatch if embeddings need to be re-enabled.
-	if !envvar.SourcegraphDotComMode() && (siteConfig.Embeddings == nil || siteConfig.Embeddings.EnterpriseOverride == nil || !*siteConfig.Embeddings.EnterpriseOverride) {
+	// Embeddings should be disabled by default
+	// This is a escape hatch if embeddings need to be re-enabled and for sourcegraph.com
+	if !experimentalEmbeddingsEnabled(siteConfig.ExperimentalFeatures) {
 		return nil
 	}
 
@@ -1139,4 +1138,10 @@ func fireworksDefaultMaxPromptTokens(model string) int {
 	}
 
 	return 4_000
+}
+
+func experimentalEmbeddingsEnabled(experimentalFeatures *schema.ExperimentalFeatures) bool {
+	return experimentalFeatures != nil &&
+		experimentalFeatures.Embeddings != nil &&
+		*experimentalFeatures.Embeddings
 }

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
 	"github.com/sourcegraph/sourcegraph/internal/license"
@@ -673,7 +672,6 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 		siteConfig   schema.SiteConfiguration
 		deployType   string
 		wantConfig   *conftypes.EmbeddingsConfig
-		dotcomMode   bool
 		wantDisabled bool
 	}{
 		{
@@ -734,18 +732,23 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 		{
 			name: "Sourcegraph provider dotcom",
 			siteConfig: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					Embeddings: pointers.Ptr(true),
+				},
 				CodyEnabled: pointers.Ptr(true),
 				LicenseKey:  licenseKey,
 				Embeddings: &schema.Embeddings{
 					Provider: "sourcegraph",
 				},
 			},
-			dotcomMode: true,
 			wantConfig: zeroConfigDefaultWithLicense,
 		},
 		{
 			name: "File filters (dotcom)",
 			siteConfig: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					Embeddings: pointers.Ptr(true),
+				},
 				CodyEnabled: pointers.Ptr(true),
 				LicenseKey:  licenseKey,
 				Embeddings: &schema.Embeddings{
@@ -757,7 +760,6 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 					},
 				},
 			},
-			dotcomMode: true,
 			wantConfig: &conftypes.EmbeddingsConfig{
 				Provider:                   "sourcegraph",
 				AccessToken:                licenseAccessToken,
@@ -781,6 +783,9 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 		{
 			name: "File filters w/o MaxFileSizeBytes (dotcom)",
 			siteConfig: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					Embeddings: pointers.Ptr(true),
+				},
 				CodyEnabled: pointers.Ptr(true),
 				LicenseKey:  licenseKey,
 				Embeddings: &schema.Embeddings{
@@ -791,7 +796,6 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 					},
 				},
 			},
-			dotcomMode: true,
 			wantConfig: &conftypes.EmbeddingsConfig{
 				Provider:                   "sourcegraph",
 				AccessToken:                licenseAccessToken,
@@ -813,9 +817,11 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 			},
 		},
 		{
-			name:       "Disable exclude failed chunk during indexing (dotcom)",
-			dotcomMode: true,
+			name: "Disable exclude failed chunk during indexing (dotcom)",
 			siteConfig: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					Embeddings: pointers.Ptr(true),
+				},
 				CodyEnabled: pointers.Ptr(true),
 				LicenseKey:  licenseKey,
 				Embeddings: &schema.Embeddings{
@@ -849,9 +855,11 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 			},
 		},
 		{
-			name:       "No provider and no token, assume Sourcegraph (dotcom)",
-			dotcomMode: true,
+			name: "No provider and no token, assume Sourcegraph (dotcom)",
 			siteConfig: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					Embeddings: pointers.Ptr(true),
+				},
 				CodyEnabled: pointers.Ptr(true),
 				LicenseKey:  licenseKey,
 				Embeddings: &schema.Embeddings{
@@ -877,9 +885,11 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 			},
 		},
 		{
-			name:       "Sourcegraph provider without license (dotcom)",
-			dotcomMode: true,
+			name: "Sourcegraph provider without license (dotcom)",
 			siteConfig: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					Embeddings: pointers.Ptr(true),
+				},
 				CodyEnabled: pointers.Ptr(true),
 				LicenseKey:  "",
 				Embeddings: &schema.Embeddings{
@@ -889,9 +899,11 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 			wantDisabled: true,
 		},
 		{
-			name:       "OpenAI provider (dotcom)",
-			dotcomMode: true,
+			name: "OpenAI provider (dotcom)",
 			siteConfig: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					Embeddings: pointers.Ptr(true),
+				},
 				CodyEnabled: pointers.Ptr(true),
 				LicenseKey:  licenseKey,
 				Embeddings: &schema.Embeddings{
@@ -920,11 +932,13 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 		{
 			name: "OpenAI provider without access token (override)",
 			siteConfig: schema.SiteConfiguration{
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					Embeddings: pointers.Ptr(true),
+				},
 				CodyEnabled: pointers.Ptr(true),
 				LicenseKey:  licenseKey,
 				Embeddings: &schema.Embeddings{
-					Provider:           "openai",
-					EnterpriseOverride: pointers.Ptr(true),
+					Provider: "openai",
 				},
 			},
 			wantDisabled: true,
@@ -934,13 +948,15 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 			siteConfig: schema.SiteConfiguration{
 				CodyEnabled: pointers.Ptr(true),
 				LicenseKey:  licenseKey,
+				ExperimentalFeatures: &schema.ExperimentalFeatures{
+					Embeddings: pointers.Ptr(true),
+				},
 				Embeddings: &schema.Embeddings{
-					EnterpriseOverride: pointers.Ptr(true),
-					Provider:           "azure-openai",
-					AccessToken:        "asdf",
-					Endpoint:           "https://acmecorp.openai.azure.com",
-					Dimensions:         1536,
-					Model:              "the-model",
+					Provider:    "azure-openai",
+					AccessToken: "asdf",
+					Endpoint:    "https://acmecorp.openai.azure.com",
+					Dimensions:  1536,
+					Model:       "the-model",
 				},
 			},
 			wantConfig: &conftypes.EmbeddingsConfig{
@@ -966,13 +982,11 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			defaultDeploy := deploy.Type()
-			envvar.MockSourcegraphDotComMode(tc.dotcomMode)
 			if tc.deployType != "" {
 				deploy.Mock(tc.deployType)
 			}
 			t.Cleanup(func() {
 				deploy.Mock(defaultDeploy)
-				envvar.MockSourcegraphDotComMode(false)
 			})
 			conf := GetEmbeddingsConfig(tc.siteConfig)
 			if tc.wantDisabled {

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -400,6 +400,9 @@ func TestGetEmbeddableRepoOpts(t *testing.T) {
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{
 		CodyEnabled: pointers.Ptr(true),
 		LicenseKey:  "asdf",
+		Embeddings: &schema.Embeddings{
+			EnterpriseOverride: pointers.Ptr(true),
+		},
 	}})
 
 	opts := GetEmbeddableRepoOpts()
@@ -415,6 +418,7 @@ func TestGetEmbeddableRepoOpts(t *testing.T) {
 		SiteConfiguration: schema.SiteConfiguration{
 			CodyEnabled: pointers.Ptr(true),
 			Embeddings: &schema.Embeddings{
+				EnterpriseOverride:         pointers.Ptr(true),
 				Provider:                   "openai",
 				AccessToken:                "asdf",
 				MinimumInterval:            "1h",

--- a/internal/embeddings/db/conf_test.go
+++ b/internal/embeddings/db/conf_test.go
@@ -19,6 +19,11 @@ func TestNewDBFromConfFunc(t *testing.T) {
 			ServiceConnectionConfig: conftypes.ServiceConnections{
 				Qdrant: "",
 			},
+			SiteConfiguration: schema.SiteConfiguration{
+				Embeddings: &schema.Embeddings{
+					EnterpriseOverride: pointers.Ptr(true),
+				},
+			},
 		})
 		getDB := NewDBFromConfFunc(logtest.Scoped(t), nil)
 		got, err := getDB()
@@ -30,9 +35,10 @@ func TestNewDBFromConfFunc(t *testing.T) {
 		conf.Mock(&conf.Unified{
 			SiteConfiguration: schema.SiteConfiguration{
 				Embeddings: &schema.Embeddings{
-					Provider:    "sourcegraph",
-					AccessToken: "fake",
-					Enabled:     pointers.Ptr(true),
+					EnterpriseOverride: pointers.Ptr(true),
+					Provider:           "sourcegraph",
+					AccessToken:        "fake",
+					Enabled:            pointers.Ptr(true),
 					Qdrant: &schema.Qdrant{
 						Enabled: true,
 					},

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -706,6 +706,8 @@ type Embeddings struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Endpoint description: The endpoint under which to reach the provider. Sensible default will be used for each provider.
 	Endpoint string `json:"endpoint,omitempty"`
+	// EnterpriseOverride description: An override to enable embeddings for enterprise.
+	EnterpriseOverride *bool `json:"enterpriseOverride,omitempty"`
 	// ExcludeChunkOnError description: Whether to cancel indexing a repo if embedding a single file fails. If true, the chunk that cannot generate embeddings is not indexed and the remainder of the repository proceeds with indexing.
 	ExcludeChunkOnError *bool `json:"excludeChunkOnError,omitempty"`
 	// ExcludedFilePathPatterns description: A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -706,8 +706,6 @@ type Embeddings struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// Endpoint description: The endpoint under which to reach the provider. Sensible default will be used for each provider.
 	Endpoint string `json:"endpoint,omitempty"`
-	// EnterpriseOverride description: An override to enable embeddings for enterprise.
-	EnterpriseOverride *bool `json:"enterpriseOverride,omitempty"`
 	// ExcludeChunkOnError description: Whether to cancel indexing a repo if embedding a single file fails. If true, the chunk that cannot generate embeddings is not indexed and the remainder of the repository proceeds with indexing.
 	ExcludeChunkOnError *bool `json:"excludeChunkOnError,omitempty"`
 	// ExcludedFilePathPatterns description: A list of glob patterns that match file paths you want to exclude from embeddings. This is useful to exclude files with low information value (e.g., SVG files, test fixtures, mocks, auto-generated files, etc.).
@@ -893,6 +891,8 @@ type ExperimentalFeatures struct {
 	CustomGitFetch []*CustomGitFetchMapping `json:"customGitFetch,omitempty"`
 	// DebugLog description: Turns on debug logging for specific debugging scenarios.
 	DebugLog *DebugLog `json:"debug.log,omitempty"`
+	// Embeddings description: Enables server side embeddings generation.
+	Embeddings *bool `json:"embeddings,omitempty"`
 	// EnableGRPC description: Enables gRPC for communication between internal services
 	EnableGRPC *bool `json:"enableGRPC,omitempty"`
 	// EnableGithubInternalRepoVisibility description: Enable support for visibility of internal Github repositories
@@ -986,6 +986,7 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 	delete(m, "batchChanges.enablePerforce")
 	delete(m, "customGitFetch")
 	delete(m, "debug.log")
+	delete(m, "embeddings")
 	delete(m, "enableGRPC")
 	delete(m, "enableGithubInternalRepoVisibility")
 	delete(m, "enablePermissionsWebhooks")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2484,6 +2484,14 @@
       "description": "Configuration for embeddings service.",
       "type": "object",
       "properties": {
+        "enterpriseOverride": {
+          "description": "An override to enable embeddings for enterprise.",
+          "type": "boolean",
+          "!go": {
+            "pointer": true
+          },
+          "default": false
+        },
         "enabled": {
           "description": "Toggles whether embedding service is enabled.",
           "type": "boolean",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -155,6 +155,14 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "embeddings": {
+          "description": "Enables server side embeddings generation.",
+          "type": "boolean",
+          "!go": {
+            "pointer": true
+          },
+          "default": false
+        },
         "searchJobs": {
           "description": "Enables search jobs (long-running exhaustive) search feature and its UI",
           "type": "boolean",
@@ -2484,14 +2492,6 @@
       "description": "Configuration for embeddings service.",
       "type": "object",
       "properties": {
-        "enterpriseOverride": {
-          "description": "An override to enable embeddings for enterprise.",
-          "type": "boolean",
-          "!go": {
-            "pointer": true
-          },
-          "default": false
-        },
         "enabled": {
           "description": "Toggles whether embedding service is enabled.",
           "type": "boolean",


### PR DESCRIPTION
This defaults enterprises to disabled embeddings, however there is an new property override added which can force embeddings back on.

Changes embeddings being disabled from an error into an allowed situation.  Worker jobs & repo resolvers shouldn't fail if embeddings are disabled. 

Embeddings for dotcom are left enabled as to not interfere with PLG rate limits or community repos that have been embedded.

## Test plan
updated unit tests
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
