### PR TITLE
Formats our autoindexing scripts according to stylua

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/lua/java.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/java.lua
@@ -1,7 +1,7 @@
-local path = require("path")
-local pattern = require("sg.autoindex.patterns")
+local path = require "path"
+local pattern = require "sg.autoindex.patterns"
 
-local recognizer = require("sg.autoindex.recognizer")
+local recognizer = require "sg.autoindex.recognizer"
 
 local java_indexer = require("sg.autoindex.indexes").get "java"
 
@@ -22,18 +22,18 @@ end
 return recognizer.new_path_recognizer {
   patterns = {
     -- Gradle
-    pattern.new_path_basename("build.gradle"),
-    pattern.new_path_basename("build.gradle.kts"),
-    pattern.new_path_basename("gradlew"),
-    pattern.new_path_basename("settings.gradle"),
+    pattern.new_path_basename "build.gradle",
+    pattern.new_path_basename "build.gradle.kts",
+    pattern.new_path_basename "gradlew",
+    pattern.new_path_basename "settings.gradle",
     -- Maven
-    pattern.new_path_basename("pom.xml"),
+    pattern.new_path_basename "pom.xml",
     -- SBT
-    pattern.new_path_basename("build.sbt"),
+    pattern.new_path_basename "build.sbt",
     -- Mill
-    pattern.new_path_basename("build.sc"),
+    pattern.new_path_basename "build.sc",
     -- SCIP build tool
-    pattern.new_path_basename("lsif-java.json")
+    pattern.new_path_basename "lsif-java.json",
   },
   generate = function(api, paths)
     local unique_paths = {}
@@ -48,7 +48,9 @@ return recognizer.new_path_recognizer {
       table.insert(unique_paths_array, path)
     end
 
-    table.sort(unique_paths_array, function(l, r) return string.len(l) < string.len(r) end)
+    table.sort(unique_paths_array, function(l, r)
+      return string.len(l) < string.len(r)
+    end)
 
     local roots = {}
 
@@ -62,10 +64,9 @@ return recognizer.new_path_recognizer {
         },
 
         generate = function(_, _)
-          local is_nested_root = project_root ~= ''
-          local is_toplevel_root = project_root == ''
-          local top_level_root_is_already_registerd =
-              roots[''] ~= nil
+          local is_nested_root = project_root ~= ""
+          local is_toplevel_root = project_root == ""
+          local top_level_root_is_already_registerd = roots[""] ~= nil
 
           local this_root_already_registered = roots[project_root] ~= nil
 
@@ -77,20 +78,20 @@ return recognizer.new_path_recognizer {
             indexer_args = { "scip-java", "index", "--build-tool=auto" },
           }
           -- top level root should be registered anyways if it has build files and source files
-          if is_toplevel_root and (not this_root_already_registered) then
+          if is_toplevel_root and not this_root_already_registered then
             roots[project_root] = true
             return job
             -- nested roots are only registered if the top level root WASN'T
             -- this is to account for multi-module builds like ones present in Maven, where
             -- nested roots might have build files but cannot be built independently
             -- in the future these situations should be handled with the auto-indexer itself
-          elseif is_nested_root and (not this_root_already_registered) and (not top_level_root_is_already_registerd) then
+          elseif is_nested_root and not this_root_already_registered and not top_level_root_is_already_registerd then
             roots[project_root] = true
             return job
           else
             return {}
           end
-        end
+        end,
       })
     end
 

--- a/internal/codeintel/autoindexing/internal/inference/lua/patterns.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/patterns.lua
@@ -4,14 +4,14 @@ local M = {}
 
 -- type: (string, array[string]) -> pattern
 local new_pattern = function(glob, pathspecs)
-    return pattern_lib.backdoor(glob, pathspecs)
+  return pattern_lib.backdoor(glob, pathspecs)
 end
 
 -- glob:     /BUILD.bazel
 -- pathspec:  BUILD.bazel
 -- type: (string) -> pattern
 M.new_path_literal = function(globlike)
-    return new_pattern("/" .. globlike, {globlike})
+  return new_pattern("/" .. globlike, { globlike })
 end
 
 -- glob:       web/
@@ -19,7 +19,7 @@ end
 -- pathspec: */web/* (non-root)
 -- type: (string) -> pattern
 M.new_path_segment = function(globlike)
-    return new_pattern(globlike .. "/", {globlike .. "/*", "*/" .. globlike .. "/*"})
+  return new_pattern(globlike .. "/", { globlike .. "/*", "*/" .. globlike .. "/*" })
 end
 
 -- glob:       gen.go
@@ -27,24 +27,24 @@ end
 -- pathspec: */gen.go (non-root)
 -- type: (string) -> pattern
 M.new_path_basename = function(globlike)
