### PR TITLE
sg msp: improve error messaging

### DIFF
--- a/dev/sg/msp/helpers.go
+++ b/dev/sg/msp/helpers.go
@@ -29,7 +29,11 @@ func useServiceArgument(c *cli.Context) (*spec.Spec, error) {
 	}
 	serviceSpecPath := msprepo.ServiceYAMLPath(serviceID)
 
-	return spec.Open(serviceSpecPath)
+	s, err := spec.Open(serviceSpecPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "load service %q", serviceID)
+	}
+	return s, nil
 }
 
 // useServiceAndEnvironmentArguments retrieves the service and environment specs
@@ -124,7 +128,7 @@ func generateTerraform(serviceID string, opts generateTerraformOptions) error {
 
 	service, err := spec.Open(serviceSpecPath)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "load service %q", serviceID)
 	}
 
 	var envs []spec.EnvironmentSpec

--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -145,14 +145,15 @@ sg msp init -owner core-services -name "MSP Example Service" msp-example
 				return ss
 			}),
 			Action: func(c *cli.Context) error {
+				if c.Args().Len() != 2 {
+					return errors.Newf("exactly 2 arguments required, '<service ID>' and '<env ID>' - " +
+						" this command is for adding an environment to an existing service, did you mean to use 'sg msp init' instead?")
+				}
 				svc, err := useServiceArgument(c)
 				if err != nil {
 					return err
 				}
-				envID := c.Args().Get(1)
-				if envID == "" {
-					return errors.New("second argument <environment ID> is required")
-				}
+				envID := c.Args().Get(1) // we already validate 2 arguments
 				if existing := svc.GetEnvironment(envID); existing != nil {
 					return errors.Newf("environment %q already exists", envID)
 				}
@@ -359,7 +360,7 @@ The '-handbook-path' flag can also be used to specify where sourcegraph/handbook
 						for _, s := range services {
 							svc, err := spec.Open(msprepo.ServiceYAMLPath(s))
 							if err != nil {
-								return err
+								return errors.Wrapf(err, "load service %q", s)
 							}
 							serviceSpecs = append(serviceSpecs, svc)
 							doc, err := operationdocs.Render(*svc, opts)


### PR DESCRIPTION
Addresses some feedback from [this thread](https://sourcegraph.slack.com/archives/C05GJPTSZCZ/p1705074439174099):

1. `init-env` might be easily confused for `init`, this change adds an up-front check that all arguments are present and returns an error message suggesting `init` just in case you haven't created a service yet
2. If a service spec can't be opened, we now return an error message `service does not exist`
3. All callsites of `spec.Open` now wrap the error with the ID of the service they are expecting to open

## Test plan

```
$ sg msp init-env dev               
❌ exactly 2 arguments required, '<service ID>' and '<env ID>' -  this command is for adding an environment to an existing service, did you mean to use 'sg msp init' instead?
$ sg msp init-env asdfasdf dev
❌ load service "asdfasdf": service does not exist: open services/asdfasdf/service.yaml: no such file or directory
```