### PR TITLE
sg/msp add senty to ops docs

### DIFF
--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -132,6 +132,7 @@ This service is operated on the %s.`,
 				return l
 			}), ", ")},
 			{"Alerts", markdown.Linkf("GCP monitoring", "https://console.cloud.google.com/monitoring/alerting?project=%s", env.ProjectID)},
+			{"Sentry", markdown.Linkf(markdown.Codef("%s-%s", s.Service.ID, env.ID), "https://sourcegraph.sentry.io/projects/%s-%s/", s.Service.ID, env.ID)},
 		}
 		if env.EnvironmentServiceSpec != nil {
 			if domain := env.Domain.GetDNSName(); domain != "" {

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
@@ -30,6 +30,7 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 | Category   | **test**                                                                                            |
 | Resources  |                                                                                                     |
 | Alerts     | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-dev-xxxx) |
+| Sentry     | [`msp-testbed-dev`](https://sourcegraph.sentry.io/projects/msp-testbed-dev/)                        |
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
@@ -30,6 +30,7 @@ If you need assistance with MSP infrastructure, reach out to the [Core Services]
 | Category   | **test**                                                                                                                    |
 | Resources  | [dev Redis](#dev-redis), [dev PostgreSQL instance](#dev-postgresql-instance), [dev BigQuery dataset](#dev-bigquery-dataset) |
 | Alerts     | [GCP monitoring](https://console.cloud.google.com/monitoring/alerting?project=msp-testbed-dev-xxxx)                         |
+| Sentry     | [`msp-testbed-dev`](https://sourcegraph.sentry.io/projects/msp-testbed-dev/)                                                |
 
 MSP infrastructure access needs to be requested using Entitle for time-bound privileges. Test environments may have less stringent requirements.
 


### PR DESCRIPTION
Add link to service Sentry project in handbook ops page
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
CI