### PR TITLE
bazel: patches to allow use_default_shell_env for e2e testing

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -1,4 +1,4 @@
-# Provides secrets like GH_TOKEN and PERCY_TOKEN via --define flag.
+# Provides secrets like GH_TOKEN and PERCY_TOKEN via --action_env flag.
 # Generated via the `.buildkite/hooks/post-checkout` hook.
 try-import %workspace%/.aspect/bazelrc/ci.generated.bazelrc
 
@@ -29,13 +29,13 @@ common --test_env=TESTDB_MAXOPENCONNS=15
 common --test_env=BUILDKITE
 
 # Needed for mocha tests
-# We have to use the `--define` flag here instead of `--test_env` because
+# We have to use the `--action_env` flag here instead of `--test_env` because
 # the mocha tests target is the build target and it's tested with `build_test`.
-common --define=E2E_HEADLESS=false
+common --action_env=E2E_HEADLESS=false
 # if we set this to localhost, chrome will refuse to conenct since local host is in its HTTP Strict Transport Security
 # by setting the loopback address we get passed that
-common --define=E2E_SOURCEGRAPH_BASE_URL="http://127.0.0.1:7080"
-common --define=DISPLAY=:99
+common --action_env=E2E_SOURCEGRAPH_BASE_URL="http://127.0.0.1:7080"
+common --action_env=DISPLAY=:99
 
 # Provides git commit, branch information to build targets like Percy via status file.
 # https://bazel.build/docs/user-manual#workspace-status

--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -31,10 +31,10 @@ common --test_env=BUILDKITE
 # Needed for mocha tests
 # We have to use the `--action_env` flag here instead of `--test_env` because
 # the mocha tests target is the build target and it's tested with `build_test`.
-common --action_env=E2E_HEADLESS=false
+common --action_env=HEADLESS=false
 # if we set this to localhost, chrome will refuse to conenct since local host is in its HTTP Strict Transport Security
 # by setting the loopback address we get passed that
-common --action_env=E2E_SOURCEGRAPH_BASE_URL="http://127.0.0.1:7080"
+common --action_env=SOURCEGRAPH_BASE_URL="http://127.0.0.1:7080"
 common --action_env=DISPLAY=:99
 
 # Provides git commit, branch information to build targets like Percy via status file.

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -13,4 +13,4 @@ echo "Running git fetch... done"
 ln -s "$(pwd)/dev/ci/scripts/annotated-command.sh" an 2>/dev/null || true
 
 # Provides secrets to the client integration tests target.
-echo -e "build --define=GH_TOKEN=$GH_TOKEN\nbuild --define=PERCY_TOKEN=$PERCY_TOKEN" >.aspect/bazelrc/ci.generated.bazelrc
+echo -e "build --action_env=GH_TOKEN=$GH_TOKEN\nbuild --action_env=PERCY_TOKEN=$PERCY_TOKEN" >.aspect/bazelrc/ci.generated.bazelrc

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "aspect_bazel_lib",
+    patch_args = ["-p1"],
+    patches = [
+        "//third_party/bazel_lib:use_default_shell_env.patch",
+    ],
     sha256 = "4d6010ca5e3bb4d7045b071205afa8db06ec11eb24de3f023d74d77cca765f66",
     strip_prefix = "bazel-lib-1.39.0",
     url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz",
@@ -30,6 +34,10 @@ http_archive(
 
 http_archive(
     name = "aspect_rules_js",
+    patch_args = ["-p1"],
+    patches = [
+        "//third_party/rules_js:use_default_shell_env.patch",
+    ],
     sha256 = "76a04ef2120ee00231d85d1ff012ede23963733339ad8db81f590791a031f643",
     strip_prefix = "rules_js-1.34.1",
     url = "https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz",

--- a/dev/mocha.bzl
+++ b/dev/mocha.bzl
@@ -65,7 +65,7 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
     ]
 
     env = dict(env, **{
-        "HEADLESS": "$$E2E_HEADLESS",
+        "HEADLESS": "$E2E_HEADLESS",
         # Add environment variable so that mocha writes its test xml
         # to the location Bazel expects.
         "MOCHA_FILE": "$$XML_OUTPUT_FILE",
@@ -73,8 +73,8 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
         # TODO(bazel): e2e test environment
         "TEST_USER_EMAIL": "test@sourcegraph.com",
         "TEST_USER_PASSWORD": "supersecurepassword",
-        "SOURCEGRAPH_BASE_URL": "$$E2E_SOURCEGRAPH_BASE_URL",
-        "GH_TOKEN": "$$GH_TOKEN",
+        "SOURCEGRAPH_BASE_URL": "$E2E_SOURCEGRAPH_BASE_URL",
+        "GH_TOKEN": "$GH_TOKEN",
         "SOURCEGRAPH_SUDO_TOKEN": "fake-sg-token",
         "NO_CLEANUP": "false",
         "KEEP_BROWSER": "false",
@@ -88,7 +88,7 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
         "INTEGRATION_TESTS": "true",
 
         # Puppeteer config
-        "DISPLAY": "$$DISPLAY",
+        "DISPLAY": "$DISPLAY",
     })
 
     if is_percy_enabled:
@@ -107,7 +107,7 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
             args = args,
             env = dict(env, **{
                 "PERCY_ON": "true",
-                "PERCY_TOKEN": "$$PERCY_TOKEN",
+                "PERCY_TOKEN": "$PERCY_TOKEN",
             }),
             use_default_shell_env = True,
             srcs = data,

--- a/dev/mocha.bzl
+++ b/dev/mocha.bzl
@@ -64,10 +64,8 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
         ":%s" % bundle_name,
     ]
 
