### PR TITLE
Filters: update repo rendering

### DIFF
--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -8,7 +8,7 @@ import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
-import { Badge, Button, Icon, H4, Input, LanguageIcon, Code } from '@sourcegraph/wildcard'
+import { Badge, Button, Icon, H4, Input, LanguageIcon, Code, Tooltip } from '@sourcegraph/wildcard'
 
 import { CodeHostIcon } from '../../../../components'
 import { URLQueryFilter } from '../../hooks'
@@ -178,14 +178,16 @@ export const languageFilter = (filter: Filter): ReactNode => (
 )
 
 export const repoFilter = (filter: Filter): ReactNode => {
-    const codeHostIcon = <CodeHostIcon repoName={filter.label} /> || (
+    const hostName = filter.label.split('/')[0]
+    const codeHostIcon = <CodeHostIcon repoName={hostName} /> || (
         <Icon svgPath={mdiSourceRepository} className={styles.icon} aria-hidden={true} />
     )
-    const displayName = displayRepoName(filter.label)
     return (
-        <>
-            {codeHostIcon} {displayName}
-        </>
+        <Tooltip content={filter.label}>
+            <span ref={null}>
+                {codeHostIcon} {displayRepoName(filter.label)}
+            </span>
+        </Tooltip>
     )
 }
 

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -3,12 +3,14 @@ import { FC, ReactNode, useMemo, useState } from 'react'
 import { mdiClose, mdiSourceRepository } from '@mdi/js'
 import classNames from 'classnames'
 
+import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
 import { Badge, Button, Icon, H4, Input, LanguageIcon, Code } from '@sourcegraph/wildcard'
 
+import { CodeHostIcon } from '../../../../components'
 import { URLQueryFilter } from '../../hooks'
 
 import styles from './SearchDynamicFilter.module.scss'
@@ -175,12 +177,17 @@ export const languageFilter = (filter: Filter): ReactNode => (
     </>
 )
 
-export const repoFilter = (filter: Filter): ReactNode => (
-    <>
+export const repoFilter = (filter: Filter): ReactNode => {
+    const codeHostIcon = <CodeHostIcon repoName={filter.label} /> || (
         <Icon svgPath={mdiSourceRepository} className={styles.icon} aria-hidden={true} />
-        {filter.label}
-    </>
-)
+    )
+    const displayName = displayRepoName(filter.label)
+    return (
+        <>
+            {codeHostIcon} {displayName}
+        </>
+    )
+}
 
 export const commitDateFilter = (filter: Filter): ReactNode => (
     <span className={styles.commitDate}>


### PR DESCRIPTION
This updates the filters panel to show only the `org/name` from the repo, removing the code host from the text by default and replacing it with a representative icon if it is a known codehost. Additionally, it adds a hover tooltip that shows the full repo name (including code host) so that a user can still see what repo it is even if it's a long repo name. 

In an ideal world, we would fetch the code host kind from the backend and use that to render the icon. However, it's non-trivial to add followup requests and caching here, so I'm just copying what we do elsewhere in the UI. So this [only renders special icons](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@6b1979f7b6267b67d72a744ca8048bdc06e1c3e3/-/blob/client/branded/src/search-ui/components/CodeHostIcon.tsx?L8-10) for `github.com`, `bitbucket.org` and `gitlab.com`, falling back to the generic icon.

Fixes https://github.com/sourcegraph/sourcegraph/issues/59444
Fixes https://github.com/sourcegraph/sourcegraph/issues/59446

Before:

![CleanShot 2024-01-09 at 11 02 57@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/9f0c21c1-dd86-4f0f-b934-c4aeab94fb97)

After:

![CleanShot 2024-01-09 at 11 23 27@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/690223e5-b521-47e8-8dc9-23c457eeb179)

## Test plan

Manual testing. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
