### PR TITLE
Update unified cody context to only use search when embeddings are disabled

### DIFF
--- a/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/cmd/frontend/internal/context/resolvers/context_test.go
@@ -33,10 +33,20 @@ import (
 func TestContextResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
 	ctx := context.Background()
-
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	repo1 := types.Repo{Name: "repo1"}
 	repo2 := types.Repo{Name: "repo2"}
+	truePtr := true
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			CodyEnabled: &truePtr,
+			Embeddings: &schema.Embeddings{
+				Provider:    "sourcegraph",
+				Enabled:     &truePtr,
+				AccessToken: "123",
+			},
+		},
+	})
 	// Create populates the IDs in the passed in types.Repo
 	err := db.Repos().Create(ctx, &repo1, &repo2)
 	require.NoError(t, err)
@@ -138,13 +148,6 @@ func TestContextResolver(t *testing.T) {
 		mockGitserver,
 		contextClient,
 	)
-
-	truePtr := true
-	conf.Mock(&conf.Unified{
-		SiteConfiguration: schema.SiteConfiguration{
-			CodyEnabled: &truePtr,
-		},
-	})
 
 	ctx = actor.WithActor(ctx, actor.FromMockUser(1))
 	ffs := featureflag.NewMemoryStore(map[string]bool{"cody": true}, nil, nil)

--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -160,6 +160,10 @@ func (c *CodyContextClient) GetCodyContext(ctx context.Context, args GetContextA
 
 // partitionRepos splits a set of repos into repos with embeddings and repos without embeddings
 func (c *CodyContextClient) partitionRepos(ctx context.Context, input []types.RepoIDName) (embedded, notEmbedded []types.RepoIDName, err error) {
+	// if embeddings are disabled , return all repos in the notEmbedded slice
+	if !conf.EmbeddingsEnabled() {
+		return embedded, input, nil
+	}
 	for _, repo := range input {
 		exists, err := c.db.Repos().RepoEmbeddingExists(ctx, repo.ID)
 		if err != nil {

--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -162,7 +162,7 @@ func (c *CodyContextClient) GetCodyContext(ctx context.Context, args GetContextA
 func (c *CodyContextClient) partitionRepos(ctx context.Context, input []types.RepoIDName) (embedded, notEmbedded []types.RepoIDName, err error) {
 	// if embeddings are disabled , return all repos in the notEmbedded slice
 	if !conf.EmbeddingsEnabled() {
-		return embedded, input, nil
+		return nil, input, nil
 	}
 	for _, repo := range input {
 		exists, err := c.db.Repos().RepoEmbeddingExists(ctx, repo.ID)


### PR DESCRIPTION
Currently when embeddings are disabled the unified cody context will continue to try to use embeddings because they were previously generated.  This results in errors for each repo, stating that embeddings are disabled.

This updates the repo partitioning to only use search if embeddings are disabled. 
## Test plan
Disabled embeddings
Used cody web client - verified additional context added to the request
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
