### PR TITLE
handle deleted users when listing team members

### DIFF
--- a/internal/database/teams.go
+++ b/internal/database/teams.go
@@ -320,6 +320,9 @@ func (s *teamStore) ListTeamMembers(ctx context.Context, opts ListTeamMembersOpt
 		opts.Limit++
 	}
 
+	joins = append(joins, sqlf.Sprintf("LEFT JOIN users ON team_members.user_id = users.id"))
+	conds = append(conds, sqlf.Sprintf("users.deleted_at IS NULL"))
+
 	q := sqlf.Sprintf(
 		listTeamMembersQueryFmtstr,
 		sqlf.Join(teamMemberColumns, ","),
@@ -359,6 +362,9 @@ func (s *teamStore) CountTeamMembers(ctx context.Context, opts ListTeamMembersOp
 	opts.Cursor = TeamMemberListCursor{}
 	conds, joins := opts.SQL()
 
+	joins = append(joins, sqlf.Sprintf("LEFT JOIN users ON team_members.user_id = users.id"))
+	conds = append(conds, sqlf.Sprintf("users.deleted_at IS NULL"))
+
 	q := sqlf.Sprintf(
 		countTeamMembersQueryFmtstr,
 		sqlf.Join(joins, "\n"),
@@ -370,7 +376,7 @@ func (s *teamStore) CountTeamMembers(ctx context.Context, opts ListTeamMembersOp
 }
 
 const countTeamMembersQueryFmtstr = `
-SELECT COUNT(*)
+SELECT COUNT(1)
 FROM team_members
 %s
 WHERE %s

--- a/internal/database/teams.go
+++ b/internal/database/teams.go
@@ -320,7 +320,9 @@ func (s *teamStore) ListTeamMembers(ctx context.Context, opts ListTeamMembersOpt
 		opts.Limit++
 	}
 
-	joins = append(joins, sqlf.Sprintf("LEFT JOIN users ON team_members.user_id = users.id"))
+	if opts.Search == "" {
+		joins = append(joins, sqlf.Sprintf("LEFT JOIN users ON team_members.user_id = users.id"))
+	}
 	conds = append(conds, sqlf.Sprintf("users.deleted_at IS NULL"))
 
 	q := sqlf.Sprintf(

--- a/internal/database/teams.go
+++ b/internal/database/teams.go
@@ -364,7 +364,9 @@ func (s *teamStore) CountTeamMembers(ctx context.Context, opts ListTeamMembersOp
 	opts.Cursor = TeamMemberListCursor{}
 	conds, joins := opts.SQL()
 
-	joins = append(joins, sqlf.Sprintf("LEFT JOIN users ON team_members.user_id = users.id"))
+	if opts.Search == "" {
+		joins = append(joins, sqlf.Sprintf("LEFT JOIN users ON team_members.user_id = users.id"))
+	}
 	conds = append(conds, sqlf.Sprintf("users.deleted_at IS NULL"))
 
 	q := sqlf.Sprintf(

--- a/internal/database/teams_test.go
+++ b/internal/database/teams_test.go
@@ -162,6 +162,10 @@ func TestTeams_GetListCount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	alex, err := db.Users().Create(internalCtx, NewUser{Username: "alex"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	store := db.Teams()
 
@@ -181,7 +185,7 @@ func TestTeams_GetListCount(t *testing.T) {
 	engineeringTeam := createTeam(&types.Team{Name: "engineering"}, johndoe.ID)
 	salesTeam := createTeam(&types.Team{Name: "sales"})
 	supportTeam := createTeam(&types.Team{Name: "support"}, johndoe.ID)
-	ownTeam := createTeam(&types.Team{Name: "sgown", ParentTeamID: engineeringTeam.ID}, alice.ID)
+	ownTeam := createTeam(&types.Team{Name: "sgown", ParentTeamID: engineeringTeam.ID}, alice.ID, alex.ID)
 	batchesTeam := createTeam(&types.Team{Name: "batches", ParentTeamID: engineeringTeam.ID}, johndoe.ID, alice.ID)
 
 	t.Run("GetByID", func(t *testing.T) {
@@ -328,6 +332,7 @@ func TestTeams_GetListCount(t *testing.T) {
 		t.Run("ForUserMember", func(t *testing.T) {
 			johnTeams := []*types.Team{engineeringTeam, supportTeam, batchesTeam}
 			aliceTeams := []*types.Team{ownTeam, batchesTeam}
+			alexTeams := []*types.Team{ownTeam}
 
 			t.Run("johndoe", func(t *testing.T) {
 				haveTeams, haveCursor, err := store.ListTeams(internalCtx, ListTeamsOpts{ForUserMember: johndoe.ID})
@@ -351,6 +356,21 @@ func TestTeams_GetListCount(t *testing.T) {
 				}
 
 				if diff := cmp.Diff(aliceTeams, haveTeams); diff != "" {
+					t.Fatal(diff)
+				}
+
+				if haveCursor != 0 {
+					t.Fatal("incorrect cursor returned")
+				}
+			})
+
+			t.Run("alex", func(t *testing.T) {
+				haveTeams, haveCursor, err := store.ListTeams(internalCtx, ListTeamsOpts{ForUserMember: alex.ID})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if diff := cmp.Diff(alexTeams, haveTeams); diff != "" {
 					t.Fatal(diff)
 				}
 
@@ -404,6 +424,11 @@ func TestTeams_GetListCount(t *testing.T) {
 			engineeringTeam: {johndoe.ID},
 			salesTeam:       {},
 			batchesTeam:     {johndoe.ID, alice.ID},
+		}
+
+		err := db.Users().Delete(internalCtx, alex.ID)
+		if err != nil {
+			t.Fatal(err)
 		}
 
 		for team, wantMembers := range allTeams {


### PR DESCRIPTION
While fetching members of a team, we currently don't check if the user is deleted which leads to an error on S2 when fetching the member's information.

![CleanShot 2024-01-10 at 14 42 03@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/50f6a2ba-fb3b-4dff-9604-c8ee5dedd417)

```graphql
query ListTeamMembers($first: Int, $after: String, $search: String, $teamName: String!) {
    team(name: $teamName) {
        id
        members(first: $first, after: $after, search: $search) {
            totalCount
            pageInfo {
                endCursor
                hasNextPage
            }
            nodes {
                ...ListTeamMemberFields
            }
        }
    }
}

fragment ListTeamMemberFields on TeamMember {
    __typename
    ... on User {
        __typename
        id
        url
        username
        displayName
        avatarURL
    }
}
```

## Test plan

* Navigate to S2
* Access the [`everyone` team on S2](https://sourcegraph.sourcegraph.com/teams/everyone/members)
* You should see the list of team members instead of the current error page on S2.
