### PR TITLE
fixing error handling

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
@@ -102,7 +102,7 @@ func (s dbLicenses) Create(ctx context.Context, subscriptionID, licenseKey strin
 
 		// Log an event when a license is created in DotCom
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseCreated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", nil); err != nil {
-			logger.Error("LogSecurityEvent", log.Error(err))
+			logger.Warn("Error logging security event", log.Error(err))
 		}
 	}
 
@@ -296,6 +296,7 @@ WHERE id = %s
 
 // List lists all product licenses that satisfy the options.
 func (s dbLicenses) List(ctx context.Context, opt dbLicensesListOptions) ([]*dbLicense, error) {
+
 	if mocks.licenses.List != nil {
 		return mocks.licenses.List(ctx, opt)
 	}
@@ -304,6 +305,10 @@ func (s dbLicenses) List(ctx context.Context, opt dbLicensesListOptions) ([]*dbL
 }
 
 func (s dbLicenses) list(ctx context.Context, conds []*sqlf.Query, limitOffset *database.LimitOffset) ([]*dbLicense, error) {
+	// TODO: put a logger on dbLicenses and scope from that
+	logger := log.Scoped("dbLicenses.List")
+	logger = trace.Logger(ctx, logger)
+
 	q := sqlf.Sprintf(`
 SELECT
 	id,
@@ -364,7 +369,7 @@ ORDER BY created_at DESC
 
 		//Log an event when liscenses list is viewed in Dotcom
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComLicenseViewed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", q.Args()); err != nil {
-			log.Error(err)
+			logger.Warn("Error logging security event", log.Error(err))
 		}
 	}
 	return results, nil

--- a/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -67,6 +68,9 @@ type dbSubscriptions struct {
 // attempts to extract the Salesforce account number from the username following
 // the format "<name>-<account number>".
 func (s dbSubscriptions) Create(ctx context.Context, userID int32, username string) (id string, err error) {
+	logger := log.Scoped("dbSubscriptions.Create")
+	logger = trace.Logger(ctx, logger)
+
 	if mocks.subscriptions.Create != nil {
 		return mocks.subscriptions.Create(userID)
 	}
@@ -91,7 +95,7 @@ INSERT INTO product_subscriptions(id, user_id, account_number) VALUES($1, $2, $3
 
 		// Log an event when a new subscription is created.
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionCreated, "", uint32(userID), "", "BACKEND", newUUID); err != nil {
-			log.Error(err)
+			logger.Warn("Error logging security event", log.Error(err))
 		}
 	}
 	return id, nil
@@ -138,6 +142,9 @@ func (o dbSubscriptionsListOptions) sqlConditions() []*sqlf.Query {
 
 // List lists all product subscriptions that satisfy the options.
 func (s dbSubscriptions) List(ctx context.Context, opt dbSubscriptionsListOptions) ([]*dbSubscription, error) {
+	logger := log.Scoped("dbSubscriptions.List")
+	logger = trace.Logger(ctx, logger)
+
 	if mocks.subscriptions.List != nil {
 		return mocks.subscriptions.List(ctx, opt)
 	}
@@ -145,7 +152,7 @@ func (s dbSubscriptions) List(ctx context.Context, opt dbSubscriptionsListOption
 
 		//Log an event when a list of subscriptions is requested.
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionsListed, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", opt); err != nil {
-			log.Error(err)
+			logger.Warn("Error logging security event", log.Error(err))
 		}
 	}
 	return s.list(ctx, opt.sqlConditions(), opt.LimitOffset)
@@ -242,6 +249,9 @@ type dbSubscriptionUpdate struct {
 
 // Update updates a product subscription.
 func (s dbSubscriptions) Update(ctx context.Context, id string, update dbSubscriptionUpdate) error {
+	logger := log.Scoped("dbSubscriptions.Update")
+	logger = trace.Logger(ctx, logger)
+
 	fieldUpdates := []*sqlf.Query{
 		sqlf.Sprintf("updated_at=now()"), // always update updated_at timestamp
 	}
@@ -298,7 +308,7 @@ func (s dbSubscriptions) Update(ctx context.Context, id string, update dbSubscri
 
 		// Log an event when a subscription is updated
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionUpdated, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
-			log.Error(err)
+			logger.Warn("Error logging security event", log.Error(err))
 		}
 	}
 	return nil
@@ -308,6 +318,9 @@ func (s dbSubscriptions) Update(ctx context.Context, id string, update dbSubscri
 //
 // 🚨 SECURITY: The caller must ensure that the actor is permitted to archive the token.
 func (s dbSubscriptions) Archive(ctx context.Context, id string) error {
+	logger := log.Scoped("dbSubscriptions.Archive")
+	logger = trace.Logger(ctx, logger)
+
 	if mocks.subscriptions.Archive != nil {
 		return mocks.subscriptions.Archive(id)
 	}
@@ -327,7 +340,7 @@ func (s dbSubscriptions) Archive(ctx context.Context, id string) error {
 
 		// Log an event when a subscription is archived
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionArchived, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
-			log.Error(err)
+			logger.Error("Error logging security event", log.Error(err))
 		}
 	}
 	return nil

--- a/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db.go
@@ -340,7 +340,7 @@ func (s dbSubscriptions) Archive(ctx context.Context, id string) error {
 
 		// Log an event when a subscription is archived
 		if err := s.db.SecurityEventLogs().LogSecurityEvent(ctx, database.SecurityEventNameDotComSubscriptionArchived, "", uint32(actor.FromContext(ctx).UID), "", "BACKEND", id); err != nil {
-			logger.Error("Error logging security event", log.Error(err))
+			logger.Warn("Error logging security event", log.Error(err))
 		}
 	}
 	return nil


### PR DESCRIPTION
The error returned from the security event log was not handled appropriately in a few places. this PR fixes those issues.

Thanks to @bobheadxi for catching this.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
Locally tested