### PR TITLE
grpc: fix retry callback logic

### DIFF
--- a/internal/grpc/retry/retry.go
+++ b/internal/grpc/retry/retry.go
@@ -261,7 +261,6 @@ func (s *serverStreamingRetryingStream) SendMsg(m any) error {
 }
 
 func (s *serverStreamingRetryingStream) CloseSend() error {
-
 	s.mu.Lock()
 	s.wasClosedSend = true
 	s.mu.Unlock()
@@ -286,9 +285,7 @@ func (s *serverStreamingRetryingStream) RecvMsg(m any) error {
 		if err := waitRetryBackoff(attempt, s.parentCtx, s.callOpts); err != nil {
 			return err
 		}
-
 		s.callOpts.onRetryCallback(s.parentCtx, attempt, lastErr)
-		// here
 		newStream, err := s.reestablishStreamAndResendBuffer(s.parentCtx)
 		if err != nil {
 			// Retry dial and transport errors of establishing stream as grpc doesn't retry.

--- a/internal/grpc/retry/retry_test.go
+++ b/internal/grpc/retry/retry_test.go
@@ -342,6 +342,15 @@ func (s *RetrySuite) TestUnary_OnRetryCallbackCalled() {
 		WithMax(10),
 		WithOnRetryCallback(func(ctx context.Context, attempt uint, err error) {
 			retryCallbackCount++
+
+			code := status.Code(err)
+			for _, c := range retriableErrors {
+				if code == c {
+					return
+				}
+			}
+
+			require.Fail(s.T(), "OnRetryCallback called with non-retriable error", "error code: %s, err: %v", code, err)
 		}),
 	)
 

--- a/internal/grpc/retry/retry_test.go
+++ b/internal/grpc/retry/retry_test.go
@@ -441,6 +441,52 @@ func (s *RetrySuite) TestServerStream_OnRetryCallbackCalled() {
 	require.EqualValues(s.T(), 2, retryCallbackCount, "two retry callbacks should be called")
 }
 
+func (s *RetrySuite) TestServerUnary_OnRetryCallbackCalled_Only_On_RetriableCodes() {
+	s.Run("context cancellation", func() {
+		var lastRetriedErr error
+		retryCallbackCount := 0
+
+		s.srv.resetUnaryOrStreamEstablishmentFailingConfiguration(alwaysSucceed, codes.OK, noSleep) // see retriable_errors
+		ctx, cancel := context.WithCancel(s.SimpleCtx())
+		cancel() // cancel the context to force a DeadlineExceeded error
+
+		_, err := s.Client.Ping(ctx, testpb.GoodPing,
+			WithOnRetryCallback(func(ctx context.Context, attempt uint, err error) {
+				retryCallbackCount++
+				lastRetriedErr = err
+			}),
+		)
+		require.Error(s.T(), err)
+
+		require.EqualValues(s.T(), 0, retryCallbackCount, "no retry callbacks should be called since the context is already cancelled")
+		if c := status.Code(err); c != codes.DeadlineExceeded && c != codes.Canceled {
+			require.Fail(s.T(), "error code should be context error")
+		}
+		require.NoError(s.T(), lastRetriedErr)
+	})
+
+	s.Run("non-retriable error code", func() {
+		var lastRetriedErr error
+		retryCallbackCount := 0
+
+		s.srv.resetUnaryOrStreamEstablishmentFailingConfiguration(failExceptModulo(3), codes.OutOfRange, noSleep) // see retriable_errors
+
+		_, err := s.Client.Ping(s.SimpleCtx(), testpb.GoodPing,
+			WithOnRetryCallback(func(ctx context.Context, attempt uint, err error) {
+				retryCallbackCount++
+				lastRetriedErr = err
+			}),
+		)
+
+		require.Error(s.T(), err)
+
+		require.EqualValues(s.T(), 0, retryCallbackCount, "no retry callbacks should be called since the context is already cancelled")
+		// Check that the returned err has codes.OutOfRange:
+		require.Equal(s.T(), codes.OutOfRange, status.Code(err), "returned error code should be codes.OutOfRange")
+		require.NoError(s.T(), lastRetriedErr)
+	})
+}
+
 func (s *RetrySuite) TestServerStream_OnRetryCallbackCalled_Only_On_RetriableCodes() {
 	s.Run("stream establishment", func() {
 		var lastRetriedErr error
@@ -462,34 +508,69 @@ func (s *RetrySuite) TestServerStream_OnRetryCallbackCalled_Only_On_RetriableCod
 	})
 
 	s.Run("stream consumption", func() {
-		var lastRetriedErr error
-		retryCallbackCount := 0
+		s.Run("context cancellation", func() {
+			var lastRetriedErr error
+			retryCallbackCount := 0
 
-		s.srv.resetUnaryOrStreamEstablishmentFailingConfiguration(alwaysSucceed, codes.OK, noSleep) // see retriable_errors
-		ctx, cancel := context.WithCancel(s.SimpleCtx())
+			s.srv.resetUnaryOrStreamEstablishmentFailingConfiguration(alwaysSucceed, codes.OK, noSleep) // see retriable_errors
+			ctx, cancel := context.WithCancel(s.SimpleCtx())
 
-		stream, err := s.Client.PingList(ctx, testpb.GoodPingList,
-			WithOnRetryCallback(func(ctx context.Context, attempt uint, err error) {
-				retryCallbackCount++
-				lastRetriedErr = err
-			}),
-		)
+			stream, err := s.Client.PingList(ctx, testpb.GoodPingList,
+				WithOnRetryCallback(func(ctx context.Context, attempt uint, err error) {
+					retryCallbackCount++
+					lastRetriedErr = err
+				}),
+			)
 
-		require.EqualValues(s.T(), 0, retryCallbackCount, "no retry callbacks should be called since the stream has not been consumed yet")
-		require.NoError(s.T(), err, "establishing the connection must always succeed")
-		cancel() // cancel the context to force a DeadlineExceeded error
+			require.EqualValues(s.T(), 0, retryCallbackCount, "no retry callbacks should be called since the stream has not been consumed yet")
+			require.NoError(s.T(), err, "establishing the connection must always succeed")
+			cancel() // cancel the context to force a DeadlineExceeded error
 
-		var lastErr error
+			var lastErr error
 
-		for {
-			_, lastErr = stream.Recv()
-			if lastErr != nil {
-				break
+			for {
+				_, lastErr = stream.Recv()
+				if lastErr != nil {
+					break
+				}
 			}
-		}
 
-		require.Error(s.T(), lastErr, "we should have received an error since the context was cancelled during stream consumption")
-		require.EqualValues(s.T(), 0, retryCallbackCount, "no retry callbacks should be called since the parent context is already cancelled, lastRetriedErr: %v", lastRetriedErr)
+			require.Error(s.T(), lastErr, "we should have received an error since the context was cancelled during stream consumption")
+			require.EqualValues(s.T(), 0, retryCallbackCount, "no retry callbacks should be called since the parent context is already cancelled, lastRetriedErr: %v", lastRetriedErr)
+		})
+
+		s.Run("non-retriable error code", func() {
+			var lastRetriedErr error
+			retryCallbackCount := 0
+
+			s.srv.resetUnaryOrStreamEstablishmentFailingConfiguration(alwaysSucceed, codes.OutOfRange, noSleep) // see retriable_errors
+			s.srv.resetStreamFailingConfiguration(func() bool { return true }, codes.OutOfRange)
+
+			stream, err := s.Client.PingList(context.Background(), testpb.GoodPingList,
+				WithOnRetryCallback(func(ctx context.Context, attempt uint, err error) {
+					retryCallbackCount++
+					lastRetriedErr = err
+				}),
+			)
+
+			require.EqualValues(s.T(), 0, retryCallbackCount, "no retry callbacks should be called since the stream has not been consumed yet")
+			require.NoError(s.T(), err, "establishing the connection must always succeed")
+
+			var lastErr error
+
+			for {
+				_, lastErr = stream.Recv()
+				if lastErr != nil {
+					break
+				}
+			}
+
+			require.EqualValues(s.T(), 0, retryCallbackCount, "no retry callbacks should be called since the error code is not declared retriable, lastRetriedErr: %v", lastRetriedErr)
+			// Check that the returned err has codes.OutOfRange:
+			require.Equal(s.T(), codes.OutOfRange, status.Code(lastErr))
+			require.Nil(s.T(), lastRetriedErr)
+		})
+
 	})
 }
 


### PR DESCRIPTION
The `retry` package's WithOnRetryCallback functionality should only run a user defined callback if the library is about to retry a request. Howevever, there was a a pre-existing bug in the library that ran the callback whenever any sort of error occurred - regardless of whether the error was actually a retriable one. (Example: the callback would fire even if the error was a context cancellation error that can never be retried). 

This had some unintended side-effects, including inaccurate Prometheus / tracing metrics (which relied on this functioanity). 

This PR fixes the issue - now the callback only fires when there is a retriable error. 

## Test plan

CI (new tests)