### PR TITLE
Remove blobstore latency alert

### DIFF
--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -229,40 +229,6 @@ Generated query for warning alert: `max((histogram_quantile(0.9, sum by (le) (ra
 
 <br />
 
-## frontend: blob_load_latency
-
-<p class="subtitle">90th percentile blob load latency over 10m</p>
-
-**Descriptions**
-
-- <span class="badge badge-critical">critical</span> frontend: 5s+ 90th percentile blob load latency over 10m for 10m0s
-
-**Next steps**
-
-- When this alert fires, calls to the blob route are slow to return a response. The UI will likely experience delays loading files and code snippets. It is likely that the gitserver and/or frontend services are experiencing issues, leading to slower responses.
-- Confirm that the Sourcegraph gitserver and frontend services have enough CPU/memory using the provisioning panels.
-- Trace a request to see what the slowest part is: https://docs.sourcegraph.com/admin/observability/tracing
-- Check that gitserver containers have enough CPU/memory and are not getting throttled.
-- More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-blob-load-latency).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "critical_frontend_blob_load_latency"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Source team](https://handbook.sourcegraph.com/departments/engineering/teams/source).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for critical alert: `max((histogram_quantile(0.9, sum by (le) (rate(src_http_request_duration_seconds_bucket{route="blob"}[10m])))) >= 5)`
-
-</details>
-
-<br />
-
 ## frontend: 99th_percentile_search_codeintel_request_duration
 
 <p class="subtitle">99th percentile code-intel successful search request duration over 5m</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -147,27 +147,6 @@ Query: `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_secon
 
 <br />
 
-#### frontend: blob_load_latency
-
-<p class="subtitle">90th percentile blob load latency over 10m</p>
-
-- The blob API route provides the files and code snippets that the UI displays.
-
-Refer to the [alerts reference](./alerts.md#frontend-blob-load-latency) for 1 alert related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/frontend/frontend?viewPanel=100021` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Source team](https://handbook.sourcegraph.com/departments/engineering/teams/source).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route="blob"}[10m])))`
-
-</details>
-
-<br />
-
 ### Frontend: Search-based code intelligence at a glance
 
 #### frontend: 99th_percentile_search_codeintel_request_duration

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -160,23 +160,6 @@ func Frontend() *monitoring.Dashboard {
 								- Trace a request to see what the slowest part is: https://docs.sourcegraph.com/admin/observability/tracing
 							`,
 						},
-						{
-							Name:        "blob_load_latency",
-							Description: "90th percentile blob load latency over 10m",
-							Query:       `histogram_quantile(0.9, sum by(le) (rate(src_http_request_duration_seconds_bucket{route="blob"}[10m])))`,
-							Critical:    monitoring.Alert().GreaterOrEqual(5).For(10 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds),
-							Owner:       monitoring.ObservableOwnerSource,
-							Interpretation: `
-								- The blob API route provides the files and code snippets that the UI displays.
-							`,
-							NextSteps: `
-								- When this alert fires, calls to the blob route are slow to return a response. The UI will likely experience delays loading files and code snippets. It is likely that the gitserver and/or frontend services are experiencing issues, leading to slower responses.
-								- Confirm that the Sourcegraph gitserver and frontend services have enough CPU/memory using the provisioning panels.
-								- Trace a request to see what the slowest part is: https://docs.sourcegraph.com/admin/observability/tracing
-								- Check that gitserver containers have enough CPU/memory and are not getting throttled.
-							`,
-						},
 					},
 				},
 			},


### PR DESCRIPTION
This alert does not seem to be useful at all and only leads to anxiety and waking up at night.

## Test plan

Removed alert.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
