### PR TITLE
Do not use locally built `sg` on aspect workflows

### DIFF
--- a/dev/ci/internal/ci/misc_operations.go
+++ b/dev/ci/internal/ci/misc_operations.go
@@ -43,7 +43,7 @@ func bazelGoModTidy() func(*bk.Pipeline) {
 func addSgLints(targets []string, opts CoreTestOperationsOptions) func(*bk.Pipeline) {
 	cmd := "./sg"
 	if opts.AspectWorkflows {
-		cmd = "go run ./dev/sg"
+		cmd = "go run ./dev/sg "
 	}
 
 	if retryCount := os.Getenv("BUILDKITE_RETRY_COUNT"); retryCount != "" && retryCount != "0" {

--- a/dev/ci/internal/ci/operations.go
+++ b/dev/ci/internal/ci/operations.go
@@ -46,7 +46,7 @@ func CoreTestOperations(buildOpts bk.BuildOptions, diff changed.Diff, opts CoreT
 	ops.Append(BazelOperations(buildOpts, opts)...)
 	linterOps := operations.NewNamedSet("Linters and static analysis")
 	if targets := changed.GetLinterTargets(diff); len(targets) > 0 {
-		linterOps.Append(addSgLints(targets))
+		linterOps.Append(addSgLints(targets, opts))
 	}
 	ops.Merge(linterOps)
 


### PR DESCRIPTION
Our aspect workflows skip running bazel prechecks, which means the dependency that sg-lint has is unsatisfied, causing all sg lint jobs to fail.

Personally I think we need a more robust solution for determining dependency satisfaction. This isn't currently possible because steps are completely programmatic and so a missing dependency cannot be synthesized in all cases. 

I think we should try to work towards doing that, but this hot-fix removes the dependency in aspect manually.

## Test plan
Runs in CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
