### PR TITLE
Remove embeddings indicators from cody web chat

### DIFF
--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import classNames from 'classnames'
 

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -9,8 +9,6 @@ import { CodyColorIcon, CodySpeechBubbleIcon } from '../chat/CodyPageIcon'
 import type { CodyChatStore } from '../useCodyChat'
 
 import { ScopeSelector } from './ScopeSelector'
-import type { IRepo } from './ScopeSelector/RepositoriesSelectorPopover'
-import { isRepoIndexed } from './ScopeSelector/RepositoriesSelectorPopover'
 
 import styles from './GettingStarted.module.scss'
 
@@ -118,34 +116,6 @@ export const GettingStarted: React.FC<
         }
     }, [conversationScope, scopeSelectorProps.scope.repositories])
 
-    const renderRepoIndexingWarning: (repos: IRepo[]) => React.ReactNode = useCallback(
-        (repos: IRepo[]) => {
-            if (conversationScope === 'general' || repos.every(isRepoIndexed)) {
-                return null
-            }
-
-            const unindexedCount = repos.filter(repo => !isRepoIndexed(repo)).length
-            const warningText =
-                repos.length === 1
-                    ? 'The selected repository is not indexed for Cody and is missing embeddings.'
-                    : `${unindexedCount} of ${repos.length} selected repositories are not indexed for Cody and are missing embeddings.`
-
-            return (
-                <Text size="small" className={styles.scopeSelectorWarning}>
-                    {warningText} This may affect the quality of the answers. To enable indexing, see the{' '}
-                    <Link
-                        className={styles.scopeSelectorWarningLink}
-                        to="/help/cody/explanations/code_graph_context#embeddings"
-                    >
-                        embeddings documentation
-                    </Link>
-                    .
-                </Text>
-            )
-        },
-        [conversationScope]
-    )
-
     return (
         <div ref={containerRef} className={styles.container}>
             {/* eslint-disable-next-line react/forbid-dom-props */}
@@ -205,7 +175,6 @@ export const GettingStarted: React.FC<
                                 <div className={styles.scopeSelectorWrapper}>
                                     <ScopeSelector
                                         {...scopeSelectorProps}
-                                        renderHint={renderRepoIndexingWarning}
                                         encourageOverlap={true}
                                         authenticatedUser={authenticatedUser}
                                     />

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -1,17 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react'
 
-import {
-    mdiChevronUp,
-    mdiChevronDown,
-    mdiMinusCircleOutline,
-    mdiCheck,
-    mdiCloseCircle,
-    mdiDatabaseOutline,
-    mdiDatabaseCheckOutline,
-    mdiDatabaseClockOutline,
-    mdiDatabaseRefreshOutline,
-    mdiDatabaseRemoveOutline,
-} from '@mdi/js'
+import { mdiChevronUp, mdiChevronDown, mdiMinusCircleOutline, mdiCheck, mdiCloseCircle } from '@mdi/js'
 import classNames from 'classnames'
 
 import type { TranscriptJSON } from '@sourcegraph/cody-shared/dist/chat/transcript'
@@ -27,8 +16,6 @@ import {
     Card,
     Text,
     Input,
-    Tooltip,
-    Link,
     useDebounce,
     Position,
     Flipping,
@@ -51,13 +38,6 @@ export interface IRepo {
     externalRepository: {
         serviceType: string
     }
-    embeddingJobs?: {
-        nodes: {
-            id: string
-            state: string
-            failureMessage: string | null
-        }[]
-    } | null
 }
 
 export const MAX_ADDITIONAL_REPOSITORIES = 10
@@ -180,9 +160,6 @@ export const RepositoriesSelectorPopover: React.FC<{
                         styles.repositoryNamesText
                     )}
                 >
-                    <div className="mr-1">
-                        <EmbeddingStatusIndicator repos={netRepositories} />
-                    </div>
                     <div className="text-truncate mr-1">
                         {netRepositories.length > 1 ? (
                             <>
@@ -266,10 +243,6 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                                 {getFileName(inferredFilePath)}
                                                             </span>
                                                         </div>
-                                                        <EmbeddingExistsIcon
-                                                            repo={inferredRepository}
-                                                            authenticatedUser={authenticatedUser}
-                                                        />
                                                     </button>
                                                 )}
                                                 <button
@@ -299,10 +272,6 @@ export const RepositoriesSelectorPopover: React.FC<{
                                                             {getRepoName(inferredRepository.name)}
                                                         </span>
                                                     </div>
-                                                    <EmbeddingExistsIcon
-                                                        repo={inferredRepository}
-                                                        authenticatedUser={authenticatedUser}
-                                                    />
                                                 </button>
                                             </div>
                                         )}
