### PR TITLE
Extract token count from streaming OpenAI responses

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     srcs = [
         "anthropic_test.go",
         "fireworks_test.go",
+        "openai_test.go",
     ],
     embed = [":completions"],
     deps = [

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks_test.go
@@ -13,7 +13,7 @@ func TestFireworksRequestGetTokenCount(t *testing.T) {
 
 	t.Run("streaming", func(t *testing.T) {
 		req := fireworksRequest{Stream: true}
-		r := strings.NewReader(streamingResponse)
+		r := strings.NewReader(fireworksStreamingResponse)
 		handler := &FireworksHandlerMethods{}
 		promptUsage, completionUsage := handler.parseResponseAndUsage(logger, req, r)
 
@@ -23,7 +23,7 @@ func TestFireworksRequestGetTokenCount(t *testing.T) {
 
 	t.Run("non-streaming", func(t *testing.T) {
 		req := fireworksRequest{Stream: false}
-		r := strings.NewReader(nonStreamingResponse)
+		r := strings.NewReader(fireworksNonStreamingResponse)
 		handler := &FireworksHandlerMethods{}
 		promptUsage, completionUsage := handler.parseResponseAndUsage(logger, req, r)
 
@@ -32,7 +32,7 @@ func TestFireworksRequestGetTokenCount(t *testing.T) {
 	})
 }
 
-var streamingResponse = `
+var fireworksStreamingResponse = `
 data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","created":1704368645,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}],"usage":null}
 
 data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","created":1704368645,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"delta":{"content":"I am a helpful AI assistant"},"finish_reason":null}],"usage":null}
@@ -50,4 +50,4 @@ data: {"id":"cmpl-448a6127ca074189b4e011ec","object":"chat.completion.chunk","cr
 data: [DONE]
 `
 
-var nonStreamingResponse = `{"id":"cmpl-a890423291fa6d7de7b8d8af","object":"chat.completion","created":1704368780,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"I don't have a \"real\" name, as I am an artificial intelligence and don't have a physical body or personal identity. I"},"finish_reason":"length"}],"usage":{"prompt_tokens":79,"total_tokens":109,"completion_tokens":30}}`
+var fireworksNonStreamingResponse = `{"id":"cmpl-a890423291fa6d7de7b8d8af","object":"chat.completion","created":1704368780,"model":"accounts/fireworks/models/mixtral-8x7b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"I don't have a \"real\" name, as I am an artificial intelligence and don't have a physical body or personal identity. I"},"finish_reason":"length"}],"usage":{"prompt_tokens":79,"total_tokens":109,"completion_tokens":30}}`

--- a/cmd/cody-gateway/internal/httpapi/completions/openai_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai_test.go
@@ -1,0 +1,65 @@
+package completions
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/log/logtest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpenAIRequestGetTokenCount(t *testing.T) {
+	logger := logtest.Scoped(t)
+
+	t.Run("streaming", func(t *testing.T) {
+		req := openaiRequest{Stream: true}
+		r := strings.NewReader(openaiStreamingResponse)
+		handler := &OpenAIHandlerMethods{}
+		promptUsage, completionUsage := handler.parseResponseAndUsage(logger, req, r)
+
+		assert.Equal(t, 427, promptUsage.tokens)
+		assert.Equal(t, 12, completionUsage.tokens)
+	})
+
+	t.Run("non-streaming", func(t *testing.T) {
+		req := openaiRequest{Stream: false}
+		r := strings.NewReader(openaiNonStreamingResponse)
+		handler := &OpenAIHandlerMethods{}
+		promptUsage, completionUsage := handler.parseResponseAndUsage(logger, req, r)
+
+		assert.Equal(t, 12, promptUsage.tokens)
+		assert.Equal(t, 9, completionUsage.tokens)
+	})
+}
+
+var openaiStreamingResponse = `
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" How"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" can"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" assist"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" you"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" with"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" your"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" coding"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" today"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+data: {"id":"chatcmpl-8elzR9LfyjxFKon8GoRMdY4BVj6Zx","object":"chat.completion.chunk","created":1704728285,"model":"gpt-4-0613","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":427,"completion_tokens":12,"total_tokens":439}}
+`
+
+var openaiNonStreamingResponse = `{"id": "chatcmpl-8emDGlSur24VWoRtKriWO8XpuuFQi","object": "chat.completion","created": 1704729142,"model": "gpt-4-0613","choices": [{"index": 0,"message": {"role": "assistant","content": "Hello! How can I assist you today?"},"logprobs": null,"finish_reason": "stop"}],"usage": {"prompt_tokens": 12,"completion_tokens": 9,"total_tokens": 21},"system_fingerprint": null}`


### PR DESCRIPTION
OpenAI has enabled usage data on streaming requests for our org, this extracts the usage data.

closes https://github.com/sourcegraph/sourcegraph/issues/59297

## Test plan
Unit test added
Manual testing running gateway.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
