### PR TITLE
Uses a debug_assert over assert for non-critical locals error

### DIFF
--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/locals.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/locals.rs
@@ -646,9 +646,13 @@ impl<'a> LocalResolver<'a> {
             }
         }
 
-        assert!(
+        debug_assert!(
             definitions_iter.next().is_none(),
             "Should've entered all definitions into the tree"
+        );
+        debug_assert!(
+            references_iter.next().is_none(),
+            "Should've entered all references into the tree"
         );
     }
 


### PR DESCRIPTION
While this signifies a programming error, it's not a valid reason to crash the program at runtime. Sorry I missed this one earlier. There are now no `assert!` macros left in here.

## Test plan

Tests run succesfully in CI
