### PR TITLE
Filters: fix icon for nonstandard codehosts

### DIFF
--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -10,7 +10,7 @@ import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settin
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
 import { Badge, Button, Icon, H4, Input, LanguageIcon, Code, Tooltip } from '@sourcegraph/wildcard'
 
-import { CodeHostIcon } from '../../../../components'
+import { CodeHostIcon, codeHostIcon } from '../../../../components'
 import { URLQueryFilter } from '../../hooks'
 
 import styles from './SearchDynamicFilter.module.scss'
@@ -178,14 +178,12 @@ export const languageFilter = (filter: Filter): ReactNode => (
 )
 
 export const repoFilter = (filter: Filter): ReactNode => {
-    const hostName = filter.label.split('/')[0]
-    const codeHostIcon = <CodeHostIcon repoName={hostName} /> || (
-        <Icon svgPath={mdiSourceRepository} className={styles.icon} aria-hidden={true} />
-    )
+    const { svgPath, color } = codeHostIcon(filter.label)
     return (
         <Tooltip content={filter.label}>
             <span ref={null}>
-                {codeHostIcon} {displayRepoName(filter.label)}
+                <Icon aria-hidden={true} svgPath={svgPath ?? mdiSourceRepository} color={color} />{' '}
+                {displayRepoName(filter.label)}
             </span>
         </Tooltip>
     )

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -10,7 +10,7 @@ import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settin
 import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
 import { Badge, Button, Icon, H4, Input, LanguageIcon, Code, Tooltip } from '@sourcegraph/wildcard'
 
-import { CodeHostIcon, codeHostIcon } from '../../../../components'
+import { codeHostIcon } from '../../../../components'
 import { URLQueryFilter } from '../../hooks'
 
 import styles from './SearchDynamicFilter.module.scss'


### PR DESCRIPTION
In my last PR, there was an issue with rendering non-standard code host icons. This fixes that.

![CleanShot 2024-01-09 at 16 01 11@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/e9fae1f4-b61f-41f2-9828-1bce747c09b2)

## Test plan

See screenshot. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
