### PR TITLE
code-search: fix for regression introduced by actions discoverability

### DIFF
--- a/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.module.scss
+++ b/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.module.scss
@@ -1,36 +1,9 @@
-.dropdown-menu {
-    min-width: 20rem;
+.container {
+    max-height: 15rem;
+    overflow-y: auto;
+    margin-left: 0.5rem;
 }
 
-.braindot {
-    position: relative;
-    margin-right: 0.625rem;
-    padding: 0.25rem;
-}
-
-.braindot::after {
-    content: '';
-    position: absolute;
-    bottom: 0.2rem;
-    right: -0.25rem;
-    border-radius: 1rem;
-    width: 0.65rem;
-    height: 0.65rem;
-    border: 2px solid var(--body-bg);
-}
-
-.braindot-success::after {
-    background-color: var(--success);
-}
-
-.braindot-warning::after {
-    background-color: var(--warning);
-}
-
-.braindot-danger::after {
-    background-color: var(--danger);
-}
-
-input[type='radio'] + label {
-    vertical-align: sub;
+.radio-btn {
+    width: fit-content;
 }

--- a/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/components/BrainDot.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { mdiBrain } from '@mdi/js'
+import classNames from 'classnames'
 
 import {
     Icon,
@@ -14,6 +15,8 @@ import {
 } from '@sourcegraph/wildcard'
 
 import { useVisibleIndexes } from '../hooks/useVisibleIndexes'
+
+import styles from './BrainDot.module.scss'
 
 export interface BrainDotProps {
     repoName: string
@@ -52,40 +55,38 @@ const BrainDotContent: React.FunctionComponent<BrainDotProps> = ({ repoName, com
         <>
             {visibleIndexesLoading && <LoadingSpinner className="mx-2" />}
             {visibleIndexes && visibleIndexes.length > 0 && (
-                <MenuHeader>
-                    {[
+                <div className={styles.container}>
+                    <RadioButton
+                        id="none"
+                        key="none"
+                        name="none"
+                        label="None"
+                        wrapperClassName={classNames(styles.radioBtn, 'py-1')}
+                        checked={visibleIndexID === undefined}
+                        onChange={() => {
+                            delete indexIDsForSnapshotData[repoName]
+                            setIndexIDForSnapshotData(indexIDsForSnapshotData)
+                        }}
+                    />
+                    {visibleIndexes.map(index => (
                         <RadioButton
-                            id="none"
-                            key="none"
-                            name="none"
-                            label="None"
-                            wrapperClassName="py-1 px-2"
-                            checked={visibleIndexID === undefined}
+                            key={index.id}
+                            id={index.id}
+                            name={index.id}
+                            checked={visibleIndexID === index.id}
+                            wrapperClassName={classNames(styles.radioBtn, 'py-1')}
+                            label={
+                                <>
+                                    Index at <Code>{index.inputCommit.slice(0, 7)}</Code>
+                                </>
+                            }
                             onChange={() => {
-                                delete indexIDsForSnapshotData[repoName]
+                                indexIDsForSnapshotData[repoName] = index.id
                                 setIndexIDForSnapshotData(indexIDsForSnapshotData)
                             }}
-                        />,
-                        ...visibleIndexes.map(index => (
-                            <RadioButton
-                                key={index.id}
-                                id={index.id}
-                                name={index.id}
-                                checked={visibleIndexID === index.id}
-                                wrapperClassName="py-1 px-2"
-                                label={
-                                    <>
-                                        Index at <Code>{index.inputCommit.slice(0, 7)}</Code>
-                                    </>
-                                }
-                                onChange={() => {
-                                    indexIDsForSnapshotData[repoName] = index.id
-                                    setIndexIDForSnapshotData(indexIDsForSnapshotData)
-                                }}
-                            />
-                        )),
-                    ]}
-                </MenuHeader>
+                        />
+                    ))}
+                </div>
             )}
             {(visibleIndexes?.length ?? 0) === 0 && !visibleIndexesLoading && (
                 <small className="px-2">No precise indexes to display debug information for.</small>

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -236,9 +236,11 @@ export const RepoHeader: React.FunctionComponent<React.PropsWithChildren<Props>>
                                 {a.element}
                             </li>
                         ))}
-                        <li className={classNames('nav-item', styles.actionListItem)}>
-                            <RepoHeaderContextMenu actions={rightActionsInContextMenu} />
-                        </li>
+                        {rightActionsInContextMenu.length > 0 && (
+                            <li className={classNames('nav-item', styles.actionListItem)}>
+                                <RepoHeaderContextMenu actions={rightActionsInContextMenu} />
+                            </li>
+                        )}
                     </ul>
                 ) : (
                     <ul className="navbar-nav">


### PR DESCRIPTION
I did a bunch of testing on S2 and Dotcom, and I noticed several bugs introduced by #58122 - this PR takes an attempt to fix them.

The lack of a `max-height` attribute on the container for the context menu causes the list to grow abnormally long. 

![CleanShot 2023-12-26 at 13 32 37@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/229c9351-5373-4c15-9829-e63aad167ae8)

Also, in a case where there are no items in the context menu (e.g the revision comparison page), the context menu renders nothing - we should hide it in this case instead of showing an empty context menu.

![CleanShot 2023-12-26 at 13 44 01@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/3a1f2a8b-d8de-4d96-85d1-b3b20c446628)

## Test plan

Navigating to a repository root page that has been indexed and contains a lot of visible indexes, the context menu shouldn't be abnormally long.

![CleanShot 2023-12-26 at 13 41 18@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/881fa4a1-546e-4396-96b1-e3a7017febab)

The radio button for indices shouldn't be hidden when the context menu is open.