### PR TITLE
ci: drop unused operation

### DIFF
--- a/dev/ci/internal/ci/bazel_helpers.go
+++ b/dev/ci/internal/ci/bazel_helpers.go
@@ -106,28 +106,6 @@ func bazelStampedCmd(args ...string) string {
 	return strings.Join(cmd, " ")
 }
 
-// bazelAnalysisPhase only runs the analasys phase, ensure that the buildfiles
-// are correct, but do not actually build anything.
-func bazelAnalysisPhase() func(*bk.Pipeline) {
-	cmd := bazelCmd(
-		"build",
-		"--nobuild", // this is the key flag to enable this.
-		"//...",
-	)
-
-	cmds := []bk.StepOpt{
-		bk.Key("bazel-analysis"),
-		bk.Agent("queue", "bazel"),
-		bk.Cmd(cmd),
-	}
-
-	return func(pipeline *bk.Pipeline) {
-		pipeline.AddStep(":bazel: Analysis phase",
-			cmds...,
-		)
-	}
-}
-
 func bazelPrechecks() func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{
 		bk.Key("bazel-prechecks"),


### PR DESCRIPTION
Noticed this op wasn't used anywhere anymore. 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
