### PR TITLE
Use interfaces instead of using structs with methods

### DIFF
--- a/cmd/cody-gateway/internal/events/events.go
+++ b/cmd/cody-gateway/internal/events/events.go
@@ -156,6 +156,9 @@ func (l *stdoutLogger) LogEvent(spanCtx context.Context, event Event) error {
 	return nil
 }
 
+// MergeMaps returns a map that contains all the keys from the given maps.
+// If two or more maps contain the same key, the last value (in the order the maps are passed as parameters) is retained.
+// dst is modified in-place.
 func MergeMaps(dst map[string]any, srcs ...map[string]any) map[string]any {
 	for _, src := range srcs {
 		for k, v := range src {

--- a/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -42,9 +42,7 @@ go_test(
     srcs = ["anthropic_test.go"],
     embed = [":completions"],
     deps = [
-        "//cmd/cody-gateway/internal/actor",
         "//cmd/cody-gateway/internal/tokenizer",
-        "//internal/codygateway",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//assert",

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
@@ -6,13 +6,10 @@ import (
 	"testing"
 
 	"github.com/grafana/regexp"
-	"github.com/sourcegraph/sourcegraph/internal/codygateway"
-
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/tokenizer"
 )
 
@@ -115,36 +112,5 @@ func TestAnthropicRequestGetPromptTokenCount(t *testing.T) {
 		count2, err := newRequest.GetPromptTokenCount(tk)
 		require.NoError(t, err)
 		assert.Equal(t, originalRequest.promptTokens.count, count2, "token count should be unchanged")
-	})
-}
-
-func TestActor_IsDotComActor(t *testing.T) {
-	t.Run("with dotcom actor", func(t *testing.T) {
-		act := &actor.Actor{
-			ID:     "d3d2b638-d0a2-4539-a099-b36860b09819",
-			Source: actor.FakeSource{codygateway.ActorSourceProductSubscription},
-		}
-
-		isDotCom := act.IsDotComActor()
-
-		require.True(t, isDotCom)
-	})
-
-	t.Run("with nondotcom actor", func(t *testing.T) {
-		act := &actor.Actor{
-			ID: "NOT_DOTCOM",
-		}
-
-		isDotCom := act.IsDotComActor()
-
-		require.False(t, isDotCom)
-	})
-
-	t.Run("with nil actor", func(t *testing.T) {
-		var act *actor.Actor = nil
-
-		isDotCom := act.IsDotComActor()
-
-		require.False(t, isDotCom)
 	})
 }

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -8,13 +8,13 @@ import (
 	"net/http"
 
 	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
+
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/events"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/limiter"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/notify"
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
-	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
@@ -34,7 +34,7 @@ func NewFireworksHandler(
 	disableSingleTenant bool,
 	autoFlushStreamingResponses bool,
 ) http.Handler {
-	return makeUpstreamHandler(
+	return makeUpstreamHandler[fireworksRequest](
 		baseLogger,
 		eventLogger,
 		rs,
@@ -49,119 +49,7 @@ func NewFireworksHandler(
 			}
 		},
 		allowedModels,
-		upstreamHandlerMethods[fireworksRequest]{
-			validateRequest: func(_ context.Context, _ log.Logger, feature codygateway.Feature, fr fireworksRequest) (int, *flaggingResult, error) {
-				return 0, nil, nil
-			},
-			transformBody: func(body *fireworksRequest, identifier string) {
-				// We don't want to let users generate multiple responses, as this would
-				// mess with rate limit counting.
-				if body.N > 1 {
-					body.N = 1
-				}
-				if disableSingleTenant {
-					oldModel := body.Model
-					if body.Model == "accounts/sourcegraph/models/starcoder-16b" {
-						body.Model = "accounts/fireworks/models/starcoder-16b-w8a16"
-					} else if body.Model == "accounts/sourcegraph/models/starcoder-7b" {
-						body.Model = "accounts/fireworks/models/starcoder-7b-w8a16"
-					}
-					if oldModel != body.Model {
-						baseLogger.Debug("rewriting model", log.String("old-model", oldModel), log.String("new-model", body.Model))
-					}
-				}
-			},
-			getRequestMetadata: func(ctx context.Context, logger log.Logger, act *actor.Actor, feature codygateway.Feature, body fireworksRequest) (model string, additionalMetadata map[string]any) {
-				// Check that this is a code completion request and that the actor is a PLG user
-				if feature == codygateway.FeatureCodeCompletions && logSelfServeCodeCompletionRequests && act.IsDotComActor() {
-					// LogEvent is a channel send (not an external request), so should be ok here
-					if err := eventLogger.LogEvent(
-						ctx,
-						events.Event{
-							Name:       codygateway.EventNameCodeCompletionLogged,
-							Source:     act.Source.Name(),
-							Identifier: act.ID,
-							Metadata: map[string]any{
-								"request": map[string]any{
-									"prompt":      body.Prompt,
-									"model":       body.Model,
-									"max_tokens":  body.MaxTokens,
-									"temperature": body.Temperature,
-									"top_p":       body.TopP,
-									"n":           body.N,
-									"stream":      body.Stream,
-									"echo":        body.Echo,
-									"stop":        body.Stop,
-								},
-							},
-						}); err != nil {
-						logger.Error("failed to log event", log.Error(err))
-					}
-				}
-				return body.Model, map[string]any{"stream": body.Stream}
-			},
-			transformRequest: func(r *http.Request) {
-				r.Header.Set("Content-Type", "application/json")
-				r.Header.Set("Authorization", "Bearer "+accessToken)
-			},
-			parseResponseAndUsage: func(logger log.Logger, reqBody fireworksRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
-				// First, extract prompt usage details from the request.
-				promptUsage.characters = len(reqBody.Prompt)
-
-				// Try to parse the request we saw, if it was non-streaming, we can simply parse
-				// it as JSON.
-				if !reqBody.Stream {
-					var res fireworksResponse
-					if err := json.NewDecoder(r).Decode(&res); err != nil {
-						logger.Error("failed to parse fireworks response as JSON", log.Error(err))
-						return promptUsage, completionUsage
-					}
-
-					promptUsage.tokens = res.Usage.PromptTokens
-					completionUsage.tokens = res.Usage.CompletionTokens
-					if len(res.Choices) > 0 {
-						// TODO: Later, we should look at the usage field.
-						completionUsage.characters = len(res.Choices[0].Text)
-					}
-					return promptUsage, completionUsage
-				}
-
-				// Otherwise, we have to parse the event stream.
-				//
-				// TODO: Does fireworks streaming include usage data?
-				// Unclear in the API currently: https://readme.fireworks.ai/reference/createcompletion
-				// For now, just count character usage, and set token counts to
-				// -1 as sentinel values.
-				promptUsage.tokens = -1
-				completionUsage.tokens = -1
-
-				dec := fireworks.NewDecoder(r)
-				// Consume all the messages, but we only care about the last completion data.
-				for dec.Scan() {
-					data := dec.Data()
-
-					// Gracefully skip over any data that isn't JSON-like.
-					if !bytes.HasPrefix(data, []byte("{")) {
-						continue
-					}
-
-					var event fireworksResponse
-					if err := json.Unmarshal(data, &event); err != nil {
-						logger.Error("failed to decode event payload", log.Error(err), log.String("body", string(data)))
-						continue
-					}
-
-					if len(event.Choices) > 0 {
-						completionUsage.characters += len(event.Choices[0].Text)
-					}
-				}
-				if err := dec.Err(); err != nil {
-					logger.Error("failed to decode Fireworks streaming response", log.Error(err))
-				}
-
-				return promptUsage, completionUsage
-			},
-		},
+		&FireworksHandlerMethods{accessToken: accessToken, baseLogger: baseLogger, eventLogger: eventLogger, logSelfServeCodeCompletionRequests: logSelfServeCodeCompletionRequests, disableSingleTenant: disableSingleTenant},
 
 		// Setting to a valuer higher than SRC_HTTP_CLI_EXTERNAL_RETRY_AFTER_MAX_DURATION to not
 		// do any retries
@@ -209,4 +97,124 @@ type fireworksResponse struct {
 		TotalTokens      int `json:"total_tokens"`
 		CompletionTokens int `json:"completion_tokens"`
 	} `json:"usage"`
+}
+
+type FireworksHandlerMethods struct {
+	accessToken                        string
+	logSelfServeCodeCompletionRequests bool
+	disableSingleTenant                bool
+	baseLogger                         log.Logger
+	eventLogger                        events.Logger
+}
+
+func (f *FireworksHandlerMethods) validateRequest(_ context.Context, _ log.Logger, _ codygateway.Feature, _ fireworksRequest) (int, *flaggingResult, error) {
+	return 0, nil, nil
+}
+func (f *FireworksHandlerMethods) transformBody(body *fireworksRequest, _ string) {
+	// We don't want to let users generate multiple responses, as this would
+	// mess with rate limit counting.
+	if body.N > 1 {
+		body.N = 1
+	}
+	if f.disableSingleTenant {
+		oldModel := body.Model
+		if body.Model == "accounts/sourcegraph/models/starcoder-16b" {
+			body.Model = "accounts/fireworks/models/starcoder-16b-w8a16"
+		} else if body.Model == "accounts/sourcegraph/models/starcoder-7b" {
+			body.Model = "accounts/fireworks/models/starcoder-7b-w8a16"
+		}
+		if oldModel != body.Model {
+			f.baseLogger.Debug("rewriting model", log.String("old-model", oldModel), log.String("new-model", body.Model))
+		}
+	}
+}
+func (f *FireworksHandlerMethods) getRequestMetadata(ctx context.Context, logger log.Logger, act *actor.Actor, feature codygateway.Feature, body fireworksRequest) (model string, additionalMetadata map[string]any) {
+	// Check that this is a code completion request and that the actor is a PLG user
+	if feature == codygateway.FeatureCodeCompletions && f.logSelfServeCodeCompletionRequests && act.IsDotComActor() {
+		// LogEvent is a channel send (not an external request), so should be ok here
+		if err := f.eventLogger.LogEvent(
+			ctx,
+			events.Event{
+				Name:       codygateway.EventNameCodeCompletionLogged,
+				Source:     act.Source.Name(),
+				Identifier: act.ID,
+				Metadata: map[string]any{
+					"request": map[string]any{
+						"prompt":      body.Prompt,
+						"model":       body.Model,
+						"max_tokens":  body.MaxTokens,
+						"temperature": body.Temperature,
+						"top_p":       body.TopP,
+						"n":           body.N,
+						"stream":      body.Stream,
+						"echo":        body.Echo,
+						"stop":        body.Stop,
+					},
+				},
+			}); err != nil {
+			logger.Error("failed to log event", log.Error(err))
+		}
+	}
+	return body.Model, map[string]any{"stream": body.Stream}
+}
+func (f *FireworksHandlerMethods) transformRequest(r *http.Request) {
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Authorization", "Bearer "+f.accessToken)
+}
+func (f *FireworksHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBody fireworksRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
+	// First, extract prompt usage details from the request.
+	promptUsage.characters = len(reqBody.Prompt)
+
+	// Try to parse the request we saw, if it was non-streaming, we can simply parse
+	// it as JSON.
+	if !reqBody.Stream {
+		var res fireworksResponse
+		if err := json.NewDecoder(r).Decode(&res); err != nil {
+			logger.Error("failed to parse fireworks response as JSON", log.Error(err))
+			return promptUsage, completionUsage
+		}
+
+		promptUsage.tokens = res.Usage.PromptTokens
+		completionUsage.tokens = res.Usage.CompletionTokens
+		if len(res.Choices) > 0 {
+			// TODO: Later, we should look at the usage field.
+			completionUsage.characters = len(res.Choices[0].Text)
+		}
+		return promptUsage, completionUsage
+	}
+
+	// Otherwise, we have to parse the event stream.
+	//
+	// TODO: Does fireworks streaming include usage data?
+	// Unclear in the API currently: https://readme.fireworks.ai/reference/createcompletion
+	// For now, just count character usage, and set token counts to
+	// -1 as sentinel values.
+	promptUsage.tokens = -1
+	completionUsage.tokens = -1
+
+	dec := fireworks.NewDecoder(r)
+	// Consume all the messages, but we only care about the last completion data.
+	for dec.Scan() {
+		data := dec.Data()
+
+		// Gracefully skip over any data that isn't JSON-like.
+		if !bytes.HasPrefix(data, []byte("{")) {
+			continue
+		}
+
+		var event fireworksResponse
+		if err := json.Unmarshal(data, &event); err != nil {
+			logger.Error("failed to decode event payload", log.Error(err), log.String("body", string(data)))
+			continue
+		}
+
+		if len(event.Choices) > 0 {
+			completionUsage.characters += len(event.Choices[0].Text)
+		}
+	}
+	if err := dec.Err(); err != nil {
+		logger.Error("failed to decode Fireworks streaming response", log.Error(err))
+	}
+
+	return promptUsage, completionUsage
 }

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -7,18 +7,17 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
-
 	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/openai"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/events"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/limiter"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/notify"
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
-	"github.com/sourcegraph/sourcegraph/internal/completions/client/openai"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 const openAIURL = "https://api.openai.com/v1/chat/completions"
@@ -34,7 +33,7 @@ func NewOpenAIHandler(
 	allowedModels []string,
 	autoFlushStreamingResponses bool,
 ) http.Handler {
-	return makeUpstreamHandler(
+	return makeUpstreamHandler[openaiRequest](
 		baseLogger,
 		eventLogger,
 		rs,
@@ -43,93 +42,7 @@ func NewOpenAIHandler(
 		string(conftypes.CompletionsProviderNameOpenAI),
 		func(_ codygateway.Feature) string { return openAIURL },
 		allowedModels,
-		upstreamHandlerMethods[openaiRequest]{
-			validateRequest: func(_ context.Context, _ log.Logger, feature codygateway.Feature, _ openaiRequest) (int, *flaggingResult, error) {
-				if feature == codygateway.FeatureCodeCompletions {
-					return http.StatusNotImplemented, nil,
-						errors.Newf("feature %q is currently not supported for OpenAI",
-							feature)
-				}
-				return 0, nil, nil
-			},
-			transformBody: func(body *openaiRequest, identifier string) {
-				// We don't want to let users generate multiple responses, as this would
-				// mess with rate limit counting.
-				if body.N > 1 {
-					body.N = 1
-				}
-				// We forward the actor ID to support tracking.
-				body.User = identifier
-			},
-			getRequestMetadata: func(_ context.Context, _ log.Logger, _ *actor.Actor, _ codygateway.Feature, body openaiRequest) (model string, additionalMetadata map[string]any) {
-				return body.Model, map[string]any{"stream": body.Stream}
-			},
-			transformRequest: func(r *http.Request) {
-				r.Header.Set("Content-Type", "application/json")
-				r.Header.Set("Authorization", "Bearer "+accessToken)
-				if orgID != "" {
-					r.Header.Set("OpenAI-Organization", orgID)
-				}
-			},
-			parseResponseAndUsage: func(logger log.Logger, body openaiRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
-				// First, extract prompt usage details from the request.
-				for _, m := range body.Messages {
-					promptUsage.characters += len(m.Content)
-				}
-
-				// Try to parse the request we saw, if it was non-streaming, we can simply parse
-				// it as JSON.
-				if !body.Stream {
-					var res openaiResponse
-					if err := json.NewDecoder(r).Decode(&res); err != nil {
-						logger.Error("failed to parse OpenAI response as JSON", log.Error(err))
-						return promptUsage, completionUsage
-					}
-
-					// Extract usage data from response
-					promptUsage.tokens = res.Usage.PromptTokens
-					completionUsage.tokens = res.Usage.CompletionTokens
-					if len(res.Choices) > 0 {
-						completionUsage.characters = len(res.Choices[0].Content)
-					}
-					return promptUsage, completionUsage
-				}
-
-				// Otherwise, we have to parse the event stream.
-				//
-				// Currently, OpenAI only reports usage on non-streaming requests
-				// Until we can tokenize the response ourselves, just count
-				// character usage, and set token counts to -1 as sentinel values.
-				// TODO: https://github.com/sourcegraph/sourcegraph/issues/56590
-				promptUsage.tokens = -1
-				completionUsage.tokens = -1
-
-				dec := openai.NewDecoder(r)
-				// Consume all the messages, but we only care about the last completion data.
-				for dec.Scan() {
-					data := dec.Data()
-
-					// Gracefully skip over any data that isn't JSON-like.
-					if !bytes.HasPrefix(data, []byte("{")) {
-						continue
-					}
-
-					var event openaiResponse
-					if err := json.Unmarshal(data, &event); err != nil {
-						logger.Error("failed to decode event payload", log.Error(err), log.String("body", string(data)))
-						continue
-					}
-					if len(event.Choices) > 0 {
-						completionUsage.characters += len(event.Choices[0].Delta.Content)
-					}
-				}
-				if err := dec.Err(); err != nil {
-					logger.Error("failed to decode OpenAI streaming response", log.Error(err))
-				}
-
-				return promptUsage, completionUsage
-			},
-		},
+		OpenAIHandlerMethods{accessToken: accessToken, orgID: orgID},
 
 		// OpenAI primarily uses tokens-per-minute ("TPM") to rate-limit spikes
 		// in requests, so set a very high retry-after to discourage Sourcegraph
@@ -191,4 +104,97 @@ type openaiResponse struct {
 	Usage   openaiUsage    `json:"usage"`
 	Model   string         `json:"model"`
 	Choices []openaiChoice `json:"choices"`
+}
+
+type OpenAIHandlerMethods struct {
+	accessToken string
+	orgID       string
+}
+
+func (_ *OpenAIHandlerMethods) validateRequest(_ context.Context, _ log.Logger, feature codygateway.Feature, _ openaiRequest) (int, *flaggingResult, error) {
+	if feature == codygateway.FeatureCodeCompletions {
+		return http.StatusNotImplemented, nil,
+			errors.Newf("feature %q is currently not supported for OpenAI",
+				feature)
+	}
+	return 0, nil, nil
+}
+func (_ *OpenAIHandlerMethods) transformBody(body *openaiRequest, identifier string) {
+	// We don't want to let users generate multiple responses, as this would
+	// mess with rate limit counting.
+	if body.N > 1 {
+		body.N = 1
+	}
+	// We forward the actor ID to support tracking.
+	body.User = identifier
+}
+func (_ *OpenAIHandlerMethods) getRequestMetadata(_ context.Context, _ log.Logger, _ *actor.Actor, _ codygateway.Feature, body openaiRequest) (model string, additionalMetadata map[string]any) {
+	return body.Model, map[string]any{"stream": body.Stream}
+}
+
+func (o *OpenAIHandlerMethods) transformRequest(r *http.Request) {
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Authorization", "Bearer "+o.accessToken)
+	if o.orgID != "" {
+		r.Header.Set("OpenAI-Organization", o.orgID)
+	}
+}
+
+func (_ *OpenAIHandlerMethods) parseResponseAndUsage(logger log.Logger, body openaiRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
+	// First, extract prompt usage details from the request.
+	for _, m := range body.Messages {
+		promptUsage.characters += len(m.Content)
+	}
+
+	// Try to parse the request we saw, if it was non-streaming, we can simply parse
+	// it as JSON.
+	if !body.Stream {
+		var res openaiResponse
+		if err := json.NewDecoder(r).Decode(&res); err != nil {
+			logger.Error("failed to parse OpenAI response as JSON", log.Error(err))
+			return promptUsage, completionUsage
+		}
+
+		// Extract usage data from response
+		promptUsage.tokens = res.Usage.PromptTokens
+		completionUsage.tokens = res.Usage.CompletionTokens
+		if len(res.Choices) > 0 {
+			completionUsage.characters = len(res.Choices[0].Content)
+		}
+		return promptUsage, completionUsage
+	}
+
+	// Otherwise, we have to parse the event stream.
+	//
+	// Currently, OpenAI only reports usage on non-streaming requests
+	// Until we can tokenize the response ourselves, just count
+	// character usage, and set token counts to -1 as sentinel values.
+	// TODO: https://github.com/sourcegraph/sourcegraph/issues/56590
+	promptUsage.tokens = -1
+	completionUsage.tokens = -1
+
+	dec := openai.NewDecoder(r)
+	// Consume all the messages, but we only care about the last completion data.
+	for dec.Scan() {
+		data := dec.Data()
+
+		// Gracefully skip over any data that isn't JSON-like.
+		if !bytes.HasPrefix(data, []byte("{")) {
+			continue
+		}
+
+		var event openaiResponse
+		if err := json.Unmarshal(data, &event); err != nil {
+			logger.Error("failed to decode event payload", log.Error(err), log.String("body", string(data)))
+			continue
+		}
+		if len(event.Choices) > 0 {
+			completionUsage.characters += len(event.Choices[0].Delta.Content)
+		}
+	}
+	if err := dec.Err(); err != nil {
+		logger.Error("failed to decode OpenAI streaming response", log.Error(err))
+	}
+
+	return promptUsage, completionUsage
 }

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -42,7 +42,7 @@ func NewOpenAIHandler(
 		string(conftypes.CompletionsProviderNameOpenAI),
 		func(_ codygateway.Feature) string { return openAIURL },
 		allowedModels,
-		OpenAIHandlerMethods{accessToken: accessToken, orgID: orgID},
+		&OpenAIHandlerMethods{accessToken: accessToken, orgID: orgID},
 
 		// OpenAI primarily uses tokens-per-minute ("TPM") to rate-limit spikes
 		// in requests, so set a very high retry-after to discourage Sourcegraph

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -42,35 +42,35 @@ type usageStats struct {
 // in the order they are defined here.
 //
 // Methods do not need to be concurrency-safe, as they are only called sequentially.
-type upstreamHandlerMethods[ReqT UpstreamRequest] struct {
+type upstreamHandlerMethods[ReqT UpstreamRequest] interface {
 	// validateRequest can be used to validate the HTTP request before it is sent upstream.
 	// Returning a non-nil error will stop further processing and return the given error
 	// code, or a 400.
 	// Second return value is a boolean indicating whether the request was flagged during validation.
 	//
 	// The provided logger already contains actor context.
-	validateRequest func(context.Context, log.Logger, codygateway.Feature, ReqT) (int, *flaggingResult, error)
+	validateRequest(context.Context, log.Logger, codygateway.Feature, ReqT) (int, *flaggingResult, error)
 	// transformBody can be used to modify the request body before it is sent
 	// upstream. To manipulate the HTTP request, use transformRequest.
 	//
 	// If the upstream supports it, the given identifier string should be
 	// provided to assist in abuse detection.
-	transformBody func(_ *ReqT, identifier string)
+	transformBody(_ *ReqT, identifier string)
 	// transformRequest can be used to modify the HTTP request before it is sent
 	// upstream. To manipulate the body, use transformBody.
-	transformRequest func(*http.Request)
+	transformRequest(*http.Request)
 	// getRequestMetadata should extract details about the request we are sending
 	// upstream for validation and tracking purposes. Usage data does not need
 	// to be reported here - instead, use parseResponseAndUsage to extract usage,
 	// which for some providers we can only know after the fact based on what
 	// upstream tells us.
-	getRequestMetadata func(context.Context, log.Logger, *actor.Actor, codygateway.Feature, ReqT) (model string, additionalMetadata map[string]any)
+	getRequestMetadata(context.Context, log.Logger, *actor.Actor, codygateway.Feature, ReqT) (model string, additionalMetadata map[string]any)
 	// parseResponseAndUsage should extract details from the response we get back from
 	// upstream as well as overall usage for tracking purposes.
 	//
 	// If data is unavailable, implementations should set relevant usage fields
 	// to -1 as a sentinel value.
-	parseResponseAndUsage func(log.Logger, ReqT, io.Reader) (promptUsage, completionUsage usageStats)
+	parseResponseAndUsage(log.Logger, ReqT, io.Reader) (promptUsage, completionUsage usageStats)
 }
 
 type UpstreamRequest interface {


### PR DESCRIPTION
Use explicit interfaces instead of a struct with inline methods to improve type safety - [context](https://sourcegraph.slack.com/archives/C05497E9MDW/p1702048403168149). 

## Test plan

- tested locally
- all existing tests pass