### PR TITLE
bzl: add additional flags for profile for AW

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -11,6 +11,9 @@ bazel:
     # TODO(gregmagolan): can be moved to .aspect/workflows/bazelrc in the future
     - --remote_download_minimal
     - --nobuild_runfile_links
+    # As per recommendation from https://analyzer.engflow.com/suggestions/829decb5-e3f4-4930-b60c-0494d154f8c1
+    - --experimental_profile_include_target_label
+    - --noslim_profile
 env:
     REDIS_CACHE_ENDPOINT: ":6379"
     GIT_PAGER: ''


### PR DESCRIPTION
Looking at interesting timing differences in between AW and our normal agents, adding some recommended flags for having additional data in the profile. 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
