### PR TITLE
Add Starcoder  to all non-overwritten enterprise configurations

### DIFF
--- a/internal/licensing/codygateway.go
+++ b/internal/licensing/codygateway.go
@@ -2,8 +2,6 @@ package licensing
 
 import (
 	"golang.org/x/exp/slices"
-
-	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
 )
 
 // CodyGatewayRateLimit indicates rate limits for Sourcegraph's managed Cody Gateway service.
@@ -35,7 +33,6 @@ func NewCodyGatewayChatRateLimit(plan Plan, userCount *int, licenseTags []string
 		"anthropic/claude-instant-v1",
 		"anthropic/claude-instant-1",
 		"anthropic/claude-instant-1.2",
-		"fireworks/" + fireworks.Mixtral8x7bInstruct,
 	}
 	// Switch on GPT models by default if the customer license has the GPT tag.
 	if slices.Contains(licenseTags, GPTLLMAccessTag) {

--- a/internal/licensing/codygateway.go
+++ b/internal/licensing/codygateway.go
@@ -1,6 +1,10 @@
 package licensing
 
-import "golang.org/x/exp/slices"
+import (
+	"golang.org/x/exp/slices"
+
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
+)
 
 // CodyGatewayRateLimit indicates rate limits for Sourcegraph's managed Cody Gateway service.
 //
@@ -31,6 +35,7 @@ func NewCodyGatewayChatRateLimit(plan Plan, userCount *int, licenseTags []string
 		"anthropic/claude-instant-v1",
 		"anthropic/claude-instant-1",
 		"anthropic/claude-instant-1.2",
+		"fireworks/" + fireworks.Mixtral8x7bInstruct,
 	}
 	// Switch on GPT models by default if the customer license has the GPT tag.
 	if slices.Contains(licenseTags, GPTLLMAccessTag) {
@@ -69,6 +74,7 @@ func NewCodyGatewayCodeRateLimit(plan Plan, userCount *int, licenseTags []string
 		"anthropic/claude-instant-v1",
 		"anthropic/claude-instant-1",
 		"anthropic/claude-instant-1.2",
+		"fireworks/starcoder",
 	}
 	// Switch on GPT models by default if the customer license has the GPT tag.
 	if slices.Contains(licenseTags, GPTLLMAccessTag) {

--- a/internal/licensing/codygateway_test.go
+++ b/internal/licensing/codygateway_test.go
@@ -80,7 +80,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			userCount:   pointers.Ptr(50),
 			licenseTags: []string{GPTLLMAccessTag},
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "openai/gpt-3.5-turbo"},
+				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "fireworks/starcoder", "openai/gpt-3.5-turbo"},
 				Limit:           50000,
 				IntervalSeconds: 60 * 60 * 24,
 			},
@@ -90,7 +90,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			plan:      PlanEnterprise1,
 			userCount: pointers.Ptr(50),
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2"},
+				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "fireworks/starcoder"},
 				Limit:           50000,
 				IntervalSeconds: 60 * 60 * 24,
 			},
@@ -99,7 +99,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			name: "Enterprise plan with no user count",
 			plan: PlanEnterprise1,
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2"},
+				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "fireworks/starcoder"},
 				Limit:           1000,
 				IntervalSeconds: 60 * 60 * 24,
 			},
@@ -108,7 +108,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			name: "Non-enterprise plan with no GPT tag and no user count",
 			plan: "unknown",
 			want: CodyGatewayRateLimit{
-				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2"},
+				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "fireworks/starcoder"},
 				Limit:           100,
 				IntervalSeconds: 60 * 60 * 24,
 			},


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/sourcegraph/pull/59522

This PR changes the default allowed model list for all cody gateway licenses that do not have an overwrite yet. On it's own, nothing will change yet. However, with access to fireworks models, an enterprise admin will be able to set the model as the default for the whole instance. 

This change is then going to be picked up by the clients as per https://github.com/sourcegraph/cody/pull/2714 allowing admins to opt-in to using Starcoder.

## Test plan

- Reset the license key overwrites for the Cody Gateway license, e.g.: 
<img width="969" alt="Screenshot 2024-01-15 at 15 12 54" src="https://github.com/sourcegraph/sourcegraph/assets/458591/55706855-77f9-48e3-95c3-37a66a56057c">
- Observe that requests to starcoder works:

```
curl 'https://sourcegraph.test:3443/.api/completions/code' \
-X POST \
-i \
-H 'authorization: token TOKEN' \
--data-raw '{"messages":[{"speaker":"human","text":"function bubbleSort(){"}],"maxTokensToSample":30,"temperature":0.2,"stopSequences":[],"timeoutMs":5000,"stream":false,"model":"fireworks/starcoder"}'
HTTP/2 200
access-control-allow-credentials: true
access-control-allow-origin:
alt-svc: h3=":3443"; ma=2592000
cache-control: no-cache, max-age=0
content-type: text/plain; charset=utf-8
date: Mon, 15 Jan 2024 14:13:28 GMT
server: Caddy
server: Caddy
set-cookie: sourcegraphDeviceId=7861bcd6-f094-469e-a027-82a495314821; Expires=Wed, 15 Jan 2025 14:13:27 GMT; Secure
vary: Cookie, Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With, Cookie
x-content-type-options: nosniff
x-frame-options: DENY
x-powered-by: Express
x-trace: cfac4cf170ebfe4a2e5601607ace8fdb
x-trace-span: d225a6b93118fd8a
x-trace-url: https://sourcegraph.test:3443/-/debug/jaeger/trace/cfac4cf170ebfe4a2e5601607ace8fdb
x-xss-protection: 1; mode=block
content-length: 116

{"completion":"\\n\"\n\tfor i in range(len(arr)):\n\t\tfor j in range(len(arr)-1):\n\t\t\tif","stopReason":"length"}%    
```