### PR TITLE
msp/monitoring: fix redis alert

### DIFF
--- a/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
@@ -267,12 +267,10 @@ func redisAlerts(stack cdktf.TerraformStack, id resourceid.ID, vars Variables) e
 			Name:        "Cloud Redis - Standard Instance Failover",
 			Description: pointers.Ptr("This alert fires if failover occurs for a standard tier instance."),
 			ThresholdAggregation: &monitoringalertpolicy.ThresholdAggregation{
-				Filters:       map[string]string{"metric.type": "redis.googleapis.com/stats/cpu_utilization_main_thread"},
-				GroupByFields: []string{"resource.label.instance_id", "resource.label.node_id"},
-				Aligner:       monitoringalertpolicy.MonitoringAlignStddev,
-				Reducer:       monitoringalertpolicy.MonitoringReduceNone,
-				Period:        "300s",
-				Threshold:     0,
+				Filters:   map[string]string{"metric.type": "redis.googleapis.com/replication/role"},
+				Aligner:   monitoringalertpolicy.MonitoringAlignStddev,
+				Period:    "300s",
+				Threshold: 0,
 			},
 		},
 	} {


### PR DESCRIPTION
Extracted from https://github.com/sourcegraph/sourcegraph/pull/59257 - I want to fix this first so that when we roll out https://github.com/sourcegraph/sourcegraph/pull/59257, we don't get hit with a swarm of alerts.

## Test plan

tested in https://github.com/sourcegraph/sourcegraph/pull/59257