### PR TITLE
Fix format:ci arg ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --list-different --config prettier.config.js --write",
     "format:changed": "prettier $( { git diff --diff-filter=d --name-only origin/main... && git ls-files --other --modified --exclude-standard ; } | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --write --list-different --config prettier.config.js",
     "format:check": "prettier '**/{*.{js?(on),ts?(x),graphql,md,scss},.*.js?(on)}' --config prettier.config.js --check --write=false",
-    "format:ci": "prettier $( { git diff --diff-filter=d --name-only $COMMIT_SHA \"$(git merge-base $COMMIT_SHA $BUILDKITE_PULL_REQUEST_BASE_BRANCH)\" && git ls-files --other --modified --exclude-standard ; } | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --config prettier.config.js --check --write=false",
+    "format:ci": "prettier $( { git diff --diff-filter=d --name-only \"$(git merge-base $COMMIT_SHA $BUILDKITE_PULL_REQUEST_BASE_BRANCH)\" $COMMIT_SHA && git ls-files --other --modified --exclude-standard ; } | grep -E '\\.(js|json|ts|tsx|graphql|md|scss)$' | xargs) --config prettier.config.js --check --write=false",
     "_lint:js": "DOCSITE_LIST=\"$(./dev/docsite.sh -config doc/docsite.json ls)\" NODE_OPTIONS=\"--max_old_space_size=16192\" eslint",
     "lint:js:changed": "pnpm _lint:js $(git diff --diff-filter=d --name-only origin/main... | grep -E '\\.[tj]sx?$' | xargs)",
     "lint:js:root": "pnpm run _lint:js --quiet '*.[tj]s?(x)'",


### PR DESCRIPTION
The order for git-diff is from-commit to-commit, so we just had them flipped. This isn't a problem for 95% of cases, but it breaks when a file is deleted in your branch because the flipped filter will think of it as added.

## Test plan
Tested locally on branch with deleted files
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
