### PR TITLE
licensing: surface license features in jscontext

### DIFF
--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -169,8 +169,9 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether the batch changes feature is enabled on the site. */
     batchChangesEnabled: boolean
 
-    /** Whether the warning about unconfigured webhooks is disabled within Batch
-     * Changes. */
+    /**
+     * Whether the warning about unconfigured webhooks is disabled within Batch Changes.
+     */
     batchChangesDisableWebhooksWarning: boolean
 
     batchChangesWebhookLogsEnabled: boolean
@@ -262,6 +263,8 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
         codeScaleExceededLimit?: boolean
         batchChanges?: BatchChangesLicenseInfo
         knownLicenseTags?: string[]
+
+        features: LicenseFeatures
     }
 
     /** sha256 hashed license key */
@@ -281,4 +284,11 @@ export interface BrandAssets {
     logo?: string
     /** The URL to the symbol used as the search icon */
     symbol?: string
+}
+
+/**
+ * Defines the license features available.
+ */
+export interface LicenseFeatures {
+    codeSearch: boolean
 }

--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -19,6 +19,12 @@ type FeatureBatchChanges struct {
 	MaxNumChangesets int `json:"maxNumChangesets"`
 }
 
+// LicenseFeatures contains information about licensed features that are
+// enabled/disabled on the current license.
+type LicenseFeatures struct {
+	CodeSearch bool `json:"codeSearch"`
+}
+
 // LicenseInfo contains non-sensitive information about the legitimate usage of the
 // current license on the instance. It is technically accessible to all users, so only
 // include information that is safe to be seen by others.
@@ -30,6 +36,8 @@ type LicenseInfo struct {
 	CodeScaleExceededLimit bool                 `json:"codeScaleExceededLimit"`
 	KnownLicenseTags       []string             `json:"knownLicenseTags"`
 	BatchChanges           *FeatureBatchChanges `json:"batchChanges"`
+
+	Features LicenseFeatures `json:"features"`
 }
 
 var GetLicenseInfo = func() *LicenseInfo { return nil }

--- a/cmd/frontend/internal/licensing/init/init.go
+++ b/cmd/frontend/internal/licensing/init/init.go
@@ -109,6 +109,8 @@ func Init(
 			}
 		}
 
+		licenseInfo.Features.CodeSearch = licensing.Check(licensing.FeatureCodeSearch) == nil
+
 		return licenseInfo
 	}
 


### PR DESCRIPTION
Closes #59516

This PR surfaces information about the features available on a license. We use this to determine whether code-search-related features should be available via the Web App. 

## Test plan

Accessing `window.context` on the Web App should return the `features` field within the `license` object.

![CleanShot 2024-01-11 at 21 40 06@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/5474dbcb-f7b5-4fbb-9048-a95ed48ccdde)
