### PR TITLE
search: update query examples on homepage

### DIFF
--- a/client/branded/src/search-ui/components/QueryExamples.constants.ts
+++ b/client/branded/src/search-ui/components/QueryExamples.constants.ts
@@ -29,10 +29,10 @@ export const exampleQueryColumns = [
 ]
 
 export const basicSyntaxColumns = (
-    keywordSearch: boolean,
     fileName: string,
     singleRepoExample: string,
-    orgReposExample: string | undefined
+    orgReposExample: string | undefined,
+    keywordSearch: boolean
 ): QueryExamplesSection[][] =>
     keywordSearch
         ? [

--- a/client/branded/src/search-ui/components/QueryExamples.constants.ts
+++ b/client/branded/src/search-ui/components/QueryExamples.constants.ts
@@ -29,43 +29,88 @@ export const exampleQueryColumns = [
 ]
 
 export const basicSyntaxColumns = (
+    keywordSearch: boolean,
     fileName: string,
     singleRepoExample: string,
     orgReposExample: string | undefined
-): QueryExamplesSection[][] => [
-    [
-        {
-            title: 'Search in files',
-            queryExamples: [
-                { query: 'fetch(' },
-                { query: 'some error message', helperText: '(no quotes needed)' },
-                { query: 'foo AND bar' },
-                { query: '/open(File|Dir)/', helperText: '(regular expression)' },
-            ],
-        },
-        {
-            title: 'Search in commit diffs',
-            queryExamples: [{ query: 'type:diff after:1week fix' }, { query: 'type:diff author:alice add' }],
-        },
-    ],
-    [
-        {
-            title: 'Filter by...',
-            queryExamples: [
-                { query: `file:${fileName} foo` },
-                { query: `repo:${singleRepoExample}` },
-                orgReposExample ? { query: `repo:${orgReposExample}`, helperText: '(all repositories in org)' } : null,
-                { query: 'lang:javascript' },
-            ].filter(isDefined),
-        },
-        {
-            title: 'Advanced',
-            queryExamples: [
-                { query: 'repo:has.description(foo)' },
-                { query: 'file:^some_path file:has.owner(alice)' },
-                { query: 'file:^some_path select:file.owners' },
-                { query: 'file:has.commit.after(1week)' },
-            ],
-        },
-    ],
-]
+): QueryExamplesSection[][] =>
+    keywordSearch
+        ? [
+              [
+                  {
+                      title: 'Search in files, paths, and repository-names',
+                      queryExamples: [
+                          { query: 'test server', helperText: '(both terms anywhere)', productStatus: 'new' },
+                          { query: '"test server"', helperText: '(a specific string)', productStatus: 'new' },
+                          { query: '\\"Error 1001\\""', helperText: '(a string in quotations)', productStatus: 'new' },
+                          { query: 'foo OR bar' },
+                          { query: '/open(File|Dir)/', helperText: '(regular expression)' },
+                      ],
+                  },
+                  {
+                      title: 'Search in commit diffs',
+                      queryExamples: [{ query: 'type:diff after:1week fix' }, { query: 'type:diff author:alice add' }],
+                  },
+              ],
+              [
+                  {
+                      title: 'Filter by...',
+                      queryExamples: [
+                          { query: `file:${fileName} foo` },
+                          { query: `repo:${singleRepoExample}` },
+                          orgReposExample
+                              ? { query: `repo:${orgReposExample}`, helperText: '(all repositories in org)' }
+                              : null,
+                          { query: 'lang:javascript' },
+                      ].filter(isDefined),
+                  },
+                  {
+                      title: 'Advanced',
+                      queryExamples: [
+                          { query: 'repo:has.description(foo)' },
+                          { query: 'file:^some_path file:has.owner(alice)' },
+                          { query: 'file:^some_path select:file.owners' },
+                          { query: 'file:has.commit.after(1week)' },
+                      ],
+                  },
+              ],
+          ]
+        : [
+              [
+                  {
+                      title: 'Search in files',
+                      queryExamples: [
+                          { query: 'fetch(' },
+                          { query: 'some error message', helperText: '(no quotes needed)' },
+                          { query: 'foo AND bar' },
+                          { query: '/open(File|Dir)/', helperText: '(regular expression)' },
+                      ],
+                  },
+                  {
+                      title: 'Search in commit diffs',
+                      queryExamples: [{ query: 'type:diff after:1week fix' }, { query: 'type:diff author:alice add' }],
+                  },
+              ],
+              [
+                  {
+                      title: 'Filter by...',
+                      queryExamples: [
+                          { query: `file:${fileName} foo` },
+                          { query: `repo:${singleRepoExample}` },
+                          orgReposExample
+                              ? { query: `repo:${orgReposExample}`, helperText: '(all repositories in org)' }
+                              : null,
+                          { query: 'lang:javascript' },
+                      ].filter(isDefined),
+                  },
+                  {
+                      title: 'Advanced',
+                      queryExamples: [
+                          { query: 'repo:has.description(foo)' },
+                          { query: 'file:^some_path file:has.owner(alice)' },
+                          { query: 'file:^some_path select:file.owners' },
+                          { query: 'file:has.commit.after(1week)' },
+                      ],
+                  },
+              ],
+          ]

