### PR TITLE
Include bazel prechecks on aspect

### DIFF
--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -6,9 +6,8 @@ import (
 )
 
 func BazelOperations(buildOpts bk.BuildOptions, opts CoreTestOperationsOptions) []operations.Operation {
-	ops := []operations.Operation{}
+	ops := []operations.Operation{bazelPrechecks()}
 	if !opts.AspectWorkflows {
-		ops = append(ops, bazelPrechecks())
 		if opts.IsMainBranch {
 			ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test", "//testing:backend_integration_test"))
 		} else {


### PR DESCRIPTION
Alternative to #59567 where we include bazel prechecks
## Test plan
CI change
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
