### PR TITLE
chore: Bump autoindexing image SHAs

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
+++ b/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
@@ -26,12 +26,12 @@ var defaultIndexers = map[string]string{
 
 // To update, run `DOCKER_USER=... DOCKER_PASS=... ./update-shas.sh`
 var defaultIndexerSHAs = map[string]string{
-	"sourcegraph/scip-go":         "sha256:4f82e2490c4385a3c47ac0d062c9c53ce5a0bfc5acf0c4032ad07486b39163ec",
+	"sourcegraph/scip-go":         "sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc",
 	"sourcegraph/lsif-rust":       "sha256:83cb769788987eb52f21a18b62d51ebb67c9436e1b0d2e99904c70fef424f9d1",
 	"sourcegraph/scip-rust":       "sha256:adf0047fc3050ba4f7be71302b42c74b49901f38fb40916d94ac5fc9181ac078",
-	"sourcegraph/scip-java":       "sha256:9f04445d3fc70f69a2db42b05964e20b22e716836eefaf1155de4a8b36e8ec19",
-	"sourcegraph/scip-python":     "sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321",
-	"sourcegraph/scip-typescript": "sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92",
+	"sourcegraph/scip-java":       "sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702",
+	"sourcegraph/scip-python":     "sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d",
+	"sourcegraph/scip-typescript": "sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8",
 	"sourcegraph/scip-ruby":       "sha256:ef53e5f1450330ddb4a3edce963b7e10d900d44ff1e7de4960680289ac25f319",
 }
 

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Gradle.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Gradle.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:9f04445d3fc70f69a2db42b05964e20b22e716836eefaf1155de4a8b36e8ec19
+  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Maven.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Maven.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:9f04445d3fc70f69a2db42b05964e20b22e716836eefaf1155de4a8b36e8ec19
+  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_SBT.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_SBT.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:9f04445d3fc70f69a2db42b05964e20b22e716836eefaf1155de4a8b36e8ec19
+  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_lsif-java.json.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_lsif-java.json.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:9f04445d3fc70f69a2db42b05964e20b22e716836eefaf1155de4a8b36e8ec19
+  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_WITHOUT_top-level_build_file.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_WITHOUT_top-level_build_file.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: my-module
-  indexer: sourcegraph/scip-java@sha256:9f04445d3fc70f69a2db42b05964e20b22e716836eefaf1155de4a8b36e8ec19
+  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
   indexer_args:
     - scip-java
     - index
@@ -11,7 +11,7 @@
 - steps: []
   local_steps: []
   root: our-module
-  indexer: sourcegraph/scip-java@sha256:9f04445d3fc70f69a2db42b05964e20b22e716836eefaf1155de4a8b36e8ec19
+  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_with_top-level_build_file.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_with_top-level_build_file.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:9f04445d3fc70f69a2db42b05964e20b22e716836eefaf1155de4a8b36e8ec19
+  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/go_files_in_root.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/go_files_in_root.yaml
@@ -8,7 +8,7 @@
         echo "No netrc config set, continuing"
       fi
   root: ""
-  indexer: sourcegraph/scip-go@sha256:4f82e2490c4385a3c47ac0d062c9c53ce5a0bfc5acf0c4032ad07486b39163ec
+  indexer: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
   indexer_args:
     - GO111MODULE=off
     - scip-go

--- a/internal/codeintel/autoindexing/internal/inference/testdata/go_modules.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/go_modules.yaml
@@ -1,6 +1,6 @@
 - steps:
     - root: foo/bar
-      image: sourcegraph/scip-go@sha256:4f82e2490c4385a3c47ac0d062c9c53ce5a0bfc5acf0c4032ad07486b39163ec
+      image: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
       commands:
         - |
           if [ "$NETRC_DATA" ]; then
@@ -19,7 +19,7 @@
         echo "No netrc config set, continuing"
       fi
   root: foo/bar
-  indexer: sourcegraph/scip-go@sha256:4f82e2490c4385a3c47ac0d062c9c53ce5a0bfc5acf0c4032ad07486b39163ec
+  indexer: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
   indexer_args:
     - scip-go
     - --no-animation
@@ -33,7 +33,7 @@
     - NETRC_DATA
 - steps:
     - root: foo/baz
-      image: sourcegraph/scip-go@sha256:4f82e2490c4385a3c47ac0d062c9c53ce5a0bfc5acf0c4032ad07486b39163ec
+      image: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
       commands:
         - |
           if [ "$NETRC_DATA" ]; then
@@ -52,7 +52,7 @@
         echo "No netrc config set, continuing"
       fi
   root: foo/baz
-  indexer: sourcegraph/scip-go@sha256:4f82e2490c4385a3c47ac0d062c9c53ce5a0bfc5acf0c4032ad07486b39163ec
+  indexer: sourcegraph/scip-go@sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc
   indexer_args:
     - scip-go
     - --no-animation

--- a/internal/codeintel/autoindexing/internal/inference/testdata/javascript_project_with_no_tsconfig_1.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/javascript_project_with_no_tsconfig_1.yaml
@@ -1,12 +1,12 @@
 - steps:
     - root: ""
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - npm install --ignore-scripts
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/javascript_project_with_no_tsconfig_2.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/javascript_project_with_no_tsconfig_2.yaml
@@ -1,12 +1,12 @@
 - steps:
     - root: ""
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - yarn --ignore-scripts
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_multiple_config_files_at_root.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_multiple_config_files_at_root.yaml
@@ -3,7 +3,7 @@
     - pip install . || true
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: x
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_multiple_roots.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_multiple_roots.yaml
@@ -3,7 +3,7 @@
     - pip install . || true
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: first_root
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index
@@ -14,7 +14,7 @@
     - pip install . || true
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: second_root
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_package_1.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_package_1.yaml
@@ -1,12 +1,12 @@
 - steps:
     - root: ""
-      image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+      image: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
       commands:
         - pip install . || true
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_package_2.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_package_2.yaml
@@ -1,12 +1,12 @@
 - steps:
     - root: ""
-      image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+      image: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
       commands:
         - pip install . || true
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index
@@ -21,13 +21,13 @@
   requestedEnvVars: []
 - steps:
     - root: ""
-      image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+      image: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
       commands:
         - pip install . || true
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: src
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_package_3.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_package_3.yaml
@@ -1,12 +1,12 @@
 - steps:
     - root: ""
-      image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+      image: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
       commands:
         - pip install . || true
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index
@@ -21,13 +21,13 @@
   requestedEnvVars: []
 - steps:
     - root: ""
-      image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+      image: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
       commands:
         - pip install . || true
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: nested/lib
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index
@@ -40,13 +40,13 @@
   requestedEnvVars: []
 - steps:
     - root: ""
-      image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+      image: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
       commands:
         - pip install . || true
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: src
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_package_with_pyproject.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_package_with_pyproject.yaml
@@ -1,12 +1,12 @@
 - steps:
     - root: ""
-      image: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+      image: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
       commands:
         - pip install . || true
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_pyproject.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_pyproject.yaml
@@ -3,7 +3,7 @@
     - pip install . || true
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_requirements.txt.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_requirements.txt.yaml
@@ -3,7 +3,7 @@
     - pip install . || true
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/python_setup.py.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/python_setup.py.yaml
@@ -3,7 +3,7 @@
     - pip install . || true
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-python@sha256:219bc4faf063172ba65d709dda95b7fe02125d1697677a59fdc45bd25cc4e321
+  indexer: sourcegraph/scip-python@sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d
   indexer_args:
     - scip-python
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/simple_tsconfig.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/simple_tsconfig.yaml
@@ -2,7 +2,7 @@
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/tsconfig_in_subdirectories.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/tsconfig_in_subdirectories.yaml
@@ -2,7 +2,7 @@
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: a
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index
@@ -13,7 +13,7 @@
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: b
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index
@@ -24,7 +24,7 @@
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: c
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/typescript_installation_steps.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/typescript_installation_steps.yaml
@@ -1,12 +1,12 @@
 - steps:
     - root: ""
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - npm install
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index
@@ -15,17 +15,17 @@
     - NPM_TOKEN
 - steps:
     - root: ""
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - npm install
     - root: foo/bar
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - yarn
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: foo/bar/baz
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index
@@ -34,21 +34,21 @@
     - NPM_TOKEN
 - steps:
     - root: ""
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - npm install
     - root: foo/bar
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - yarn
     - root: foo/bar/bonk
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - npm install
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: foo/bar/bonk
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index
@@ -57,13 +57,13 @@
     - NPM_TOKEN
 - steps:
     - root: ""
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - npm install
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: foo/baz
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/typescript_with_lerna_configuration.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/typescript_with_lerna_configuration.yaml
@@ -1,12 +1,12 @@
 - steps:
     - root: ""
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - yarn
   local_steps:
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/typescript_with_node_version.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/typescript_with_node_version.yaml
@@ -1,6 +1,6 @@
 - steps:
     - root: ""
-      image: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+      image: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
       commands:
         - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
         - npm install
@@ -8,7 +8,7 @@
     - N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto
     - if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi
   root: ""
-  indexer: sourcegraph/scip-typescript@sha256:4c9b65a449916bf2d8716c8b4b0a45666cd303a05b78e02980d25b23c1e55e92
+  indexer: sourcegraph/scip-typescript@sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8
   indexer_args:
     - scip-typescript
     - index


### PR DESCRIPTION
The indexers have had various updates; this incorporates those.

Updated snapshots with `go test go test ./internal/codeintel/autoindexing/internal/inference -update`

## Test plan

n/a