### PR TITLE
sg msp: use stable generation by default

### DIFF
--- a/dev/sg/msp/sg_msp.go
+++ b/dev/sg/msp/sg_msp.go
@@ -212,8 +212,8 @@ sg msp generate -all <service>
 				},
 				&cli.BoolFlag{
 					Name:  "stable",
-					Usage: "Disable updating of any values that are evaluated at generation time",
-					Value: false,
+					Usage: "Configure updating of any values that are evaluated at generation time",
+					Value: true,
 				},
 			},
 			BashComplete: msprepo.ServicesAndEnvironmentsCompletion(),


### PR DESCRIPTION
There are a few issues with unstable output by default:

1. Rolling out TF changes can inadvertently deploy new revisions
2. Some services have private images that the operator might not have access to - we don't want image update to block `sg msp generate` by default
3. Updating images via subscription should primarily be done via automation, or manually and explicitly

This change toggles `-stable=true` by default. I will update our image update workflow to use `-stable=false` explicitly.

## Test plan

n/a