### PR TITLE
sg msp: 'init-env' fixes

### DIFF
--- a/dev/sg/msp/example/example_test.go
+++ b/dev/sg/msp/example/example_test.go
@@ -117,7 +117,7 @@ func TestNewJob(t *testing.T) {
   id: msp-example
   name: Msp Example
   owners:
-  - core-services
+    - core-services
 
 build:
   # TODO: Configure the correct image for your job here. If you use a private
@@ -130,29 +130,29 @@ build:
     dir: cmd/msp-example
 
 environments:
-- id: dev
-  projectID: msp-example-dev-TestNewJob
-  # TODO: We initially provision in 'test' to make it easy to access the project
-  # during setup. Once done, you should change this to 'external' or 'internal'.
-  category: test
-  # Specify a strategy for updating the image.
-  deploy:
-    type: manual
-    manual:
-      tag: insiders
-  # Specify the schedule at which to run your job.
-  schedule:
-    cron: 0 * * * *
-    deadline: 600 # 10 minutes
-  # Specify environment configuration your service needs to operate.
-  env:
-    SRC_LOG_LEVEL: info
-    SRC_LOG_FORMAT: json_gcp
-  # Specify the resources your job gets.
-  instances:
-    resources:
-      cpu: 1
-      memory: 1Gi
+  - id: dev
+    projectID: msp-example-dev-TestNewJob
+    # TODO: We initially provision in 'test' to make it easy to access the project
+    # during setup. Once done, you should change this to 'external' or 'internal'.
+    category: test
+    # Specify a strategy for updating the image.
+    deploy:
+      type: manual
+      manual:
+        tag: insiders
+    # Specify the schedule at which to run your job.
+    schedule:
+      cron: 0 * * * *
+      deadline: 600 # 10 minutes
+    # Specify environment configuration your service needs to operate.
+    env:
+      SRC_LOG_LEVEL: info
+      SRC_LOG_FORMAT: json_gcp
+    # Specify the resources your job gets.
+    instances:
+      resources:
+        cpu: 1
+        memory: 1Gi
 `).Equal(t, string(f))
 
 	t.Run("is valid", func(t *testing.T) {

--- a/dev/sg/msp/example/example_test.go
+++ b/dev/sg/msp/example/example_test.go
@@ -45,7 +45,7 @@ func TestNewService(t *testing.T) {
   id: msp-example
   name: Msp Example
   owners:
-  - core-services
+    - core-services
 
 build:
   # TODO: Configure the correct image for your service here. If you use a private
@@ -58,37 +58,37 @@ build:
     dir: cmd/msp-example
 
 environments:
-- id: dev
-  projectID: msp-example-dev-TestNewService
-  # TODO: We initially provision in 'test' to make it easy to access the project
-  # during setup. Once done, you should change this to 'external' or 'internal'.
-  category: test
-  # Specify a deployment strategy for upgrades.
-  deploy:
-    type: manual
-    manual:
-      tag: insiders
-  # Specify an externally facing domain.
-  domain:
-    type: cloudflare
-    cloudflare:
-      subdomain: msp-example
-      zone: sgdev.org
-  # Specify environment configuration your service needs to operate.
-  env:
-    SRC_LOG_LEVEL: info
-    SRC_LOG_FORMAT: json_gcp
-  # Specify how your service should scale.
-  instances:
-    resources:
-      cpu: 1
-      memory: 1Gi
-    scaling:
-      maxCount: 3
-      minCount: 1
-  startupProbe:
-    # Only enable if your service implements MSP /-/healthz conventions.
-    disabled: true
+  - id: dev
+    projectID: msp-example-dev-TestNewService
+    # TODO: We initially provision in 'test' to make it easy to access the project
+    # during setup. Once done, you should change this to 'external' or 'internal'.
+    category: test
+    # Specify a deployment strategy for upgrades.
+    deploy:
+      type: manual
+      manual:
+        tag: insiders
+    # Specify an externally facing domain.
+    domain:
+      type: cloudflare
+      cloudflare:
+        subdomain: msp-example
+        zone: sgdev.org
+    # Specify environment configuration your service needs to operate.
+    env:
+      SRC_LOG_LEVEL: info
+      SRC_LOG_FORMAT: json_gcp
+    # Specify how your service should scale.
+    instances:
+      resources:
+        cpu: 1
+        memory: 1Gi
+      scaling:
+        maxCount: 3
+        minCount: 1
+    startupProbe:
+      # Only enable if your service implements MSP /-/healthz conventions.
+      disabled: true
 `).Equal(t, string(f))
 
 	t.Run("is valid", func(t *testing.T) {

--- a/dev/sg/msp/example/job.template.yaml
+++ b/dev/sg/msp/example/job.template.yaml
@@ -3,7 +3,7 @@ service:
   id: {{ .ID }}
   name: {{ .Name }}
   owners:
-  - {{ .Owner }}
+    - {{ .Owner }}
 
 build:
   # TODO: Configure the correct image for your job here. If you use a private
@@ -16,26 +16,26 @@ build:
     dir: cmd/{{ .ID }}
 
 environments:
-- id: {{ if .Dev }}dev{{ else }}prod{{ end }}
-  projectID: {{ if .Dev }}{{ newProjectID .ID "dev" .ProjectIDSuffixLength }}{{ else }}{{ newProjectID .ID "dev" .ProjectIDSuffixLength }}{{ end }}
-  # TODO: We initially provision in 'test' to make it easy to access the project
-  # during setup. Once done, you should change this to 'external' or 'internal'.
-  category: test
-  # Specify a strategy for updating the image.
-  deploy:
-    type: manual
-    manual:
-      tag: insiders
-  # Specify the schedule at which to run your job.
-  schedule:
-    cron: 0 * * * *
-    deadline: 600 # 10 minutes
-  # Specify environment configuration your service needs to operate.
-  env:
-    SRC_LOG_LEVEL: info
-    SRC_LOG_FORMAT: json_gcp
-  # Specify the resources your job gets.
-  instances:
-    resources:
-      cpu: 1
-      memory: 1Gi
+  - id: {{ if .Dev }}dev{{ else }}prod{{ end }}
+    projectID: {{ if .Dev }}{{ newProjectID .ID "dev" .ProjectIDSuffixLength }}{{ else }}{{ newProjectID .ID "dev" .ProjectIDSuffixLength }}{{ end }}
+    # TODO: We initially provision in 'test' to make it easy to access the project
+    # during setup. Once done, you should change this to 'external' or 'internal'.
+    category: test
+    # Specify a strategy for updating the image.
+    deploy:
+      type: manual
+      manual:
+        tag: insiders
+    # Specify the schedule at which to run your job.
+    schedule:
+      cron: 0 * * * *
+      deadline: 600 # 10 minutes
+    # Specify environment configuration your service needs to operate.
+    env:
+      SRC_LOG_LEVEL: info
+      SRC_LOG_FORMAT: json_gcp
+    # Specify the resources your job gets.
+    instances:
+      resources:
+        cpu: 1
+        memory: 1Gi

--- a/dev/sg/msp/example/service.template.yaml
+++ b/dev/sg/msp/example/service.template.yaml
@@ -2,7 +2,7 @@ service:
   id: {{ .ID }}
   name: {{ .Name }}
   owners:
-  - {{ .Owner }}
+    - {{ .Owner }}
 
 build:
   # TODO: Configure the correct image for your service here. If you use a private
@@ -15,34 +15,34 @@ build:
     dir: cmd/{{ .ID }}
 
 environments:
-- id: {{ if .Dev }}dev{{ else }}prod{{ end }}
-  projectID: {{ if .Dev }}{{ newProjectID .ID "dev" .ProjectIDSuffixLength }}{{ else }}{{ newProjectID .ID "dev" .ProjectIDSuffixLength }}{{ end }}
-  # TODO: We initially provision in 'test' to make it easy to access the project
-  # during setup. Once done, you should change this to 'external' or 'internal'.
-  category: test
-  # Specify a deployment strategy for upgrades.
-  deploy:
-    type: manual
-    manual:
-      tag: insiders
-  # Specify an externally facing domain.
-  domain:
-    type: cloudflare
-    cloudflare:
-      subdomain: {{ .ID }}
-      zone: {{ if .Dev }}sgdev.org{{ else }}sourcegraph.com{{ end }}
-  # Specify environment configuration your service needs to operate.
-  env:
-    SRC_LOG_LEVEL: info
-    SRC_LOG_FORMAT: json_gcp
-  # Specify how your service should scale.
-  instances:
-    resources:
-      cpu: 1
-      memory: 1Gi
-    scaling:
-      maxCount: 3
-      minCount: 1
-  startupProbe:
-    # Only enable if your service implements MSP /-/healthz conventions.
-    disabled: true
+  - id: {{ if .Dev }}dev{{ else }}prod{{ end }}
+    projectID: {{ if .Dev }}{{ newProjectID .ID "dev" .ProjectIDSuffixLength }}{{ else }}{{ newProjectID .ID "dev" .ProjectIDSuffixLength }}{{ end }}
+    # TODO: We initially provision in 'test' to make it easy to access the project
+    # during setup. Once done, you should change this to 'external' or 'internal'.
+    category: test
+    # Specify a deployment strategy for upgrades.
+    deploy:
+      type: manual
+      manual:
+        tag: insiders
+    # Specify an externally facing domain.
+    domain:
+      type: cloudflare
+      cloudflare:
+        subdomain: {{ .ID }}
+        zone: {{ if .Dev }}sgdev.org{{ else }}sourcegraph.com{{ end }}
+    # Specify environment configuration your service needs to operate.
+    env:
+      SRC_LOG_LEVEL: info
+      SRC_LOG_FORMAT: json_gcp
+    # Specify how your service should scale.
+    instances:
+      resources:
+        cpu: 1
+        memory: 1Gi
+      scaling:
+        maxCount: 3
+        minCount: 1
+    startupProbe:
+      # Only enable if your service implements MSP /-/healthz conventions.
+      disabled: true

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -143,7 +143,7 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 				if err != nil {
 					return err
 				}
-				envID := c.Args().Get(0)
+				envID := c.Args().Get(1)
 				if envID == "" {
 					return errors.New("second argument <environment ID> is required")
 				}
@@ -160,7 +160,7 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 					return errors.Wrap(err, "example.NewEnvironment")
 				}
 
-				specPath := msprepo.ServiceYAMLPath(msprepo.ServiceYAMLPath(svc.Service.ID))
+				specPath := msprepo.ServiceYAMLPath(svc.Service.ID)
 				specData, err := os.ReadFile(specPath)
 				if err != nil {
 					return errors.Wrap(err, "ReadFile")


### PR DESCRIPTION
Fix path generation and arguments from https://github.com/sourcegraph/sourcegraph/pull/59220 for the `sg msp init-env` command.

Also updates the initial example service spec to match the one generated from writing the YAML back to disk - there's not too much control over the indentation offered by the library.

## Test plan

```
sg msp init-env pings dev
```