### PR TITLE
web: Revert <kbd> tag styling

### DIFF
--- a/client/wildcard/src/global-styles/code.scss
+++ b/client/wildcard/src/global-styles/code.scss
@@ -34,19 +34,18 @@ code,
 }
 
 kbd {
-    font-family: var(--font-family-base);
+    font-family: var(--code-font-family);
     font-size: var(--code-font-size);
     display: inline-block;
     line-height: (16/12);
-    height: 1.2rem;
-    width: 1.2rem;
-    text-align: center;
-    padding-top: 0.1rem;
+    height: 1.125rem;
+    padding: 0 0.25rem;
     margin: 0 0.125rem;
     vertical-align: middle;
     border-radius: 3px;
     color: var(--body-color);
-    background-color: var(--color-bg-3);
+    background-color: var(--color-bg-2);
+    box-shadow: inset 0 -2px 0 var(--color-bg-3);
 }
 
 // Search examples that link to the results page should use this class.


### PR DESCRIPTION
e9b0ce5c3d42 changed the styles of the `<kbd>` tag. Presumably the assumption was that content of this tag will always be a single character, but that's not the case. It's used in various places and the content can differ between platforms.

This PR reverts this particular change.

Before: 
![2024-01-06_20-53_1](https://github.com/sourcegraph/sourcegraph/assets/179026/7adb96a5-ef40-4d9d-9a7d-05b363c70881)

After: 
![2024-01-06_20-53](https://github.com/sourcegraph/sourcegraph/assets/179026/01ae0f66-8315-4237-89ac-d6b854f86705)


## Test plan

Looked at various places where we use this tag, e.g. search input suggestions.