### PR TITLE
msp/operationdocs: talk more about TFC and Cloud Run

### DIFF
--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
@@ -31,17 +31,51 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 | Resources  |                                                                                                     |
 | Alerts     | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-dev-xxxx) |
 
-MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
-Test environments have less stringent requirements.
+MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
 |          ACCESS          |                                                                                                                                                                 ENTITLE REQUEST TEMPLATE                                                                                                                                                                  |
 |--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 | GCP project write access | [Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
+For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
+
 #### dev Cloud Run
 
-| PROPERTY |                                                                                                                                                              DETAILS                                                                                                                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Console  | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx)                                                                                                                                                                                                                                            |
-| Logs     | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-dev-xxxx) |
+The msp-testbed dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
+
+|   PROPERTY   |                                                                                                                                                              DETAILS                                                                                                                                                              |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Console      | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx)                                                                                                                                                                                                                                            |
+| Service logs | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-dev-xxxx) |
+
+You can also use `sg msp` to quickly open a link to your service logs:
+
+```bash
+sg msp logs msp-testbed dev
+```
+
+#### dev Terraform Cloud
+
+This service's configuration is defined in [`sourcegraph/managed-services/services/msp-testbed/service.yaml`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml), and `sg msp generate msp-testbed dev` generates the required infrastructure configuration for this environment in Terraform.
+Terraform Cloud (TFC) workspaces specific to each service then provisions the required infrastructure from this configuration.
+You may want to check your service environment's TFC workspaces if a Terraform apply fails (reported via GitHub commit status checks in the [`sourcegraph/managed-services`](https://github.com/sourcegraph/managed-services) repository, or in #alerts-msp-tfc).
+
+> [!NOTE]
+> If you are looking for service logs, see the [dev Cloud Run](#dev-cloud-run) section instead. In general:
+> 
+> - check service logs ([dev Cloud Run](#dev-cloud-run)) if your service has gone down or is misbehaving
+> - check TFC workspaces for infrastructure provisioning or configuration issues
+
+To access this environment's Terraform Cloud workspaces, you will need to [log in to Terraform Cloud](https://app.terraform.io/app/sourcegraph) and then [request Entitle access to membership in the "Managed Services Platform Operator" TFC team](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjM2MDAiLCJqdXN0aWZpY2F0aW9uIjoiSlVTVElGSUNBVElPTiBIRVJFIiwicm9sZUlkcyI6W3siaWQiOiJiMzg3MzJjYy04OTUyLTQ2Y2QtYmIxZS1lZjI2ODUwNzIyNmIiLCJ0aHJvdWdoIjoiYjM4NzMyY2MtODk1Mi00NmNkLWJiMWUtZWYyNjg1MDcyMjZiIiwidHlwZSI6InJvbGUifV19).
+The "Managed Services Platform Operator" team has access to all MSP TFC workspaces.
+
+> [!WARNING]
+> You **must [log in to Terraform Cloud](https://app.terraform.io/app/sourcegraph) before making your Entitle request**.
+> If you make your Entitle request, then log in, you will be removed from any team memberships granted through Entitle by Terraform Cloud's SSO implementation.
+
+The Terraform Cloud workspaces for this service environment are [grouped under the `msp-msp-testbed-dev` tag](https://app.terraform.io/app/sourcegraph/workspaces?tag=msp-msp-testbed-dev), or you can use:
+
+```bash
+sg msp tfc view msp-testbed dev
+```

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
@@ -31,20 +31,29 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 | Resources  | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
 | Alerts     | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-dev-xxxx)                         |
 
-MSP infrastructure access needs to be requested using Entitle for time-bound privileges.
-Test environments have less stringent requirements.
+MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 
 |          ACCESS          |                                                                                                                                                                 ENTITLE REQUEST TEMPLATE                                                                                                                                                                  |
 |--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | GCP project read access  | [Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiZGY3NWJkNWMtYmUxOC00MjhmLWEzNjYtYzlhYTU1MGIwODIzIiwidGhyb3VnaCI6ImRmNzViZDVjLWJlMTgtNDI4Zi1hMzY2LWM5YWE1NTBiMDgyMyIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 | GCP project write access | [Entitle request for the 'Engineering Projects' folder](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjIxNjAwIiwianVzdGlmaWNhdGlvbiI6IkVOVEVSIEpVU1RJRklDQVRJT04gSEVSRSIsInJvbGVJZHMiOlt7ImlkIjoiYzJkMTUwOGEtMGQ0ZS00MjA1LWFiZWUtOGY1ODg1ZGY3ZDE4IiwidGhyb3VnaCI6ImMyZDE1MDhhLTBkNGUtNDIwNS1hYmVlLThmNTg4NWRmN2QxOCIsInR5cGUiOiJyb2xlIn1dfQ%3D%3D) |
 
+For Terraform Cloud access, see [dev Terraform Cloud](#dev-terraform-cloud).
+
 #### dev Cloud Run
 
-| PROPERTY |                                                                                                                                                              DETAILS                                                                                                                                                              |
-|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Console  | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx)                                                                                                                                                                                                                                            |
-| Logs     | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-dev-xxxx) |
+The msp-testbed dev service implementation is deployed on [Google Cloud Run](https://cloud.google.com/run).
+
+|   PROPERTY   |                                                                                                                                                              DETAILS                                                                                                                                                              |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Console      | [Cloud Run service](https://console.cloud.google.com/run?project=msp-testbed-dev-xxxx)                                                                                                                                                                                                                                            |
+| Service logs | [GCP logging](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%20-logName%3D~%22logs%2Frun.googleapis.com%252Frequests%22;summaryFields=jsonPayload%252FInstrumentationScope,jsonPayload%252FBody,jsonPayload%252FAttributes%252Ferror:false:32:end?project=msp-testbed-dev-xxxx) |
+
+You can also use `sg msp` to quickly open a link to your service logs:
+
+```bash
+sg msp logs msp-testbed dev
+```
 
 #### dev Redis
 
@@ -76,3 +85,28 @@ sg msp pg connect -write-access msp-testbed dev
 | Dataset Project | `msp-testbed-dev-xxxx`                                                                                                                                                                                                         |
 | Dataset ID      | `msp_testbed`                                                                                                                                                                                                                  |
 | Tables          | [`bar`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/bar.bigquerytable.json), [`baz`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/baz.bigquerytable.json) |
+
+#### dev Terraform Cloud
+
+This service's configuration is defined in [`sourcegraph/managed-services/services/msp-testbed/service.yaml`](https://github.com/sourcegraph/managed-services/blob/main/services/msp-testbed/service.yaml), and `sg msp generate msp-testbed dev` generates the required infrastructure configuration for this environment in Terraform.
+Terraform Cloud (TFC) workspaces specific to each service then provisions the required infrastructure from this configuration.
+You may want to check your service environment's TFC workspaces if a Terraform apply fails (reported via GitHub commit status checks in the [`sourcegraph/managed-services`](https://github.com/sourcegraph/managed-services) repository, or in #alerts-msp-tfc).
+
+> [!NOTE]
+> If you are looking for service logs, see the [dev Cloud Run](#dev-cloud-run) section instead. In general:
+> 
+> - check service logs ([dev Cloud Run](#dev-cloud-run)) if your service has gone down or is misbehaving
+> - check TFC workspaces for infrastructure provisioning or configuration issues
+
+To access this environment's Terraform Cloud workspaces, you will need to [log in to Terraform Cloud](https://app.terraform.io/app/sourcegraph) and then [request Entitle access to membership in the "Managed Services Platform Operator" TFC team](https://app.entitle.io/request?data=eyJkdXJhdGlvbiI6IjM2MDAiLCJqdXN0aWZpY2F0aW9uIjoiSlVTVElGSUNBVElPTiBIRVJFIiwicm9sZUlkcyI6W3siaWQiOiJiMzg3MzJjYy04OTUyLTQ2Y2QtYmIxZS1lZjI2ODUwNzIyNmIiLCJ0aHJvdWdoIjoiYjM4NzMyY2MtODk1Mi00NmNkLWJiMWUtZWYyNjg1MDcyMjZiIiwidHlwZSI6InJvbGUifV19).
+The "Managed Services Platform Operator" team has access to all MSP TFC workspaces.
+
+> [!WARNING]
+> You **must [log in to Terraform Cloud](https://app.terraform.io/app/sourcegraph) before making your Entitle request**.
+> If you make your Entitle request, then log in, you will be removed from any team memberships granted through Entitle by Terraform Cloud's SSO implementation.
+
+The Terraform Cloud workspaces for this service environment are [grouped under the `msp-msp-testbed-dev` tag](https://app.terraform.io/app/sourcegraph/workspaces?tag=msp-msp-testbed-dev), or you can use:
+
+```bash
+sg msp tfc view msp-testbed dev
+```


### PR DESCRIPTION
Makes some additions to the docs aimed at clarifying [some confusion we saw recently](https://sourcegraph.slack.com/archives/C05GJPTSZCZ/p1704979291858529?thread_ts=1704733470.477189&cid=C05GJPTSZCZ), where it might not be immediately obvious where to go to find your service for those who are unfamiliar.

## Test plan

Golden tests