### PR TITLE
New Filters Panel: encase before/after values in double quotes where necessary

### DIFF
--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -78,8 +78,8 @@ const (
 
 	// After/Before Values
 	YESTERDAY     = "yesterday"
-	ONE_WEEK_AGO  = "1 week ago"
-	ONE_MONTH_AGO = "1 month ago"
+	ONE_WEEK_AGO  = `"1 week ago"`
+	ONE_MONTH_AGO = `"1 month ago"`
 )
 
 type dateFilterInfo struct {
@@ -114,7 +114,7 @@ func determineTimeframe(date time.Time) dateFilterInfo {
 	default:
 		return dateFilterInfo{
 			Timeframe: BEFORE,
-			Value:     "2 months ago",
+			Value:     `"2 months ago"`,
 			Label:     "Older than 2 months",
 		}
 	}


### PR DESCRIPTION
Values for before/after were reading as search terms instead of as values for before and after filters.

Used to be: `after:1 week ago`
Now is: `before:"1 week ago"`

Otherwise, we would be returning results for 'week ago'.
## Test plan
CI/CD

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