@@ -474,7 +443,6 @@ const AdditionalRepositoriesListItem: React.FC<{
                 <ExternalRepositoryIcon externalRepo={repository.externalRepository} className={styles.repoIcon} />
                 <span className="text-truncate">{getRepoName(repository.name)}</span>
             </div>
-            <EmbeddingExistsIcon repo={repository} authenticatedUser={authenticatedUser} />
         </button>
     )
 })
@@ -529,7 +497,6 @@ const SearchResultsListItem: React.FC<{
                 <ExternalRepositoryIcon externalRepo={repository.externalRepository} className={styles.repoIcon} />
                 {getTintedText(getRepoName(repository.name), searchText)}
             </div>
-            <EmbeddingExistsIcon repo={repository} authenticatedUser={authenticatedUser} />
         </button>
     )
 })
@@ -567,212 +534,3 @@ export const getRepoName = (path: string): string => {
     const parts = path.split('/')
     return parts.slice(-2).join('/')
 }
-
-enum RepoEmbeddingStatus {
-    NOT_INDEXED = 'NOT_INDEXED',
-    QUEUED = 'QUEUED',
-    INDEXING = 'INDEXING',
-    INDEXED = 'INDEXED',
-    FAILED = 'FAILED',
-}
-
-const getEmbeddingStatus = ({
-    embeddingExists,
-    embeddingJobs,
-}: IRepo): { status: RepoEmbeddingStatus; tooltip: string; icon: string; className: string } => {
-    if (embeddingExists) {
-        return {
-            status: RepoEmbeddingStatus.INDEXED,
-            tooltip: 'Repository is indexed',
-            icon: mdiDatabaseCheckOutline,
-            className: 'text-success',
-        }
-    }
-
-    if (!embeddingJobs?.nodes.length) {
-        return {
-            status: RepoEmbeddingStatus.NOT_INDEXED,
-            tooltip: 'Repository is not indexed',
-            icon: mdiDatabaseRemoveOutline,
-            className: 'text-warning',
-        }
-    }
-
-    const job = embeddingJobs.nodes[0]
-    switch (job.state) {
-        case 'QUEUED': {
-            return {
-                status: RepoEmbeddingStatus.QUEUED,
-                tooltip: 'Repository is queued for indexing',
-                icon: mdiDatabaseClockOutline,
-                className: 'text-warning',
-            }
-        }
-        case 'PROCESSING': {
-            return {
-                status: RepoEmbeddingStatus.INDEXING,
-                tooltip: 'Repository is being indexed',
-                icon: mdiDatabaseRefreshOutline,
-                className: 'text-warning',
-            }
-        }
-        case 'COMPLETED': {
-            return {
-                status: RepoEmbeddingStatus.INDEXED,
-                tooltip: 'Repository is indexed',
-                icon: mdiDatabaseCheckOutline,
-                className: 'text-success',
-            }
-        }
-        case 'ERRORED': {
-            return {
-                status: RepoEmbeddingStatus.FAILED,
-                tooltip: `Repository indexing failed: ${job.failureMessage || 'unknown error'}`,
-                icon: mdiDatabaseRemoveOutline,
-                className: 'text-danger',
-            }
-        }
-        case 'FAILED': {
-            return {
-                status: RepoEmbeddingStatus.FAILED,
-                tooltip: `Repository indexing failed: ${job.failureMessage || 'unknown error'}`,
-                icon: mdiDatabaseRemoveOutline,
-                className: 'text-danger',
-            }
-        }
-        default: {
-            return {
-                status: RepoEmbeddingStatus.NOT_INDEXED,
-                tooltip: 'Repository is not indexed',
-                icon: mdiDatabaseRemoveOutline,
-                className: 'text-warning',
-            }
-        }
-    }
-}
-
-export const isRepoIndexed = (repo: IRepo): boolean => getEmbeddingStatus(repo).status === RepoEmbeddingStatus.INDEXED
-
-const EmbeddingExistsIcon: React.FC<{
-    repo: IRepo
-    authenticatedUser: AuthenticatedUser | null
-}> = React.memo(function EmbeddingExistsIconContent({ repo, authenticatedUser }) {
-    const { tooltip, icon, className } = getEmbeddingStatus(repo)
-
-    return (
-        <Tooltip content={tooltip}>
-            {authenticatedUser?.siteAdmin ? (
-                <Link to="/site-admin/embeddings" className="text-body" onClick={event => event.stopPropagation()}>
-                    <Icon aria-hidden={true} className={classNames(styles.icon, className)} svgPath={icon} />
-                </Link>
-            ) : (
-                <Icon aria-hidden={true} className={classNames(styles.icon, className)} svgPath={icon} />
-            )}
-        </Tooltip>
-    )
-})
-
-const EmbeddingStatusIndicator: React.FC<{ repos: IRepo[] }> = React.memo(function EmbeddingsStatusIndicatorContent({
-    repos,
-}) {
-    const repoStatusCounts = useMemo(
-        () =>
-            repos.reduce(
-                (statuses, repo) => {
-                    const { status } = getEmbeddingStatus(repo)
-                    statuses[status] = statuses[status] + 1
-                    return statuses
-                },
-                {
-                    [RepoEmbeddingStatus.NOT_INDEXED]: 0,
-                    [RepoEmbeddingStatus.INDEXING]: 0,
-                    [RepoEmbeddingStatus.INDEXED]: 0,
-                    [RepoEmbeddingStatus.QUEUED]: 0,
-                    [RepoEmbeddingStatus.FAILED]: 0,
-                } as Record<RepoEmbeddingStatus, number>
-            ),
-        [repos]
-    )
-
-    if (!repos.length) {
-        return (
-            <Icon
-                aria-label="Database icon"
-                className={classNames('align-center text-muted', styles.icon)}
-                svgPath={mdiDatabaseOutline}
-            />
-        )
-    }
-
-    if (repos.length === 1) {
-        const { tooltip, icon, className } = getEmbeddingStatus(repos[0])
-
-        return (
-            <Tooltip content={tooltip}>
-                <Icon
-                    aria-label="Database icon"
-                    className={classNames('align-center', styles.icon, className)}
-                    svgPath={icon}
-                />
-            </Tooltip>
-        )
-    }
-
-    if (repoStatusCounts[RepoEmbeddingStatus.FAILED]) {
-        return (
-            <Tooltip content="Indexing failed for some repositories">
-                <Icon
-                    aria-label="Database icon"
-                    className={classNames('align-center text-danger', styles.icon)}
-                    svgPath={mdiDatabaseRemoveOutline}
-                />
-            </Tooltip>
-        )
-    }
-
-    if (repoStatusCounts[RepoEmbeddingStatus.INDEXING]) {
-        return (
-            <Tooltip content="Some repositories are being indexed">
-                <Icon
-                    aria-label="Database icon"
-                    className={classNames('align-center text-warning', styles.icon)}
-                    svgPath={mdiDatabaseRefreshOutline}
-                />
-            </Tooltip>
-        )
-    }
-
-    if (repoStatusCounts[RepoEmbeddingStatus.QUEUED]) {
-        return (
-            <Tooltip content="Some repositories are queued for indexing">
-                <Icon
-                    aria-label="Database icon"
-                    className={classNames('align-center text-warning', styles.icon)}
-                    svgPath={mdiDatabaseClockOutline}
-                />
-            </Tooltip>
-        )
-    }
-
-    if (repoStatusCounts[RepoEmbeddingStatus.NOT_INDEXED]) {
-        return (
-            <Tooltip content="Some repositories are not indexed">
-                <Icon
-                    aria-label="Database icon"
-                    className={classNames('align-center text-warning', styles.icon)}
-                    svgPath={mdiDatabaseRemoveOutline}
-                />
-            </Tooltip>
-        )
-    }
-
-    return (
-        <Tooltip content="All repositories are indexed">
-            <Icon
-                aria-label="Database icon with a check mark"
-                className={classNames('align-center text-success', styles.icon)}
-                svgPath={mdiDatabaseCheckOutline}
-            />
-        </Tooltip>
-    )
-})

