### PR TITLE
New Filters Panel: replace 'show all' logic with 'show more/less' logic

### DIFF
--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -95,7 +95,7 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
     const filtersToShow =
         mergedFilters.length <= visibleFilters ? filteredFilters : filteredFilters.slice(0, visibleFilters)
 
-    const moreOrLessFilters = () => {
+    const moreOrLessFilters = (): void => {
         const filtersDisplayed = visibleFilters + MAX_FILTERS_NUMBER
 
         if (allFiltersDisplayed) {

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -15,7 +15,7 @@ import { URLQueryFilter } from '../../hooks'
 
 import styles from './SearchDynamicFilter.module.scss'
 
-const MAX_FILTERS_NUMBER = 7
+const MAX_FILTERS_NUMBER = 5
 
 interface SearchDynamicFilterProps {
     /** Name title of the filter section */
@@ -60,8 +60,9 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
     renderItem,
     onSelectedFilterChange,
 }) => {
-    const [showAllFilters, setShowAllFilters] = useState(false)
     const [searchTerm, setSearchTerm] = useState<string>('')
+    const [allFiltersDisplayed, setAllFiltersDisplayed] = useState(false)
+    const [visibleFilters, setVisibleFilters] = useState<number>(MAX_FILTERS_NUMBER)
 
     const relevantSelectedFilters = selectedFilters.filter(sf => sf.kind === filterKind)
     const relevantFilters = filters?.filter(f => f.kind === filterKind) ?? []
@@ -91,7 +92,26 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
 
     const lowerSearchTerm = searchTerm.toLowerCase()
     const filteredFilters = mergedFilters.filter(filter => filter.label.toLowerCase().includes(lowerSearchTerm))
-    const filtersToShow = showAllFilters ? filteredFilters : filteredFilters.slice(0, MAX_FILTERS_NUMBER)
+    const filtersToShow =
+        mergedFilters.length <= visibleFilters ? filteredFilters : filteredFilters.slice(0, visibleFilters)
+
+    const moreOrLessFilters = () => {
+        const filtersDisplayed = visibleFilters + MAX_FILTERS_NUMBER
+
+        if (allFiltersDisplayed) {
+            setAllFiltersDisplayed(false)
+            setVisibleFilters(MAX_FILTERS_NUMBER)
+            return
+        }
+
+        if (mergedFilters.length <= filtersDisplayed) {
+            setVisibleFilters(filtersDisplayed)
+            setAllFiltersDisplayed(true)
+            return
+        }
+
+        setVisibleFilters(filtersDisplayed)
+    }
 
     return (
         <div className={styles.root}>
@@ -118,8 +138,8 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
                 ))}
             </ul>
             {filteredFilters.length > MAX_FILTERS_NUMBER && (
-                <Button variant="link" size="sm" onClick={() => setShowAllFilters(!showAllFilters)}>
-                    {showAllFilters ? `Show less ${filterKind} filters` : `Show all ${filterKind} filters`}
+                <Button variant="link" size="sm" onClick={() => moreOrLessFilters()}>
+                    {allFiltersDisplayed ? `Show less ${filterKind}s...` : `Show more ${filterKind}s...`}
                 </Button>
             )}
         </div>

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useEffect, useMemo, useState } from 'react'
+import { FC, ReactNode, useMemo, useState } from 'react'
 
 import { mdiClose, mdiSourceRepository } from '@mdi/js'
 import classNames from 'classnames'
@@ -61,7 +61,6 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
     onSelectedFilterChange,
 }) => {
     const [searchTerm, setSearchTerm] = useState<string>('')
-    const [allFiltersDisplayed, setAllFiltersDisplayed] = useState(false)
     const [visibleFilters, setVisibleFilters] = useState<number>(MAX_FILTERS_NUMBER)
 
     const relevantSelectedFilters = selectedFilters.filter(sf => sf.kind === filterKind)
@@ -94,19 +93,20 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
     const filteredFilters = mergedFilters.filter(filter => filter.label.toLowerCase().includes(lowerSearchTerm))
     const filtersToShow =
         filteredFilters.length <= visibleFilters ? filteredFilters : filteredFilters.slice(0, visibleFilters)
+    const allFiltersDisplayed = visibleFilters >= filteredFilters.length
 
     const moreOrLessFilters = (): void => {
         const filtersDisplayed = visibleFilters + MAX_FILTERS_NUMBER
 
         if (allFiltersDisplayed) {
-            setAllFiltersDisplayed(false)
+            // setAllFiltersDisplayed(false)
             setVisibleFilters(MAX_FILTERS_NUMBER)
             return
         }
 
         if (filteredFilters.length <= filtersDisplayed) {
             setVisibleFilters(filtersDisplayed)
-            setAllFiltersDisplayed(true)
+            // setAllFiltersDisplayed(true)
             return
         }
 

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useMemo, useState } from 'react'
+import { FC, ReactNode, useEffect, useMemo, useState } from 'react'
 
 import { mdiClose, mdiSourceRepository } from '@mdi/js'
 import classNames from 'classnames'
@@ -93,7 +93,7 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
     const lowerSearchTerm = searchTerm.toLowerCase()
     const filteredFilters = mergedFilters.filter(filter => filter.label.toLowerCase().includes(lowerSearchTerm))
     const filtersToShow =
-        mergedFilters.length <= visibleFilters ? filteredFilters : filteredFilters.slice(0, visibleFilters)
+        filteredFilters.length <= visibleFilters ? filteredFilters : filteredFilters.slice(0, visibleFilters)
 
     const moreOrLessFilters = (): void => {
         const filtersDisplayed = visibleFilters + MAX_FILTERS_NUMBER
@@ -104,7 +104,7 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
             return
         }
 
-        if (mergedFilters.length <= filtersDisplayed) {
+        if (filteredFilters.length <= filtersDisplayed) {
             setVisibleFilters(filtersDisplayed)
             setAllFiltersDisplayed(true)
             return
@@ -139,7 +139,7 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
             </ul>
             {filteredFilters.length > MAX_FILTERS_NUMBER && (
                 <Button variant="link" size="sm" onClick={() => moreOrLessFilters()}>
-                    {allFiltersDisplayed ? `Show less ${filterKind}s...` : `Show more ${filterKind}s...`}
+                    {allFiltersDisplayed ? `Show less ${filterKind}s` : `Show more ${filterKind}s`}
                 </Button>
             )}
         </div>


### PR DESCRIPTION
Before, filters with many results would show either all, or no filters. Now, the `show more [filter]s` button adds 5 at a time until `allFiltersAreDisplayed`, at which point the button will change to a `Show less [filter]s`, collapsing back to 5 when clicked. 

https://github.com/sourcegraph/sourcegraph/assets/62355966/5a2cce74-1707-470d-b171-006cddaee081

## Test plan
CI/CD should be enough.
