### PR TITLE
search jobs: refactor SearchQuery interface

### DIFF
--- a/cmd/worker/internal/search/exhaustive_search_repo_revision.go
+++ b/cmd/worker/internal/search/exhaustive_search_repo_revision.go
@@ -72,7 +72,10 @@ func (h *exhaustiveSearchRepoRevHandler) Handle(ctx context.Context, logger log.
 		return err
 	}
 
-	csvWriter := service.NewBlobstoreCSVWriter(ctx, h.uploadStore, fmt.Sprintf("%d-%d", jobID, record.ID))
+	csvWriter, err := service.NewCSVWriter(ctx, h.uploadStore, fmt.Sprintf("%d-%d", jobID, record.ID))
+	if err != nil {
+		return err
+	}
 
 	err = q.Search(ctx, repoRev, csvWriter)
 	if closeErr := csvWriter.Close(); closeErr != nil {

--- a/cmd/worker/internal/search/exhaustive_search_test.go
+++ b/cmd/worker/internal/search/exhaustive_search_test.go
@@ -118,9 +118,9 @@ func TestExhaustiveSearch(t *testing.T) {
 		}
 		sort.Strings(vals)
 		require.Equal([]string{
-			"repo,revspec,revision\n1,spec,rev1\n",
-			"repo,revspec,revision\n1,spec,rev2\n",
-			"repo,revspec,revision\n2,spec,rev3\n",
+			"repository,revision,file_path,match_count,first_match_url\n1,rev1,path/to/file.go,0,/1@rev1/-/blob/path/to/file.go\n",
+			"repository,revision,file_path,match_count,first_match_url\n1,rev2,path/to/file.go,0,/1@rev2/-/blob/path/to/file.go\n",
+			"repository,revision,file_path,match_count,first_match_url\n2,rev3,path/to/file.go,0,/2@rev3/-/blob/path/to/file.go\n",
 		}, vals)
 	}
 

--- a/internal/search/exhaustive/service/matchcsv.go
+++ b/internal/search/exhaustive/service/matchcsv.go
@@ -1,31 +1,42 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/uploadstore"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type matchCSVWriter struct {
-	w         CSVWriter
+type MatchCSVWriter struct {
+	w         CSVWriterCloser
 	headerTyp string
 	host      *url.URL
 }
 
