### PR TITLE
Filters panel: refine type icons

### DIFF
--- a/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
+++ b/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
@@ -1,13 +1,6 @@
 import { FC } from 'react'
 
-import {
-    mdiBook,
-    mdiCodeBrackets,
-    mdiFileOutline,
-    mdiPlusMinus,
-    mdiShapeSquareRoundedPlus,
-    mdiSourceCommit,
-} from '@mdi/js'
+import { mdiSourceFork, mdiCodeBraces, mdiFileOutline, mdiPlusMinus, mdiFunction, mdiSourceCommit } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Button, Icon } from '@sourcegraph/wildcard'
@@ -78,10 +71,10 @@ export const FilterTypeList: FC<SearchFilterTypesProps> = props => {
 }
 
 const FILTER_TYPE_ICONS = {
-    [SearchFilterType.Code]: mdiCodeBrackets,
-    [SearchFilterType.Repositories]: mdiBook,
+    [SearchFilterType.Code]: mdiCodeBraces,
+    [SearchFilterType.Repositories]: mdiSourceFork,
     [SearchFilterType.Paths]: mdiFileOutline,
-    [SearchFilterType.Symbols]: mdiShapeSquareRoundedPlus,
+    [SearchFilterType.Symbols]: mdiFunction,
     [SearchFilterType.Commits]: mdiSourceCommit,
     [SearchFilterType.Diffs]: mdiPlusMinus,
 }


### PR DESCRIPTION
- Changed the "Code" icon to curly braces so we didn't have so many vaguely-rectangular icons
- Changed the "Repositories" icon to a fork icon because the normal "Source Repository" icon stands out much more than the other icons and it looked out of place. 
- Changed the "Symbols" icon to the function icon, which is widely used to represent generic "symbols" elsewhere.

Before:
![CleanShot 2024-01-04 at 15 58 56@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/5eed12e0-0932-4056-a6b2-cef138b8cb3b)

After:
![CleanShot 2024-01-04 at 15 58 45@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/7a942fe9-f38d-4e8d-bce8-d120efd3b1f6)

# Test Plan

See screenshots. We'll let design have a pass at this too once Taiyab is back. 