### PR TITLE
sg msp: trigger resources validation

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -113,6 +113,7 @@ func (s EnvironmentSpec) Validate() []error {
 
 	errs = append(errs, s.Deploy.Validate()...)
 	errs = append(errs, s.Resources.Validate()...)
+	errs = append(errs, s.Instances.Validate()...)
 	return errs
 }
 


### PR DESCRIPTION
Valdiation was added in #59535 , but it was not called.

## Test plan

```
 managed-services git:(main) ✗ sg msp generate -all releaseregistry
❌ load service "releaseregistry": spec.parse: resources.memory must be >= 512Mi
```