-func newMatchCSVWriter(w CSVWriter) (*matchCSVWriter, error) {
+func (w *MatchCSVWriter) Close() error {
+	return w.w.Close()
+}
+
+func NewCSVWriter(ctx context.Context, store uploadstore.Store, prefix string) (*MatchCSVWriter, error) {
+	csvWriter := newBlobstoreCSVWriter(ctx, store, prefix)
+	return newMatchCSVWriter(csvWriter)
+}
+
+func newMatchCSVWriter(w CSVWriterCloser) (*MatchCSVWriter, error) {
 	externalURL := conf.Get().ExternalURL
 	u, err := url.Parse(externalURL)
 	if err != nil {
 		return nil, err
 	}
-	return &matchCSVWriter{w: w, host: u}, nil
+	return &MatchCSVWriter{w: w, host: u}, nil
 }
 
-func (w *matchCSVWriter) Write(match result.Match) error {
+func (w *MatchCSVWriter) Write(match result.Match) error {
 	// TODO compare to logic used by the webapp to convert
 	// results into csv. See
 	// client/web/src/search/results/export/searchResultsExport.ts
@@ -38,7 +49,7 @@ func (w *matchCSVWriter) Write(match result.Match) error {
 	}
 }
 
-func (w *matchCSVWriter) writeFileMatch(fm *result.FileMatch) error {
+func (w *MatchCSVWriter) writeFileMatch(fm *result.FileMatch) error {
 	// Differences to "Export CSV" in webapp. We have removed columns since it
 	// is easier to add columns than to remove them.
 	//
@@ -159,7 +170,7 @@ func minRange(ranges result.Ranges) (result.Range, bool) {
 	return min, true
 }
 
-func (w *matchCSVWriter) writeHeader(typ string) (bool, error) {
+func (w *MatchCSVWriter) writeHeader(typ string) (bool, error) {
 	if w.headerTyp == "" {
 		w.headerTyp = typ
 		return true, nil

--- a/internal/search/exhaustive/service/matchcsv.go
+++ b/internal/search/exhaustive/service/matchcsv.go
@@ -13,7 +13,7 @@ import (
 )
 
 type MatchCSVWriter struct {
-	w         CSVWriterCloser
+	w         CSVWriter
 	headerTyp string
 	host      *url.URL
 }
@@ -23,7 +23,7 @@ func NewCSVWriter(ctx context.Context, store uploadstore.Store, prefix string) (
 	return newMatchCSVWriter(csvWriter)
 }
 
-func newMatchCSVWriter(w CSVWriterCloser) (*MatchCSVWriter, error) {
+func newMatchCSVWriter(w CSVWriter) (*MatchCSVWriter, error) {
 	externalURL := conf.Get().ExternalURL
 	u, err := url.Parse(externalURL)
 	if err != nil {

--- a/internal/search/exhaustive/service/matchcsv.go
+++ b/internal/search/exhaustive/service/matchcsv.go
@@ -18,10 +18,6 @@ type MatchCSVWriter struct {
 	host      *url.URL
 }
 
-func (w *MatchCSVWriter) Close() error {
-	return w.w.Close()
-}
-
 func NewCSVWriter(ctx context.Context, store uploadstore.Store, prefix string) (*MatchCSVWriter, error) {
 	csvWriter := newBlobstoreCSVWriter(ctx, store, prefix)
 	return newMatchCSVWriter(csvWriter)
@@ -34,6 +30,10 @@ func newMatchCSVWriter(w CSVWriterCloser) (*MatchCSVWriter, error) {
 		return nil, err
 	}
 	return &MatchCSVWriter{w: w, host: u}, nil
+}
+
+func (w *MatchCSVWriter) Close() error {
+	return w.w.Close()
 }
 
 func (w *MatchCSVWriter) Write(match result.Match) error {

--- a/internal/search/exhaustive/service/search.go
+++ b/internal/search/exhaustive/service/search.go
@@ -83,12 +83,8 @@ type MatchWriter interface {
 	Write(match result.Match) error
 }
 
-// CSVWriter makes it so we can avoid caring about search types and leave it
+// CSVWriter makes it, so we can avoid caring about search types and leave it
 // up to the search job to decide the shape of data.
-//
-// Note: I expect the implementation of this to handle things like chunking up
-// the CSV/etc. EG once we hit 100MB of data it can write the data out then
-// start a new file. It takes care of remembering the header for the new file.
 type CSVWriter interface {
 	// WriteHeader should be called first and only once.
 	WriteHeader(...string) error
@@ -96,10 +92,7 @@ type CSVWriter interface {
 	// WriteRow should have the same number of values as WriteHeader and can be
 	// called zero or more times.
 	WriteRow(...string) error
-}
 
-type CSVWriterCloser interface {
-	CSVWriter
 	io.Closer
 }
 

--- a/internal/search/exhaustive/service/search_test.go
+++ b/internal/search/exhaustive/service/search_test.go
@@ -63,6 +63,10 @@ func (c *csvBuffer) WriteRow(row ...string) error {
 	return err
 }
 
+func (c *csvBuffer) Close() error {
+	return nil
+}
+
 func TestBlobstoreCSVWriter(t *testing.T) {
 	mockStore := setupMockStore(t)
 

--- a/internal/search/exhaustive/service/search_test.go
+++ b/internal/search/exhaustive/service/search_test.go
@@ -66,7 +66,7 @@ func (c *csvBuffer) WriteRow(row ...string) error {
 func TestBlobstoreCSVWriter(t *testing.T) {
 	mockStore := setupMockStore(t)
 
-	csvWriter := NewBlobstoreCSVWriter(context.Background(), mockStore, "blob")
+	csvWriter := newBlobstoreCSVWriter(context.Background(), mockStore, "blob")
 	csvWriter.maxBlobSizeBytes = 12
 
 	err := csvWriter.WriteHeader("h", "h", "h") // 3 bytes (letters) + 2 bytes (commas) + 1 byte (newline) = 6 bytes
@@ -116,7 +116,7 @@ func TestBlobstoreCSVWriter(t *testing.T) {
 
 func TestNoUploadIfNotData(t *testing.T) {
 	mockStore := setupMockStore(t)
-	csvWriter := NewBlobstoreCSVWriter(context.Background(), mockStore, "blob")
+	csvWriter := newBlobstoreCSVWriter(context.Background(), mockStore, "blob")
 
 	// No data written, so no upload should happen.
 	err := csvWriter.Close()

--- a/internal/search/exhaustive/service/searcher.go
+++ b/internal/search/exhaustive/service/searcher.go
@@ -161,7 +161,7 @@ func (s searchQuery) toRepoRevSpecs(ctx context.Context, repoRevSpec types.Repos
 	}, nil
 }
 
-func (s searchQuery) Search(ctx context.Context, repoRev types.RepositoryRevision, w CSVWriter) error {
+func (s searchQuery) Search(ctx context.Context, repoRev types.RepositoryRevision, matchWriter MatchWriter) error {
 	if err := isSameUser(ctx, s.userID); err != nil {
 		return err
 	}
@@ -181,10 +181,6 @@ func (s searchQuery) Search(ctx context.Context, repoRev types.RepositoryRevisio
 
 	var mu sync.Mutex     // serialize writes to w
 	var writeRowErr error // capture if w.Write fails
-	matchWriter, err := newMatchCSVWriter(w)
-	if err != nil {
-		return err
-	}
 
 	// TODO currently ignoring returned Alert
 	_, err = job.Run(ctx, s.clients, streaming.StreamFunc(func(se streaming.SearchEvent) {

--- a/internal/search/exhaustive/service/searcher_test.go
+++ b/internal/search/exhaustive/service/searcher_test.go
@@ -365,7 +365,7 @@ func testNewSearcher(t *testing.T, ctx context.Context, newSearcher NewSearcher,
 
 	// Test Search
 	var csv csvBuffer
-	matchWriter, err := newMatchCSVWriter(NopCloser(&csv))
+	matchWriter, err := newMatchCSVWriter(&csv)
 	assert.NoError(err)
 
 	for _, repoRev := range repoRevs {
@@ -375,16 +375,4 @@ func testNewSearcher(t *testing.T, ctx context.Context, newSearcher NewSearcher,
 	if tc.WantCSV != nil {
 		tc.WantCSV.Equal(t, csv.buf.String())
 	}
-}
-
-func NopCloser(w CSVWriter) CSVWriterCloser {
-	return nopCloser{w}
-}
-
-type nopCloser struct {
-	CSVWriter
-}
-
-func (nopCloser) Close() error {
-	return nil
 }

--- a/internal/search/exhaustive/service/searcher_test.go
+++ b/internal/search/exhaustive/service/searcher_test.go
@@ -38,10 +38,10 @@ func TestBackendFake(t *testing.T) {
 		Query:        "1@rev1 1@rev2 2@rev3",
 		WantRefSpecs: "RepositoryRevSpec{1@spec} RepositoryRevSpec{2@spec}",
 		WantRepoRevs: "RepositoryRevision{1@rev1} RepositoryRevision{1@rev2} RepositoryRevision{2@rev3}",
-		WantCSV: autogold.Expect(`repo,revspec,revision
-1,spec,rev1
-1,spec,rev2
-2,spec,rev3
+		WantCSV: autogold.Expect(`repository,revision,file_path,match_count,first_match_url
+1,rev1,path/to/file.go,0,/1@rev1/-/blob/path/to/file.go
+1,rev2,path/to/file.go,0,/1@rev2/-/blob/path/to/file.go
+2,rev3,path/to/file.go,0,/2@rev3/-/blob/path/to/file.go
 `),
 	})
 }
@@ -365,11 +365,26 @@ func testNewSearcher(t *testing.T, ctx context.Context, newSearcher NewSearcher,
 
 	// Test Search
 	var csv csvBuffer
+	matchWriter, err := newMatchCSVWriter(NopCloser(&csv))
+	assert.NoError(err)
+
 	for _, repoRev := range repoRevs {
-		err := searcher.Search(ctx, repoRev, &csv)
+		err := searcher.Search(ctx, repoRev, matchWriter)
 		assert.NoError(err)
 	}
 	if tc.WantCSV != nil {
 		tc.WantCSV.Equal(t, csv.buf.String())
 	}
+}
+
+func NopCloser(w CSVWriter) CSVWriterCloser {
+	return nopCloser{w}
+}
+
+type nopCloser struct {
+	CSVWriter
+}
+
+func (nopCloser) Close() error {
+	return nil
 }


### PR DESCRIPTION
Relates to #59329 

This is mostly a refactor to prepare for a JSON writer that replaces our CSV writer.

The high-level plan is to switch the internal (object storage) AND the external (download) format from CSV to JSON.

Test plan:
- CI
- Note: I had to update `SearcherFake`, hence some of the test data changed. It only affects a few tests and the character of the tests remains the same.