--- a/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
+++ b/client/web/src/cody/components/ScopeSelector/RepositoriesSelectorPopover.tsx
@@ -34,7 +34,6 @@ import styles from './ScopeSelector.module.scss'
 export interface IRepo {
     id: string
     name: string
-    embeddingExists: boolean
     externalRepository: {
         serviceType: string
     }
@@ -104,12 +103,12 @@ export const RepositoriesSelectorPopover: React.FC<{
         if (searchTextDebounced) {
             /* eslint-disable no-console */
             searchRepositories({
-                variables: { query: searchTextDebounced, includeJobs: !!authenticatedUser?.siteAdmin },
+                variables: { query: searchTextDebounced },
                 pollInterval: 5000,
             }).catch(console.error)
             /* eslint-enable no-console */
         }
-    }, [searchTextDebounced, searchRepositories, authenticatedUser?.siteAdmin])
+    }, [searchTextDebounced, searchRepositories])
 
     const [isCalloutDismissed = true, setIsCalloutDismissed] = useTemporarySetting(
         'cody.contextCallout.dismissed',

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -64,10 +64,9 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
         }
 
         loadReposStatus({
-            variables: { repoNames, first: repoNames.length, includeJobs: !!authenticatedUser?.siteAdmin },
-            pollInterval: 2000,
+            variables: { repoNames, first: repoNames.length },
         }).catch(() => null)
