### PR TITLE
Filters panel: title-case symbol kind

### DIFF
--- a/internal/search/streaming/BUILD.bazel
+++ b/internal/search/streaming/BUILD.bazel
@@ -19,6 +19,8 @@ go_library(
         "//internal/search",
         "//internal/search/result",
         "@com_github_grafana_regexp//:regexp",
+        "@org_golang_x_text//cases",
+        "@org_golang_x_text//language",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/grafana/regexp"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
@@ -162,7 +165,7 @@ func (s *SearchFilters) Update(event SearchEvent) {
 		for _, sym := range symbols {
 			selectKind := result.ToSelectKind[strings.ToLower(sym.Symbol.Kind)]
 			filter := fmt.Sprintf(`select:symbol.%s`, selectKind)
-			s.filters.Add(filter, selectKind, 1, "symbol type")
+			s.filters.Add(filter, cases.Title(language.English, cases.Compact).String(selectKind), 1, "symbol type")
 		}
 	}
 

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -206,19 +206,19 @@ func TestSymbolCounts(t *testing.T) {
 			wantFilters: map[string]*Filter{
 				"select:symbol.class": &Filter{
 					Value: "select:symbol.class",
-					Label: "class",
+					Label: "Class",
 					Count: 1,
 					Kind:  "symbol type",
 				},
 				"select:symbol.variable": &Filter{
 					Value: "select:symbol.variable",
-					Label: "variable",
+					Label: "Variable",
 					Count: 2,
 					Kind:  "symbol type",
 				},
 				"select:symbol.constant": &Filter{
 					Value: "select:symbol.constant",
-					Label: "constant",
+					Label: "Constant",
 					Count: 4,
 					Kind:  "symbol type",
 				},


### PR DESCRIPTION
The label for symbol kind is being returned from the backend as all lower-case. This title-cases the label. We could do this in the client too, but IMO labels should be returned from the API as "intended-case".

Before:
![CleanShot 2024-01-09 at 10 33 18@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/14d2a247-0546-4414-8b95-308b549bcf4c)

After:
![CleanShot 2024-01-09 at 10 32 32@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/90c2ef71-c93d-4637-b20c-53fa65de4ef0)

## Test plan

Manual. See screenshots
