### PR TITLE
msp/cloudrun: do not provision default rules for Sentry

### DIFF
--- a/dev/managedservicesplatform/stacks/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/cloudrun.go
@@ -302,6 +302,7 @@ func NewStack(stacks *stack.Set, vars Variables) (crossStackOutput *CrossStackOu
 			Name:         pointers.Stringf("%s - %s", vars.Service.GetName(), vars.Environment.ID),
 			Slug:         pointers.Stringf("%s-%s", vars.Service.ID, vars.Environment.ID),
 			Teams:        &[]*string{sentryTeam.Slug()},
+			DefaultRules: pointers.Ptr(false),
 		})
 
 		// Create a DSN


### PR DESCRIPTION
https://registry.terraform.io/providers/jianyuan/sentry/latest/docs/resources/project#default_rules

## Test plan

n/a