### PR TITLE
Chore: clean up `RepositoryResolver`

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -433,7 +433,6 @@ func (r *GitCommitResolver) repoRevURL() *url.URL {
 	} else {
 		rev = string(r.oid)
 	}
-	// Dereference to copy to avoid mutation
 	repoUrl := r.repoResolver.url()
 	if rev != "" {
 		repoUrl.Path += "@" + rev
@@ -442,10 +441,9 @@ func (r *GitCommitResolver) repoRevURL() *url.URL {
 }
 
 func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {
-	// Dereference to copy the URL to avoid mutation
-	repoUrl := *r.repoResolver.RepoMatch.URL()
+	repoUrl := r.repoResolver.url()
 	repoUrl.Path += "@" + string(r.oid)
-	return &repoUrl
+	return repoUrl
 }
 
 func (r *GitCommitResolver) Ownership(ctx context.Context, args ListOwnershipArgs) (OwnershipConnectionResolver, error) {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -427,18 +427,18 @@ func (r *GitCommitResolver) inputRevOrImmutableRev() string {
 // portion (unlike for commit page URLs, which must include some revspec in
 // "/REPO/-/commit/REVSPEC").
 func (r *GitCommitResolver) repoRevURL() *url.URL {
-	// Dereference to copy to avoid mutation
-	repoUrl := *r.repoResolver.RepoMatch.URL()
 	var rev string
 	if r.inputRev != nil {
 		rev = *r.inputRev // use the original input rev from the user
 	} else {
 		rev = string(r.oid)
 	}
+	// Dereference to copy to avoid mutation
+	repoUrl := r.repoResolver.url()
 	if rev != "" {
 		repoUrl.Path += "@" + rev
 	}
-	return &repoUrl
+	return repoUrl
 }
 
 func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {

--- a/cmd/frontend/graphqlbackend/perforce_changelist.go
+++ b/cmd/frontend/graphqlbackend/perforce_changelist.go
@@ -83,15 +83,12 @@ func (r *PerforceChangelistResolver) CanonicalURL() string {
 }
 
 func (r *PerforceChangelistResolver) cidURL() *url.URL {
-	// Do not mutate the URL on the RepoMatch object.
-	repoURL := *r.repositoryResolver.RepoMatch.URL()
-
+	repoURL := r.repositoryResolver.url()
 	// We don't expect cid to be empty, but guard against any potential bugs.
 	if r.cid != "" {
 		repoURL.Path += "@" + r.cid
 	}
-
-	return &repoURL
+	return repoURL
 }
 
 func (r *PerforceChangelistResolver) Commit(ctx context.Context) (_ *GitCommitResolver, err error) {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -36,22 +35,17 @@ import (
 )
 
 type RepositoryResolver struct {
-	logger    log.Logger
-	hydration sync.Once
-	err       error
+	id   api.RepoID
+	name api.RepoName
 
-	// Invariant: Name and ID of RepoMatch are always set and safe to use. They are
-	// used to hydrate the inner repo, and should always be the same as the name and
-	// id of the inner repo, but referring to the inner repo directly is unsafe
-	// because it may cause a race during hydration.
-	result.RepoMatch
+	logger log.Logger
+
+	hydration sync.Once
+	innerRepo *types.Repo
+	err       error
 
 	db              database.DB
 	gitserverClient gitserver.Client
-
-	// innerRepo may only contain ID and Name information.
-	// To access any other repo information, use repo() instead.
-	innerRepo *types.Repo
 
 	defaultBranchOnce sync.Once
 	defaultBranch     *GitRefResolver
@@ -60,21 +54,19 @@ type RepositoryResolver struct {
 
 func NewRepositoryResolver(db database.DB, client gitserver.Client, repo *types.Repo) *RepositoryResolver {
 	// Protect against a nil repo
-	var name api.RepoName
 	var id api.RepoID
+	var name api.RepoName
 	if repo != nil {
 		name = repo.Name
 		id = repo.ID
 	}
 
 	return &RepositoryResolver{
+		id:              id,
+		name:            name,
 		db:              db,
 		innerRepo:       repo,
 		gitserverClient: client,
-		RepoMatch: result.RepoMatch{
-			Name: name,
-			ID:   id,
-		},
 		logger: log.Scoped("repositoryResolver").
 			With(log.Object("repo",
 				log.String("name", string(name)),
@@ -87,7 +79,7 @@ func (r *RepositoryResolver) ID() graphql.ID {
 }
 
 func (r *RepositoryResolver) IDInt32() api.RepoID {
-	return r.RepoMatch.ID
+	return r.id
 }
 
 func (r *RepositoryResolver) EmbeddingExists(ctx context.Context) (bool, error) {
@@ -140,11 +132,11 @@ func (r *RepositoryResolver) repo(ctx context.Context) (*types.Repo, error) {
 }
 
 func (r *RepositoryResolver) RepoName() api.RepoName {
-	return r.RepoMatch.Name
+	return r.name
 }
 
 func (r *RepositoryResolver) Name() string {
-	return string(r.RepoMatch.Name)
+	return string(r.name)
 }
 
 func (r *RepositoryResolver) ExternalRepo(ctx context.Context) (*api.ExternalRepoSpec, error) {
@@ -413,7 +405,7 @@ func (r *RepositoryResolver) URL() string {
 }
 
 func (r *RepositoryResolver) url() *url.URL {
-	return &url.URL{Path: "/" + string(r.innerRepo.Name)}
+	return &url.URL{Path: "/" + string(r.name)}
 }
 
 func (r *RepositoryResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {
@@ -424,18 +416,8 @@ func (r *RepositoryResolver) ExternalURLs(ctx context.Context) ([]*externallink.
 	return externallink.Repository(ctx, r.db, repo)
 }
 
-func (r *RepositoryResolver) Rev() string {
-	return r.RepoMatch.Rev
-}
-
 func (r *RepositoryResolver) Label() (Markdown, error) {
-	var label string
-	if r.Rev() != "" {
-		label = r.Name() + "@" + r.Rev()
-	} else {
-		label = r.Name()
-	}
-	text := "[" + label + "](" + r.URL() + ")"
+	text := "[" + r.Name() + "](" + r.URL() + ")"
 	return Markdown(text), nil
 }
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -413,7 +413,7 @@ func (r *RepositoryResolver) URL() string {
 }
 
 func (r *RepositoryResolver) url() *url.URL {
-	return r.RepoMatch.URL()
+	return &url.URL{Path: "/" + string(r.innerRepo.Name)}
 }
 
 func (r *RepositoryResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -209,10 +208,6 @@ func TestRepositoryLabel(t *testing.T) {
 	test := func(name string) string {
 		r := &RepositoryResolver{
 			logger: logtest.Scoped(t),
-			RepoMatch: result.RepoMatch{
-				Name: api.RepoName(name),
-				ID:   api.RepoID(0),
-			},
 		}
 		markdown, _ := r.Label()
 		html, err := markdown.HTML()
@@ -258,7 +253,7 @@ func TestRepository_DefaultBranch(t *testing.T) {
 			gsClient := gitserver.NewMockClient()
 			gsClient.GetDefaultBranchFunc.SetDefaultReturn(tt.getDefaultBranchRefName, "", tt.getDefaultBranchErr)
 
-			res := &RepositoryResolver{RepoMatch: result.RepoMatch{Name: "repo"}, logger: logtest.Scoped(t), gitserverClient: gsClient}
+			res := &RepositoryResolver{name: "repo", logger: logtest.Scoped(t), gitserverClient: gsClient}
 			branch, err := res.DefaultBranch(ctx)
 			if tt.wantErr != nil && err != nil {
 				if tt.wantErr.Error() != err.Error() {

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -207,6 +207,7 @@ func assertRepoResolverHydrated(ctx context.Context, t *testing.T, r *Repository
 func TestRepositoryLabel(t *testing.T) {
 	test := func(name string) string {
 		r := &RepositoryResolver{
+			name:   api.RepoName(name),
 			logger: logtest.Scoped(t),
 		}
 		markdown, _ := r.Label()

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/symbol"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 type symbolsArgs struct {
@@ -19,7 +20,15 @@ type symbolsArgs struct {
 }
 
 func (r *GitTreeEntryResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
-	symbols, err := symbol.DefaultZoektSymbolsClient().Compute(ctx, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.commit.inputRev, args.Query, args.First, args.IncludePatterns)
+	symbols, err := symbol.DefaultZoektSymbolsClient().Compute(
+		ctx,
+		types.MinimalRepo{ID: r.commit.repoResolver.id, Name: r.commit.repoResolver.name},
+		api.CommitID(r.commit.oid),
+		r.commit.inputRev,
+		args.Query,
+		args.First,
+		args.IncludePatterns,
+	)
 	if err != nil && len(symbols) == 0 {
 		return nil, err
 	}
@@ -33,7 +42,14 @@ func (r *GitTreeEntryResolver) Symbol(ctx context.Context, args *struct {
 	Line      int32
 	Character int32
 }) (*symbolResolver, error) {
-	symbolMatch, err := symbol.DefaultZoektSymbolsClient().GetMatchAtLineCharacter(ctx, r.commit.repoResolver.RepoMatch.RepoName(), api.CommitID(r.commit.oid), r.Path(), int(args.Line), int(args.Character))
+	symbolMatch, err := symbol.DefaultZoektSymbolsClient().GetMatchAtLineCharacter(
+		ctx,
+		types.MinimalRepo{ID: r.commit.repoResolver.id, Name: r.commit.repoResolver.name},
+		api.CommitID(r.commit.oid),
+		r.Path(),
+		int(args.Line),
+		int(args.Character),
+	)
 	if err != nil || symbolMatch == nil {
 		return nil, err
 	}
@@ -41,7 +57,15 @@ func (r *GitTreeEntryResolver) Symbol(ctx context.Context, args *struct {
 }
 
 func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*symbolConnectionResolver, error) {
-	symbols, err := symbol.DefaultZoektSymbolsClient().Compute(ctx, r.repoResolver.RepoMatch.RepoName(), api.CommitID(r.oid), r.inputRev, args.Query, args.First, args.IncludePatterns)
+	symbols, err := symbol.DefaultZoektSymbolsClient().Compute(
+		ctx,
+		types.MinimalRepo{ID: r.repoResolver.id, Name: r.repoResolver.name},
+		api.CommitID(r.oid),
+		r.inputRev,
+		args.Query,
+		args.First,
+		args.IncludePatterns,
+	)
 	if err != nil && len(symbols) == 0 {
 		return nil, err
 	}

--- a/cmd/frontend/internal/compute/resolvers/resolvers.go
+++ b/cmd/frontend/internal/compute/resolvers/resolvers.go
@@ -187,18 +187,13 @@ func pathAndCommitFromResult(m result.Match) (string, string) {
 func toResultResolverList(ctx context.Context, cmd compute.Command, matches []result.Match, db database.DB) ([]gql.ComputeResultResolver, error) {
 	gitserverClient := gitserver.NewClient("graphql.compute")
 
-	type repoKey struct {
-		Name types.MinimalRepo
-		Rev  string
-	}
-	repoResolvers := make(map[repoKey]*gql.RepositoryResolver, 10)
-	getRepoResolver := func(repoName types.MinimalRepo, rev string) *gql.RepositoryResolver {
-		if existing, ok := repoResolvers[repoKey{repoName, rev}]; ok {
+	repoResolvers := make(map[types.MinimalRepo]*gql.RepositoryResolver, 10)
+	getRepoResolver := func(repoName types.MinimalRepo) *gql.RepositoryResolver {
+		if existing, ok := repoResolvers[repoName]; ok {
 			return existing
 		}
 		resolver := gql.NewRepositoryResolver(db, gitserverClient, repoName.ToRepo())
-		resolver.RepoMatch.Rev = rev
-		repoResolvers[repoKey{repoName, rev}] = resolver
+		repoResolvers[repoName] = resolver
 		return resolver
 	}
 
@@ -214,7 +209,7 @@ func toResultResolverList(ctx context.Context, cmd compute.Command, matches []re
 			continue
 		}
 
-		repoResolver := getRepoResolver(m.RepoName(), "")
+		repoResolver := getRepoResolver(m.RepoName())
 		path, commit := pathAndCommitFromResult(m)
 		resolver := toComputeResultResolver(computeResult, repoResolver, path, commit)
 		results = append(results, resolver)

--- a/internal/cmd/search-blitz/search.graphql
+++ b/internal/cmd/search-blitz/search.graphql
@@ -73,9 +73,6 @@ fragment RepositoryFields on Repository {
         serviceType
         url
     }
-    label {
-        html
-    }
 }
 
 fragment SearchResultsAlertFields on SearchResults {


### PR DESCRIPTION
For reasons I don't fully understand even though it's probably my doing, `RepositoryResolver` depends on the search result type `RepoMatch`. There was some really convoluted logic about how only the `name` and `id` fields of `RepoMatch` were set, which is particularly confusing because a `RepoMatch` isn't even required to construct the `RepositoryResolver`. The only information being provided by `RepoMatch` was `rev`, which it really shouldn't be since a repository domain object should not even have a rev (that should be relegated to the `GitCommitResolver` or `GitRefResolver`, which contain a `RepositoryResolver`). 

Anyways, this removes the dependency on the search result type.

## Test plan

CI. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