-    # `--define` flags are used to set environment variables here because
-    # we use `js_run_binary` as a target and it doesn't work with `--test_env`.
     env = dict(env, **{
-        "HEADLESS": "$(E2E_HEADLESS)",
+        "HEADLESS": "$$E2E_HEADLESS",
         # Add environment variable so that mocha writes its test xml
         # to the location Bazel expects.
         "MOCHA_FILE": "$$XML_OUTPUT_FILE",
@@ -75,8 +73,8 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
         # TODO(bazel): e2e test environment
         "TEST_USER_EMAIL": "test@sourcegraph.com",
         "TEST_USER_PASSWORD": "supersecurepassword",
-        "SOURCEGRAPH_BASE_URL": "$(E2E_SOURCEGRAPH_BASE_URL)",
-        "GH_TOKEN": "$(GH_TOKEN)",
+        "SOURCEGRAPH_BASE_URL": "$$E2E_SOURCEGRAPH_BASE_URL",
+        "GH_TOKEN": "$$GH_TOKEN",
         "SOURCEGRAPH_SUDO_TOKEN": "fake-sg-token",
         "NO_CLEANUP": "false",
         "KEEP_BROWSER": "false",
@@ -90,7 +88,7 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
         "INTEGRATION_TESTS": "true",
 
         # Puppeteer config
-        "DISPLAY": "$(DISPLAY)",
+        "DISPLAY": "$$DISPLAY",
     })
 
     if is_percy_enabled:
@@ -109,8 +107,9 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
             args = args,
             env = dict(env, **{
                 "PERCY_ON": "true",
-                "PERCY_TOKEN": "$(PERCY_TOKEN)",
+                "PERCY_TOKEN": "$$PERCY_TOKEN",
             }),
+            use_default_shell_env = True,
             srcs = data,
             out_dirs = ["out"],
             silent_on_success = True,
@@ -134,5 +133,6 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
             args = args,
             data = data,
             env = env,
+            use_default_shell_env = True,
             **kwargs
         )

--- a/dev/mocha.bzl
+++ b/dev/mocha.bzl
@@ -64,8 +64,16 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
         ":%s" % bundle_name,
     ]
 
+    # Some values are passed down from --action_env. Bazel unfortunately
+    # doesn't let us rename them without attempting to do analysis-time
+    # variable substitution, which causes analysis-time errors if the variables
+    # are not declared.
+    # - SOURCEGRAPH_BASE_URL
+    # - GH_TOKEN
+    # - DISPLAY
+    # - HEADLESS
+    # - PERCY_TOKEN
     env = dict(env, **{
-        "HEADLESS": "$E2E_HEADLESS",
         # Add environment variable so that mocha writes its test xml
         # to the location Bazel expects.
         "MOCHA_FILE": "$$XML_OUTPUT_FILE",
@@ -73,8 +81,6 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
         # TODO(bazel): e2e test environment
         "TEST_USER_EMAIL": "test@sourcegraph.com",
         "TEST_USER_PASSWORD": "supersecurepassword",
-        "SOURCEGRAPH_BASE_URL": "$E2E_SOURCEGRAPH_BASE_URL",
-        "GH_TOKEN": "$GH_TOKEN",
         "SOURCEGRAPH_SUDO_TOKEN": "fake-sg-token",
         "NO_CLEANUP": "false",
         "KEEP_BROWSER": "false",
@@ -86,9 +92,6 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
 
         # Enable findDom on CodeMirror
         "INTEGRATION_TESTS": "true",
-
-        # Puppeteer config
-        "DISPLAY": "$DISPLAY",
     })
 
     if is_percy_enabled:
@@ -107,7 +110,6 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
             args = args,
             env = dict(env, **{
                 "PERCY_ON": "true",
-                "PERCY_TOKEN": "$PERCY_TOKEN",
             }),
             use_default_shell_env = True,
             srcs = data,

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1583,13 +1583,13 @@ tests:
       else
         BAZEL_FLAGS=""
       fi
