### PR TITLE
Allow last_used_at to be semi-stale

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
@@ -2,10 +2,14 @@ package productsubscription
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"strings"
+	"time"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -83,33 +87,56 @@ func (e dotcomUserNotFoundError) NotFound() bool {
 	return true
 }
 
-// LookupDotcomUserIDByAccessToken returns the userID
-// corresponding to a token, trimming token prefixes if there are any.
+// LookupDotcomUserIDByAccessToken returns the userID corresponding to the given token.
+// Requires the token has the DotcomUserGatewayAccessTokenPrefix, otherwise fails.
 func (t dbTokens) LookupDotcomUserIDByAccessToken(ctx context.Context, token string) (int, error) {
 	if !strings.HasPrefix(token, accesstoken.DotcomUserGatewayAccessTokenPrefix) {
 		return 0, dotcomUserNotFoundError{reason: "invalid token with unknown prefix"}
 	}
-	decoded, err := hex.DecodeString(strings.TrimPrefix(token, accesstoken.DotcomUserGatewayAccessTokenPrefix))
+	rawToken := strings.TrimPrefix(token, accesstoken.DotcomUserGatewayAccessTokenPrefix)
+	decoded, err := hex.DecodeString(rawToken)
 	if err != nil {
 		return 0, dotcomUserNotFoundError{reason: "invalid token encoding"}
 	}
 
+	// Query the token's id, subject_user_id, and last_used_at.
 	query := sqlf.Sprintf(`
-UPDATE access_tokens t SET last_used_at=now()
-WHERE t.id IN (
-	SELECT t2.id FROM access_tokens t2
-	JOIN users subject_user ON t2.subject_user_id=subject_user.id AND subject_user.deleted_at IS NULL
-	JOIN users creator_user ON t2.creator_user_id=creator_user.id AND creator_user.deleted_at IS NULL
-	WHERE digest(value_sha256, 'sha256')=%s AND t2.deleted_at IS NULL
-)
-RETURNING t.subject_user_id`,
-		decoded,
+	SELECT t.id, t.subject_user_id, t.last_used_at
+	FROM access_tokens t
+	WHERE t.id IN (
+		SELECT t2.id
+		FROM access_tokens t2
+		JOIN users subject_user ON t2.subject_user_id=subject_user.id AND subject_user.deleted_at IS NULL
+		JOIN users creator_user ON t2.creator_user_id=creator_user.id AND creator_user.deleted_at IS NULL
+		WHERE digest(value_sha256, 'sha256')=%s AND t2.deleted_at IS NULL
+	)`,
+		decoded)
+
+	var (
+		tokenID    int64
+		subjectID  int
+		lastUsedAt time.Time
 	)
-	userID, found, err := basestore.ScanFirstInt(t.store.Query(ctx, query))
+	row := t.store.QueryRow(ctx, query)
+	err = row.Scan(&tokenID, &subjectID, &lastUsedAt)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, dotcomUserNotFoundError{reason: "no associated token"}
+		}
 		return 0, err
-	} else if !found {
-		return 0, dotcomUserNotFoundError{reason: "no associated token"}
 	}
-	return userID, nil
+
+	// If the token hasn't been used recently, update the last_used_at value
+	// so indicate it is still in-use.
+	if time.Since(lastUsedAt) > database.MaxAccessTokenLastUsedAtAge {
+		// We ignore the error on updating the token, since hopefully we can just
+		// update the last used at time successfully the next time the token gets used.
+		updateQuery := sqlf.Sprintf(
+			`UPDATE access_tokens t SET last_used_at=now()
+			WHERE t.id=%d AND t.deleted_at IS NULL`,
+			tokenID)
+		_ = t.store.Exec(ctx, updateQuery)
+	}
+
+	return subjectID, nil
 }

--- a/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
-	"errors"
 	"strings"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"

--- a/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
@@ -115,7 +115,7 @@ func (t dbTokens) LookupDotcomUserIDByAccessToken(ctx context.Context, token str
 	var (
 		tokenID    int64
 		subjectID  int
-		lastUsedAt time.Time
+		lastUsedAt *time.Time
 	)
 	row := t.store.QueryRow(ctx, query)
 	err = row.Scan(&tokenID, &subjectID, &lastUsedAt)
@@ -128,7 +128,7 @@ func (t dbTokens) LookupDotcomUserIDByAccessToken(ctx context.Context, token str
 
 	// If the token hasn't been used recently, update the last_used_at value
 	// so indicate it is still in-use.
-	if time.Since(lastUsedAt) > database.MaxAccessTokenLastUsedAtAge {
+	if lastUsedAt == nil || time.Since(*lastUsedAt) > database.MaxAccessTokenLastUsedAtAge {
 		// We ignore the error on updating the token, since hopefully we can just
 		// update the last used at time successfully the next time the token gets used.
 		updateQuery := sqlf.Sprintf(

--- a/cmd/frontend/internal/dotcom/productsubscription/tokens_db_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/tokens_db_test.go
@@ -97,7 +97,8 @@ func TestLookupProductSubscriptionIDByAccessToken(t *testing.T) {
 
 		dbTokens := newDBTokens(db)
 
-		// Confirm that a side effect of LookupDotcomUserIDByAccessToken sets last_used_at.
+		// Call LookupDotcomUserIDByAccessToken. This will have a side-effect of updating the
+		// token's last_used_at column.
 		token, err := accesstoken.GenerateDotcomUserGatewayAccessToken(testTokenValue)
 		if err != nil {
 			t.Fatalf("Generating dotcom user gateway token: %v", err)

--- a/cmd/frontend/internal/dotcom/productsubscription/tokens_db_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/tokens_db_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/license"
@@ -57,5 +58,74 @@ func TestLookupProductSubscriptionIDByAccessToken(t *testing.T) {
 		gotPS, err := newDBTokens(db).LookupProductSubscriptionIDByAccessToken(ctx, accessToken)
 		require.NoError(t, err)
 		assert.Equal(t, gotPS, ps)
+	})
+
+	t.Run("last_used_at Updates", func(t *testing.T) {
+		// Create a new access token.
+		subject, err := db.Users().Create(ctx, database.NewUser{
+			Email:                 "u1@example.com",
+			Username:              "u1",
+			Password:              "p1",
+			EmailVerificationCode: "c1",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		creator, err := db.Users().Create(ctx, database.NewUser{
+			Email:                 "u2@example.com",
+			Username:              "u2",
+			Password:              "p2",
+			EmailVerificationCode: "c2",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testTokenID, testTokenValue, err := db.AccessTokens().Create(ctx, subject.ID, []string{"a", "b", "c"}, "n0", creator.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Fetches the test access token. Confirm its default state has last_used_at of nil.
+		initialToken, err := db.AccessTokens().GetByID(ctx, testTokenID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if initialToken.LastUsedAt != nil {
+			t.Fatal("last_used_at was not nil upon token creation")
+		}
+
+		dbTokens := newDBTokens(db)
+
+		// Confirm that a side effect of LookupDotcomUserIDByAccessToken sets last_used_at.
+		token, err := accesstoken.GenerateDotcomUserGatewayAccessToken(testTokenValue)
+		if err != nil {
+			t.Fatalf("Generating dotcom user gateway token: %v", err)
+		}
+		gotUserID, err := dbTokens.LookupDotcomUserIDByAccessToken(ctx, token)
+		if err != nil {
+			t.Fatalf("Looking up dotcom User by Access Token: %v", err)
+		}
+		if gotUserID != int(subject.ID) {
+			t.Errorf("LookupDotcomUserIDByAccessToken returned unexpected user ID: %d", gotUserID)
+		}
+
+		// Now lookup the token and confirm that last_used_at was updated as expected.
+		currentToken, err := db.AccessTokens().GetByID(ctx, testTokenID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if currentToken.LastUsedAt == nil {
+			t.Fatal("last_used_at was not set after calling LookupDotcomUserIDByAccessToken")
+		}
+		if time.Since(*currentToken.LastUsedAt) > 2*time.Second {
+			t.Errorf("last_used_at was updated, but it seems to have the wrong timestamp.")
+		}
+
+		// Cleanup
+		err = db.AccessTokens().DeleteByID(ctx, testTokenID)
+		if err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -39,6 +39,10 @@ type AccessToken struct {
 // but it does not exist.
 var ErrAccessTokenNotFound = errors.New("access token not found")
 
+// MaxAccessTokenLastUsedAtAge is the maximum amount of time we will wait before updating an access token's
+// last_used_at column. We are OK letting the value get a little stale in order to cut down on database writes.
+const MaxAccessTokenLastUsedAtAge = 5 * time.Minute
+
 // InvalidTokenError is returned when decoding the hex encoded token passed to any
 // of the methods on AccessTokenStore.
 type InvalidTokenError struct {
@@ -125,7 +129,7 @@ type AccessTokenStore interface {
 	//
 	// The token prefix "sgp_", if present, is stripped.
 	//
-	// Calling Lookup also updates the access token's last-used-at date.
+	// Calling Lookup also updates the access token's last-used-at date as applicable.
 	//
 	// 🚨 SECURITY: This returns a user ID if and only if the token corresponds to a valid,
 	// non-deleted access token.
@@ -273,25 +277,35 @@ type TokenLookupOpts struct {
 	RequiredScope string
 }
 
-func (o TokenLookupOpts) ToQuery() string {
+// Returns a query to upload the token's LastUsedAt column to "now". The returned query
+// requires one parameter: the token ID to update.
+func (o TokenLookupOpts) toUpdateLastUsedQuery() string {
+	return `
+	UPDATE access_tokens t SET last_used_at=now()
+	WHERE t.id=$1 AND t.deleted_at IS NULL
+`
+}
+
+// toGetQuery returns a SQL query that will return the following columns from
+// the access_tokens table.
+// - id
+// - subject_user_id
+// - last_used_at
+//
+// The query requires two parameters: the token's value_sha256 and scopes.
+func (o TokenLookupOpts) toGetQuery() string {
 	query := `
-UPDATE access_tokens t SET last_used_at=now()
-WHERE t.id IN (
-	SELECT t2.id FROM access_tokens t2
+	SELECT id, subject_user_id, last_used_at
+	FROM access_tokens t
 	JOIN users subject_user ON t2.subject_user_id=subject_user.id AND subject_user.deleted_at IS NULL
 	JOIN users creator_user ON t2.creator_user_id=creator_user.id AND creator_user.deleted_at IS NULL
-	WHERE t2.value_sha256=$1 AND t2.deleted_at IS NULL AND
-	$2 = ANY (t2.scopes)
-	`
+	WHERE t.value_sha256=$1 AND t.deleted_at IS NULL AND
+	$2 = ANY (t.scopes)
+`
 
 	if o.OnlyAdmin {
 		query += "AND subject_user.site_admin"
 	}
-
-	query += `
-	)
-RETURNING t.subject_user_id
-`
 
 	return query
 }
@@ -306,16 +320,31 @@ func (s *accessTokenStore) Lookup(ctx context.Context, token string, opts TokenL
 		return 0, errors.Wrap(err, "AccessTokens.Lookup")
 	}
 
-	if err := s.Handle().QueryRowContext(ctx,
+	var (
+		tokenID    int64
+		subjectID  int64
+		lastUsedAt time.Time
+	)
+	row := s.Handle().QueryRowContext(ctx,
 		// Ensure that subject and creator users still exist.
-		opts.ToQuery(),
-		tokenHash, opts.RequiredScope,
-	).Scan(&subjectUserID); err != nil {
-		if err == sql.ErrNoRows {
+		opts.toGetQuery(),
+		tokenHash, opts.RequiredScope)
+	err = row.Scan(&tokenID, &subjectID, &lastUsedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrAccessTokenNotFound
 		}
 		return 0, err
 	}
+
+	if time.Until(lastUsedAt) < -MaxAccessTokenLastUsedAtAge {
+		s.logger.Debug("Updating access token's last_used_at value.")
+		_, err := s.Handle().ExecContext(ctx, opts.toUpdateLastUsedQuery(), tokenID)
+		if err != nil {
+			s.logger.Warn("Error trying to update token's last_used_at value.", log.Error(err))
+		}
+	}
+
 	return subjectUserID, nil
 }
 

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -338,10 +338,12 @@ func (s *accessTokenStore) Lookup(ctx context.Context, token string, opts TokenL
 	}
 
 	if lastUsedAt == nil || time.Until(*lastUsedAt) < -MaxAccessTokenLastUsedAtAge {
-		s.logger.Debug("Updating access token's last_used_at value.")
+        logger := s.logger.With(log.Int64("tokenID", tokenID), log.Int32("subjectID", subjectID)) 
 		_, err := s.Handle().ExecContext(ctx, opts.toUpdateLastUsedQuery(), tokenID)
 		if err != nil {
-			s.logger.Warn("Error trying to update token's last_used_at value.", log.Error(err))
+			logger.Warn("error trying to update token's last_used_at value", log.Error(err))
+		} else {
+		    logger.Debug("updated access token's last_used_at value")
 		}
 	}
 

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -338,12 +338,12 @@ func (s *accessTokenStore) Lookup(ctx context.Context, token string, opts TokenL
 	}
 
 	if lastUsedAt == nil || time.Until(*lastUsedAt) < -MaxAccessTokenLastUsedAtAge {
-        logger := s.logger.With(log.Int64("tokenID", tokenID), log.Int32("subjectID", subjectID)) 
+		logger := s.logger.With(log.Int64("tokenID", tokenID), log.Int32("subjectID", subjectID))
 		_, err := s.Handle().ExecContext(ctx, opts.toUpdateLastUsedQuery(), tokenID)
 		if err != nil {
 			logger.Warn("error trying to update token's last_used_at value", log.Error(err))
 		} else {
-		    logger.Debug("updated access token's last_used_at value")
+			logger.Debug("updated access token's last_used_at value")
 		}
 	}
 


### PR DESCRIPTION
It appears that we update a token's `last_used_at` value every time `AccessTokenStore.Lookup` is called. However, this causes far more writes than are useful.

This PR updates `Lookup()` to just have a read-only query, and only update the token's `last_used_at` if it is been greater than five minutes. The tradeoff being the common case of token access will be much faster, but once every five minutes -- or first lookup in a while -- will require 2x database queries. And moving forward the `last_used_at` value may be up to 5m stale.

## Test Plan

Added unit tests for the new functionality.