### PR TITLE
msp/cloudflare: proxy by default

### DIFF
--- a/dev/managedservicesplatform/internal/resource/cloudflare/cloudflare.go
+++ b/dev/managedservicesplatform/internal/resource/cloudflare/cloudflare.go
@@ -45,7 +45,7 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 			Name:    &config.Spec.Subdomain,
 			Type:    pointers.Ptr("A"),
 			Value:   config.Target.ExternalAddress.Address(),
-			Proxied: pointers.Ptr(config.Spec.Proxied),
+			Proxied: pointers.Ptr(config.Spec.ShouldProxy()),
 			Comment: pointers.Ptr("Managed Services Platform service"),
 			Tags:    pointers.Ptr(pointers.Slice([]string{"msp"})),
 		})

--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -96,7 +96,7 @@ This service is operated on the [Managed Services Platform (MSP)](https://handbo
 		if env.EnvironmentServiceSpec != nil {
 			if domain := env.Domain.GetDNSName(); domain != "" {
 				overview = append(overview, []string{"Domain", markdown.Link(domain, "https://"+domain)})
-				if env.Domain.Cloudflare != nil && env.Domain.Cloudflare.Proxied {
+				if env.Domain.Cloudflare != nil && env.Domain.Cloudflare.ShouldProxy() {
 					overview = append(overview, []string{"Cloudflare WAF", "✅"})
 				}
 			}

--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -265,11 +265,21 @@ type EnvironmentDomainCloudflareSpec struct {
 
 	// Proxied configures whether Cloudflare should proxy all traffic to get
 	// WAF protection instead of only DNS resolution.
-	Proxied bool `yaml:"proxied,omitempty"`
+	//
+	// Default: true
+	Proxied *bool `yaml:"proxied,omitempty"`
 
 	// Required configures whether traffic can only be allowed through Cloudflare.
 	// TODO: Unimplemented.
 	Required bool `yaml:"required,omitempty"`
+}
+
+// ShouldProxy evaluates whether Cloudflare WAF proxying should be used.
+func (e *EnvironmentDomainCloudflareSpec) ShouldProxy() bool {
+	if e == nil {
+		return false
+	}
+	return pointers.Deref(e.Proxied, true)
 }
 
 type EnvironmentInstancesSpec struct {

--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
@@ -250,7 +250,7 @@ func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variable
 
 		// Provision SSL cert
 		var sslCertificate loadbalancer.SSLCertificate
-		if domain.Cloudflare.Proxied {
+		if domain.Cloudflare.ShouldProxy() {
 			sslCertificate = cloudflareorigincert.New(stack,
 				resourceid.New("cf-origin-cert"),
 				cloudflareorigincert.Config{


### PR DESCRIPTION
For most use cases, services should be behind the default Cloudflare proxy. Addresses https://github.com/sourcegraph/managed-services/pull/334#discussion_r1446496498

The only services that should not be proxied, pings and telemetry-gateway, both specify `proxied: false` explicitly already (these services should have static IPs available)

## Test plan

https://github.com/sourcegraph/managed-services/actions/runs/7482506337
