### PR TITLE
Fix broken monaco code completion

### DIFF
--- a/client/web/dist/BUILD.bazel
+++ b/client/web/dist/BUILD.bazel
@@ -21,12 +21,14 @@ copy_to_directory(
         "//client/web:bundle",
         "//client/web-sveltekit",
         "//client/web/dist/img",
+        "//client/web/dist/scripts",
     ],
     out = "dist",
     replace_prefixes = {
         "client/web/bundle": "",
         "client/web-sveltekit/build": "",
         "client/web/dist/img": "img",
+        "client/web/dist/scripts": "scripts",
         "client/browser/integration-assets": "",
     },
 )

--- a/client/web/dist/scripts/BUILD.bazel
+++ b/client/web/dist/scripts/BUILD.bazel
@@ -11,6 +11,6 @@ filegroup(
 
 copy_to_bin(
     name = "copy",
-    srcs = ["//client/web/dist/scripts"],
+    srcs = [":scripts"],
     visibility = ["//client/web-sveltekit:__pkg__"],
 )

--- a/client/web/dist/scripts/BUILD.bazel
+++ b/client/web/dist/scripts/BUILD.bazel
@@ -2,7 +2,10 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
 filegroup(
     name = "scripts",
-    srcs = glob(["**/*.*"]),
+    srcs = glob(
+        ["**/*.*"],
+        ["BUILD.bazel"],
+    ),
     visibility = ["//visibility:public"],
 )
 

--- a/client/web/dist/scripts/BUILD.bazel
+++ b/client/web/dist/scripts/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+
+filegroup(
+    name = "scripts",
+    srcs = glob(["**/*.*"]),
+    visibility = ["//visibility:public"],
+)
+
+copy_to_bin(
+    name = "copy",
+    srcs = ["//client/web/dist/scripts"],
+    visibility = ["//client/web-sveltekit:__pkg__"],
+)


### PR DESCRIPTION
Code completion in the site config on dotcom has been broken for a while now. The monaco editor depends on some worker scripts being available at `/.assets/scripts` for code completion suggestions to work in the online editor.

This is not an issue locally because we run an esbuild dev server that proxies requests to `/.assets`

This PR attempts to fix it by adding the `scripts` folder to the bazel build target for `//client/web/dist`

## Test plan

Tested locally by inspecting the output of `bazel-bin/client/web/dist` after running `bazel build //client/web/dist`, but I'm not sure how thorough this test is.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
