### PR TITLE
search: don't highlight operators inside "..."

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1824,4 +1824,32 @@ describe('scanSearchQuery() and decorate()', () => {
             ]
         `)
     })
+
+    test('Do not highlight keywords inside quotes for newStandardRC1', () => {
+        expect(getTokens(toSuccess(scanSearchQuery('"foo and bar" and bas', false, SearchPatternType.newStandardRC1))))
+            .toMatchInlineSnapshot(`
+              [
+                {
+                  "startIndex": 0,
+                  "scopes": "identifier"
+                },
+                {
+                  "startIndex": 13,
+                  "scopes": "whitespace"
+                },
+                {
+                  "startIndex": 14,
+                  "scopes": "keyword"
+                },
+                {
+                  "startIndex": 17,
+                  "scopes": "whitespace"
+                },
+                {
+                  "startIndex": 18,
+                  "scopes": "identifier"
+                }
+              ]
+            `)
+    })
 })

--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -19,13 +19,13 @@ describe('newStandardRC1()', () => {
 
     test('single quoted patterns are interpreted as literal', () => {
         expect(scanSearchQuery("'foo or bar'", false, SearchPatternType.newStandardRC1)).toMatchInlineSnapshot(
-            `{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":12},"kind":1,"value":"foo or bar","delimited":true}]}`
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":12},"kind":1,"value":"foo or bar","delimited":true}]}'
         )
     })
 
     test('recognize keywords outside quoted patterns', () => {
         expect(scanSearchQuery('"foo or bar" or bas', false, SearchPatternType.newStandardRC1)).toMatchInlineSnapshot(
-            `{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":12},"kind":1,"value":"foo or bar","delimited":true},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"keyword","value":"or","range":{"start":13,"end":15},"kind":"or"},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"pattern","range":{"start":16,"end":19},"kind":1,"value":"bas","delimited":false}]}`
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":12},"kind":1,"value":"foo or bar","delimited":true},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"keyword","value":"or","range":{"start":13,"end":15},"kind":"or"},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"pattern","range":{"start":16,"end":19},"kind":1,"value":"bas","delimited":false}]}'
         )
     })
 

--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -10,6 +10,32 @@ expect.addSnapshotSerializer({
     test: () => true,
 })
 
+describe('newStandardRC1()', () => {
+    test('double quoted patterns are interpreted as literal', () => {
+        expect(scanSearchQuery('"foo and bar"', false, SearchPatternType.newStandardRC1)).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":13},"kind":1,"value":"foo and bar","delimited":true}]}'
+        )
+    })
+
+    test('single quoted patterns are interpreted as literal', () => {
+        expect(scanSearchQuery("'foo or bar'", false, SearchPatternType.newStandardRC1)).toMatchInlineSnapshot(
+            `{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":12},"kind":1,"value":"foo or bar","delimited":true}]}`
+        )
+    })
+
+    test('recognize keywords outside quoted patterns', () => {
+        expect(scanSearchQuery('"foo or bar" or bas', false, SearchPatternType.newStandardRC1)).toMatchInlineSnapshot(
+            `{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":12},"kind":1,"value":"foo or bar","delimited":true},{"type":"whitespace","range":{"start":12,"end":13}},{"type":"keyword","value":"or","range":{"start":13,"end":15},"kind":"or"},{"type":"whitespace","range":{"start":15,"end":16}},{"type":"pattern","range":{"start":16,"end":19},"kind":1,"value":"bas","delimited":false}]}`
+        )
+    })
+
+    test('scan literal and regexp patterns', () => {
+        expect(scanSearchQuery('pfalz /mosel/', false, SearchPatternType.newStandardRC1)).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":5},"kind":1,"value":"pfalz","delimited":false},{"type":"whitespace","range":{"start":5,"end":6}},{"type":"pattern","range":{"start":6,"end":13},"kind":2,"value":"mosel","delimited":true}]}'
+        )
+    })
+})
+
 describe('scanBalancedPattern()', () => {
     const scanBalancedPattern = toPatternResult(scanBalancedLiteral, PatternKind.Literal)
     test('balanced, scans up to whitespace', () => {


### PR DESCRIPTION
Relates to: #58815 

This PR fixes a bug in keyword search, where 'OR', 'AND', and 'NOT' were highlighted within quoted patterns, such as `"foo and bar"`. In keyword search, however, we want to treat quoted patterns as literals and the operators shouldn't be highlighted.

before:
<img width="778" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/6fadf825-7fa9-473f-b50a-3d41f5d9bcb4">

after:
![image](https://github.com/sourcegraph/sourcegraph/assets/26413131/42c06a28-c7bf-44b3-ab11-33b1b9a9cefa)

Test plan:
new unit tests

