### PR TITLE
Perf: cache whether subrepo perms are enabled for a repo

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -641,7 +641,7 @@ func TestSubRepoFiltering(t *testing.T) {
 					}
 					return authz.Read, nil
 				})
-				checker.EnabledForRepoFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName) (bool, error) {
+				checker.EnabledForRepoIDFunc.SetDefaultHook(func(context.Context, api.RepoID) (bool, error) {
 					return true, nil
 				})
 				return checker

--- a/internal/authz/subrepoperms/BUILD.bazel
+++ b/internal/authz/subrepoperms/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "@com_github_hashicorp_golang_lru_v2//:golang-lru",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
+        "@com_github_roaringbitmap_roaring//:roaring",
         "@org_golang_x_sync//singleflight",
         "@org_uber_go_atomic//:atomic",
     ],
@@ -34,5 +35,6 @@ go_test(
         "//internal/authz",
         "//internal/conf",
         "//schema",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/authz/subrepoperms/sub_repo_perms.go
+++ b/internal/authz/subrepoperms/sub_repo_perms.go
@@ -48,8 +48,14 @@ type SubRepoPermsClient struct {
 }
 
 const (
-	defaultCacheSize           = 1000
-	defaultCacheTTL            = 10 * time.Second
+	defaultCacheSize = 1000
+	defaultCacheTTL  = 10 * time.Second
+
+	// We maintain a relatively high TTL for the repo enabled cache
+	// because it only stores whether the repo is a perforce repo and
+	// whether the repo is private. These properties should not change
+	// frequently, and are notably not updated when repo permissions
+	// are enabled/disabled.
 	defaultRepoEnabledCacheTTL = time.Hour
 )
 
@@ -354,6 +360,7 @@ func (s *SubRepoPermsClient) EnabledForRepoID(ctx context.Context, id api.RepoID
 		return enabled, nil
 	}
 
+	// TODO(camdencheek): Ideally, refreshing the cache could be handled in a background goroutine so it never blocks a caller
 	enabled, err := s.permissionsGetter.RepoIDSupported(ctx, id)
 	if err != nil {
 		return false, err

--- a/internal/authz/subrepoperms/sub_repo_perms.go
+++ b/internal/authz/subrepoperms/sub_repo_perms.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/RoaringBitmap/roaring"
 	"github.com/gobwas/glob"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -39,14 +41,16 @@ type SubRepoPermsClient struct {
 	clock             func() time.Time
 	since             func(time.Time) time.Duration
 
-	group   *singleflight.Group
-	cache   *lru.Cache[int32, cachedRules]
-	enabled *atomic.Bool
+	group            *singleflight.Group
+	cache            *lru.Cache[int32, cachedRules]
+	enabled          *atomic.Bool
+	repoEnabledCache repoEnabledCache
 }
 
 const (
-	defaultCacheSize = 1000
-	defaultCacheTTL  = 10 * time.Second
+	defaultCacheSize           = 1000
+	defaultCacheTTL            = 10 * time.Second
+	defaultRepoEnabledCacheTTL = time.Hour
 )
 
 // cachedRules caches the perms rules known for a particular user by repo.
@@ -128,6 +132,7 @@ func NewSubRepoPermsClient(permissionsGetter SubRepoPermissionsGetter) *SubRepoP
 		group:             &singleflight.Group{},
 		cache:             cache,
 		enabled:           enabled,
+		repoEnabledCache:  newRepoEnabledCache(defaultRepoEnabledCacheTTL),
 	}
 }
 
