### PR TITLE
Return an empty embeddings job list when embeddings are disabled

### DIFF
--- a/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
+++ b/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs.go
@@ -262,3 +262,37 @@ func (r *repoEmbeddingJobStatsResolver) FilesSkipped() int32 {
 	}
 	return int32(skipped)
 }
+
+func NewEmptyRepoEmbeddingJobsResolver(
+	args graphqlbackend.ListRepoEmbeddingJobsArgs,
+) (*graphqlutil.ConnectionResolver[graphqlbackend.RepoEmbeddingJobResolver], error) {
+	opts := &graphqlutil.ConnectionResolverOptions{}
+	return graphqlutil.NewConnectionResolver[graphqlbackend.RepoEmbeddingJobResolver](&emptyEmbeddingJobStore{}, &args.ConnectionResolverArgs, opts)
+}
+
+type emptyEmbeddingJobStore struct{}
+
+func (s *emptyEmbeddingJobStore) ComputeNodes(ctx context.Context, args *database.PaginationArgs) ([]graphqlbackend.RepoEmbeddingJobResolver, error) {
+	return []graphqlbackend.RepoEmbeddingJobResolver{}, nil
+}
+func (s *emptyEmbeddingJobStore) ComputeTotal(ctx context.Context) (int32, error) {
+	return 0, nil
+}
+func (s *emptyEmbeddingJobStore) MarshalCursor(node graphqlbackend.RepoEmbeddingJobResolver, _ database.OrderBy) (*string, error) {
+	return nil, nil
+}
+
+func (s *emptyEmbeddingJobStore) UnmarshalCursor(cursor string, _ database.OrderBy) ([]any, error) {
+	return nil, nil
+}
+func (r *emptyEmbeddingJobStore) Nodes() []graphqlbackend.RepoEmbeddingJobResolver {
+	return []graphqlbackend.RepoEmbeddingJobResolver{}
+}
+
+func (r *emptyEmbeddingJobStore) TotalCount() int32 {
+	return 0
+}
+
+func (r *emptyEmbeddingJobStore) PageInfo() *graphqlutil.PageInfo {
+	return &graphqlutil.PageInfo{}
+}


### PR DESCRIPTION
When embeddings are disabled and admins view the web client no repositories were listed because the embeddings jobs query would return an error indicating embeddings are disabled and the first nullable resolver is the root resolver.

This updates the embeddings jobs resolver to return an empty list when embeddings are disabled.  Ideally we would allow and handle the error but it would be a major refactor since currently nothing is nullable.

Additionally this moves the security checks prior to return any errors regarding enable/disable.

## Test plan
Added unit test
disabled embeddings and logged in as admin verified that repo list available in web chat.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
