### PR TITLE
sg/msp: add 'sg msp tfc graph' for resources

### DIFF
--- a/dev/sg/msp/BUILD.bazel
+++ b/dev/sg/msp/BUILD.bazel
@@ -16,6 +16,9 @@ go_library(
         "//dev/managedservicesplatform/stacks",
         "//dev/managedservicesplatform/stacks/cloudrun",
         "//dev/managedservicesplatform/stacks/iam",
+        "//dev/managedservicesplatform/stacks/monitoring",
+        "//dev/managedservicesplatform/stacks/project",
+        "//dev/managedservicesplatform/stacks/tfcworkspaces",
         "//dev/managedservicesplatform/terraformcloud",
         "//dev/sg/cloudsqlproxy",
         "//dev/sg/internal/category",
@@ -29,6 +32,7 @@ go_library(
         "//lib/errors",
         "//lib/output",
         "//lib/pointers",
+        "@com_github_sourcegraph_run//:run",
         "@com_github_urfave_cli_v2//:cli",
     ],
 )

--- a/dev/sg/msp/repo/BUILD.bazel
+++ b/dev/sg/msp/repo/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "repo",
     srcs = [
+        "graph.go",
         "repo.go",
         "root.go",
     ],
@@ -13,6 +14,8 @@ go_library(
         "//dev/sg/internal/std",
         "//lib/cliutil/completions",
         "//lib/errors",
+        "@com_github_sourcegraph_run//:run",
         "@com_github_urfave_cli_v2//:cli",
+        "@dev_bobheadxi_go_streamline//pipeline",
     ],
 )

--- a/dev/sg/msp/repo/graph.go
+++ b/dev/sg/msp/repo/graph.go
@@ -1,0 +1,55 @@
+package repo
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/sourcegraph/run"
+	"go.bobheadxi.dev/streamline/pipeline"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// TerraformGraph uses 'terraform graph' and runs some rudimentary filtering
+// on the output dot-format graph to clean it up.
+func TerraformGraph(ctx context.Context, serviceID, envID string, stack string) (string, error) {
+	if err := run.Cmd(ctx, "terraform init").
+		Dir(ServiceStackPath(serviceID, envID, stack)).
+		Run().Wait(); err != nil {
+		return "", errors.Wrapf(err, "terraform init %q", stack)
+	}
+
+	out, err := run.Cmd(ctx, "terraform graph").
+		Dir(ServiceStackPath(serviceID, envID, stack)).
+		Run().
+		Pipeline(pipeline.Filter(func(line []byte) bool {
+			l := string(line)
+			// Ignore stuff just point to the root node
+			if strings.Contains(l, "[root] root") ||
+				// Remove provider nodes
+				strings.Contains(l, "[root] provider[") ||
+				// Remove generated outputs
+				strings.Contains(l, "output.output-") ||
+				strings.Contains(l, "google_secret_manager_secret.output") ||
+				strings.Contains(l, "google_secret_manager_secret_version.output") {
+				return false
+			}
+			return true
+		})).
+		Pipeline(pipeline.Map(func(line []byte) []byte {
+			// Make things easier to read
+			return bytes.ReplaceAll(
+				bytes.ReplaceAll(line, []byte("[root] "), []byte("")),
+				[]byte(" (expand)"), []byte(""))
+		})).
+		String()
+	if err != nil {
+		return "", errors.Wrapf(err, "terraform graph %q", stack)
+	}
+
+	// Future: we could use https://github.com/awalterschulze/gographviz for more
+	// tweaking of the graphs.
+
+	return out, nil
+}

