### PR TITLE
licensing: surface cody feature status

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
@@ -39,7 +39,7 @@ export const Overview: StoryFn = () => (
 )
 
 export const OverviewWithBusinessLicense: StoryFn = () => {
-    window.context.licenseInfo = { currentPlan: 'business-0', features: { codeSearch: true } }
+    window.context.licenseInfo = { currentPlan: 'business-0', features: { codeSearch: true, cody: true } }
     return (
         <WebStory>
             {webProps => (

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -48,6 +48,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         },
         features: {
             codeSearch: true,
+            cody: true,
         },
     },
     needServerRestart: false,

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -291,4 +291,5 @@ export interface BrandAssets {
  */
 export interface LicenseFeatures {
     codeSearch: boolean
+    cody: boolean
 }

--- a/cmd/frontend/hooks/hooks.go
+++ b/cmd/frontend/hooks/hooks.go
@@ -23,6 +23,7 @@ type FeatureBatchChanges struct {
 // enabled/disabled on the current license.
 type LicenseFeatures struct {
 	CodeSearch bool `json:"codeSearch"`
+	Cody       bool `json:"cody"`
 }
 
 // LicenseInfo contains non-sensitive information about the legitimate usage of the

--- a/cmd/frontend/internal/licensing/init/init.go
+++ b/cmd/frontend/internal/licensing/init/init.go
@@ -109,7 +109,10 @@ func Init(
 			}
 		}
 
-		licenseInfo.Features.CodeSearch = licensing.Check(licensing.FeatureCodeSearch) == nil
+		licenseInfo.Features = hooks.LicenseFeatures{
+			CodeSearch: licensing.Check(licensing.FeatureCodeSearch) == nil,
+			Cody:       licensing.Check(licensing.FeatureCody) == nil,
+		}
 
 		return licenseInfo
 	}


### PR DESCRIPTION
Similar to #59528, this surfaces the cody feature status.

## Test plan

`features.cody` should be available in the JSContext.