### PR TITLE
Add context to the error returned from dotcom

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/attribution/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/attribution/handler.go
@@ -46,7 +46,7 @@ func NewHandler(client graphql.Client, baseLogger log.Logger) http.Handler {
 		}
 		searchResponse, err := dotcom.SnippetAttribution(ctx, client, request.Snippet, limit)
 		if err != nil {
-			response.JSONError(logger, w, http.StatusServiceUnavailable, err)
+			response.JSONError(logger, w, http.StatusServiceUnavailable, errors.Wrap(err, "fetching SnippetAttribution from sourcegraph.com"))
 			return
 		}
 		var rs []codygateway.AttributionRepository

--- a/cmd/cody-gateway/internal/httpapi/attribution/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/attribution/handler.go
@@ -46,7 +46,7 @@ func NewHandler(client graphql.Client, baseLogger log.Logger) http.Handler {
 		}
 		searchResponse, err := dotcom.SnippetAttribution(ctx, client, request.Snippet, limit)
 		if err != nil {
-			response.JSONError(logger, w, http.StatusServiceUnavailable, errors.Wrap(err, "fetching SnippetAttribution from sourcegraph.com"))
+			response.JSONError(logger, w, http.StatusBadGateway, errors.Wrap(err, "fetching SnippetAttribution from sourcegraph.com"))
 			return
 		}
 		var rs []codygateway.AttributionRepository


### PR DESCRIPTION
Slack [conversation](https://sourcegraph.slack.com/archives/C05497E9MDW/p1705574718346319) - this PR improves the error message (to indicate the error came from Sourcegraph.com) and changes the status code.

## Test plan

- tested locally
- CI