### PR TITLE
Extract token count from streaming Fireworks requests

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -39,12 +39,16 @@ go_library(
 
 go_test(
     name = "completions_test",
-    srcs = ["anthropic_test.go"],
+    srcs = [
+        "anthropic_test.go",
+        "fireworks_test.go",
+    ],
     embed = [":completions"],
     deps = [
         "//cmd/cody-gateway/internal/tokenizer",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -212,6 +212,7 @@ func (f *FireworksHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 		if len(event.Choices) > 0 {
 			completionUsage.characters += len(event.Choices[0].Text)
 		}
+		// these are only included in the last message, so we're not worried about overwriting
 		if event.Usage.PromptTokens > 0 {
 			promptUsage.tokens = event.Usage.PromptTokens
 		}
@@ -221,6 +222,9 @@ func (f *FireworksHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 	}
 	if err := dec.Err(); err != nil {
 		logger.Error("failed to decode Fireworks streaming response", log.Error(err))
+	}
+	if completionUsage.tokens <= 0 || promptUsage.tokens <= 0 {
+		logger.Warn("did not extract token counts from Fireworks streaming response", log.Int("prompt-tokens", promptUsage.tokens), log.Int("completion-tokens", completionUsage.tokens))
 	}
 
 	return promptUsage, completionUsage

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -212,7 +212,7 @@ func (f *FireworksHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 		if len(event.Choices) > 0 {
 			completionUsage.characters += len(event.Choices[0].Text)
 		}
-		// these are only included in the last message, so we're not worried about overwriting
+		// These are only included in the last message, so we're not worried about overwriting
 		if event.Usage.PromptTokens > 0 {
 			promptUsage.tokens = event.Usage.PromptTokens
 		}

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -211,6 +211,12 @@ func (f *FireworksHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 		if len(event.Choices) > 0 {
 			completionUsage.characters += len(event.Choices[0].Text)
 		}
+		if event.Usage.PromptTokens > 0 {
+			promptUsage.tokens = event.Usage.PromptTokens
+		}
+		if event.Usage.CompletionTokens > 0 {
+			completionUsage.tokens = event.Usage.CompletionTokens
+		}
 	}
 	if err := dec.Err(); err != nil {
 		logger.Error("failed to decode Fireworks streaming response", log.Error(err))

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
 

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -223,7 +223,7 @@ func (f *FireworksHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 	if err := dec.Err(); err != nil {
 		logger.Error("failed to decode Fireworks streaming response", log.Error(err))
 	}
-	if completionUsage.tokens <= 0 || promptUsage.tokens <= 0 {
+	if completionUsage.tokens == -1 || promptUsage.tokens == -1 {
 		logger.Warn("did not extract token counts from Fireworks streaming response", log.Int("prompt-tokens", promptUsage.tokens), log.Int("completion-tokens", completionUsage.tokens))
 	}
 

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks_test.go
@@ -1,0 +1,53 @@
+package completions
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFireworksRequestGetTokenCount(t *testing.T) {
+	logger := logtest.Scoped(t)
+
+	t.Run("streaming", func(t *testing.T) {
+		req := fireworksRequest{Stream: true}
+		r := strings.NewReader(streamingResponse)
+		handler := &FireworksHandlerMethods{}
+		promptUsage, completionUsage := handler.parseResponseAndUsage(logger, req, r)
+
+		assert.Equal(t, 79, promptUsage.tokens)
+		assert.Equal(t, 30, completionUsage.tokens)
+	})
+
+	t.Run("non-streaming", func(t *testing.T) {
+		req := fireworksRequest{Stream: false}
+		r := strings.NewReader(nonStreamingResponse)
+		handler := &FireworksHandlerMethods{}
+		promptUsage, completionUsage := handler.parseResponseAndUsage(logger, req, r)
+
+		assert.Equal(t, 79, promptUsage.tokens)
+		assert.Equal(t, 30, completionUsage.tokens)
+	})
+}
+
+var streamingResponse = `
+data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","created":1704368645,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}],"usage":null}
+
+data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","created":1704368645,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"delta":{"content":"I am a helpful AI assistant"},"finish_reason":null}],"usage":null}
+
+data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","created":1704368645,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"delta":{"content":" and I don't"},"finish_reason":null}],"usage":null}
+
+data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","created":1704368645,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"delta":{"content":" have a personal name."},"finish_reason":null}],"usage":null}
+
+data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","created":1704368645,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"delta":{"content":" That's why I"},"finish_reason":null}],"usage":null}
+
+data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","created":1704368645,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"delta":{"content":" introduced myself as Cody"},"finish_reason":null}],"usage":null}
+
+data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","created":1704368645,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"delta":{"content":", to make it"},"finish_reason":"length"}],"usage":{"prompt_tokens":79,"total_tokens":109,"completion_tokens":30}}
+
+data: [DONE]
+`
+
+var nonStreamingResponse = `{"id":"cmpl-a890423291fa6d7de7b8d8af","object":"chat.completion","created":1704368780,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"I don't have a \"real\" name, as I am an artificial intelligence and don't have a physical body or personal identity. I"},"finish_reason":"length"}],"usage":{"prompt_tokens":79,"total_tokens":109,"completion_tokens":30}}`

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -100,17 +100,10 @@ func HandleFeature(
 			limitedCause := "quota"
 			defer func() {
 				limitMap := map[string]any{}
-<<<<<<< HEAD
 				var limitExceededError limiter.RateLimitExceededError
 				if errors.As(err, &limitExceededError) {
 					limitMap["limit"] = limitExceededError.Limit
 					limitMap["retry_after"] = limitExceededError.RetryAfter
-=======
-				var rlErr limiter.RateLimitExceededError
-				if errors.As(err, &rlErr) {
-					limitMap["limit"] = rlErr.Limit
-					limitMap["retry_after"] = rlErr.RetryAfter
->>>>>>> 70ec8c5a09 (Add information about rate_limits that were hit)
 				}
 				if loggerErr := eventLogger.LogEvent(
 					r.Context(),

--- a/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
+++ b/cmd/cody-gateway/internal/httpapi/featurelimiter/featurelimiter.go
@@ -100,10 +100,17 @@ func HandleFeature(
 			limitedCause := "quota"
 			defer func() {
 				limitMap := map[string]any{}
+<<<<<<< HEAD
 				var limitExceededError limiter.RateLimitExceededError
 				if errors.As(err, &limitExceededError) {
 					limitMap["limit"] = limitExceededError.Limit
 					limitMap["retry_after"] = limitExceededError.RetryAfter
+=======
+				var rlErr limiter.RateLimitExceededError
+				if errors.As(err, &rlErr) {
+					limitMap["limit"] = rlErr.Limit
+					limitMap["retry_after"] = rlErr.RetryAfter
+>>>>>>> 70ec8c5a09 (Add information about rate_limits that were hit)
 				}
 				if loggerErr := eventLogger.LogEvent(
 					r.Context(),


### PR DESCRIPTION
Extract token counts from streaming Fireworks requests - [context](https://sourcegraph.slack.com/archives/C060RPB9H1T/p1704283962290259?thread_ts=1704213101.928429&cid=C060RPB9H1T). 
Non-streaming requests already set token counts correctly.

Closes https://github.com/sourcegraph/sourcegraph/issues/56704

## Test plan

- tested locally
- unit tests added