### PR TITLE
Search: add 'AND' queries to search blitz

### DIFF
--- a/internal/cmd/search-blitz/queries.txt
+++ b/internal/cmd/search-blitz/queries.txt
@@ -101,3 +101,9 @@ repo:^github\.com/sgtest/megarepo$ patterntype:literal lang:go -file:vendor/ cou
 
 # mono_rev_literal_large
 repo:^github\.com/sgtest/megarepo$ patterntype:literal lang:go -file:vendor/ count:1000 TempDir index:no
+
+# mono_boolean_large
+repo:^github\.com/sgtest/megarepo$ patterntype:literal test AND server
+
+# mono_rev_boolean_large
+repo:^github\.com/sgtest/megarepo$ patterntype:literal test AND server index:no


### PR DESCRIPTION
This adds and 'AND' query to search blitz. The performance of 'AND' queries
will be important going forward, since we're changing the default search
strategy to interpret spaces as AND instead of performing an exact match.

It adds both an indexed search (hitting Zoekt) and unindexed search (hitting
searcher).

## Test plan

Tested these queries on dot com.