### PR TITLE
Add an option for disabling HTTP/2 when communicating with Cody Gateway

### DIFF
--- a/dev/Caddyfile
+++ b/dev/Caddyfile
@@ -18,3 +18,9 @@
 :3081 {
 	reverse_proxy 127.0.0.1:3082
 }
+
+# Caddy (:3083) -> Cody Gateway (:9992)
+{$SOURCEGRAPH_HTTPS_DOMAIN}:3083 {
+    tls internal
+	reverse_proxy 127.0.0.1:9992
+}

--- a/internal/completions/client/client.go
+++ b/internal/completions/client/client.go
@@ -39,7 +39,7 @@ func getBasic(endpoint string, provider conftypes.CompletionsProviderName, acces
 	case conftypes.CompletionsProviderNameAzureOpenAI:
 		return azureopenai.NewClient(azureopenai.GetAPIClient, endpoint, accessToken)
 	case conftypes.CompletionsProviderNameSourcegraph:
-		return codygateway.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken)
+		return codygateway.NewClient(httpcli.CodyGatewayDoer, endpoint, accessToken)
 	case conftypes.CompletionsProviderNameFireworks:
 		return fireworks.NewClient(httpcli.UncachedExternalDoer, endpoint, accessToken), nil
 	case conftypes.CompletionsProviderNameAWSBedrock:

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -827,9 +827,7 @@ func NewMaxIdleConnsPerHostOpt(max int) Opt {
 		}
 
 		tr.MaxIdleConnsPerHost = max
-		tr.ForceAttemptHTTP2 = false
-		tr.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
-		tr.TLSClientConfig = &tls.Config{}
+
 		return nil
 	}
 }

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -111,6 +111,7 @@ var (
 	externalRetryDelayMax, _         = time.ParseDuration(env.Get("SRC_HTTP_CLI_EXTERNAL_RETRY_DELAY_MAX", "3s", "Max retry delay duration for external HTTP requests"))
 	externalRetryMaxAttempts, _      = strconv.Atoi(env.Get("SRC_HTTP_CLI_EXTERNAL_RETRY_MAX_ATTEMPTS", "20", "Max retry attempts for external HTTP requests"))
 	externalRetryAfterMaxDuration, _ = time.ParseDuration(env.Get("SRC_HTTP_CLI_EXTERNAL_RETRY_AFTER_MAX_DURATION", "3s", "Max duration to wait in retry-after header before we won't auto-retry"))
+	codyGatewayDisableHTTP2          = env.MustGetBool("SRC_HTTP_CLI_DISABLE_CODY_GATEWAY_HTTP2", false, "Whether we should disable HTTP2 for Cody Gateway communication")
 )
 
 // NewExternalClientFactory returns a httpcli.Factory with common options
@@ -177,6 +178,10 @@ var ExternalDoer, _ = ExternalClientFactory.Doer()
 // convenience for existing uses of http.DefaultClient.
 // This client does not cache responses. To cache responses see ExternalDoer instead.
 var UncachedExternalDoer, _ = UncachedExternalClientFactory.Doer()
+
+// CodyGatewayDoer is a client for communication with Cody Gateway.
+// This client does not cache responses.
+var CodyGatewayDoer, _ = UncachedExternalClientFactory.Doer(NewDisableHTTP2Opt(codyGatewayDisableHTTP2))
 
 // TestExternalClientFactory is a httpcli.Factory with common options
 // and is created for tests where you'd normally use an ExternalClientFactory.
@@ -822,7 +827,25 @@ func NewMaxIdleConnsPerHostOpt(max int) Opt {
 		}
 
 		tr.MaxIdleConnsPerHost = max
+		tr.ForceAttemptHTTP2 = false
+		tr.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
+		tr.TLSClientConfig = &tls.Config{}
+		return nil
+	}
+}
 
+// NewDisableHTTP2Opt returns an Opt that makes the http.Client use HTTP/1.1 (instead of defaulting to HTTP/2).
+func NewDisableHTTP2Opt(disable bool) Opt {
+	return func(cli *http.Client) error {
+		tr, err := getTransportForMutation(cli)
+		if err != nil {
+			return errors.Wrap(err, "httpcli.NewDisableHTTP2Opt")
+		}
+		if disable {
+			tr.ForceAttemptHTTP2 = false
+			tr.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
+			tr.TLSClientConfig = &tls.Config{}
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
Add a way to disable HTTP2 for sourcegraph.com -> Cody Gateway communication. This should unblock experimentation with features that require low time-to-first-event for streaming requests (currently affected by GOAWAY errors, see https://github.com/sourcegraph/cody/issues/2180 and [Slack](https://sourcegraph.slack.com/archives/C05497E9MDW/p1704734964553649) for context).

This is unlikely to be the real/permanent fix, but should unblock us for now (until we find a way to reproduce and fix the issue). 
## Test plan

- tested locally 
- off-by-default