### PR TITLE
productsubscription: fix panic on license creation

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//internal/productsubscription",
         "//internal/redispool",
         "//internal/slack",
+        "//internal/trace",
         "//internal/types",
         "//lib/errors",
         "//lib/pointers",

--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
@@ -20,7 +20,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/hashutil"
 	"github.com/sourcegraph/sourcegraph/internal/license"
 	"github.com/sourcegraph/sourcegraph/internal/slack"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 // dbLicense describes an product license row in the product_licenses DB table.
@@ -66,6 +69,10 @@ func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey strin
 		return mocks.licenses.Create(subscriptionID, licenseKey)
 	}
 
+	// TODO: put a logger on dbLicenses and scope from that
+	logger := log.Scoped("dbLicenses.Create")
+	logger = trace.Logger(ctx, logger)
+
 	newUUID, err := uuid.NewRandom()
 	if err != nil {
 		return "", errors.Wrap(err, "new UUID")
@@ -95,13 +102,35 @@ func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey strin
 
 		// Log an event when a license is created in DotCom
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseCreated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
-			log.Error(err)
+			logger.Error("LogSecurityEvent", log.Error(err))
 		}
 	}
 
-	postLicenseCreationToSlack(ctx, subscriptionID, version, expiresAt, info)
+	postLicenseCreationToSlack(ctx, logger, subscriptionID, version, expiresAt, info)
 
 	return id, nil
+}
+
+func postLicenseCreationToSlack(ctx context.Context, logger log.Logger, subscriptionID string, version int, expiresAt *time.Time, info license.Info) {
+	dotcom := conf.Get().Dotcom
+	if dotcom == nil {
+		return
+	}
+
+	licenseCreator, err := actor.FromContext(ctx).User(ctx, database.Users(logger))
+	if err != nil {
+		logger.Error("error looking up license creator user", log.Error(err))
+		return
+	}
+
+	client := slack.New(dotcom.SlackLicenseCreationWebhook)
+	err = client.Post(ctx, &slack.Payload{
+		Text: renderLicenseCreationSlackMessage(licenseCreator, subscriptionID, version, expiresAt, info),
+	})
+	if err != nil {
+		logger.Error("error sending Slack message", log.Error(err))
+		return
+	}
 }
 
 const slackLicenseCreationMessageFmt = `
@@ -119,43 +148,27 @@ Reply with a :approved_stamp: when this is approved
 Reply with a :white_check_mark: when this has been sent to the customer
 `
 
-func postLicenseCreationToSlack(ctx context.Context, subscriptionID string, version int, expiresAt *time.Time, info license.Info) {
-	dotcom := conf.Get().Dotcom
-	if dotcom == nil {
-		return
-	}
-
-	logger := log.Scoped("license creation Slack notification")
-
-	licenseCreator, err := actor.FromContext(ctx).User(ctx, database.Users(logger))
-	if err != nil {
-		logger.Error("error looking up license creator user", log.Error(err))
-		return
-	}
-
+func renderLicenseCreationSlackMessage(licenseCreator *types.User, subscriptionID string, version int, expiresAt *time.Time, info license.Info) string {
 	pacificLoc, _ := time.LoadLocation("America/Los_Angeles")
 
-	client := slack.New(dotcom.SlackLicenseCreationWebhook)
-	err = client.Post(ctx, &slack.Payload{
-		Text: fmt.Sprintf(slackLicenseCreationMessageFmt,
-			licenseCreator.Username,
-			subscriptionID,
-			subscriptionID,
-			strconv.Itoa(version),
-			expiresAt.Format("Jan 2, 2006 3:04pm MST"),
-			strconv.FormatFloat(time.Until(*expiresAt).Hours()/24, 'f', 1, 64),
-			expiresAt.In(pacificLoc).Format("Jan 2, 2006 3:04pm MST"),
-			strconv.FormatUint(uint64(info.UserCount), 10),
-			"`"+strings.Join(info.Tags, "`, `")+"`",
-			*info.SalesforceSubscriptionID,
-			*info.SalesforceOpportunityID,
-			*info.SalesforceOpportunityID,
-		),
-	})
-	if err != nil {
-		logger.Error("error sending Slack message", log.Error(err))
-		return
-	}
+	// Safely dereference optional properties
+	sfSubscriptionID := pointers.Deref(info.SalesforceSubscriptionID, "unknown")
+	sfOpportunityID := pointers.Deref(info.SalesforceOpportunityID, "unknown")
+
+	return fmt.Sprintf(slackLicenseCreationMessageFmt,
+		licenseCreator.Username,
+		subscriptionID,
+		subscriptionID,
+		strconv.Itoa(version),
+		expiresAt.Format("Jan 2, 2006 3:04pm MST"),
+		strconv.FormatFloat(time.Until(*expiresAt).Hours()/24, 'f', 1, 64),
+		expiresAt.In(pacificLoc).Format("Jan 2, 2006 3:04pm MST"),
+		strconv.FormatUint(uint64(info.UserCount), 10),
+		"`"+strings.Join(info.Tags, "`, `")+"`",
+		sfSubscriptionID,
+		sfOpportunityID,
+		sfOpportunityID,
+	)
 }
 
 // GetByID retrieves the product license (if any) given its ID.

--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hexops/autogold/v2"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -380,4 +381,16 @@ func TestRevokeLicense(t *testing.T) {
 	// Revoke non-existent license
 	err = store.Revoke(ctx, "12345678-1234-5678-1234-567812345678", "reason")
 	require.Error(t, err, "product license not found")
+}
+
+func TestRenderLicenseCreationSlackMessage(t *testing.T) {
+	staticTime, err := time.Parse(time.RFC3339, "2023-02-24T14:48:30Z")
+	require.NoError(t, err)
+
+	message := renderLicenseCreationSlackMessage(
+		&types.User{},
+		"1234", 123,
+		&staticTime,
+		license.Info{})
+	autogold.Expect("\nA new license was created by ** for subscription <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/1234|1234>:\n\n• *License version*: 123\n• *Expiration (UTC)*: Feb 24, 2023 2:48pm UTC (-312.6 days remaining)\n• *Expiration (PT)*: Feb 24, 2023 6:48am PST\n• *User count*: 0\n• *License tags*: ``\n• *Salesforce subscription ID*: unknown\n• *Salesforce opportunity ID*: <https://sourcegraph2020.lightning.force.com/lightning/r/Opportunity/unknown|unknown>\n\nReply with a :approved_stamp: when this is approved\nReply with a :white_check_mark: when this has been sent to the customer\n").Equal(t, message)
 }


### PR DESCRIPTION
Fixes a panic when rendering a notification introduced in https://github.com/sourcegraph/sourcegraph/pull/59214 when an optional field is referenced. This change dereferences those fields safely as "unknown" and adds a test over zero values of various inputs to do a simple sanity-check that it doesn't blow up.

I also spotted a stray `log.Error` without a logger - fixed that while I was in here.

## Test plan

Unit test panicked without change, no longer panics with change