### PR TITLE
msp: emit StackLocals as GSM secrets

### DIFF
--- a/dev/managedservicesplatform/googlesecretsmanager/googlesecretsmanager.go
+++ b/dev/managedservicesplatform/googlesecretsmanager/googlesecretsmanager.go
@@ -1,8 +1,8 @@
 package googlesecretsmanager
 
-// ProjectID is the Google Cloud Project that must have the secrets listed in
+// SharedSecretsProjectID is the Google Cloud Project that must have the secrets listed in
 // this package available in Google Secrets Manager for MSP.
-const ProjectID = "sourcegraph-secrets"
+const SharedSecretsProjectID = "sourcegraph-secrets"
 
 const (
 	/// SecretTFCOrgToken is used for managing TFC workspaces. It cannot
@@ -35,6 +35,8 @@ const (
 	// The current bot user is https://api.slack.com/apps/A06C4TF6YF7/oauth
 	SecretSlackOperatorOAuthToken = "SLACK_OPERATOR_BOT_OAUTH_TOKEN"
 
+	// SecretSourcegraphWildcardKey and SecretSourcegraphWildcardCert are used
+	// for configuring Cloudflare TLS.
 	SecretSourcegraphWildcardKey  = "SOURCEGRAPH_WILDCARD_KEY"
 	SecretSourcegraphWildcardCert = "SOURCEGRAPH_WILDCARD_CERT"
 )

--- a/dev/managedservicesplatform/internal/resource/cloudflareorigincert/cloudflareorigincert.go
+++ b/dev/managedservicesplatform/internal/resource/cloudflareorigincert/cloudflareorigincert.go
@@ -36,11 +36,11 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) *Output {
 
 				PrivateKey: &gsmsecret.Get(scope, id.Group("secret-origin-private-key"), gsmsecret.DataConfig{
 					Secret:    googlesecretsmanager.SecretSourcegraphWildcardKey,
-					ProjectID: googlesecretsmanager.ProjectID,
+					ProjectID: googlesecretsmanager.SharedSecretsProjectID,
 				}).Value,
 				Certificate: &gsmsecret.Get(scope, id.Group("secret-origin-cert"), gsmsecret.DataConfig{
 					Secret:    googlesecretsmanager.SecretSourcegraphWildcardCert,
-					ProjectID: googlesecretsmanager.ProjectID,
+					ProjectID: googlesecretsmanager.SharedSecretsProjectID,
 				}).Value,
 
 				Lifecycle: &cdktf.TerraformResourceLifecycle{

--- a/dev/managedservicesplatform/internal/stack/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/stack/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/stack",
     visibility = ["//dev/managedservicesplatform:__subpackages__"],
     deps = [
+        "//dev/managedservicesplatform/internal/resource/gsmsecret",
         "//dev/managedservicesplatform/internal/resourceid",
         "//lib/pointers",
         "@com_github_hashicorp_terraform_cdk_go_cdktf//:cdktf",

--- a/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/internal/stack/cloudrun/cloudrun.go
@@ -72,7 +72,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		googleprovider.With(vars.ProjectID),
 		cloudflareprovider.With(gsmsecret.DataConfig{
 			Secret:    googlesecretsmanager.SecretCloudflareAPIToken,
-			ProjectID: googlesecretsmanager.ProjectID,
+			ProjectID: googlesecretsmanager.SharedSecretsProjectID,
 		}),
 		randomprovider.With(),
 		dynamicvariables.With(vars.StableGenerate, func() (stack.TFVars, error) {
@@ -228,7 +228,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		cloudRunBuilder.AddDependency(pgRoles.WorkloadSuperuserGrant)
 
 		// Add output for connecting to the instance
-		locals.Add("cloudsql_connection_name", sqlInstance.Instance.ConnectionName(),
+		locals.Add("cloudsql_connection_name", *sqlInstance.Instance.ConnectionName(),
 			"Cloud SQL database connection name")
 	}
 
@@ -284,7 +284,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 		"Cloud Run resource name")
 	locals.Add("cloud_run_location", *cloudRunResource.Location(),
 		"Cloud Run resource location")
-	locals.Add("image_tag", imageTag.StringValue,
+	locals.Add("image_tag", *imageTag.StringValue,
 		"Resolved tag of service image to deploy")
 	return &CrossStackOutput{
 		RedisInstanceID: redisInstanceID,

--- a/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/internal/stack/monitoring/monitoring.go
@@ -104,11 +104,11 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 		googleprovider.With(vars.ProjectID),
 		opsgenieprovider.With(gsmsecret.DataConfig{
 			Secret:    googlesecretsmanager.SecretOpsgenieAPIToken,
-			ProjectID: googlesecretsmanager.ProjectID,
+			ProjectID: googlesecretsmanager.SharedSecretsProjectID,
 		}),
 		slackprovider.With(gsmsecret.DataConfig{
 			Secret:    googlesecretsmanager.SecretSlackOperatorOAuthToken,
-			ProjectID: googlesecretsmanager.ProjectID,
+			ProjectID: googlesecretsmanager.SharedSecretsProjectID,
 		}))
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	// Configure Slack channels
 	slackToken := gsmsecret.Get(stack, id.Group("slack_token"), gsmsecret.DataConfig{
 		Secret:    googlesecretsmanager.SecretSlackOAuthToken,
-		ProjectID: googlesecretsmanager.ProjectID,
+		ProjectID: googlesecretsmanager.SharedSecretsProjectID,
 	})
 	for _, channel := range []struct {
 		Name             string

--- a/dev/managedservicesplatform/internal/stack/options/googleprovider/google.go
+++ b/dev/managedservicesplatform/internal/stack/options/googleprovider/google.go
@@ -20,6 +20,9 @@ func With(projectID string) stack.NewStackOption {
 			// Make project ID available to custom TF
 			s.Locals().Add("project_id", projectID,
 				"Primary Google Project to use for all GCP resources")
+			// Make all subsequent locals exported to GSM so we can access it
+			// more easily in tooling
+			s.Metadata[stack.MetadataKeyStackLocalsGSMProjectID] = projectID
 		}
 		_ = google.NewGoogleProvider(s.Stack, pointers.Ptr("google"), &google.GoogleProviderConfig{
 			Project: project,

--- a/dev/managedservicesplatform/internal/stack/project/project.go
+++ b/dev/managedservicesplatform/internal/stack/project/project.go
@@ -149,7 +149,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	}
 
 	// Collect outputs
-	locals.Add("project_id", project.ProjectId(), "Generated project ID")
+	locals.Add("project_id", *project.ProjectId(), "Generated project ID")
 	return &CrossStackOutput{Project: project}, nil
 }
 

--- a/dev/managedservicesplatform/internal/stack/tfcworkspaces/tfcworkspaces.go
+++ b/dev/managedservicesplatform/internal/stack/tfcworkspaces/tfcworkspaces.go
@@ -33,11 +33,10 @@ const StackName = "tfcworkspaces"
 // configurations.
 func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	scope, _, err := stacks.New(StackName,
-		// googleprovider only needed for GSM access to set up tfeprovider
-		googleprovider.With(googlesecretsmanager.ProjectID),
+		googleprovider.With(""),
 		tfeprovider.With(gsmsecret.DataConfig{
 			Secret:    googlesecretsmanager.SecretTFCMSPTeamToken,
-			ProjectID: googlesecretsmanager.ProjectID,
+			ProjectID: googlesecretsmanager.SharedSecretsProjectID,
 		}))
 	if err != nil {
 		return nil, err
@@ -51,7 +50,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 			Organization: pointers.Ptr(terraformcloud.Organization),
 			Token: &gsmsecret.Get(scope, resourceid.New("tfe-org-provider-token"), gsmsecret.DataConfig{
 				Secret:    googlesecretsmanager.SecretTFCOrgToken,
-				ProjectID: googlesecretsmanager.ProjectID,
+				ProjectID: googlesecretsmanager.SharedSecretsProjectID,
 			}).Value,
 		})
 
@@ -159,7 +158,7 @@ func getAndConfigureWorkspace(
 			DestinationType: pointers.Ptr("slack"),
 			Url: &gsmsecret.Get(scope, id.Group("slack_webhook"), gsmsecret.DataConfig{
 				Secret:    googlesecretsmanager.SecretTFCMSPSlackWebhook,
-				ProjectID: googlesecretsmanager.ProjectID,
+				ProjectID: googlesecretsmanager.SharedSecretsProjectID,
 			}).Value,
 			// Trigger options are documented here:
 			// https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/notification_configuration#triggers

--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -63,7 +63,7 @@ func getTFCRunsClient(c *cli.Context) (*terraformcloud.RunsClient, error) {
 	tfcMSPAccessToken, err := secretStore.GetExternal(c.Context, secrets.ExternalSecret{
 		// We use a team token to get workspace runs
 		Name:    googlesecretsmanager.SecretTFCMSPTeamToken,
-		Project: googlesecretsmanager.ProjectID,
+		Project: googlesecretsmanager.SharedSecretsProjectID,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "get TFC OAuth client ID")

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -511,14 +511,14 @@ Supports completions on services and environments.`,
 						}
 						tfcAccessToken, err := secretStore.GetExternal(c.Context, secrets.ExternalSecret{
 							Name:    googlesecretsmanager.SecretTFCOrgToken,
-							Project: googlesecretsmanager.ProjectID,
+							Project: googlesecretsmanager.SharedSecretsProjectID,
 						})
 						if err != nil {
 							return errors.Wrap(err, "get AccessToken")
 						}
 						tfcOAuthClient, err := secretStore.GetExternal(c.Context, secrets.ExternalSecret{
 							Name:    googlesecretsmanager.SecretTFCOAuthClientID,
-							Project: googlesecretsmanager.ProjectID,
+							Project: googlesecretsmanager.SharedSecretsProjectID,
 						})
 						if err != nil {
 							return errors.Wrap(err, "get TFC OAuth client ID")


### PR DESCRIPTION
Right now, commands like `sg msp db connect` need to access TFC workspace outputs. This is clunky because it requires another Entitle roundtrip to get credentials and access to TFC.

Now that we configure project ID up-front, `sg msp` can just reach out to the service environment's project ID for secrets - by adding all local variables/TF outputs to GSM as well, we can now get access to everything with just one Entitle request on the environment project or folder.

This change only emits StackLocals as GSM secrets - I'll make the actual tooling changes in a follow-up.

## Test plan

<img width="970" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/58db901a-5562-48da-893e-4ca16dc1e2f7">

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/acdf7d62-597b-4325-8cf7-5de013c80651)
