### PR TITLE
bzl: drop unused target and data glob

### DIFF
--- a/cmd/gitserver/internal/BUILD.bazel
+++ b/cmd/gitserver/internal/BUILD.bazel
@@ -95,7 +95,6 @@ go_test(
         "repo_info_test.go",
         "server_test.go",
     ],
-    data = glob(["testdata/**"]),
     embed = [":internal"],
     # This test loads coursier as a side effect, so we ensure the
     # path is sandboxed properly.

--- a/internal/extsvc/rubygems/BUILD.bazel
+++ b/internal/extsvc/rubygems/BUILD.bazel
@@ -16,21 +16,6 @@ go_library(
 )
 
 go_test(
-    name = "client_test",
-    timeout = "short",
-    srcs = ["client_test.go"],
-    data = glob(["testdata/**"]),
-    embed = [":rubygems"],
-    deps = [
-        "//internal/conf/reposource",
-        "//internal/httptestutil",
-        "//internal/unpack",
-        "@com_github_stretchr_testify//require",
-        "@org_golang_x_time//rate",
-    ],
-)
-
-go_test(
     name = "rubygems_test",
     srcs = ["client_test.go"],
     data = glob(["testdata/**"]),


### PR DESCRIPTION
Investigating at why some caching is not kicking in for the gitserver internal package tests, stumbled across a useless `data` attr. Found along the way, a duplicated target which I dropped. 

## Test plan

CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
