### PR TITLE
token: disable Authorize button on mobile device

### DIFF
--- a/client/common/BUILD.bazel
+++ b/client/common/BUILD.bazel
@@ -33,6 +33,7 @@ ts_project(
         "src/types/utils.ts",
         "src/util/browserDetection.ts",
         "src/util/compatNavigate.ts",
+        "src/util/deviceDetection.ts",
         "src/util/fetchCache.ts",
         "src/util/hashCode.ts",
         "src/util/highlightNode.ts",

--- a/client/common/src/util/deviceDetection.ts
+++ b/client/common/src/util/deviceDetection.ts
@@ -1,0 +1,6 @@
+export function isMobile(): boolean {
+    return (
+        typeof window !== 'undefined' &&
+        window.navigator.userAgent.match(/Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i) !== null
+    )
+}

--- a/client/common/src/util/deviceDetection.ts
+++ b/client/common/src/util/deviceDetection.ts
@@ -1,3 +1,8 @@
+/**
+ * Checks if the user agent indicates the browser is running on a mobile device.
+ *
+ * Returns true if the user agent matches common mobile device patterns, false otherwise.
+ */
 export function isMobile(): boolean {
     return (
         typeof window !== 'undefined' &&

--- a/client/common/src/util/deviceDetection.ts
+++ b/client/common/src/util/deviceDetection.ts
@@ -6,6 +6,6 @@
 export function isMobile(): boolean {
     return (
         typeof window !== 'undefined' &&
-        window.navigator.userAgent.match(/Android|webOS|iPhone|iPad|iPod|BlackBerry|Windows Phone/i) !== null
+        window.navigator.userAgent.match(/android|webos|iphone|ipad|ipod|blackberry|windows phone/i) !== null
     )
 }

--- a/client/common/src/util/index.ts
+++ b/client/common/src/util/index.ts
@@ -1,5 +1,6 @@
 export * from './browserDetection'
 export * from './compatNavigate'
+export * from './deviceDetection'
 export * from './fetchCache'
 export * from './hashCode'
 export * from './highlightNode'

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -185,6 +185,8 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
         setNote(REQUESTERS[requestFrom].name)
     }, [isSourcegraphDotCom, location.search, navigate, requestFrom, requester, port, destination])
 
+    const isRequestFromMobileDevice = isMobile()
+
     /**
      * We use this to handle token creation request from redirections.
      * Don't create token if this page wasn't linked to from a valid
@@ -200,7 +202,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                                 // SECURITY: If the request was from a valid requester and from a non-mobile device,
                                 // redirect to the allowlisted redirect URL.
                                 // SECURITY: Local context ONLY
-                                if (requester && !isMobile()) {
+                                if (requester && !isRequestFromMobileDevice) {
                                     onDidCreateAccessToken(result)
                                     setNewToken(result.token)
                                     let uri = replacePlaceholder(requester?.redirectURL, 'TOKEN', result.token)
@@ -226,7 +228,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                         )
                     )
                 ),
-            [requester, user.id, note, onDidCreateAccessToken, requestFrom, port]
+            [requester, user.id, note, onDidCreateAccessToken, requestFrom, port, isRequestFromMobileDevice]
         )
     )
 
@@ -258,6 +260,9 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                             variant="primary"
                             label="Authorize"
                             loading={creationOrError === 'loading'}
+                            // we disable this if the request is made from a mobile device so the access token doesn't
+                            // get created at all. This prevents redirecting to an external site from a mobile app.
+                            disabled={isRequestFromMobileDevice}
                             onClick={onAuthorize}
                         />
                         <Button

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -200,7 +200,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                         (requester ? createAccessToken(user.id, [AccessTokenScopes.UserAll], note) : NEVER).pipe(
                             tap(result => {
                                 // SECURITY: If the request was from a valid requester and from a non-mobile device,
-                                // redirect to the allowlisted redirect URL.
+                                // redirect to the allowlisted redirect URL. (https://github.com/sourcegraph/security-issues/issues/361)
                                 // SECURITY: Local context ONLY
                                 if (requester && !isRequestFromMobileDevice) {
                                     onDidCreateAccessToken(result)

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -197,7 +197,8 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                     switchMap(() =>
                         (requester ? createAccessToken(user.id, [AccessTokenScopes.UserAll], note) : NEVER).pipe(
                             tap(result => {
-                                // SECURITY: If the request was from a valid requester, redirect to the allowlisted redirect URL.
+                                // SECURITY: If the request was from a valid requester and from a non-mobile device,
+                                // redirect to the allowlisted redirect URL.
                                 // SECURITY: Local context ONLY
                                 if (requester && !isMobile()) {
                                     onDidCreateAccessToken(result)

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { NEVER, type Observable } from 'rxjs'
 import { catchError, startWith, switchMap, tap } from 'rxjs/operators'
 
-import { asError, isErrorLike } from '@sourcegraph/common'
+import { asError, isErrorLike, isMobile } from '@sourcegraph/common'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Button, Link, Text, ErrorAlert, Card, H1, H2, useEventObservable } from '@sourcegraph/wildcard'
@@ -199,7 +199,7 @@ export const UserSettingsCreateAccessTokenCallbackPage: React.FC<Props> = ({
                             tap(result => {
                                 // SECURITY: If the request was from a valid requester, redirect to the allowlisted redirect URL.
                                 // SECURITY: Local context ONLY
-                                if (requester) {
+                                if (requester && !isMobile()) {
                                     onDidCreateAccessToken(result)
                                     setNewToken(result.token)
                                     let uri = replacePlaceholder(requester?.redirectURL, 'TOKEN', result.token)


### PR DESCRIPTION
Closes [#361](https://github.com/sourcegraph/security-issues/issues/361)

Details in the above issue.

## Test plan
I followed the recommendation from the issue I've attached.
I tested it on an Android device. The `Authorize` button is disabled.