### PR TITLE
Enables tree-sitter based locals references for Go

### DIFF
--- a/internal/highlight/language.go
+++ b/internal/highlight/language.go
@@ -136,6 +136,7 @@ var baseEngineConfig = syntaxEngineConfig{
 		"perl":   EngineScipSyntax,
 		"matlab": EngineScipSyntax,
 		"java":   EngineScipSyntax,
+		"go":     EngineScipSyntax,
 	},
 }
 


### PR DESCRIPTION
## Test plan

Locally tested with the following patch:

```patch
diff --git a/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts b/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
index 7c45907c51..84c9594549 100644
--- a/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
+++ b/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts
@@ -141,6 +141,7 @@ export async function searchBasedReferences({
                 occurrence.symbol?.startsWith('local ') &&
                 occurrence.range.contains(new ScipPosition(position.line, position.character))
             ) {
+                debugger;
                 return occurrences
                     .filter(reference => reference.symbol === occurrence.symbol)
                     .map(reference => ({
```
Steps:

1. Open a Go file in the sourcegraph/sourcegraph repo
2. Hover over a local variable
3. a) Before this commit the debugger is not hit
    b) After this commit it is, which means we've succesfully extracted information about locals from the tree-sitter highlighting