### PR TITLE
Adjust license anomalies checks

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"sync/atomic"
-	"text/template"
 	"time"
 
 	"github.com/derision-test/glock"

--- a/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
@@ -131,7 +131,7 @@ SELECT EXTRACT(EPOCH FROM p50)::int AS p50_seconds FROM percentiles
 `
 
 const slackMessageFmt = `
-The license key ID <%s/site-admin/dotcom/product/subscriptions/%s#%s|%s> seems to be used on multiple customer instances with the same site ID: "%s.
+The license key ID <%s/site-admin/dotcom/product/subscriptions/%s#%s|%s> seems to be used on multiple customer instances with the same site ID: "%s".
 
 To fix it, <https://app.golinks.io/internal-licensing-faq-slack-multiple|follow the guide to update the siteID and license key for all customer instances>.
 `
@@ -147,7 +147,7 @@ func checkP50CallTimeForLicense(ctx context.Context, logger log.Logger, db datab
 		return
 	}
 
-	q := sqlf.Sprintf(percentileTimeDiffQuery, clock.Now().UTC(), *license.SiteID)
+	q := sqlf.Sprintf(percentileTimeDiffQuery, clock.Now().UTC(), license.LicenseKey, *license.SiteID)
 	timeDiff, ok, err := basestore.ScanFirstNullInt64(db.Handle().QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...))
 	if err != nil {
 		logger.Error("error getting time difference from event_logs", log.Error(err))

--- a/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_anomaly.go
@@ -141,7 +141,12 @@ To fix this, <https://app.golinks.io/internal-licensing-faq-slack-multiple|follo
 `
 
 func formatSlackMessage(externalURL *url.URL, license *dbLicense) string {
-	return fmt.Sprintf(slackMessageFmt, *license.SiteID, externalURL.String(), url.QueryEscape(license.ProductSubscriptionID), url.QueryEscape(license.ID), license.ID)
+	return fmt.Sprintf(slackMessageFmt,
+		*license.SiteID,
+		externalURL.String(),
+		url.QueryEscape(license.ProductSubscriptionID),
+		url.QueryEscape(license.ID),
+		license.ID)
 }
 
 // checkP50CallTimeForLicense checks the p50 time difference between license-check calls for a specific license.

