### PR TITLE
Add logic to auto disable google signups from non-gmail domain for 24hrs if too many signups from same domain.

### DIFF
--- a/cmd/frontend/auth/BUILD.bazel
+++ b/cmd/frontend/auth/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/frontend/backend",
+        "//cmd/frontend/envvar",
         "//cmd/frontend/globals",
         "//cmd/frontend/internal/app/router",
         "//cmd/frontend/internal/app/ui/router",
@@ -30,6 +31,7 @@ go_library(
         "//internal/extsvc",
         "//internal/featureflag",
         "//internal/lazyregexp",
+        "//internal/security",
         "//internal/session",
         "//internal/telemetry",
         "//internal/telemetry/teestore",

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -37,6 +37,53 @@ type GetAndSaveUserOp struct {
 	LookUpByUsername    bool
 }
 
+// Checks if the user's email defined in the GetAndSaveUserOp is banned.
+// This is done by first checking a list of banned email domains.
+// If the domain is not banned, we then check if the email is a Google account
+// that's hosted on a non-gmail.com domain. Then, if too many signups have
+// happend recently, we prevent the signup.
+func checkIfEmailDomainIsBanned(ctx context.Context, recorder *telemetry.BestEffortEventRecorder, op GetAndSaveUserOp, acct *extsvc.Account) (string, error) {
+	domain, _ := security.ParseEmailDomain(op.UserProps.Email)
+
+	banned, err := security.IsEmailBanned(op.UserProps.Email)
+	if err != nil {
+		return "could not determine if email domain is banned", err
+	}
+
+	if banned {
+		recorder.Record(ctx, telemetry.FeaturesSignUpBlockedBannedDomain, telemetry.ActionFailed, &telemetry.EventParameters{
+			PrivateMetadata: map[string]any{
+				"serviceType": acct.AccountSpec.ServiceType,
+				"serviceId":   acct.AccountSpec.ServiceID,
+				"emailDomain": domain,
+			},
+		})
+
+		return "this email address is not allowed to register", errors.New("email domain banned")
+	}
+
+	if acct.AccountSpec.ServiceID == "https://accounts.google.com" && domain != "gmail.com" {
+		banned, err := security.IsEmailBlockedDueToTooManySignups(op.UserProps.Email)
+		if err != nil {
+			return "could not determine if email domain is banned", err
+		}
+
+		if banned {
+			recorder.Record(ctx, telemetry.FeaturesSignUpBlockedTooManySignups, telemetry.ActionFailed, &telemetry.EventParameters{
+				PrivateMetadata: map[string]any{
+					"serviceType": acct.AccountSpec.ServiceType,
+					"serviceId":   acct.AccountSpec.ServiceID,
+					"emailDomain": domain,
+				},
+			})
+
+			return "There seem to be too many signups occurring today. Please try again at a later time.", errors.New("Email not allowed to register due to too many signups")
+		}
+	}
+
+	return "", nil
+}
+
 // GetAndSaveUser accepts authentication information associated with a given user, validates and applies
 // the necessary updates to the DB, and returns the user ID after the updates have been applied.
 //
@@ -132,43 +179,9 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (n
 		}
 
 		if envvar.SourcegraphDotComMode() {
-			domain, _ := security.ParseEmailDomain(op.UserProps.Email)
-
-			banned, err := security.IsEmailBanned(op.UserProps.Email)
+			reason, err := checkIfEmailDomainIsBanned(ctx, recorder, op, acct)
 			if err != nil {
-				return 0, false, false, "could not determine if email domain is banned", err
-			}
-
-			if banned {
-				recorder.Record(ctx, telemetry.FeaturesSignUpBlockedBannedDomain, telemetry.ActionFailed, &telemetry.EventParameters{
-					PrivateMetadata: map[string]any{
-						"serviceType": acct.AccountSpec.ServiceType,
-						"serviceId":   acct.AccountSpec.ServiceID,
-						"emailDomain": domain,
-					},
-				})
-
-				return 0, false, false, "this email address is not allowed to register", errors.New("email domain banned")
-			}
-
-			if acct.AccountSpec.ServiceID == "https://accounts.google.com" && domain != "gmail.com" {
-				banned, err := security.IsEmailBlockedDueToTooManySignups(op.UserProps.Email)
-
-				if err != nil {
-					return 0, false, false, "could not determine if email domain is banned", err
-				}
-
-				if banned {
-					recorder.Record(ctx, telemetry.FeaturesSignUpBlockedTooManySignups, telemetry.ActionFailed, &telemetry.EventParameters{
-						PrivateMetadata: map[string]any{
-							"serviceType": acct.AccountSpec.ServiceType,
-							"serviceId":   acct.AccountSpec.ServiceID,
-							"emailDomain": domain,
-						},
-					})
-
-					return 0, false, false, "There seem to be too many signups occurring today. Please try again at a later time.", errors.New("Email not allowed to register due to too many signups")
-				}
+				return 0, false, false, reason, err
 			}
 		}
 
@@ -392,7 +405,4 @@ func addCodyProForTestUsers(ctx context.Context, db database.DB, userID int32, l
 			logger.Error("failed to create feature flag override", sglog.Error(err))
 		}
 	}
