### PR TITLE
Remove owner of NoAlert observable

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -8068,4 +8068,3 @@ Generated query for critical alert: `min((sum by (app) (up{app=~".*embeddings"})
 </details>
 
 <br />
-

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5110,7 +5110,7 @@ Query: `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="s
 
 <p class="subtitle">P95 time to handle incoming webhooks</p>
 
-							p95 response time to incoming webhook requests from code hosts.
+p95 response time to incoming webhook requests from code hosts.
 
 							Increases in response time can point to too much load on the database to keep up with the incoming requests.
 
@@ -24347,7 +24347,7 @@ To see this dashboard, visit `/-/debug/grafana/d/codeintel-autoindexing/codeinte
 
 ### Code Intelligence > Autoindexing: Codeintel: Autoindexing > Summary
 
-#### codeintel-autoindexing:
+####codeintel-autoindexing:
 
 <p class="subtitle">Auto-index jobs inserted over 5m</p>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -4178,7 +4178,6 @@ This panel has no related alerts.
 
 To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=102800` on your Sourcegraph instance.
 
-<sub>*Managed by the [Sourcegraph Cody team](https://handbook.sourcegraph.com/departments/engineering/teams/cody).*</sub>
 
 <details>
 <summary>Technical details</summary>
@@ -7545,7 +7544,7 @@ Query: `sum by (code) (rate(src_http_request_duration_seconds_count{app="gitserv
 
 <p class="subtitle">95th percentile duration by route, when status code is 200</p>
 
-The 95th percentile duration by route when the status code is 200 
+The 95th percentile duration by route when the status code is 200
 
 This panel has no related alerts.
 
@@ -7566,7 +7565,7 @@ Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_buck
 
 <p class="subtitle">95th percentile duration by route, when status code is not 200</p>
 
-The 95th percentile duration by route when the status code is not 200 
+The 95th percentile duration by route when the status code is not 200
 
 This panel has no related alerts.
 
@@ -15691,7 +15690,7 @@ Query: `sum by (code) (rate(src_http_request_duration_seconds_count{app="repo-up
 
 <p class="subtitle">95th percentile duration by route, when status code is 200</p>
 
-The 95th percentile duration by route when the status code is 200 
+The 95th percentile duration by route when the status code is 200
 
 This panel has no related alerts.
 
@@ -15712,7 +15711,7 @@ Query: `histogram_quantile(0.95, sum(rate(src_http_request_duration_seconds_buck
 
 <p class="subtitle">95th percentile duration by route, when status code is not 200</p>
 
-The 95th percentile duration by route when the status code is not 200 
+The 95th percentile duration by route when the status code is not 200
 
 This panel has no related alerts.
 
@@ -24348,7 +24347,7 @@ To see this dashboard, visit `/-/debug/grafana/d/codeintel-autoindexing/codeinte
 
 ### Code Intelligence > Autoindexing: Codeintel: Autoindexing > Summary
 
-#### codeintel-autoindexing: 
+#### codeintel-autoindexing:
 
 <p class="subtitle">Auto-index jobs inserted over 5m</p>
 
@@ -32033,4 +32032,3 @@ Query: `rate(src_embeddings_cache_miss_bytes[10m])`
 </details>
 
 <br />
-

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -639,7 +639,6 @@ func Frontend() *monitoring.Dashboard {
 					Query:          `sum by (route, code)(irate(src_http_request_duration_seconds_count{route=~"^completions.*"}[5m]))`,
 					NoAlert:        true,
 					Panel:          monitoring.Panel().Unit(monitoring.RequestsPerSecond),
-					Owner:          monitoring.ObservableOwnerCody,
 					Interpretation: `Rate (QPS) of requests to cody related endpoints. completions.stream is for the conversational endpoints. completions.code is for the code auto-complete endpoints.`,
 				}}},
 			},

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -50,7 +50,14 @@ func fprintSubtitle(w io.Writer, text string) {
 // See `observableAnchor`.
 func fprintObservableHeader(w io.Writer, c *Dashboard, o *Observable, headerLevel int) {
 	fmt.Fprint(w, strings.Repeat("#", headerLevel))
-	fmt.Fprintf(w, " %s: %s\n\n", c.Name, o.Name)
+	if o.Name == "" {
+		// TODO: It seems that we have an issue here, it generates the following:
+		// see https://gist.github.com/jhchabran/9ceaed75abe1a78136c200b6bc98c584
+		// to help you understand where it's possibly broken.
+		fmt.Fprintf(w, "%s:\n\n", strings.TrimSpace(c.Name))
+	} else {
+		fmt.Fprintf(w, " %s: %s\n\n", c.Name, o.Name)
+	}
 }
 
 // fprintOwnedBy prints information about who owns a particular monitoring definition.
@@ -196,7 +203,7 @@ func (d *documentation) renderDashboardPanelEntry(c *Dashboard, o Observable, pa
 	// render interpretation reference if available
 	if o.Interpretation != "" && o.Interpretation != "none" {
 		interpretation, _ := toMarkdown(o.Interpretation, false)
-		fmt.Fprintf(&d.dashboards, "%s\n\n", interpretation)
+		fmt.Fprintf(&d.dashboards, "%s\n\n", strings.TrimSpace(interpretation))
 	}
 
 	// add link to alerts reference IF there is an alert attached

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -1,6 +1,7 @@
 package monitoring
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -321,7 +322,11 @@ func generateAll(
 			{path: filepath.Join(opts.DocsDir, alertsDocsFile), data: docs.alertDocs.Bytes()},
 			{path: filepath.Join(opts.DocsDir, dashboardsDocsFile), data: docs.dashboards.Bytes()},
 		} {
-			err = os.WriteFile(docOut.path, docOut.data, os.ModePerm)
+			// By default, due to how we assemble content, we might end up with two \n chars at the end,
+			// which will yield linter errors. So instead, drop spaces at the end of the file and manually
+			// add the last \n.
+			b := append(bytes.TrimSpace(docOut.data), byte('\n'))
+			err = os.WriteFile(docOut.path, b, os.ModePerm)
 			if err != nil {
 				return generatedAssets, errors.Wrapf(err, "Could not write docs to path %q", docOut.path)
 			}


### PR DESCRIPTION
Removing owner from monitoring definition we don't alert on. [Context](https://sourcegraph.slack.com/archives/C03L2R35ENL/p1704240126855279)
## Test plan

- CI

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@rg/remove_no_alert_owner)