### PR TITLE
bazel: remove explicit running of backend_integration_test

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -31,7 +31,6 @@ tasks:
       include_eternal_tests: true
       targets:
           - //...
-          - //testing:backend_integration_test
           # This target should only really run when on main which we aren't handling. For the time being while we
           # evaluate Aspect Workflows it is ok
           # TODO(burmudar): Let this only run on main branch

--- a/dev/ci/internal/ci/bazel_operations.go
+++ b/dev/ci/internal/ci/bazel_operations.go
@@ -9,7 +9,7 @@ func BazelOperations(buildOpts bk.BuildOptions, opts CoreTestOperationsOptions) 
 	ops := []operations.Operation{bazelPrechecks()}
 	if !opts.AspectWorkflows {
 		if opts.IsMainBranch {
-			ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test", "//testing:backend_integration_test"))
+			ops = append(ops, bazelTest("//...", "//client/web:test", "//testing:codeintel_integration_test"))
 		} else {
 			ops = append(ops, bazelTest("//...", "//client/web:test"))
 		}


### PR DESCRIPTION
they are executed automatically by bazel as part of //...

## Test plan
CI