### PR TITLE
Filters panel: fix label for commit dates

### DIFF
--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -181,7 +181,7 @@ func (s *SearchFilters) Update(event SearchEvent) {
 
 		df := determineTimeframe(cd)
 		filter := fmt.Sprintf("%s:%s", df.Timeframe, df.Value)
-		s.filters.Add(filter, df.Label, 1, "date")
+		s.filters.Add(filter, df.Label, 1, "commit date")
 	}
 
 	if event.Stats.ExcludedForks > 0 {


### PR DESCRIPTION

This just fixes the string label for commit date filters. It didn't match what we expected in the client, so that panel wasn't showing.

## Test plan

Quick manual test