### PR TITLE
sg/msp: add prototype 'sg msp docs'

### DIFF
--- a/dev/managedservicesplatform/internal/resource/bigquery/bigquery.go
+++ b/dev/managedservicesplatform/internal/resource/bigquery/bigquery.go
@@ -1,8 +1,6 @@
 package bigquery
 
 import (
-	"strings"
-
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
 
@@ -43,9 +41,7 @@ type Config struct {
 // New creates a BigQuery dataset and all configured tables.
 func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, error) {
 	var (
-		datasetID = pointers.Deref(config.Spec.DatasetID,
-			// Dataset IDs must be alphanumeric (plus underscores)
-			strings.ReplaceAll(config.ServiceID, "-", "_"))
+		datasetID = config.Spec.GetDatasetID(config.ServiceID)
 		projectID = pointers.Deref(config.Spec.ProjectID,
 			config.DefaultProjectID)
 		location = pointers.Deref(config.Spec.Location, "US")

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -79,9 +79,8 @@ func (r *Renderer) RenderEnvironment(
 
 	// Render all required CDKTF stacks for this environment
 	projectOutput, err := project.NewStack(stacks, project.Variables{
-		ProjectID: env.ProjectID,
-		DisplayName: fmt.Sprintf("%s - %s",
-			pointers.Deref(svc.Name, svc.ID), env.ID),
+		ProjectID:   env.ProjectID,
+		DisplayName: fmt.Sprintf("%s - %s", svc.GetName(), env.ID),
 
 		Category: env.Category,
 		Labels: map[string]string{

--- a/dev/managedservicesplatform/operationdocs/BUILD.bazel
+++ b/dev/managedservicesplatform/operationdocs/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "operationdocs",
+    srcs = [
+        "links.go",
+        "operationdocs.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/operationdocs",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//dev/managedservicesplatform/operationdocs/internal/markdown",
+        "//dev/managedservicesplatform/spec",
+        "//lib/errors",
+        "//lib/pointers",
+        "@com_github_vvakame_gcplogurl//:gcplogurl",
+    ],
+)

--- a/dev/managedservicesplatform/operationdocs/BUILD.bazel
+++ b/dev/managedservicesplatform/operationdocs/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -14,5 +15,17 @@ go_library(
         "//lib/errors",
         "//lib/pointers",
         "@com_github_vvakame_gcplogurl//:gcplogurl",
+    ],
+)
+
+go_test(
+    name = "operationdocs_test",
+    srcs = ["operationdocs_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":operationdocs"],
+    deps = [
+        "//dev/managedservicesplatform/spec",
+        "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/dev/managedservicesplatform/operationdocs/internal/markdown/BUILD.bazel
+++ b/dev/managedservicesplatform/operationdocs/internal/markdown/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "markdown",
+    srcs = [
+        "inline.go",
+        "markdown.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/operationdocs/internal/markdown",
+    visibility = ["//dev/managedservicesplatform/operationdocs:__subpackages__"],
+    deps = ["@com_github_olekukonko_tablewriter//:tablewriter"],
+)
+
+go_test(
+    name = "markdown_test",
+    srcs = ["inline_test.go"],
+    embed = [":markdown"],
+    deps = ["@com_github_hexops_autogold_v2//:autogold"],
+)

--- a/dev/managedservicesplatform/operationdocs/internal/markdown/inline.go
+++ b/dev/managedservicesplatform/operationdocs/internal/markdown/inline.go
@@ -1,0 +1,105 @@
+package markdown
+
+import (
+	"fmt"
+	neturl "net/url"
+	"reflect"
+	"strings"
+)
+
+// HeadingLink generates a link to a heading that has not been written yet.
+// A Heading must be added with the returned heading eventually, or this link
+// will point to nothing.
+func HeadingLinkf(title string, vars ...any) (link, heading string) {
+	heading = fmt.Sprintf(title, vars...)
+	id := sanitizeHeadingID(heading)
+	return Linkf(heading, "#%s", id), heading
+}
+
+// Headingf writes a heading at the desired level. It automatically adds newlines.
+// Returns the sanitized anchor id for the heading and the link to this heading
+func Headingf(level int, title string, vars ...any) (id string, link string, content string) {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("\n%s ", strings.Repeat("#", level)))
+	link, heading := HeadingLinkf(title, vars...)
+	b.WriteString(heading)
+	b.WriteString("\n")
+	return id, link, b.String()
+}
+
+func Code(v string) string {
+	return fmt.Sprintf("`%s`", v)
+}
+
+func Codef(v string, vars ...any) string {
+	return Code(fmt.Sprintf(v, vars...))
+}
+
+func Bold(v string) string {
+	return fmt.Sprintf("**%s**", v)
+}
+
+func Boldf(v string, vars ...any) string {
+	return Bold(fmt.Sprintf(v, vars...))
+}
+
+// Link generates a Markdown link.
+func Link(text, url string) string {
+	// some urls params are not escaped properly, let's fix that magically
+	parsedUrl, err := neturl.Parse(url)
+	// we are intentionally ignoring the error here
+	// if the user supplied an invalid url, it may or may not be intentional
+	// either way, not this method's problem
+	if err == nil {
+		params := neturl.Values{}
+		for k, v := range parsedUrl.Query() {
+			for _, vv := range v {
+				params.Add(k, vv)
+			}
+		}
+		parsedUrl.RawQuery = params.Encode()
+		url = parsedUrl.String()
+	}
+	return fmt.Sprintf("[%s](%s)", text, url)
+}
+
+// Linkf generates a Markdown link. Format arguments only apply to the URL.
+func Linkf(text, url string, vars ...any) string {
+	return Link(text, fmt.Sprintf(url, vars...))
+}
+
+// List generates a Markdown list.
+// It supports arbitrary nesting of lists of string, and each sub-list will be indented.
+func List(lines any) string {
+	return renderList(lines, -1)
+}
+
+// renderList is a helper method to render unknown depth list of strings.
+// depth has to start from -1 because the first line is not indented.
+//
+// You should use the exported List() or List() from Builder struct instead.
+func renderList(lines any, depth int) string {
+	var buffer strings.Builder
+
+	s := reflect.ValueOf(lines)
+	t := reflect.TypeOf(s.Interface())
+	v := reflect.ValueOf(s.Interface())
+	switch t.Kind() {
+	case reflect.String:
+		buffer.WriteString(indent(depth))
+		buffer.WriteString(fmt.Sprintf("- %v\n", v))
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			buffer.WriteString(renderList(v.Index(i).Interface(), depth+1))
+		}
+	default:
+		buffer.WriteString(indent(depth))
+		buffer.WriteString(fmt.Sprintf("- unknown type: %T\n", v.Interface()))
+	}
+
+	return buffer.String()
+}
+
+func indent(d int) string {
+	return strings.Repeat("  ", d)
+}

--- a/dev/managedservicesplatform/operationdocs/internal/markdown/inline_test.go
+++ b/dev/managedservicesplatform/operationdocs/internal/markdown/inline_test.go
@@ -1,0 +1,67 @@
+package markdown
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+)
+
+func TestList(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines any
+		want  autogold.Value
+	}{
+		{
+			name:  "flat",
+			lines: []string{"1", "2", "3"},
+			want:  autogold.Expect("- 1\n- 2\n- 3\n"),
+		},
+		// write more more test
+		{
+			name: "nested",
+			lines: []any{
+				"item 1",
+				[]any{
+					"item 2a",
+					"item 2b",
+					[]any{
+						"item 3a",
+						"item 3b",
+						[]any{
+							"item 4a",
+							"item 4b",
+						},
+					},
+					"item 2c",
+				},
+				"item 4",
+			},
+			want: autogold.Expect(`- item 1
+  - item 2a
+  - item 2b
+    - item 3a
+    - item 3b
+      - item 4a
+      - item 4b
+  - item 2c
+- item 4
+`),
+		},
+		{
+			name: "unsupported type",
+			lines: []any{
+				"item 1",
+				2,
+				"item 3",
+			},
+			want: autogold.Expect("- item 1\n- unknown type: int\n- item 3\n"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := List(tt.lines)
+			tt.want.Equal(t, b)
+		})
+	}
+}

--- a/dev/managedservicesplatform/operationdocs/internal/markdown/markdown.go
+++ b/dev/managedservicesplatform/operationdocs/internal/markdown/markdown.go
@@ -1,0 +1,163 @@
+// Package markdown is slightly modified copy-pasta from
+// https://sourcegraph.sourcegraph.com/github.com/sourcegraph/controller/-/tree/internal/markdown
+package markdown
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+// Builder can be used to generate Markdown content piecewise. It implements the internal
+// Renderer interface.
+type Builder struct{ acc *strings.Builder }
+
+// NewBuilder creates a Builder that can be used to generate Markdown content piecewise.
+func NewBuilder() *Builder {
+	return &Builder{
+		acc: &strings.Builder{},
+	}
+}
+
+// Headingf writes a heading at the desired level. It automatically adds newlines.
+// Returns the sanitized anchor id for the heading and the link to this heading
+func (b *Builder) Headingf(level int, title string, vars ...any) (id string, link string) {
+	var content string
+	id, link, content = Headingf(level, title, vars...)
+	b.acc.WriteString(content)
+	return id, link
+}
+
+// sanitizeHeadingID returns a sanitized anchor name for the given text.
+// Taken from https://github.com/shurcooL/sanitized_anchor_name/blob/master/main.go#L14:1
+// copy from https://sourcegraph.com/github.com/gomarkdown/markdown@663e2500819c19ed2d3f4bf955931b16fa9adf63/-/blob/parser/block.go?L83-104
+func sanitizeHeadingID(text string) string {
+	var anchorName []rune
+	var futureDash = false
+	for _, r := range text {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			if futureDash && len(anchorName) > 0 {
+				anchorName = append(anchorName, '-')
+			}
+			futureDash = false
+			anchorName = append(anchorName, unicode.ToLower(r))
+		default:
+			futureDash = true
+		}
+	}
+	if len(anchorName) == 0 {
+		return "empty"
+	}
+	return string(anchorName)
+}
+
+type AdmonitionLevel string
+
+const (
+	AdmonitionWarning   AdmonitionLevel = "Warning"
+	AdmonitionNote      AdmonitionLevel = "Note"
+	AdmonitionImportant AdmonitionLevel = "Important"
+)
+
+// Admonitionf renders a blockquote admonition that is supported by GitHub:
+// https://github.com/orgs/community/discussions/16925
+//
+// These render nicely as callouts for the reader to take note of based on the
+// AdmonitionLevel.
+func (b *Builder) Admonitionf(level AdmonitionLevel, content string, args ...any) {
+	b.acc.WriteString("\n")
+	switch level {
+	case AdmonitionNote:
+		b.acc.WriteString("> [!NOTE]\n")
+	case AdmonitionWarning:
+		b.acc.WriteString("> [!WARNING]\n")
+	case AdmonitionImportant:
+		b.acc.WriteString("> [!IMPORTANT]\n")
+	default:
+		panic(fmt.Sprintf("unknown admonition level %q", level))
+	}
+	for _, line := range strings.Split(strings.TrimSpace(fmt.Sprintf(content, args...)), "\n") {
+		b.acc.WriteString("> " + line)
+		b.acc.WriteString("\n")
+	}
+}
+
+// Paragraphf adds a new paragraph with the given text. It automatically adds newlines.
+func (b *Builder) Paragraphf(content string, vars ...any) {
+	b.acc.WriteString("\n")
+	b.acc.WriteString(strings.TrimSpace(fmt.Sprintf(content, vars...)))
+	b.acc.WriteString("\n")
+}
+
+// List adds the given lines as list items. It automatically adds newlines.
+// It supports arbitrary nesting of lists of string, and each sub-list will be indented.
+func (b *Builder) List(lines any) {
+	b.acc.WriteString("\n")
+	b.acc.WriteString(renderList(lines, -1))
+	// already has trailing newline
+}
+
+// CodeBlock adds a new code block in the given language with the given text. It
+// automatically adds newlines.
+func (b *Builder) CodeBlock(lang string, content string) {
+	b.acc.WriteString(fmt.Sprintf("\n```%s\n", lang))
+	b.acc.WriteString(strings.ReplaceAll(strings.TrimSpace(content), "\t", "  "))
+	b.acc.WriteString("\n```\n")
+}
+
+// CodeBlockf adds a new code block in the given language with the given text. It
+// automatically adds newlines.
+func (b *Builder) CodeBlockf(lang string, content string, vars ...any) {
+	b.acc.WriteString(fmt.Sprintf("\n```%s\n", lang))
+	b.acc.WriteString(strings.ReplaceAll(strings.TrimSpace(fmt.Sprintf(content, vars...)), "\t", "  "))
+	b.acc.WriteString("\n```\n")
+}
+
+// EscapedCodeBlock adds a new code block in the given language with the given text. It
+// automatically adds newlines.
+// It uses four backticks instead of three, so that you can have nested code blocks.
+func (b *Builder) EscapedCodeBlock(lang string, content string) {
+	b.acc.WriteString(fmt.Sprintf("\n````%s\n", lang))
+	b.acc.WriteString(strings.ReplaceAll(strings.TrimSpace(content), "\t", "  "))
+	b.acc.WriteString("\n````\n")
+}
+
+// Table adds a new table with the given headers and data. It automatically adds new
+// lines.
+func (b *Builder) Table(headers []string, data [][]string) {
+	b.acc.WriteString("\n")
+
+	table := tablewriter.NewWriter(b.acc)
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetCenterSeparator("|")
+	table.SetAutoWrapText(false) // avoid test wrapping spanning multiple rows, it looks weird
+	table.SetHeader(headers)
+	table.AppendBulk(data)
+
+	table.Render() // adds a new line
+}
+
+// Quotef creates a quote for the given text. It automatically adds newlines.
+func (b *Builder) Quotef(content string, vars ...any) {
+	b.acc.WriteString("\n")
+	b.acc.WriteString("> ")
+	b.acc.WriteString(strings.TrimSpace(fmt.Sprintf(content, vars...)))
+	b.acc.WriteString("\n")
+}
+
+// Commentf inserts a Markdown comment - these do not get rendered in most
+// Markdown viewers.
+func (b *Builder) Commentf(content string, vars ...any) {
+	b.acc.WriteString("\n")
+	b.acc.WriteString("<!--\n")
+	b.acc.WriteString(strings.TrimSpace(fmt.Sprintf(content, vars...)))
+	b.acc.WriteString("\n-->\n")
+}
+
+// String returns the accumulated content as a raw Markdown string.
+func (b *Builder) String() string {
+	return strings.TrimPrefix(b.acc.String(), "\n")
+}

--- a/dev/managedservicesplatform/operationdocs/links.go
+++ b/dev/managedservicesplatform/operationdocs/links.go
@@ -1,0 +1,62 @@
+package operationdocs
+
+import (
+	"github.com/vvakame/gcplogurl"
+
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/operationdocs/internal/markdown"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+)
+
+// entitleEditorLinksByCategory is a mapping of preconfigured links for
+// requesting the appropriate 'mspServiceReader' role.
+var entitleReaderLinksByCategory = map[spec.EnvironmentCategory]string{
+	spec.EnvironmentCategoryTest: "no Entitle request needed; all engineers have access to this environment through the 'Engineering Projects' folder",
+	spec.EnvironmentCategoryInternal: markdown.Link("Entitle request for 'Internal Services' folder",
+		"https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D"),
+	spec.EnvironmentCategoryExternal: markdown.Link("Entitle request for 'Managed Services ' folder",
+		"https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D"),
+}
+
+// entitleEditorLinksByCategory is a mapping of preconfigured links for
+// requesting the appropriate 'mspServiceEditor' role.
+var entitleEditorLinksByCategory = map[spec.EnvironmentCategory]string{
+	spec.EnvironmentCategoryTest: "no Entitle request needed; all engineers have access to this environment through the 'Engineering Projects' folder",
+	spec.EnvironmentCategoryInternal: markdown.Link("Entitle request for the 'Internal Services' folder",
+		"https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZTEyYTJkZDktYzY1ZC00YzM0LTlmNDgtMzYzNTNkZmY0MDkyIiwidGhyb3VnaCI6ImUxMmEyZGQ5LWM2NWQtNGMzNC05ZjQ4LTM2MzUzZGZmNDA5MiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D"),
+	spec.EnvironmentCategoryExternal: markdown.Link("Entitle request for the 'Managed Services' folder",
+		"https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiODQzNTYxNzktZjkwMi00MDVlLTlhMTQtNTY3YTY1NmM5MzdmIiwidGhyb3VnaCI6Ijg0MzU2MTc5LWY5MDItNDA1ZS05YTE0LTU2N2E2NTZjOTM3ZiIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D"),
+}
+
+func ServiceLogsURL(serviceKind spec.ServiceKind, envProjectID string) string {
+	switch serviceKind {
+	case spec.ServiceKindJob:
+		return (&gcplogurl.Explorer{
+			ProjectID: envProjectID,
+			Query:     gcplogurl.Query(`resource.type = "cloud_run_job"`),
+			SummaryFields: &gcplogurl.SummaryFields{
+				Fields: []string{
+					// execution identifier
+					`labels/"run.googleapis.com/execution_name"`,
+					// fields from structured logs by sourcegraph/log
+					"jsonPayload/InstrumentationScope",
+					"jsonPayload/Body",
+					"jsonPayload/Attributes/error",
+				},
+			},
+		}).String()
+
+	default:
+		return (&gcplogurl.Explorer{
+			ProjectID: envProjectID,
+			Query:     gcplogurl.Query(`resource.type = "cloud_run_revision" -logName=~"logs/run.googleapis.com%2Frequests"`),
+			SummaryFields: &gcplogurl.SummaryFields{
+				Fields: []string{
+					// fields from structured logs by sourcegraph/log
+					"jsonPayload/InstrumentationScope",
+					"jsonPayload/Body",
+					"jsonPayload/Attributes/error",
+				},
+			},
+		}).String()
+	}
+}

--- a/dev/managedservicesplatform/operationdocs/links.go
+++ b/dev/managedservicesplatform/operationdocs/links.go
@@ -11,9 +11,9 @@ import (
 // requesting the appropriate 'mspServiceReader' role.
 var entitleReaderLinksByCategory = map[spec.EnvironmentCategory]string{
 	spec.EnvironmentCategoryTest: "no Entitle request needed; all engineers have access to this environment through the 'Engineering Projects' folder",
-	spec.EnvironmentCategoryInternal: markdown.Link("Entitle request for 'Internal Services' folder",
+	spec.EnvironmentCategoryInternal: markdown.Link("Entitle request for the 'Internal Services' folder",
 		"https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiNzg0M2MxYWYtYzU2MS00ZDMyLWE3ZTAtYjZkNjY0NDM4MzAzIiwidGhyb3VnaCI6Ijc4NDNjMWFmLWM1NjEtNGQzMi1hN2UwLWI2ZDY2NDQzODMwMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D"),
-	spec.EnvironmentCategoryExternal: markdown.Link("Entitle request for 'Managed Services ' folder",
+	spec.EnvironmentCategoryExternal: markdown.Link("Entitle request for the 'Managed Services ' folder",
 		"https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjEwODAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYTQ4OWM2MDktNTBlYy00ODAzLWIzZjItMzYzZGJhMTgwMWJhIiwidGhyb3VnaCI6ImE0ODljNjA5LTUwZWMtNDgwMy1iM2YyLTM2M2RiYTE4MDFiYSIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D"),
 }
 

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -91,6 +91,7 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 				resourceHeadings[k] = h
 				return l
 			}), ", ")},
+			{"Alerts", markdown.Linkf("GCP monitoring", "https://console.cloud.google.com/monitoring/alerting?project=%s", env.ProjectID)},
 		}
 		if env.EnvironmentServiceSpec != nil {
 			if domain := env.Domain.GetDNSName(); domain != "" {

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -98,8 +98,8 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 			md.Paragraphf("MSP infrastructure access needs to be requested using Entitle for time-bound privileges.")
 		}
 		md.Table([]string{"Access", "Entitle request template"}, [][]string{
-			{"Project", entitleReaderLinksByCategory[env.Category]},
-			{"Project write access", entitleEditorLinksByCategory[env.Category]},
+			{"GCP project read access", entitleReaderLinksByCategory[env.Category]},
+			{"GCP project write access", entitleEditorLinksByCategory[env.Category]},
 		})
 		// TODO: Add a comment about per-project access as well?
 

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -85,7 +85,7 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 		}
 		if env.EnvironmentServiceSpec != nil {
 			if domain := env.Domain.GetDNSName(); domain != "" {
-				overview = append(overview, []string{"Domain", markdown.Link(domain, domain)})
+				overview = append(overview, []string{"Domain", markdown.Link(domain, "https://"+domain)})
 				if env.Domain.Cloudflare != nil && env.Domain.Cloudflare.Proxied {
 					overview = append(overview, []string{"Cloudflare WAF", markdown.Code("true")})
 				}

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -87,7 +87,14 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 			if domain := env.Domain.GetDNSName(); domain != "" {
 				overview = append(overview, []string{"Domain", markdown.Link(domain, "https://"+domain)})
 				if env.Domain.Cloudflare != nil && env.Domain.Cloudflare.Proxied {
-					overview = append(overview, []string{"Cloudflare WAF", markdown.Code("true")})
+					overview = append(overview, []string{"Cloudflare WAF", "✅"})
+				}
+			}
+			if env.Authentication != nil {
+				if pointers.DerefZero(env.Authentication.Sourcegraph) {
+					overview = append(overview, []string{"Authentication", "sourcegraph.com GSuite users"})
+				} else {
+					overview = append(overview, []string{"Authentication", "Restricted"})
 				}
 			}
 		}

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -1,0 +1,128 @@
+package operationdocs
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/operationdocs/internal/markdown"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+type Options struct {
+	GenerateCommand string
+}
+
+// Render creates a Markdown string with operational guidance for a MSP specification
+// and runtime properties using OutputsClient.
+func Render(s spec.Spec, opts Options) (string, error) {
+	md := markdown.NewBuilder()
+
+	md.Headingf(1, "%s infrastructure operations", s.Service.GetName())
+
+	if opts.GenerateCommand != "" {
+		md.Commentf("Generated documentation; DO NOT EDIT. Regenerate using this command: '%s'",
+			opts.GenerateCommand)
+	}
+
+	md.Paragraphf(`This document describes operational guidance for %s infrastructure.
+This service is operated on the [Managed Services Platform (MSP)](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform/).`,
+		s.Service.GetName())
+
+	type environmentHeader struct {
+		environmentID string
+		header        string
+		link          string
+	}
+	var environmentHeaders []environmentHeader
+
+	md.Headingf(2, "Service overview")
+	serviceKind := pointers.Deref(s.Service.Kind, spec.ServiceKindService)
+	md.Table(
+		[]string{"Property", "Details"},
+		[][]string{
+			{"Service ID", markdown.Code(s.Service.ID)},
+			{"Owners", markdown.Bold(strings.Join(s.Service.Owners, ", "))},
+			{"Service kind", fmt.Sprintf("Cloud Run %s", string(serviceKind))},
+			{"Environments", strings.Join(mapTo(s.Environments, func(e spec.EnvironmentSpec) string {
+				l, h := markdown.HeadingLinkf("%s environment", markdown.Code(e.ID))
+				environmentHeaders = append(environmentHeaders, environmentHeader{
+					environmentID: e.ID,
+					header:        h,
+					link:          l,
+				})
+				return l
+			}), ", ")},
+			{"Docker image", markdown.Code(s.Build.Image)},
+			{"Source code", markdown.Linkf(
+				fmt.Sprintf("%s - %s", markdown.Code(s.Build.Source.Repo), markdown.Code(s.Build.Source.Dir)),
+				"https://%s/tree/HEAD/%s", s.Build.Source.Repo, path.Clean(s.Build.Source.Dir))},
+		})
+
+	md.Headingf(2, "Environments")
+	for _, section := range environmentHeaders {
+		md.Headingf(3, section.header)
+		env := s.GetEnvironment(section.environmentID)
+
+		var cloudRunURL string
+		switch serviceKind {
+		case spec.ServiceKindService:
+			cloudRunURL = fmt.Sprintf("https://console.cloud.google.com/run?project=%s",
+				env.ProjectID)
+		case spec.ServiceKindJob:
+			cloudRunURL = fmt.Sprintf("https://console.cloud.google.com/run/jobs?project=%s",
+				env.ProjectID)
+		default:
+			return "", errors.Newf("unknown service kind %q", serviceKind)
+		}
+
+		overview := [][]string{
+			{"Project ID", markdown.Linkf(markdown.Code(env.ProjectID), cloudRunURL)},
+			{"Category", markdown.Bold(string(env.Category))},
+			{"Resources", strings.Join(env.Resources.List(), ", ")},
+		}
+		if domain := env.Domain.GetDNSName(); domain != "" {
+			overview = append(overview, []string{"Domain", markdown.Link(domain, domain)})
+			if env.Domain.Cloudflare != nil && env.Domain.Cloudflare.Proxied {
+				overview = append(overview, []string{"Cloudflare WAF", markdown.Code("true")})
+			}
+		}
+		md.Table(
+			[]string{"Property", "Details"},
+			overview,
+		)
+
+		if env.Category != spec.EnvironmentCategoryTest {
+			md.Paragraphf("MSP infrastructure access needs to be requested using Entitle for time-bound privileges.")
+		}
+		md.Table([]string{"Access", "Entitle request template"}, [][]string{
+			{"Project", entitleReaderLinksByCategory[env.Category]},
+			{"Project write access", entitleEditorLinksByCategory[env.Category]},
+		})
+		// TODO: Add a comment about per-project access as well?
+
+		md.Headingf(4, "Cloud Run")
+		md.Table(
+			[]string{"Property", "Details"},
+			[][]string{
+				{"Console", markdown.Linkf(
+					fmt.Sprintf("Cloud Run %ss", string(serviceKind)), cloudRunURL)},
+				{"Logs", markdown.Link("GCP logging", ServiceLogsURL(serviceKind, env.ProjectID))},
+			},
+		)
+
+		// TODO: Individual resources
+	}
+
+	return md.String(), nil
+}
+
+func mapTo[InputT any, OutputT any](input []InputT, mapFn func(InputT) OutputT) []OutputT {
+	var output []OutputT
+	for _, i := range input {
+		output = append(output, mapFn(i))
+	}
+	return output
+}

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -44,7 +44,7 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 		[]string{"Property", "Details"},
 		[][]string{
 			{"Service ID", markdown.Code(s.Service.ID)},
-			{"Owners", markdown.Bold(strings.Join(s.Service.Owners, ", "))},
+			{"Owners", strings.Join(mapTo(s.Service.Owners, markdown.Bold), ", ")},
 			{"Service kind", fmt.Sprintf("Cloud Run %s", string(serviceKind))},
 			{"Environments", strings.Join(mapTo(s.Environments, func(e spec.EnvironmentSpec) string {
 				l, h := markdown.HeadingLinkf("%s environment", markdown.Code(e.ID))
@@ -83,10 +83,12 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 			{"Category", markdown.Bold(string(env.Category))},
 			{"Resources", strings.Join(env.Resources.List(), ", ")},
 		}
-		if domain := env.Domain.GetDNSName(); domain != "" {
-			overview = append(overview, []string{"Domain", markdown.Link(domain, domain)})
-			if env.Domain.Cloudflare != nil && env.Domain.Cloudflare.Proxied {
-				overview = append(overview, []string{"Cloudflare WAF", markdown.Code("true")})
+		if env.EnvironmentServiceSpec != nil {
+			if domain := env.Domain.GetDNSName(); domain != "" {
+				overview = append(overview, []string{"Domain", markdown.Link(domain, domain)})
+				if env.Domain.Cloudflare != nil && env.Domain.Cloudflare.Proxied {
+					overview = append(overview, []string{"Cloudflare WAF", markdown.Code("true")})
+				}
 			}
 		}
 		md.Table(
@@ -94,9 +96,9 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 			overview,
 		)
 
-		if env.Category != spec.EnvironmentCategoryTest {
-			md.Paragraphf("MSP infrastructure access needs to be requested using Entitle for time-bound privileges.")
-		}
+		md.Paragraphf(`MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
+Test environments have less stringent requirements.`)
+
 		md.Table([]string{"Access", "Entitle request template"}, [][]string{
 			{"GCP project read access", entitleReaderLinksByCategory[env.Category]},
 			{"GCP project write access", entitleEditorLinksByCategory[env.Category]},

--- a/dev/managedservicesplatform/operationdocs/operationdocs_test.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs_test.go
@@ -1,0 +1,43 @@
+package operationdocs
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+)
+
+func TestRender(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec spec.Spec
+		opts Options
+	}{{
+		name: "basic",
+		spec: spec.Spec{
+			Service: spec.ServiceSpec{
+				ID: "msp-testbed",
+			},
+			Build: spec.BuildSpec{
+				Image: "us.gcr.io/sourcegraph-dev/msp-example",
+				Source: spec.BuildSourceSpec{
+					Repo: "github.com/sourcegraph/sourcegraph",
+					Dir:  "cmd/msp-example",
+				},
+			},
+			Environments: []spec.EnvironmentSpec{{
+				ID:        "dev",
+				Category:  spec.EnvironmentCategoryTest,
+				ProjectID: "msp-testbed-dev-xxxx",
+			}},
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := Render(tc.spec, tc.opts)
+			require.NoError(t, err)
+			autogold.ExpectFile(t, autogold.Raw(doc))
+		})
+	}
+}

--- a/dev/managedservicesplatform/operationdocs/operationdocs_test.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs_test.go
@@ -33,6 +33,34 @@ func TestRender(t *testing.T) {
 				ProjectID: "msp-testbed-dev-xxxx",
 			}},
 		},
+	}, {
+		name: "resources",
+		spec: spec.Spec{
+			Service: spec.ServiceSpec{
+				ID: "msp-testbed",
+			},
+			Build: spec.BuildSpec{
+				Image: "us.gcr.io/sourcegraph-dev/msp-example",
+				Source: spec.BuildSourceSpec{
+					Repo: "github.com/sourcegraph/sourcegraph",
+					Dir:  "cmd/msp-example",
+				},
+			},
+			Environments: []spec.EnvironmentSpec{{
+				ID:        "dev",
+				Category:  spec.EnvironmentCategoryTest,
+				ProjectID: "msp-testbed-dev-xxxx",
+				Resources: &spec.EnvironmentResourcesSpec{
+					Redis: &spec.EnvironmentResourceRedisSpec{},
+					PostgreSQL: &spec.EnvironmentResourcePostgreSQLSpec{
+						Databases: []string{"foo", "bar"},
+					},
+					BigQueryDataset: &spec.EnvironmentResourceBigQueryDatasetSpec{
+						Tables: []string{"bar", "baz"},
+					},
+				},
+			}},
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			doc, err := Render(tc.spec, tc.opts)

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
@@ -1,0 +1,40 @@
+# msp-testbed infrastructure operations
+
+This document describes operational guidance for msp-testbed infrastructure.
+This service is operated on the [Managed Services Platform (MSP)](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform/).
+
+## Service overview
+
+|   PROPERTY   |                                                             DETAILS                                                              |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------|
+| Service ID   | `msp-testbed`                                                                                                                    |
+| Owners       |                                                                                                                                  |
+| Service kind | Cloud Run service                                                                                                                |
+| Environments | [`dev` environment](#dev-environment)                                                                                            |
+| Docker image | `us.gcr.io/sourcegraph-dev/msp-example`                                                                                          |
+| Source code  | [`github.com/sourcegraph/sourcegraph` - `cmd/msp-example`](https://github.com/sourcegraph/sourcegraph/tree/HEAD/cmd/msp-example) |
+
+## Environments
+
+### `dev` environment
+
+|  PROPERTY  |                                           DETAILS                                           |
+|------------|---------------------------------------------------------------------------------------------|
+| Project ID | [`msp-testbed-dev-xxxx`](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx) |
+| Category   | **test**                                                                                    |
+| Resources  |                                                                                             |
+
+MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
+Test environments have less stringent requirements.
+
+|          ACCESS          |                                              ENTITLE REQUEST TEMPLATE                                              |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------|
+| GCP project read access  | no Entitle request needed; all engineers have access to this environment through the 'Engineering Projects' folder |
+| GCP project write access | no Entitle request needed; all engineers have access to this environment through the 'Engineering Projects' folder |
+
+#### Cloud Run
+
+| PROPERTY |                                                                                                                                                              DETAILS                                                                                                                                                              |
+|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Console  | [Cloud Run services](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx)                                                                                                                                                                                                                                           |
+| Logs     | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-dev-xxxx) |

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
@@ -18,11 +18,12 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 
 ### dev environment
 
-|  PROPERTY  |                                           DETAILS                                           |
-|------------|---------------------------------------------------------------------------------------------|
-| Project ID | [`msp-testbed-dev-xxxx`](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx) |
-| Category   | **test**                                                                                    |
-| Resources  |                                                                                             |
+|  PROPERTY  |                                               DETAILS                                               |
+|------------|-----------------------------------------------------------------------------------------------------|
+| Project ID | [`msp-testbed-dev-xxxx`](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx)         |
+| Category   | **test**                                                                                            |
+| Resources  |                                                                                                     |
+| Alerts     | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-dev-xxxx) |
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 Test environments have less stringent requirements.

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
@@ -18,11 +18,11 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 
 ### dev environment
 
-|  PROPERTY  |                                           DETAILS                                           |
-|------------|---------------------------------------------------------------------------------------------|
-| Project ID | [`msp-testbed-dev-xxxx`](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx) |
-| Category   | **test**                                                                                    |
-| Resources  |                                                                                             |
+|  PROPERTY  |                                                           DETAILS                                                           |
+|------------|-----------------------------------------------------------------------------------------------------------------------------|
+| Project ID | [`msp-testbed-dev-xxxx`](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx)                                 |
+| Category   | **test**                                                                                                                    |
+| Resources  | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 Test environments have less stringent requirements.
@@ -38,3 +38,34 @@ Test environments have less stringent requirements.
 |----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Console  | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx)                                                                                                                                                                                                                                            |
 | Logs     | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-dev-xxxx) |
+
+#### dev Redis
+
+| PROPERTY |                                                         DETAILS                                                          |
+|----------|--------------------------------------------------------------------------------------------------------------------------|
+| Console  | [Memorystore Redis instances](https://console.cloud.google.com/memorystore/redis/instances?project=msp-testbed-dev-xxxx) |
+
+#### dev PostgreSQL instance
+
+| PROPERTY  |                                              DETAILS                                               |
+|-----------|----------------------------------------------------------------------------------------------------|
+| Console   | [Cloud SQL instances](https://console.cloud.google.com/sql/instances?project=msp-testbed-dev-xxxx) |
+| Databases | `foo`, `bar`                                                                                       |
+
+To connect to the PostgreSQL instance in this environment, use `sg msp` in the [`sourcegraph/managed-services`](https://github.com/sourcegraph/managed-services) repository:
+
+```bash
+# For read-only access
+sg msp pg connect msp-testbed dev
+
+# For write access - use with caution!
+sg msp pg connect -write-access msp-testbed dev
+```
+
+#### dev BigQuery dataset
+
+|    PROPERTY     |                                                                                                            DETAILS                                                                                                             |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Dataset Project | `msp-testbed-dev-xxxx`                                                                                                                                                                                                         |
+| Dataset ID      | `msp_testbed`                                                                                                                                                                                                                  |
+| Tables          | [`bar`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/bar.bigquerytable.json), [`baz`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/baz.bigquerytable.json) |

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
@@ -23,6 +23,7 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 | Project ID | [`msp-testbed-dev-xxxx`](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx)                                 |
 | Category   | **test**                                                                                                                    |
 | Resources  | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
+| Alerts     | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-dev-xxxx)                         |
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
 Test environments have less stringent requirements.

--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -400,6 +400,25 @@ type EnvironmentResourcesSpec struct {
 	BigQueryDataset *EnvironmentResourceBigQueryDatasetSpec `yaml:"bigQueryDataset,omitempty"`
 }
 
+// List collects a list of provisioned resources for human reference.
+func (s *EnvironmentResourcesSpec) List() []string {
+	if s == nil {
+		return nil
+	}
+
+	var resources []string
+	if s.Redis != nil {
+		resources = append(resources, "Redis")
+	}
+	if s.PostgreSQL != nil {
+		resources = append(resources, "PostgreSQL")
+	}
+	if s.BigQueryDataset != nil {
+		resources = append(resources, "BigQuery dataset")
+	}
+	return resources
+}
+
 func (s *EnvironmentResourcesSpec) Validate() []error {
 	if s == nil {
 		return nil

--- a/dev/managedservicesplatform/spec/service.go
+++ b/dev/managedservicesplatform/spec/service.go
@@ -32,6 +32,11 @@ type ServiceSpec struct {
 	IAM *ServiceIAMSpec `yaml:"iam,omitempty"`
 }
 
+// GetName returns Name if configured, otherwise the ID.
+func (s ServiceSpec) GetName() string {
+	return pointers.Deref(s.Name, s.ID)
+}
+
 func (s ServiceSpec) Validate() []error {
 	var errs []error
 

--- a/dev/managedservicesplatform/spec/spec.go
+++ b/dev/managedservicesplatform/spec/spec.go
@@ -10,7 +10,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 // Spec is a Managed Services Platform (MSP) service.
@@ -127,8 +126,7 @@ func (s Spec) Validate() []error {
 	}
 
 	for _, env := range s.Environments {
-		projectDisplayName := fmt.Sprintf("%s - %s",
-			pointers.Deref(s.Service.Name, s.Service.ID), env.ID)
+		projectDisplayName := fmt.Sprintf("%s - %s", s.Service.GetName(), env.ID)
 		if len(projectDisplayName) > 30 {
 			errs = append(errs, errors.Newf(
 				"full environment name %q exceeds 30 characters limit - try a shorter service name or environment ID",

--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/job/job.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/job/job.go
@@ -151,10 +151,9 @@ func (b *jobBuilder) Build(stack cdktf.TerraformStack, vars builder.Variables) (
 
 	if schedule := pointers.DerefZero(vars.Environment.EnvironmentJobSpec).Schedule; schedule != nil {
 		invoker := serviceaccount.New(stack, resourceid.New("job_invoker"), serviceaccount.Config{
-			ProjectID: vars.GCPProjectID,
-			AccountID: fmt.Sprintf("%s-job-sa", vars.Service.ID),
-			DisplayName: fmt.Sprintf("%s Job-Invoker Service Account",
-				pointers.Deref(vars.Service.Name, vars.Service.ID)),
+			ProjectID:   vars.GCPProjectID,
+			AccountID:   fmt.Sprintf("%s-job-sa", vars.Service.ID),
+			DisplayName: fmt.Sprintf("%s Job-Invoker Service Account", vars.Service.GetName()),
 		})
 
 		invokerMember := cloudrunv2jobiammember.NewCloudRunV2JobIamMember(stack, pointers.Ptr("cloudrun_scheduler_job_invoker"), &cloudrunv2jobiammember.CloudRunV2JobIamMemberConfig{

--- a/dev/managedservicesplatform/stacks/iam/iam.go
+++ b/dev/managedservicesplatform/stacks/iam/iam.go
@@ -113,10 +113,9 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 			ProjectID: vars.ProjectID,
 			// These might be used to grant access across other projects so
 			// a human-usable ID and name are preferred over random values.
-			AccountID: fmt.Sprintf("%s-sa", vars.Service.ID),
-			DisplayName: fmt.Sprintf("%s Service Account",
-				pointers.Deref(vars.Service.Name, vars.Service.ID)),
-			Roles: serviceAccountRoles,
+			AccountID:   fmt.Sprintf("%s-sa", vars.Service.ID),
+			DisplayName: fmt.Sprintf("%s Service Account", vars.Service.GetName()),
+			Roles:       serviceAccountRoles,
 
 			// There may be external references to the service account to allow
 			// the workload access to external resources, so guard it from deletes.
@@ -134,10 +133,9 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 	operatorAccessServiceAccount := serviceaccount.New(stack,
 		id.Group("operatoraccess"),
 		serviceaccount.Config{
-			ProjectID: vars.ProjectID,
-			AccountID: operatorAccessAccountID.HexValue,
-			DisplayName: fmt.Sprintf("%s Operator Access Service Account",
-				pointers.Deref(vars.Service.Name, vars.Service.ID)),
+			ProjectID:   vars.ProjectID,
+			AccountID:   operatorAccessAccountID.HexValue,
+			DisplayName: fmt.Sprintf("%s Operator Access Service Account", vars.Service.GetName()),
 			Roles: []serviceaccount.Role{
 				// Roles for connecting to Cloud SQL
 				{

--- a/dev/managedservicesplatform/stacks/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/stacks/monitoring/monitoring.go
@@ -210,8 +210,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 		if channel.ProvisionChannel {
 			description := pointers.Stringf(
 				"Alerts from %s (%s) deployed on Managed Services Platform",
-				pointers.Deref(vars.Service.Name, vars.Service.ID),
-				vars.EnvironmentID)
+				vars.Service.GetName(), vars.EnvironmentID)
 			// https://registry.terraform.io/providers/pablovarela/slack/latest/docs/resources/conversation#argument-reference
 			slackChannel = slackconversation.NewConversation(stack, id.TerraformID("channel"), &slackconversation.ConversationConfig{
 				Name:      pointers.Ptr(strings.TrimPrefix(channel.Name, "#")),

--- a/dev/sg/msp/BUILD.bazel
+++ b/dev/sg/msp/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//dev/managedservicesplatform",
         "//dev/managedservicesplatform/googlesecretsmanager",
+        "//dev/managedservicesplatform/operationdocs",
         "//dev/managedservicesplatform/spec",
         "//dev/managedservicesplatform/stacks",
         "//dev/managedservicesplatform/stacks/cloudrun",
@@ -29,6 +30,5 @@ go_library(
         "//lib/output",
         "//lib/pointers",
         "@com_github_urfave_cli_v2//:cli",
-        "@com_github_vvakame_gcplogurl//:gcplogurl",
     ],
 )

--- a/go.mod
+++ b/go.mod
@@ -546,7 +546,7 @@ require (
 	github.com/nightlyone/lockfile v1.0.0 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.22
 	github.com/pandatix/go-cvss v0.5.2
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect


### PR DESCRIPTION
This is a start to https://github.com/sourcegraph/managed-services/issues/328 and not meant to be complete - it creates some Markdown that can be read in terminal for now. Eventually we may want to persist this somewhere.

Aiming to land this roughly as-is since this is a large initial diff with a lot of copy-pasta from `sourcegraph/controller`.

## Test plan

```
sg msp operations sams
```