### PR TITLE
msp: check matching EnvironmentDeploySpec is provided

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -150,11 +150,16 @@ type EnvironmentDeploySpec struct {
 func (s EnvironmentDeploySpec) Validate() []error {
 	var errs []error
 	if s.Type == EnvironmentDeployTypeSubscription {
-		if s.Subscription == nil {
+		if s.Manual != nil {
+			errs = append(errs, errors.New("manual deploy spec provided when type is subscription"))
+		} else if s.Subscription == nil {
 			errs = append(errs, errors.New("no subscription specified when deploy type is subscription"))
-		}
-		if s.Subscription.Tag == "" {
+		} else if s.Subscription.Tag == "" {
 			errs = append(errs, errors.New("no tag in image subscription specified"))
+		}
+	} else if s.Type == EnvironmentDeployTypeManual {
+		if s.Subscription != nil {
+			errs = append(errs, errors.New("subscription deploy spec provided when type is manual"))
 		}
 	}
 	return errs


### PR DESCRIPTION
Old code tried to check `s.Subscription.Tag`  even if `s.Subscription` was `nil`. It also did not verify whether the provided `s.Subscription` or `s.Manual` was actually expected based on `s.Type`
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
- CI
- tested locally