### PR TITLE
gomod: update zoekt to include chunkmatch perf fix

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5728,8 +5728,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:WhN5CjTjPc4cdv5LD0umuudb6ffvb3cFSo7VGIPvxGc=",
-        version = "v0.0.0-20231211160200-e92f6c764b56",
+        sum = "h1:TB4KxGtcJm98TfyDHhSkbffngM+EVlTu0epG3SxUU0U=",
+        version = "v0.0.0-20240110094557-7487a0d53131",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -568,7 +568,7 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20231018142932-e00da332dac5
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20231211160200-e92f6c764b56
+	github.com/sourcegraph/zoekt v0.0.0-20240110094557-7487a0d53131
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1668,8 +1668,8 @@ github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008 h1:Wu8W50q
 github.com/sourcegraph/tiktoken-go v0.0.0-20230905173153-caab340cf008/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20231211160200-e92f6c764b56 h1:WhN5CjTjPc4cdv5LD0umuudb6ffvb3cFSo7VGIPvxGc=
-github.com/sourcegraph/zoekt v0.0.0-20231211160200-e92f6c764b56/go.mod h1:DA42q8CujJGj9zLcJfgvVV3VI6rykt/VrjkLaGdmNp4=
+github.com/sourcegraph/zoekt v0.0.0-20240110094557-7487a0d53131 h1:TB4KxGtcJm98TfyDHhSkbffngM+EVlTu0epG3SxUU0U=
+github.com/sourcegraph/zoekt v0.0.0-20240110094557-7487a0d53131/go.mod h1:DA42q8CujJGj9zLcJfgvVV3VI6rykt/VrjkLaGdmNp4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
This bump only includes one commit from zoekt which is a performance fix. See the commit in the zoekt repo for details.

- https://github.com/sourcegraph/zoekt/commit/7487a0d53131a188fcf769ed64ceee07f8acdfd2 chunkmatches: reuse last calculated column when filling

Test Plan: tested in zoekt repo and this CI
