### PR TITLE
Filters panel: skip unknown symbol kinds

### DIFF
--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -160,7 +160,12 @@ func (s *SearchFilters) Update(event SearchEvent) {
 
 	addSymbolFilter := func(symbols []*result.SymbolMatch) {
 		for _, sym := range symbols {
-			selectKind := result.ToSelectKind[strings.ToLower(sym.Symbol.Kind)]
+			selectKind, ok := result.ToSelectKind[strings.ToLower(sym.Symbol.Kind)]
+			if !ok {
+				// Skip any symbols we don't know how to select
+				// TODO(@camdencheek): figure out which symbols are missing from result.ToSelectKind
+				continue
+			}
 			filter := fmt.Sprintf(`select:symbol.%s`, selectKind)
 			s.filters.Add(filter, selectKind, 1, "symbol type")
 		}


### PR DESCRIPTION
There seem to be situations where we get back symbols with kinds that are not enumerated by our symbol kinds list. I'm not sure where these come from yet, but in any case, it's not possible to run a query to search for only that kind of symbol, so I skip them for the purpose of calculating filter groups.

## Test plan

Manual test that seasrch which previously returned an empty symbol kind now doesn't. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