-    return new_pattern(globlike, {globlike, "*/" .. globlike})
+  return new_pattern(globlike, { globlike, "*/" .. globlike })
 end
 
 -- glob:     *.md
 -- pathspec: *.md
 -- type: (string) -> pattern
 M.new_path_extension = function(globlike)
-    return new_pattern("*." .. globlike, {"*." .. globlike})
+  return new_pattern("*." .. globlike, { "*." .. globlike })
 end
 
 -- type: ((pattern | table[pattern])...) -> pattern
 M.new_path_combine = function(one_or_more_patterns)
-    return pattern_lib.path_combine(one_or_more_patterns)
+  return pattern_lib.path_combine(one_or_more_patterns)
 end
 
 -- type: ((pattern | table[pattern])...) -> pattern
 M.new_path_exclude = function(one_or_more_patterns)
-    return pattern_lib.path_exclude(one_or_more_patterns)
+  return pattern_lib.path_exclude(one_or_more_patterns)
 end
 
 return M

--- a/internal/codeintel/autoindexing/internal/inference/lua/python.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/python.lua
@@ -78,7 +78,8 @@ local handle_one_pkg_info = function(libraries, filepath, content)
   })
 end
 
-local increase_node_mem_step = 'if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi'
+local increase_node_mem_step =
+  'if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi'
 
 local make_job = function(root, name, version, additional_args)
   return {
@@ -90,7 +91,7 @@ local make_job = function(root, name, version, additional_args)
         commands = { "pip install . || true" },
       },
     },
