### PR TITLE
Searcher: fix issues with negated patterns

### DIFF
--- a/cmd/searcher/internal/search/hybrid_test.go
+++ b/cmd/searcher/internal/search/hybrid_test.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/log/logtest"
-	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
-	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
-	proto "github.com/sourcegraph/sourcegraph/internal/searcher/v1"
 	"github.com/sourcegraph/zoekt"
 	zoektgrpc "github.com/sourcegraph/zoekt/cmd/zoekt-webserver/grpc/server"
 	"google.golang.org/grpc"
+
+	internalgrpc "github.com/sourcegraph/sourcegraph/internal/grpc"
+	"github.com/sourcegraph/sourcegraph/internal/grpc/defaults"
+	proto "github.com/sourcegraph/sourcegraph/internal/searcher/v1"
 
 	webproto "github.com/sourcegraph/zoekt/grpc/protos/zoekt/webserver/v1"
 	"github.com/sourcegraph/zoekt/query"
@@ -171,6 +172,23 @@ added.md:1:1:
 hello world I am added
 `,
 	}, {
+		Name:    "example",
+		Pattern: protocol.PatternInfo{Pattern: "example"},
+		Want: `
+unchanged.md:3:3:
+Hello world example in go
+`,
+	}, {
+		Name: "negated-pattern-example",
+		Pattern: protocol.PatternInfo{
+			Pattern:   "example",
+			IsNegated: true,
+		},
+		Want: `
+added.md
+changed.go
+`,
+	}, {
 		Name: "path-include",
 		Pattern: protocol.PatternInfo{
 			IncludePatterns: []string{"^added"},
@@ -217,6 +235,17 @@ unchanged.md
 changed.go
 unchanged.md:3:3:
 Hello world example in go
+`,
+	}, {
+		Name: "negated-pattern-path",
+		Pattern: protocol.PatternInfo{
+			Pattern:            "go",
+			IsNegated:          true,
+			PatternMatchesPath: true,
+		},
+		Want: `
+added.md
+unchanged.md
 `,
 	}}
 

