### PR TITLE
Svelte: add topic badges to repo search results

### DIFF
--- a/client/web-sveltekit/src/lib/search/results.ts
+++ b/client/web-sveltekit/src/lib/search/results.ts
@@ -45,9 +45,9 @@ export function getRepositoryBadges(
     }))
     const metaBadges = enableMetadata
         ? Object.entries(repo.metadata ?? {}).map(([key, value]) => ({
-            label: `${key}:${value}`,
-            urlQuery: buildSearchURLQueryForMeta(queryState, key, value),
-        }))
+              label: `${key}:${value}`,
+              urlQuery: buildSearchURLQueryForMeta(queryState, key, value),
+          }))
         : []
     return sortBy([...topicBadges, ...metaBadges], ['label'])
 }

--- a/client/web-sveltekit/src/lib/search/results.ts
+++ b/client/web-sveltekit/src/lib/search/results.ts
@@ -29,23 +29,43 @@ export interface Meta {
     value?: string | null
 }
 
-export function getMetadata(result: RepositoryMatch): Meta[] {
-    const { metadata } = result
-    if (!metadata) {
-        return []
-    }
-    return sortBy(
-        Object.entries(metadata).map(([key, value]) => ({ key, value })),
-        ['key', 'value']
+export interface RepositoryBadge {
+    label: string
+    urlQuery: string
+}
+
+export function getRepositoryBadges(
+    queryState: QueryState,
+    repo: RepositoryMatch,
+    enableMetadata: boolean
+): RepositoryBadge[] {
+    const topicBadges = (repo.topics ?? []).map(topic => ({
+        label: topic,
+        urlQuery: buildSearchURLQueryForTopic(queryState, topic),
+    }))
+    const metaBadges = enableMetadata
+        ? Object.entries(repo.metadata ?? {}).map(([key, value]) => ({
+            label: `${key}:${value}`,
+            urlQuery: buildSearchURLQueryForMeta(queryState, key, value),
+        }))
+        : []
+    return sortBy([...topicBadges, ...metaBadges], ['label'])
+}
+
+function buildSearchURLQueryForTopic(queryState: QueryState, topic: string): string {
+    const query = appendFilter(queryState.query, 'repo', `has.topic(${topic})`)
+
+    return buildSearchURLQuery(
+        query,
+        queryState.patternType,
+        queryState.caseSensitive,
+        queryState.searchContext,
+        queryState.searchMode
     )
 }
 
-export function buildSearchURLQueryForMeta(queryState: QueryState, meta: Meta): string {
-    const query = appendFilter(
-        queryState.query,
-        'repo',
-        meta.value ? `has.meta(${meta.key}:${meta.value})` : `has.meta(${meta.key})`
-    )
+function buildSearchURLQueryForMeta(queryState: QueryState, key: string, value?: string): string {
+    const query = appendFilter(queryState.query, 'repo', value ? `has.meta(${key}:${value})` : `has.meta(${key})`)
 
     return buildSearchURLQuery(
         query,

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -16,8 +16,8 @@
 
     export let result: RepositoryMatch
 
-    const queryState = getSearchResultsContext().queryState
     const enableRepositoryMetadata = featureFlag('repository-metadata')
+    const queryState = getSearchResultsContext().queryState
 
     $: repoAtRevisionURL = getRepoMatchUrl(result)
     $: badges = getRepositoryBadges($queryState, result, $enableRepositoryMetadata)

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -1,25 +1,26 @@
 <svelte:options immutable />
 
 <script lang="ts">
-    import Icon from '$lib/Icon.svelte'
-    import { featureFlag } from '$lib/featureflags'
-    import { displayRepoName, getRepoMatchUrl, type RepositoryMatch } from '$lib/shared'
     import { mdiArchive, mdiLock, mdiSourceFork } from '@mdi/js'
-    import CodeHostIcon from './CodeHostIcon.svelte'
 
-    import SearchResult from './SearchResult.svelte'
-    import { Badge } from '$lib/wildcard'
-    import { getSearchResultsContext } from './searchResultsContext'
-    import { limitDescription, getMetadata, buildSearchURLQueryForMeta, simplifyLineRange } from '$lib/search/results'
     import { highlightRanges } from '$lib/dom'
+    import { featureFlag } from '$lib/featureflags'
+    import Icon from '$lib/Icon.svelte'
+    import { limitDescription, getRepositoryBadges, simplifyLineRange } from '$lib/search/results'
+    import { displayRepoName, getRepoMatchUrl, type RepositoryMatch } from '$lib/shared'
+    import { Badge } from '$lib/wildcard'
+
+    import CodeHostIcon from './CodeHostIcon.svelte'
+    import SearchResult from './SearchResult.svelte'
+    import { getSearchResultsContext } from './searchResultsContext'
 
     export let result: RepositoryMatch
 
-    const enableRepositoryMetadata = featureFlag('repository-metadata')
     const queryState = getSearchResultsContext().queryState
+    const enableRepositoryMetadata = featureFlag('repository-metadata')
 
     $: repoAtRevisionURL = getRepoMatchUrl(result)
-    $: metadata = $enableRepositoryMetadata ? getMetadata(result) : []
+    $: badges = getRepositoryBadges($queryState, result, $enableRepositoryMetadata)
     $: description = limitDescription(result.description ?? '')
     $: repoName = displayRepoName(result.repository)
 
@@ -69,20 +70,13 @@
             </p>
         {/key}
     {/if}
-    {#if metadata.length > 0}
+    {#if badges.length > 0}
         <ul class="p-2">
-            {#each metadata as meta}
+            {#each badges as badge}
                 <li>
                     <Badge variant="outlineSecondary">
-                        <a
-                            slot="custom"
-                            let:class={className}
-                            class={className}
-                            href="/search?{buildSearchURLQueryForMeta($queryState, meta)}"
-                        >
-                            <code
-                                >{meta.key}{#if meta.value}:{meta.value}{/if}</code
-                            >
+                        <a slot="custom" let:class={className} class={className} href={`/search?${badge.urlQuery}`}>
+                            <code>{badge.label}</code>
                         </a>
                     </Badge>
                 </li>


### PR DESCRIPTION
We already had metadata badges. This just adds additional badges for topics to match the behavior of the react webapp. I think we can upgrade repo metadata out of experimental as well and show it by default, but I'll do that in a followup PR.

![CleanShot 2024-01-03 at 15 26 52@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/553cd4ee-ff35-46da-802e-6ed48de5aa9c)

## Test plan

Manually tested that the links work as expected. 
