### PR TITLE
Fix bazel config for backend integration tests

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -28,7 +28,7 @@ tasks:
       include_eternal_tests: true
       targets:
           - //...
-          - //testing:grpc_backend_integration_test
+          - //testing:backend_integration_test
           # This target should only really run when on main which we aren't handling. For the time being while we
           # evaluate Aspect Workflows it is ok
           # TODO(burmudar): Let this only run on main branch

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -10,7 +10,7 @@ func BazelOperations(buildOpts bk.BuildOptions, opts CoreTestOperationsOptions) 
 	if !opts.AspectWorkflows {
 		ops = append(ops, bazelPrechecks())
 		if opts.IsMainBranch {
-			ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test", "//testing:grpc_backend_integration_test"))
+			ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test", "//testing:backend_integration_test"))
 		} else {
 			ops = append(ops, bazelTest("//...", "//client/web:test"))
 		}


### PR DESCRIPTION
Renamed this job when we got rid of HTTP because that's the only version we need to run now.

## Test plan

CI will fail if the new name is still wrong.