--- a/client/branded/src/search-ui/components/QueryExamples.constants.ts
+++ b/client/branded/src/search-ui/components/QueryExamples.constants.ts
@@ -42,7 +42,7 @@ export const basicSyntaxColumns = (
                       queryExamples: [
                           { query: 'test server', helperText: '(both terms anywhere)', productStatus: 'new' },
                           { query: '"test server"', helperText: '(a specific string)', productStatus: 'new' },
-                          { query: '\\"Error 1001\\""', helperText: '(a string in quotations)', productStatus: 'new' },
+                          { query: '"\\"Error 1001\\""', helperText: '(a string in quotations)', productStatus: 'new' },
                           { query: 'foo OR bar' },
                           { query: '/open(File|Dir)/', helperText: '(regular expression)' },
                       ],

--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -7,41 +7,41 @@ import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
 import {
-    H2,
-    Link,
-    Icon,
-    Tabs,
-    TabList,
-    TabPanels,
-    TabPanel,
-    Tab,
     ButtonLink,
+    H2,
+    Icon,
+    Link,
     ProductStatusBadge,
     ProductStatusType,
+    Tab,
+    TabList,
+    TabPanel,
+    TabPanels,
+    Tabs,
 } from '@sourcegraph/wildcard'
 
 import { exampleQueryColumns } from './QueryExamples.constants'
 import { SyntaxHighlightedSearchQuery } from './SyntaxHighlightedSearchQuery'
-import { useQueryExamples, type QueryExamplesSection } from './useQueryExamples'
+import { type QueryExamplesSection, useQueryExamples } from './useQueryExamples'
 
 import styles from './QueryExamples.module.scss'
 
 export interface QueryExamplesProps extends TelemetryProps {
     selectedSearchContextSpec?: string
     isSourcegraphDotCom?: boolean
-    keywordSearch?: boolean
+    patternType: SearchPatternType
 }
 
 export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
     selectedSearchContextSpec,
     telemetryService,
     isSourcegraphDotCom = false,
-    keywordSearch = false,
+    patternType,
 }) => {
     const exampleSyntaxColumns = useQueryExamples(
         selectedSearchContextSpec ?? 'global',
         isSourcegraphDotCom,
-        keywordSearch
+        patternType === SearchPatternType.newStandardRC1
     )
 
     const onQueryExampleClick = useCallback(
@@ -62,24 +62,38 @@ export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
                     <QueryExamplesLayout
                         queryColumns={exampleSyntaxColumns}
                         onQueryExampleClick={onQueryExampleClick}
+                        patternType={patternType}
                     />
                 </TabPanel>
                 <TabPanel className={styles.tabPanel}>
-                    <QueryExamplesLayout queryColumns={exampleQueryColumns} onQueryExampleClick={onQueryExampleClick} />
+                    <QueryExamplesLayout
+                        queryColumns={exampleQueryColumns}
+                        onQueryExampleClick={onQueryExampleClick}
+                        patternType={patternType}
+                    />
                 </TabPanel>
             </TabPanels>
         </Tabs>
     ) : (
-        <QueryExamplesLayout queryColumns={exampleSyntaxColumns} onQueryExampleClick={onQueryExampleClick} />
+        <QueryExamplesLayout
+            queryColumns={exampleSyntaxColumns}
+            onQueryExampleClick={onQueryExampleClick}
+            patternType={patternType}
+        />
     )
 }
 
 interface QueryExamplesLayout {
     queryColumns: QueryExamplesSection[][]
     onQueryExampleClick: (query: string) => void
+    patternType: SearchPatternType
 }
 