-      bazel test //testing:e2e_test $BAZEL_FLAGS --define=E2E_HEADLESS=false --define=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --define=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --define=GH_TOKEN=$GH_TOKEN --define=DISPLAY=$DISPLAY
+      bazel test //testing:e2e_test $BAZEL_FLAGS --action_env=E2E_HEADLESS=false --action_env=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --action_env=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --action_env=GH_TOKEN=$GH_TOKEN --action_env=DISPLAY=$DISPLAY
 
   bazel-web-integration:
     cmd: |
       export GH_TOKEN=$(gcloud secrets versions access latest --secret=GITHUB_TOKEN --quiet --project=sourcegraph-ci)
       export PERCY_TOKEN=$(gcloud secrets versions access latest --secret=PERCY_TOKEN --quiet --project=sourcegraph-ci)
-      bazel test //client/web/src/integration:integration-tests --define=E2E_HEADLESS=false --define=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --define=GH_TOKEN=$GH_TOKEN --define=DISPLAY=$DISPLAY --define=PERCY_TOKEN=$PERCY_TOKEN
+      bazel test //client/web/src/integration:integration-tests --action_env=E2E_HEADLESS=false --action_env=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --action_env=GH_TOKEN=$GH_TOKEN --action_env=DISPLAY=$DISPLAY --action_env=PERCY_TOKEN=$PERCY_TOKEN
 
   backend-integration:
     cmd: cd dev/gqltest && go test -long -base-url $BASE_URL -email $EMAIL -username $USERNAME -password $PASSWORD ./gqltest

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1583,13 +1583,13 @@ tests:
       else
         BAZEL_FLAGS=""
       fi
-      bazel test //testing:e2e_test $BAZEL_FLAGS --action_env=E2E_HEADLESS=false --action_env=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --action_env=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --action_env=GH_TOKEN=$GH_TOKEN --action_env=DISPLAY=$DISPLAY
+      bazel test //testing:e2e_test $BAZEL_FLAGS --action_env=HEADLESS=false --action_env=SOURCEGRAPH_BASE_URL="http://localhost:7080" --action_env=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --action_env=GH_TOKEN=$GH_TOKEN --action_env=DISPLAY=$DISPLAY
 
   bazel-web-integration:
     cmd: |
       export GH_TOKEN=$(gcloud secrets versions access latest --secret=GITHUB_TOKEN --quiet --project=sourcegraph-ci)
       export PERCY_TOKEN=$(gcloud secrets versions access latest --secret=PERCY_TOKEN --quiet --project=sourcegraph-ci)
