### PR TITLE
msp-example: close BigQuery client

### DIFF
--- a/cmd/msp-example/internal/example/bigquery.go
+++ b/cmd/msp-example/internal/example/bigquery.go
@@ -16,7 +16,7 @@ func writeBigQueryEvent(ctx context.Context, contract runtime.Contract, eventNam
 	if err != nil {
 		return errors.Wrap(err, "BigQuery.GetTableWriter")
 	}
-	defer func() { _ = bq.Close() }
+	defer func() { _ = bq.Close() }()
 
 	return bq.Write(ctx, bigQueryEntry{
 		Name:      eventName,

--- a/cmd/msp-example/internal/example/bigquery.go
+++ b/cmd/msp-example/internal/example/bigquery.go
@@ -16,7 +16,7 @@ func writeBigQueryEvent(ctx context.Context, contract runtime.Contract, eventNam
 	if err != nil {
 		return errors.Wrap(err, "BigQuery.GetTableWriter")
 	}
-	defer bq.Close()
+	defer func() { _ = bq.Close() }
 
 	return bq.Write(ctx, bigQueryEntry{
 		Name:      eventName,

--- a/cmd/msp-example/internal/example/bigquery.go
+++ b/cmd/msp-example/internal/example/bigquery.go
@@ -16,6 +16,7 @@ func writeBigQueryEvent(ctx context.Context, contract runtime.Contract, eventNam
 	if err != nil {
 		return errors.Wrap(err, "BigQuery.GetTableWriter")
 	}
+	defer bq.Close()
 
 	return bq.Write(ctx, bigQueryEntry{
 		Name:      eventName,

--- a/lib/managedservicesplatform/bigquerywriter/bigquerywriter.go
+++ b/lib/managedservicesplatform/bigquerywriter/bigquerywriter.go
@@ -2,13 +2,18 @@ package bigquerywriter
 
 import (
 	"context"
+	"io"
 
 	"cloud.google.com/go/bigquery"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // Writer adds helpers for best practices around using a bigquery.Inserter.
+//
+// On service shutdown, (*Writer).Close() must be called.
 type Writer struct {
+	client io.Closer
 	// Inserter is the underlying bigquery.Inserter that can be used if you
 	// know what you are doing. Use with care!
 	Inserter *bigquery.Inserter
@@ -37,4 +42,9 @@ func (w *Writer) Write(ctx context.Context, values ...bigquery.ValueSaver) error
 	}
 	// Otherwise, insert all values.
 	return w.Inserter.Put(ctx, values)
+}
+
+// Close closes any underlying resources.
+func (w *Writer) Close() error {
+	return w.client.Close()
 }

--- a/lib/managedservicesplatform/runtime/contract_bigquery.go
+++ b/lib/managedservicesplatform/runtime/contract_bigquery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"cloud.google.com/go/bigquery"
+
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/bigquerywriter"
 )


### PR DESCRIPTION
Similar to #59598, I think this is another leak in the example service. This is less of an issue in services that create the `Writer` once, but in general things should be shut down cleanly.

## Test plan

n/a