### PR TITLE
Symbol search: clean up job logic

### DIFF
--- a/cmd/frontend/internal/search/BUILD.bazel
+++ b/cmd/frontend/internal/search/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//internal/search/exhaustive/service",
         "//internal/search/exhaustive/store",
         "//internal/search/exhaustive/uploadstore",
+        "//internal/search/query",
         "//internal/search/result",
         "//internal/search/streaming",
         "//internal/search/streaming/api",

--- a/internal/search/alert.go
+++ b/internal/search/alert.go
@@ -84,7 +84,7 @@ func (q *QueryDescription) QueryString() string {
 
 // AlertForQuery converts errors in the query to search alerts.
 func AlertForQuery(queryString string, err error) *Alert {
-	if errors.HasType(err, &query.UnsupportedError{}) || errors.HasType(err, &query.ExpectedOperand{}) {
+	if errors.HasType(err, &query.ExpectedOperand{}) {
 		return &Alert{
 			PrometheusType: "unsupported_and_or_query",
 			Title:          "Unable To Process Query",

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -959,12 +959,6 @@ func TestToTextPatternInfo(t *testing.T) {
 		input:  `repo:go-diff patterntype:literal HunkNoChunksize select:commit`,
 		output: autogold.Expect(`{"Pattern":"HunkNoChunksize","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":["commit"],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
 	}, {
-		input:  `repo:go-diff patterntype:literal HunkNoChunksize select:symbol`,
-		output: autogold.Expect(`{"Pattern":"HunkNoChunksize","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":["symbol"],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
-	}, {
-		input:  `repo:go-diff patterntype:literal type:symbol HunkNoChunksize select:symbol`,
-		output: autogold.Expect(`{"Pattern":"HunkNoChunksize","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":["symbol"],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":false,"PatternMatchesPath":false,"Languages":null}`),
-	}, {
 		input:  `foo\d "bar*" patterntype:regexp`,
 		output: autogold.Expect(`{"Pattern":"(?:foo\\d).*?(?:bar\\*)","IsNegated":false,"IsRegExp":true,"IsStructuralPat":false,"CombyRule":"","IsCaseSensitive":false,"FileMatchLimit":30,"Index":"yes","Select":[],"IncludePatterns":null,"ExcludePattern":"","PathPatternsAreCaseSensitive":false,"PatternMatchesContent":true,"PatternMatchesPath":true,"Languages":null}`),
 	}, {
@@ -997,6 +991,53 @@ func TestToTextPatternInfo(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.input, func(t *testing.T) {
 			tc.output.Equal(t, test(tc.input))
+		})
+	}
+}
+
+func TestToSymbolSearchRequest(t *testing.T) {
+	cases := []struct {
+		input   string
+		output  autogold.Value
+		wantErr bool
+	}{{
+		input:  `repo:go-diff patterntype:literal HunkNoChunksize select:symbol  file:^README\.md `,
+		output: autogold.Expect(`{"RegexpPattern":"HunkNoChunksize","IsCaseSensitive":false,"IncludePatterns":["^README\\.md"],"ExcludePattern":""}`),
+	}, {
+		input:  `repo:go-diff patterntype:literal type:symbol HunkNoChunksize select:symbol -file:^README\.md `,
+		output: autogold.Expect(`{"RegexpPattern":"HunkNoChunksize","IsCaseSensitive":false,"IncludePatterns":null,"ExcludePattern":"^README\\.md"}`),
+	}, {
+		input:   `type:symbol NOT option`,
+		output:  autogold.Expect("null"),
+		wantErr: true,
+	}}
+
+	createRequest := func(input string) (*searcher.SymbolSearchRequest, error) {
+		plan, err := query.Pipeline(query.Init(input, query.SearchTypeLiteral))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b := plan[0]
+		var pattern query.Pattern
+		if p, ok := b.Pattern.(query.Pattern); ok {
+			pattern = p
+		} else {
+			t.Fatal(err)
+		}
+
+		f := query.Flat{Parameters: b.Parameters, Pattern: &pattern}
+		return toSymbolSearchRequest(f)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			r, err := createRequest(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("mismatch error = %v, wantErr %v", err, tc.wantErr)
+			}
+			v, _ := json.Marshal(r)
+			tc.output.Equal(t, string(v))
 		})
 	}
 }

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -443,10 +443,7 @@ func TestNewPlanJob(t *testing.T) {
               (repoOpts.repoFilters . [test])
               (PARTIALREPOS
                 (SEARCHERSYMBOLSEARCH
-                  (patternInfo.pattern . test)
-                  (patternInfo.isRegexp . true)
-                  (patternInfo.fileMatchLimit . 500)
-                  (patternInfo.patternMatchesPath . true)
+                  (request.pattern . test)
                   (numRepos . 0)
                   (limit . 500))))
             NOOP))))))`),
@@ -525,10 +522,7 @@ func TestNewPlanJob(t *testing.T) {
               (repoOpts.repoFilters . [test])
               (PARTIALREPOS
                 (SEARCHERSYMBOLSEARCH
-                  (patternInfo.pattern . test)
-                  (patternInfo.isRegexp . true)
-                  (patternInfo.fileMatchLimit . 500)
-                  (patternInfo.patternMatchesPath . true)
+                  (request.pattern . test)
                   (numRepos . 0)
                   (limit . 500))))
             NOOP))))))`),

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/limits"
 )
 
