### PR TITLE
Flush chat responses

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -376,7 +376,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 			// if this is a streaming request, we want to flush ourselves instead of leaving that to the http.Server
 			// (so events are sent to the client as soon as possible)
 			var responseWriter io.Writer = w
-			if autoFlushStreamingResponses && body.ShouldStream() && feature == codygateway.FeatureCodeCompletions {
+			if autoFlushStreamingResponses && body.ShouldStream() {
 				if fw, err := response.NewAutoFlushingWriter(w); err == nil {
 					responseWriter = fw
 				} else {


### PR DESCRIPTION
Flush streaming responses for chat, not only code completions.

## Test plan

- tested locally (events are returned immediately, without buffering)