### PR TITLE
client: Delete unused code involving getModeForPath

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -104,14 +104,6 @@ export interface UIRangeSpec {
     range: UIRange
 }
 
-/**
- * Specifies an LSP mode.
- */
-export interface ModeSpec {
-    /** The LSP mode, which identifies the language server to use. */
-    mode: string
-}
-
 // `panelID` is intended for substitution (e.g. `sub(panel.url, 'panelID', 'implementations')`)
 export type BlobViewState = 'def' | 'references' | 'panelID'
 

--- a/client/web/src/repo/RepositoryFileTreePage.tsx
+++ b/client/web/src/repo/RepositoryFileTreePage.tsx
@@ -44,7 +44,6 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
     }
 
     const objectType = maybeObjectType || 'tree'
-    const mode = getModeFromPath(filePath)
 
     // Redirect OpenGrok-style line number hashes (#123, #123-321) to query parameter (?L123, ?L123-321)
     const hashLineNumberMatch = location.hash.match(/^#?(\d+)(-\d+)?$/)
@@ -101,7 +100,6 @@ export const RepositoryFileTreePage: FC<RepositoryFileTreePageProps> = props => 
                                     repoName={repoName}
                                     repoUrl={repo?.url}
                                     repoServiceType={repo?.externalRepository?.serviceType}
-                                    mode={mode}
                                     repoHeaderContributionsLifecycleProps={
                                         context.repoHeaderContributionsLifecycleProps
                                     }

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -92,7 +92,6 @@ const RenderedNotebookMarkdown = lazyComponent(() => import('./RenderedNotebookM
 
 interface BlobPageProps
     extends RepoFile,
-        ModeSpec,
         RepoHeaderContributionsLifecycleProps,
         SettingsCascadeProps,
         PlatformContextProps,
@@ -133,7 +132,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
     const { span } = useCurrentSpan()
     const [wrapCode, setWrapCode] = useState(ToggleLineWrap.getValue())
     let renderMode = getModeFromURL(location)
-    const { repoID, repoName, repoServiceType, revision, commitID, filePath, useBreadcrumb, mode } = props
+    const { repoID, repoName, repoServiceType, revision, commitID, filePath, useBreadcrumb } = props
     const enableLazyBlobSyntaxHighlighting = useExperimentalFeatures(
         features => features.enableLazyBlobSyntaxHighlighting ?? true
     )
@@ -209,7 +208,6 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                                 repoName,
                                 revision,
                                 filePath,
-                                mode,
                                 languages: blob.languages,
                                 // Properties used in `BlobPage` but not `Blob`
                                 richHTML: blob.richHTML,
@@ -224,7 +222,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                         })
                     )
                 ),
-            [filePath, mode, repoName, revision, span, indexIDsForSnapshotData]
+            [filePath, repoName, revision, span, indexIDsForSnapshotData]
         )
     )
 
@@ -263,7 +261,6 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                             repoName,
                             revision,
                             filePath,
-                            mode,
                             languages: blob.languages,
                             // Properties used in `BlobPage` but not `Blob`
                             richHTML: blob.richHTML,
@@ -276,7 +273,7 @@ export const BlobPage: React.FunctionComponent<BlobPageProps> = ({ className, co
                     }),
                     catchError((error): [ErrorLike] => [asError(error)])
                 ),
-            [repoName, revision, filePath, mode, indexIDsForSnapshotData]
+            [repoName, revision, filePath, indexIDsForSnapshotData]
         )
     )
 


### PR DESCRIPTION
The blob view now has access to all the potential languages.
See: https://github.com/sourcegraph/sourcegraph/pull/58962

So we can remove this call to `getModeForPath` as the return
value is not used.

## Test plan

Type-checking in CI should be enough