+// ExpectedOperand is a 'marker' error type that the frontend logic
+// knows how to convert into a user-facing alert.
 type ExpectedOperand struct {
 	Msg string
 }
@@ -19,6 +21,8 @@ func (e *ExpectedOperand) Error() string {
 	return e.Msg
 }
 
+// UnsupportedError is a 'marker' error type that the frontend logic
+// knows how to convert into a user-facing alert.
 type UnsupportedError struct {
 	Msg string
 }

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -20,9 +20,9 @@ import (
 )
 
 type SymbolSearchJob struct {
-	PatternInfo *search.TextPatternInfo
-	Repos       []*search.RepositoryRevisions // the set of repositories to search with searcher.
-	Limit       int
+	Request *SymbolSearchRequest
+	Repos   []*search.RepositoryRevisions // the set of repositories to search with searcher.
+	Limit   int
 }
 
 // Run calls the searcher service to search symbols.
@@ -46,7 +46,7 @@ func (s *SymbolSearchJob) Run(ctx context.Context, clients job.RuntimeClients, s
 		}
 
 		p.Go(func(ctx context.Context) error {
-			matches, err := searchInRepo(ctx, clients.Gitserver, repoRevs, s.PatternInfo, s.Limit)
+			matches, err := searchInRepo(ctx, clients.Gitserver, repoRevs, s.Request, s.Limit)
 			status, limitHit, err := search.HandleRepoSearchResult(repoRevs.Repo.ID, repoRevs.Revs, len(matches) > s.Limit, false, err)
 			stream.Send(streaming.SearchEvent{
 				Results: matches,
@@ -74,7 +74,7 @@ func (s *SymbolSearchJob) Attributes(v job.Verbosity) (res []attribute.KeyValue)
 	case job.VerbosityMax:
 		fallthrough
 	case job.VerbosityBasic:
-		res = append(res, trace.Scoped("patternInfo", s.PatternInfo.Fields()...)...)
+		res = append(res, trace.Scoped("patternInfo", s.Request.Fields()...)...)
 		res = append(res,
 			attribute.Int("numRepos", len(s.Repos)),
 			attribute.Int("limit", s.Limit),
@@ -86,7 +86,7 @@ func (s *SymbolSearchJob) Attributes(v job.Verbosity) (res []attribute.KeyValue)
 func (s *SymbolSearchJob) Children() []job.Describer       { return nil }
 func (s *SymbolSearchJob) MapChildren(job.MapFunc) job.Job { return s }
 
-func searchInRepo(ctx context.Context, gitserverClient gitserver.Client, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.Match, err error) {
+func searchInRepo(ctx context.Context, gitserverClient gitserver.Client, repoRevs *search.RepositoryRevisions, request *SymbolSearchRequest, limit int) (res []result.Match, err error) {
 	inputRev := repoRevs.Revs[0]
 	tr, ctx := trace.New(ctx, "symbols.searchInRepo",
 		repoRevs.Repo.Name.Attr(),
@@ -106,11 +106,11 @@ func searchInRepo(ctx context.Context, gitserverClient gitserver.Client, repoRev
 	symbols, err := symbols.DefaultClient.Search(ctx, search.SymbolsParameters{
 		Repo:            repoRevs.Repo.Name,
 		CommitID:        commitID,
-		Query:           patternInfo.Pattern,
-		IsCaseSensitive: patternInfo.IsCaseSensitive,
-		IsRegExp:        patternInfo.IsRegExp,
-		IncludePatterns: patternInfo.IncludePatterns,
-		ExcludePattern:  patternInfo.ExcludePattern,
+		Query:           request.RegexpPattern,
+		IsCaseSensitive: request.IsCaseSensitive,
+		IsRegExp:        true,
+		IncludePatterns: request.IncludePatterns,
+		ExcludePattern:  request.ExcludePattern,
 		// Ask for limit + 1 so we can detect whether there are more results than the limit.
 		First: limit + 1,
 	})
@@ -161,4 +161,33 @@ func symbolsToMatches(symbols []result.Symbol, repo types.MinimalRepo, commitID 
 	// Make the results deterministic
 	sort.Sort(matches)
 	return matches
+}
+
+// SymbolSearchRequest defines a symbol search. It's only used to build the job tree,
+// and is converted to search.SymbolsParameters when calling the symbols client.
+type SymbolSearchRequest struct {
+	RegexpPattern   string
+	IsCaseSensitive bool
+	IncludePatterns []string
+	ExcludePattern  string
+}
+
+func (r *SymbolSearchRequest) Fields() []attribute.KeyValue {
+	res := make([]attribute.KeyValue, 0, 4)
+	add := func(fs ...attribute.KeyValue) {
+		res = append(res, fs...)
+	}
+
+	add(attribute.String("pattern", r.RegexpPattern))
+	if r.IsCaseSensitive {
+		add(attribute.Bool("isCaseSensitive", r.IsCaseSensitive))
+	}
+
+	if len(r.IncludePatterns) > 0 {
+		add(attribute.StringSlice("includePatterns", r.IncludePatterns))
+	}
+	if r.ExcludePattern != "" {
+		add(attribute.String("excludePattern", r.ExcludePattern))
+	}
+	return res
 }

--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -74,7 +74,7 @@ func (s *SymbolSearchJob) Attributes(v job.Verbosity) (res []attribute.KeyValue)
 	case job.VerbosityMax:
 		fallthrough
 	case job.VerbosityBasic:
-		res = append(res, trace.Scoped("patternInfo", s.Request.Fields()...)...)
+		res = append(res, trace.Scoped("request", s.Request.Fields()...)...)
 		res = append(res,
 			attribute.Int("numRepos", len(s.Repos)),
 			attribute.Int("limit", s.Limit),


### PR DESCRIPTION
The search planning code uses the same `TextPatternInfo` struct for unindexed
search, structural search, and symbol search. However, most of the parameters
don't make sense for symbol search. This PR pulls out a dedicated
`SymbolSearchRequest` struct for symbol search to use instead.

This uncovered an error with symbol search where negation was allowed, but gave
the wrong results. With this change, we just return an error.

Relates to https://github.com/sourcegraph/sourcegraph/issues/59038

## Test plan

Existing tests for symbol search, as well as manual testing