@@ -344,7 +349,18 @@ func (s *SubRepoPermsClient) Enabled() bool {
 }
 
 func (s *SubRepoPermsClient) EnabledForRepoID(ctx context.Context, id api.RepoID) (bool, error) {
-	return s.permissionsGetter.RepoIDSupported(ctx, id)
+	enabled, hit := s.repoEnabledCache.RepoIsEnabled(id)
+	if hit {
+		return enabled, nil
+	}
+
+	enabled, err := s.permissionsGetter.RepoIDSupported(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	s.repoEnabledCache.SetRepoIsEnabled(id, enabled)
+
+	return enabled, nil
 }
 
 func (s *SubRepoPermsClient) EnabledForRepo(ctx context.Context, repo api.RepoName) (bool, error) {
@@ -400,4 +416,50 @@ func NewSimpleChecker(repo api.RepoName, paths []string) authz.SubRepoPermission
 	getter.RepoSupportedFunc.SetDefaultReturn(true, nil)
 	getter.RepoIDSupportedFunc.SetDefaultReturn(true, nil)
 	return NewSubRepoPermsClient(getter)
+}
+
+type repoEnabledCache struct {
+	mu        sync.Mutex
+	ttl       time.Duration
+	createdAt time.Time
+	enabled   *roaring.Bitmap
+	valid     *roaring.Bitmap
+}
+
+func newRepoEnabledCache(ttl time.Duration) repoEnabledCache {
+	return repoEnabledCache{
+		ttl:       ttl,
+		createdAt: time.Now(),
+		enabled:   roaring.NewBitmap(),
+		valid:     roaring.NewBitmap(),
+	}
+}
+
+func (r *repoEnabledCache) RepoIsEnabled(repoID api.RepoID) (enabled bool, hit bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.resetIfExpired()
+
+	return r.enabled.Contains(uint32(repoID)), r.valid.Contains(uint32(repoID))
+}
+
+func (r *repoEnabledCache) SetRepoIsEnabled(repoID api.RepoID, enabled bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.resetIfExpired()
+
+	r.valid.Add(uint32(repoID))
+	if enabled {
+		r.enabled.Add(uint32(repoID))
+	}
+}
+
+// r.mu must be held to safely call this method
+func (r *repoEnabledCache) resetIfExpired() {
+	if time.Since(r.createdAt) >= r.ttl {
+		r.valid.Clear()
+		r.enabled.Clear()
+	}
 }

--- a/internal/authz/subrepoperms/sub_repo_perms_test.go
+++ b/internal/authz/subrepoperms/sub_repo_perms_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSubRepoPermsPermissions(t *testing.T) {
@@ -416,4 +417,26 @@ func TestSubRepoPermsPermissionsCache(t *testing.T) {
 	if len(h) != 2 {
 		t.Fatal("Should have been called twice")
 	}
+}
+
+func Test_repoEnabledCache(t *testing.T) {
+	cache := newRepoEnabledCache(time.Hour)
+
+	_, cacheHit := cache.RepoIsEnabled(api.RepoID(42))
+	require.False(t, cacheHit)
+
+	cache.SetRepoIsEnabled(api.RepoID(42), true)
+	enabled, cacheHit := cache.RepoIsEnabled(api.RepoID(42))
+	require.True(t, cacheHit)
+	require.True(t, enabled)
+
+	cache.SetRepoIsEnabled(api.RepoID(43), false)
+	enabled, cacheHit = cache.RepoIsEnabled(api.RepoID(43))
+	require.True(t, cacheHit)
+	require.False(t, enabled)
+
+	cache.createdAt = time.Now().Add(-10 * time.Hour)
+
+	_, cacheHit = cache.RepoIsEnabled(api.RepoID(42))
+	require.False(t, cacheHit)
 }

--- a/internal/authz/subrepoperms/sub_repo_perms_test.go
+++ b/internal/authz/subrepoperms/sub_repo_perms_test.go
@@ -435,7 +435,7 @@ func Test_repoEnabledCache(t *testing.T) {
 	require.True(t, cacheHit)
 	require.False(t, enabled)
 
-	cache.createdAt = time.Now().Add(-10 * time.Hour)
+	cache.lastReset = time.Now().Add(-10 * time.Hour)
 
 	_, cacheHit = cache.RepoIsEnabled(api.RepoID(42))
 	require.False(t, cacheHit)

--- a/internal/authz/subrepoperms/sub_repo_perms_test.go
+++ b/internal/authz/subrepoperms/sub_repo_perms_test.go
@@ -419,7 +419,7 @@ func TestSubRepoPermsPermissionsCache(t *testing.T) {
 	}
 }
 
-func Test_repoEnabledCache(t *testing.T) {
+func TestRepoEnabledCache(t *testing.T) {
 	cache := newRepoEnabledCache(time.Hour)
 
 	_, cacheHit := cache.RepoIsEnabled(api.RepoID(42))

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -23,7 +23,6 @@ var (
 	supportedTypesQuery           = make([]*sqlf.Query, len(SubRepoSupportedCodeHostTypes))
 )
 
-// TODO: just make this a called function at init time
 func init() {
 	// Build this up at startup, so we don't need to rebuild it every time
 	// RepoSupported is called

--- a/internal/database/sub_repo_perms_store.go
+++ b/internal/database/sub_repo_perms_store.go
@@ -23,6 +23,7 @@ var (
 	supportedTypesQuery           = make([]*sqlf.Query, len(SubRepoSupportedCodeHostTypes))
 )
 
+// TODO: just make this a called function at init time
 func init() {
 	// Build this up at startup, so we don't need to rebuild it every time
 	// RepoSupported is called

--- a/internal/own/background/BUILD.bazel
+++ b/internal/own/background/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
         "//internal/own",
         "//internal/own/types",
         "//internal/ratelimit",
-        "//internal/rcache",
         "//internal/types",
         "//internal/workerutil",
         "//internal/workerutil/dbworker",

--- a/internal/own/background/analytics.go
+++ b/internal/own/background/analytics.go
@@ -34,14 +34,13 @@ func handleAnalytics(ctx context.Context, lgr log.Logger, repoId api.RepoID, db 
 }
 
 type analyticsIndexer struct {
-	client            gitserver.Client
-	db                database.DB
-	logger            log.Logger
-	subRepoPermsCache rcache.Cache
+	client gitserver.Client
+	db     database.DB
+	logger log.Logger
 }
 
 func newAnalyticsIndexer(client gitserver.Client, db database.DB, subRepoPermsCache *rcache.Cache, lgr log.Logger) *analyticsIndexer {
-	return &analyticsIndexer{client: client, db: db, subRepoPermsCache: *subRepoPermsCache, logger: lgr}
+	return &analyticsIndexer{client: client, db: db, logger: lgr}
 }
 
 var ownAnalyticsFilesCounter = promauto.NewCounter(prometheus.CounterOpts{
@@ -51,7 +50,7 @@ var ownAnalyticsFilesCounter = promauto.NewCounter(prometheus.CounterOpts{
 
 func (r *analyticsIndexer) indexRepo(ctx context.Context, repoId api.RepoID, checker authz.SubRepoPermissionChecker) error {
 	// If the repo has sub-repo perms enabled, skip indexing
-	isSubRepoPermsRepo, err := isSubRepoPermsRepo(ctx, repoId, r.subRepoPermsCache, checker)
+	isSubRepoPermsRepo, err := authz.SubRepoEnabledForRepoID(ctx, checker, repoId)
 	if err != nil {
 		return errcode.MakeNonRetryable(err)
 	} else if isSubRepoPermsRepo {

--- a/internal/own/background/analytics_test.go
+++ b/internal/own/background/analytics_test.go
@@ -73,7 +73,7 @@ func TestAnalyticsIndexerSuccess(t *testing.T) {
 	checker.EnabledForRepoIDFunc.SetDefaultReturn(false, nil)
 	require.NoError(t, db.AssignedOwners().Insert(ctx, user.ID, repoID, "owned/file1.go", user.ID))
 	require.NoError(t, db.AssignedOwners().Insert(ctx, user.ID, repoID, "assigned.go", user.ID))
-	require.NoError(t, newAnalyticsIndexer(client, db, rcache.New("test_own_signal"), logger).indexRepo(ctx, repoID, checker))
+	require.NoError(t, newAnalyticsIndexer(client, db, logger).indexRepo(ctx, repoID, checker))
 
 	totalFileCount, err := db.RepoPaths().AggregateFileCount(ctx, database.TreeLocationOpts{})
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestAnalyticsIndexerSkipsReposWithSubRepoPerms(t *testing.T) {
 	checker := authz.NewMockSubRepoPermissionChecker()
 	checker.EnabledFunc.SetDefaultReturn(true)
 	checker.EnabledForRepoIDFunc.SetDefaultReturn(true, nil)
-	err = newAnalyticsIndexer(client, db, rcache.New("test_own_signal"), logger).indexRepo(ctx, repoID, checker)
+	err = newAnalyticsIndexer(client, db, logger).indexRepo(ctx, repoID, checker)
 	require.NoError(t, err)
 
 	totalFileCount, err := db.RepoPaths().AggregateFileCount(ctx, database.TreeLocationOpts{})
@@ -138,7 +138,7 @@ func TestAnalyticsIndexerNoCodeowners(t *testing.T) {
 	checker := authz.NewMockSubRepoPermissionChecker()
 	checker.EnabledFunc.SetDefaultReturn(true)
 	checker.EnabledForRepoIDFunc.SetDefaultReturn(false, nil)
-	err = newAnalyticsIndexer(client, db, rcache.New("test_own_signal"), logger).indexRepo(ctx, repoID, checker)
+	err = newAnalyticsIndexer(client, db, logger).indexRepo(ctx, repoID, checker)
 	require.NoError(t, err)
 
 	totalFileCount, err := db.RepoPaths().AggregateFileCount(ctx, database.TreeLocationOpts{})

--- a/internal/own/background/background.go
+++ b/internal/own/background/background.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/own/types"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
-	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
@@ -145,10 +144,9 @@ func makeWorker(ctx context.Context, db database.DB, observationCtx *observation
 	})
 
 	task := handler{
-		workerStore:       workerStore,
-		limiter:           indexLimiter,
-		db:                db,
-		subRepoPermsCache: rcache.NewWithTTL("own_signals_subrepoperms", 3600),
+		workerStore: workerStore,
+		limiter:     indexLimiter,
+		db:          db,
 	}
 
 	worker := dbworker.NewWorker(ctx, workerStore, workerutil.Handler[*Job](&task), workerutil.WorkerOptions{
@@ -170,11 +168,10 @@ func makeWorker(ctx context.Context, db database.DB, observationCtx *observation
 }
 
 type handler struct {
-	db                database.DB
-	workerStore       dbworkerstore.Store[*Job]
-	limiter           *ratelimit.InstrumentedLimiter
-	op                *observation.Operation
-	subRepoPermsCache *rcache.Cache
+	db          database.DB
+	workerStore dbworkerstore.Store[*Job]
+	limiter     *ratelimit.InstrumentedLimiter
+	op          *observation.Operation
 }
 
 func (h *handler) Handle(ctx context.Context, lgr log.Logger, record *Job) error {
@@ -193,10 +190,10 @@ func (h *handler) Handle(ctx context.Context, lgr log.Logger, record *Job) error
 		return errcode.MakeNonRetryable(errors.New("unsupported own index job type"))
 	}
 
-	return delegate(ctx, lgr, api.RepoID(record.RepoId), h.db, h.subRepoPermsCache)
+	return delegate(ctx, lgr, api.RepoID(record.RepoId), h.db)
 }
 
-type signalIndexFunc func(ctx context.Context, lgr log.Logger, repoId api.RepoID, db database.DB, cache *rcache.Cache) error
+type signalIndexFunc func(ctx context.Context, lgr log.Logger, repoId api.RepoID, db database.DB) error
 
 // janitorQuery is split into 2 parts. The first half is records that are finished (either completed or failed), the second half is records for jobs that are not enabled.
 func janitorQuery(deleteSince time.Time) *sqlf.Query {

--- a/internal/own/background/recent_contributors_test.go
+++ b/internal/own/background/recent_contributors_test.go
@@ -61,7 +61,7 @@ func Test_RecentContributorIndexFromGitserver(t *testing.T) {
 
 	client := gitserver.NewMockClient()
 	client.CommitLogFunc.SetDefaultReturn(fakeCommitsToLog(commits), nil)
-	indexer := newRecentContributorsIndexer(client, db, logger, rcache.New("testing_own_signals"))
+	indexer := newRecentContributorsIndexer(client, db, logger)
 	checker := authz.NewMockSubRepoPermissionChecker()
 	checker.EnabledFunc.SetDefaultReturn(true)
 	checker.EnabledForRepoIDFunc.SetDefaultReturn(false, nil)
@@ -137,7 +137,7 @@ func Test_RecentContributorIndex_CanSeePrivateRepos(t *testing.T) {
 	require.NoError(t, err)
 
 	client := gitserver.NewMockClient()
-	indexer := newRecentContributorsIndexer(client, db, logger, rcache.New("testing_own_signals"))
+	indexer := newRecentContributorsIndexer(client, db, logger)
 
 	t.Run("non-internal user", func(t *testing.T) {
 		// this is kind of an unrelated test just to provide a baseline that there is actually a difference when
@@ -198,7 +198,7 @@ func Test_RecentContributorIndexSkipsSubrepoPermsRepos(t *testing.T) {
 
 	client := gitserver.NewMockClient()
 	client.CommitLogFunc.SetDefaultReturn(fakeCommitsToLog(commits), nil)
-	indexer := newRecentContributorsIndexer(client, db, logger, rcache.New("testing_own_signals"))
+	indexer := newRecentContributorsIndexer(client, db, logger)
 	checker := authz.NewMockSubRepoPermissionChecker()
 	checker.EnabledFunc.SetDefaultReturn(true)
 	checker.EnabledForRepoIDFunc.SetDefaultReturn(true, nil)

--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -85,7 +85,6 @@ func applySubRepoFiltering(ctx context.Context, checker authz.SubRepoPermissionC
 	// Filter matches in place
 	filtered := matches[:0]
 
-	subRepoPermsCache := map[api.RepoName]bool{}
 	errCache := map[api.RepoName]struct{}{} // cache repos that errored
 
 	for _, m := range matches {
@@ -93,25 +92,16 @@ func applySubRepoFiltering(ctx context.Context, checker authz.SubRepoPermissionC
 		if _, ok := errCache[m.RepoName().Name]; ok {
 			continue
 		}
-		// Skip check if sub-repo perms are disabled for the repository
-		enabled, ok := subRepoPermsCache[m.RepoName().Name]
-		if ok && !enabled {
-			filtered = append(filtered, m)
+		enabled, err := authz.SubRepoEnabledForRepoID(ctx, checker, m.RepoName().ID)
+		if err != nil {
+			// If an error occurs while checking sub-repo perms, we omit it from the results
+			logger.Error("Could not determine if sub-repo permissions are enabled for repo, skipping", log.Error(err), log.String("repoName", string(m.RepoName().Name)))
+			errCache[m.RepoName().Name] = struct{}{}
 			continue
 		}
-		if !ok {
-			enabled, err := authz.SubRepoEnabledForRepo(ctx, checker, m.RepoName().Name)
-			if err != nil {
-				// If an error occurs while checking sub-repo perms, we omit it from the results
-				logger.Error("Could not determine if sub-repo permissions are enabled for repo, skipping", log.Error(err), log.String("repoName", string(m.RepoName().Name)))
-				errCache[m.RepoName().Name] = struct{}{}
-				continue
-			}
-			subRepoPermsCache[m.RepoName().Name] = enabled // cache the result for this repo name
-			if !enabled {
-				filtered = append(filtered, m)
-				continue
-			}
+		if !enabled {
+			filtered = append(filtered, m)
+			continue
 		}
 		switch mm := m.(type) {
 		case *result.FileMatch:

--- a/internal/search/job/jobutil/sub_repo_perms_job_test.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job_test.go
@@ -46,8 +46,9 @@ func TestApplySubRepoFiltering(t *testing.T) {
 		}, nil
 	})
 
-	checker.EnabledForRepoFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName) (bool, error) {
-		if rn.Equal("noSubRepoPerms") {
+	noSubRepoPermsID := api.RepoID(42)
+	checker.EnabledForRepoIDFunc.SetDefaultHook(func(ctx context.Context, id api.RepoID) (bool, error) {
+		if id == noSubRepoPermsID {
 			return false, nil
 		}
 		return true, nil
@@ -212,7 +213,7 @@ func TestApplySubRepoFiltering(t *testing.T) {
 					&result.CommitMatch{
 						ModifiedFiles: []string{unauthorizedFileName},
 						Repo: types.MinimalRepo{
-							Name: "noSubRepoPerms",
+							ID: noSubRepoPermsID,
 						},
 					},
 					&result.CommitMatch{
@@ -227,7 +228,7 @@ func TestApplySubRepoFiltering(t *testing.T) {
 				&result.CommitMatch{
 					ModifiedFiles: []string{unauthorizedFileName},
 					Repo: types.MinimalRepo{
-						Name: "noSubRepoPerms",
+						ID: noSubRepoPermsID,
 					},
 				},
 			},


### PR DESCRIPTION
Currently, in the `SubRepoPermsJob`, we filter each search event in the stream serially. This is problematic because these checks require a database call, which means we're making a serial database call for each unique repo in our search results. We pay this cost whether or not the repo is a perforce repo because we're making the DB call specifically to check whether the repo is a perforce repo. This is currently adding ~2ms per unique repo in a set of search results when subrepo permissions are enabled (such as on S2).

Example trace: 

![image](https://github.com/sourcegraph/sourcegraph/assets/12631702/62429a12-e6e1-4c96-9a58-c3562056b324)


We had various layers of caching of this information that I consolidated into a cache on the checker itself so the caller doesn't need to worry about cache logic and so the cache can be shared between dependents of a client. Whether a repo is a perforce repo is likely to be _quite_ stable, so I set a default cache TTL of 1 hour. This can realistically probably be higher, but I'd rather err on the side of caution since this is a security feature. The cache itself is very dense since it uses roaring bitmaps. I am not concerned about memory usage given that we already have a much larger cache for the actual rules. 

Since the cache lives on the client, it persists for the lifetime of the client. In most cases, this is the lifetime of the process since we use the global `DefaultSubRepoPermsClient` in most cases.

## Test plan

Added unit tests for the cache itself. We've got a handful of backend integration tests that cover this pretty well. The change itself is small. I'll do some followup checks of S2 traces to double check that they do, in fact, look better than the screenshot above. 