### PR TITLE
UI test coverage: add test for createUrl

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1930,6 +1930,7 @@ ts_project(
         "src/repo/RepositoriesPopover/RepositoriesPopover.test.tsx",
         "src/repo/RevisionsPopover/RevisionsPopover.mocks.ts",
         "src/repo/RevisionsPopover/RevisionsPopover.test.tsx",
+        "src/repo/actions/actions.test.ts",
         "src/repo/blob/actions/ToggleRenderedFileMode.test.tsx",
         "src/repo/blob/codemirror/codeintel/utils.test.ts",
         "src/repo/blob/codemirror/document-highlights.test.ts",

--- a/client/web/src/repo/actions/CopyPermalinkAction.tsx
+++ b/client/web/src/repo/actions/CopyPermalinkAction.tsx
@@ -93,7 +93,7 @@ export const CopyPermalinkAction: React.FunctionComponent<CopyPermalinkActionPro
 
     const copyPermalink = (): void => {
         telemetryService.log('CopyPermalink')
-        copy(`${rootUrl}${permalinkURL}`)
+        copy(createUrl(rootUrl, permalinkURL))
         setCopiedPermalink(true)
         screenReaderAnnounce('Permalink copied to clipboard')
 
@@ -102,7 +102,7 @@ export const CopyPermalinkAction: React.FunctionComponent<CopyPermalinkActionPro
 
     const copyLink = (): void => {
         telemetryService.log('CopyLink')
-        copy(`${rootUrl}${linkURL}`)
+        copy(createUrl(rootUrl, linkURL))
         setCopiedLink(true)
         screenReaderAnnounce('Link copied to clipboard')
 
@@ -169,3 +169,5 @@ export const CopyPermalinkAction: React.FunctionComponent<CopyPermalinkActionPro
         </Menu>
     )
 }
+
+export const createUrl = (rooturl: string, path: string): string => `${rooturl}${path}`

--- a/client/web/src/repo/actions/actions.test.ts
+++ b/client/web/src/repo/actions/actions.test.ts
@@ -1,0 +1,13 @@
+import { expect, describe, test } from 'vitest'
+
+import { createUrl } from './CopyPermalinkAction'
+
+describe('URL', () => {
+    test('should return the correct URL', () => {
+        let rooturl = 'http://localhost:3000'
+        let path = '/api/v1'
+        let combined = createUrl(rooturl, path)
+
+        expect(combined).toBe('http://localhost:3000/api/v1')
+    })
+})


### PR DESCRIPTION
Add a test for making sure the right url is returned

## Test plan
The PR itself is a unit test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
