### PR TITLE
Mock current time for stability

### DIFF
--- a/client/branded/src/components/Timestamp/Timestamp.test.tsx
+++ b/client/branded/src/components/Timestamp/Timestamp.test.tsx
@@ -4,20 +4,26 @@ import { describe, expect, test } from 'vitest'
 import { Timestamp, TimestampFormat } from './Timestamp'
 
 describe('Timestamp', () => {
-    test('mocked current time', () => expect(render(<Timestamp date="2006-01-02" />).asFragment()).toMatchSnapshot())
+    const getDate = () => new Date('2023-12-11')
+
+    test('mocked current time', () =>
+        expect(render(<Timestamp date="2006-01-02" now={getDate} />).asFragment()).toMatchSnapshot())
 
     test('with time time', () =>
-        expect(render(<Timestamp date="2006-01-02T01:02:00Z" />).asFragment()).toMatchSnapshot())
+        expect(render(<Timestamp date="2006-01-02T01:02:00Z" now={getDate} />).asFragment()).toMatchSnapshot())
 
-    test('noAbout', () => expect(render(<Timestamp date="2006-01-02" noAbout={true} />).asFragment()).toMatchSnapshot())
+    test('noAbout', () =>
+        expect(render(<Timestamp date="2006-01-02" now={getDate} noAbout={true} />).asFragment()).toMatchSnapshot())
 
-    test('noAgo', () => expect(render(<Timestamp date="2006-01-02" noAgo={true} />).asFragment()).toMatchSnapshot())
+    test('noAgo', () =>
+        expect(render(<Timestamp date="2006-01-02" now={getDate} noAgo={true} />).asFragment()).toMatchSnapshot())
 
     test('absolute time with formatting', () =>
         expect(
             render(
                 <Timestamp
                     date="2006-01-02T01:02:00Z"
+                    now={getDate}
                     timestampFormat={TimestampFormat.FULL_TIME}
                     preferAbsolute={true}
                 />


### PR DESCRIPTION
Mocks current time for snapshot tests stability.

Reported in [this](https://sourcegraph.slack.com/archives/C07KZF47K/p1704194857934479) Slack thread.

## Test plan
- CI passes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