-    local_steps = {increase_node_mem_step},
+    local_steps = { increase_node_mem_step },
     root = root,
     indexer = indexer,
     indexer_args = {
@@ -112,7 +113,7 @@ return recognizer.new_path_recognizer {
     pattern.new_path_basename "PKG-INFO",
     pattern.new_path_basename "requirements.txt",
     pattern.new_path_basename "pyproject.toml",
-    pattern.new_path_basename "setup.py"
+    pattern.new_path_basename "setup.py",
   },
 
   patterns_for_content = {
@@ -180,10 +181,10 @@ return recognizer.new_path_recognizer {
       for root in pairs(roots) do
         table.insert(jobs, {
           steps = {},
-          local_steps = {"pip install . || true", increase_node_mem_step},
+          local_steps = { "pip install . || true", increase_node_mem_step },
           root = root,
           indexer = indexer,
-          indexer_args = {"scip-python", "index"},
+          indexer_args = { "scip-python", "index" },
           outfile = outfile,
         })
       end

--- a/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
+++ b/internal/codeintel/autoindexing/internal/inference/lua/typescript.lua
@@ -1,17 +1,17 @@
-local json = require("json")
-local path = require("path")
-local recognizer = require("sg.autoindex.recognizer")
-local pattern = require("sg.autoindex.patterns")
+local json = require "json"
+local path = require "path"
+local recognizer = require "sg.autoindex.recognizer"
+local pattern = require "sg.autoindex.patterns"
 
-local shared = require("sg.autoindex.shared")
-local util = require("sg.autoindex.util")
+local shared = require "sg.autoindex.shared"
+local util = require "sg.autoindex.util"
 
 local indexer = require("sg.autoindex.indexes").get "typescript"
 local typescript_nmusl_command =
-	"N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto"
+  "N_NODE_MIRROR=https://unofficial-builds.nodejs.org/download/release n --arch x64-musl auto"
 
 local exclude_paths = pattern.new_path_combine(shared.exclude_paths, {
-	pattern.new_path_segment("node_modules"),
+  pattern.new_path_segment "node_modules",
 })
 
 local safe_decode = function(encoded)
@@ -23,151 +23,151 @@ local safe_decode = function(encoded)
 end
 
 local check_lerna_file = function(root, contents_by_path)
-	local ancestors = path.ancestors(root)
-	for i = 1, #ancestors do
-		local payload = safe_decode(contents_by_path[path.join(ancestors[i], "lerna.json")] or "")
-		if payload and payload["npmClient"] == "yarn" then
-			return true
-		end
-	end
+  local ancestors = path.ancestors(root)
+  for i = 1, #ancestors do
+    local payload = safe_decode(contents_by_path[path.join(ancestors[i], "lerna.json")] or "")
+    if payload and payload["npmClient"] == "yarn" then
+      return true
+    end
+  end
 
-	return false
+  return false
 end
 
 local can_derive_node_version = function(root, paths, contents_by_path)
-	local ancestors = path.ancestors(root)
+  local ancestors = path.ancestors(root)
 
-	for i = 1, #ancestors do
-		local payload = safe_decode(contents_by_path[path.join(ancestors[i], "package.json")] or "")
-		if payload and payload["engines"] and payload["engines"]["node"] then
-			return true
-		end
-	end
+  for i = 1, #ancestors do
+    local payload = safe_decode(contents_by_path[path.join(ancestors[i], "package.json")] or "")
+    if payload and payload["engines"] and payload["engines"]["node"] then
+      return true
+    end
+  end
 
-	for i = 1, #ancestors do
-		local candidates = {
-			path.join(ancestors[i], ".nvmrc"),
-			path.join(ancestors[i], ".node-version"),
-			path.join(ancestors[i], ".n-node-version"),
-		}
-		if util.contains_any(paths, candidates) then
-			return true
-		end
-	end
+  for i = 1, #ancestors do
+    local candidates = {
+      path.join(ancestors[i], ".nvmrc"),
+      path.join(ancestors[i], ".node-version"),
+      path.join(ancestors[i], ".n-node-version"),
+    }
+    if util.contains_any(paths, candidates) then
+      return true
+    end
+  end
 
-	return false
+  return false
 end
 
 local infer_typescript_job = function(api, tsconfig_path, should_infer_config)
-	local root = path.dirname(tsconfig_path)
-	local reverse_ancestors = util.reverse(path.ancestors(tsconfig_path))
+  local root = path.dirname(tsconfig_path)
+  local reverse_ancestors = util.reverse(path.ancestors(tsconfig_path))
 
-	api:register(recognizer.new_path_recognizer({
-		patterns = {
-			-- To disambiguate installation steps
-			pattern.new_path_basename("yarn.lock"),
-			-- Try to determine version
-			pattern.new_path_basename(".n-node-version"),
-			pattern.new_path_basename(".node-version"),
-			pattern.new_path_basename(".nvmrc"),
-			-- To reinvoke simple cases with no other files
-			pattern.new_path_basename("tsconfig.json"),
-			pattern.new_path_exclude(exclude_paths),
-		},
+  api:register(recognizer.new_path_recognizer {
+    patterns = {
+      -- To disambiguate installation steps
+      pattern.new_path_basename "yarn.lock",
+      -- Try to determine version
+      pattern.new_path_basename ".n-node-version",
+      pattern.new_path_basename ".node-version",
+      pattern.new_path_basename ".nvmrc",
+      -- To reinvoke simple cases with no other files
+      pattern.new_path_basename "tsconfig.json",
+      pattern.new_path_exclude(exclude_paths),
+    },
 
-		patterns_for_content = {
-			-- To read explicitly configured engines and npm client
-			pattern.new_path_basename("package.json"),
-			pattern.new_path_basename("lerna.json"),
-			pattern.new_path_exclude(exclude_paths),
-		},
+    patterns_for_content = {
+      -- To read explicitly configured engines and npm client
+      pattern.new_path_basename "package.json",
+      pattern.new_path_basename "lerna.json",
+      pattern.new_path_exclude(exclude_paths),
+    },
 
-		-- Invoked when any of the files listed in the patterns above exist.
-		generate = function(api, paths, contents_by_path)
-			local is_yarn = check_lerna_file(root, contents_by_path)
+    -- Invoked when any of the files listed in the patterns above exist.
+    generate = function(api, paths, contents_by_path)
+      local is_yarn = check_lerna_file(root, contents_by_path)
 
-			local docker_steps = {}
-			for i = 1, #reverse_ancestors do
-				if contents_by_path[path.join(reverse_ancestors[i], "package.json")] then
-					local install_command = ""
-					if is_yarn or util.contains(paths, path.join(reverse_ancestors[i], "yarn.lock")) then
-						install_command = "yarn"
-					else
-						install_command = "npm install"
-					end
+      local docker_steps = {}
+      for i = 1, #reverse_ancestors do
+        if contents_by_path[path.join(reverse_ancestors[i], "package.json")] then
+          local install_command = ""
+          if is_yarn or util.contains(paths, path.join(reverse_ancestors[i], "yarn.lock")) then
+            install_command = "yarn"
+          else
+            install_command = "npm install"
+          end
 
-					local install_command_suffix = ""
-					if should_infer_config then
-						install_command_suffix = " --ignore-scripts"
-					end
+          local install_command_suffix = ""
+          if should_infer_config then
+            install_command_suffix = " --ignore-scripts"
+          end
 
-					table.insert(docker_steps, {
-						root = reverse_ancestors[i],
-						image = indexer,
-						commands = { install_command .. install_command_suffix },
-					})
-				end
-			end
+          table.insert(docker_steps, {
+            root = reverse_ancestors[i],
+            image = indexer,
+            commands = { install_command .. install_command_suffix },
+          })
+        end
+      end
 
-			local local_steps = {}
-			if can_derive_node_version(root, paths, contents_by_path) then
-				for i = 1, #docker_steps do
-					-- Add `n` invocation command before each docker step
-					docker_steps[i].commands = util.with_new_head(docker_steps[i].commands, typescript_nmusl_command)
-				end
+      local local_steps = {}
+      if can_derive_node_version(root, paths, contents_by_path) then
+        for i = 1, #docker_steps do
+          -- Add `n` invocation command before each docker step
+          docker_steps[i].commands = util.with_new_head(docker_steps[i].commands, typescript_nmusl_command)
+        end
 
-				-- Add `n` invocation (in indexing container) before indexer runs
-				local_steps = { typescript_nmusl_command }
-			end
+        -- Add `n` invocation (in indexing container) before indexer runs
+        local_steps = { typescript_nmusl_command }
+      end
 
-			table.insert(
-				local_steps,
-				'if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi'
-			)
+      table.insert(
+        local_steps,
+        'if [ -n "${VM_MEM_MB:-}" ]; then export NODE_OPTIONS="--max-old-space-size=$VM_MEM_MB"; fi'
+      )
 
-			local args = { "scip-typescript", "index" }
-			if should_infer_config then
-				table.insert(args, "--infer-tsconfig")
-			end
+      local args = { "scip-typescript", "index" }
+      if should_infer_config then
+        table.insert(args, "--infer-tsconfig")
+      end
 
-			return {
-				steps = docker_steps,
-				local_steps = local_steps,
-				root = root,
-				indexer = indexer,
-				indexer_args = args,
-				outfile = "index.scip",
-				requested_envvars = { "NPM_TOKEN" },
-			}
-		end,
-	}))
+      return {
+        steps = docker_steps,
+        local_steps = local_steps,
+        root = root,
+        indexer = indexer,
+        indexer_args = args,
+        outfile = "index.scip",
+        requested_envvars = { "NPM_TOKEN" },
+      }
+    end,
+  })
 
-	return {}
+  return {}
 end
 
-return recognizer.new_path_recognizer({
-	patterns = {
-		pattern.new_path_basename("package.json"),
-		pattern.new_path_basename("tsconfig.json"),
-		pattern.new_path_exclude(exclude_paths),
-	},
+return recognizer.new_path_recognizer {
+  patterns = {
+    pattern.new_path_basename "package.json",
+    pattern.new_path_basename "tsconfig.json",
+    pattern.new_path_exclude(exclude_paths),
+  },
 
-	-- Invoked when package.json or tsconfig.json files exist
-	generate = function(api, paths)
-		local has_tsconfig = false
-		for i = 1, #paths do
-			if path.basename(paths[i]) == "tsconfig.json" then
-				-- Infer typescript jobs
-				infer_typescript_job(api, paths[i], false)
-				has_tsconfig = true
-			end
-		end
+  -- Invoked when package.json or tsconfig.json files exist
+  generate = function(api, paths)
+    local has_tsconfig = false
+    for i = 1, #paths do
+      if path.basename(paths[i]) == "tsconfig.json" then
+        -- Infer typescript jobs
+        infer_typescript_job(api, paths[i], false)
+        has_tsconfig = true
+      end
+    end
 
-		if not has_tsconfig then
-			-- Infer javascript jobs if there's no tsconfig.json found
-			infer_typescript_job(api, "tsconfig.json", true)
-		end
+    if not has_tsconfig then
+      -- Infer javascript jobs if there's no tsconfig.json found
+      infer_typescript_job(api, "tsconfig.json", true)
+    end
 
-		return {}
-	end,
-})
+    return {}
+  end,
+}


### PR DESCRIPTION
According to the `README.md` and the `.stylua.toml` file in this directory, this is how things ought to be formatted. Doing this in a separate PR to not clutter my follow-up one.

Using `stylua 0.19.1` I ran the command `stylua *.lua` inside `internal/codeintel/autoindexing/internal/inference/lua`, which produced this changeset.

## Test plan

Just formatting, so nothing should've changed here