### PR TITLE
Blob view: scroll search results to center of view

### DIFF
--- a/client/web/src/repo/blob/codemirror/search.tsx
+++ b/client/web/src/repo/blob/codemirror/search.tsx
@@ -322,10 +322,24 @@ class SearchPanel implements Panel {
 
     private findNext = (): void => {
         findNext(this.view)
+        // Scroll the selection into the middle third of the view
+        this.view.dispatch({
+            effects: EditorView.scrollIntoView(this.view.state.selection.main.from, {
+                y: 'nearest',
+                yMargin: this.view.dom.getBoundingClientRect().height / 3,
+            }),
+        })
     }
 
     private findPrevious = (): void => {
         findPrevious(this.view)
+        // Scroll the selection into the middle third of the view
+        this.view.dispatch({
+            effects: EditorView.scrollIntoView(this.view.state.selection.main.from, {
+                y: 'nearest',
+                yMargin: this.view.dom.getBoundingClientRect().height / 3,
+            }),
+        })
     }
 
     // Taken from CodeMirror's default search panel implementation. This is


### PR DESCRIPTION
Fixes #57897 

This adds an effect on `findNext` that scrolls the newly-selected item into the middle third of the view rather than just scrolling the minimum amount for it to show up in the view. If it is already visible in the view, no scrolling happens.


https://github.com/sourcegraph/sourcegraph/assets/12631702/121ec818-4eb4-4dd9-9351-c36c375d253b


## Test plan

Manually tested that the scrolling feels right. 
