### PR TITLE
Syntax highlight package.json files

### DIFF
--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -231,7 +231,6 @@ func (r *GitTreeEntryResolver) Binary(ctx context.Context) (bool, error) {
 
 var (
 	syntaxHighlightFileBlocklist = []string{
-		"package.json",
 		"yarn.lock",
 		"pnpm-lock.yaml",
 		"package-lock.json",
@@ -250,7 +249,7 @@ func (r *GitTreeEntryResolver) Highlight(ctx context.Context, args *HighlightArg
 		return nil, err
 	}
 
-	// special handling in dotcom to prevent syntax highlighting large files
+	// special handling in dotcom to prevent syntax highlighting large lock files
 	if envvar.SourcegraphDotComMode() {
 		for _, f := range syntaxHighlightFileBlocklist {
 			if strings.HasSuffix(r.Path(), f) {


### PR DESCRIPTION
It's not a lockfile, so it usually doesn't grow large enough to cause trouble for syntax highlighting

This was ignored for syntax highlighting in #59010, but I think `package.json` was included by accident.

## Test plan

Tested locally

`sg start` -> search for `package.json` -> see highlighted file
