### PR TITLE
ci: run pnpm-dedupe only if pnpm files changed

### DIFF
--- a/dev/ci/internal/ci/changed/diff.go
+++ b/dev/ci/internal/ci/changed/diff.go
@@ -3,6 +3,8 @@ package changed
 import (
 	"bytes"
 	"os"
+	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -15,6 +17,7 @@ const (
 	Go Diff = 1 << iota
 	ClientBrowserExtensions
 	Client
+	Pnpm
 	GraphQL
 	DatabaseSchema
 	Docs
@@ -93,6 +96,11 @@ func ParseDiff(files []string) (diff Diff, changedFiles ChangedFiles) {
 		if !strings.HasSuffix(p, ".md") && (isRootClientFile(p) || strings.HasPrefix(p, "client/")) {
 			diff |= Client
 		}
+
+		if slices.Contains(pnpmFiles, filepath.Base(p)) {
+			diff |= Pnpm
+		}
+
 		// dev/release contains a nodejs script that doesn't have tests but needs to be
 		// linted with Client linters. We skip the release config file to reduce friction editing during releases.
 		if strings.HasPrefix(p, "dev/release/") && !strings.Contains(p, "release-config") {
@@ -227,6 +235,8 @@ func (d Diff) String() string {
 		return "Go"
 	case Client:
 		return "Client"
+	case Pnpm:
+		return "pnpm"
 	case ClientBrowserExtensions:
 		return "ClientBrowserExtensions"
 	case GraphQL:

--- a/dev/ci/internal/ci/changed/diff_test.go
+++ b/dev/ci/internal/ci/changed/diff_test.go
@@ -34,70 +34,83 @@ func TestParseDiff(t *testing.T) {
 		wantAffects      []Diff
 		wantChangedFiles ChangedFiles
 		doNotWantAffects []Diff
-	}{{
-		name:             "None",
-		files:            []string{"asdf"},
-		wantAffects:      []Diff{None},
-		wantChangedFiles: make(ChangedFiles),
-		doNotWantAffects: []Diff{Go, Client, DatabaseSchema, All},
-	}, {
-		name:             "Go",
-		files:            []string{"main.go", "func.go"},
-		wantAffects:      []Diff{Go},
-		wantChangedFiles: make(ChangedFiles),
-		doNotWantAffects: []Diff{Client, All},
-	}, {
-		name:             "go testdata",
-		files:            []string{"internal/cmd/search-blitz/queries.txt"},
-		wantAffects:      []Diff{Go},
-		wantChangedFiles: make(ChangedFiles),
-		doNotWantAffects: []Diff{Client, All},
-	}, {
-		name:             "DB schema implies Go and DB schema diff",
-		files:            []string{"migrations/file1", "migrations/file2"},
-		wantAffects:      []Diff{Go, DatabaseSchema},
-		wantChangedFiles: make(ChangedFiles),
-		doNotWantAffects: []Diff{Client, All},
-	}, {
-		name:             "Or",
-		files:            []string{"client/file1", "file2.graphql"},
-		wantAffects:      []Diff{Client | GraphQL},
-		wantChangedFiles: make(ChangedFiles),
-		doNotWantAffects: []Diff{Go, All},
-	}, {
-		name:        "Wolfi",
-		files:       []string{"wolfi-images/image-test.yaml", "wolfi-packages/package-test.yaml"},
-		wantAffects: []Diff{WolfiBaseImages, WolfiPackages},
-		wantChangedFiles: ChangedFiles{
-			WolfiBaseImages: []string{"wolfi-images/image-test.yaml"},
-			WolfiPackages:   []string{"wolfi-packages/package-test.yaml"},
+	}{
+		{
+			name:             "None",
+			files:            []string{"asdf"},
+			wantAffects:      []Diff{None},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{Go, Client, DatabaseSchema, All},
+		}, {
+			name:             "Go",
+			files:            []string{"main.go", "func.go"},
+			wantAffects:      []Diff{Go},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{Client, All},
+		}, {
+			name:             "go testdata",
+			files:            []string{"internal/cmd/search-blitz/queries.txt"},
+			wantAffects:      []Diff{Go},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{Client, All},
+		}, {
+			name:             "DB schema implies Go and DB schema diff",
+			files:            []string{"migrations/file1", "migrations/file2"},
+			wantAffects:      []Diff{Go, DatabaseSchema},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{Client, All},
+		}, {
+			name:             "Or",
+			files:            []string{"client/file1", "file2.graphql"},
+			wantAffects:      []Diff{Client, GraphQL},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{Go, Pnpm, All},
+		}, {
+			name:        "Wolfi",
+			files:       []string{"wolfi-images/image-test.yaml", "wolfi-packages/package-test.yaml"},
+			wantAffects: []Diff{WolfiBaseImages, WolfiPackages},
+			wantChangedFiles: ChangedFiles{
+				WolfiBaseImages: []string{"wolfi-images/image-test.yaml"},
+				WolfiPackages:   []string{"wolfi-packages/package-test.yaml"},
+			},
+			doNotWantAffects: []Diff{},
+		}, {
+			name:             "Protobuf definitions",
+			files:            []string{"cmd/searcher/messages.proto"},
+			wantAffects:      []Diff{Protobuf},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{},
+		}, {
+			name:             "Protobuf generated code",
+			files:            []string{"cmd/searcher/messages.pb.go"},
+			wantAffects:      []Diff{Protobuf, Go},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{},
+		}, {
+			name:             "Buf CLI module configuration",
+			files:            []string{"cmd/searcher/buf.yaml"},
+			wantAffects:      []Diff{Protobuf},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{},
+		}, {
+			name:             "Buf CLI generated code configuration",
+			files:            []string{"cmd/searcher/buf.gen.yaml"},
+			wantAffects:      []Diff{Protobuf},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{},
+		}, {
+			name:             "PNPM file changes",
+			files:            []string{"pnpm-workspace.yaml"},
+			wantAffects:      []Diff{Pnpm, Client},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{},
+		}, {
+			name:             "PNPM sub-package file changes",
+			files:            []string{"client/package.json"},
+			wantAffects:      []Diff{Pnpm, Client},
+			wantChangedFiles: make(ChangedFiles),
+			doNotWantAffects: []Diff{},
 		},
-		doNotWantAffects: []Diff{},
-	}, {
-		name:             "Protobuf definitions",
-		files:            []string{"cmd/searcher/messages.proto"},
-		wantAffects:      []Diff{Protobuf},
-		wantChangedFiles: make(ChangedFiles),
-		doNotWantAffects: []Diff{},
-	}, {
-		name:             "Protobuf generated code",
-		files:            []string{"cmd/searcher/messages.pb.go"},
-		wantAffects:      []Diff{Protobuf, Go},
-		wantChangedFiles: make(ChangedFiles),
-		doNotWantAffects: []Diff{},
-	}, {
-		name:             "Buf CLI module configuration",
-		files:            []string{"cmd/searcher/buf.yaml"},
-		wantAffects:      []Diff{Protobuf},
-		wantChangedFiles: make(ChangedFiles),
-		doNotWantAffects: []Diff{},
-	}, {
-		name:             "Buf CLI generated code configuration",
-		files:            []string{"cmd/searcher/buf.gen.yaml"},
-		wantAffects:      []Diff{Protobuf},
-		wantChangedFiles: make(ChangedFiles),
-		doNotWantAffects: []Diff{},
-	},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dev/ci/internal/ci/changed/files.go
+++ b/dev/ci/internal/ci/changed/files.go
@@ -5,10 +5,14 @@ import (
 	"slices"
 )
 
-// Changes in the root directory files should trigger client tests.
-var clientRootFiles = []string{
+var pnpmFiles = []string{
 	"package.json",
 	"pnpm-lock.yaml",
+	"pnpm-workspace.yaml",
+}
+
+// Changes in the root directory files should trigger client tests.
+var clientRootFiles = append(pnpmFiles, []string{
 	"vitest.workspace.ts",
 	"vitest.shared.ts",
 	"postcss.config.js",
@@ -16,7 +20,7 @@ var clientRootFiles = []string{
 	"tsconfig.json",
 	".percy.yml",
 	".eslintrc.js",
-}
+}...)
 
 func isRootClientFile(p string) bool {
 	return filepath.Dir(p) == "." && slices.Contains(clientRootFiles, p)

--- a/dev/sg/linters/linters.go
+++ b/dev/sg/linters/linters.go
@@ -77,10 +77,16 @@ var Targets = []Target{
 		Description: "Check client code for linting errors, forbidden imports, etc",
 		Checks: []*linter{
 			timeCheck(inlineTemplates),
-			timeCheck(runScriptSerialized("pnpm dedupe", "dev/check/pnpm-deduplicate.sh")),
 			// we only run this linter locally, since on CI it has it's own job
 			onlyLocal(runScriptSerialized("pnpm lint:js:web", "dev/ci/pnpm-run.sh lint:js:web")),
 			timeCheck(checkUnversionedDocsLinks()),
+		},
+	},
+	{
+		Name:        "pnpm",
+		Description: "Check pnpm lockfiles for optimality",
+		Checks: []*linter{
+			timeCheck(runScriptSerialized("pnpm dedupe", "dev/check/pnpm-deduplicate.sh")),
 		},
 	},
 	{


### PR DESCRIPTION
Eliminate running `pnpm dedupe --check` if no (p)npm files are changed

## Test plan

No `pnpm` check being run https://buildkite.com/sourcegraph/sourcegraph/builds/258158#018d1274-b292-4e66-8865-7ab8426149ff