### PR TITLE
Disables embeddings for all instances that are not dotcom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to Sourcegraph are documented in this file.
 - The notepad UI, notebook creation feature. [#58217](https://github.com/sourcegraph/sourcegraph/pull/58217)
 - The experimental `indexRepositoryName` option for the rust packages code host connection has been removed. [#59176](https://github.com/sourcegraph/sourcegraph/pull/59176)
 - The column "Repository metadata" in the CSV export of repository search results is now deprecated and will be removed in a future release. Use "Repository metadata JSON" instead [#59334](https://github.com/sourcegraph/sourcegraph/pull/59334)
+- Remote embeddings as context source for Cody has been removed. [#59493](https://github.com/sourcegraph/sourcegraph/pull/59493)
 
 ## Unreleased 5.2.6
 

--- a/cmd/frontend/graphqlbackend/embeddings.graphql
+++ b/cmd/frontend/graphqlbackend/embeddings.graphql
@@ -21,7 +21,7 @@ extend type Query {
         The number of text results to return. Text results contain Markdown files and similar file types primarily used for writing documentation.
         """
         textResultsCount: Int!
-    ): EmbeddingsSearchResults!
+    ): EmbeddingsSearchResults! @deprecated(reason: "use getCodyContext instead.")
 
     """
     Experimental: Searches a set of repositories for similar code and text results using embeddings.
@@ -45,7 +45,7 @@ extend type Query {
         The number of text results to return. Text results contain Markdown files and similar file types primarily used for writing documentation.
         """
         textResultsCount: Int!
-    ): EmbeddingsSearchResults!
+    ): EmbeddingsSearchResults! @deprecated(reason: "use getCodyContext instead.")
 
     """
     Experimental: Determines whether the given query requires further context before it can be answered.

--- a/cmd/frontend/internal/context/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/context/resolvers/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
         "requires-network",
     ],
     deps = [
+        "//cmd/frontend/envvar",
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
         "//internal/api",

--- a/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/cmd/frontend/internal/context/resolvers/context_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -39,6 +40,8 @@ func TestContextResolver(t *testing.T) {
 	repo1 := types.Repo{Name: "repo1"}
 	repo2 := types.Repo{Name: "repo2"}
 	truePtr := true
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{
 			CodyEnabled: &truePtr,
@@ -51,8 +54,9 @@ func TestContextResolver(t *testing.T) {
 		},
 	})
 
+	oldMock := licensing.MockCheckFeature
 	defer func() {
-		licensing.MockParseProductLicenseKeyWithBuiltinOrGenerationKey = nil
+		licensing.MockCheckFeature = oldMock
 	}()
 
 	licensing.MockCheckFeature = func(feature licensing.Feature) error {

--- a/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/embeddings/resolvers/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     embed = [":resolvers"],
     tags = ["requires-network"],
     deps = [
+        "//cmd/frontend/envvar",
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
         "//internal/api",

--- a/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -39,6 +40,8 @@ func TestDBPaginationWithRepoFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enable embeddings, so that resolvers work:
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{
 			CodyEnabled: pointers.Ptr(true),

--- a/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -29,7 +30,8 @@ import (
 
 func TestEmbeddingSearchResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
-
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
 	oldMock := licensing.MockCheckFeature
 	licensing.MockCheckFeature = func(feature licensing.Feature) error {
 		return nil
@@ -42,6 +44,9 @@ func TestEmbeddingSearchResolver(t *testing.T) {
 	mockRepos := dbmocks.NewMockRepoStore()
 	mockRepos.GetByIDsFunc.SetDefaultReturn([]*types.Repo{{ID: 1, Name: "repo1"}}, nil)
 	mockDB.ReposFunc.SetDefaultReturn(mockRepos)
+	mockUsers := dbmocks.NewMockUserStore()
+	mockUsers.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1, SiteAdmin: true}, nil)
+	mockDB.UsersFunc.SetDefaultReturn(mockUsers)
 
 	type Perm struct {
 		namespace rtypes.PermissionNamespace
@@ -99,6 +104,7 @@ func TestEmbeddingSearchResolver(t *testing.T) {
 		SiteConfiguration: schema.SiteConfiguration{
 			CodyEnabled: pointers.Ptr(true),
 			LicenseKey:  "asdf",
+			Embeddings:  &schema.Embeddings{},
 		},
 	})
 

--- a/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
@@ -57,7 +57,7 @@ func TestEmbeddingSearchResolver(t *testing.T) {
 	}
 	users := dbmocks.NewMockUserStore()
 	users.GetByCurrentAuthUserFunc.SetDefaultHook(func(ctx context.Context) (*types.User, error) {
-		return &types.User{ID: 1, SiteAdmin: false}, nil
+		return &types.User{ID: 1, SiteAdmin: true}, nil
 	})
 	mockDB.UsersFunc.SetDefaultReturn(users)
 	permissions := dbmocks.NewMockPermissionStore()

--- a/cmd/worker/internal/embeddings/repo/handler.go
+++ b/cmd/worker/internal/embeddings/repo/handler.go
@@ -58,7 +58,8 @@ var splitOptions = codeintelContext.SplitOptions{
 func (h *handler) Handle(ctx context.Context, logger log.Logger, record *bgrepo.RepoEmbeddingJob) (err error) {
 	embeddingsConfig := conf.GetEmbeddingsConfig(conf.Get().SiteConfig())
 	if embeddingsConfig == nil {
-		return errors.New("embeddings are not configured or disabled")
+		logger.Warn("embeddings are not configured or disabled")
+		return nil
 	}
 
 	ctx = featureflag.WithFlags(ctx, h.db.FeatureFlags())

--- a/internal/codygateway/client.go
+++ b/internal/codygateway/client.go
@@ -47,30 +47,16 @@ type Client interface {
 func NewClientFromSiteConfig(cli httpcli.Doer) (_ Client, ok bool) {
 	config := conf.Get().SiteConfig()
 	cc := conf.GetCompletionsConfig(config)
-	ec := conf.GetEmbeddingsConfig(config)
-
-	// If neither completions nor embeddings are configured, return empty.
-	if cc == nil && ec == nil {
-		return nil, false
-	}
 
 	// TODO: What if customer is BYOK? How do we talk to gateway then?
-	// If neither completions nor embeddings use Cody Gateway, return empty.
+	// If completions isn't using Cody Gateway, return empty.
 	ccUsingGateway := cc != nil && cc.Provider == conftypes.CompletionsProviderNameSourcegraph
-	ecUsingGateway := ec != nil && ec.Provider == conftypes.EmbeddingsProviderNameSourcegraph
-	if !ccUsingGateway && !ecUsingGateway {
+	if !ccUsingGateway {
 		return nil, false
 	}
 
-	// It's possible the user is only using Cody Gateway for completions _or_ embeddings
-	// make sure to get the url/token for the sourcegraph provider
-	// start with the embeddings since there are fewer options
-	endpoint := ec.Endpoint
-	token := ec.AccessToken
-	if ec.Provider != conftypes.EmbeddingsProviderNameSourcegraph {
-		endpoint = cc.Endpoint
-		token = cc.AccessToken
-	}
+	endpoint := cc.Endpoint
+	token := cc.AccessToken
 
 	return NewClient(cli, endpoint, token), true
 }

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/cronexpr"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/conf/deploy"
@@ -885,6 +886,11 @@ const embeddingsMaxFileSizeBytes = 1000000
 func GetEmbeddingsConfig(siteConfig schema.SiteConfiguration) *conftypes.EmbeddingsConfig {
 	// If cody is disabled, don't use embeddings.
 	if !codyEnabled(siteConfig) {
+		return nil
+	}
+
+	// Only allow embeddings on dotcom
+	if !envvar.SourcegraphDotComMode() {
 		return nil
 	}
 

--- a/internal/embeddings/background/repo/BUILD.bazel
+++ b/internal/embeddings/background/repo/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "requires-network",
     ],
     deps = [
+        "//cmd/frontend/envvar",
         "//internal/api",
         "//internal/codeintel/policies/shared",
         "//internal/conf",

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/policies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -22,6 +23,8 @@ import (
 
 func TestRepoEmbeddingJobsStore(t *testing.T) {
 	t.Parallel()
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
 
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
@@ -243,6 +246,8 @@ func TestCancelRepoEmbeddingJob(t *testing.T) {
 
 func TestGetEmbeddableRepos(t *testing.T) {
 	t.Parallel()
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
 
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
@@ -395,6 +400,8 @@ func TestGetEmbeddableReposLimit(t *testing.T) {
 }
 
 func TestGetEmbeddableRepoOpts(t *testing.T) {
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
 	conf.Mock(&conf.Unified{})
 	defer conf.Mock(nil)
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestRepoEmbeddingJobsStore(t *testing.T) {
-	t.Parallel()
 	envvar.MockSourcegraphDotComMode(true)
 	defer envvar.MockSourcegraphDotComMode(false)
 
@@ -145,8 +144,6 @@ func TestRepoEmbeddingJobsStore(t *testing.T) {
 }
 
 func TestRescheduleAll(t *testing.T) {
-	t.Parallel()
-
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
@@ -189,8 +186,6 @@ func TestRescheduleAll(t *testing.T) {
 }
 
 func TestCancelRepoEmbeddingJob(t *testing.T) {
-	t.Parallel()
-
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()
@@ -245,7 +240,6 @@ func TestCancelRepoEmbeddingJob(t *testing.T) {
 }
 
 func TestGetEmbeddableRepos(t *testing.T) {
-	t.Parallel()
 	envvar.MockSourcegraphDotComMode(true)
 	defer envvar.MockSourcegraphDotComMode(false)
 
@@ -292,8 +286,6 @@ func TestGetEmbeddableRepos(t *testing.T) {
 }
 
 func TestEmbeddingsPolicyWithFailures(t *testing.T) {
-	t.Parallel()
-
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	repoStore := db.Repos()

--- a/internal/embeddings/db/BUILD.bazel
+++ b/internal/embeddings/db/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     ],
     embed = [":db"],
     deps = [
+        "//cmd/frontend/envvar",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//lib/pointers",

--- a/internal/embeddings/db/conf_test.go
+++ b/internal/embeddings/db/conf_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
@@ -14,6 +15,8 @@ import (
 )
 
 func TestNewDBFromConfFunc(t *testing.T) {
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(false)
 	t.Run("default nil", func(t *testing.T) {
 		conf.Mock(&conf.Unified{
 			ServiceConnectionConfig: conftypes.ServiceConnections{

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -2551,6 +2551,7 @@
       "group": "Cody"
     },
     "embeddings": {
+      "deprecationMessage": "Deprecated changes to this section will not be respected.",
       "description": "Configuration for embeddings service.",
       "type": "object",
       "properties": {


### PR DESCRIPTION
Overrides the embeddings config to default embeddings to disabled unless the site is running in dotcom mode.  This is a first minimal step to removing embeddings, dotcom is still dependent on the embeddings config to supply PLG rate limits for local generated embeddings and the current extension versions still use remote embeddings from dotcom as an additional context source.  

When embeddings are no longer need for dotcom the code related to embeddings can be removed. 

closes https://github.com/sourcegraph/sourcegraph/issues/59308

## Test plan
unit tests updated
manual test using `sg start` - extension didn't attempt to search embeddings because they are disabled.
manual test using `sg start dotcom` - extension saw embeddings enabled for repo and searched successfully
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
