### PR TITLE
productsubscription: stabilize license notification test

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db.go
@@ -125,7 +125,7 @@ func postLicenseCreationToSlack(ctx context.Context, logger log.Logger, subscrip
 
 	client := slack.New(dotcom.SlackLicenseCreationWebhook)
 	err = client.Post(ctx, &slack.Payload{
-		Text: renderLicenseCreationSlackMessage(licenseCreator, subscriptionID, version, expiresAt, info),
+		Text: renderLicenseCreationSlackMessage(time.Now(), licenseCreator, subscriptionID, version, expiresAt, info),
 	})
 	if err != nil {
 		logger.Error("error sending Slack message", log.Error(err))
@@ -148,7 +148,14 @@ Reply with a :approved_stamp: when this is approved
 Reply with a :white_check_mark: when this has been sent to the customer
 `
 
-func renderLicenseCreationSlackMessage(licenseCreator *types.User, subscriptionID string, version int, expiresAt *time.Time, info license.Info) string {
+func renderLicenseCreationSlackMessage(
+	now time.Time,
+	licenseCreator *types.User,
+	subscriptionID string,
+	version int,
+	expiresAt *time.Time,
+	info license.Info,
+) string {
 	pacificLoc, _ := time.LoadLocation("America/Los_Angeles")
 
 	// Safely dereference optional properties
@@ -161,7 +168,7 @@ func renderLicenseCreationSlackMessage(licenseCreator *types.User, subscriptionI
 		subscriptionID,
 		strconv.Itoa(version),
 		expiresAt.Format("Jan 2, 2006 3:04pm MST"),
-		strconv.FormatFloat(time.Until(*expiresAt).Hours()/24, 'f', 1, 64),
+		strconv.FormatFloat(expiresAt.Sub(now).Hours()/24, 'f', 1, 64),
 		expiresAt.In(pacificLoc).Format("Jan 2, 2006 3:04pm MST"),
 		strconv.FormatUint(uint64(info.UserCount), 10),
 		"`"+strings.Join(info.Tags, "`, `")+"`",

--- a/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -384,13 +384,18 @@ func TestRevokeLicense(t *testing.T) {
 }
 
 func TestRenderLicenseCreationSlackMessage(t *testing.T) {
-	staticTime, err := time.Parse(time.RFC3339, "2023-02-24T14:48:30Z")
+	staticExpiresAt, err := time.Parse(time.RFC3339, "2023-02-24T14:48:30Z")
 	require.NoError(t, err)
 
+	// Typical case is that license expires in the future, so emulate now to
+	// be some time before that
+	staticNow := staticExpiresAt.Add(-72 * time.Hour)
+
 	message := renderLicenseCreationSlackMessage(
+		staticNow,
 		&types.User{},
 		"1234", 123,
-		&staticTime,
+		&staticExpiresAt,
 		license.Info{})
-	autogold.Expect("\nA new license was created by ** for subscription <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/1234|1234>:\n\n• *License version*: 123\n• *Expiration (UTC)*: Feb 24, 2023 2:48pm UTC (-313.1 days remaining)\n• *Expiration (PT)*: Feb 24, 2023 6:48am PST\n• *User count*: 0\n• *License tags*: ``\n• *Salesforce subscription ID*: unknown\n• *Salesforce opportunity ID*: <https://sourcegraph2020.lightning.force.com/lightning/r/Opportunity/unknown|unknown>\n\nReply with a :approved_stamp: when this is approved\nReply with a :white_check_mark: when this has been sent to the customer\n").Equal(t, message)
+	autogold.Expect("\nA new license was created by ** for subscription <https://sourcegraph.com/site-admin/dotcom/product/subscriptions/1234|1234>:\n\n• *License version*: 123\n• *Expiration (UTC)*: Feb 24, 2023 2:48pm UTC (3.0 days remaining)\n• *Expiration (PT)*: Feb 24, 2023 6:48am PST\n• *User count*: 0\n• *License tags*: ``\n• *Salesforce subscription ID*: unknown\n• *Salesforce opportunity ID*: <https://sourcegraph2020.lightning.force.com/lightning/r/Opportunity/unknown|unknown>\n\nReply with a :approved_stamp: when this is approved\nReply with a :white_check_mark: when this has been sent to the customer\n").Equal(t, message)
 }


### PR DESCRIPTION
Previously this test depended on `time.Until` - instead, we inject a stable `time.Time` as `now` and evaluate the difference based on that.

## Test plan

Autogold assertion shows the expected time diff (3 days) - this should be stable now