### PR TITLE
otel: Only log type for unknown arguments in sql

### DIFF
--- a/internal/database/dbconn/open.go
+++ b/internal/database/dbconn/open.go
@@ -376,7 +376,7 @@ func argsAsAttributes(ctx context.Context, _ otelsql.Method, _ string, args []dr
 			attrs[i] = attribute.StringSlice(key, strings)
 
 		default: // in case we miss anything
-			attrs[i] = attribute.String(key, fmt.Sprintf("%v", v))
+			attrs[i] = attribute.String(key, fmt.Sprintf("%T", v))
 		}
 	}
 	return attrs

--- a/internal/database/dbconn/open.go
+++ b/internal/database/dbconn/open.go
@@ -376,8 +376,7 @@ func argsAsAttributes(ctx context.Context, _ otelsql.Method, _ string, args []dr
 			attrs[i] = attribute.StringSlice(key, strings)
 
 		default: // in case we miss anything
-			// To prevent very large attributes, render at most 128 characters.
-			attrs[i] = attribute.String(key, fmt.Sprintf("%.128v", v))
+			attrs[i] = attribute.String(key, fmt.Sprintf("%v", v))
 		}
 	}
 	return attrs


### PR DESCRIPTION
This reverts commit 24fc9f5923328233c3257e72b10f74fb7682d658.

It doesn't have the intended effect on []int, and instead prints even longer values. 

## Test plan

CI. 