### PR TITLE
Revert "sonarscan: add property to allow old java version (#59575)"

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,6 +16,3 @@ sonar.cpp.file.suffixes=-
 sonar.objc.file.suffixes=-
 sonar.sourceEncoding=UTF-8
 sonar.cpd.exclusions=**/*_test.go
-
-# temporary till a newer version of java is rolled out to the agents
-sonar.scanner.force-deprecated-java-version=true


### PR DESCRIPTION
This reverts commit bf077013507d830e754f6d52fb6869260c4468c0.

With this PR the agents got updated to use a newer version of sonar scan and also use the newer JVM
- https://github.com/sourcegraph/infrastructure/pull/5745

## Test plan
Tested here https://buildkite.com/sourcegraph/sourcegraph/builds/257912#018d0dd2-9bc6-4949-8639-897bdc65b6d0