### PR TITLE
Expose the right model name when querying the completions model via GQL

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -640,7 +640,7 @@ func (c *codyLLMConfigurationResolver) FastChatModelMaxTokens() *int32 {
 }
 
 func (c *codyLLMConfigurationResolver) Provider() string        { return string(c.config.Provider) }
-func (c *codyLLMConfigurationResolver) CompletionModel() string { return c.config.FastChatModel }
+func (c *codyLLMConfigurationResolver) CompletionModel() string { return c.config.CompletionModel }
 func (c *codyLLMConfigurationResolver) CompletionModelMaxTokens() *int32 {
 	if c.config.CompletionModelMaxTokens != 0 {
 		max := int32(c.config.CompletionModelMaxTokens)


### PR DESCRIPTION
While working on support for StarCoder for Enterprise I noticed the GQL API was reporting the wrong model. This was probably a typo.

## Test plan

- Setting a custom completions model works as expected
<img width="1261" alt="Screenshot 2024-01-12 at 16 33 10" src="https://github.com/sourcegraph/sourcegraph/assets/458591/96b2f390-6c72-439d-addc-e4867dc389ab">