-}
-
-func logBannedDomainEvent(ctx context.Context, db database.DB, logger sglog.Logger, reason string, domain string, acct *extsvc.Account) {
 }

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -151,8 +151,7 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (n
 				return 0, false, false, "this email address is not allowed to register", errors.New("email domain banned")
 			}
 
-			//if acct.AccountSpec.ServiceID == "https://accounts.google.com" && domain != "gmail.com" {
-			if true {
+			if acct.AccountSpec.ServiceID == "https://accounts.google.com" && domain != "gmail.com" {
 				banned, err := security.IsEmailBlockedDueToTooManySignups(op.UserProps.Email)
 
 				if err != nil {
@@ -168,7 +167,7 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (n
 						},
 					})
 
-					return 0, false, false, "this email address is not allowed to register", errors.New("Email not allowed to register")
+					return 0, false, false, "There seem to be too many signups occurring today. Please try again at a later time.", errors.New("Email not allowed to register due to too many signups")
 				}
 			}
 		}

--- a/internal/security/BUILD.bazel
+++ b/internal/security/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//internal/conf",
         "//internal/errcode",
         "//internal/lazyregexp",
+        "//internal/redispool",
         "//lib/errors",
     ],
 )

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -50,32 +51,76 @@ func ensureBannedEmailDomainsLoaded() error {
 	return bannedEmailDomainsErr
 }
 
