### PR TITLE
Searcher: simplify the 'matcher' interface

### DIFF
--- a/cmd/searcher/internal/search/hybrid.go
+++ b/cmd/searcher/internal/search/hybrid.go
@@ -264,7 +264,7 @@ func zoektCompile(p *protocol.PatternInfo) (zoektquery.Q, error) {
 	// feels nicer than passing in a regexMatcher since handle path directly.
 	if m, err := compilePattern(p); err != nil {
 		return nil, err
-	} else if m.MatchesAllContent() { // we are just matching paths
+	} else if m == nil { // we are just matching paths
 		parts = append(parts, &zoektquery.Const{Value: true})
 	} else {
 		q, err := m.ToZoektQuery(p.PatternMatchesContent, p.PatternMatchesPath)

--- a/cmd/searcher/internal/search/matcher.go
+++ b/cmd/searcher/internal/search/matcher.go
@@ -15,9 +15,6 @@ import (
 )
 
 type matcher interface {
-	// IgnoreCase returns whether matches will ignore case
-	IgnoreCase() bool
-
 	// MatchesString returns whether the string matches
 	MatchesString(s string) bool
 
@@ -148,10 +145,6 @@ func longestLiteral(re *syntax.Regexp) string {
 
 func (rm *regexMatcher) String() string {
 	return fmt.Sprintf("re: %q", rm.re)
-}
-
-func (rm *regexMatcher) IgnoreCase() bool {
-	return rm.ignoreCase
 }
 
 func (rm *regexMatcher) MatchesString(s string) bool {

--- a/cmd/searcher/internal/search/matcher.go
+++ b/cmd/searcher/internal/search/matcher.go
@@ -2,27 +2,19 @@ package search
 
 import (
 	"bytes"
+	"fmt"
 	"regexp/syntax"
 	"strings"
 
 	"github.com/grafana/regexp"
 	"github.com/sourcegraph/zoekt/query"
-	"go.opentelemetry.io/otel/attribute"
+	zoektquery "github.com/sourcegraph/zoekt/query"
 
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/search/casetransform"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
-
-	zoektquery "github.com/sourcegraph/zoekt/query"
 )
 
 type matcher interface {
-	// AddAttributes adds attributes to the trace
-	AddAttributes(tr trace.Trace)
-
-	// MatchesAllContent returns whether the pattern will match all content
-	MatchesAllContent() bool
-
 	// IgnoreCase returns whether matches will ignore case
 	IgnoreCase() bool
 
@@ -34,6 +26,9 @@ type matcher interface {
 
 	// ToZoektQuery returns a zoekt query representing the same rules as as this matcher
 	ToZoektQuery(matchContent bool, matchPath bool) (zoektquery.Q, error)
+
+	// String returns a simple string representation of the matcher
+	String() string
 }
 
 type regexMatcher struct {
@@ -53,60 +48,65 @@ type regexMatcher struct {
 	literalSubstring []byte
 }
 
-// compilePattern returns a matcher for matching p.
+// compilePattern returns a matcher for matching p. If the pattern
+// is empty, then it returns a nil matcher.
 func compilePattern(p *protocol.PatternInfo) (matcher, error) {
 	var (
 		re               *regexp.Regexp
 		literalSubstring []byte
 	)
-	if p.Pattern != "" {
-		expr := p.Pattern
-		if !p.IsRegExp {
-			expr = regexp.QuoteMeta(expr)
-		}
-		if p.IsRegExp {
-			// We don't do the search line by line, therefore we want the
-			// regex engine to consider newlines for anchors (^$).
-			expr = "(?m:" + expr + ")"
-		}
 
-		// Transforms on the parsed regex
-		{
-			re, err := syntax.Parse(expr, syntax.Perl)
-			if err != nil {
-				return nil, err
-			}
+	if p.Pattern == "" {
+		return nil, nil
+	}
 
-			if !p.IsCaseSensitive {
-				// We don't just use (?i) because regexp library doesn't seem
-				// to contain good optimizations for case insensitive
-				// search. Instead we lowercase the input and pattern.
-				casetransform.LowerRegexpASCII(re)
-			}
+	expr := p.Pattern
+	if !p.IsRegExp {
+		expr = regexp.QuoteMeta(expr)
+	}
 
-			// OptimizeRegexp currently only converts capture groups into
-			// non-capture groups (faster for stdlib regexp to execute).
-			re = query.OptimizeRegexp(re, syntax.Perl)
+	if p.IsRegExp {
+		// We don't do the search line by line, therefore we want the
+		// regex engine to consider newlines for anchors (^$).
+		expr = "(?m:" + expr + ")"
+	}
 
-			expr = re.String()
-		}
-
-		var err error
-		re, err = regexp.Compile(expr)
+	// Transforms on the parsed regex
+	{
+		re, err := syntax.Parse(expr, syntax.Perl)
 		if err != nil {
 			return nil, err
 		}
 
-		// Only use literalSubstring optimization if the regex engine doesn't
-		// have a prefix to use.
-		if pre, _ := re.LiteralPrefix(); pre == "" {
-			ast, err := syntax.Parse(expr, syntax.Perl)
-			if err != nil {
-				return nil, err
-			}
-			ast = ast.Simplify()
-			literalSubstring = []byte(longestLiteral(ast))
+		if !p.IsCaseSensitive {
+			// We don't just use (?i) because regexp library doesn't seem
+			// to contain good optimizations for case insensitive
+			// search. Instead we lowercase the input and pattern.
+			casetransform.LowerRegexpASCII(re)
 		}
+
+		// OptimizeRegexp currently only converts capture groups into
+		// non-capture groups (faster for stdlib regexp to execute).
+		re = query.OptimizeRegexp(re, syntax.Perl)
+
+		expr = re.String()
+	}
+
+	var err error
+	re, err = regexp.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only use literalSubstring optimization if the regex engine doesn't
+	// have a prefix to use.
+	if pre, _ := re.LiteralPrefix(); pre == "" {
+		ast, err := syntax.Parse(expr, syntax.Perl)
+		if err != nil {
+			return nil, err
+		}
+		ast = ast.Simplify()
+		literalSubstring = []byte(longestLiteral(ast))
 	}
 
 	return &regexMatcher{
@@ -146,14 +146,8 @@ func longestLiteral(re *syntax.Regexp) string {
 	return ""
 }
 
-func (rm *regexMatcher) AddAttributes(tr trace.Trace) {
-	if rm.re != nil {
-		tr.SetAttributes(attribute.Stringer("re", rm.re))
-	}
-}
-
-func (rm *regexMatcher) MatchesAllContent() bool {
-	return rm.re == nil
+func (rm *regexMatcher) String() string {
+	return fmt.Sprintf("re: %q", rm.re)
 }
 
 func (rm *regexMatcher) IgnoreCase() bool {
@@ -166,9 +160,6 @@ func (rm *regexMatcher) MatchesString(s string) bool {
 }
 
 func (rm *regexMatcher) matchesString(s string) bool {
-	if rm.re == nil {
-		return true
-	}
 	if rm.ignoreCase {
 		s = strings.ToLower(s)
 	}

--- a/cmd/searcher/internal/search/search.go
+++ b/cmd/searcher/internal/search/search.go
@@ -254,7 +254,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request, sender matchS
 	}
 	defer zf.Close()
 
-	return regexSearch(ctx, rm, pm, zf, p.PatternMatchesContent, p.PatternMatchesPath, sender, p.NumContextLines)
+	return regexSearch(ctx, rm, pm, zf, p.PatternMatchesContent, p.PatternMatchesPath, p.IsCaseSensitive, sender, p.NumContextLines)
 }
 
 func (s *Service) getZipFile(ctx context.Context, tr trace.Trace, p *protocol.Request, paths []string) (string, *zipFile, error) {

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -24,11 +24,12 @@ func regexSearchBatch(
 	zf *zipFile,
 	limit int,
 	patternMatchesContent, patternMatchesPaths bool,
+	isCaseSensitive bool,
 	contextLines int32,
 ) ([]protocol.FileMatch, bool, error) {
 	ctx, cancel, sender := newLimitedStreamCollector(ctx, limit)
 	defer cancel()
-	err := regexSearch(ctx, m, pm, zf, patternMatchesContent, patternMatchesPaths, sender, contextLines)
+	err := regexSearch(ctx, m, pm, zf, patternMatchesContent, patternMatchesPaths, isCaseSensitive, sender, contextLines)
 	return sender.collected, sender.LimitHit(), err
 }
 
@@ -52,6 +53,7 @@ func regexSearch(
 	pm *pathMatcher,
 	zf *zipFile,
 	patternMatchesContent, patternMatchesPaths bool,
+	isCaseSensitive bool,
 	sender matchSender,
 	contextLines int32,
 ) (err error) {
@@ -142,7 +144,7 @@ func regexSearch(
 				// data (for Preview).
 				fileBuf := zf.DataFor(f)
 				fileMatchBuf := fileBuf
-				if m.IgnoreCase() {
+				if !isCaseSensitive {
 					// If we are ignoring case, we transform the input instead of
 					// relying on the regular expression engine which can be
 					// slow. compilePattern has already lowercased the pattern. We also

--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -58,8 +58,10 @@ func regexSearch(
 	tr, ctx := trace.New(ctx, "regexSearch")
 	defer tr.EndWithErr(&err)
 
-	m.AddAttributes(tr)
 	tr.SetAttributes(attribute.Stringer("path", pm))
+	if m != nil {
+		tr.SetAttributes(attribute.String("matcher", m.String()))
+	}
 
 	if !patternMatchesContent && !patternMatchesPaths {
 		patternMatchesContent = true
@@ -81,11 +83,11 @@ func regexSearch(
 		files = zf.Files
 	)
 
-	if m.MatchesAllContent() || (patternMatchesPaths && !patternMatchesContent) {
+	if m == nil || (patternMatchesPaths && !patternMatchesContent) {
 		// Fast path for only matching file paths (or with a nil pattern, which matches all files,
 		// so is effectively matching only on file paths).
 		for _, f := range files {
-			if pm.Matches(f.Name) && m.MatchesString(f.Name) {
+			if pm.Matches(f.Name) && (m == nil || m.MatchesString(f.Name)) {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -445,13 +445,11 @@ func TestRegexSearch(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name: "nil re returns a FileMatch with no LineMatches",
+			name: "nil matcher returns a FileMatch with no LineMatches",
 			args: args{
 				ctx: context.Background(),
-				m: &regexMatcher{
-					// Check this case specifically.
-					re: nil,
-				},
+				// Check this case specifically.
+				m:  nil,
 				pm: match,
 				zf: &zipFile{
 					Files: []srcFile{

--- a/cmd/searcher/internal/search/search_regex_test.go
+++ b/cmd/searcher/internal/search/search_regex_test.go
@@ -228,7 +228,7 @@ func benchSearchRegex(b *testing.B, p *protocol.Request) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		_, _, err := regexSearchBatch(ctx, m, pm, zf, 99999999, p.PatternMatchesContent, p.PatternMatchesPath, 0)
+		_, _, err := regexSearchBatch(ctx, m, pm, zf, 99999999, p.PatternMatchesContent, p.PatternMatchesPath, p.IsCaseSensitive, 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -329,7 +329,7 @@ func TestMaxMatches(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileMatches, limitHit, err := regexSearchBatch(context.Background(), m, pm, zf, maxMatches, true, false, 0)
+	fileMatches, limitHit, err := regexSearchBatch(context.Background(), m, pm, zf, maxMatches, true, false, false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,7 +383,7 @@ func TestPathMatches(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fileMatches, _, err := regexSearchBatch(context.Background(), m, pm, zf, 10, true, true, 0)
+	fileMatches, _, err := regexSearchBatch(context.Background(), m, pm, zf, 10, true, true, false, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -422,7 +422,6 @@ func TestRegexSearch(t *testing.T) {
 	match, err := compilePathPatterns(&protocol.PatternInfo{
 		IncludePatterns: []string{`a\.go`},
 		ExcludePattern:  `README\.md`,
-		IsCaseSensitive: false,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -467,7 +466,7 @@ func TestRegexSearch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFm, gotLimitHit, err := regexSearchBatch(tt.args.ctx, tt.args.m, tt.args.pm, tt.args.zf, tt.args.limit, tt.args.patternMatchesContent, tt.args.patternMatchesPaths, 0)
+			gotFm, gotLimitHit, err := regexSearchBatch(tt.args.ctx, tt.args.m, tt.args.pm, tt.args.zf, tt.args.limit, tt.args.patternMatchesContent, tt.args.patternMatchesPaths, false, 0)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("regexSearch() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/searcher/internal/search/search_structural.go
+++ b/cmd/searcher/internal/search/search_structural.go
@@ -419,7 +419,7 @@ func filteredStructuralSearch(
 		return err
 	}
 
-	fileMatches, _, err := regexSearchBatch(ctx, m, pm, zf, p.Limit, true, false, contextLines)
+	fileMatches, _, err := regexSearchBatch(ctx, m, pm, zf, p.Limit, true, false, p.IsCaseSensitive, contextLines)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This simplifies the 'matcher' interface in preparation for adding two new implementations, `orMatcher` and `andMatcher`. Changes:
* Remove `MatchesAllContent`. Now the matcher is just nil if it matches everything
* Remove `AddAttributes` in favor of a `String` method
* Remove `IgnoreCase` method, since this is not really a property of a specific matcher/ clause

## Test plan

Refactor is covered by existing unit tests
