### PR TITLE
fix: replace 'replace' with 'edit'

### DIFF
--- a/doc/cody/capabilities/commands.md
+++ b/doc/cody/capabilities/commands.md
@@ -214,7 +214,7 @@ See the [examples](#examples) and [configuration properties](#configuration-prop
   - `"ask"` — Focus the chat view and add to the current chat
   - `"inline"` — Start a new inline chat
   - `"insert"` — Insert the response above the code
-  - `"replace"` — Replace the code with the response
+  - `"edit"` — Edit highlighted code with the response
 
 #### `commands.<id>.context`
 


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/2186

There is no `replace` mode in custom command. The correct mode should be `edit`: https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/lib/shared/src/chat/prompts/index.ts?L81


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

This is a doc update