### PR TITLE
sg msp: expand destroy protection to more features

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -79,7 +79,8 @@ type EnvironmentSpec struct {
 
 	// AllowDestroys, if false, configures Terraform lifecycle guards against
 	// deletion of potentially critical resources. This includes things like the
-	// environment project and databases.
+	// environment project and databases, and also guards against the deletion
+	// of Terraform Cloud workspaces as well.
 	// https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion
 	//
 	// To tear down an environment, or to apply a change that intentionally

--- a/dev/managedservicesplatform/terraformcloud/terraformcloud.go
+++ b/dev/managedservicesplatform/terraformcloud/terraformcloud.go
@@ -89,6 +89,8 @@ type workspaceOptions struct {
 	GlobalRemoteState *bool
 
 	QueueAllRuns *bool
+
+	AllowDestroy bool
 }
 
 // AsCreate should be kept up to date with AsUpdate.
@@ -110,6 +112,8 @@ func (c workspaceOptions) AsCreate(tags []*tfe.Tag) tfe.WorkspaceCreateOptions {
 		GlobalRemoteState: c.GlobalRemoteState,
 
 		QueueAllRuns: c.QueueAllRuns,
+
+		AllowDestroyPlan: &c.AllowDestroy,
 	}
 }
 
@@ -131,6 +135,8 @@ func (c workspaceOptions) AsUpdate() tfe.WorkspaceUpdateOptions {
 		GlobalRemoteState: c.GlobalRemoteState,
 
 		QueueAllRuns: c.QueueAllRuns,
+
+		AllowDestroyPlan: &c.AllowDestroy,
 	}
 }
 
@@ -229,6 +235,8 @@ func (c *Client) SyncWorkspaces(ctx context.Context, svc spec.ServiceSpec, env s
 
 			// Allow all stacks to reference each other.
 			GlobalRemoteState: pointers.Ptr(true),
+
+			AllowDestroy: pointers.DerefZero(env.AllowDestroys),
 		}
 		switch c.workspaceConfig.RunMode {
 		case WorkspaceRunModeVCS:

--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -16,6 +16,7 @@ import (
 	msprepo "github.com/sourcegraph/sourcegraph/dev/sg/msp/repo"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 // useServiceArgument retrieves the service spec corresponding to the first
@@ -82,6 +83,10 @@ func syncEnvironmentWorkspaces(c *cli.Context, tfc *terraformcloud.Client, servi
 	renderPending.Destroy() // We need to destroy this pending so we can prompt on deletion.
 
 	if c.Bool("delete") {
+		if !pointers.DerefZero(env.AllowDestroys) {
+			return errors.Newf("environments[%s].allowDestroys must be 'true' to delete workspaces", env.ID)
+		}
+
 		std.Out.Promptf("[%s] Deleting workspaces for environment %q - are you sure? (y/N) ",
 			service.ID, env.ID)
 		var input string


### PR DESCRIPTION
Adds `allowDestroys` checks to:

1. Workspaces via `AllowDestroyPlan`
2. `sg msp tfc sync -delete`

## Test plan

n/a