### PR TITLE
nix: patch bazel_7 with hardcoded bin paths

### DIFF
--- a/dev/nix/bazel.nix
+++ b/dev/nix/bazel.nix
@@ -1,0 +1,52 @@
+{ nixpkgs
+, pkgs
+, bazel_7
+, lib
+, substituteAll
+, bash
+, coreutils
+, diffutils
+, file
+, findutils
+, gawk
+, gnugrep
+, gnupatch
+, gnused
+, gnutar
+, gzip
+, python3
+, unzip
+, which
+, zip
+}: {
+  bazel_7 = bazel_7.overrideAttrs (oldAttrs:
+    let
+      # yoinked from https://sourcegraph.com/github.com/NixOS/nixpkgs/-/blob/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix?L77-120
+      defaultShellUtils = [
+        bash
+        coreutils
+        diffutils
+        file
+        findutils
+        gawk
+        gnugrep
+        gnupatch
+        gnused
+        gnutar
+        gzip
+        python3
+        unzip
+        which
+        zip
+      ];
+    in
+    {
+      # https://github.com/NixOS/nixpkgs/pull/262152#issuecomment-1879053113
+      patches = (oldAttrs.patches or [ ]) ++ [
+        (substituteAll {
+          src = "${nixpkgs}/pkgs/development/tools/build-managers/bazel/bazel_6/actions_path.patch";
+          actionsPathPatch = lib.makeBinPath defaultShellUtils;
+        })
+      ];
+    });
+}


### PR DESCRIPTION
bazel (and its community of rules) is a bit of a mess when it comes to passing around env values, including $PATH, resulting in some actions not receiving the $PATH value set via `--action_path=PATH=...` that we rely on. Bazel 6 in nixpkgs had [the following patch](https://sourcegraph.com/github.com/NixOS/nixpkgs/-/blob/pkgs/development/tools/build-managers/bazel/bazel_6/actions_path.patch) that hardcodes a set of packages to include in that case, which is currently missing from Bazel 7 in nixpkgs, so we (temporarily, hopefully) reintroduce that patch locally. 

See: https://github.com/NixOS/nixpkgs/pull/262152#issuecomment-1879053113 and https://github.com/NixOS/nixpkgs/issues/94222 for some reading

I plan to move more bazel stuff out of shell.nix perhaps, into bazel.nix, as its a tad messy all-in-one

## Test plan

`bazel build //client/web/dist` is successful