-const QueryExamplesLayout: React.FunctionComponent<QueryExamplesLayout> = ({ queryColumns, onQueryExampleClick }) => (
+const QueryExamplesLayout: React.FunctionComponent<QueryExamplesLayout> = ({
+    queryColumns,
+    onQueryExampleClick,
+    patternType,
+}) => (
     <div className={styles.queryExamplesSectionsColumns}>
         {queryColumns.map((column, index) => (
             <div key={`column-${queryColumns[index][0].title}`}>
@@ -89,6 +103,7 @@ const QueryExamplesLayout: React.FunctionComponent<QueryExamplesLayout> = ({ que
                         title={title}
                         queryExamples={queryExamples}
                         onQueryExampleClick={onQueryExampleClick}
+                        patternType={patternType}
                     />
                 ))}
                 {/* Add docs link to last column */}
@@ -107,9 +122,15 @@ const QueryExamplesLayout: React.FunctionComponent<QueryExamplesLayout> = ({ que
 
 interface ExamplesSection extends QueryExamplesSection {
     onQueryExampleClick: (query: string) => void
+    patternType: SearchPatternType
 }
 
-const ExamplesSection: React.FunctionComponent<ExamplesSection> = ({ title, queryExamples, onQueryExampleClick }) => (
+const ExamplesSection: React.FunctionComponent<ExamplesSection> = ({
+    title,
+    queryExamples,
+    onQueryExampleClick,
+    patternType,
+}) => (
     <div className={styles.queryExamplesSection}>
         <H2 className={styles.queryExamplesSectionTitle}>{title}</H2>
         <ul className={classNames('list-unstyled', styles.queryExamplesItems)}>
@@ -122,6 +143,7 @@ const ExamplesSection: React.FunctionComponent<ExamplesSection> = ({ title, quer
                         helperText={helperText}
                         onClick={onQueryExampleClick}
                         productStatus={productStatus}
+                        patternType={patternType}
                     />
                 ))}
         </ul>
@@ -130,6 +152,7 @@ const ExamplesSection: React.FunctionComponent<ExamplesSection> = ({ title, quer
 
 interface QueryExample {
     query: string
+    patternType: SearchPatternType
     helperText?: string
     productStatus?: ProductStatusType
 }
@@ -145,11 +168,12 @@ const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
     className,
     onClick,
     productStatus,
+    patternType,
 }) => (
     <li className={classNames('d-flex align-items-center', className)}>
         <ButtonLink
             className={styles.queryExampleChip}
-            to={`/search?${buildSearchURLQuery(query, SearchPatternType.standard, false)}`}
+            to={`/search?${buildSearchURLQuery(query, patternType, false)}`}
             onClick={() => onClick(query)}
         >
             <SyntaxHighlightedSearchQuery query={query} searchPatternType={SearchPatternType.standard} />

--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -41,7 +41,7 @@ export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
     const exampleSyntaxColumns = useQueryExamples(
         selectedSearchContextSpec ?? 'global',
         isSourcegraphDotCom,
-        patternType === SearchPatternType.newStandardRC1
+        patternType === SearchPatternType.keyword
     )
 
     const onQueryExampleClick = useCallback(

--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -6,7 +6,19 @@ import classNames from 'classnames'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
-import { H2, Link, Icon, Tabs, TabList, TabPanels, TabPanel, Tab, ButtonLink } from '@sourcegraph/wildcard'
+import {
+    H2,
+    Link,
+    Icon,
+    Tabs,
+    TabList,
+    TabPanels,
+    TabPanel,
+    Tab,
+    ButtonLink,
+    ProductStatusBadge,
+    ProductStatusType,
+} from '@sourcegraph/wildcard'
 
 import { exampleQueryColumns } from './QueryExamples.constants'
 import { SyntaxHighlightedSearchQuery } from './SyntaxHighlightedSearchQuery'
@@ -17,14 +29,20 @@ import styles from './QueryExamples.module.scss'
 export interface QueryExamplesProps extends TelemetryProps {
     selectedSearchContextSpec?: string
     isSourcegraphDotCom?: boolean
+    keywordSearch?: boolean
 }
 
 export const QueryExamples: React.FunctionComponent<QueryExamplesProps> = ({
     selectedSearchContextSpec,
     telemetryService,
     isSourcegraphDotCom = false,
+    keywordSearch = false,
 }) => {
-    const exampleSyntaxColumns = useQueryExamples(selectedSearchContextSpec ?? 'global', isSourcegraphDotCom)
+    const exampleSyntaxColumns = useQueryExamples(
+        selectedSearchContextSpec ?? 'global',
+        isSourcegraphDotCom,
+        keywordSearch
+    )
 
     const onQueryExampleClick = useCallback(
         (query: string) => {
@@ -97,8 +115,14 @@ const ExamplesSection: React.FunctionComponent<ExamplesSection> = ({ title, quer
         <ul className={classNames('list-unstyled', styles.queryExamplesItems)}>
             {queryExamples
                 .filter(({ query }) => query.length > 0)
-                .map(({ query, helperText }) => (
-                    <QueryExampleChip key={query} query={query} helperText={helperText} onClick={onQueryExampleClick} />
+                .map(({ query, helperText, productStatus }) => (
+                    <QueryExampleChip
+                        key={query}
+                        query={query}
+                        helperText={helperText}
+                        onClick={onQueryExampleClick}
+                        productStatus={productStatus}
+                    />
                 ))}
         </ul>
     </div>
@@ -107,6 +131,7 @@ const ExamplesSection: React.FunctionComponent<ExamplesSection> = ({ title, quer
 interface QueryExample {
     query: string
     helperText?: string
+    productStatus?: ProductStatusType
 }
 
 interface QueryExampleChipProps extends QueryExample {
@@ -119,6 +144,7 @@ const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
     helperText,
     className,
     onClick,
+    productStatus,
 }) => (
     <li className={classNames('d-flex align-items-center', className)}>
         <ButtonLink
@@ -133,5 +159,6 @@ const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
                 <small>{helperText}</small>
             </span>
         )}
+        {productStatus && <ProductStatusBadge status={productStatus} className="ml-2" />}
     </li>
 )

--- a/client/branded/src/search-ui/components/useQueryExamples.tsx
+++ b/client/branded/src/search-ui/components/useQueryExamples.tsx
@@ -151,5 +151,5 @@ export function useQueryExamples(
         const fileName = quoteIfNeeded(filePathParts.at(-1)!)
 
         return basicSyntaxColumns(fileName, singleRepoExample, orgReposExample, keywordSearch)
-    }, [queryExamplesContent, isSourcegraphDotCom])
+    }, [queryExamplesContent, isSourcegraphDotCom, keywordSearch])
 }

--- a/client/branded/src/search-ui/components/useQueryExamples.tsx
+++ b/client/branded/src/search-ui/components/useQueryExamples.tsx
@@ -139,7 +139,7 @@ export function useQueryExamples(
     return useMemo(() => {
         // Static examples for Sourcegraph.com.
         if (isSourcegraphDotCom) {
-            return basicSyntaxColumns(keywordSearch, 'test', 'facebook/react', 'kubernetes/')
+            return basicSyntaxColumns('test', 'facebook/react', 'kubernetes/', keywordSearch)
         }
         if (!queryExamplesContent) {
             return []
@@ -150,6 +150,6 @@ export function useQueryExamples(
         const filePathParts = filePath.split('/')
         const fileName = quoteIfNeeded(filePathParts.at(-1)!)
 
-        return basicSyntaxColumns(keywordSearch, fileName, singleRepoExample, orgReposExample)
+        return basicSyntaxColumns(fileName, singleRepoExample, orgReposExample, keywordSearch)
     }, [queryExamplesContent, isSourcegraphDotCom])
 }

--- a/client/branded/src/search-ui/components/useQueryExamples.tsx
+++ b/client/branded/src/search-ui/components/useQueryExamples.tsx
@@ -2,7 +2,6 @@ import { useMemo, useEffect, useState, useCallback } from 'react'
 
 import { differenceInHours, formatISO, parseISO } from 'date-fns'
 
-import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { streamComputeQuery } from '@sourcegraph/shared/src/search/stream'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { ProductStatusType } from '@sourcegraph/wildcard'

--- a/client/branded/src/search-ui/components/useQueryExamples.tsx
+++ b/client/branded/src/search-ui/components/useQueryExamples.tsx
@@ -2,6 +2,7 @@ import { useMemo, useEffect, useState, useCallback } from 'react'
 
 import { differenceInHours, formatISO, parseISO } from 'date-fns'
 
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { streamComputeQuery } from '@sourcegraph/shared/src/search/stream'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import { ProductStatusType } from '@sourcegraph/wildcard'

--- a/client/branded/src/search-ui/components/useQueryExamples.tsx
+++ b/client/branded/src/search-ui/components/useQueryExamples.tsx
@@ -4,6 +4,7 @@ import { differenceInHours, formatISO, parseISO } from 'date-fns'
 
 import { streamComputeQuery } from '@sourcegraph/shared/src/search/stream'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { ProductStatusType } from '@sourcegraph/wildcard'
 
 import { basicSyntaxColumns } from './QueryExamples.constants'
 
@@ -17,6 +18,7 @@ export interface QueryExamplesSection {
     queryExamples: {
         query: string
         helperText?: string
+        productStatus?: ProductStatusType
     }[]
 }
 
@@ -63,7 +65,8 @@ function getRepoFilterExamples(repositoryName: string): { singleRepoExample: str
 
 export function useQueryExamples(
     selectedSearchContextSpec: string,
-    isSourcegraphDotCom: boolean = false
+    isSourcegraphDotCom: boolean = false,
+    keywordSearch: boolean = false
 ): QueryExamplesSection[][] {
     const [queryExamplesContent, setQueryExamplesContent] = useState<QueryExamplesContent>()
     const [cachedQueryExamplesContent, setCachedQueryExamplesContent, cachedQueryExamplesContentLoadStatus] =
@@ -136,7 +139,7 @@ export function useQueryExamples(
     return useMemo(() => {
         // Static examples for Sourcegraph.com.
         if (isSourcegraphDotCom) {
-            return basicSyntaxColumns('test', 'facebook/react', 'kubernetes/')
+            return basicSyntaxColumns(keywordSearch, 'test', 'facebook/react', 'kubernetes/')
         }
         if (!queryExamplesContent) {
             return []
@@ -147,6 +150,6 @@ export function useQueryExamples(
         const filePathParts = filePath.split('/')
         const fileName = quoteIfNeeded(filePathParts.at(-1)!)
 
-        return basicSyntaxColumns(fileName, singleRepoExample, orgReposExample)
+        return basicSyntaxColumns(keywordSearch, fileName, singleRepoExample, orgReposExample)
     }, [queryExamplesContent, isSourcegraphDotCom])
 }

--- a/client/branded/src/search-ui/results/NoResultsPage.tsx
+++ b/client/branded/src/search-ui/results/NoResultsPage.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect } from 'react'
 import { mdiClose, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { type SearchContextProps, SearchMode, type SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { NoResultsSectionID as SectionID } from '@sourcegraph/shared/src/settings/temporary/searchSidebar'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
@@ -47,6 +48,7 @@ const Container: React.FunctionComponent<React.PropsWithChildren<ContainerProps>
 interface NoResultsPageProps extends TelemetryProps, Pick<SearchContextProps, 'searchContextsEnabled'> {
     isSourcegraphDotCom: boolean
     showSearchContext: boolean
+    queryExamplesPatternType: SearchPatternType
     showQueryExamples?: boolean
     searchMode?: SearchMode
     setSearchMode?: (mode: SearchMode) => void
@@ -68,6 +70,7 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
     caseSensitive,
     searchQueryFromURL,
     selectedSearchContextSpec,
+    queryExamplesPatternType,
 }) => {
     const [hiddenSectionIDs, setHiddenSectionIds] = useTemporarySetting('search.hiddenNoResultsSections')
 
@@ -108,6 +111,7 @@ export const NoResultsPage: React.FunctionComponent<React.PropsWithChildren<NoRe
                             selectedSearchContextSpec={selectedSearchContextSpec}
                             telemetryService={telemetryService}
                             isSourcegraphDotCom={isSourcegraphDotCom}
+                            patternType={queryExamplesPatternType}
                         />
                     </div>
                 </>

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -8,6 +8,7 @@ import type { FetchFileParameters } from '@sourcegraph/shared/src/backend/file'
 import { type FilePrefetcher, PrefetchableFile } from '@sourcegraph/shared/src/components/PrefetchableFile'
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoLink'
 import { VirtualList } from '@sourcegraph/shared/src/components/VirtualList'
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type {
     BuildSearchQueryURLParameters,
@@ -71,7 +72,12 @@ export interface StreamingSearchResultsListProps
     enableKeyboardNavigation?: boolean
 
     showQueryExamplesOnNoResultsPage?: boolean
-
+    /**
+     *  Determines the type of search pattern for the query examples.
+     *  For now, we only want to show the query examples in the style
+     *  of keyword search on the homepage and the search results page.
+     */
+    queryExamplesPatternType?: SearchPatternType
     /**
      * The query state to be used for the query examples and owner search.
      * If not provided, the query examples and owner search will not
@@ -124,6 +130,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     searchQueryFromURL,
     logSearchResultClicked,
     enableRepositoryMetadata,
+    queryExamplesPatternType = SearchPatternType.standard,
 }) => {
     const resultsNumber = results?.results.length || 0
     const { itemsToShow, handleBottomHit } = useItemsToShow(executedQuery, resultsNumber)
@@ -309,6 +316,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                 submitSearch={submitSearch}
                                 caseSensitive={caseSensitive}
                                 searchQueryFromURL={searchQueryFromURL}
+                                queryExamplesPatternType={queryExamplesPatternType}
                             />
                         )}
                     </>

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
@@ -311,6 +311,7 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                             searchQueryFromURL={submittedURLQuery}
                             selectedSearchContextSpec={selectedSearchContextSpec}
                             logSearchResultClicked={onLogSearchResultClick}
+                            queryExamplesPatternType={patternType}
                         />
                     </>
                 )}

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { QueryExamples } from '@sourcegraph/branded/src/search-ui/components/QueryExamples'
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import type { QueryState } from '@sourcegraph/shared/src/search'
 import { getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
 import { appendContextFilter, omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
@@ -14,6 +15,7 @@ import { BrandLogo } from '../../../components/branding/BrandLogo'
 import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
 import { useLegacyContext_onlyInStormRoutes } from '../../../LegacyRouteContext'
 import { useV2QueryInput } from '../../../search/useV2QueryInput'
+import { useNavbarQueryState } from '../../../stores'
 import { GettingStartedTour } from '../../../tour/GettingStartedTour'
 import { useShowOnboardingTour } from '../../../tour/hooks'
 
@@ -68,6 +70,8 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
 
     const showOnboardingTour = useShowOnboardingTour({ authenticatedUser, isSourcegraphDotCom })
     const showCodyCTA = !showOnboardingTour
+
+    const keywordSearch = useNavbarQueryState.getState().searchPatternType === SearchPatternType.newStandardRC1
 
     return (
         <div className={classNames('d-flex flex-column align-items-center px-3', styles.searchPage)}>
@@ -148,6 +152,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                             selectedSearchContextSpec={selectedSearchContextSpec}
                             telemetryService={telemetryService}
                             isSourcegraphDotCom={isSourcegraphDotCom}
+                            keywordSearch={keywordSearch}
                         />
                     )}
                 </div>

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { QueryExamples } from '@sourcegraph/branded/src/search-ui/components/QueryExamples'
-import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import type { QueryState } from '@sourcegraph/shared/src/search'
 import { getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
 import { appendContextFilter, omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
@@ -71,7 +70,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
     const showOnboardingTour = useShowOnboardingTour({ authenticatedUser, isSourcegraphDotCom })
     const showCodyCTA = !showOnboardingTour
 
-    const keywordSearch = useNavbarQueryState.getState().searchPatternType === SearchPatternType.newStandardRC1
+    const patternType = useNavbarQueryState.getState().searchPatternType
 
     return (
         <div className={classNames('d-flex flex-column align-items-center px-3', styles.searchPage)}>
@@ -152,7 +151,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                             selectedSearchContextSpec={selectedSearchContextSpec}
                             telemetryService={telemetryService}
                             isSourcegraphDotCom={isSourcegraphDotCom}
-                            keywordSearch={keywordSearch}
+                            patternType={patternType}
                         />
                     )}
                 </div>


### PR DESCRIPTION
This updates the examples on the homepage depending on whether keyword search is activated or not.

Test plan:
manual testing


![image](https://github.com/sourcegraph/sourcegraph/assets/26413131/b27540d3-c75c-4130-9842-c37c5f8dffd1)
