### PR TITLE
otel: Log at most 128 characters for generic pq Arrays

### DIFF
--- a/internal/database/dbconn/open.go
+++ b/internal/database/dbconn/open.go
@@ -376,7 +376,8 @@ func argsAsAttributes(ctx context.Context, _ otelsql.Method, _ string, args []dr
 			attrs[i] = attribute.StringSlice(key, strings)
 
 		default: // in case we miss anything
-			attrs[i] = attribute.String(key, fmt.Sprintf("%v", v))
+			// To prevent very large attributes, render at most 128 characters.
+			attrs[i] = attribute.String(key, fmt.Sprintf("%.128v", v))
 		}
 	}
 	return attrs


### PR DESCRIPTION
We sometimes pass huge data here, and this can cause a very large attribute to be rendered. This PR limits it to at most 128 characters, which was chosen arbitrarily.

## Test plan

Verified with go playground that this syntax works.