### PR TITLE
ci: use ci bazelrc flags everywhere

### DIFF
--- a/dev/ci/bazel-build-sg.sh
+++ b/dev/ci/bazel-build-sg.sh
@@ -2,13 +2,10 @@
 
 set -o errexit -o nounset -o pipefail
 
-echo "--- :bazel: Build sg cli"
-bazel \
-  --bazelrc=.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
-  build \
-  //dev/sg:sg
+bazelrc=(--bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc)
 
-sg_cli="$(bazel cquery //dev/sg:sg --output files)"
+echo "--- :bazel: Build sg cli"
+bazel "${bazelrc[@]}" build //dev/sg:sg
+
+sg_cli="$(bazel cquery "${bazelrc[@]}" //dev/sg:sg --output files)"
 cp "$sg_cli" ./sg

--- a/dev/ci/bazel-build-sg.sh
+++ b/dev/ci/bazel-build-sg.sh
@@ -7,5 +7,5 @@ bazelrc=(--bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspe
 echo "--- :bazel: Build sg cli"
 bazel "${bazelrc[@]}" build //dev/sg:sg
 
-sg_cli="$(bazel cquery "${bazelrc[@]}" //dev/sg:sg --output files)"
+sg_cli="$(bazel "${bazelrc[@]}" cquery //dev/sg:sg --output files)"
 cp "$sg_cli" ./sg

--- a/dev/ci/bazel-configure.sh
+++ b/dev/ci/bazel-configure.sh
@@ -13,7 +13,11 @@ export ASPECT_REENTRANT=
 
 cd "${BUILD_WORKSPACE_DIRECTORY}"
 
-bazel configure
+bazel \
+  --bazelrc=.bazelrc \
+  --bazelrc=.aspect/bazelrc/ci.bazelrc \
+  --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+  configure
 
 if [ "${CI:-}" ]; then
   git ls-files --exclude-standard --others | xargs git add --intent-to-add || true

--- a/dev/ci/bazel-gomodtidy.sh
+++ b/dev/ci/bazel-gomodtidy.sh
@@ -8,7 +8,11 @@ runGoModTidy() {
   dir=$1
   cd "$dir"
   echo "--- :bazel: Running go mod tidy in $dir"
-  bazel run @go_sdk//:bin/go -- mod tidy
+  bazel \
+    --bazelrc=.bazelrc \
+    --bazelrc=.aspect/bazelrc/ci.bazelrc \
+    --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+    run @go_sdk//:bin/go -- mod tidy
   cd -
 }
 

--- a/dev/ci/bazel-gomodtidy.sh
+++ b/dev/ci/bazel-gomodtidy.sh
@@ -3,15 +3,20 @@
 set -eu
 EXIT_CODE=0
 
+# go mod tidy gets run in different subdirectories
+# so the bazelrc files are looked up relative to that,
+# but we need to check from root
+root=$(pwd)
+
 runGoModTidy() {
   local dir
   dir=$1
   cd "$dir"
   echo "--- :bazel: Running go mod tidy in $dir"
   bazel \
-    --bazelrc=.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+    --bazelrc="$root/.bazelrc" \
+    --bazelrc="$root/.aspect/bazelrc/ci.bazelrc" \
+    --bazelrc="$root/.aspect/bazelrc/ci.sourcegraph.bazelrc" \
     run @go_sdk//:bin/go -- mod tidy
   cd -
 }

--- a/dev/ci/gen-pipeline.sh
+++ b/dev/ci/gen-pipeline.sh
@@ -2,18 +2,17 @@
 
 set -e
 
+bazelrc=(--bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc)
+
 echo "--- :books: Annotating build with Glossary"
 buildkite-agent annotate --style info <./dev/ci/glossary.md
 
 echo "--- :bazel: Build pipeline generator"
-bazel \
-  --bazelrc=.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.bazelrc \
-  --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+bazel "${bazelrc[@]}" \
   build \
   //dev/ci:ci
 
-pipeline_gen="$(bazel cquery //dev/ci:ci --output files)"
+pipeline_gen="$(bazel "${bazelrc[@]}" cquery //dev/ci:ci --output files)"
 
 echo "--- :writing_hand: Generate pipeline"
 $pipeline_gen | tee generated-pipeline.yml

--- a/dev/ci/integration/executors/test.sh
+++ b/dev/ci/integration/executors/test.sh
@@ -7,4 +7,8 @@ set -e
 export SOURCEGRAPH_BASE_URL="${1:-"http://localhost:7080"}"
 export SRC_LOG_LEVEL=dbug
 
-bazel run //dev/ci/integration/executors/tester:tester
+bazel \
+  --bazelrc=.bazelrc \
+  --bazelrc=.aspect/bazelrc/ci.bazelrc \
+  --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+  run //dev/ci/integration/executors/tester:tester

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -32,7 +32,7 @@ function create_push_command() {
   done
 
   cmd="bazel \
-    ${bazelrc[@]} \
+    ${bazelrc[*]} \
     run \
     $target \
     --stamp \

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+bazelrc=(--bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc)
+
 function preview_tags() {
   IFS=' ' read -r -a registries <<<"$1"
   IFS=' ' read -r -a tags <<<"$2"
@@ -30,9 +32,7 @@ function create_push_command() {
   done
 
   cmd="bazel \
-    --bazelrc=.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.bazelrc \
-    --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+    ${bazelrc[@]} \
     run \
     $target \
     --stamp \
@@ -114,7 +114,7 @@ if $push_prod; then
   done
 fi
 
-images=$(bazel query 'kind("oci_push rule", //...)')
+images=$(bazel "${bazelrc[@]}" query 'kind("oci_push rule", //...)')
 
 job_file=$(mktemp)
 # shellcheck disable=SC2064

--- a/dev/ci/scripts/wolfi/update-base-image-hashes.sh
+++ b/dev/ci/scripts/wolfi/update-base-image-hashes.sh
@@ -5,7 +5,11 @@ set -eu -o pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
 # Update hashes for all base images
-bazel run //dev/sg -- wolfi update-hashes
+bazel \
+  --bazelrc=.bazelrc \
+  --bazelrc=.aspect/bazelrc/ci.bazelrc \
+  --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc \
+  run //dev/sg -- wolfi update-hashes
 # Print diff
 git diff dev/oci_deps.bzl
 


### PR DESCRIPTION
Differences in flags are causing a lot of analysis cache discarding in CI due to differences.

We mightnt see the results for this until every branch has these changes, as bazel only keeps one analysis cache around.

But also sometimes builds are very fast even when analysis cache is busted :upside_down_face: so who knows

## Test plan

:eye: Observing sourcegraph & aspect pipelines :eye:
