### PR TITLE
search: remove check for structural search from backend

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -354,14 +354,6 @@ func EventLoggingEnabled() bool {
 	return val == "enabled"
 }
 
-func StructuralSearchEnabled() bool {
-	val := ExperimentalFeatures().StructuralSearch
-	if val == "" {
-		return false
-	}
-	return val == "enabled"
-}
-
 // SearchDocumentRanksWeight controls the impact of document ranks on the final ranking when
 // SearchOptions.UseDocumentRanks is enabled. The default is 0.5 * 9000 (half the zoekt default),
 // to match existing behavior where ranks are given half the priority as existing scoring signals.

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -98,10 +98,6 @@ func (s *searchClient) Plan(
 	}
 	searchType = overrideSearchType(searchQuery, searchType)
 
-	if searchType == query.SearchTypeStructural && !conf.StructuralSearchEnabled() {
-		return nil, errors.New("Structural search is disabled in the site configuration.")
-	}
-
 	settings, err := s.settingsService.UserFromContext(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to resolve user settings")


### PR DESCRIPTION
This removes the check for structural search from the backend.  This means, even if the `[ ]`-toggle is hidden in the UI (default from 5.3 on), our backend will still support structural search for the time being.

The intend is to give customers a few releases to either explicitly enable structural search or to migrate their links, code insights and scripts to regexp.

Test plan:
I tested manually that structural search queries work if the pattern type is specified explicitly in the search bar.