-    }, [activeEditor, scope.repositories, loadReposStatus, authenticatedUser?.siteAdmin])
+    }, [activeEditor, scope.repositories, loadReposStatus])
 
     const allRepositories = useMemo(() => reposStatusData?.repositories.nodes || [], [reposStatusData])
 

--- a/client/web/src/cody/components/ScopeSelector/backend.ts
+++ b/client/web/src/cody/components/ScopeSelector/backend.ts
@@ -4,7 +4,6 @@ const REPO_FIELDS = gql`
     fragment ContextSelectorRepoFields on Repository {
         id
         name
-        embeddingExists
         externalRepository {
             id
             serviceType
@@ -12,42 +11,23 @@ const REPO_FIELDS = gql`
     }
 `
 
-const EMBEDDING_JOB_FIELDS = gql`
-    fragment ContextSelectorEmbeddingJobFields on RepoEmbeddingJob {
-        id
-        state
-        failureMessage
-    }
-`
-
 export const ReposSelectorSearchQuery = gql`
-    query ReposSelectorSearch($query: String!, $includeJobs: Boolean!) {
+    query ReposSelectorSearch($query: String!) {
         repositories(query: $query, first: 15) {
             nodes {
                 ...ContextSelectorRepoFields
-                embeddingJobs(first: 1) @include(if: $includeJobs) {
-                    nodes {
-                        ...ContextSelectorEmbeddingJobFields
-                    }
-                }
             }
         }
     }
 
     ${REPO_FIELDS}
-    ${EMBEDDING_JOB_FIELDS}
 `
 
 export const SuggestedReposQuery = gql`
-    query SuggestedRepos($names: [String!]!, $numResults: Int!, $includeJobs: Boolean!) {
+    query SuggestedRepos($names: [String!]!, $numResults: Int!) {
         byName: repositories(names: $names, first: $numResults) {
             nodes {
                 ...ContextSelectorRepoFields
-                embeddingJobs(first: 1) @include(if: $includeJobs) {
-                    nodes {
-                        ...ContextSelectorEmbeddingJobFields
-                    }
-                }
             }
         }
         # We also grab the first $numResults embedded repos available on the site
@@ -55,33 +35,21 @@ export const SuggestedReposQuery = gql`
         firstN: repositories(first: $numResults, embedded: true) {
             nodes {
                 ...ContextSelectorRepoFields
-                embeddingJobs(first: 1) @include(if: $includeJobs) {
-                    nodes {
-                        ...ContextSelectorEmbeddingJobFields
-                    }
-                }
             }
         }
     }
 
     ${REPO_FIELDS}
-    ${EMBEDDING_JOB_FIELDS}
 `
 
 export const ReposStatusQuery = gql`
-    query ReposStatus($repoNames: [String!]!, $first: Int!, $includeJobs: Boolean!) {
+    query ReposStatus($repoNames: [String!]!, $first: Int!) {
         repositories(names: $repoNames, first: $first) {
             nodes {
                 ...ContextSelectorRepoFields
-                embeddingJobs(first: 1) @include(if: $includeJobs) {
-                    nodes {
-                        ...ContextSelectorEmbeddingJobFields
-                    }
-                }
             }
         }
     }
 
     ${REPO_FIELDS}
-    ${EMBEDDING_JOB_FIELDS}
 `

--- a/client/web/src/cody/components/ScopeSelector/useRepoSuggestions.ts
+++ b/client/web/src/cody/components/ScopeSelector/useRepoSuggestions.ts
@@ -132,7 +132,6 @@ export const useRepoSuggestions = (
         variables: {
             names: suggestedRepoNames,
             numResults: numSuggestions,
-            includeJobs: !!authenticatedUser?.siteAdmin,
         },
         fetchPolicy: 'cache-first',
     })


### PR DESCRIPTION
Removes icon indicators and warnings from Cody web chat regarding presence or absence for embeddings. 

This also removes the repo status polling because there is no longer a status change. 

part of https://github.com/sourcegraph/sourcegraph/issues/59309
## Test plan
Opened webclient, selected repos ensured context was requested from those repos.
before 
<img width="875" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/3116fffc-b120-48fa-8b2e-06d4b14accd7">

after
<img width="847" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/13328945-bfb0-450a-9f0f-b044b29d7d24">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
