### PR TITLE
Allow repo wide pr-auditor opt-out of test plans and reviews

### DIFF
--- a/dev/pr-auditor/check-pr.sh
+++ b/dev/pr-auditor/check-pr.sh
@@ -9,4 +9,6 @@ echo "--- Running 'pr-auditor'"
 go run ./dev/pr-auditor/ \
   -github.payload-path="$GITHUB_EVENT_PATH" \
   -github.token="$GITHUB_TOKEN" \
-  -github.run-url="$GITHUB_RUN_URL"
+  -github.run-url="$GITHUB_RUN_URL" \
+  -skip-check-test-plan="${SKIP_CHECK_TEST_PLAN:-False}" \
+  -skip-check-reviews="${SKIP_CHECK_REVIEWS:-False}"

--- a/dev/pr-auditor/check.go
+++ b/dev/pr-auditor/check.go
@@ -13,8 +13,8 @@ type checkResult struct {
 	// ReviewSatisfied indicates that *any* review has been made on the PR. It is also set to
 	// true if the test plan indicates that this PR does not need to be review.
 	ReviewSatisfied bool
-	// TestPlanSatisfied indicates that either a test plan was provided or flags indicate no test plan is needed.
-	TestPlanSatisfied bool
+	// CanSkipTestPlan indicates that the test plan is not required for audit.
+	CanSkipTestPlan bool
 	// TestPlan is the content provided after the acceptance checklist checkbox.
 	TestPlan string
 	// ProtectedBranch indicates that the base branch for this PR is protected and merges
@@ -25,7 +25,11 @@ type checkResult struct {
 }
 
 func (r checkResult) IsSatisfied() bool {
-	return r.TestPlanSatisfied && r.ReviewSatisfied && !r.ProtectedBranch
+	return r.IsTestPlanSatisfied() && r.ReviewSatisfied && !r.ProtectedBranch
+}
+
+func (r checkResult) IsTestPlanSatisfied() bool {
+	return r.CanSkipTestPlan || r.TestPlan != ""
 }
 
 var (
@@ -38,9 +42,9 @@ var (
 )
 
 type checkOpts struct {
-	ValidateReviews  bool
-	ValidateTestPlan bool
-	ProtectedBranch  string
+	SkipReviews     bool
+	SkipTestPlan    bool
+	ProtectedBranch string
 }
 
 func isProtectedBranch(payload *EventPayload, protectedBranch string) bool {
@@ -54,7 +58,7 @@ func checkPR(ctx context.Context, ghc *github.Client, payload *EventPayload, opt
 	// might not have any comments so we need to double-check through the GitHub API
 	var err error
 	reviewed := pr.ReviewComments > 0
-	if !reviewed && opts.ValidateReviews {
+	if !reviewed && !opts.SkipReviews {
 		owner, repo := payload.Repository.GetOwnerAndName()
 		var reviews []*github.PullRequestReview
 		// Continue, but return err later
@@ -66,9 +70,9 @@ func checkPR(ctx context.Context, ghc *github.Client, payload *EventPayload, opt
 	sections := testPlanDividerRegexp.Split(pr.Body, 2)
 	if len(sections) < 2 {
 		return checkResult{
-			ReviewSatisfied:   reviewed,
-			TestPlanSatisfied: !opts.ValidateTestPlan,
-			Error:             err,
+			ReviewSatisfied: reviewed,
+			CanSkipTestPlan: opts.SkipTestPlan,
+			Error:           err,
 		}
 	}
 
@@ -94,11 +98,11 @@ func checkPR(ctx context.Context, ghc *github.Client, payload *EventPayload, opt
 	mergeAgainstProtected := isProtectedBranch(payload, opts.ProtectedBranch)
 
 	return checkResult{
-		ReviewSatisfied:   reviewed,
-		TestPlanSatisfied: testPlan != "" || !opts.ValidateTestPlan,
-		TestPlan:          testPlan,
-		ProtectedBranch:   mergeAgainstProtected,
-		Error:             err,
+		ReviewSatisfied: reviewed,
+		CanSkipTestPlan: opts.SkipTestPlan,
+		TestPlan:        testPlan,
+		ProtectedBranch: mergeAgainstProtected,
+		Error:           err,
 	}
 }
 

--- a/dev/pr-auditor/issue.go
+++ b/dev/pr-auditor/issue.go
@@ -28,7 +28,7 @@ func generateExceptionIssue(payload *EventPayload, result *checkResult, addition
 		exceptionLabels = append(exceptionLabels, "exception/review")
 	}
 
-	if !result.TestPlanSatisfied {
+	if !result.IsTestPlanSatisfied() {
 		exceptionLabels = append(exceptionLabels, "exception/test-plan")
 	}
 	if result.ProtectedBranch {
@@ -36,16 +36,16 @@ func generateExceptionIssue(payload *EventPayload, result *checkResult, addition
 	}
 
 	if !result.ReviewSatisfied {
-		if result.TestPlanSatisfied {
+		if result.IsTestPlanSatisfied() {
 			issueBody = fmt.Sprintf("%s %q **has a test plan (or does not require one)** but **was not reviewed**.", payload.PullRequest.URL, prTitle)
 		} else {
 			issueBody = fmt.Sprintf("%s %q **has no test plan** and **was not reviewed**.", payload.PullRequest.URL, prTitle)
 		}
-	} else if !result.TestPlanSatisfied {
+	} else if !result.IsTestPlanSatisfied() {
 		issueBody = fmt.Sprintf("%s %q **has no test plan**.", payload.PullRequest.URL, prTitle)
 	}
 
-	if !result.TestPlanSatisfied {
+	if !result.IsTestPlanSatisfied() {
 		issueBody += fmt.Sprintf("\n\nLearn more about test plans in our [testing guidelines](%s).", testPlanDocs)
 	}
 

--- a/dev/pr-auditor/issue.go
+++ b/dev/pr-auditor/issue.go
@@ -24,27 +24,28 @@ func generateExceptionIssue(payload *EventPayload, result *checkResult, addition
 		issueAssignees  = []string{}
 	)
 
-	if !result.Reviewed {
+	if !result.ReviewSatisfied {
 		exceptionLabels = append(exceptionLabels, "exception/review")
 	}
-	if !result.HasTestPlan() {
+
+	if !result.TestPlanSatisfied {
 		exceptionLabels = append(exceptionLabels, "exception/test-plan")
 	}
 	if result.ProtectedBranch {
 		exceptionLabels = append(exceptionLabels, "exception/protected-branch")
 	}
 
-	if !result.Reviewed {
-		if result.HasTestPlan() {
-			issueBody = fmt.Sprintf("%s %q **has a test plan** but **was not reviewed**.", payload.PullRequest.URL, prTitle)
+	if !result.ReviewSatisfied {
+		if result.TestPlanSatisfied {
+			issueBody = fmt.Sprintf("%s %q **has a test plan (or does not require one)** but **was not reviewed**.", payload.PullRequest.URL, prTitle)
 		} else {
 			issueBody = fmt.Sprintf("%s %q **has no test plan** and **was not reviewed**.", payload.PullRequest.URL, prTitle)
 		}
-	} else if !result.HasTestPlan() {
+	} else if !result.TestPlanSatisfied {
 		issueBody = fmt.Sprintf("%s %q **has no test plan**.", payload.PullRequest.URL, prTitle)
 	}
 
-	if !result.HasTestPlan() {
+	if !result.TestPlanSatisfied {
 		issueBody += fmt.Sprintf("\n\nLearn more about test plans in our [testing guidelines](%s).", testPlanDocs)
 	}
 

--- a/dev/pr-auditor/issue_test.go
+++ b/dev/pr-auditor/issue_test.go
@@ -35,7 +35,7 @@ func TestGenerateExceptionIssue(t *testing.T) {
 		name:    "not reviewed, not planned",
 		payload: payload,
 		result: checkResult{
-			Reviewed: false,
+			ReviewSatisfied: false,
 		},
 		wantAssignees:    []string{"robert"},
 		wantLabels:       []string{"exception/review", "exception/test-plan", "bobheadxi/robert"},
@@ -45,8 +45,9 @@ func TestGenerateExceptionIssue(t *testing.T) {
 		name:    "not reviewed, planned",
 		payload: payload,
 		result: checkResult{
-			Reviewed: false,
-			TestPlan: "A plan!",
+			ReviewSatisfied:   false,
+			TestPlan:          "A plan!",
+			TestPlanSatisfied: true,
 		},
 		wantAssignees:    []string{"robert"},
 		wantLabels:       []string{"exception/review", "bobheadxi/robert"},
@@ -56,7 +57,7 @@ func TestGenerateExceptionIssue(t *testing.T) {
 		name:    "not planned, reviewed",
 		payload: payload,
 		result: checkResult{
-			Reviewed: true,
+			ReviewSatisfied: true,
 		},
 		wantAssignees:    []string{"robert"},
 		wantLabels:       []string{"exception/test-plan", "bobheadxi/robert"},

--- a/dev/pr-auditor/issue_test.go
+++ b/dev/pr-auditor/issue_test.go
@@ -45,9 +45,19 @@ func TestGenerateExceptionIssue(t *testing.T) {
 		name:    "not reviewed, planned",
 		payload: payload,
 		result: checkResult{
-			ReviewSatisfied:   false,
-			TestPlan:          "A plan!",
-			TestPlanSatisfied: true,
+			ReviewSatisfied: false,
+			TestPlan:        "A plan!",
+		},
+		wantAssignees:    []string{"robert"},
+		wantLabels:       []string{"exception/review", "bobheadxi/robert"},
+		wantBodyContains: []string{"some pull request", "has a test plan", "was not reviewed"},
+		wantBodyExcludes: []string{"protected"},
+	}, {
+		name:    "not reviewed, not planned, but plan skipping is disabled",
+		payload: payload,
+		result: checkResult{
+			ReviewSatisfied: false,
+			CanSkipTestPlan: true,
 		},
 		wantAssignees:    []string{"robert"},
 		wantLabels:       []string{"exception/review", "bobheadxi/robert"},

--- a/dev/pr-auditor/main.go
+++ b/dev/pr-auditor/main.go
@@ -32,6 +32,9 @@ type Flags struct {
 
 	// SkipStatus if true will skip updating commit status on GitHub and just record exceptions. Useful when crawling through failed runs caused by infrastructure issues.
 	SkipStatus bool
+
+	SkipCheckTestPlan bool
+	SkipCheckReview   bool
 }
 
 func (f *Flags) Parse() {
@@ -43,6 +46,8 @@ func (f *Flags) Parse() {
 	flag.StringVar(&f.ProtectedBranch, "protected-branch", "", "name of branch that if set as the base branch in a PR, will always open an exception")
 	flag.StringVar(&f.AdditionalContext, "additional-context", "", "additional information that will be appended to the recorded exception, if any.")
 	flag.BoolVar(&f.SkipStatus, "skip-status", false, "skip updating commit status on GitHub and just record exceptions")
+	flag.BoolVar(&f.SkipCheckTestPlan, "skip-check-test-plan", false, "Allows PRs without a test plan to pass audit")
+	flag.BoolVar(&f.SkipCheckReview, "skip-check-review", false, "Allows PRs without any approving reviews to be merged")
 	flag.Parse()
 }
 
@@ -115,12 +120,13 @@ const (
 
 func postMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayload, flags *Flags) error {
 	result := checkPR(ctx, ghc, payload, checkOpts{
-		ValidateReviews: true,
+		ValidateReviews: !flags.SkipCheckReview,
+		ValidateTestPlan: flags.SkipCheckTestPlan,
 		ProtectedBranch: flags.ProtectedBranch,
 	})
 	log.Printf("checkPR: %+v\n", result)
 
-	if result.HasTestPlan() && result.Reviewed && !result.ProtectedBranch {
+	if result.IsSatisfied() {
 		log.Println("Acceptance checked and PR reviewed, done")
 		// Don't create status that likely nobody will check anyway
 		return nil
@@ -176,6 +182,7 @@ func postMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPaylo
 func preMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayload, flags *Flags) error {
 	result := checkPR(ctx, ghc, payload, checkOpts{
 		ValidateReviews: false, // only validate reviews on post-merge
+		ValidateTestPlan: flags.SkipCheckTestPlan,
 		ProtectedBranch: flags.ProtectedBranch,
 	})
 	log.Printf("checkPR: %+v\n", result)
@@ -186,7 +193,7 @@ func preMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayloa
 	case result.Error != nil:
 		prState = "error"
 		stateDescription = fmt.Sprintf("checkPR: %s", result.Error.Error())
-	case !result.HasTestPlan():
+	case !result.TestPlanSatisfied:
 		prState = "failure"
 		stateDescription = "No test plan detected - please provide one!"
 		stateURL = "https://docs.sourcegraph.com/dev/background-information/testing_principles#test-plans"

--- a/dev/pr-auditor/main.go
+++ b/dev/pr-auditor/main.go
@@ -120,8 +120,8 @@ const (
 
 func postMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayload, flags *Flags) error {
 	result := checkPR(ctx, ghc, payload, checkOpts{
-		ValidateReviews: !flags.SkipCheckReview,
-		ValidateTestPlan: flags.SkipCheckTestPlan,
+		SkipReviews:     flags.SkipCheckReview,
+		SkipTestPlan:    flags.SkipCheckTestPlan,
 		ProtectedBranch: flags.ProtectedBranch,
 	})
 	log.Printf("checkPR: %+v\n", result)
@@ -181,8 +181,8 @@ func postMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPaylo
 
 func preMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayload, flags *Flags) error {
 	result := checkPR(ctx, ghc, payload, checkOpts{
-		ValidateReviews: false, // only validate reviews on post-merge
-		ValidateTestPlan: flags.SkipCheckTestPlan,
+		SkipReviews:     true, // only validate reviews on post-merge
+		SkipTestPlan:    flags.SkipCheckTestPlan,
 		ProtectedBranch: flags.ProtectedBranch,
 	})
 	log.Printf("checkPR: %+v\n", result)
@@ -193,7 +193,7 @@ func preMergeAudit(ctx context.Context, ghc *github.Client, payload *EventPayloa
 	case result.Error != nil:
 		prState = "error"
 		stateDescription = fmt.Sprintf("checkPR: %s", result.Error.Error())
-	case !result.TestPlanSatisfied:
+	case !result.IsTestPlanSatisfied():
 		prState = "failure"
 		stateDescription = "No test plan detected - please provide one!"
 		stateURL = "https://docs.sourcegraph.com/dev/background-information/testing_principles#test-plans"


### PR DESCRIPTION
Adds two new environment variables to the pr-auditor workflow that allow opting out of test plans or review requirements at a repo level. Flips some of the polarities of flags so that the zero-value of options structs are the defaults.

## Test plan
Includes unit tests and github actions will be manually tested

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
