### PR TITLE
New Filters Panel: change background on hover

### DIFF
--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
@@ -32,7 +32,7 @@
     }
 
     &:not(&-selected):hover {
-        background-color: var(--color-bg-2) !important;
+        background-color: var(--color-bg-3) !important;
     }
 
     &-text {

--- a/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.module.scss
@@ -17,7 +17,7 @@
         font-weight: normal;
 
         &:not(&-selected):hover {
-            background-color: var(--color-bg-2) !important;
+            background-color: var(--color-bg-3) !important;
         }
     }
 }


### PR DESCRIPTION
Before, when dark mode is enabled, filters in the new filters panel had no hover behavior. Now, the background changes when the user hovers over individual filters in both light, and dark mode. 

## Test plan
CI/CD & manual/visual testing
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
