### PR TITLE
chore: unexport version.MockTimestamp as it's only used in tests

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -39,14 +39,14 @@ func Mock(mockVersion string) {
 	version = mockVersion
 }
 
-// MockTimeStamp is used by tests to mock the current build timestamp
-func MockTimestamp(mockTimestamp string) {
-	timestamp = mockTimestamp
-}
-
 // timestamp is the build timestamp configured at build time via ldflags like this:
 // -ldflags "-X github.com/sourcegraph/sourcegraph/internal/version.timestamp=$UNIX_SECONDS"
 var timestamp = devTimestamp
+
+// mockTimeStamp is used by tests to mock the current build timestamp
+func mockTimestamp(mockTimestamp string) {
+	timestamp = mockTimestamp
+}
 
 // HowLongOutOfDate returns a time in months since this build of Sourcegraph was created. It is
 // based on a constant baked into the Go binary at build time.

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -98,6 +98,7 @@ func Test_monthsFromDays(t *testing.T) {
 		})
 	}
 }
+
 func TestHowLongOutOfDate(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -130,7 +131,7 @@ func TestHowLongOutOfDate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			MockTimestamp(tt.buildTimestamp)
+			mockTimestamp(tt.buildTimestamp)
 			got, err := HowLongOutOfDate(tt.now)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("HowLongOutOfDate() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
We were initially about to move some constants from `internal/database/migration/shared/data/cmd/generator/consts.go` so we can group all constants that needs to be stamped on a release in the same place, but decided to go against it, as it would trigger rebuilding targets that depends on `internal/version`. 

Still found out a small chore along the way, so here it is. 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
