### PR TITLE
telemetrygateway: add InternalEventRecord for gen_bq_schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -301,6 +301,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.20.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.41.0 // indirect
+	github.com/GoogleCloudPlatform/protoc-gen-bq-schema v0.0.0-20230915083002-8edab4bb6c81 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/alexflint/go-arg v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.41.0/go.mod h1:Ei53Im4CWT7FHDaMBvmQzZ8p91+X1IAaifp7QF+ewQQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.41.0 h1:MWQ81b2TkSLbDpLINiKdZdoht1VMEHCKr4BSZpb/KQ8=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.41.0/go.mod h1:lz6DEePTxmjvYMtusOoS3qDAErC0STi/wmvqJucKY28=
+github.com/GoogleCloudPlatform/protoc-gen-bq-schema v0.0.0-20230915083002-8edab4bb6c81 h1:eXgT4APykDzxgaewZA2cjp1hOYriaKGeEWQTDlhH9Lw=
+github.com/GoogleCloudPlatform/protoc-gen-bq-schema v0.0.0-20230915083002-8edab4bb6c81/go.mod h1:ZWP6hShlkP3umZRP3V9jft8h1egCZWZnX5CgYQIDbuU=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvKIROun94nF7v2cua9qP+thov/7M50KEoeSU=
@@ -802,6 +804,7 @@ github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EO
 github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f h1:16RtHeWGkJMc80Etb8RPCcKevXGldr57+LOyZt8zOlg=
 github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f/go.mod h1:ijRvpgDJDI262hYq/IQVYgf8hd8IHUs93Ol0kvMBAx4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=
 github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/telemetrygateway/v1/telemetrygateway.proto
+++ b/internal/telemetrygateway/v1/telemetrygateway.proto
@@ -228,3 +228,17 @@ message EventInteraction {
   // originating client's IP address (which we do not collect).
   optional Geolocation geolocation = 3;
 }
+
+// https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema
+import "bq_table.proto";
+import "bq_field.proto";
+
+// InternalEventRecord is the shape of the internally published event.
+message InternalEventRecord {
+  option (gen_bq_schema.bigquery_opts).table_name = "telemetry_events";
+
+  // Metadata associated with the request to publish this event.
+  RecordEventsRequestMetadata metadata = 1;
+  // Event data.
+  Event event = 2;
+}


### PR DESCRIPTION
We want to be able to generate a "real" schema of the payload for ease of query. We might be able to do this with https://github.com/GoogleCloudPlatform/protoc-gen-bq-schema

## Test plan
