### PR TITLE
bazel: use rules_go 0.45

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,10 +55,10 @@ http_archive(
     patches = [
         "//third_party/rules_go:package_main.patch",
     ],
-    sha256 = "c8035e8ae248b56040a65ad3f0b7434712e2037e5dfdcebfe97576e620422709",
+    sha256 = "de7974538c31f76658e0d333086c69efdf6679dbc6a466ac29e65434bf47076d",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.44.0/rules_go-v0.44.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.44.0/rules_go-v0.44.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.45.0/rules_go-v0.45.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.45.0/rules_go-v0.45.0.zip",
     ],
 )
 
@@ -284,7 +284,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//:sg_nogo",
-    version = "1.21.4",
+    version = "1.21.6",
 )
 
 linter_dependencies()

--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -1,6 +1,4 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("//client/shared/dev:generate_graphql_operations.bzl", "generate_graphql_operations")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//:vite/package_json.bzl", vite_bin = "bin")
 
@@ -38,9 +36,9 @@ SRCS = [
         "src/**/*.gql.d.ts",
     ],
 ) + glob([
-        "dev/**/*.cjs",
-        "dev/**/*.ts"
-    ])
+    "dev/**/*.cjs",
+    "dev/**/*.ts",
+])
 
 BUILD_DEPS = [
     ":node_modules/@faker-js/faker",

--- a/third_party/rules_go/package_main.patch
+++ b/third_party/rules_go/package_main.patch
@@ -19,7 +19,7 @@ index a4e737ee..16d545e0 100644
              out_lib = out_lib,
              out_export = out_export,
 diff --git a/go/private/actions/compilepkg.bzl b/go/private/actions/compilepkg.bzl
-index 03096a92..533425a9 100644
+index 48adb910..016a6a66 100644
 --- a/go/private/actions/compilepkg.bzl
 +++ b/go/private/actions/compilepkg.bzl
 @@ -44,6 +44,7 @@ def emit_compilepkg(
@@ -39,7 +39,7 @@ index 03096a92..533425a9 100644
 
      args.add("-o", out_lib)
 diff --git a/go/tools/builders/compilepkg.go b/go/tools/builders/compilepkg.go
-index b3a6d283..6c1da815 100644
+index bcbdb642..f57062e8 100644
 --- a/go/tools/builders/compilepkg.go
 +++ b/go/tools/builders/compilepkg.go
 @@ -51,7 +51,7 @@ func compilePkg(args []string) error {
@@ -75,17 +75,17 @@ index b3a6d283..6c1da815 100644
  	srcs archiveSrcs,
  	deps []archive,
  	coverMode string,
-@@ -453,7 +456,7 @@ func compileArchive(
+@@ -441,7 +444,7 @@ func compileArchive(
  		ctx, cancel := context.WithCancel(context.Background())
  		nogoChan = make(chan error)
  		go func() {
--			nogoChan <- runNogo(ctx, workDir, nogoPath, nogoSrcs, deps, packagePath, importcfgPath, outFactsPath)
-+			nogoChan <- runNogo(ctx, workDir, nogoPath, nogoSrcs, deps, realPackagePath, importcfgPath, outFactsPath)
+-			nogoChan <- runNogo(ctx, workDir, nogoPath, goSrcsNogo, deps, packagePath, importcfgPath, outFactsPath)
++			nogoChan <- runNogo(ctx, workDir, nogoPath, goSrcsNogo, deps, realPackagePath, importcfgPath, outFactsPath)
  		}()
  		defer func() {
  			if nogoChan != nil {
 diff --git a/go/tools/builders/nogo_main.go b/go/tools/builders/nogo_main.go
-index 17ff5314..3ce75fa5 100644
+index 17ff5314..2a6c98b2 100644
 --- a/go/tools/builders/nogo_main.go
 +++ b/go/tools/builders/nogo_main.go
 @@ -78,6 +78,10 @@ func run(args []string) error {
@@ -93,7 +93,7 @@ index 17ff5314..3ce75fa5 100644
  	srcs := flags.Args()
 
 +	if *packagePath == "main" {
-+		panic("packagePath='main' is invalid, expected fully qualified package path")
++		panic("packagePath='main' is invalid, expected full qualified package path")
 +	}
 +
  	packageFile, importMap, err := readImportCfg(*importcfg)


### PR DESCRIPTION
upgrade rules_go and use newer go compiler version
## Test plan
CI + `bazel build //dev/sg:sg`
