### PR TITLE
Blob UI: Use memoize rendering behavior for the tabbed panels

### DIFF
--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -136,7 +136,7 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
     const activeTab: Panel | undefined = panels[tabIndex]
 
     return (
-        <Tabs className={styles.panel} index={tabIndex} onChange={handleActiveTab}>
+        <Tabs lazy={true} behavior="memoize" className={styles.panel} index={tabIndex} onChange={handleActiveTab}>
             <TabList
                 wrapperClassName={classNames(styles.panelHeader, 'sticky-top')}
                 actions={
@@ -185,7 +185,7 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
                             className={styles.tabsContent}
                             data-testid="panel-tabs-content"
                         >
-                            {id === activeTab.id ? element : null}
+                            {({ shouldRender }) => shouldRender && element}
                         </TabPanel>
                     ))
                 ) : (

--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -118,13 +118,15 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
         [currentTabLabel, navigate, panels, pathname, search]
     )
 
-    const tabIndex = useMemo<number>(() => {
-        return panels
-            ? panels.findIndex(({ id, matchesTabID }) =>
-                  matchesTabID ? matchesTabID(currentTabID) : id === currentTabID
-              )
-            : 0
-    }, [panels, currentTabID])
+    const tabIndex = useMemo(
+        (): number =>
+            panels
+                ? panels.findIndex(({ id, matchesTabID }) =>
+                      matchesTabID ? matchesTabID(currentTabID) : id === currentTabID
+                  )
+                : 0,
+        [panels, currentTabID]
+    )
 
     if (!panels) {
         return <EmptyPanelView className={styles.panel} />

--- a/client/branded/src/components/panel/TabbedPanelContent.tsx
+++ b/client/branded/src/components/panel/TabbedPanelContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
@@ -83,7 +83,6 @@ export function useBuiltinTabbedPanelViews(panels: Panel[]): void {
  * Other components can contribute panel items to the panel with the `useBuildinPanelViews` hook.
  */
 export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
-    const [tabIndex, setTabIndex] = useState(0)
     const { hash, pathname, search } = useLocation()
     const navigate = useNavigate()
 
@@ -119,15 +118,13 @@ export const TabbedPanelContent = React.memo<TabbedPanelContentProps>(props => {
         [currentTabLabel, navigate, panels, pathname, search]
     )
 
-    useEffect(() => {
-        setTabIndex(
-            panels
-                ? panels.findIndex(({ id, matchesTabID }) =>
-                      matchesTabID ? matchesTabID(currentTabID) : id === currentTabID
-                  )
-                : 0
-        )
-    }, [panels, hash, currentTabID])
+    const tabIndex = useMemo<number>(() => {
+        return panels
+            ? panels.findIndex(({ id, matchesTabID }) =>
+                  matchesTabID ? matchesTabID(currentTabID) : id === currentTabID
+              )
+            : 0
+    }, [panels, currentTabID])
 
     if (!panels) {
         return <EmptyPanelView className={styles.panel} />

--- a/client/wildcard/src/components/Tabs/Tabs.tsx
+++ b/client/wildcard/src/components/Tabs/Tabs.tsx
@@ -14,6 +14,7 @@ import {
     useTabsContext,
 } from '@reach/tabs'
 import classNames from 'classnames'
+import { isFunction } from 'lodash'
 
 import { useElementObscuredArea } from '../../hooks'
 import type { ForwardReferenceComponent } from '../../types'
@@ -71,7 +72,13 @@ export interface TabProps extends ReachTabProps {}
 
 export interface TabPanelsProps extends ReachTabPanelsProps {}
 
-export interface TabPanelProps extends ReachTabPanelProps {}
+export interface TabPanelContext {
+    shouldRender: boolean
+}
+
+export interface TabPanelProps extends Omit<ReachTabPanelProps, 'children'> {
+    children?: React.ReactNode | ((tabContext: TabPanelContext) => React.ReactNode)
+}
 
 /**
  * reach UI tabs component with steroids, this tabs handles how the data should be loaded
@@ -247,7 +254,7 @@ export const TabPanel = React.forwardRef((props, reference) => {
     const shouldRender = useShouldPanelRender(children)
     return (
         <ReachTabPanel data-testid="wildcard-tab-panel" as={as} ref={reference} {...reachProps}>
-            {shouldRender ? children : null}
+            {isFunction(children) ? children({ shouldRender }) : shouldRender ? children : null}
         </ReachTabPanel>
     )
 }) as ForwardReferenceComponent<'div', TabPanelProps>

--- a/client/wildcard/src/components/Tabs/useShouldPanelRender.ts
+++ b/client/wildcard/src/components/Tabs/useShouldPanelRender.ts
@@ -4,7 +4,9 @@ import { useTabsContext as useReachTabsContext } from '@reach/tabs'
 
 import { useTablePanelIndex, useTabsState } from './context'
 
-export function useShouldPanelRender(children: ReactNode): boolean {
+type FunctionLikeChildren = ReactNode | ((context: any) => ReactNode)
+
+export function useShouldPanelRender(children: FunctionLikeChildren): boolean {
     const { selectedIndex } = useReachTabsContext()
     const index = useTablePanelIndex()
     const {
@@ -26,5 +28,6 @@ export function useShouldPanelRender(children: ReactNode): boolean {
             return wasRendered
         }
     }
+
     return true
 }


### PR DESCRIPTION

https://github.com/sourcegraph/sourcegraph/assets/18492575/a98c6394-98eb-4097-9cc1-0623d94514e3

## Test plan
- Check that you load only data that you need for open tab on the initial rendering
- Check that as you switch to the new tab (if it's first render of the panel you should see loading) if it's second render you should see tab content UI immediately with no loaders

@jasonhawkharris I didn't link any issue here but if we have some can you add it to this PR description 


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
