### PR TITLE
bazel: updates for hermetic_cc_toolchain flakiness

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,12 +19,6 @@ try-import %workspace%/.aspect/bazelrc/user.bazelrc
 # Enable bazel hack for autogold; apply to both build & test to avoid busting analysis cache
 build --test_env=ENABLE_BAZEL_PACKAGES_LOAD_HACK=true
 
-# Needed by https://github.com/uber/hermetic_cc_toolchain which we use to cross-compile
-# CGo code for cmd/symbols to be used in containers.
-build:incompat-zig-linux-amd64 --platforms @zig_sdk//platform:linux_amd64
-build:incompat-zig-linux-amd64 --extra_toolchains @zig_sdk//toolchain:linux_amd64_musl
-build:incompat-zig-linux-amd64 --sandbox_add_mount_pair=/tmp
-
 # Except in CI run E2E tests in headless mode
 try-import %workspace%/user.bazelrc
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -19,11 +19,11 @@ try-import %workspace%/.aspect/bazelrc/user.bazelrc
 # Enable bazel hack for autogold; apply to both build & test to avoid busting analysis cache
 build --test_env=ENABLE_BAZEL_PACKAGES_LOAD_HACK=true
 
-# Needed by https://github.com/uber/bazel-zig-cc which we use to cross-compile
+# Needed by https://github.com/uber/hermetic_cc_toolchain which we use to cross-compile
 # CGo code for cmd/symbols to be used in containers.
-build:incompat-zig-linux-amd64 --incompatible_enable_cc_toolchain_resolution
 build:incompat-zig-linux-amd64 --platforms @zig_sdk//platform:linux_amd64
 build:incompat-zig-linux-amd64 --extra_toolchains @zig_sdk//toolchain:linux_amd64_musl
+build:incompat-zig-linux-amd64 --sandbox_add_mount_pair=/tmp
 
 # Except in CI run E2E tests in headless mode
 try-import %workspace%/user.bazelrc
@@ -32,9 +32,9 @@ try-import %workspace%/user.bazelrc
 try-import %workspace%/.bazelrc-nix
 
 # Used to locally cross compile, when targeting docker images
-build:darwin-docker --incompatible_enable_cc_toolchain_resolution
 build:darwin-docker --platforms @zig_sdk//platform:linux_amd64
-build:darwin-docker --extra_toolchains @zig_sdk//toolchain:linux_amd64_gnu.2.31
+build:darwin-docker --extra_toolchains @zig_sdk//toolchain:linux_amd64_gnu.2.34
+build:darwin-docker --sandbox_add_mount_pair=/tmp
  # build setting to tell some go test runner to force targeting to macos even if we're building containers with the linux/amd64 toolchain.
 build:darwin-docker --//:darwin_docker=True
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -347,12 +347,12 @@ crate_repositories()
 load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
 
 zig_toolchains(
-    # Fixes flakiness with zig 0.11.0
-    # https://bazelbuild.slack.com/archives/C04N6NE1GRM/p1704306009190609?thread_ts=1704306009.190609&cid=C04N6NE1GRM
-    version = "0.12.0-dev.2030+2ac315c24",
     host_platform_sha256 = {
         "macos-aarch64": "ed946cd65d00b18342d9a9ee9666b0869025ac2cd544a0fec3c337b5b0ee53c3",
     },
+    # Fixes flakiness with zig 0.11.0
+    # https://bazelbuild.slack.com/archives/C04N6NE1GRM/p1704306009190609?thread_ts=1704306009.190609&cid=C04N6NE1GRM
+    version = "0.12.0-dev.2030+2ac315c24",
 )
 
 # containers steup       ===============================

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -134,7 +134,7 @@ http_archive(
 )
 
 # hermetic_cc_toolchain setup ================================
-HERMETIC_CC_TOOLCHAIN_VERSION = "v2.1.2"
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.1.3"
 
 # Please note that we only use hermetic-cc for local development purpose and Nix, at it eases the path to cross-compile
 # so we can produce container images locally on Mac laptops.
