### PR TITLE
nix: use interactive bash instead of non-interactive in shell

### DIFF
--- a/dev/nix/nodejs.nix
+++ b/dev/nix/nodejs.nix
@@ -15,7 +15,7 @@ pkgs.nodejs_20.overrideAttrs (oldAttrs: {
     };
     # fetching typescript 5.2.2 from npm registry results in an archive with a missing package-lock.json, which nix
     # refuses to build without. We can generate this lock file with `npm install --package-lock-only` but at the time I didn't
-    # want to vendor the file. Fortunately, nixpkgs-unstable has typescript at 5.3.2
-    typescript = assert typescript.version == "5.3.2"; typescript;
+    # want to vendor the file. Fortunately, nixpkgs-unstable has typescript at 5.3.3
+    typescript = assert typescript.version == "5.3.3"; typescript;
   });
 })

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701336116,
-        "narHash": "sha256-kEmpezCR/FpITc6yMbAh4WrOCiT2zg5pSjnKrq51h5Y=",
+        "lastModified": 1704008649,
+        "narHash": "sha256-rGPSWjXTXTurQN9beuHdyJhB8O761w1Zc5BqSSmHvoM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5c27c6136db4d76c30e533c20517df6864c46ee",
+        "rev": "d44d59d2b5bd694cd9d996fd8c51d03e3e9ba7f7",
         "type": "github"
       },
       "original": {

--- a/shell.nix
+++ b/shell.nix
@@ -69,6 +69,8 @@ mkShell {
 
   # The packages in the `buildInputs` list will be added to the PATH in our shell
   nativeBuildInputs = with pkgs; [
+    bashInteractive
+
     # nix language server.
     nil
 
@@ -135,7 +137,7 @@ mkShell {
   # Some of the bazel actions require some tools assumed to be in the PATH defined by the "strict action env" that we enable
   # through --incompatible_strict_action_env. We can poke a custom PATH through with --action_env=PATH=$BAZEL_ACTION_PATH.
   # See https://sourcegraph.com/github.com/bazelbuild/bazel@6.1.2/-/blob/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java?L532-547
-  BAZEL_ACTION_PATH = with pkgs; lib.makeBinPath [ bash stdenv.cc coreutils unzip zip curl gzip gnutar gnugrep gnused git patch openssh findutils perl python39 which ];
+  BAZEL_ACTION_PATH = with pkgs; lib.makeBinPath [ bashInteractive stdenv.cc coreutils unzip zip curl gzip gnutar gnugrep gnused git patch openssh findutils perl python39 which ];
 
   # bazel complains when the bazel version differs even by a patch version to whats defined in .bazelversion,
   # so we tell it to h*ck off here.


### PR DESCRIPTION
standard bash is a non-interactive shell meant for a build environment instead of an interactive environment.

Also bumping nixpkgs while we're here

## Test plan

run `bash` in `nix develop` 