### PR TITLE
ci: avoid dropping ALL executors binary if BUILDKITE_TAG is empty

### DIFF
--- a/cmd/executor/_binary.push.sh
+++ b/cmd/executor/_binary.push.sh
@@ -36,6 +36,15 @@ fi
 
 # If this is a tagged release, we want to create a directory for it.
 if [ "${EXECUTOR_IS_TAGGED_RELEASE}" = "true" ]; then
+  # This is a failsafe, to avoid dropping the entire folder whenever we
+  # run this code without a proper tag, typically when testing releases.
+  #
+  # Without it, the tag will be empty and the gsutil rm -rf below will
+  # drop the entire folder.
+  if [ -z "$BUILDKITE_TAG" ] || [ "$BUILDKITE_TAG" = "" ]; then
+    exit 1
+  fi
+
   echo "Uploading binaries for the ${BUILDKITE_TAG} tag"
   # Drop the tag if existing, allowing for rebuilds.
   "$gsutil" rm -rf "gs://sourcegraph-artifacts/executor/${BUILDKITE_TAG}" || true


### PR DESCRIPTION
Just noticed I had my "test/dev" branch/branch for releases here that was dropping many binaries from `main` here https://buildkite.com/sourcegraph/sourcegraph/builds/257179#018cef14-5cbf-4c4c-837b-008fa62e6660/27-4550 

This adds a failsafe so we don't accidentaly reproduce the same mistake. 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
