### PR TITLE
Adjust blobstore latency alert

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -8350,3 +8350,4 @@ Generated query for critical alert: `min((sum by (app) (up{app=~".*embeddings"})
 </details>
 
 <br />
+

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -231,7 +231,7 @@ Generated query for warning alert: `max((histogram_quantile(0.9, sum by (le) (ra
 
 ## frontend: blob_load_latency
 
-<p class="subtitle">90th percentile blob load latency over 10m for 10m0s</p>
+<p class="subtitle">90th percentile blob load latency over 10m</p>
 
 **Descriptions**
 

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -231,11 +231,11 @@ Generated query for warning alert: `max((histogram_quantile(0.9, sum by (le) (ra
 
 ## frontend: blob_load_latency
 
-<p class="subtitle">90th percentile blob load latency over 10m</p>
+<p class="subtitle">90th percentile blob load latency over 10m for 10m0s</p>
 
 **Descriptions**
 
-- <span class="badge badge-critical">critical</span> frontend: 5s+ 90th percentile blob load latency over 10m
+- <span class="badge badge-critical">critical</span> frontend: 5s+ 90th percentile blob load latency over 10m for 10m0s
 
 **Next steps**
 
@@ -8350,4 +8350,3 @@ Generated query for critical alert: `min((sum by (app) (up{app=~".*embeddings"})
 </details>
 
 <br />
-

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -149,7 +149,7 @@ Query: `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_secon
 
 #### frontend: blob_load_latency
 
-<p class="subtitle">90th percentile blob load latency over 10m for 10m0s</p>
+<p class="subtitle">90th percentile blob load latency over 10m</p>
 
 - The blob API route provides the files and code snippets that the UI displays.
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -149,7 +149,7 @@ Query: `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_secon
 
 #### frontend: blob_load_latency
 
-<p class="subtitle">90th percentile blob load latency over 10m</p>
+<p class="subtitle">90th percentile blob load latency over 10m for 10m0s</p>
 
 - The blob API route provides the files and code snippets that the UI displays.
 
@@ -7583,7 +7583,7 @@ Query: `sum by (code) (rate(src_http_request_duration_seconds_count{app="gitserv
 
 <p class="subtitle">95th percentile duration by route, when status code is 200</p>
 
-The 95th percentile duration by route when the status code is 200 
+The 95th percentile duration by route when the status code is 200
 
 This panel has no related alerts.
 
@@ -7604,7 +7604,7 @@ Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_buck
 
 <p class="subtitle">95th percentile duration by route, when status code is not 200</p>
 
-The 95th percentile duration by route when the status code is not 200 
+The 95th percentile duration by route when the status code is not 200
 
 This panel has no related alerts.
 
@@ -15771,7 +15771,7 @@ Query: `sum by (code) (rate(src_http_request_duration_seconds_count{app="repo-up
 
 <p class="subtitle">95th percentile duration by route, when status code is 200</p>
 
-The 95th percentile duration by route when the status code is 200 
+The 95th percentile duration by route when the status code is 200
 
 This panel has no related alerts.
 
@@ -15792,7 +15792,7 @@ Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_buck
 
 <p class="subtitle">95th percentile duration by route, when status code is not 200</p>
 
-The 95th percentile duration by route when the status code is not 200 
+The 95th percentile duration by route when the status code is not 200
 
 This panel has no related alerts.
 
@@ -24491,7 +24491,7 @@ To see this dashboard, visit `/-/debug/grafana/d/codeintel-autoindexing/codeinte
 
 ### Code Intelligence > Autoindexing: Codeintel: Autoindexing > Summary
 
-#### codeintel-autoindexing: 
+#### codeintel-autoindexing:
 
 <p class="subtitle">Auto-index jobs inserted over 5m</p>
 
@@ -32197,4 +32197,3 @@ Query: `rate(src_embeddings_cache_miss_bytes[10m])`
 </details>
 
 <br />
-

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -7583,7 +7583,7 @@ Query: `sum by (code) (rate(src_http_request_duration_seconds_count{app="gitserv
 
 <p class="subtitle">95th percentile duration by route, when status code is 200</p>
 
-The 95th percentile duration by route when the status code is 200
+The 95th percentile duration by route when the status code is 200 
 
 This panel has no related alerts.
 
@@ -7604,7 +7604,7 @@ Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_buck
 
 <p class="subtitle">95th percentile duration by route, when status code is not 200</p>
 
-The 95th percentile duration by route when the status code is not 200
+The 95th percentile duration by route when the status code is not 200 
 
 This panel has no related alerts.
 
@@ -15771,7 +15771,7 @@ Query: `sum by (code) (rate(src_http_request_duration_seconds_count{app="repo-up
 
 <p class="subtitle">95th percentile duration by route, when status code is 200</p>
 
-The 95th percentile duration by route when the status code is 200
+The 95th percentile duration by route when the status code is 200 
 
 This panel has no related alerts.
 
@@ -15792,7 +15792,7 @@ Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_buck
 
 <p class="subtitle">95th percentile duration by route, when status code is not 200</p>
 
-The 95th percentile duration by route when the status code is not 200
+The 95th percentile duration by route when the status code is not 200 
 
 This panel has no related alerts.
 
@@ -24491,7 +24491,7 @@ To see this dashboard, visit `/-/debug/grafana/d/codeintel-autoindexing/codeinte
 
 ### Code Intelligence > Autoindexing: Codeintel: Autoindexing > Summary
 
-#### codeintel-autoindexing:
+#### codeintel-autoindexing: 
 
 <p class="subtitle">Auto-index jobs inserted over 5m</p>
 
@@ -32197,3 +32197,4 @@ Query: `rate(src_embeddings_cache_miss_bytes[10m])`
 </details>
 
 <br />
+

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -164,7 +164,7 @@ func Frontend() *monitoring.Dashboard {
 							Name:        "blob_load_latency",
 							Description: "90th percentile blob load latency over 10m",
 							Query:       `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route="blob"}[10m])))`,
-							Critical:    monitoring.Alert().GreaterOrEqual(5),
+							Critical:    monitoring.Alert().GreaterOrEqual(5).For(10 * time.Minute),
 							Panel:       monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds),
 							Owner:       monitoring.ObservableOwnerSource,
 							Interpretation: `
@@ -757,7 +757,8 @@ func Frontend() *monitoring.Dashboard {
 											RefID:        "2",
 											Expr:         "sum(increase(src_search_ranking_result_clicked_count{type=\"filePathMatch\"}[6h])) / sum(increase(src_search_ranking_result_clicked_count[6h])) * 100",
 											LegendFormat: "filePathMatch",
-										}}
+										},
+									}
 									p.GraphPanel.Tooltip.Shared = true
 								}),
 							Owner:          monitoring.ObservableOwnerSearchCore,

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -162,7 +162,7 @@ func Frontend() *monitoring.Dashboard {
 						},
 						{
 							Name:        "blob_load_latency",
-							Description: "90th percentile blob load latency over 10m for 10m0s",
+							Description: "90th percentile blob load latency over 10m",
 							Query:       `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route="blob"}[10m])))`,
 							Critical:    monitoring.Alert().GreaterOrEqual(5).For(10 * time.Minute),
 							Panel:       monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds),

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -162,7 +162,7 @@ func Frontend() *monitoring.Dashboard {
 						},
 						{
 							Name:        "blob_load_latency",
-							Description: "90th percentile blob load latency over 10m",
+							Description: "90th percentile blob load latency over 10m for 10m0s",
 							Query:       `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route="blob"}[10m])))`,
 							Critical:    monitoring.Alert().GreaterOrEqual(5).For(10 * time.Minute),
 							Panel:       monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds),


### PR DESCRIPTION
The >5s blobstore latency alert triggers _very_ eagerly, and it's also self-resolving. I don't think the current threshold works very well as an alert system, as it turns into a boy-who-cried-wolf scenario.

This PR requires that the blobstore latency be >5s for 10 minutes before an alert is triggered.

## Test plan

Alert update

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
