### PR TITLE
Search Filters: use codeintel languages to determine language

### DIFF
--- a/internal/search/streaming/BUILD.bazel
+++ b/internal/search/streaming/BUILD.bazel
@@ -14,10 +14,10 @@ go_library(
     deps = [
         "//internal/api",
         "//internal/gitserver/gitdomain",
-        "//internal/inventory",
         "//internal/lazyregexp",
         "//internal/search",
         "//internal/search/result",
+        "//lib/codeintel/languages",
         "@com_github_grafana_regexp//:regexp",
         "@org_golang_x_text//cases",
         "@org_golang_x_text//language",

--- a/internal/search/streaming/search_filters_test.go
+++ b/internal/search/streaming/search_filters_test.go
@@ -95,6 +95,24 @@ func TestSearchFiltersUpdate(t *testing.T) {
 			wantFilterCount: 2,
 		},
 		{
+			name: "FileMatch, lang: filter",
+			events: []SearchEvent{
+				{
+					Results: []result.Match{
+						&result.FileMatch{
+							File: result.File{
+								Path: "testing.yaml",
+							},
+							ChunkMatches: result.ChunkMatches{{Ranges: make(result.Ranges, 2)}},
+						},
+					},
+				},
+			},
+			wantFilterValue: "lang:yaml",
+			wantFilterKind:  "lang",
+			wantFilterCount: 2,
+		},
+		{
 			name: "SymbolMatch",
 			events: []SearchEvent{
 				{


### PR DESCRIPTION
Fixes #59611

Previously, we were using `internal/inventory` to determine the language for a file name. This led to weird things like `.yaml` files being detected as `MiniYAML`. Instead, this switches filters to use the more accurate `lib/codeintel/languages` package, which we should be standardizing on as our source of truth for language detection.

Note: the codeintel package requires the file contents for best accuracy, but we do not want to put network requests in this hot path in the search stream, nor do I want to thread a gitserver client through to this caller. Ideally, the language would be detected by our search backends and streamed back on search results instead of detecting it at the API boundary because we already have the file contents readily available. cc @sourcegraph/search-platform in case you want to tackle that at some point. 

also cc @sourcegraph/team-graph  for visibility

## Test plan

Added a test for detecting YAML as a language, also for coverage of the `lang` filter in general.

![CleanShot 2024-01-15 at 19 07 11@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/19fd97f1-2a55-457d-8873-2138a9fb777b)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
