### PR TITLE
Notebooks: fix highlighted code

### DIFF
--- a/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
+++ b/client/web/src/notebooks/blocks/file/NotebookFileBlock.tsx
@@ -81,7 +81,9 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
         const hideInputs = useCallback(() => setShowInputs(false), [setShowInputs])
 
         const isFileSelected = input.repositoryName.length > 0 && input.filePath.length > 0
-        const blobLines = useObservable(useMemo(() => output?.pipe(startWith(LOADING)) ?? of(undefined), [output]))
+        const highlightedLines = useObservable(
+            useMemo(() => output?.pipe(startWith(LOADING)) ?? of(undefined), [output])
+        )
         const commonMenuActions = useCommonBlockMenuActions({ id, isReadOnly, ...props })
         const fileURL = useMemo(
             () =>
@@ -186,19 +188,20 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
                         {...props}
                     />
                 )}
-                {blobLines && blobLines === LOADING && (
+                {highlightedLines && highlightedLines === LOADING && (
                     <div className="d-flex justify-content-center py-3">
                         <LoadingSpinner inline={false} />
                     </div>
                 )}
-                {blobLines && blobLines !== LOADING && !isErrorLike(blobLines) && (
+                {highlightedLines && highlightedLines !== LOADING && !isErrorLike(highlightedLines) && (
                     <div>
                         <CodeExcerpt
                             className={styles.code}
                             repoName={input.repositoryName}
                             commitID={input.revision}
                             filePath={input.filePath}
-                            plaintextLines={blobLines}
+                            plaintextLines={[]}
+                            highlightedLines={highlightedLines}
                             highlightRanges={[]}
                             startLine={input.lineRange?.startLine ?? 0}
                             endLine={input.lineRange?.endLine ?? 1}
@@ -206,9 +209,9 @@ export const NotebookFileBlock: React.FunctionComponent<React.PropsWithChildren<
                         />
                     </div>
                 )}
-                {blobLines && blobLines !== LOADING && isErrorLike(blobLines) && (
+                {highlightedLines && highlightedLines !== LOADING && isErrorLike(highlightedLines) && (
                     <Alert className="m-3" variant="danger">
-                        {blobLines.message}
+                        {highlightedLines.message}
                     </Alert>
                 )}
             </NotebookBlock>

--- a/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
+++ b/client/web/src/notebooks/blocks/symbol/NotebookSymbolBlock.tsx
@@ -196,7 +196,8 @@ export const NotebookSymbolBlock: React.FunctionComponent<React.PropsWithChildre
                                 repoName={input.repositoryName}
                                 commitID={input.revision}
                                 filePath={input.filePath}
-                                plaintextLines={symbolOutput.highlightedLines}
+                                plaintextLines={[]}
+                                highlightedLines={symbolOutput.highlightedLines}
                                 highlightRanges={[symbolOutput.highlightSymbolRange]}
                                 {...symbolOutput.highlightLineRange}
                                 onCopy={logEventOnCopy}


### PR DESCRIPTION
The changes to `CodeExcerpt` rendering broke notebooks rendering of code for file blocks and symbol blocks. This fixes the rendering of highlighted code in notebooks by passing in the highlighted code as `highlightedLines` rather than `plaintextLines`.

Fixes https://github.com/sourcegraph/sourcegraph/issues/59252

## Test plan

![CleanShot 2024-01-01 at 13 55 53@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/dd208f10-6143-4748-bb18-182731271a7a)
