### PR TITLE
Adding Config options for Siteadmins to configure whether clients can use Chat/autocomplete/commands

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7391,6 +7391,9 @@ type Site implements SettingsSubject {
     """
     codyLLMConfiguration: CodyLLMConfiguration
 
+
+    codyConfigFeatures: CodyConfigFeatures
+
     """
     Returns the status of the Cody Rate limits when using the `sourcegraph` provider.
     If the instance is not using the Cody Gateway there will be no rate limits.
@@ -7433,6 +7436,13 @@ type CodyLLMConfiguration {
     Name of the provider being used for LLM interactions.
     """
     provider: String!
+}
+
+type CodyConfigFeatures {
+    """
+    Name of the model being used for chat
+    """
+    chat: Boolean!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7391,7 +7391,6 @@ type Site implements SettingsSubject {
     """
     codyLLMConfiguration: CodyLLMConfiguration
 
-
     codyConfigFeatures: CodyConfigFeatures
 
     """
@@ -7440,9 +7439,19 @@ type CodyLLMConfiguration {
 
 type CodyConfigFeatures {
     """
-    Name of the model being used for chat
+    Enable Cody chat feature.
     """
     chat: Boolean!
+
+    """
+    Enable Cody autocomplete feature.
+    """
+    autoComplete: Boolean!
+
+    """
+    Enable Cody special commands feature.
+    """
+    commands: Boolean!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7391,6 +7391,11 @@ type Site implements SettingsSubject {
     """
     codyLLMConfiguration: CodyLLMConfiguration
 
+    """
+    Decides which features to enable for the users of this SG instance
+
+    Site-admin only.
+    """
     codyConfigFeatures: CodyConfigFeatures
 
     """
@@ -7437,6 +7442,10 @@ type CodyLLMConfiguration {
     provider: String!
 }
 
+"""
+Cody Config features contains information about which LLM features are enabled
+for this SG instance
+"""
 type CodyConfigFeatures {
     """
     Enable Cody chat feature.

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -592,12 +591,14 @@ func (r *siteResolver) CodyConfigFeatures(ctx context.Context) *codyConfigFeatur
 	if c == nil {
 		return nil
 	}
-	fmt.Println("This is a reading")
-	fmt.Println(c)
 	return &codyConfigFeaturesResolver{config: c}
 }
 
 func (c *codyConfigFeaturesResolver) Chat() bool { return c.config.Chat }
+
+func (c *codyConfigFeaturesResolver) AutoComplete() bool { return c.config.AutoComplete }
+
+func (c *codyConfigFeaturesResolver) Commands() bool { return c.config.Commands }
 
 type codyLLMConfigurationResolver struct {
 	config *conftypes.CompletionsConfig

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -587,23 +587,24 @@ func (r *siteResolver) CodyLLMConfiguration(ctx context.Context) *codyLLMConfigu
 	return &codyLLMConfigurationResolver{config: c}
 }
 
-func (r *siteResolver) CodyConfigFeatures(ctx context.Context) *codyLLMConfigurationResolver {
-	mySite := conf.Get().SiteConfig()
-	c := conf.GetCompletionsConfig(mySite)
+func (r *siteResolver) CodyConfigFeatures(ctx context.Context) *codyConfigFeaturesResolver {
+	c := conf.GetConfigFeatures(conf.Get().SiteConfig())
 	if c == nil {
 		return nil
 	}
-
-	wholeConf := conf.GetConfigFeatures(mySite)
 	fmt.Println("This is a reading")
-	fmt.Println(wholeConf)
-	return &codyLLMConfigurationResolver{config: c}
+	fmt.Println(c)
+	return &codyConfigFeaturesResolver{config: c}
 }
 
-func (c *codyLLMConfigurationResolver) Chat() bool { return false }
+func (c *codyConfigFeaturesResolver) Chat() bool { return c.config.Chat }
 
 type codyLLMConfigurationResolver struct {
 	config *conftypes.CompletionsConfig
+}
+
+type codyConfigFeaturesResolver struct {
+	config *conftypes.ConfigFeatures
 }
 
 func (c *codyLLMConfigurationResolver) ChatModel() string { return c.config.ChatModel }

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -585,6 +586,21 @@ func (r *siteResolver) CodyLLMConfiguration(ctx context.Context) *codyLLMConfigu
 
 	return &codyLLMConfigurationResolver{config: c}
 }
+
+func (r *siteResolver) CodyConfigFeatures(ctx context.Context) *codyLLMConfigurationResolver {
+	mySite := conf.Get().SiteConfig()
+	c := conf.GetCompletionsConfig(mySite)
+	if c == nil {
+		return nil
+	}
+
+	wholeConf := conf.GetConfigFeatures(mySite)
+	fmt.Println("This is a reading")
+	fmt.Println(wholeConf)
+	return &codyLLMConfigurationResolver{config: c}
+}
+
+func (c *codyLLMConfigurationResolver) Chat() bool { return false }
 
 type codyLLMConfigurationResolver struct {
 	config *conftypes.CompletionsConfig

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -802,12 +802,11 @@ func GetConfigFeatures(siteConfig schema.SiteConfiguration) (c *conftypes.Config
 	// If no completions configuration is set at all, but cody is enabled, assume a default configuration
 	// where all the features are enabled this is to handle edge cases where no config is set etc
 	if configFeatures == nil {
-		defaultConfig := &conftypes.ConfigFeatures{
+		return &conftypes.ConfigFeatures{
 			Chat:         true,
 			AutoComplete: true,
 			Commands:     true,
 		}
-		return defaultConfig
 	}
 
 	computedConfig := &conftypes.ConfigFeatures{

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"encoding/hex"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -790,6 +791,14 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 		PerProUserCodeCompletionsDailyInteractionLimit:         completionsConfig.PerProUserCodeCompletionsDailyInteractionLimit,
 	}
 
+	return computedConfig
+}
+
+func GetConfigFeatures(siteConfig schema.SiteConfiguration) (c *conftypes.ConfigFeatures) {
+	computedConfig := &conftypes.ConfigFeatures{
+		Chat: true,
+	}
+	fmt.Println(computedConfig)
 	return computedConfig
 }
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -794,18 +794,26 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 }
 
 func GetConfigFeatures(siteConfig schema.SiteConfiguration) (c *conftypes.ConfigFeatures) {
+	// If cody is disabled, don't use any of the other features.
+	if !codyEnabled(siteConfig) {
+		return nil
+	}
 	configFeatures := siteConfig.ConfigFeatures
-	// If no completions configuration is set at all, but cody is enabled, assume
-	// a default configuration.
+	// If no completions configuration is set at all, but cody is enabled, assume a default configuration
+	// where all the features are enabled this is to handle edge cases where no config is set etc
 	if configFeatures == nil {
 		defaultConfig := &conftypes.ConfigFeatures{
-			Chat: true,
+			Chat:         true,
+			AutoComplete: true,
+			Commands:     true,
 		}
 		return defaultConfig
 	}
 
 	computedConfig := &conftypes.ConfigFeatures{
-		Chat: configFeatures.Chat,
+		Chat:         configFeatures.Chat,
+		AutoComplete: configFeatures.AutoComplete,
+		Commands:     configFeatures.Commands,
 	}
 	return computedConfig
 }

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -2,7 +2,6 @@ package conf
 
 import (
 	"encoding/hex"
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -795,10 +794,19 @@ func GetCompletionsConfig(siteConfig schema.SiteConfiguration) (c *conftypes.Com
 }
 
 func GetConfigFeatures(siteConfig schema.SiteConfiguration) (c *conftypes.ConfigFeatures) {
-	computedConfig := &conftypes.ConfigFeatures{
-		Chat: true,
+	configFeatures := siteConfig.ConfigFeatures
+	// If no completions configuration is set at all, but cody is enabled, assume
+	// a default configuration.
+	if configFeatures == nil {
+		defaultConfig := &conftypes.ConfigFeatures{
+			Chat: true,
+		}
+		return defaultConfig
 	}
-	fmt.Println(computedConfig)
+
+	computedConfig := &conftypes.ConfigFeatures{
+		Chat: configFeatures.Chat,
+	}
 	return computedConfig
 }
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -799,7 +799,7 @@ func GetConfigFeatures(siteConfig schema.SiteConfiguration) (c *conftypes.Config
 		return nil
 	}
 	configFeatures := siteConfig.ConfigFeatures
-	// If no completions configuration is set at all, but cody is enabled, assume a default configuration
+	// If no features configuration is set at all, but cody is enabled, assume a default configuration
 	// where all the features are enabled this is to handle edge cases where no config is set etc
 	if configFeatures == nil {
 		return &conftypes.ConfigFeatures{

--- a/internal/conf/conftypes/consts.go
+++ b/internal/conf/conftypes/consts.go
@@ -26,6 +26,9 @@ type CompletionsConfig struct {
 	PerProUserChatDailyInteractionLimit                    int
 	PerProUserCodeCompletionsDailyInteractionLimit         int
 }
+type ConfigFeatures struct {
+	Chat bool
+}
 
 type CompletionsProviderName string
 

--- a/internal/conf/conftypes/consts.go
+++ b/internal/conf/conftypes/consts.go
@@ -27,7 +27,9 @@ type CompletionsConfig struct {
 	PerProUserCodeCompletionsDailyInteractionLimit         int
 }
 type ConfigFeatures struct {
-	Chat bool
+	Chat         bool
+	AutoComplete bool
+	Commands     bool
 }
 
 type CompletionsProviderName string

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -644,8 +644,12 @@ type Completions struct {
 
 // ConfigFeatures description: Configuration for the completions service.
 type ConfigFeatures struct {
-	// Chat description: The model used for chat completions. If using the default provider 'sourcegraph', a reasonable default model will be set.
+	// AutoComplete description: Enable/Disable AutoComplete for the clients
+	AutoComplete bool `json:"autoComplete,omitempty"`
+	// Chat description: Enable/Disable Chat for the clients
 	Chat bool `json:"chat,omitempty"`
+	// Commands description: Enable/Disable special commands for the clients
+	Commands bool `json:"commands,omitempty"`
 }
 
 // CustomGitFetchMapping description: Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -642,6 +642,12 @@ type Completions struct {
 	Provider string `json:"provider,omitempty"`
 }
 
+// ConfigFeatures description: Configuration for the completions service.
+type ConfigFeatures struct {
+	// Chat description: The model used for chat completions. If using the default provider 'sourcegraph', a reasonable default model will be set.
+	Chat bool `json:"chat,omitempty"`
+}
+
 // CustomGitFetchMapping description: Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.
 type CustomGitFetchMapping struct {
 	// DomainPath description: Git clone URL domain/path
@@ -2687,6 +2693,8 @@ type SiteConfiguration struct {
 	CodyRestrictUsersFeatureFlag *bool `json:"cody.restrictUsersFeatureFlag,omitempty"`
 	// Completions description: Configuration for the completions service.
 	Completions *Completions `json:"completions,omitempty"`
+	// ConfigFeatures description: Configuration for the completions service.
+	ConfigFeatures *ConfigFeatures `json:"configFeatures,omitempty"`
 	// CorsOrigin description: Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.
 	CorsOrigin string `json:"corsOrigin,omitempty"`
 	// DebugSearchSymbolsParallelism description: (debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.
@@ -2944,6 +2952,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "cody.enabled")
 	delete(m, "cody.restrictUsersFeatureFlag")
 	delete(m, "completions")
+	delete(m, "configFeatures")
 	delete(m, "corsOrigin")
 	delete(m, "debug.search.symbolsParallelism")
 	delete(m, "defaultRateLimit")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2872,7 +2872,15 @@
       "type": "object",
       "properties": {
         "chat": {
-          "description": "The model used for chat completions. If using the default provider 'sourcegraph', a reasonable default model will be set.",
+          "description": "Enable/Disable Chat for the clients",
+          "type": "boolean"
+        },
+        "autoComplete": {
+          "description": "Enable/Disable AutoComplete for the clients",
+          "type": "boolean"
+        },
+        "commands": {
+          "description": "Enable/Disable special commands for the clients",
           "type": "boolean"
         }
       },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2866,6 +2866,21 @@
           "perUserDailyLimit": 100
         }
       ]
+    },
+    "configFeatures": {
+      "description": "Configuration for the completions service.",
+      "type": "object",
+      "properties": {
+        "chat": {
+          "description": "The model used for chat completions. If using the default provider 'sourcegraph', a reasonable default model will be set.",
+          "type": "boolean"
+        }
+      },
+      "examples": [
+        {
+          "chat": true
+        }
+      ]
     }
   },
   "definitions": {


### PR DESCRIPTION
Main Issue https://github.com/sourcegraph/sourcegraph/issues/58631
Related PR https://github.com/sourcegraph/dev-private/pull/82

## Test plan
Run in Dev mode and test the GQL by tweaking the site admin config.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
