### PR TITLE
Filters panel: make search case-insensitive

### DIFF
--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -87,8 +87,8 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
         return null
     }
 
-    // TODO: should this be case-insensitive search?
-    const filteredFilters = mergedFilters.filter(filter => filter.label.includes(searchTerm))
+    const lowerSearchTerm = searchTerm.toLowerCase()
+    const filteredFilters = mergedFilters.filter(filter => filter.label.toLowerCase().includes(lowerSearchTerm))
     const filtersToShow = showAllFilters ? filteredFilters : filteredFilters.slice(0, MAX_FILTERS_NUMBER)
 
     return (


### PR DESCRIPTION
Just a small change to make the search functionality in the filters panel case-insensitive.

## Test plan

Manually tested that case-insensitive search works for languages and repos