### PR TITLE
Add non-blocking error handling for semgrep findings

### DIFF
--- a/dev/ci/semgrep-scan.sh
+++ b/dev/ci/semgrep-scan.sh
@@ -16,7 +16,9 @@ if [ ! -d "security-semgrep-rules/semgrep-rules/" ]; then
   echo ":red_circle: Semgrep rules directory not found. Reachout to security team at #discuss-security for support :red_circle:"
 fi
 
-# run semgrep
+# run semgrep scan on changeset using CI subcommand
+# || true is used to prevent build from failing if semgrep scan reports on blocking findings
+# reference: https://semgrep.dev/docs/semgrep-ci/configuring-blocking-and-errors-in-ci/#configuration-options-for-blocking-findings-and-errors
 semgrep ci -f security-semgrep-rules/semgrep-rules/ --metrics=off --oss-only --sarif -o results.sarif --exclude='semgrep-rules' --baseline-commit main || true
 
 echo -e "--- :rocket: reporting scan results to GitHub\n"

--- a/dev/ci/semgrep-scan.sh
+++ b/dev/ci/semgrep-scan.sh
@@ -17,7 +17,7 @@ if [ ! -d "security-semgrep-rules/semgrep-rules/" ]; then
 fi
 
 # run semgrep
-semgrep ci -f security-semgrep-rules/semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif --exclude='semgrep-rules' --baseline-commit main
+semgrep ci -f security-semgrep-rules/semgrep-rules/ --metrics=off --oss-only --sarif -o results.sarif --exclude='semgrep-rules' --baseline-commit main || true
 
 echo -e "--- :rocket: reporting scan results to GitHub\n"
 


### PR DESCRIPTION
This PR attempts to add non-blocking error handling for semgrep findings. Semgrep binary returns 1 for high severity issue report and then fails the buildkite job. Rather than blocking CI, code scanning feature will automatically block for high severity issues. (Currently disabled but can be enabled from `code scanning` settings.

## Test plan

- [x] Semgrep scan shouldn't fail for high severity issues

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
