### PR TITLE
fix code actions color mismatch

### DIFF
--- a/client/web/src/open-in-editor/OpenInEditorActionItem.module.scss
+++ b/client/web/src/open-in-editor/OpenInEditorActionItem.module.scss
@@ -1,7 +1,7 @@
 .icon {
     width: 0.75rem;
     height: 0.75rem;
-    fill: var(--icon-color) !important
+    fill: var(--icon-color) !important;
 }
 
 .item {

--- a/client/web/src/open-in-editor/OpenInEditorActionItem.module.scss
+++ b/client/web/src/open-in-editor/OpenInEditorActionItem.module.scss
@@ -1,6 +1,7 @@
 .icon {
     width: 0.75rem;
     height: 0.75rem;
+    fill: var(--icon-color) !important
 }
 
 .item {

--- a/client/web/src/opencodegraph/global/ToggleOpenCodeGraphVisibility.module.scss
+++ b/client/web/src/opencodegraph/global/ToggleOpenCodeGraphVisibility.module.scss
@@ -1,0 +1,3 @@
+.repo-action-icon {
+    fill: var(--icon-color) !important;
+}

--- a/client/web/src/opencodegraph/global/ToggleOpenCodeGraphVisibility.tsx
+++ b/client/web/src/opencodegraph/global/ToggleOpenCodeGraphVisibility.tsx
@@ -10,6 +10,8 @@ import { RepoHeaderActionAnchor, RepoHeaderActionMenuLink } from '../../repo/com
 
 import { useOpenCodeGraphVisibility } from './useOpenCodeGraphVisibility'
 
+import styles from './ToggleOpenCodeGraphVisibility.module.scss'
+
 interface Props {
     source?: 'repoHeader' | 'actionItemsBar'
     actionType?: 'nav' | 'dropdown'
@@ -34,7 +36,7 @@ export const ToggleOpenCodeGraphVisibilityAction: React.FC<Props> = props => {
     if (props.source === 'actionItemsBar') {
         return (
             <SimpleActionItem tooltip={descriptiveText} isActive={visible} onSelect={onCycle} disabled={disabled}>
-                <Icon aria-hidden={true} svgPath={icon} />
+                <Icon aria-hidden={true} svgPath={icon} className={styles.repoActionIcon} />
             </SimpleActionItem>
         )
     }
@@ -42,7 +44,7 @@ export const ToggleOpenCodeGraphVisibilityAction: React.FC<Props> = props => {
     if (props.actionType === 'dropdown') {
         return (
             <RepoHeaderActionMenuLink file={true} as={Button} onClick={onCycle} disabled={disabled}>
-                <Icon aria-hidden={true} svgPath={icon} />
+                <Icon aria-hidden={true} svgPath={icon} className={styles.repoActionIcon} />
                 <span>{descriptiveText}</span>
             </RepoHeaderActionMenuLink>
         )
@@ -55,7 +57,7 @@ export const ToggleOpenCodeGraphVisibilityAction: React.FC<Props> = props => {
                 disabled={disabled}
                 className="d-flex justify-content-center align-items-center"
             >
-                <Icon aria-hidden={true} svgPath={icon} />
+                <Icon aria-hidden={true} svgPath={icon} className={styles.repoActionIcon} />
             </RepoHeaderActionAnchor>
         </Tooltip>
     )

--- a/client/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/client/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -122,6 +122,7 @@ export const GoToCodeHostAction: React.FunctionComponent<
                   props.range,
                   props.position
               )
+
     if (!serviceKind || !url) {
         return null
     }


### PR DESCRIPTION
[Thread](https://sourcegraph.slack.com/archives/C05EA9KQUTA/p1704903083081249)

This fixes the color mismatch in the repo actions navbar.

![CleanShot 2024-01-10 at 22 46 58@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/d7a78ed4-92bb-4d25-a066-264638ce399b)

## Test plan

Navigate to a file view `/github.com/sourcegraph/code-intel-extensions@525da1bc7a1dd5c068091f881c38b6b8210d3351/-/blob/schema/schema.graphql`