### PR TITLE
msp-example: close redis client

### DIFF
--- a/cmd/msp-example/internal/example/redis.go
+++ b/cmd/msp-example/internal/example/redis.go
@@ -22,6 +22,7 @@ func testRedisConnection(ctx context.Context, c runtime.Contract) error {
 	}
 
 	client := goredis.NewClient(redisOpts)
+	defer client.Close()
 	pong := client.Ping(ctx)
 	return pong.Err()
 }


### PR DESCRIPTION
@jac spotted a profile indicating we might have a resource leak on the clients created here. The client implements a closer, so we should use it.

## Test plan

n/a