### PR TITLE
msp: upgrade to Terraform 1.3.10

### DIFF
--- a/dev/managedservicesplatform/internal/terraform/terraform.go
+++ b/dev/managedservicesplatform/internal/terraform/terraform.go
@@ -2,7 +2,7 @@ package terraform
 
 import "os"
 
-const defaultVersion = "1.3.3"
+const defaultVersion = "1.3.10"
 
 // Version is the version of Terraform to use, configurable by MSP_TERRAFORM_VERSION
 var Version = func() string {


### PR DESCRIPTION
Eyeing potentially upgrading our Terraform version to the latest ones eventually, as we started pretty far behind because I copy-pasta'd some old configs from elsewhere. The release notes of the latest one https://github.com/hashicorp/terraform/releases/tag/v1.7.0-rc2 mentions that upgraders should be on the latest patch of their `major.minor` release, which for us means 1.3.10. This should be safe to do as it's just patches.

## Test plan

n/a