### PR TITLE
Fix data access race condition in gRPC retry logic

### DIFF
--- a/internal/grpc/retry/options.go
+++ b/internal/grpc/retry/options.go
@@ -116,10 +116,7 @@ type CallOption struct {
 	applyFunc            func(opt *options)
 }
 
-func reuseOrNewWithCallOptions(opt *options, callOptions []CallOption) *options {
-	if len(callOptions) == 0 {
-		return opt
-	}
+func newWithCallOptions(opt *options, callOptions []CallOption) *options {
 	optCopy := &options{}
 	*optCopy = *opt
 	for _, f := range callOptions {

--- a/internal/grpc/retry/retry.go
+++ b/internal/grpc/retry/retry.go
@@ -38,7 +38,7 @@ const (
 // The default configuration of the interceptor is to not retry *at all*. This behaviour can be
 // changed through options (e.g. WithMax) on creation of the interceptor or on call (through grpc.CallOptions).
 func UnaryClientInterceptor(logger log.Logger, optFuncs ...CallOption) grpc.UnaryClientInterceptor {
-	intOpts := reuseOrNewWithCallOptions(defaultOptions, optFuncs)
+	intOpts := newWithCallOptions(defaultOptions, optFuncs)
 	return func(parentCtx context.Context, fullMethod string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		tr := trace.FromContext(parentCtx)
 		tr.SetAttributes(attribute.Bool(retriedTraceAttributeKey, false))
@@ -46,7 +46,7 @@ func UnaryClientInterceptor(logger log.Logger, optFuncs ...CallOption) grpc.Unar
 		service, method := grpcutil.SplitMethodName(fullMethod)
 
 		grpcOpts, retryOpts := filterCallOptions(opts)
-		callOpts := reuseOrNewWithCallOptions(intOpts, retryOpts)
+		callOpts := newWithCallOptions(intOpts, retryOpts)
 
 		doTrace := makeTracingCallback(parentCtx, logger, service, method)
 		originalCallback := callOpts.onRetryCallback
@@ -104,7 +104,7 @@ func UnaryClientInterceptor(logger log.Logger, optFuncs ...CallOption) grpc.Unar
 // to buffer the messages sent by the client. If retry is enabled on any other streams (ClientStreams,
 // BidiStreams), the retry interceptor will fail the call.
 func StreamClientInterceptor(logger log.Logger, optFuncs ...CallOption) grpc.StreamClientInterceptor {
-	intOpts := reuseOrNewWithCallOptions(defaultOptions, optFuncs)
+	intOpts := newWithCallOptions(defaultOptions, optFuncs)
 	return func(parentCtx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, fullMethod string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
 		tr := trace.FromContext(parentCtx)
 		tr.SetAttributes(attribute.Bool(retriedTraceAttributeKey, false))
@@ -112,7 +112,7 @@ func StreamClientInterceptor(logger log.Logger, optFuncs ...CallOption) grpc.Str
 		service, method := grpcutil.SplitMethodName(fullMethod)
 
 		grpcOpts, retryOpts := filterCallOptions(opts)
-		callOpts := reuseOrNewWithCallOptions(intOpts, retryOpts)
+		callOpts := newWithCallOptions(intOpts, retryOpts)
 		// short circuit for simplicity, and avoiding allocations.
 
 		doTrace := makeTracingCallback(parentCtx, logger, service, method)


### PR DESCRIPTION
```
		callOpts := reuseOrNewWithCallOptions(intOpts, retryOpts) // callOpts are recycled here if no call opts given

		doTrace := makeTracingCallback(parentCtx, logger, service, method)
		originalCallback := callOpts.onRetryCallback
		callOpts.onRetryCallback = func(ctx context.Context, attempt uint, err error) { // and is overwritten here, potentially by multiple callers at the same time.
			doTrace(attempt, err)

			if originalCallback != nil {
				originalCallback(ctx, attempt, err)
			}
		}
```

## Test plan

`go test ./cmd/gitserver/internal/integration_tests -race -count=5` consistently fails before this change on branch `es/grpc-cleanup` where we switched the integration test suite from HTTP to gRPC (the default option). With this patch applied, it no longer fails.