### PR TITLE
sg: bump git version requirement

### DIFF
--- a/dev/sg/dependencies/mac.go
+++ b/dev/sg/dependencies/mac.go
@@ -40,7 +40,7 @@ var Mac = []category{
 		Checks: []*dependency{
 			{
 				Name:  "git",
-				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.38.1"))),
+				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.42.0"))),
 				Fix:   cmdFix(`brew install git`),
 			},
 			{

--- a/dev/sg/dependencies/ubuntu.go
+++ b/dev/sg/dependencies/ubuntu.go
@@ -31,7 +31,7 @@ var Ubuntu = []category{
 			},
 			{
 				Name:  "git",
-				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.38.1"))),
+				Check: checkAction(check.Combine(check.InPath("git"), checkGitVersion(">= 2.42.0"))),
 				Fix:   aptGetInstall("git", "sudo add-apt-repository -y ppa:git-core/ppa"),
 			}, {
 				Name:  "pcre",


### PR DESCRIPTION
On older versions like 2.39.2, the no-locahost-guard script would incorrectly report false positives.

Note: https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.39.3.txt specifically fixes the issue with the script. 


## Test plan

locally testd

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