--- a/cmd/frontend/internal/dotcom/productsubscription/license_anomaly_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_anomaly_test.go
@@ -163,7 +163,7 @@ func TestCheckAnomalies(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	slackMessage := fmt.Sprintf(slackMessageFmt, "https://sourcegraph.acme.com", url.QueryEscape(sub2ID), url.QueryEscape(licenseID), licenseID, siteID)
+	slackMessage := fmt.Sprintf(slackMessageFmt, "could not load customer name", siteID, "https://sourcegraph.acme.com", url.QueryEscape(sub2ID), url.QueryEscape(licenseID), licenseID)
 
 	tests := []struct {
 		name      string

--- a/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/license_check_handler.go
@@ -191,7 +191,7 @@ func NewLicenseCheckHandler(db database.DB) http.Handler {
 		}
 
 		if license.SiteID == nil {
-			if license, err = lStore.AssignSiteID(r.Context(), license, siteID); err != nil {
+			if _, err = lStore.AssignSiteID(r.Context(), license, siteID); err != nil {
 				logger.Warn("failed to assign site ID to license")
 				replyWithJSON(w, http.StatusInternalServerError, licensing.LicenseCheckResponse{
 					Error: ErrFailedToAssignSiteIDMsg,

--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
@@ -92,7 +92,6 @@ func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey strin
 	}
 
 	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
-
 		// Log an event when a license is created in DotCom
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseCreated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
 			log.Error(err)
@@ -175,7 +174,7 @@ func (s dbLicenses) GetByID(ctx context.Context, id string) (*dbLicense, error) 
 	return results[0], nil
 }
 
-// GetByLicenseKey retrieves the product license (if any) given its check license token.
+// GetByAccessToken retrieves the product license (if any) given its check license token.
 // The accessToken is of the format created by GenerateLicenseKeyBasedAccessToken.
 //
 // 🚨 SECURITY: The caller must ensure that errTokenInvalid error is handled appropriately
@@ -198,7 +197,7 @@ func (s dbLicenses) GetByAccessToken(ctx context.Context, accessToken string) (*
 	return results[0], nil
 }
 
-// GetByID retrieves the product license (if any) given its license key.
+// GetByLicenseKey retrieves the product license (if any) given its license key.
 func (s dbLicenses) GetByLicenseKey(ctx context.Context, licenseKey string) (*dbLicense, error) {
 	if mocks.licenses.GetByLicenseKey != nil {
 		return mocks.licenses.GetByLicenseKey(licenseKey)
@@ -348,8 +347,7 @@ ORDER BY created_at DESC
 	}
 
 	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
-
-		//Log an event when liscenses list is viewed in Dotcom
+		// Log an event when liscenses list is viewed in Dotcom
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", q.Args()); err != nil {
 			log.Error(err)
 		}

--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
@@ -265,19 +265,26 @@ func (s dbLicenses) Active(ctx context.Context, subscriptionID string) (*dbLicen
 	return licenses[0], nil
 }
 
-// AssignSiteID marks the existing license as used by a specific siteID
-func (s dbLicenses) AssignSiteID(ctx context.Context, id, siteID string) error {
+// AssignSiteID marks the existing license as used by a specific siteID, and
+// returns the updated license. The original dbLicense struct is modified.
+func (s dbLicenses) AssignSiteID(ctx context.Context, license *dbLicense, siteID string) (*dbLicense, error) {
 	q := sqlf.Sprintf(`
 UPDATE product_licenses
 SET site_id = %s
 WHERE id = %s
 	`,
 		siteID,
-		id,
+		license.ID,
 	)
 
 	_, err := s.db.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
-	return err
+	if err != nil {
+		return nil, err
+	}
+
+	license.SiteID = &siteID
+
+	return license, nil
 }
 
 // List lists all product licenses that satisfy the options.
@@ -347,7 +354,7 @@ ORDER BY created_at DESC
 	}
 
 	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
-		// Log an event when liscenses list is viewed in Dotcom
+		// Log an event when liscense list is viewed in Dotcom
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", q.Args()); err != nil {
 			log.Error(err)
 		}

--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -165,7 +165,7 @@ func TestAssignSiteID(t *testing.T) {
 	license := insertLicense(t, ctx, db, u, "key")
 
 	siteID := uuid.NewString()
-	err = store.AssignSiteID(ctx, license.ID, siteID)
+	_, err = store.AssignSiteID(ctx, license, siteID)
 	require.NoError(t, err)
 
 	license, err = store.GetByID(ctx, license.ID)
@@ -267,7 +267,7 @@ func TestProductLicenses_List(t *testing.T) {
 			require.NoError(t, err)
 		}
 		if l.siteID != "" {
-			err = store.AssignSiteID(ctx, id, l.siteID)
+			_, err = store.AssignSiteID(ctx, &dbLicense{ID: id}, l.siteID)
 			require.NoError(t, err)
 		}
 	}

--- a/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -88,7 +88,6 @@ INSERT INTO product_subscriptions(id, user_id, account_number) VALUES($1, $2, $3
 		return "", errors.Wrap(err, "insert")
 	}
 	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
-
 		// Log an event when a new subscription is created.
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionCreated, "", uint32(userID), "", "BACKEND", newUUID); err != nil {
 			log.Error(err)
@@ -142,8 +141,7 @@ func (s dbSubscriptions) List(ctx context.Context, opt dbSubscriptionsListOption
 		return mocks.subscriptions.List(ctx, opt)
 	}
 	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
-
-		//Log an event when a list of subscriptions is requested.
+		// Log an event when a list of subscriptions is requested.
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionsListed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", opt); err != nil {
 			log.Error(err)
 		}
@@ -295,7 +293,6 @@ func (s dbSubscriptions) Update(ctx context.Context, id string, update dbSubscri
 		return errSubscriptionNotFound
 	}
 	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
-
 		// Log an event when a subscription is updated
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
 			log.Error(err)
@@ -324,7 +321,6 @@ func (s dbSubscriptions) Archive(ctx context.Context, id string) error {
 		return errSubscriptionNotFound
 	}
 	if featureflag.FromContext(ctx).GetBoolOr("auditlog-expansion", false) {
-
 		// Log an event when a subscription is archived
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionArchived, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
 			log.Error(err)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -866,6 +866,16 @@ type User struct {
 	CodyProEnabledAt      *time.Time
 }
 
+// Returns a name for the user. If the user has a display name,
+// that is returned, otherwise their username is returned.
+func (u *User) Name() string {
+	if u.DisplayName != "" {
+		return u.DisplayName
+	}
+
+	return u.Username
+}
+
 // UserForSCIM extends user with email addresses and SCIM external ID.
 type UserForSCIM struct {
 	User

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -866,7 +866,7 @@ type User struct {
 	CodyProEnabledAt      *time.Time
 }
 
-// Returns a name for the user. If the user has a display name,
+// Name returns a name for the user. If the user has a display name,
 // that is returned, otherwise their username is returned.
 func (u *User) Name() string {
 	if u.DisplayName != "" {


### PR DESCRIPTION
This PR reworks the way we do our license checks a bit with the following goals:

- Have license checks be less noisy
- Ensure license alerts are actionable

Originally, once a site ID was assigned to a license key, it would be permanently assigned and any pings from a new license key would trigger alerts. However, there are valid reasons under which a customer's site ID could change, such as them redeploying Sourcegraph.

In cases where customers are using the same license key on their dev and prod instances, the only way to fix this would be for someone to issue **two** new license keys for the customer: one for each instance. This is because the license key would be claimed by the dev instance, and then be rendered useless to any other instance without some SQL magic.

**AFTER THIS PR**

We now assign the site ID from the latest ping to the license key and send an alert in our Slack channel whenever a site ID associated with a license key changes. This solves two issues:

- Customer can redeploy Sourcegraph and use the same license key. We will only receive one alert when this happens, but this is perfectly reasonable.
- If we repeatedly receive site ID change alerts for the same customer, it means the license key is being shared between two instances. This issue can be resolved by simply  issuing a (possibly more limited) dev license key to customers, after which the alerts will stop and the prod instance will claim the correct license key instead.

We also have a bit more detail about who the license key belongs to to make it easier to follow up with.

## Test plan

Unit tests adjusted

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
