### PR TITLE
gitserver: Update out-of-date doc comment for ReadFile

### DIFF
--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -416,8 +416,8 @@ type Client interface {
 	// longer required.
 	Diff(ctx context.Context, opts DiffOptions) (*DiffFileIterator, error)
 
-	// ReadFile returns the first maxBytes of the named file at commit. If maxBytes <= 0, the entire
-	// file is read. (If you just need to check a file's existence, use Stat, not ReadFile.)
+	// ReadFile returns the full contents of the named file at commit.
+	// (If you just need to check a file's existence, use Stat, not ReadFile.)
 	ReadFile(ctx context.Context, repo api.RepoName, commit api.CommitID, name string) ([]byte, error)
 
 	// BranchesContaining returns a map from branch names to branch tip hashes for

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -1459,8 +1459,8 @@ func (c *clientImplementor) GetBehindAhead(ctx context.Context, repo api.RepoNam
 	return &gitdomain.BehindAhead{Behind: uint32(b), Ahead: uint32(a)}, nil
 }
 
-// ReadFile returns the first maxBytes of the named file at commit. If maxBytes <= 0, the entire
-// file is read. (If you just need to check a file's existence, use Stat, not ReadFile.)
+// ReadFile returns the full contents of the named file at commit.
+// (If you just need to check a file's existence, use Stat, not ReadFile.)
 func (c *clientImplementor) ReadFile(ctx context.Context, repo api.RepoName, commit api.CommitID, name string) (_ []byte, err error) {
 	ctx, _, endObservation := c.operations.readFile.With(ctx, &err, observation.Args{
 		MetricLabelValues: []string{c.scope},


### PR DESCRIPTION
Previously, the doc comment referred to a non-existent `maxBytes` parameter.

In the modified `commands.go`, you can see these two lines:

```
    r := io.Reader(br)
	data, err := io.ReadAll(r)
```

slightly below the modified doc comment, indicating that the full contents are read.

## Test plan

n/a