-      bazel test //client/web/src/integration:integration-tests --action_env=E2E_HEADLESS=false --action_env=E2E_SOURCEGRAPH_BASE_URL="http://localhost:7080" --action_env=GH_TOKEN=$GH_TOKEN --action_env=DISPLAY=$DISPLAY --action_env=PERCY_TOKEN=$PERCY_TOKEN
+      bazel test //client/web/src/integration:integration-tests --action_env=HEADLESS=false --action_env=SOURCEGRAPH_BASE_URL="http://localhost:7080" --action_env=GH_TOKEN=$GH_TOKEN --action_env=DISPLAY=$DISPLAY --action_env=PERCY_TOKEN=$PERCY_TOKEN
 
   backend-integration:
     cmd: cd dev/gqltest && go test -long -base-url $BASE_URL -email $EMAIL -username $USERNAME -password $PASSWORD ./gqltest

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -30,8 +30,8 @@ server_integration_test(
     },
     env_inherit = [
         "DISPLAY",
-        "E2E_HEADLESS",
-        "E2E_SOURCEGRAPH_BASE_URL",
+        "HEADLESS",
+        "SOURCEGRAPH_BASE_URL",
         "GHE_GITHUB_TOKEN",
         "GH_TOKEN",
         "SOURCEGRAPH_LICENSE_GENERATION_KEY",

--- a/testing/e2e_test.sh
+++ b/testing/e2e_test.sh
@@ -9,6 +9,8 @@ e2e_test="$3"
 mocha_config="$4"
 files="$5"
 
+E2E_SOURCEGRAPH_BASE_URL="$SOURCEGRAPH_BASE_URL"
+
 url="http://localhost:$PORT"
 
 SOURCEGRAPH_BASE_URL="$url"
@@ -23,6 +25,9 @@ ALLOW_SINGLE_DOCKER_CODE_INSIGHTS="true"
 export ALLOW_SINGLE_DOCKER_CODE_INSIGHTS
 
 run_server_image "$tarball" "$image_name" "$url" "$PORT"
+
+SOURCEGRAPH_BASE_URL="$E2E_SOURCEGRAPH_BASE_URL"
+export SOURCEGRAPH_BASE_URL
 
 echo "--- e2e test //client/web/src/end-to-end:e2e"
 "$e2e_test" --config "$mocha_config" --retries 4 "$files"

--- a/third_party/bazel_lib/BUILD.bazel
+++ b/third_party/bazel_lib/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/third_party/bazel_lib/use_default_shell_env.patch
+++ b/third_party/bazel_lib/use_default_shell_env.patch
@@ -1,0 +1,37 @@
+diff --git a/lib/private/run_binary.bzl b/lib/private/run_binary.bzl
+index 7ba4210..55bd984 100644
+--- a/lib/private/run_binary.bzl
++++ b/lib/private/run_binary.bzl
+@@ -76,7 +76,7 @@ Possible fixes:
+         mnemonic = ctx.attr.mnemonic if ctx.attr.mnemonic else None,
+         progress_message = ctx.attr.progress_message if ctx.attr.progress_message else None,
+         execution_requirements = ctx.attr.execution_requirements if ctx.attr.execution_requirements else None,
+-        use_default_shell_env = False,
++        use_default_shell_env = True,
+         env = dicts.add(ctx.configuration.default_shell_env, envs),
+         input_manifests = tool_input_mfs,
+     )
+@@ -95,6 +95,7 @@ _run_binary = rule(
+             cfg = "exec",
+         ),
+         "env": attr.string_dict(),
++        "use_default_shell_env": attr.bool(default = False),
+         "srcs": attr.label_list(
+             allow_files = True,
+         ),
+@@ -113,6 +114,7 @@ def run_binary(
+         srcs = [],
+         args = [],
+         env = {},
++        use_default_shell_env = False,
+         outs = [],
+         out_dirs = [],
+         mnemonic = "RunBinary",
+@@ -220,6 +222,7 @@ def run_binary(
+         srcs = srcs,
+         args = args,
+         env = env,
++        use_default_shell_env = use_default_shell_env,
+         outs = outs,
+         out_dirs = out_dirs + ([name] if output_dir else []),
+         mnemonic = mnemonic,

--- a/third_party/rules_js/BUILD.bazel
+++ b/third_party/rules_js/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/third_party/rules_js/use_default_shell_env.patch
+++ b/third_party/rules_js/use_default_shell_env.patch
@@ -1,0 +1,32 @@
+diff --git a/js/private/js_binary.bzl b/js/private/js_binary.bzl
+index b683eca..46b0ca0 100644
+--- a/js/private/js_binary.bzl
++++ b/js/private/js_binary.bzl
+@@ -130,6 +130,7 @@ _ATTRS = {
+         and ["Make variable"](https://bazel.build/reference/be/make-variables) substitution.
+         """,
+     ),
++    "use_default_shell_env": attr.bool(),
+     "fixed_args": attr.string_list(
+         doc = """Fixed command line arguments to pass to the Node.js when this
+         binary target is executed.
+diff --git a/js/private/js_run_binary.bzl b/js/private/js_run_binary.bzl
+index 6b7d109..27dd001 100644
+--- a/js/private/js_run_binary.bzl
++++ b/js/private/js_run_binary.bzl
+@@ -22,6 +22,7 @@ def js_run_binary(
+         name,
+         tool,
+         env = {},
++        use_default_shell_env = False,
+         srcs = [],
+         outs = [],
+         out_dirs = [],
+@@ -358,6 +359,7 @@ See https://github.com/aspect-build/rules_js/tree/main/docs#using-binaries-publi
+         name = name,
+         tool = tool,
+         env = dicts.add(fixed_env, env),
++        use_default_shell_env = use_default_shell_env,
+         srcs = srcs + extra_srcs,
+         outs = outs + extra_outs,
+         out_dirs = out_dirs,


### PR DESCRIPTION
Another step towards https://github.com/sourcegraph/sourcegraph/issues/59155, previously `bazel test //...` would error at analysis time on `//client/web/src/end-to-end:e2e` due to it attempting to perform variable substitution for env vars e.g. `"HEADLESS": "$(E2E_HEADLESS)"`, for values not defined via `--define` (we only set these explicitly in .aspect/bazelrc/ci.sourcegraph.bazelrc and some `sg` targets).

By leveraging https://bazel.build/rules/lib/builtins/actions#run.use_default_shell_env, we can allow the test to read values from `--action_env` while _also_ having explicit values set via `env` macro parameter. Previously, setting `env` macro parameter would completely shadow any `--action_env` values. 
Unfortunately, we cant use `--test_env` for this, as `js_run_binary` is an action not a test (or something like that?).

We also cant do env renaming anymore, meaning we have to drop the `E2E_` prefix for some env vars. At least one script needed some reworking to accommodate that `e2e_test.sh` 

![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/133a98c6-411d-4a10-95fd-4abd42cedb24)


## Test plan

:eye: CI once again :eye: 
