### PR TITLE
ci: only run prettier on files changed between <commit> and <PR base branch>

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different --config prettier.config.js --write",
     "format:changed": "prettier $( { git diff --diff-filter=d --name-only origin/main... && git ls-files --other --modified --exclude-standard ; } | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --write --list-different --config prettier.config.js",
     "format:check": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --config prettier.config.js --check --write=false",
+    "format:ci": "prettier $( { git diff --diff-filter=d --name-only $COMMIT_SHA \"$(git merge-base $COMMIT_SHA $BUILDKITE_PULL_REQUEST_BASE_BRANCH)\" && git ls-files --other --modified --exclude-standard ; } | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --config prettier.config.js --check --write=false",
     "_lint:js": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" NODE_OPTIONS=\"--max_old_space_size=16192\" eslint",
     "lint:js:changed": "pnpm _lint:js $(git diff --diff-filter=d --name-only origin/main... | grep -E '\\.[tj]sx?$' | xargs)",
     "lint:js:root": "pnpm run _lint:js --quiet '*.[tj]s?(x)'",


### PR DESCRIPTION
`sg lint`'s `format` target runs `./dev/ci/pnpm-run.sh format:check`, which runs prettier against _every_ file. We can do better than that in CI by only running it against files that have been modified between the current branch and the base branch of the PR.

~**TODO:** this probably breaks when run on `main`, so we need to fix that first.~ Format step isnt run on main, so I _think_ this is safe

Before (left) After (right)
![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/f63de00e-2726-4ffa-8334-7f4d962330ef)


## Test plan

Tested on a branch based off https://github.com/sourcegraph/sourcegraph/tree/vk/add-mobile-layout-for-new-filters (https://github.com/sourcegraph/sourcegraph/tree/nsc-vk/lint-test_add-mobile-layout-for-new-filters

https://buildkite.com/sourcegraph/sourcegraph/builds/257779#_
