### PR TITLE
fix jetbrains plugin url

### DIFF
--- a/client/web/src/cody/onboarding/instructions/JetBrains.tsx
+++ b/client/web/src/cody/onboarding/instructions/JetBrains.tsx
@@ -34,7 +34,7 @@ export function JetBrainsInstructions({
                                 <div>
                                     <Text className="mb-1" weight="bold">
                                         Open the Plugins Page (or via the{' '}
-                                        <Link to="https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai">
+                                        <Link to="https://plugins.jetbrains.com/plugin/9682-sourcegraph-cody--code-search">
                                             JetBrains Marketplace
                                         </Link>
                                         )


### PR DESCRIPTION
Updated the URL, the original one leads to VS Code plugin and not a JetBrains one.

## Test plan
previewed locally