@@ -149,8 +149,9 @@ http_archive(
     patch_args = ["-p1"],
     patches = [
         "//third_party/hermetic_cc:disable_ubsan.patch",
+        "//third_party/hermetic_cc:zig_0.12.0_pr140.patch",
     ],
-    sha256 = "28fc71b9b3191c312ee83faa1dc65b38eb70c3a57740368f7e7c7a49bedf3106",
+    sha256 = "a5caccbf6d86d4f60afd45b541a05ca4cc3f5f523aec7d3f7711e584600fb075",
     urls = [
         "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
         "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
@@ -345,7 +346,14 @@ crate_repositories()
 
 load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_toolchains = "toolchains")
 
-zig_toolchains()
+zig_toolchains(
+    # Fixes flakiness with zig 0.11.0
+    # https://bazelbuild.slack.com/archives/C04N6NE1GRM/p1704306009190609?thread_ts=1704306009.190609&cid=C04N6NE1GRM
+    version = "0.12.0-dev.2030+2ac315c24",
+    host_platform_sha256 = {
+        "macos-aarch64": "ed946cd65d00b18342d9a9ee9666b0869025ac2cd544a0fec3c337b5b0ee53c3",
+    },
+)
 
 # containers steup       ===============================
 load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")

--- a/docker-images/syntax-highlighter/rust-toolchain.toml
+++ b/docker-images/syntax-highlighter/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.73.0"
 # Keep in sync with /WORKSPACE and docker-images/syntax-highlighter/Dockerfile

--- a/third_party/hermetic_cc/zig_0.12.0_pr140.patch
+++ b/third_party/hermetic_cc/zig_0.12.0_pr140.patch
@@ -1,0 +1,22 @@
+diff --git a/toolchain/zig-wrapper.zig b/toolchain/zig-wrapper.zig
+index 4a0fab4..8a740f7 100644
+--- a/toolchain/zig-wrapper.zig
++++ b/toolchain/zig-wrapper.zig
+@@ -328,7 +328,7 @@ test "zig-wrapper:parseArgs" {
+     // not using testing.allocator, because parseArgs is designed to be used
+     // with an arena.
+     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+-    var allocator = gpa.allocator();
++    const allocator = gpa.allocator();
+
+     const tests = [_]struct {
+         args: []const [:0]const u8,
+@@ -428,7 +428,7 @@ test "zig-wrapper:parseArgs" {
+             try tmp.dir.makePath(dir);
+
+         var argv_it = TestArgIterator{ .argv = tt.args };
+-        var res = try parseArgs(allocator, tmp.dir, &argv_it);
++        const res = try parseArgs(allocator, tmp.dir, &argv_it);
+
+         switch (tt.want_result) {
+             .err => |want_msg| try testing.expectEqualStrings(


### PR DESCRIPTION
Changes:
- Bumps hermetic_cc_toolchain to [v2.1.3](https://github.com/uber/hermetic_cc_toolchain/releases/tag/v2.1.3) for macOS specific fixes
- Removed now-unused `incompat-zig-linux-amd64` bazel config
- Removed now-true-by-default in bazel7 `--incompatible_enable_cc_toolchain_resolution`
- Added `--sandbox_add_mount_pair=/tmp` to `darwin-docker` bazel config as recommended for hermetic_cc_toolchain
- Bumps glibc version used in `darwin-docker` config to be closer to the version in our wolfi images
- Bumps zig to 0.12.0-dev build to fix occasional flakiness 
- Brings rust-toolchains.toml in-line again with WORKSPACE

## Test plan

- `bazel build //docker-images/syntax-highlighter:syntect_server --config=darwin-docker` with various combinations of `bazel clean`, `bazel clean --expunge` and `rm -rf /tmp/zig-cache`
- `bazel test //docker-images/syntax-highlighter:image_test --config=darwin-docker`