### PR TITLE
ci: fix typo in executor op

### DIFF
--- a/dev/ci/internal/ci/executor_operations.go
+++ b/dev/ci/internal/ci/executor_operations.go
@@ -51,7 +51,7 @@ func bazelPublishExecutorVM(c Config, alwaysRebuild bool) operations.Operation {
 			stepOpts = append(stepOpts,
 				// Soft-fail with code 222 if nothing has changed
 				bk.SoftFail(222),
-				bk.Cmd("if ! ./cmd/executors/ci-should-rebuild.sh; then exit 222; fi"))
+				bk.Cmd("if ! ./cmd/executor/ci-should-rebuild.sh; then exit 222; fi"))
 		}
 
 		stepOpts = append(stepOpts, bk.Cmd(cmd))


### PR DESCRIPTION
Dumb typo I missed before EOY PTO :/ 

## Test plan

CI + double checked 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
