### PR TITLE
msp: supress all opsgenie alerts for now

### DIFF
--- a/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
@@ -118,11 +118,12 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	var channels []monitoringnotificationchannel.MonitoringNotificationChannel
 
 	// Configure opsgenie channels
-	var opsgenieAlerts bool
-	switch vars.EnvironmentCategory {
-	case spec.EnvironmentCategoryInternal, spec.EnvironmentCategoryExternal:
-		opsgenieAlerts = true
-	}
+	// TODO: Enable after we dogfood the alerts for a while.
+	// var opsgenieAlerts bool
+	// switch vars.EnvironmentCategory {
+	// case spec.EnvironmentCategoryInternal, spec.EnvironmentCategoryExternal:
+	// 	opsgenieAlerts = true
+	// }
 	for i, owner := range vars.Owners {
 		// Use index because Opsgenie team names has lax character requirements
 		id := id.Group("opsgenie_owner_%d", i)
@@ -149,7 +150,8 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 				// Supress all notifications if opsgenieAlerts is disabled -
 				// this allows us to see the alerts, but not necessarily get
 				// paged by it.
-				SuppressNotifications: pointers.Ptr(!opsgenieAlerts),
+				// TODO: Enable after we dogfood the alerts for a while.
+				SuppressNotifications: pointers.Ptr(false),
 
 				// Point alerts sent through this integration at the Opsgenie team.
 				Responders: []*opsgenieintegration.ApiIntegrationResponders{{


### PR DESCRIPTION
We may have jumped the gun here - let's dogfood the alerts for a while with just Slack, and add Opsgenie further down the line. We may want to allow services to opt out of Opsgenie entirely with a mechanism other than Category as well.

## Test plan

n/a