### PR TITLE
[Backport 5.2] accesstokens: allow last_used_at to be semi-stale (#59284)

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//cmd/frontend/graphqlbackend",
         "//cmd/frontend/graphqlbackend/graphqlutil",
+        "//internal/accesstoken",
         "//internal/actor",
         "//internal/audit",
         "//internal/auth",

--- a/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/tokens_db.go
@@ -2,10 +2,15 @@ package productsubscription
 
 import (
 	"context"
+	"database/sql"
 	"encoding/hex"
 	"strings"
+	"time"
 
 	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
@@ -82,37 +87,56 @@ func (e dotcomUserNotFoundError) NotFound() bool {
 	return true
 }
 
-// dotcomUserGatewayAccessTokenPrefix is the prefix used for identifying tokens
-// generated for dotcom users to access the cody-gateway.
-const dotcomUserGatewayAccessTokenPrefix = "sgd_"
-
 // LookupDotcomUserIDByAccessToken returns the userID
 // corresponding to a token, trimming token prefixes if there are any.
 func (t dbTokens) LookupDotcomUserIDByAccessToken(ctx context.Context, token string) (int, error) {
-	if !strings.HasPrefix(token, dotcomUserGatewayAccessTokenPrefix) {
+	if !strings.HasPrefix(token, accesstoken.DotcomUserGatewayAccessTokenPrefix) {
 		return 0, dotcomUserNotFoundError{reason: "invalid token with unknown prefix"}
 	}
-	decoded, err := hex.DecodeString(strings.TrimPrefix(token, dotcomUserGatewayAccessTokenPrefix))
+	rawToken := strings.TrimPrefix(token, accesstoken.DotcomUserGatewayAccessTokenPrefix)
+	decoded, err := hex.DecodeString(rawToken)
 	if err != nil {
 		return 0, dotcomUserNotFoundError{reason: "invalid token encoding"}
 	}
 
+	// Query the token's id, subject_user_id, and last_used_at.
 	query := sqlf.Sprintf(`
-UPDATE access_tokens t SET last_used_at=now()
-WHERE t.id IN (
-	SELECT t2.id FROM access_tokens t2
-	JOIN users subject_user ON t2.subject_user_id=subject_user.id AND subject_user.deleted_at IS NULL
-	JOIN users creator_user ON t2.creator_user_id=creator_user.id AND creator_user.deleted_at IS NULL
-	WHERE digest(value_sha256, 'sha256')=%s AND t2.deleted_at IS NULL
-)
-RETURNING t.subject_user_id`,
-		decoded,
+	SELECT t.id, t.subject_user_id, t.last_used_at
+	FROM access_tokens t
+	WHERE t.id IN (
+		SELECT t2.id
+		FROM access_tokens t2
+		JOIN users subject_user ON t2.subject_user_id=subject_user.id AND subject_user.deleted_at IS NULL
+		JOIN users creator_user ON t2.creator_user_id=creator_user.id AND creator_user.deleted_at IS NULL
+		WHERE digest(value_sha256, 'sha256')=%s AND t2.deleted_at IS NULL
+	)`,
+		decoded)
+
+	var (
+		tokenID    int64
+		subjectID  int
+		lastUsedAt *time.Time
 	)
-	userID, found, err := basestore.ScanFirstInt(t.store.Query(ctx, query))
+	row := t.store.QueryRow(ctx, query)
+	err = row.Scan(&tokenID, &subjectID, &lastUsedAt)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, dotcomUserNotFoundError{reason: "no associated token"}
+		}
 		return 0, err
-	} else if !found {
-		return 0, dotcomUserNotFoundError{reason: "no associated token"}
 	}
-	return userID, nil
+
+	// If the token hasn't been used recently, update the last_used_at value
+	// so indicate it is still in-use.
+	if lastUsedAt == nil || time.Since(*lastUsedAt) > database.MaxAccessTokenLastUsedAtAge {
+		// We ignore the error on updating the token, since hopefully we can just
+		// update the last used at time successfully the next time the token gets used.
+		updateQuery := sqlf.Sprintf(
+			`UPDATE access_tokens t SET last_used_at=now()
+			WHERE t.id=%d AND t.deleted_at IS NULL`,
+			tokenID)
+		_ = t.store.Exec(ctx, updateQuery)
+	}
+
+	return subjectID, nil
 }

--- a/cmd/frontend/internal/dotcom/productsubscription/tokens_db_test.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/tokens_db_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/license"
@@ -57,5 +58,75 @@ func TestLookupProductSubscriptionIDByAccessToken(t *testing.T) {
 		gotPS, err := newDBTokens(db).LookupProductSubscriptionIDByAccessToken(ctx, accessToken)
 		require.NoError(t, err)
 		assert.Equal(t, gotPS, ps)
+	})
+
+	t.Run("last_used_at Updates", func(t *testing.T) {
+		// Create a new access token.
+		subject, err := db.Users().Create(ctx, database.NewUser{
+			Email:                 "u1@example.com",
+			Username:              "u1",
+			Password:              "p1",
+			EmailVerificationCode: "c1",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		creator, err := db.Users().Create(ctx, database.NewUser{
+			Email:                 "u2@example.com",
+			Username:              "u2",
+			Password:              "p2",
+			EmailVerificationCode: "c2",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testTokenID, testTokenValue, err := db.AccessTokens().Create(ctx, subject.ID, []string{"a", "b", "c"}, "n0", creator.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Fetches the test access token. Confirm its default state has last_used_at of nil.
+		initialToken, err := db.AccessTokens().GetByID(ctx, testTokenID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if initialToken.LastUsedAt != nil {
+			t.Fatal("last_used_at was not nil upon token creation")
+		}
+
+		dbTokens := newDBTokens(db)
+
+		// Call LookupDotcomUserIDByAccessToken. This will have a side-effect of updating the
+		// token's last_used_at column.
+		token, err := accesstoken.GenerateDotcomUserGatewayAccessToken(testTokenValue)
+		if err != nil {
+			t.Fatalf("Generating dotcom user gateway token: %v", err)
+		}
+		gotUserID, err := dbTokens.LookupDotcomUserIDByAccessToken(ctx, token)
+		if err != nil {
+			t.Fatalf("Looking up dotcom User by Access Token: %v", err)
+		}
+		if gotUserID != int(subject.ID) {
+			t.Errorf("LookupDotcomUserIDByAccessToken returned unexpected user ID: %d", gotUserID)
+		}
+
+		// Now lookup the token and confirm that last_used_at was updated as expected.
+		currentToken, err := db.AccessTokens().GetByID(ctx, testTokenID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if currentToken.LastUsedAt == nil {
+			t.Fatal("last_used_at was not set after calling LookupDotcomUserIDByAccessToken")
+		}
+		if time.Since(*currentToken.LastUsedAt) > 2*time.Second {
+			t.Errorf("last_used_at was updated, but it seems to have the wrong timestamp.")
+		}
+
+		// Cleanup
+		err = db.AccessTokens().DeleteByID(ctx, testTokenID)
+		if err != nil {
+			t.Fatal(err)
+		}
 	})
 }

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -117,7 +117,9 @@ func AccessTokenAuthMiddleware(db database.DB, baseLogger log.Logger, next http.
 			} else {
 				requiredScope = authz.ScopeSiteAdminSudo
 			}
-			subjectUserID, err := db.AccessTokens().Lookup(r.Context(), token, requiredScope)
+			subjectUserID, err := db.AccessTokens().Lookup(r.Context(), token, database.TokenLookupOpts{
+				RequiredScope: requiredScope,
+			})
 			if err != nil {
 				if err == database.ErrAccessTokenNotFound || errors.HasType(err, database.InvalidTokenError{}) {
 					anonymousId, anonCookieSet := cookie.AnonymousUID(r)

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -104,12 +104,12 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 			req.Header.Set("Authorization", headerValue)
 
 			accessTokens := dbmocks.NewMockAccessTokenStore()
-			accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
+			accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded string, opts database.TokenLookupOpts) (subjectUserID int32, err error) {
 				if want := "abcdef"; tokenHexEncoded != want {
 					t.Errorf("got %q, want %q", tokenHexEncoded, want)
 				}
-				if want := authz.ScopeUserAll; requiredScope != want {
-					t.Errorf("got %q, want %q", requiredScope, want)
+				if want := authz.ScopeUserAll; opts.RequiredScope != want {
+					t.Errorf("got %q, want %q", opts.RequiredScope, want)
 				}
 				return 123, nil
 			})
@@ -127,12 +127,12 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 		req = req.WithContext(sgactor.WithActor(context.Background(), &sgactor.Actor{UID: 456}))
 
 		accessTokens := dbmocks.NewMockAccessTokenStore()
-		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
+		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded string, opts database.TokenLookupOpts) (subjectUserID int32, err error) {
 			if want := "abcdef"; tokenHexEncoded != want {
 				t.Errorf("got %q, want %q", tokenHexEncoded, want)
 			}
-			if want := authz.ScopeUserAll; requiredScope != want {
-				t.Errorf("got %q, want %q", requiredScope, want)
+			if want := authz.ScopeUserAll; opts.RequiredScope != want {
+				t.Errorf("got %q, want %q", opts.RequiredScope, want)
 			}
 			return 123, nil
 		})
@@ -160,12 +160,12 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 			req = req.WithContext(sgactor.WithActor(context.Background(), &sgactor.Actor{UID: 456}))
 
 			accessTokens := dbmocks.NewMockAccessTokenStore()
-			accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
+			accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded string, opts database.TokenLookupOpts) (subjectUserID int32, err error) {
 				if want := "abcdef"; tokenHexEncoded != want {
 					t.Errorf("got %q, want %q", tokenHexEncoded, want)
 				}
-				if want := authz.ScopeUserAll; requiredScope != want {
-					t.Errorf("got %q, want %q", requiredScope, want)
+				if want := authz.ScopeUserAll; opts.RequiredScope != want {
+					t.Errorf("got %q, want %q", opts.RequiredScope, want)
 				}
 				return 123, nil
 			})
@@ -181,12 +181,12 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 		req.Header.Set("Authorization", `token-sudo token="abcdef",user="alice"`)
 
 		accessTokens := dbmocks.NewMockAccessTokenStore()
-		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
+		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded string, opts database.TokenLookupOpts) (subjectUserID int32, err error) {
 			if want := "abcdef"; tokenHexEncoded != want {
 				t.Errorf("got %q, want %q", tokenHexEncoded, want)
 			}
-			if want := authz.ScopeSiteAdminSudo; requiredScope != want {
-				t.Errorf("got %q, want %q", requiredScope, want)
+			if want := authz.ScopeSiteAdminSudo; opts.RequiredScope != want {
+				t.Errorf("got %q, want %q", opts.RequiredScope, want)
 			}
 			return 123, nil
 		})
@@ -228,12 +228,12 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 		req.Header.Set("Authorization", `token-sudo token="abcdef",user="alice"`)
 
 		accessTokens := dbmocks.NewMockAccessTokenStore()
-		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
+		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded string, opts database.TokenLookupOpts) (subjectUserID int32, err error) {
 			if want := "abcdef"; tokenHexEncoded != want {
 				t.Errorf("got %q, want %q", tokenHexEncoded, want)
 			}
-			if want := authz.ScopeSiteAdminSudo; requiredScope != want {
-				t.Errorf("got %q, want %q", requiredScope, want)
+			if want := authz.ScopeSiteAdminSudo; opts.RequiredScope != want {
+				t.Errorf("got %q, want %q", opts.RequiredScope, want)
 			}
 			return 123, nil
 		})
@@ -279,12 +279,12 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 		req.Header.Set("Authorization", `token-sudo token="abcdef",user="alice"`)
 
 		accessTokens := dbmocks.NewMockAccessTokenStore()
-		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
+		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded string, opts database.TokenLookupOpts) (subjectUserID int32, err error) {
 			if want := "abcdef"; tokenHexEncoded != want {
 				t.Errorf("got %q, want %q", tokenHexEncoded, want)
 			}
-			if want := authz.ScopeSiteAdminSudo; requiredScope != want {
-				t.Errorf("got %q, want %q", requiredScope, want)
+			if want := authz.ScopeSiteAdminSudo; opts.RequiredScope != want {
+				t.Errorf("got %q, want %q", opts.RequiredScope, want)
 			}
 			return 123, nil
 		})
@@ -319,12 +319,12 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 		req.Header.Set("Authorization", `token-sudo token="abcdef",user="doesntexist"`)
 
 		accessTokens := dbmocks.NewMockAccessTokenStore()
-		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded, requiredScope string) (subjectUserID int32, err error) {
+		accessTokens.LookupFunc.SetDefaultHook(func(_ context.Context, tokenHexEncoded string, opts database.TokenLookupOpts) (subjectUserID int32, err error) {
 			if want := "abcdef"; tokenHexEncoded != want {
 				t.Errorf("got %q, want %q", tokenHexEncoded, want)
 			}
-			if want := authz.ScopeSiteAdminSudo; requiredScope != want {
-				t.Errorf("got %q, want %q", requiredScope, want)
+			if want := authz.ScopeSiteAdminSudo; opts.RequiredScope != want {
+				t.Errorf("got %q, want %q", opts.RequiredScope, want)
 			}
 			return 123, nil
 		})

--- a/internal/apptoken/apptoken.go
+++ b/internal/apptoken/apptoken.go
@@ -73,7 +73,9 @@ func isExistingAppTokenPresent(ctx context.Context, db database.DB, appTokenFile
 	}
 
 	// Validate the token to confirm that it will be accepted by the API.
-	subjectUserId, err := db.AccessTokens().Lookup(ctx, payload.Token, appTokenScope)
+	subjectUserId, err := db.AccessTokens().Lookup(ctx, payload.Token, database.TokenLookupOpts{
+		RequiredScope: appTokenScope,
+	})
 	if err != nil {
 		return false
 	}

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -40,6 +40,10 @@ type AccessToken struct {
 // but it does not exist.
 var ErrAccessTokenNotFound = errors.New("access token not found")
 
+// MaxAccessTokenLastUsedAtAge is the maximum amount of time we will wait before updating an access token's
+// last_used_at column. We are OK letting the value get a little stale in order to cut down on database writes.
+const MaxAccessTokenLastUsedAtAge = 5 * time.Minute
+
 // InvalidTokenError is returned when decoding the hex encoded token passed to any
 // of the methods on AccessTokenStore.
 type InvalidTokenError struct {
@@ -119,11 +123,11 @@ type AccessTokenStore interface {
 	//
 	// The token prefix "sgp_", if present, is stripped.
 	//
-	// Calling Lookup also updates the access token's last-used-at date.
+	// Calling Lookup also updates the access token's last-used-at date as applicable.
 	//
 	// 🚨 SECURITY: This returns a user ID if and only if the token corresponds to a valid,
 	// non-deleted access token.
-	Lookup(ctx context.Context, token, requiredScope string) (subjectUserID int32, err error)
+	Lookup(ctx context.Context, token string, opts TokenLookupOpts) (subjectUserID int32, err error)
 
 	WithTransact(context.Context, func(AccessTokenStore) error) error
 	With(basestore.ShareableStore) AccessTokenStore
@@ -233,8 +237,84 @@ INSERT INTO access_tokens(subject_user_id, scopes, value_sha256, note, creator_u
 	return id, token, nil
 }
 
-func (s *accessTokenStore) Lookup(ctx context.Context, token, requiredScope string) (subjectUserID int32, err error) {
-	if requiredScope == "" {
+func (s *accessTokenStore) GetOrCreateInternalToken(ctx context.Context, subjectUserID int32, scopes []string) ([]byte, error) {
+	sha256, err := s.getInternalToken(ctx, subjectUserID)
+	if err != nil {
+		_, _, err = s.CreateInternal(ctx, subjectUserID, scopes, "Created by GetOrCreateInternalToken", subjectUserID)
+		if err != nil {
+			return nil, err
+		}
+		return s.getInternalToken(ctx, subjectUserID)
+	}
+	return sha256, nil
+}
+
+// getInternalToken returns the SHA256 hash of a random internal access token for the given user.
+func (s *accessTokenStore) getInternalToken(ctx context.Context, subjectUserID int32) ([]byte, error) {
+	conds := []*sqlf.Query{
+		sqlf.Sprintf("subject_user_id=%d", subjectUserID),
+		sqlf.Sprintf("deleted_at IS NULL"),
+		sqlf.Sprintf("internal IS TRUE"),
+	}
+	q := sqlf.Sprintf(`SELECT value_sha256 FROM access_tokens WHERE (%s) LIMIT 1`,
+		sqlf.Join(conds, ") AND ("),
+	)
+
+	rows, err := s.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var sha256 []byte
+	rows.Next()
+	err = rows.Scan(&sha256)
+	if err != nil {
+		return nil, err
+	}
+	return sha256, nil
+}
+
+type TokenLookupOpts struct {
+	OnlyAdmin     bool
+	RequiredScope string
+}
+
+// Returns a query to upload the token's LastUsedAt column to "now". The returned query
+// requires one parameter: the token ID to update.
+func (o TokenLookupOpts) toUpdateLastUsedQuery() string {
+	return `
+	UPDATE access_tokens t SET last_used_at=now()
+	WHERE t.id=$1 AND t.deleted_at IS NULL
+`
+}
+
+// toGetQuery returns a SQL query that will return the following columns from
+// the access_tokens table.
+// - id
+// - subject_user_id
+// - last_used_at
+//
+// The query requires two parameters: the token's value_sha256 and scopes.
+func (o TokenLookupOpts) toGetQuery() string {
+	query := `
+	SELECT t.id, t.subject_user_id, t.last_used_at
+	FROM access_tokens t
+	JOIN users subject_user ON t.subject_user_id=subject_user.id AND subject_user.deleted_at IS NULL
+	JOIN users creator_user ON t.creator_user_id=creator_user.id AND creator_user.deleted_at IS NULL
+	WHERE t.value_sha256=$1 AND t.deleted_at IS NULL AND
+	$2 = ANY (t.scopes)
+`
+
+	if o.OnlyAdmin {
+		query += "AND subject_user.site_admin"
+	}
+
+	return query
+}
+
+func (s *accessTokenStore) Lookup(ctx context.Context, token string, opts TokenLookupOpts) (subjectUserID int32, err error) {
+	if opts.RequiredScope == "" {
 		return 0, errors.New("no scope provided in access token lookup")
 	}
 
@@ -243,27 +323,34 @@ func (s *accessTokenStore) Lookup(ctx context.Context, token, requiredScope stri
 		return 0, errors.Wrap(err, "AccessTokens.Lookup")
 	}
 
-	if err := s.Handle().QueryRowContext(ctx,
+	var (
+		tokenID    int64
+		subjectID  int32
+		lastUsedAt *time.Time
+	)
+	row := s.Handle().QueryRowContext(ctx,
 		// Ensure that subject and creator users still exist.
-		`
-UPDATE access_tokens t SET last_used_at=now()
-WHERE t.id IN (
-	SELECT t2.id FROM access_tokens t2
-	JOIN users subject_user ON t2.subject_user_id=subject_user.id AND subject_user.deleted_at IS NULL
-	JOIN users creator_user ON t2.creator_user_id=creator_user.id AND creator_user.deleted_at IS NULL
-	WHERE t2.value_sha256=$1 AND t2.deleted_at IS NULL AND
-	$2 = ANY (t2.scopes)
-)
-RETURNING t.subject_user_id
-`,
-		tokenHash, requiredScope,
-	).Scan(&subjectUserID); err != nil {
-		if err == sql.ErrNoRows {
+		opts.toGetQuery(),
+		tokenHash, opts.RequiredScope)
+	err = row.Scan(&tokenID, &subjectID, &lastUsedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrAccessTokenNotFound
 		}
 		return 0, err
 	}
-	return subjectUserID, nil
+
+	if lastUsedAt == nil || time.Until(*lastUsedAt) < -MaxAccessTokenLastUsedAtAge {
+		logger := s.logger.With(log.Int64("tokenID", tokenID), log.Int32("subjectID", subjectID))
+		_, err := s.Handle().ExecContext(ctx, opts.toUpdateLastUsedQuery(), tokenID)
+		if err != nil {
+			logger.Warn("error trying to update token's last_used_at value", log.Error(err))
+		} else {
+			logger.Debug("updated access token's last_used_at value")
+		}
+	}
+
+	return subjectID, nil
 }
 
 func (s *accessTokenStore) GetByID(ctx context.Context, id int64) (*AccessToken, error) {

--- a/internal/database/access_tokens_test.go
+++ b/internal/database/access_tokens_test.go
@@ -5,7 +5,9 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 
@@ -95,7 +97,7 @@ func testAccessTokens_Create(t *testing.T) {
 		t.Errorf("got %q, want %q", got.Note, want)
 	}
 
-	gotSubjectUserID, err := db.AccessTokens().Lookup(ctx, tv0, "a")
+	gotSubjectUserID, err := db.AccessTokens().Lookup(ctx, tv0, TokenLookupOpts{RequiredScope: "a"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -324,7 +326,17 @@ func testAccessTokens_Lookup(t *testing.T) {
 	}
 	logger := logtest.Scoped(t)
 	t.Parallel()
+
+	// Create the DB instance as well as a handle to the underlying implementation,
+	// so we can modify the table directly. We alias db because the local variable
+	// db will shadow the type without any way to disambiguate.
+	type dbType = db
 	db := NewDB(logger, dbtest.NewDB(logger, t))
+	rawDB, ok := db.(*dbType)
+	if !ok {
+		t.Fatal("NewDB returns a DB handle that is using unexpected implementation.")
+	}
+
 	ctx := context.Background()
 
 	subject, err := db.Users().Create(ctx, NewUser{
@@ -353,7 +365,7 @@ func testAccessTokens_Lookup(t *testing.T) {
 	}
 
 	for _, scope := range []string{"a", "b"} {
-		gotSubjectUserID, err := db.AccessTokens().Lookup(ctx, tv0, scope)
+		gotSubjectUserID, err := db.AccessTokens().Lookup(ctx, tv0, TokenLookupOpts{RequiredScope: scope})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -363,12 +375,12 @@ func testAccessTokens_Lookup(t *testing.T) {
 	}
 
 	// Lookup with a nonexistent scope and ensure it fails.
-	if _, err := db.AccessTokens().Lookup(ctx, tv0, "x"); err == nil {
+	if _, err := db.AccessTokens().Lookup(ctx, tv0, TokenLookupOpts{RequiredScope: "x"}); err == nil {
 		t.Fatal(err)
 	}
 
 	// Lookup with an empty scope and ensure it fails.
-	if _, err := db.AccessTokens().Lookup(ctx, tv0, ""); err == nil {
+	if _, err := db.AccessTokens().Lookup(ctx, tv0, TokenLookupOpts{RequiredScope: ""}); err == nil {
 		t.Fatal(err)
 	}
 
@@ -376,14 +388,92 @@ func testAccessTokens_Lookup(t *testing.T) {
 	if err := db.AccessTokens().DeleteByID(ctx, tid0); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.AccessTokens().Lookup(ctx, tv0, "a"); err == nil {
+	if _, err := db.AccessTokens().Lookup(ctx, tv0, TokenLookupOpts{RequiredScope: "a"}); err == nil {
 		t.Fatal(err)
 	}
 
 	// Try to Lookup a token that was never created.
-	if _, err := db.AccessTokens().Lookup(ctx, "abcdefg" /* this token value was never created */, "a"); err == nil {
+	if _, err := db.AccessTokens().Lookup(ctx, "abcdefg" /* this token value was never created */, TokenLookupOpts{RequiredScope: "a"}); err == nil {
 		t.Fatal(err)
 	}
+
+	// Calls to .Lookup() will automatically refresh the last_used_at column, but no more than a fixed
+	// frequency.
+	t.Run("last_used_at Updates", func(t *testing.T) {
+		// Create a new access token.
+		testTokenID, testTokenValue, err := db.AccessTokens().Create(ctx, subject.ID, []string{"a", "b", "c"}, "n0", creator.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Fetches the test access token. On any error aborts the test.
+		mustGetTestToken := func() *AccessToken {
+			token, err := db.AccessTokens().GetByID(ctx, testTokenID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return token
+		}
+
+		assertLastUsedSinceShorterThan := func(lastUsedAt *time.Time, maxTimeSince time.Duration) {
+			t.Helper()
+			if lastUsedAt == nil {
+				t.Fatal("time passed was nil.")
+			}
+			if time.Since(*lastUsedAt) > maxTimeSince {
+				t.Fatalf("last_used_at value is more recent than %v", maxTimeSince)
+			}
+		}
+
+		// Check the current value. last_used_at is initialized to be nil.
+		initialState := mustGetTestToken()
+		if initialState.LastUsedAt != nil {
+			t.Fatal("last_used_at was not nil upon token creation")
+		}
+
+		// Confirm that a side-effect of Lookup will initialize last_used_at.
+		// When we fetch the token again, it's value should be recent.
+		_, err = db.AccessTokens().Lookup(ctx, testTokenValue, TokenLookupOpts{RequiredScope: "a"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		postLookup := mustGetTestToken()
+		assertLastUsedSinceShorterThan(postLookup.LastUsedAt, 2*time.Second)
+
+		// Update the token's last_used_at to be old enough to force an update
+		// on the next call to .Lookup()
+		now := time.Now()
+		updateQuery := sqlf.Sprintf(
+			`UPDATE access_tokens SET last_used_at = %s WHERE id = %d`,
+			now.Add(-MaxAccessTokenLastUsedAtAge-2*time.Second), testTokenID)
+		err = rawDB.Store.Exec(ctx, updateQuery)
+		if err != nil {
+			t.Fatalf("Updating test token's last_used_at: %v", err)
+		}
+
+		// Confirm the token was updated, and last_used_at is old.
+		staleState := mustGetTestToken()
+		if staleState.LastUsedAt == nil {
+			t.Fatal("token did not have last_used_at")
+		}
+		if time.Since(*staleState.LastUsedAt) < MaxAccessTokenLastUsedAtAge {
+			t.Fatalf("last_used_at value should be older than %v", *staleState.LastUsedAt)
+		}
+
+		// Now lookup the token. A side-effect of this will update the last_used_at.
+		_, err = db.AccessTokens().Lookup(ctx, testTokenValue, TokenLookupOpts{RequiredScope: "a"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		currentState := mustGetTestToken()
+		assertLastUsedSinceShorterThan(currentState.LastUsedAt, 2*time.Second)
+
+		err = db.AccessTokens().DeleteByID(ctx, testTokenID)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 // 🚨 SECURITY: This tests that deleting the subject or creator user of an access token invalidates
@@ -425,7 +515,7 @@ func testAccessTokens_Lookup_deletedUser(t *testing.T) {
 		if err := db.Users().Delete(ctx, subject.ID); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := db.AccessTokens().Lookup(ctx, tv0, "a"); err == nil {
+		if _, err := db.AccessTokens().Lookup(ctx, tv0, TokenLookupOpts{RequiredScope: "a"}); err == nil {
 			t.Fatal("Lookup: want error looking up token for deleted subject user")
 		}
 
@@ -461,7 +551,7 @@ func testAccessTokens_Lookup_deletedUser(t *testing.T) {
 		if err := db.Users().Delete(ctx, creator.ID); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := db.AccessTokens().Lookup(ctx, tv0, "a"); err == nil {
+		if _, err := db.AccessTokens().Lookup(ctx, tv0, TokenLookupOpts{RequiredScope: "a"}); err == nil {
 			t.Fatal("Lookup: want error looking up token for deleted creator user")
 		}
 

--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -2500,15 +2500,15 @@ func (c AccessTokenStoreListFuncCall) Results() []interface{} {
 // AccessTokenStoreLookupFunc describes the behavior when the Lookup method
 // of the parent MockAccessTokenStore instance is invoked.
 type AccessTokenStoreLookupFunc struct {
-	defaultHook func(context.Context, string, string) (int32, error)
-	hooks       []func(context.Context, string, string) (int32, error)
+	defaultHook func(context.Context, string, database.TokenLookupOpts) (int32, error)
+	hooks       []func(context.Context, string, database.TokenLookupOpts) (int32, error)
 	history     []AccessTokenStoreLookupFuncCall
 	mutex       sync.Mutex
 }
 
 // Lookup delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockAccessTokenStore) Lookup(v0 context.Context, v1 string, v2 string) (int32, error) {
+func (m *MockAccessTokenStore) Lookup(v0 context.Context, v1 string, v2 database.TokenLookupOpts) (int32, error) {
 	r0, r1 := m.LookupFunc.nextHook()(v0, v1, v2)
 	m.LookupFunc.appendCall(AccessTokenStoreLookupFuncCall{v0, v1, v2, r0, r1})
 	return r0, r1
@@ -2546,7 +2546,7 @@ func (f *AccessTokenStoreLookupFunc) PushReturn(r0 int32, r1 error) {
 	})
 }
 
-func (f *AccessTokenStoreLookupFunc) nextHook() func(context.Context, string, string) (int32, error) {
+func (f *AccessTokenStoreLookupFunc) nextHook() func(context.Context, string, database.TokenLookupOpts) (int32, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2587,7 +2587,7 @@ type AccessTokenStoreLookupFuncCall struct {
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 string
+	Arg2  database.TokenLookupOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int32

--- a/internal/database/dbmocks/mocks_temp.go
+++ b/internal/database/dbmocks/mocks_temp.go
@@ -1269,7 +1269,7 @@ func NewMockAccessTokenStore() *MockAccessTokenStore {
 			},
 		},
 		LookupFunc: &AccessTokenStoreLookupFunc{
-			defaultHook: func(context.Context, string, string) (r0 int32, r1 error) {
+			defaultHook: func(context.Context, string, database.TokenLookupOpts) (r0 int32, r1 error) {
 				return
 			},
 		},
@@ -1341,7 +1341,7 @@ func NewStrictMockAccessTokenStore() *MockAccessTokenStore {
 			},
 		},
 		LookupFunc: &AccessTokenStoreLookupFunc{
-			defaultHook: func(context.Context, string, string) (int32, error) {
+			defaultHook: func(context.Context, string, database.TokenLookupOpts) (int32, error) {
 				panic("unexpected invocation of MockAccessTokenStore.Lookup")
 			},
 		},
@@ -2517,7 +2517,7 @@ func (m *MockAccessTokenStore) Lookup(v0 context.Context, v1 string, v2 database
 // SetDefaultHook sets function that is called when the Lookup method of the
 // parent MockAccessTokenStore instance is invoked and the hook queue is
 // empty.
-func (f *AccessTokenStoreLookupFunc) SetDefaultHook(hook func(context.Context, string, string) (int32, error)) {
+func (f *AccessTokenStoreLookupFunc) SetDefaultHook(hook func(context.Context, string, database.TokenLookupOpts) (int32, error)) {
 	f.defaultHook = hook
 }
 
@@ -2525,7 +2525,7 @@ func (f *AccessTokenStoreLookupFunc) SetDefaultHook(hook func(context.Context, s
 // Lookup method of the parent MockAccessTokenStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *AccessTokenStoreLookupFunc) PushHook(hook func(context.Context, string, string) (int32, error)) {
+func (f *AccessTokenStoreLookupFunc) PushHook(hook func(context.Context, string, database.TokenLookupOpts) (int32, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2534,14 +2534,14 @@ func (f *AccessTokenStoreLookupFunc) PushHook(hook func(context.Context, string,
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
 func (f *AccessTokenStoreLookupFunc) SetDefaultReturn(r0 int32, r1 error) {
-	f.SetDefaultHook(func(context.Context, string, string) (int32, error) {
+	f.SetDefaultHook(func(context.Context, string, database.TokenLookupOpts) (int32, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
 func (f *AccessTokenStoreLookupFunc) PushReturn(r0 int32, r1 error) {
-	f.PushHook(func(context.Context, string, string) (int32, error) {
+	f.PushHook(func(context.Context, string, database.TokenLookupOpts) (int32, error) {
 		return r0, r1
 	})
 }
@@ -2587,7 +2587,7 @@ type AccessTokenStoreLookupFuncCall struct {
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2  database.TokenLookupOpts
+	Arg2 database.TokenLookupOpts
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int32


### PR DESCRIPTION
This backports #59284, which changes the `last_used_at` column of access tokens to only be updated after a period of time so that we avoid significant database contention in periods of high token-auth'd API traffic that we've been observing in Sourcegraph.com due to the Cody PLG launch.

I'm backporting this because it turns out we are seeing similar problems placing significant database load on Cloud instances that have adopted Cody as they start increasing their API access traffic in a way that probably never happened before as most Code Search usage happens via UI - I've seen this alert fire many times on multiple Cloud instances. On a spot-check, at least several of the spikes in Cloud `pgsql` database (equivalent to the dotcom `sg` database) are entirely attributable to access token lookups - see [Slack message](https://sourcegraph.slack.com/archives/C05SZB829D0/p1705084254251499?thread_ts=1704221033.599109&cid=C05SZB829D0)

This was a tricky backport, so would appreciate a careful review 🙏 

(cherry picked from commit 3d9f69df4fd43c87b2b3216db81ae0e94a4eadb7)

Test plan: automated tests