### PR TITLE
nix: unset TMP and TMPDIR for bazel

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -26,6 +26,7 @@ let
     unset CC CXX
     exec ${pkgs.bazelisk}/bin/bazelisk "$@"
   '' else ''
+    unset TMPDIR TMP
     if [ "$1" == "configure" ]; then
       exec env --unset=USE_BAZEL_VERSION ${pkgs.bazelisk}/bin/bazelisk "$@"
     fi


### PR DESCRIPTION
Due to a newly enabled (in bazel 7) `--incompatible_sandbox_hermetic_tmp`, and nix setting TMP/TMPDIR to something below /tmp, we encounter https://github.com/bazelbuild/bazel/issues/5900

## Test plan

`nix develop --command bazel build //dev/sg` is successfull