--- a/cmd/searcher/internal/search/matcher.go
+++ b/cmd/searcher/internal/search/matcher.go
@@ -26,12 +26,11 @@ type matcher interface {
 	// IgnoreCase returns whether matches will ignore case
 	IgnoreCase() bool
 
-	// MatchesString returns whether the pattern matches the given string
+	// MatchesString returns whether the string matches
 	MatchesString(s string) bool
 
-	// MatchesFile returns a LineMatch for each line that matches rm in reader.
-	// LimitHit is true if some matches may not have been included in the result.
-	MatchesFile(fileBuf []byte, limit int) [][]int
+	// MatchesFile returns whether the file matches, plus a LineMatch for each line that matches
+	MatchesFile(fileBuf []byte, limit int) (match bool, matches [][]int)
 
 	// ToZoektQuery returns a zoekt query representing the same rules as as this matcher
 	ToZoektQuery(matchContent bool, matchPath bool) (zoektquery.Q, error)
@@ -43,6 +42,9 @@ type regexMatcher struct {
 
 	// ignoreCase if true means we need to do case insensitive matching.
 	ignoreCase bool
+
+	// isNegated indicates whether matches on the pattern should be negated (representing a 'NOT' in the query)
+	isNegated bool
 
 	// literalSubstring is used to test if a file is worth considering for
 	// matches. literalSubstring is guaranteed to appear in any match found by
@@ -113,6 +115,7 @@ func compilePattern(p *protocol.PatternInfo) (matcher, error) {
 	return &regexMatcher{
 		re:               re,
 		ignoreCase:       !p.IsCaseSensitive,
+		isNegated:        p.IsNegated,
 		literalSubstring: literalSubstring,
 	}, nil
 }
@@ -161,6 +164,11 @@ func (rm *regexMatcher) IgnoreCase() bool {
 }
 
 func (rm *regexMatcher) MatchesString(s string) bool {
+	matches := rm.matchesString(s)
+	return matches == !rm.isNegated
+}
+
+func (rm *regexMatcher) matchesString(s string) bool {
 	if rm.re == nil {
 		return true
 	}
@@ -170,7 +178,13 @@ func (rm *regexMatcher) MatchesString(s string) bool {
 	return rm.re.MatchString(s)
 }
 
-func (rm *regexMatcher) MatchesFile(fileBuf []byte, limit int) [][]int {
+func (rm *regexMatcher) MatchesFile(fileBuf []byte, limit int) (bool, [][]int) {
+	matches := rm.matchesFile(fileBuf, limit)
+	match := len(matches) > 0
+	return match == !rm.isNegated, matches
+}
+
+func (rm *regexMatcher) matchesFile(fileBuf []byte, limit int) [][]int {
 	// Most files will not have a match and we bound the number of matched
 	// files we return. So we can avoid the overhead of parsing out new lines
 	// and repeatedly running the regex engine by running a single match over
@@ -192,24 +206,36 @@ func (rm *regexMatcher) ToZoektQuery(matchContent bool, matchPath bool) (zoektqu
 		return nil, err
 	}
 	re = zoektquery.OptimizeRegexp(re, syntax.Perl)
+
 	if matchContent && matchPath {
 		return zoektquery.NewOr(
-			&zoektquery.Regexp{
-				Regexp:        re,
-				Content:       true,
-				CaseSensitive: !rm.ignoreCase,
-			},
-			&zoektquery.Regexp{
-				Regexp:        re,
-				FileName:      true,
-				CaseSensitive: !rm.ignoreCase,
-			},
+			rm.negateIfNeeded(
+				&zoektquery.Regexp{
+					Regexp:        re,
+					Content:       true,
+					CaseSensitive: !rm.ignoreCase,
+				}),
+			rm.negateIfNeeded(
+				&zoektquery.Regexp{
+					Regexp:        re,
+					FileName:      true,
+					CaseSensitive: !rm.ignoreCase,
+				}),
 		), nil
 	}
-	return &zoektquery.Regexp{
-		Regexp:        re,
-		Content:       matchContent,
-		FileName:      matchPath,
-		CaseSensitive: !rm.ignoreCase,
-	}, nil
+
+	return rm.negateIfNeeded(
+		&zoektquery.Regexp{
+			Regexp:        re,
+			Content:       matchContent,
+			FileName:      matchPath,
+			CaseSensitive: !rm.ignoreCase,
+		}), nil
+}
+
+func (rm *regexMatcher) negateIfNeeded(q zoektquery.Q) zoektquery.Q {
+	if rm.isNegated {
+		return &zoektquery.Not{Child: q}
+	}
+	return q
 }

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -256,7 +256,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	}
 	defer zf.Close()
 
-	return regexSearch(ctx, rm, pm, zf, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated, sender, int32(p.NumContextLines))
+	return regexSearch(ctx, rm, pm, zf, p.PatternMatchesContent, p.PatternMatchesPath, sender, p.NumContextLines)
 }
 
 func (s *Service) getZipFile(ctx context.Context, tr trace.Trace, p *protocol.Request, paths []string) (string, *zipFile, error) {

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -85,7 +85,7 @@ func regexSearch(
 		// Fast path for only matching file paths (or with a nil pattern, which matches all files,
 		// so is effectively matching only on file paths).
 		for _, f := range files {
-			if match := pm.Matches(f.Name) && m.MatchesString(f.Name); match {
+			if pm.Matches(f.Name) && m.MatchesString(f.Name) {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -24,12 +24,11 @@ func regexSearchBatch(
 	zf *zipFile,
 	limit int,
 	patternMatchesContent, patternMatchesPaths bool,
-	isPatternNegated bool,
 	contextLines int32,
 ) ([]protocol.FileMatch, bool, error) {
 	ctx, cancel, sender := newLimitedStreamCollector(ctx, limit)
 	defer cancel()
-	err := regexSearch(ctx, m, pm, zf, patternMatchesContent, patternMatchesPaths, isPatternNegated, sender, contextLines)
+	err := regexSearch(ctx, m, pm, zf, patternMatchesContent, patternMatchesPaths, sender, contextLines)
 	return sender.collected, sender.LimitHit(), err
 }
 
@@ -53,7 +52,6 @@ func regexSearch(
 	pm *pathMatcher,
 	zf *zipFile,
 	patternMatchesContent, patternMatchesPaths bool,
-	isPatternNegated bool,
 	sender matchSender,
 	contextLines int32,
 ) (err error) {
@@ -87,7 +85,7 @@ func regexSearch(
 		// Fast path for only matching file paths (or with a nil pattern, which matches all files,
 		// so is effectively matching only on file paths).
 		for _, f := range files {
-			if match := pm.Matches(f.Name) && m.MatchesString(f.Name); match == !isPatternNegated {
+			if match := pm.Matches(f.Name) && m.MatchesString(f.Name); match {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
@@ -155,9 +153,8 @@ func regexSearch(
 					casetransform.BytesToLowerASCII(fileMatchBuf, fileBuf)
 				}
 
-				locs := m.MatchesFile(fileMatchBuf, sender.Remaining())
+				match, locs := m.MatchesFile(fileMatchBuf, sender.Remaining())
 				fm := locsToFileMatch(fileBuf, f.Name, locs, contextLines)
-				match := len(fm.ChunkMatches) > 0
 				if !match && patternMatchesPaths {
 					// Try matching against the file path.
 					match = m.MatchesString(f.Name)
@@ -165,7 +162,7 @@ func regexSearch(
 						fm.Path = f.Name
 					}
 				}
-				if match == !isPatternNegated {
+				if match {
 					sender.Send(fm)
 				}
 			}

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -228,7 +228,7 @@ func benchSearchRegex(b *testing.B, p *protocol.Request) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		_, _, err := regexSearchBatch(ctx, m, pm, zf, 99999999, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated, 0)
+		_, _, err := regexSearchBatch(ctx, m, pm, zf, 99999999, p.PatternMatchesContent, p.PatternMatchesPath, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -329,7 +329,7 @@ func TestMaxMatches(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileMatches, limitHit, err := regexSearchBatch(context.Background(), m, pm, zf, maxMatches, true, false, false, 0)
+	fileMatches, limitHit, err := regexSearchBatch(context.Background(), m, pm, zf, maxMatches, true, false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,7 +383,7 @@ func TestPathMatches(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileMatches, _, err := regexSearchBatch(context.Background(), m, pm, zf, 10, true, true, false, 0)
+	fileMatches, _, err := regexSearchBatch(context.Background(), m, pm, zf, 10, true, true, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -469,7 +469,7 @@ func TestRegexSearch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFm, gotLimitHit, err := regexSearchBatch(tt.args.ctx, tt.args.m, tt.args.pm, tt.args.zf, tt.args.limit, tt.args.patternMatchesContent, tt.args.patternMatchesPaths, false, 0)
+			gotFm, gotLimitHit, err := regexSearchBatch(tt.args.ctx, tt.args.m, tt.args.pm, tt.args.zf, tt.args.limit, tt.args.patternMatchesContent, tt.args.patternMatchesPaths, 0)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("regexSearch() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -420,7 +420,7 @@ func filteredStructuralSearch(
 		return err
 	}
 
-	fileMatches, _, err := regexSearchBatch(ctx, m, pm, zf, p.Limit, true, false, false, contextLines)
+	fileMatches, _, err := regexSearchBatch(ctx, m, pm, zf, p.Limit, true, false, contextLines)
 	if err != nil {
 		return err
 	}

--- a/cmd/searcher/internal/search/search_test.go
+++ b/cmd/searcher/internal/search/search_test.go
@@ -339,6 +339,13 @@ nonutf8.txt
 symlink
 `),
 	}, {
+		arg: protocol.PatternInfo{Pattern: "go", IsNegated: true, PatternMatchesPath: true, ExcludePattern: "\\.txt"},
+		want: autogold.Expect(`README.md
+file++.plus
+milton.png
+symlink
+`),
+	}, {
 		arg:  protocol.PatternInfo{Pattern: "abc", PatternMatchesPath: true, PatternMatchesContent: true},
 		want: autogold.Expect("abc.txt\nsymlink:1:1:\nabc.txt\n"),
 	}, {


### PR DESCRIPTION
This refactors the searcher logic to handle negated patterns within `matcher`, instead of the main file processing loop. This will be really helpful when adding support for 'and' and 'or' matchers to searcher, since now negation is handled at the level of a query atom.

The refactor uncovered two bugs in the negation logic, which are now fixed:
* When the pattern was negated, in some cases we ignored file include/ exclude patterns
* Hybrid search was totally ignoring pattern negation

Relates to #59038

## Test plan

New unit tests to cover the bug fixes