### PR TITLE
[Backport 5.2] Bump hermetic_cc_toolchain to v2.1.2 (#58132)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,7 +107,7 @@ http_archive(
 )
 
 # hermetic_cc_toolchain setup ================================
-HERMETIC_CC_TOOLCHAIN_VERSION = "v2.0.0"
+HERMETIC_CC_TOOLCHAIN_VERSION = "v2.1.2"
 
 # Please note that we only use hermetic-cc for local development purpose and Nix, at it eases the path to cross-compile
 # so we can produce container images locally on Mac laptops.
@@ -123,7 +123,7 @@ http_archive(
     patches = [
         "//third_party/hermetic_cc:disable_ubsan.patch",
     ],
-    sha256 = "57f03a6c29793e8add7bd64186fc8066d23b5ffd06fe9cc6b0b8c499914d3a65",
+    sha256 = "28fc71b9b3191c312ee83faa1dc65b38eb70c3a57740368f7e7c7a49bedf3106",
     urls = [
         "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
         "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),


### PR DESCRIPTION
This bumps the version of hermetic_cc_toolchain to v2.1.2 to fix a build issue I ran into when running sg start otel after upgrading to Sonoma.

(cherry picked from commit a465ffc0887093ad6ec6df27aee06e649ce36264)

Cherry-picking to 5.2 for verifying that a patch works, and I've already upgraded the macOS version on my dev machine.

## Test plan

Run `sg start enterprise-codeintel` locally and see that it works instead of running into https://github.com/sourcegraph/devx-support/issues/366