-func IsEmailBanned(email string) (bool, error) {
-	if err := ensureBannedEmailDomainsLoaded(); err != nil {
-		return false, err
-	}
-	if bannedEmailDomains.IsEmpty() {
-		return false, nil
-	}
-
+func ParseEmailDomain(email string) (string, error) {
 	addr, err := mail.ParseAddress(email)
 	if err != nil {
-		return false, err
+		return "", err
 	}
 
 	if len(addr.Address) == 0 {
-		return true, nil
+		return "", errors.New("email address is empty")
 	}
 
 	parts := strings.Split(addr.Address, "@")
 
 	if len(parts) < 2 {
+		return "", errors.New("email address is missing domain")
+	}
+
+	return strings.ToLower(parts[len(parts)-1]), nil
+}
+
+func IsEmailBanned(email string) (bool, error) {
+	if err := ensureBannedEmailDomainsLoaded(); err != nil {
+		return false, err
+	}
+
+	if bannedEmailDomains.IsEmpty() {
+		return false, nil
+	}
+
+	domain, err := ParseEmailDomain(email)
+	if err != nil {
+		return false, err
+	}
+
+	_, banned := bannedEmailDomains[domain]
+
+	return banned, nil
+}
+
+var (
+	redisStore    = redispool.Store
+	redisScopeKey = "auth:emails:"
+)
+
+func IsEmailBlockedDueToTooManySignups(email string) (bool, error) {
+	limit := conf.Get().SiteConfig().AuthDailyEmailDomainSignupLimit
+
+	if limit == 0 {
+		return false, nil
+	}
+
+	domain, err := ParseEmailDomain(email)
+	if err != nil {
+		return false, err
+	}
+
+	key := redisScopeKey + domain
+	value := redisStore.Get(key)
+
+	if value.IsNil() {
+		err := redisStore.SetEx(key, 24*60*60, 1)
+		return false, err
+	}
+
+	if emailsRegisteredInLast24Hours, _ := value.Int(); emailsRegisteredInLast24Hours > limit {
 		return true, nil
 	}
 
-	_, banned := bannedEmailDomains[strings.ToLower(parts[len(parts)-1])]
+	_, err = redisStore.Incr(key)
 
-	return banned, nil
+	return false, err
 }
 
 // ValidateRemoteAddr validates if the input is a valid IP or a valid hostname.

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -51,21 +51,16 @@ func ensureBannedEmailDomainsLoaded() error {
 	return bannedEmailDomainsErr
 }
 
+// Retrieves the domain name from an email address.
+// e.g. "user@example.com" -> "example.com"
+// The email address must be valid, or else an error is returned.
 func ParseEmailDomain(email string) (string, error) {
 	addr, err := mail.ParseAddress(email)
 	if err != nil {
 		return "", err
 	}
 
-	if len(addr.Address) == 0 {
-		return "", errors.New("email address is empty")
-	}
-
 	parts := strings.Split(addr.Address, "@")
-
-	if len(parts) < 2 {
-		return "", errors.New("email address is missing domain")
-	}
 
 	return strings.ToLower(parts[len(parts)-1]), nil
 }
@@ -131,7 +126,6 @@ func ValidateRemoteAddr(raddr string) bool {
 	if err == nil {
 		raddr = host
 		_, err := strconv.Atoi(port)
-
 		// return false if port is not an int
 		if err != nil {
 			return false
@@ -175,7 +169,6 @@ const maxPasswordRunes = 256
 
 // ValidatePassword: Validates that a password meets the required criteria
 func ValidatePassword(passwd string) error {
-
 	if conf.PasswordPolicyEnabled() {
 		return validatePasswordUsingPolicy(passwd)
 	}
@@ -223,7 +216,7 @@ func validatePasswordUsingPolicy(passwd string) error {
 		case unicode.IsLetter(c) || c == ' ':
 			chars++
 		default:
-			//ignore
+			// ignore
 		}
 	}
 	// Check for blank password

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -13,9 +13,11 @@ type eventFeature string
 const (
 	FeatureExample eventFeature = "exampleFeature"
 
-	FeatureSignIn  eventFeature = "signIn"
-	FeatureSignOut eventFeature = "signOut"
-	FeatureSignUp  eventFeature = "signUp"
+	FeatureSignIn                       eventFeature = "signIn"
+	FeatureSignOut                      eventFeature = "signOut"
+	FeatureSignUp                       eventFeature = "signUp"
+	FeaturesSignUpBlockedBannedDomain   eventFeature = "signUpBlocked:BannedDomain"
+	FeaturesSignUpBlockedTooManySignups eventFeature = "signUpBlocked:TooManySignups"
 )
 
 // eventAction defines the action associated with an event. Values should

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2618,6 +2618,8 @@ type SiteConfiguration struct {
 	AuthAccessTokens *AuthAccessTokens `json:"auth.accessTokens,omitempty"`
 	// AuthAllowedIpAddress description: IP allowlist for access to the Sourcegraph instance. If set, only requests from these IP addresses will be allowed. By default client IP is infered connected client IP address, and you may configure to use a request header to determine the user IP.
 	AuthAllowedIpAddress *AuthAllowedIpAddress `json:"auth.allowedIpAddress,omitempty"`
+	// AuthDailyEmailDomainSignupLimit description: The maximum number of users that can sign from Google using the same email domain in a 24 hour period.
+	AuthDailyEmailDomainSignupLimit int `json:"auth.dailyEmailDomainSignupLimit,omitempty"`
 	// AuthEnableUsernameChanges description: Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.
 	AuthEnableUsernameChanges bool `json:"auth.enableUsernameChanges,omitempty"`
 	// AuthLockout description: The config options for account lockout
@@ -2923,6 +2925,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "auth.accessRequest")
 	delete(m, "auth.accessTokens")
 	delete(m, "auth.allowedIpAddress")
+	delete(m, "auth.dailyEmailDomainSignupLimit")
 	delete(m, "auth.enableUsernameChanges")
 	delete(m, "auth.lockout")
 	delete(m, "auth.minPasswordLength")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1136,6 +1136,11 @@
         }
       ]
     },
+    "auth.dailyEmailDomainSignupLimit": {
+      "type": "integer",
+      "default": 0,
+      "description": "The maximum number of users that can sign from Google using the same email domain in a 24 hour period."
+    },
     "auth.accessTokens": {
       "description": "Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.",
       "type": "object",


### PR DESCRIPTION
1. Add logic to auto-disable Google signups from non-Gmail domains during a 24-hour window if too many (> 30) signups from the same domain.
2. Check if is email domain is banned based on SRC_EMAIL_DOMAIN_DENY_LIST for social logins as well. Currently only used for user password signup.


## Test plan
.
