### PR TITLE
Streaming search: only flush filters when dirty

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -755,8 +755,9 @@ func (h *eventHandler) flushTick() {
 
 	// a nil flushTimer indicates that Done() was called
 	if h.flushTimer != nil {
-		// TODO(camdencheek): add a `dirty` to filters so we don't send them every tick
-		h.eventWriter.Filters(h.filters.Compute(), false)
+		if h.filters.Dirty {
+			h.eventWriter.Filters(h.filters.Compute(), false)
+		}
 		h.matchesBuf.Flush()
 		if h.progress.Dirty {
 			h.eventWriter.Progress(h.progress.Current())


### PR DESCRIPTION
This modifies the search streaming code to only send filters when they've changed (plus a final flush at the end of the search just in case). Previously, we would send every filter on every flush tick, which is once ever 100ms. For a 10 second search, this comes out to 100 filters events. After this change, the same search only sends 4 filters events.

This makes debugging easier (fewer events to sift through) and improves performance (only need to compute/parse/send/render the filters a few times).

@fkling [pointed this out](https://sourcegraph.slack.com/archives/C05R619V4F8/p1702635431363339) a while ago, and I was working in this code today, so I went ahead and fixed it while I was here.

## Test plan

Tested a few searches and ensured that the filters events that come through are all unique and equivalent to the streamed events before this change. 
