### PR TITLE
gitserver: remove noisy alert

### DIFF
--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -191,24 +191,6 @@ func GitServer() *monitoring.Dashboard {
 					},
 					{
 						{
-							Name:        "running_git_commands",
-							Description: "git commands running on each gitserver instance",
-							Query:       "sum by (instance, cmd) (src_gitserver_exec_running{instance=~`${shard:regex}`})",
-							Warning:     monitoring.Alert().GreaterOrEqual(50).For(2 * time.Minute),
-							Critical:    monitoring.Alert().GreaterOrEqual(100).For(5 * time.Minute),
-							Panel: monitoring.Panel().LegendFormat("{{instance}} {{cmd}}").
-								With(monitoring.PanelOptions.LegendOnRight()),
-							Owner: monitoring.ObservableOwnerSource,
-							Interpretation: `
-								A high value signals load.
-							`,
-							NextSteps: `
-								- **Check if the problem may be an intermittent and temporary peak** using the "Container monitoring" section at the bottom of the Git Server dashboard.
-								- **Single container deployments:** Consider upgrading to a [Docker Compose deployment](../deploy/docker-compose/migrate.md) which offers better scalability and resource isolation.
-								- **Kubernetes and Docker Compose:** Check that you are running a similar number of git server replicas and that their CPU/memory limits are allocated according to what is shown in the [Sourcegraph resource estimator](../deploy/resource_estimator.md).
-							`,
-						},
-						{
 							Name:           "git_commands_received",
 							Description:    "rate of git commands received across all instances",
 							Query:          "sum by (cmd) (rate(src_gitserver_exec_duration_seconds_count[5m]))",


### PR DESCRIPTION
wait for CI to run then fix the generator instead of trying to figure out which bazel target to run.

## Test plan

CI