--- a/dev/sg/msp/repo/repo.go
+++ b/dev/sg/msp/repo/repo.go
@@ -64,7 +64,7 @@ func ListServices() ([]string, error) {
 
 // ServicesAndEnvironmentsCompletion provides completions capabilities for
 // commands that accept '<service ID> <environment ID>' positional arguments.
-func ServicesAndEnvironmentsCompletion() cli.BashCompleteFunc {
+func ServicesAndEnvironmentsCompletion(additionalArgs ...func(args cli.Args) (options []string)) cli.BashCompleteFunc {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil
@@ -73,8 +73,8 @@ func ServicesAndEnvironmentsCompletion() cli.BashCompleteFunc {
 	if err != nil {
 		return nil
 	}
-	return completions.CompletePositionalArgs(
-		func(args cli.Args) (options []string) {
+	args := []func(cli.Args) []string{
+		func(cli.Args) (options []string) {
 			services, _ := listServicesFromRoot(repoRoot)
 			return services
 		},
@@ -87,9 +87,14 @@ func ServicesAndEnvironmentsCompletion() cli.BashCompleteFunc {
 			}
 			return svc.ListEnvironmentIDs()
 		},
-	)
+	}
+	return completions.CompletePositionalArgs(append(args, additionalArgs...)...)
 }
 
 func ServiceYAMLPath(serviceID string) string {
 	return filepath.Join("services", serviceID, "service.yaml")
+}
+
+func ServiceStackPath(serviceID, envID, stackID string) string {
+	return filepath.Join("services", serviceID, "terraform", envID, "stacks", stackID)
 }

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -9,12 +9,17 @@ import (
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/sourcegraph/run"
+
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/googlesecretsmanager"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/operationdocs"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/stacks"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/stacks/cloudrun"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/stacks/iam"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/stacks/monitoring"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/stacks/project"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/stacks/tfcworkspaces"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/terraformcloud"
 	"github.com/sourcegraph/sourcegraph/dev/sg/cloudsqlproxy"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
@@ -575,6 +580,66 @@ Supports completions on services and environments.`,
 							}
 						}
 
+						return nil
+					},
+				},
+				{
+					Name:      "graph",
+					Usage:     "EXPERIMENTAL: Graph the core resources within a Terraform workspace.",
+					ArgsUsage: "<service ID> <environment ID> <stack ID>",
+					Flags: []cli.Flag{
+						&cli.BoolFlag{
+							Name:  "dot",
+							Usage: "Dump dot graph configuration instead of rendering the image with 'dot'",
+						},
+					},
+					BashComplete: msprepo.ServicesAndEnvironmentsCompletion(
+						func(cli.Args) (options []string) {
+							// Common stack names
+							return []string{
+								project.StackName,
+								iam.StackName,
+								cloudrun.StackName,
+								monitoring.StackName,
+								tfcworkspaces.StackName,
+							}
+						},
+					),
+					Action: func(c *cli.Context) error {
+						service, env, err := useServiceAndEnvironmentArguments(c)
+						if err != nil {
+							return err
+						}
+
+						stack := c.Args().Get(2)
+						if stack == "" {
+							return errors.New("third argument <stack ID> is required")
+						}
+
+						dotgraph, err := msprepo.TerraformGraph(c.Context, service.Service.ID, env.ID, stack)
+						if err != nil {
+							return err
+						}
+
+						if c.Bool("dot") {
+							std.Out.Write(dotgraph)
+							return nil
+						}
+
+						output := fmt.Sprintf("./%s-%s.%s.png", service.Service.ID, env.ID, stack)
+						f, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, 0o644)
+						if err != nil {
+							return errors.Wrapf(err, "open %q", output)
+						}
+						defer f.Close()
+						if err := run.Cmd(c.Context, "dot -Tpng").
+							Input(strings.NewReader(dotgraph + "\n")).
+							Environ(os.Environ()).
+							Run().
+							Stream(f); err != nil {
+							return err
+						}
+						std.Out.WriteSuccessf("Graph rendered in %q", output)
 						return nil
 					},
 				},


### PR DESCRIPTION
We likely need architecture diagrams eventually, especially for SOC2, and I thought it might be good to explore what we can generate, since MSP infra architecture is a bit conditional on service specification, documenting by hand can prove rather difficult, outside of `sg msp ops`.

I tried walking the `cdktf.TerraformStack` graph, but couldn't figure out how to get dependencies correctly. In the end @michaellzc pointed me to `terraform graph`, which uses TF plans to prepare a graph. It includes stuff that doesn't feel very important, so I added a bunch of crude filtering to make the graph a bit more usable.

The layout is not _great_ - I tried the various [dot layout engines](https://graphviz.org/docs/layouts/) but none of them worked very well for our use case - but the information is actually kind of useful, and does illustrate a realistic graph of the various pieces involved.

A default rendering of the graph is available with `sg msp tfc graph`, and you can get the dot-format configuration with `sg msp tfc graph -dot`.

Part of https://github.com/sourcegraph/managed-services/issues/361 and https://github.com/sourcegraph/managed-services/issues/328

## Test plan

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/9c4e4441-9405-4610-b773-5b960fbb0c23)