### PR TITLE
Code Insights: Remove no new line check from capture group insight

### DIFF
--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
@@ -15,19 +15,12 @@ interface SearchQueryChecksProps {
         isValidPatternType: true | false | undefined
         isNotRepo: true | false | undefined
         isNotCommitOrDiff: true | false | undefined
-        isNoNewLines: true | false | undefined
         isNotRev: true | false | undefined
     }
 }
 
 export const SearchQueryChecks: FC<SearchQueryChecksProps> = ({ checks }) => (
     <ul aria-label="Search query validation checks list" className={classNames(styles.checks)}>
-        <CheckListItem
-            errorMessage="shouldn't contains a match over more than a single line"
-            valid={checks?.isNoNewLines}
-        >
-            Does not contain a match over more than a single line.
-        </CheckListItem>
         <CheckListItem
             errorMessage="shouldn't contain boolean operators, AND, OR, NOT (regular
                 expression boolean operators can still be used)"

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
@@ -10,7 +10,6 @@ const PASSING_VALIDATION = {
     isNotRepo: true,
     isNotContext: true,
     isNotCommitOrDiff: true,
-    isNoNewLines: true,
     isNotRev: true,
 }
 
@@ -40,17 +39,7 @@ describe('searchQueryValidator', () => {
         })
     })
 
-    it('validates no new lines', () => {
-        expect(searchQueryValidator(`${GOOD_QUERY} \\n`)).toEqual({
-            ...PASSING_VALIDATION,
-            isNoNewLines: false,
-        })
-    })
-
     it('validates not using `rev`', () => {
-        expect(searchQueryValidator(`${GOOD_QUERY} rev:any`)).toEqual({
-            ...PASSING_VALIDATION,
-            isNotRev: false,
-        })
+        expect(searchQueryValidator(`${GOOD_QUERY} rev:any`)).toEqual(PASSING_VALIDATION)
     })
 })

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.test.ts
@@ -40,6 +40,9 @@ describe('searchQueryValidator', () => {
     })
 
     it('validates not using `rev`', () => {
-        expect(searchQueryValidator(`${GOOD_QUERY} rev:any`)).toEqual(PASSING_VALIDATION)
+        expect(searchQueryValidator(`${GOOD_QUERY} rev:any`)).toEqual({
+            ...PASSING_VALIDATION,
+            isNotRev: false,
+        })
     })
 })

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
@@ -1,6 +1,6 @@
 import { FilterType, resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
-import type { Filter, Keyword, Pattern } from '@sourcegraph/shared/src/search/query/token'
+import type { Filter, Keyword } from '@sourcegraph/shared/src/search/query/token'
 
 export interface Checks {
     isValidOperator: true | false | undefined
@@ -8,7 +8,6 @@ export interface Checks {
     isNotRepo: true | false | undefined
     isNotContext: true | false | undefined
     isNotCommitOrDiff: true | false | undefined
-    isNoNewLines: true | false | undefined
     isNotRev: true | false | undefined
 }
 
@@ -20,7 +19,6 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
             isNotRepo: undefined,
             isNotContext: undefined,
             isNotCommitOrDiff: undefined,
-            isNoNewLines: undefined,
             isNotRev: undefined,
         }
     }
@@ -30,7 +28,6 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
     if (tokens.type === 'success') {
         const filters = tokens.term.filter(token => token.type === 'filter') as Filter[]
         const keywords = tokens.term.filter(token => token.type === 'keyword') as Keyword[]
-        const patterns = tokens.term.filter(token => token.type === 'pattern') as Pattern[]
 
         const hasAnd = keywords.some(filter => filter.kind === 'and')
         const hasOr = keywords.some(filter => filter.kind === 'or')
@@ -67,15 +64,12 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
             filter => resolveFilter(filter.field.value)?.type === FilterType.type && filter.value?.value === 'diff'
         )
 
-        const hasNewLines = patterns.some(term => term.value === '\\n')
-
         return {
             isValidOperator: !hasAnd && !hasOr && !hasNot,
             isValidPatternType: !hasLiteralPattern && !hasStructuralPattern,
             isNotRepo: !hasRepo,
             isNotContext: !hasContext,
             isNotCommitOrDiff: !hasCommit && !hasDiff,
-            isNoNewLines: !hasNewLines,
             isNotRev: !hasRev,
         }
     }
@@ -86,7 +80,6 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
         isNotRepo: false,
         isNotContext: false,
         isNotCommitOrDiff: false,
-        isNoNewLines: false,
         isNotRev: false,
     }
 }


### PR DESCRIPTION
Based on this slack thread https://sourcegraph.slack.com/archives/C05EA9KQUTA/p1704741483847149

**TL;DR** 
We basically don't want to restrict multi line query in the capture group insight query field since we don't have restriction about capture group being single-line anymore. 


## Test plan
- Check multi-line capture group query passes client validation in the creation UI form

