### PR TITLE
licensing: hide code-search related links when on Global Navbar Cody-only license

### DIFF
--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -46,10 +46,6 @@ describe('GlobalNavbar', () => {
     })
 
     test('default', () => {
-        // vi.spyOn(liceseUtils, 'isCodeSearchOnlyLicense').mockReturnValue(false)
-        // vi.spyOn(liceseUtils, 'isCodeSearchPlusCodyLicense').mockReturnValue(true)
-        // vi.spyOn(liceseUtils, 'isCodyOnlyLicense').mockReturnValue(false)
-
         vi.mock('../util/license', () => ({
             isCodeSearchOnlyLicense: () => false,
             isCodeSearchPlusCodyLicense: () => true,

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi, afterAll, beforeAll } from 'vitest'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import {
@@ -41,7 +41,73 @@ const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
 }
 
 describe('GlobalNavbar', () => {
+    const origContext = window.context
+    beforeAll(() => {
+        window.context = {
+            ...origContext,
+            licenseInfo: {
+                currentPlan: 'enterprise-0',
+                features: {
+                    cody: true,
+                    codeSearch: true,
+                },
+            },
+        } as any
+    })
+    afterAll(() => {
+        window.context = origContext
+    })
+
     test('default', () => {
+        window.context = {
+            ...origContext,
+            licenseInfo: {
+                currentPlan: 'enterprise-0',
+                features: {
+                    cody: true,
+                    codeSearch: true,
+                },
+            },
+        } as any
+
+        const { asFragment } = renderWithBrandedContext(
+            <MockedTestProvider>
+                <GlobalNavbar {...PROPS} />
+            </MockedTestProvider>
+        )
+        expect(asFragment()).toMatchSnapshot()
+    })
+
+    test('cody only license', () => {
+        window.context = {
+            ...origContext,
+            licenseInfo: {
+                features: {
+                    cody: true,
+                    codeSearch: false,
+                },
+            },
+        } as any
+
+        const { asFragment } = renderWithBrandedContext(
+            <MockedTestProvider>
+                <GlobalNavbar {...PROPS} />
+            </MockedTestProvider>
+        )
+        expect(asFragment()).toMatchSnapshot()
+    })
+
+    test('code search only license', () => {
+        window.context = {
+            ...origContext,
+            licenseInfo: {
+                features: {
+                    cody: false,
+                    codeSearch: true,
+                },
+            },
+        } as any
+
         const { asFragment } = renderWithBrandedContext(
             <MockedTestProvider>
                 <GlobalNavbar {...PROPS} />

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { describe, expect, test, vi, afterAll, beforeAll } from 'vitest'
+import { describe, expect, test, vi, afterAll } from 'vitest'
 
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import {
@@ -41,34 +41,20 @@ const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
 }
 
 describe('GlobalNavbar', () => {
-    const origContext = window.context
-    beforeAll(() => {
-        window.context = {
-            ...origContext,
-            licenseInfo: {
-                currentPlan: 'enterprise-0',
-                features: {
-                    cody: true,
-                    codeSearch: true,
-                },
-            },
-        } as any
-    })
     afterAll(() => {
-        window.context = origContext
+        vi.restoreAllMocks()
     })
 
     test('default', () => {
-        window.context = {
-            ...origContext,
-            licenseInfo: {
-                currentPlan: 'enterprise-0',
-                features: {
-                    cody: true,
-                    codeSearch: true,
-                },
-            },
-        } as any
+        // vi.spyOn(liceseUtils, 'isCodeSearchOnlyLicense').mockReturnValue(false)
+        // vi.spyOn(liceseUtils, 'isCodeSearchPlusCodyLicense').mockReturnValue(true)
+        // vi.spyOn(liceseUtils, 'isCodyOnlyLicense').mockReturnValue(false)
+
+        vi.mock('../util/license', () => ({
+            isCodeSearchOnlyLicense: () => false,
+            isCodeSearchPlusCodyLicense: () => true,
+            isCodyOnlyLicense: () => false,
+        }))
 
         const { asFragment } = renderWithBrandedContext(
             <MockedTestProvider>
@@ -79,15 +65,11 @@ describe('GlobalNavbar', () => {
     })
 
     test('cody only license', () => {
-        window.context = {
-            ...origContext,
-            licenseInfo: {
-                features: {
-                    cody: true,
-                    codeSearch: false,
-                },
-            },
-        } as any
+        vi.mock('../util/license', () => ({
+            isCodeSearchOnlyLicense: () => false,
+            isCodeSearchPlusCodyLicense: () => false,
+            isCodyOnlyLicense: () => true,
+        }))
 
         const { asFragment } = renderWithBrandedContext(
             <MockedTestProvider>
@@ -98,15 +80,11 @@ describe('GlobalNavbar', () => {
     })
 
     test('code search only license', () => {
-        window.context = {
-            ...origContext,
-            licenseInfo: {
-                features: {
-                    cody: false,
-                    codeSearch: true,
-                },
-            },
-        } as any
+        vi.mock('../util/license', () => ({
+            isCodeSearchOnlyLicense: () => true,
+            isCodeSearchPlusCodyLicense: () => false,
+            isCodyOnlyLicense: () => false,
+        }))
 
         const { asFragment } = renderWithBrandedContext(
             <MockedTestProvider>

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -335,57 +335,69 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
         return items.filter<NavDropdownItem>((item): item is NavDropdownItem => !!item)
     }, [showOwn, showSearchContext, showCodySearch, showSearchJobs])
 
+    const searchNavigation =
+        searchNavBarItems.length > 0 ? (
+            <NavDropdown
+                toggleItem={{
+                    path: PageRoutes.Search,
+                    altPath: PageRoutes.RepoContainer,
+                    icon: MagnifyIcon,
+                    content: 'Code Search',
+                    variant: navLinkVariant,
+                }}
+                routeMatch={routeMatch}
+                homeItem={{ content: 'Search home' }}
+                items={searchNavBarItems}
+                name="search"
+            />
+        ) : (
+            <NavItem icon={MagnifyIcon}>
+                <NavLink variant={navLinkVariant} to={PageRoutes.Search}>
+                    Code Search
+                </NavLink>
+            </NavItem>
+        )
+
+    const codyNavigation = showCodyDropdown ? (
+        <NavDropdown
+            toggleItem={{
+                path: PageRoutes.CodyManagement,
+                icon: CodyLogo,
+                content: 'Cody',
+                variant: navLinkVariant,
+            }}
+            routeMatch={routeMatch}
+            items={[
+                {
+                    path: PageRoutes.CodyManagement,
+                    content: 'Dashboard',
+                },
+                {
+                    path: PageRoutes.CodyChat,
+                    content: 'Web Chat',
+                },
+            ]}
+            name="cody"
+        />
+    ) : (
+        <NavItem icon={CodyLogo}>
+            <NavLink variant={navLinkVariant} to={PageRoutes.CodyChat}>
+                Cody AI
+            </NavLink>
+        </NavItem>
+    )
+
+    let prioritizedLinks: JSX.Element[] = [searchNavigation, codyNavigation]
+
+    if (isCodyOnlyLicense()) {
+        // This should be cheap considering there will only be two items in the array.
+        prioritizedLinks = prioritizedLinks.reverse()
+    }
+
     return (
         <NavGroup ref={navbarReference} className={classNames(className, styles.list)}>
-            {searchNavBarItems.length > 0 ? (
-                <NavDropdown
-                    toggleItem={{
-                        path: PageRoutes.Search,
-                        altPath: PageRoutes.RepoContainer,
-                        icon: MagnifyIcon,
-                        content: 'Code Search',
-                        variant: navLinkVariant,
-                    }}
-                    routeMatch={routeMatch}
-                    homeItem={{ content: 'Search home' }}
-                    items={searchNavBarItems}
-                    name="search"
-                />
-            ) : (
-                <NavItem icon={MagnifyIcon}>
-                    <NavLink variant={navLinkVariant} to={PageRoutes.Search}>
-                        Code Search
-                    </NavLink>
-                </NavItem>
-            )}
-            {showCodyDropdown ? (
-                <NavDropdown
-                    toggleItem={{
-                        path: PageRoutes.CodyManagement,
-                        icon: CodyLogo,
-                        content: 'Cody',
-                        variant: navLinkVariant,
-                    }}
-                    routeMatch={routeMatch}
-                    items={[
-                        {
-                            path: PageRoutes.CodyManagement,
-                            content: 'Dashboard',
-                        },
-                        {
-                            path: PageRoutes.CodyChat,
-                            content: 'Web Chat',
-                        },
-                    ]}
-                    name="cody"
-                />
-            ) : (
-                <NavItem icon={CodyLogo}>
-                    <NavLink variant={navLinkVariant} to={PageRoutes.CodyChat}>
-                        Cody
-                    </NavLink>
-                </NavItem>
-            )}
+            {prioritizedLinks}
+
             {showSearchNotebook && (
                 <NavItem icon={BookOutlineIcon}>
                     <NavLink variant={navLinkVariant} to={PageRoutes.Notebooks}>
@@ -400,9 +412,6 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
                     </NavLink>
                 </NavItem>
             )}
-            {/* This is the only circumstance where we show something
-                batch-changes-related even if the instance does not have batch
-                changes enabled, for marketing purposes on sourcegraph.com */}
             {showBatchChanges && <BatchChangesNavItem variant={navLinkVariant} />}
             {showCodeInsights && (
                 <NavItem icon={BarChartIcon}>

--- a/client/web/src/nav/NavBar/NavBar.tsx
+++ b/client/web/src/nav/NavBar/NavBar.tsx
@@ -18,6 +18,7 @@ import {
 } from '@sourcegraph/wildcard'
 
 import { PageRoutes } from '../../routes.constants'
+import { isCodyOnlyLicense } from '../../util/license'
 
 import navActionStyles from './NavAction.module.scss'
 import navBarStyles from './NavBar.module.scss'
@@ -51,12 +52,13 @@ export interface NavLinkProps extends NavItemProps, Pick<LinkProps, 'to'> {
 }
 
 export const NavBar = forwardRef(function NavBar({ children, logo }, reference): JSX.Element {
+    const logoUrl = isCodyOnlyLicense() ? PageRoutes.Cody : PageRoutes.Search
     return (
         <nav aria-label="Main" className={navBarStyles.navbar} ref={reference}>
             {logo && (
                 <>
                     <H1 className={navBarStyles.logo}>
-                        <RouterNavLink className="d-flex align-items-center" to={PageRoutes.Search}>
+                        <RouterNavLink className="d-flex align-items-center" to={logoUrl}>
                             {logo}
                         </RouterNavLink>
                     </H1>

--- a/client/web/src/nav/UserNavItem.test.tsx
+++ b/client/web/src/nav/UserNavItem.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import sinon from 'sinon'
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
@@ -10,6 +10,12 @@ import { AnchorLink, RouterLink, setLinkComponent } from '@sourcegraph/wildcard'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { UserNavItem, type UserNavItemProps } from './UserNavItem'
+
+vi.mock('../util/license', () => ({
+    isCodeSearchOnlyLicense: () => false,
+    isCodeSearchPlusCodyLicense: () => true,
+    isCodyOnlyLicense: () => false,
+}))
 
 describe('UserNavItem', () => {
     beforeAll(() => {

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -1,5 +1,433 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`GlobalNavbar > code search only license 1`] = `
+<DocumentFragment>
+  <nav
+    aria-label="Main"
+    class="navbar"
+  >
+    <h1
+      class="h1 logo"
+    >
+      <a
+        class="d-flex align-items-center"
+        href="/search"
+      >
+        BrandLogo
+      </a>
+    </h1>
+    <hr
+      aria-hidden="true"
+      class="divider"
+    />
+    <div
+      class="menu list"
+    >
+      <ul
+        class="list"
+      >
+        <li
+          class="item wrapper"
+        >
+          <div
+            class="link d-flex align-items-center p-0"
+            data-test-active="false"
+            data-test-id="/search"
+          >
+            <button
+              aria-controls=""
+              aria-haspopup="true"
+              aria-label="Show search menu"
+              class="btn itemFocusable button"
+              data-reach-menu-button=""
+              id="menu-button-test-id"
+              type="button"
+            >
+              <span
+                class="itemFocusableContent"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="mdi-icon mdi-icon iconInline icon"
+                  fill="currentColor"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z"
+                  />
+                </svg>
+                <span
+                  class="text iconIncluded"
+                >
+                  Code Search
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="mdi-icon iconInline icon"
+                  fill="currentColor"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </li>
+        <li
+          class="item"
+        >
+          <a
+            class="link"
+            href="/cody/chat"
+          >
+            <span
+              class="linkContent"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline icon"
+                fill="none"
+                height="20"
+                role="img"
+                viewBox="0 0 20 20"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M13.9088 4C14.756 4 15.4429 4.69836 15.4429 5.55983V8.33286C15.4429 9.19433 14.756 9.89269 13.9088 9.89269C13.0615 9.89269 12.3747 9.19433 12.3747 8.33286V5.55983C12.3747 4.69836 13.0615 4 13.9088 4Z"
+                  fill="#a6b6d9"
+                />
+                <path
+                  d="M4.19287 7.63942C4.19287 6.77795 4.87971 6.07959 5.72696 6.07959H8.45423C9.30148 6.07959 9.98832 6.77795 9.98832 7.63942C9.98832 8.50089 9.30148 9.19925 8.45423 9.19925H5.72696C4.87971 9.19925 4.19287 8.50089 4.19287 7.63942Z"
+                  fill="#a6b6d9"
+                />
+                <path
+                  d="M17.5756 12.1801C18.1216 12.7075 18.1437 13.5851 17.625 14.1403L17.1423 14.6569C13.3654 18.6994 6.99777 18.5987 3.34628 14.4387C2.84481 13.8674 2.89377 12.9909 3.45565 12.481C4.01752 11.9711 4.87954 12.0209 5.38102 12.5922C7.97062 15.5424 12.4865 15.6139 15.1651 12.747L15.6477 12.2304C16.1664 11.6752 17.0296 11.6527 17.5756 12.1801Z"
+                  fill="#a6b6d9"
+                />
+              </svg>
+              <span
+                class="text iconIncluded"
+              >
+                Cody
+              </span>
+            </span>
+          </a>
+        </li>
+        <li
+          class="item"
+        >
+          <a
+            class="link"
+            href="/notebooks"
+          >
+            <span
+              class="linkContent"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon mdi-icon iconInline icon"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M18,2A2,2 0 0,1 20,4V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V4A2,2 0 0,1 6,2H18M18,4H13V12L10.5,9.75L8,12V4H6V20H18V4Z"
+                />
+              </svg>
+              <span
+                class="text iconIncluded"
+              >
+                Notebooks
+              </span>
+            </span>
+          </a>
+        </li>
+        <li
+          class="item"
+        >
+          <a
+            class="link"
+            href="/code-monitoring"
+          >
+            <span
+              class="linkContent"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline icon"
+                fill="currentColor"
+                height="20"
+                role="img"
+                viewBox="0 0 20 20"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              <span
+                class="text iconIncluded"
+              >
+                Monitoring
+              </span>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <ul
+      class="actions"
+    >
+      <li
+        class="action"
+      >
+        <div>
+          <a
+            class="anchorLink btn btnSecondary btnOutline btnSm mr-1"
+            href="/sign-in?returnTo=/"
+          >
+            Sign in
+          </a>
+        </div>
+      </li>
+    </ul>
+  </nav>
+  <div
+    class="searchNavBar"
+  >
+    SearchNavbarItem
+  </div>
+</DocumentFragment>
+`;
+
+exports[`GlobalNavbar > cody only license 1`] = `
+<DocumentFragment>
+  <nav
+    aria-label="Main"
+    class="navbar"
+  >
+    <h1
+      class="h1 logo"
+    >
+      <a
+        class="d-flex align-items-center"
+        href="/search"
+      >
+        BrandLogo
+      </a>
+    </h1>
+    <hr
+      aria-hidden="true"
+      class="divider"
+    />
+    <div
+      class="menu list"
+    >
+      <ul
+        class="list"
+      >
+        <li
+          class="item wrapper"
+        >
+          <div
+            class="link d-flex align-items-center p-0"
+            data-test-active="false"
+            data-test-id="/search"
+          >
+            <button
+              aria-controls=""
+              aria-haspopup="true"
+              aria-label="Show search menu"
+              class="btn itemFocusable button"
+              data-reach-menu-button=""
+              id="menu-button-test-id"
+              type="button"
+            >
+              <span
+                class="itemFocusableContent"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="mdi-icon mdi-icon iconInline icon"
+                  fill="currentColor"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z"
+                  />
+                </svg>
+                <span
+                  class="text iconIncluded"
+                >
+                  Code Search
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="mdi-icon iconInline icon"
+                  fill="currentColor"
+                  height="24"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width="24"
+                >
+                  <path
+                    d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </li>
+        <li
+          class="item"
+        >
+          <a
+            class="link"
+            href="/cody/chat"
+          >
+            <span
+              class="linkContent"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline icon"
+                fill="none"
+                height="20"
+                role="img"
+                viewBox="0 0 20 20"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M13.9088 4C14.756 4 15.4429 4.69836 15.4429 5.55983V8.33286C15.4429 9.19433 14.756 9.89269 13.9088 9.89269C13.0615 9.89269 12.3747 9.19433 12.3747 8.33286V5.55983C12.3747 4.69836 13.0615 4 13.9088 4Z"
+                  fill="#a6b6d9"
+                />
+                <path
+                  d="M4.19287 7.63942C4.19287 6.77795 4.87971 6.07959 5.72696 6.07959H8.45423C9.30148 6.07959 9.98832 6.77795 9.98832 7.63942C9.98832 8.50089 9.30148 9.19925 8.45423 9.19925H5.72696C4.87971 9.19925 4.19287 8.50089 4.19287 7.63942Z"
+                  fill="#a6b6d9"
+                />
+                <path
+                  d="M17.5756 12.1801C18.1216 12.7075 18.1437 13.5851 17.625 14.1403L17.1423 14.6569C13.3654 18.6994 6.99777 18.5987 3.34628 14.4387C2.84481 13.8674 2.89377 12.9909 3.45565 12.481C4.01752 11.9711 4.87954 12.0209 5.38102 12.5922C7.97062 15.5424 12.4865 15.6139 15.1651 12.747L15.6477 12.2304C16.1664 11.6752 17.0296 11.6527 17.5756 12.1801Z"
+                  fill="#a6b6d9"
+                />
+              </svg>
+              <span
+                class="text iconIncluded"
+              >
+                Cody
+              </span>
+            </span>
+          </a>
+        </li>
+        <li
+          class="item"
+        >
+          <a
+            class="link"
+            href="/notebooks"
+          >
+            <span
+              class="linkContent"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon mdi-icon iconInline icon"
+                fill="currentColor"
+                height="24"
+                role="img"
+                viewBox="0 0 24 24"
+                width="24"
+              >
+                <path
+                  d="M18,2A2,2 0 0,1 20,4V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V4A2,2 0 0,1 6,2H18M18,4H13V12L10.5,9.75L8,12V4H6V20H18V4Z"
+                />
+              </svg>
+              <span
+                class="text iconIncluded"
+              >
+                Notebooks
+              </span>
+            </span>
+          </a>
+        </li>
+        <li
+          class="item"
+        >
+          <a
+            class="link"
+            href="/code-monitoring"
+          >
+            <span
+              class="linkContent"
+            >
+              <svg
+                aria-hidden="true"
+                class="mdi-icon iconInline icon"
+                fill="currentColor"
+                height="20"
+                role="img"
+                viewBox="0 0 20 20"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              <span
+                class="text iconIncluded"
+              >
+                Monitoring
+              </span>
+            </span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <ul
+      class="actions"
+    >
+      <li
+        class="action"
+      >
+        <div>
+          <a
+            class="anchorLink btn btnSecondary btnOutline btnSm mr-1"
+            href="/sign-in?returnTo=/"
+          >
+            Sign in
+          </a>
+        </div>
+      </li>
+    </ul>
+  </nav>
+  <div
+    class="searchNavBar"
+  >
+    SearchNavbarItem
+  </div>
+</DocumentFragment>
+`;
+
 exports[`GlobalNavbar > default 1`] = `
 <DocumentFragment>
   <nav

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`GlobalNavbar > code search only license 1`] = `
               <span
                 class="text iconIncluded"
               >
-                Cody
+                Cody AI
               </span>
             </span>
           </a>
@@ -331,7 +331,7 @@ exports[`GlobalNavbar > cody only license 1`] = `
               <span
                 class="text iconIncluded"
               >
-                Cody
+                Cody AI
               </span>
             </span>
           </a>
@@ -545,7 +545,7 @@ exports[`GlobalNavbar > default 1`] = `
               <span
                 class="text iconIncluded"
               >
-                Cody
+                Cody AI
               </span>
             </span>
           </a>

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -155,10 +155,6 @@ const codeSearchRoutes: readonly RouteObject[] = [
         element: <OwnPage />,
     },
     {
-        path: PageRoutes.Search,
-        element: <LegacyRoute render={props => <SearchPageWrapper {...props} />} />,
-    },
-    {
         path: PageRoutes.SearchConsole,
         element: <LegacyRoute render={props => <SearchConsolePageOrRedirect {...props} />} />,
     },
@@ -302,6 +298,11 @@ export const routes: RouteObject[] = [
     {
         path: PageRoutes.ApiConsole,
         element: <ApiConsole />,
+    },
+    // TODO(BolajiOlajide): render landing page instead of SearchPageWrapper when on Cody-only license
+    {
+        path: PageRoutes.Search,
+        element: <LegacyRoute render={props => <SearchPageWrapper {...props} />} />,
     },
     {
         path: PageRoutes.UserArea,

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -158,23 +158,6 @@ const codeSearchRoutes: readonly RouteObject[] = [
         path: PageRoutes.SearchConsole,
         element: <LegacyRoute render={props => <SearchConsolePageOrRedirect {...props} />} />,
     },
-    {
-        path: PageRoutes.RepoContainer,
-        element: (
-            <LegacyRoute
-                render={props => (
-                    <CodySidebarStoreProvider authenticatedUser={props.authenticatedUser}>
-                        <RepoContainer {...props} />
-                    </CodySidebarStoreProvider>
-                )}
-            />
-        ),
-        // In RR6, the useMatches hook will only give you the location that is matched
-        // by the path rule and not the path rule instead. Since we need to be able to
-        // detect if we're inside the repo container reliably inside the Layout, we
-        // expose this information in the handle object instead.
-        handle: { isRepoContainer: true },
-    },
 ]
 
 const codyRoutes: readonly RouteObject[] = [
@@ -323,6 +306,30 @@ export const routes: RouteObject[] = [
     ...communitySearchContextsRoutes,
     ...(isCodeSearchOnlyLicense() ? [] : codyRoutes),
     ...(isCodyOnlyLicense() ? [] : codeSearchRoutes),
+
+    // this should be the last route to be regustered because it's a catch all route
+    // when the instance has the code search feature.
+    ...(isCodyOnlyLicense()
+        ? []
+        : [
+              {
+                  path: PageRoutes.RepoContainer,
+                  element: (
+                      <LegacyRoute
+                          render={props => (
+                              <CodySidebarStoreProvider authenticatedUser={props.authenticatedUser}>
+                                  <RepoContainer {...props} />
+                              </CodySidebarStoreProvider>
+                          )}
+                      />
+                  ),
+                  // In RR6, the useMatches hook will only give you the location that is matched
+                  // by the path rule and not the path rule instead. Since we need to be able to
+                  // detect if we're inside the repo container reliably inside the Layout, we
+                  // expose this information in the handle object instead.
+                  handle: { isRepoContainer: true },
+              },
+          ]),
 ]
 
 function SearchConsolePageOrRedirect(props: LegacyLayoutRouteContext): JSX.Element {


### PR DESCRIPTION
Closes #59662

| Cody Only  | 
|---|
| ![CleanShot 2024-01-19 at 12 15 26@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/37f2f6d9-7134-4034-8d17-118c9810d7f4)  |  

| Code Search Only  | 
|---|
| ![CleanShot 2024-01-17 at 11 34 04@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/61907434-3166-4c94-95e1-9fc35531b42a) |  

| Code Search + Cody  | 
|---|
| ![CleanShot 2024-01-17 at 11 34 04@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/61907434-3166-4c94-95e1-9fc35531b42a) |  

## Test plan

* CI checks.
* Manual testing

