### PR TITLE
New setting to specify the maximum number of active access tokens a user is allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Topics synced from GitHub and GitLab are now displayed for repository matches in the search results and on the repository tree page. [#58927](https://github.com/sourcegraph/sourcegraph/pull/58927)
 - Added a new column "Repository metadata JSON" to the CSV export of repository search results, which includes the JSON encoded object of metadata key-value pairs. [#59334](https://github.com/sourcegraph/sourcegraph/pull/59334)
 - Expiry to access tokens. Users can now select a maximum timespan for which a token is valid. Tokens will automatically lose access after this period. Default timeframes and an override to allow access tokens without expiration can be configured in the `auth.accessTokens` section of the site configuration. [#59565](https://github.com/sourcegraph/sourcegraph/pull/59565)
+- Limit the number of active access tokens for a user. By default users are able to have 25 active access tokens. This limit can be configured using the `maxTokensPerUser` setting in the `auth.accessTokens` section of the site configuration. [#59731](https://github.com/sourcegraph/sourcegraph/pull/59731)
 
 ### Changed
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -71,6 +71,15 @@ func AccessTokensAllow() AccessTokenAllow {
 	}
 }
 
+func AccessTokensMaxPerUser() int {
+	defaultValue := 25
+	cfg := Get().AuthAccessTokens
+	if cfg == nil || cfg.MaxTokensPerUser == nil {
+		return defaultValue
+	}
+	return *cfg.MaxTokensPerUser
+}
+
 // AccessTokensAllowNoExpiration returns whether access tokens can be created without expiration.
 func AccessTokensAllowNoExpiration() bool {
 	cfg := Get().AuthAccessTokens

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -214,7 +214,7 @@ WITH subject_user AS (
 		  subject_user_id = $1
 		  AND deleted_at IS NULL
 		  AND (expires_at IS NULL OR expires_at > NOW())
-		  AND internal IS NOT True
+		  AND internal IS NOT TRUE
 	) AS active_tokens
    FROM users WHERE id=$1 AND deleted_at IS NULL FOR UPDATE
 ),

--- a/internal/database/access_tokens.go
+++ b/internal/database/access_tokens.go
@@ -44,6 +44,9 @@ type AccessToken struct {
 // but it does not exist.
 var ErrAccessTokenNotFound = errors.New("access token not found")
 
+// ErrTooManyAccessTokens is returned when creating an access token would exceed the configured maximum number of active access tokens.
+var ErrTooManyAccessTokens = errors.New("number of active access tokens exceeds limit")
+
 // MaxAccessTokenLastUsedAtAge is the maximum amount of time we will wait before updating an access token's
 // last_used_at column. We are OK letting the value get a little stale in order to cut down on database writes.
 const MaxAccessTokenLastUsedAtAge = 5 * time.Minute
@@ -202,7 +205,18 @@ func (s *accessTokenStore) createToken(ctx context.Context, subjectUserID int32,
 		// not been deleted. If they were deleted, the query will return an error.
 		`
 WITH subject_user AS (
-  SELECT id FROM users WHERE id=$1 AND deleted_at IS NULL FOR UPDATE
+  SELECT
+    id,
+	(
+		SELECT COUNT(*)
+		FROM access_tokens
+		WHERE
+		  subject_user_id = $1
+		  AND deleted_at IS NULL
+		  AND (expires_at IS NULL OR expires_at > NOW())
+		  AND internal IS NOT True
+	) AS active_tokens
+   FROM users WHERE id=$1 AND deleted_at IS NULL FOR UPDATE
 ),
 creator_user AS (
   SELECT id FROM users WHERE id=$5 AND deleted_at IS NULL FOR UPDATE
@@ -210,11 +224,21 @@ creator_user AS (
 insert_values AS (
   SELECT subject_user.id AS subject_user_id, $2::text[] AS scopes, $3::bytea AS value_sha256, $4::text AS note, creator_user.id AS creator_user_id, $6::timestamp with time zone AS expires_at, $7::boolean AS internal
   FROM subject_user, creator_user
+  WHERE subject_user.active_tokens < $8::int OR $7::boolean
 )
 INSERT INTO access_tokens(subject_user_id, scopes, value_sha256, note, creator_user_id, expires_at, internal) SELECT * FROM insert_values RETURNING id
 `,
-		subjectUserID, pq.Array(scopes), hashutil.ToSHA256Bytes(b[:]), note, creatorUserID, dbutil.NullTimeColumn(expiresAt), internal,
+		subjectUserID, pq.Array(scopes), hashutil.ToSHA256Bytes(b[:]), note, creatorUserID, dbutil.NullTimeColumn(expiresAt), internal, conf.AccessTokensMaxPerUser(),
 	).Scan(&id); err != nil {
+		// if creation failed check to see if it was because too many tokens already
+		count, countErr := s.Count(ctx, AccessTokensListOptions{SubjectUserID: subjectUserID})
+		// if checking the count fails just return the original error
+		if countErr != nil {
+			return 0, "", err
+		}
+		if count >= conf.AccessTokensMaxPerUser() {
+			return 0, "", ErrTooManyAccessTokens
+		}
 		return 0, "", err
 	}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -94,6 +94,8 @@ type AuthAccessTokens struct {
 	DefaultExpirationDays *int `json:"defaultExpirationDays,omitempty"`
 	// ExpirationOptionDays description: Options users will see for the number of days until token expiration. The defaultExpirationDays will be added to the list if not already present.
 	ExpirationOptionDays []int `json:"expirationOptionDays,omitempty"`
+	// MaxTokensPerUser description: The maximum number of active access tokens a user may have.
+	MaxTokensPerUser *int `json:"maxTokensPerUser,omitempty"`
 }
 
 // AuthAllowedIpAddress description: IP allowlist for access to the Sourcegraph instance. If set, only requests from these IP addresses will be allowed. By default client IP is infered connected client IP address, and you may configure to use a request header to determine the user IP.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -14,13 +14,17 @@
         "pointer": true
       },
       "group": "Search",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "search.index.shardConcurrency": {
       "description": "The number of threads each indexserver should use to index shards. If not set, indexserver will use the number of available CPUs. This is exposed as a safeguard and should usually not require being set.",
       "type": "integer",
       "group": "Search",
-      "examples": ["10"]
+      "examples": [
+        "10"
+      ]
     },
     "search.largeFiles": {
       "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.",
@@ -29,13 +33,21 @@
         "type": "string"
       },
       "group": "Search",
-      "examples": [["go.sum", "package-lock.json", "**/*.thrift"]]
+      "examples": [
+        [
+          "go.sum",
+          "package-lock.json",
+          "**/*.thrift"
+        ]
+      ]
     },
     "debug.search.symbolsParallelism": {
       "description": "(debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.",
       "type": "integer",
       "group": "Debug",
-      "examples": ["20"]
+      "examples": [
+        "20"
+      ]
     },
     "cloneProgress.log": {
       "description": "Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.",
@@ -181,7 +193,10 @@
         "eventLogging": {
           "description": "Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "enabled"
         },
         "passwordPolicy": {
@@ -232,62 +247,92 @@
         "structuralSearch": {
           "description": "Enables structural search.",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "perforce": {
           "description": "Allow adding Perforce code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "enabled",
           "deprecationMessage": "Deprecated, Perforce is always enabled, setting is no longer used."
         },
         "perforceChangelistMapping": {
           "description": "Allow mapping of Perforce changelists to their commit SHAs in the DB",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "goPackages": {
           "description": "Allow adding Go package host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "jvmPackages": {
           "description": "Allow adding JVM package host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "npmPackages": {
           "description": "Allow adding npm package code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "pythonPackages": {
           "description": "Allow adding Python package code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "rustPackages": {
           "description": "Allow adding Rust package code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "rubyPackages": {
           "description": "Allow adding Ruby package host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "pagure": {
           "description": "Allow adding Pagure code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "subRepoPermissions": {
@@ -329,7 +374,9 @@
               "items": {
                 "type": "string",
                 "pattern": "^-----BEGIN CERTIFICATE-----\n",
-                "examples": ["-----BEGIN CERTIFICATE-----\n..."]
+                "examples": [
+                  "-----BEGIN CERTIFICATE-----\n..."
+                ]
               }
             }
           }
@@ -342,7 +389,10 @@
             "description": "Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.",
             "type": "object",
             "additionalProperties": false,
-            "required": ["domainPath", "fetch"],
+            "required": [
+              "domainPath",
+              "fetch"
+            ],
             "properties": {
               "domainPath": {
                 "description": "Git clone URL domain/path",
@@ -375,10 +425,14 @@
             "type": "object",
             "title": "SearchIndexRevisionsRule",
             "additionalProperties": false,
-            "required": ["revisions"],
+            "required": [
+              "revisions"
+            ],
             "anyOf": [
               {
-                "required": ["name"]
+                "required": [
+                  "name"
+                ]
               }
             ],
             "properties": {
@@ -401,7 +455,11 @@
             [
               {
                 "name": "^github.com/org/.*",
-                "revisions": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"]
+                "revisions": [
+                  "3.17",
+                  "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
+                  "v3.17.1"
+                ]
               }
             ]
           ]
@@ -418,8 +476,14 @@
           },
           "examples": [
             {
-              "github.com/sourcegraph/sourcegraph": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"],
-              "name/of/repo": ["develop"]
+              "github.com/sourcegraph/sourcegraph": [
+                "3.17",
+                "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
+                "v3.17.1"
+              ],
+              "name/of/repo": [
+                "develop"
+              ]
             }
           ]
         },
@@ -573,13 +637,18 @@
         "languageDetection": {
           "description": "Setting for customizing language detection behavior",
           "type": "object",
-          "required": ["graphQL"],
+          "required": [
+            "graphQL"
+          ],
           "additionalProperties": false,
           "properties": {
             "graphQL": {
               "description": "What to take into account for computing 'languages' for the GraphQL API. This setting indirectly affects client-side code attempting to determine languages, such as search-based code navigation and the files sidebar.",
               "type": "string",
-              "enum": ["useFileContents", "useFileNamesOnly"],
+              "enum": [
+                "useFileContents",
+                "useFileNamesOnly"
+              ],
               "default": "useFileContents"
             }
           }
@@ -600,7 +669,9 @@
         },
         {
           "tls.external": {
-            "certificates": ["-----BEGIN CERTIFICATE-----\n..."],
+            "certificates": [
+              "-----BEGIN CERTIFICATE-----\n..."
+            ],
             "insecureSkipVerify": true
           }
         }
@@ -647,7 +718,9 @@
       "items": {
         "title": "BatchChangeRolloutWindow",
         "type": "object",
-        "required": ["rate"],
+        "required": [
+          "rate"
+        ],
         "additionalProperties": false,
         "properties": {
           "rate": {
@@ -684,13 +757,18 @@
           }
         },
         "dependencies": {
-          "start": ["end"]
+          "start": [
+            "end"
+          ]
         }
       },
       "examples": [
         {
           "rate": "10/hour",
-          "days": ["saturday", "sunday"],
+          "days": [
+            "saturday",
+            "sunday"
+          ],
           "start": "06:00",
           "end": "20:00"
         }
@@ -706,7 +784,11 @@
       "description": "How long changesets will be retained after they have been detached from a batch change.",
       "type": "string",
       "group": "BatchChanges",
-      "examples": ["336h", "48h", "5h30m40s"]
+      "examples": [
+        "336h",
+        "48h",
+        "5h30m40s"
+      ]
     },
     "codeIntelAutoIndexing.enabled": {
       "description": "Enables/disables the code intel auto-indexing feature. Currently experimental.",
@@ -772,13 +854,17 @@
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": ["dev"]
+      "examples": [
+        "dev"
+      ]
     },
     "codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix": {
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (excluding the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": [""]
+      "examples": [
+        ""
+      ]
     },
     "codeIntelRanking.staleResultsAge": {
       "description": "The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.",
@@ -789,7 +875,9 @@
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",
-      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"],
+      "examples": [
+        "https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"
+      ],
       "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",
       "group": "Security"
     },
@@ -829,7 +917,10 @@
       "items": {
         "title": "UpdateIntervalRule",
         "type": "object",
-        "required": ["pattern", "interval"],
+        "required": [
+          "pattern",
+          "interval"
+        ],
         "additionalProperties": false,
         "properties": {
           "pattern": {
@@ -862,7 +953,9 @@
       "description": "DEPRECATED! Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.",
       "type": "boolean",
       "group": "External services",
-      "examples": [true],
+      "examples": [
+        true
+      ],
       "deprecationMessage": "Deprecated because it's no longer supported and hasn't been working for a while."
     },
     "git.cloneURLToRepositoryName": {
@@ -873,7 +966,10 @@
         "description": "Describes a mapping from clone URL to repository name. The `from` field contains a regular expression with named capturing groups. The `to` field contains a template string that references capturing group names. For instance, if `from` is \"^../(?P<name>\\w+)$\" and `to` is \"github.com/user/{name}\", the clone URL \"../myRepository\" would be mapped to the repository name \"github.com/user/myRepository\".",
         "type": "object",
         "additionalProperties": false,
-        "required": ["from", "to"],
+        "required": [
+          "from",
+          "to"
+        ],
         "properties": {
           "from": {
             "description": "A regular expression that matches a set of clone URLs. The regular expression should use the Go regular expression syntax (https://golang.org/pkg/regexp/) and contain at least one named capturing group. The regular expression matches partially by default, so use \"^...$\" if whole-string matching is desired.",
@@ -920,24 +1016,37 @@
       "title": "SyntaxHighlighting",
       "description": "Syntax highlighting configuration",
       "type": "object",
-      "required": ["engine", "languages"],
+      "required": [
+        "engine",
+        "languages"
+      ],
       "properties": {
         "engine": {
           "title": "SyntaxHighlightingEngine",
           "type": "object",
-          "required": ["default"],
+          "required": [
+            "default"
+          ],
           "properties": {
             "default": {
               "description": "The default syntax highlighting engine to use",
               "type": "string",
-              "enum": ["tree-sitter", "syntect", "scip-syntax"]
+              "enum": [
+                "tree-sitter",
+                "syntect",
+                "scip-syntax"
+              ]
             },
             "overrides": {
               "description": "Manually specify overrides for syntax highlighting engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": ["tree-sitter", "syntect", "scip-syntax"]
+                "enum": [
+                  "tree-sitter",
+                  "syntect",
+                  "scip-syntax"
+                ]
               }
             }
           }
@@ -945,7 +1054,10 @@
         "languages": {
           "title": "SyntaxHighlightingLanguage",
           "type": "object",
-          "required": ["extensions", "patterns"],
+          "required": [
+            "extensions",
+            "patterns"
+          ],
           "properties": {
             "extensions": {
               "description": "Map of extension to language",
@@ -960,7 +1072,10 @@
               "items": {
                 "title": "SyntaxHighlightingLanguagePatterns",
                 "type": "object",
-                "required": ["pattern", "language"],
+                "required": [
+                  "pattern",
+                  "language"
+                ],
                 "properties": {
                   "pattern": {
                     "description": "Regular expression which matches the filepath",
@@ -980,14 +1095,20 @@
           "title": "SymbolConfiguration",
           "description": "Configure symbol generation",
           "type": "object",
-          "required": ["engine"],
+          "required": [
+            "engine"
+          ],
           "properties": {
             "engine": {
               "description": "Manually specify overrides for symbol generation engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": ["universal-ctags", "scip-ctags", "off"]
+                "enum": [
+                  "universal-ctags",
+                  "scip-ctags",
+                  "off"
+                ]
               }
             }
           }
@@ -1060,7 +1181,10 @@
     },
     "scim.identityProvider": {
       "type": "string",
-      "enum": ["STANDARD", "Azure AD"],
+      "enum": [
+        "STANDARD",
+        "Azure AD"
+      ],
       "description": "Identity provider used for SCIM support.  \"STANDARD\" should be used unless a more specific value is available",
       "default": "STANDARD",
       "group": "External services"
@@ -1140,7 +1264,11 @@
         "allow": {
           "description": "Allow or restrict the use of access tokens. The default is \"all-users-create\", which enables all users to create access tokens. Use \"none\" to disable access tokens entirely. Use \"site-admin-create\" to restrict creation of new tokens to admin users (existing tokens will still work until revoked).",
           "type": "string",
-          "enum": ["all-users-create", "site-admin-create", "none"],
+          "enum": [
+            "all-users-create",
+            "site-admin-create",
+            "none"
+          ],
           "default": "all-users-create"
         },
         "allowNoExpiration": {
@@ -1151,13 +1279,27 @@
         "expirationOptionDays": {
           "description": "Options users will see for the number of days until token expiration. The defaultExpirationDays will be added to the list if not already present.",
           "type": "array",
-          "default": [7, 14, 30, 60, 90],
+          "default": [
+            7,
+            14,
+            30,
+            60,
+            90
+          ],
           "items": {
             "type": "integer",
             "maximum": 365,
             "minimum": 1
           },
-          "examples": [[7, 14, 30, 60, 90]]
+          "examples": [
+            [
+              7,
+              14,
+              30,
+              60,
+              90
+            ]
+          ]
         },
         "defaultExpirationDays": {
           "description": "The default duration selection when creating a new access token. This value will be added to the expirationOptionDays if it is not already present",
@@ -1168,25 +1310,53 @@
           "default": 90,
           "maximum": 365,
           "minimum": 1
+        },
+        "maxTokensPerUser": {
+          "description": "The maximum number of active access tokens a user may have.",
+          "type": "integer",
+          "!go": {
+            "pointer": true
+          },
+          "default": 25,
+          "maximum": 100,
+          "minimum": 1
         }
       },
       "default": {
         "allow": "all-users-create",
         "allowNoExpiration": false,
-        "expirationOptionDays": [7, 14, 30, 60, 90],
+        "expirationOptionDays": [
+          7,
+          14,
+          30,
+          60,
+          90
+        ],
         "defaultExpirationDays": 90
       },
       "examples": [
         {
           "allow": "site-admin-create",
           "allowNoExpiration": true,
-          "expirationOptionDays": [7, 14, 30, 60, 90],
+          "expirationOptionDays": [
+            7,
+            14,
+            30,
+            60,
+            90
+          ],
           "defaultExpirationDays": 90
         },
         {
           "allow": "none",
           "allowNoExpiration": false,
-          "expirationOptionDays": [7, 14, 30, 60, 90],
+          "expirationOptionDays": [
+            7,
+            14,
+            30,
+            60,
+            90
+          ],
           "defaultExpirationDays": 45
         }
       ],
@@ -1207,7 +1377,10 @@
           "items": {
             "type": "string"
           },
-          "examples": ["100.100.100.0/25", "23.34.56.21"]
+          "examples": [
+            "100.100.100.0/25",
+            "23.34.56.21"
+          ]
         },
         "trustedClientIpAddress": {
           "description": "List of trusted client IP addresses that will bypass user IP address check. If empty, nothing can be bypass. This is useful to support access from trusted internal services. It will always permit connection from `127.0.0.1`. You must include the IP range allocated for the Sourcegraph deployment services to allow inter-service communication, e.g., kubernetes pod ip range.",
@@ -1215,7 +1388,10 @@
           "items": {
             "type": "string"
           },
-          "examples": ["100.100.100.0/25", "23.34.56.21"]
+          "examples": [
+            "100.100.100.0/25",
+            "23.34.56.21"
+          ]
         },
         "userIpAddress": {
           "description": "List of user IP addresses to allow. If empty, all IP addresses are allowed.",
@@ -1223,7 +1399,10 @@
           "items": {
             "type": "string"
           },
-          "examples": ["100.100.100.0/25", "23.34.56.21"]
+          "examples": [
+            "100.100.100.0/25",
+            "23.34.56.21"
+          ]
         },
         "userIpRequestHeaders": {
           "description": "An optional list of case-insensitive request header names to use for resolving the callers user IP address. You must ensure that the header is coming from a trusted source. If the header contains multiple IP addresses, the right-most is used. If no IP is found from provided headers, the connected client IP address is used.",
@@ -1231,7 +1410,11 @@
           "items": {
             "type": "string"
           },
-          "examples": ["X-Forwarded-For", "X-Real-IP", "CF-Connecting-IP"]
+          "examples": [
+            "X-Forwarded-For",
+            "X-Real-IP",
+            "CF-Connecting-IP"
+          ]
         },
         "errorMessageTemplate": {
           "description": "A template to customize the error message display to users on unauthorized access.  Available template variables: `{{.Error}}`, `{{.UserIP}}`",
@@ -1268,7 +1451,10 @@
         "bindID": {
           "description": "The type of identifier to identify a user. The default is \"email\", which uses the email address to identify a user. Use \"username\" to identify a user by their username. Changing this setting will erase any permissions created for users that do not yet exist.",
           "type": "string",
-          "enum": ["email", "username"],
+          "enum": [
+            "email",
+            "username"
+          ],
           "default": "email"
         }
       },
@@ -1384,7 +1570,11 @@
       "description": "The SMTP server used to send transactional emails.\nPlease see https://docs.sourcegraph.com/admin/config/email",
       "type": "object",
       "additionalProperties": false,
-      "required": ["host", "port", "authentication"],
+      "required": [
+        "host",
+        "port",
+        "authentication"
+      ],
       "properties": {
         "host": {
           "description": "The SMTP server host.",
@@ -1405,7 +1595,11 @@
         "authentication": {
           "description": "The type of authentication to use for the SMTP server.",
           "type": "string",
-          "enum": ["none", "PLAIN", "CRAM-MD5"]
+          "enum": [
+            "none",
+            "PLAIN",
+            "CRAM-MD5"
+          ]
         },
         "domain": {
           "description": "The HELO domain to provide to the SMTP server (if needed).",
@@ -1421,7 +1615,10 @@
           "items": {
             "title": "Header",
             "type": "object",
-            "required": ["key", "value"],
+            "required": [
+              "key",
+              "value"
+            ],
             "additionalProperties": false,
             "properties": {
               "key": {
@@ -1460,14 +1657,19 @@
       "type": "string",
       "format": "email",
       "group": "Email",
-      "examples": ["noreply@sourcegraph.example.com"]
+      "examples": [
+        "noreply@sourcegraph.example.com"
+      ]
     },
     "email.senderName": {
       "description": "The name to use in the \"from\" address for emails sent by this server.",
       "type": "string",
       "group": "Email",
       "default": "Sourcegraph",
-      "examples": ["Our Company Sourcegraph", "Example Inc Sourcegraph"]
+      "examples": [
+        "Our Company Sourcegraph",
+        "Example Inc Sourcegraph"
+      ]
     },
     "email.templates": {
       "description": "Configurable templates for some email types sent by Sourcegraph.",
@@ -1499,7 +1701,9 @@
     "executors.frontendURL": {
       "description": "The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.",
       "type": "string",
-      "examples": ["https://sourcegraph.example.com"]
+      "examples": [
+        "https://sourcegraph.example.com"
+      ]
     },
     "executors.srcCLIImage": {
       "description": "The image to use for src-cli in executors. Use this value to pull from a custom image registry.",
@@ -1509,12 +1713,16 @@
     "executors.srcCLIImageTag": {
       "description": "The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": ["4.1.0"]
+      "examples": [
+        "4.1.0"
+      ]
     },
     "executors.lsifGoImage": {
       "description": "The tag to use for the lsif-go image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": ["sourcegraph/lsif-go"]
+      "examples": [
+        "sourcegraph/lsif-go"
+      ]
     },
     "executors.batcheshelperImage": {
       "description": "The image to use for batch changes in executors. Use this value to pull from a custom image registry.",
@@ -1524,13 +1732,17 @@
     "executors.batcheshelperImageTag": {
       "description": "The tag to use for the batcheshelper image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": ["4.1.0"]
+      "examples": [
+        "4.1.0"
+      ]
     },
     "executors.accessToken": {
       "description": "The shared secret between Sourcegraph and executors. The value must contain at least 20 characters.",
       "type": "string",
       "pattern": "^(.{20,}|REDACTED)$",
-      "examples": ["my-super-secret-access-token"]
+      "examples": [
+        "my-super-secret-access-token"
+      ]
     },
     "executors.multiqueue": {
       "description": "The configuration for multiqueue executors.",
@@ -1543,7 +1755,10 @@
             "batches": {
               "description": "The configuration for the batches queue.",
               "type": "object",
-              "required": ["limit", "weight"],
+              "required": [
+                "limit",
+                "weight"
+              ],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1560,7 +1775,10 @@
             "codeintel": {
               "description": "The configuration for the codeintel queue.",
               "type": "object",
-              "required": ["limit", "weight"],
+              "required": [
+                "limit",
+                "weight"
+              ],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1589,7 +1807,9 @@
       },
       "examples": [
         {
-          "*": ["myorg1"]
+          "*": [
+            "myorg1"
+          ]
         }
       ],
       "hide": true
@@ -1654,10 +1874,19 @@
               "deprecationMessage": "No effect, audit logs are always set to SRC_LOG_LEVEL",
               "description": "DEPRECATED: No effect, audit logs are always set to SRC_LOG_LEVEL",
               "type": "string",
-              "enum": ["DEBUG", "INFO", "WARN", "ERROR"]
+              "enum": [
+                "DEBUG",
+                "INFO",
+                "WARN",
+                "ERROR"
+              ]
             }
           },
-          "required": ["internalTraffic", "graphQL", "gitserverAccess"],
+          "required": [
+            "internalTraffic",
+            "graphQL",
+            "gitserverAccess"
+          ],
           "examples": [
             {
               "internalTraffic": false,
@@ -1674,7 +1903,12 @@
             "location": {
               "description": "Where to output the security event log [none, auditlog, database, all] where auditlog is the default logging to stdout with the specified audit log format",
               "type": "string",
-              "enum": ["none", "auditlog", "database", "all"],
+              "enum": [
+                "none",
+                "auditlog",
+                "database",
+                "all"
+              ],
               "default": "auditlog"
             }
           },
@@ -1689,7 +1923,9 @@
     "externalURL": {
       "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.",
       "type": "string",
-      "examples": ["https://sourcegraph.example.com"]
+      "examples": [
+        "https://sourcegraph.example.com"
+      ]
     },
     "observability.client": {
       "description": "EXPERIMENTAL: Configuration for client observability",
@@ -1703,7 +1939,10 @@
             "endpoint": {
               "description": "OpenTelemetry tracing collector endpoint. By default, Sourcegraph's \"/-/debug/otlp\" endpoint forwards data to the configured collector backend.",
               "type": "string",
-              "examples": ["/-/debug/otlp", "https://COLLECTOR_ENDPOINT"],
+              "examples": [
+                "/-/debug/otlp",
+                "https://COLLECTOR_ENDPOINT"
+              ],
               "default": "/-/debug/otlp"
             }
           }
@@ -1729,13 +1968,20 @@
         "sampling": {
           "description": "Determines the conditions under which distributed traces are recorded. \"none\" turns off tracing entirely. \"selective\" (default) sends traces whenever `?trace=1` is present in the URL (though background jobs may still emit traces). \"all\" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. To learn more about additional sampling and traace export configuration with the default tracing type \"opentelemetry\", refer to https://docs.sourcegraph.com/admin/observability/opentelemetry#tracing ",
           "type": "string",
-          "enum": ["selective", "all", "none"],
+          "enum": [
+            "selective",
+            "all",
+            "none"
+          ],
           "default": "selective"
         },
         "type": {
           "description": "Determines what tracing provider to enable. For \"opentelemetry\", the required backend is an OpenTelemetry collector instance (deployed by default with Sourcegraph). For \"jaeger\", a Jaeger instance is required to be configured via Jaeger client environment variables: https://github.com/jaegertracing/jaeger-client-go#environment-variables",
           "type": "string",
-          "enum": ["opentelemetry", "jaeger"],
+          "enum": [
+            "opentelemetry",
+            "jaeger"
+          ],
           "default": "opentelemetry"
         },
         "debug": {
@@ -1774,19 +2020,31 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["level", "notifier"],
+        "required": [
+          "level",
+          "notifier"
+        ],
         "properties": {
           "level": {
             "description": "Sourcegraph alert level to subscribe to notifications for.",
             "type": "string",
-            "enum": ["warning", "critical"]
+            "enum": [
+              "warning",
+              "critical"
+            ]
           },
           "notifier": {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["slack", "pagerduty", "webhook", "email", "opsgenie"]
+                "enum": [
+                  "slack",
+                  "pagerduty",
+                  "webhook",
+                  "email",
+                  "opsgenie"
+                ]
               }
             },
             "oneOf": [
@@ -1843,7 +2101,9 @@
           "level": "warning",
           "notifier": {
             "type": "email",
-            "addresses": ["alerts@example.com"]
+            "addresses": [
+              "alerts@example.com"
+            ]
           }
         }
       ]
@@ -1854,25 +2114,39 @@
       "items": {
         "type": "string"
       },
-      "examples": [["warning_gitserver_disk_space_remaining"], ["critical_frontend_down", "warning_high_load"]]
+      "examples": [
+        [
+          "warning_gitserver_disk_space_remaining"
+        ],
+        [
+          "critical_frontend_down",
+          "warning_high_load"
+        ]
+      ]
     },
     "observability.logSlowSearches": {
       "description": "(debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [10000]
+      "examples": [
+        10000
+      ]
     },
     "observability.logSlowGraphQLRequests": {
       "description": "(debug) logs all GraphQL requests slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [10000]
+      "examples": [
+        10000
+      ]
     },
     "observability.captureSlowGraphQLRequestsLimit": {
       "description": "(debug) Set a limit to the amount of captured slow GraphQL requests being stored for visualization. For defining the threshold for a slow GraphQL request, see observability.logSlowGraphQLRequests.",
       "type": "integer",
       "group": "Debug",
-      "examples": [2000]
+      "examples": [
+        2000
+      ]
     },
     "insights.backfill.interruptAfter": {
       "description": "Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.",
@@ -1899,14 +2173,19 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 1,
-      "examples": [10]
+      "examples": [
+        10
+      ]
     },
     "insights.query.worker.rateLimit": {
       "description": "Maximum number of Code Insights queries initiated per second on a worker node.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10.0, 0.5],
+      "examples": [
+        10.0,
+        0.5
+      ],
       "!go": {
         "pointer": true
       }
@@ -1916,14 +2195,20 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10, 20]
+      "examples": [
+        10,
+        20
+      ]
     },
     "insights.historical.worker.rateLimit": {
       "description": "Maximum number of historical Code Insights data frames that may be analyzed per second.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [50.0, 0.5],
+      "examples": [
+        50.0,
+        0.5
+      ],
       "!go": {
         "pointer": true
       }
@@ -1933,7 +2218,10 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10, 20]
+      "examples": [
+        10,
+        20
+      ]
     },
     "insights.aggregations.bufferSize": {
       "description": "The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend",
@@ -1953,7 +2241,11 @@
       "group": "CodeInsights",
       "default": 30,
       "maximum": 90,
-      "examples": [12, 24, 50]
+      "examples": [
+        12,
+        24,
+        50
+      ]
     },
     "own.bestEffortTeamMatching": {
       "description": "The Own service will attempt to match a Team by the last part of its handle if it contains a slash and no match is found for its full handle.",
@@ -2066,14 +2358,29 @@
           "items": {
             "type": "string"
           },
-          "default": ["show", "rev-parse", "log", "diff", "ls-tree"]
+          "default": [
+            "show",
+            "rev-parse",
+            "log",
+            "diff",
+            "ls-tree"
+          ]
         }
       },
       "examples": [
         {
           "size": 1000,
-          "repos": ["github.com/sourcegraph/sourcegraph", "github.com/gorilla/mux"],
-          "ignoredGitCommands": ["show", "rev-parse", "log", "diff", "ls-tree"]
+          "repos": [
+            "github.com/sourcegraph/sourcegraph",
+            "github.com/gorilla/mux"
+          ],
+          "ignoredGitCommands": [
+            "show",
+            "rev-parse",
+            "log",
+            "diff",
+            "ls-tree"
+          ]
         }
       ]
     },
@@ -2127,7 +2434,10 @@
         "srcCliVersionCache": {
           "description": "Configuration related to the src-cli version cache. This should only be used on sourcegraph.com.",
           "type": "object",
-          "required": ["enabled", "github"],
+          "required": [
+            "enabled",
+            "github"
+          ],
           "group": "Sourcegraph.com",
           "properties": {
             "enabled": {
@@ -2138,7 +2448,10 @@
             "github": {
               "description": "GitHub configuration, both for queries and receiving release webhooks.",
               "type": "object",
-              "required": ["token", "webhookSecret"],
+              "required": [
+                "token",
+                "webhookSecret"
+              ],
               "properties": {
                 "repository": {
                   "description": "The repository to get the latest version of.",
@@ -2205,7 +2518,10 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["key", "message"],
+        "required": [
+          "key",
+          "message"
+        ],
         "properties": {
           "key": {
             "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
@@ -2230,7 +2546,9 @@
       "description": "The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).",
       "type": "array",
       "items": {
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "properties": {
           "type": {
             "type": "string",
@@ -2298,7 +2616,9 @@
       "type": "string",
       "description": "The duration of a user session, after which it expires and the user is required to re-authenticate. The default is 90 days. There is typically no need to set this, but some users may have specific internal security requirements.\n\nThe string format is that of the Duration type in the Go time package (https://golang.org/pkg/time/#ParseDuration). E.g., \"720h\", \"43200m\", \"2592000s\" all indicate a timespan of 30 days.\n\nNote: changing this field does not affect the expiration of existing sessions. If you would like to enforce this limit for existing sessions, you must log out currently signed-in users. You can force this by removing all keys beginning with \"session_\" from the Redis store:\n\n* For deployments using `sourcegraph/server`: `docker exec $CONTAINER_ID redis-cli --raw keys 'session_*' | xargs docker exec $CONTAINER_ID redis-cli del`\n* For cluster deployments: \n  ```\n  REDIS_POD=\"$(kubectl get pods -l app=redis-store -o jsonpath={.items[0].metadata.name})\";\n  kubectl exec \"$REDIS_POD\" -- redis-cli --raw keys 'session_*' | xargs kubectl exec \"$REDIS_POD\" -- redis-cli --raw del;\n  ```\n",
       "default": "2160h",
-      "examples": ["168h"],
+      "examples": [
+        "168h"
+      ],
       "group": "Authentication"
     },
     "auth.enableUsernameChanges": {
@@ -2393,10 +2713,17 @@
     },
     "update.channel": {
       "description": "The channel on which to automatically check for Sourcegraph updates.",
-      "type": ["string"],
-      "enum": ["release", "none"],
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "release",
+        "none"
+      ],
       "default": "release",
-      "examples": ["none"],
+      "examples": [
+        "none"
+      ],
       "group": "Misc."
     },
     "productResearchPage.enabled": {
@@ -2499,12 +2826,16 @@
       "!go": {
         "pointer": true
       },
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "organizationInvitations": {
       "description": "Configuration for organization invitations.",
       "type": "object",
-      "required": ["signingKey"],
+      "required": [
+        "signingKey"
+      ],
       "properties": {
         "expiryTime": {
           "description": "Time before the invitation expires, in hours (experimental, not enforced at the moment).",
@@ -2578,7 +2909,11 @@
         "provider": {
           "type": "string",
           "description": "The provider to use for generating embeddings. Defaults to sourcegraph.",
-          "enum": ["openai", "azure-openai", "sourcegraph"]
+          "enum": [
+            "openai",
+            "azure-openai",
+            "sourcegraph"
+          ]
         },
         "endpoint": {
           "type": "string",
@@ -2630,7 +2965,13 @@
               "items": {
                 "type": "string"
               },
-              "examples": ["*.go", "*.ts", "*.md", "src/", "cmd/"]
+              "examples": [
+                "*.go",
+                "*.ts",
+                "*.md",
+                "src/",
+                "cmd/"
+              ]
             },
             "maxFileSizeBytes": {
               "description": "The maximum file size (in bytes) to include in embeddings. Must be between 0 and 100000 (1 MB).",
@@ -2817,7 +3158,11 @@
           "model": "text-embedding-ada-002",
           "accessToken": "your-access-token",
           "url": "https://api.openai.com/v1/embeddings",
-          "excludedFilePathPatterns": ["*.svg", "**/__mocks__/**", "**/test/**"]
+          "excludedFilePathPatterns": [
+            "*.svg",
+            "**/__mocks__/**",
+            "**/test/**"
+          ]
         }
       ]
     },
@@ -2869,7 +3214,14 @@
           "type": "string",
           "description": "The external completions provider. Defaults to 'sourcegraph'.",
           "default": "sourcegraph",
-          "enum": ["anthropic", "openai", "sourcegraph", "azure-openai", "aws-bedrock", "fireworks"]
+          "enum": [
+            "anthropic",
+            "openai",
+            "sourcegraph",
+            "azure-openai",
+            "aws-bedrock",
+            "fireworks"
+          ]
         },
         "endpoint": {
           "type": "string",
@@ -2988,7 +3340,9 @@
       "description": "Configures the builtin username-password authentication provider.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3005,7 +3359,12 @@
       "description": "Configures the OpenID Connect authentication provider for SSO.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "issuer", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "issuer",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3064,11 +3423,20 @@
       "description": "Configures the SAML authentication provider for SSO.\n\nNote: if you are using IdP-initiated login, you must have *at most one* SAMLAuthProvider in the `auth.providers` array.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "dependencies": {
-        "serviceProviderCertificate": ["serviceProviderPrivateKey"],
-        "serviceProviderPrivateKey": ["serviceProviderCertificate"],
-        "signRequests": ["serviceProviderCertificate", "serviceProviderPrivateKey"]
+        "serviceProviderCertificate": [
+          "serviceProviderPrivateKey"
+        ],
+        "serviceProviderPrivateKey": [
+          "serviceProviderCertificate"
+        ],
+        "signRequests": [
+          "serviceProviderCertificate",
+          "serviceProviderPrivateKey"
+        ]
       },
       "properties": {
         "type": {
@@ -3179,7 +3547,10 @@
       "description": "Configures the HTTP header authentication provider (which authenticates users by consulting an HTTP request header set by an authentication proxy such as https://github.com/bitly/oauth2_proxy).",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "usernameHeader"],
+      "required": [
+        "type",
+        "usernameHeader"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3188,17 +3559,23 @@
         "usernameHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the username of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": ["X-Forwarded-User"]
+          "examples": [
+            "X-Forwarded-User"
+          ]
         },
         "stripUsernameHeaderPrefix": {
           "description": "The prefix that precedes the username portion of the HTTP header specified in `usernameHeader`. If specified, the prefix will be stripped from the header value and the remainder will be used as the username. For example, if using Google Identity-Aware Proxy (IAP) with Google Sign-In, set this value to `accounts.google.com:`.",
           "type": "string",
-          "examples": ["accounts.google.com:"]
+          "examples": [
+            "accounts.google.com:"
+          ]
         },
         "emailHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the email of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": ["X-App-Email"]
+          "examples": [
+            "X-App-Email"
+          ]
         }
       }
     },
@@ -3206,7 +3583,11 @@
       "description": "Configures the GitHub (or GitHub Enterprise) OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitHub instance: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/. When a user signs into Sourcegraph or links their GitHub account to their existing Sourcegraph account, GitHub will prompt the user for the repo scope.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3266,8 +3647,13 @@
           },
           "examples": [
             {
-              "orgName": ["team1"],
-              "anotherOrgName": ["team2", "team3"]
+              "orgName": [
+                "team1"
+              ],
+              "anotherOrgName": [
+                "team2",
+                "team3"
+              ]
             }
           ]
         },
@@ -3282,7 +3668,11 @@
       "description": "Configures the GitLab OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitLab instance: https://docs.gitlab.com/ee/integration/oauth_provider.html. The application should have `api` and `read_user` scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/gitlab/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3325,7 +3715,10 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "api",
-          "enum": ["api", "read_api"]
+          "enum": [
+            "api",
+            "read_api"
+          ]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via GitLab authentication. If false, users signing in via GitLab must have an existing Sourcegraph account, which will be linked to their GitLab identity after sign-in.",
@@ -3343,7 +3736,13 @@
             "type": "string",
             "minLength": 1
           },
-          "examples": [["group", "group/subgroup", "group/subgroup/subgroup"]]
+          "examples": [
+            [
+              "group",
+              "group/subgroup",
+              "group/subgroup/subgroup"
+            ]
+          ]
         },
         "tokenRefreshWindowMinutes": {
           "description": "Time in minutes before token expiry when we should attempt to refresh it",
@@ -3364,7 +3763,11 @@
       "description": "Configures the Bitbucket Cloud OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your Bitbucket Cloud workspace: https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/. The application should have account, email, and repository scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/bitbucketcloud/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientKey", "clientSecret"],
+      "required": [
+        "type",
+        "clientKey",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3402,7 +3805,11 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "account,email,repository",
-          "enum": ["account", "email", "repository"]
+          "enum": [
+            "account",
+            "email",
+            "repository"
+          ]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via Bitbucket Cloud authentication. If false, users signing in via Bitbucket Cloud must have an existing Sourcegraph account, which will be linked to their Bitbucket Cloud identity after sign-in.",
@@ -3415,7 +3822,10 @@
       "description": "Gerrit auth provider",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3447,7 +3857,11 @@
       "description": "Azure auth provider for dev.azure.com",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3532,7 +3946,9 @@
     "NotifierSlack": {
       "description": "Slack notifier",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3563,7 +3979,10 @@
     "NotifierPagerduty": {
       "description": "PagerDuty notifier",
       "type": "object",
-      "required": ["type", "integrationKey"],
+      "required": [
+        "type",
+        "integrationKey"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3585,7 +4004,10 @@
     "NotifierWebhook": {
       "description": "Webhook notifier",
       "type": "object",
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3608,7 +4030,10 @@
     "NotifierEmail": {
       "description": "Email notifier",
       "type": "object",
-      "required": ["type", "address"],
+      "required": [
+        "type",
+        "address"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3623,7 +4048,9 @@
     "NotifierOpsGenie": {
       "description": "OpsGenie notifier",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3651,7 +4078,12 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["team", "user", "escalation", "schedule"]
+                "enum": [
+                  "team",
+                  "user",
+                  "escalation",
+                  "schedule"
+                ]
               },
               "id": {
                 "type": "string"
@@ -3665,13 +4097,22 @@
             },
             "oneOf": [
               {
-                "required": ["type", "id"]
+                "required": [
+                  "type",
+                  "id"
+                ]
               },
               {
-                "required": ["type", "name"]
+                "required": [
+                  "type",
+                  "name"
+                ]
               },
               {
-                "required": ["type", "username"]
+                "required": [
+                  "type",
+                  "username"
+                ]
               }
             ]
           }
@@ -3681,11 +4122,18 @@
     "EncryptionKey": {
       "description": "Config for a key",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["cloudkms", "awskms", "mounted", "noop"]
+          "enum": [
+            "cloudkms",
+            "awskms",
+            "mounted",
+            "noop"
+          ]
         }
       },
       "oneOf": [
@@ -3709,7 +4157,10 @@
     "CloudKMSEncryptionKey": {
       "description": "Google Cloud KMS Encryption Key, used to encrypt data in Google Cloud environments",
       "type": "object",
-      "required": ["type", "keyname"],
+      "required": [
+        "type",
+        "keyname"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3726,7 +4177,10 @@
     "AWSKMSEncryptionKey": {
       "description": "AWS KMS Encryption Key, used to encrypt data in AWS environments",
       "type": "object",
-      "required": ["type", "keyId"],
+      "required": [
+        "type",
+        "keyId"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3746,7 +4200,10 @@
     "MountedEncryptionKey": {
       "description": "This encryption key is mounted from a given file path or an environment variable.",
       "type": "object",
-      "required": ["type", "keyname"],
+      "required": [
+        "type",
+        "keyname"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3769,7 +4226,9 @@
     "NoOpEncryptionKey": {
       "description": "This encryption key is a no op, leaving your data in plaintext (not recommended).",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3779,7 +4238,10 @@
     },
     "EmailTemplate": {
       "type": "object",
-      "required": ["subject", "html"],
+      "required": [
+        "subject",
+        "html"
+      ],
       "properties": {
         "subject": {
           "description": "Template for email subject header",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -14,17 +14,13 @@
         "pointer": true
       },
       "group": "Search",
-      "examples": [
-        true
-      ]
+      "examples": [true]
     },
     "search.index.shardConcurrency": {
       "description": "The number of threads each indexserver should use to index shards. If not set, indexserver will use the number of available CPUs. This is exposed as a safeguard and should usually not require being set.",
       "type": "integer",
       "group": "Search",
-      "examples": [
-        "10"
-      ]
+      "examples": ["10"]
     },
     "search.largeFiles": {
       "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.",
@@ -33,21 +29,13 @@
         "type": "string"
       },
       "group": "Search",
-      "examples": [
-        [
-          "go.sum",
-          "package-lock.json",
-          "**/*.thrift"
-        ]
-      ]
+      "examples": [["go.sum", "package-lock.json", "**/*.thrift"]]
     },
     "debug.search.symbolsParallelism": {
       "description": "(debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.",
       "type": "integer",
       "group": "Debug",
-      "examples": [
-        "20"
-      ]
+      "examples": ["20"]
     },
     "cloneProgress.log": {
       "description": "Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.",
@@ -193,10 +181,7 @@
         "eventLogging": {
           "description": "Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "enabled"
         },
         "passwordPolicy": {
@@ -247,92 +232,62 @@
         "structuralSearch": {
           "description": "Enables structural search.",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "perforce": {
           "description": "Allow adding Perforce code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "enabled",
           "deprecationMessage": "Deprecated, Perforce is always enabled, setting is no longer used."
         },
         "perforceChangelistMapping": {
           "description": "Allow mapping of Perforce changelists to their commit SHAs in the DB",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "goPackages": {
           "description": "Allow adding Go package host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "jvmPackages": {
           "description": "Allow adding JVM package host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "npmPackages": {
           "description": "Allow adding npm package code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "pythonPackages": {
           "description": "Allow adding Python package code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "rustPackages": {
           "description": "Allow adding Rust package code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "rubyPackages": {
           "description": "Allow adding Ruby package host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "pagure": {
           "description": "Allow adding Pagure code host connections",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ],
+          "enum": ["enabled", "disabled"],
           "default": "disabled"
         },
         "subRepoPermissions": {
@@ -374,9 +329,7 @@
               "items": {
                 "type": "string",
                 "pattern": "^-----BEGIN CERTIFICATE-----\n",
-                "examples": [
-                  "-----BEGIN CERTIFICATE-----\n..."
-                ]
+                "examples": ["-----BEGIN CERTIFICATE-----\n..."]
               }
             }
           }
@@ -389,10 +342,7 @@
             "description": "Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.",
             "type": "object",
             "additionalProperties": false,
-            "required": [
-              "domainPath",
-              "fetch"
-            ],
+            "required": ["domainPath", "fetch"],
             "properties": {
               "domainPath": {
                 "description": "Git clone URL domain/path",
@@ -425,14 +375,10 @@
             "type": "object",
             "title": "SearchIndexRevisionsRule",
             "additionalProperties": false,
-            "required": [
-              "revisions"
-            ],
+            "required": ["revisions"],
             "anyOf": [
               {
-                "required": [
-                  "name"
-                ]
+                "required": ["name"]
               }
             ],
             "properties": {
@@ -455,11 +401,7 @@
             [
               {
                 "name": "^github.com/org/.*",
-                "revisions": [
-                  "3.17",
-                  "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
-                  "v3.17.1"
-                ]
+                "revisions": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"]
               }
             ]
           ]
@@ -476,14 +418,8 @@
           },
           "examples": [
             {
-              "github.com/sourcegraph/sourcegraph": [
-                "3.17",
-                "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
-                "v3.17.1"
-              ],
-              "name/of/repo": [
-                "develop"
-              ]
+              "github.com/sourcegraph/sourcegraph": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"],
+              "name/of/repo": ["develop"]
             }
           ]
         },
@@ -637,18 +573,13 @@
         "languageDetection": {
           "description": "Setting for customizing language detection behavior",
           "type": "object",
-          "required": [
-            "graphQL"
-          ],
+          "required": ["graphQL"],
           "additionalProperties": false,
           "properties": {
             "graphQL": {
               "description": "What to take into account for computing 'languages' for the GraphQL API. This setting indirectly affects client-side code attempting to determine languages, such as search-based code navigation and the files sidebar.",
               "type": "string",
-              "enum": [
-                "useFileContents",
-                "useFileNamesOnly"
-              ],
+              "enum": ["useFileContents", "useFileNamesOnly"],
               "default": "useFileContents"
             }
           }
@@ -669,9 +600,7 @@
         },
         {
           "tls.external": {
-            "certificates": [
-              "-----BEGIN CERTIFICATE-----\n..."
-            ],
+            "certificates": ["-----BEGIN CERTIFICATE-----\n..."],
             "insecureSkipVerify": true
           }
         }
@@ -718,9 +647,7 @@
       "items": {
         "title": "BatchChangeRolloutWindow",
         "type": "object",
-        "required": [
-          "rate"
-        ],
+        "required": ["rate"],
         "additionalProperties": false,
         "properties": {
           "rate": {
@@ -757,18 +684,13 @@
           }
         },
         "dependencies": {
-          "start": [
-            "end"
-          ]
+          "start": ["end"]
         }
       },
       "examples": [
         {
           "rate": "10/hour",
-          "days": [
-            "saturday",
-            "sunday"
-          ],
+          "days": ["saturday", "sunday"],
           "start": "06:00",
           "end": "20:00"
         }
@@ -784,11 +706,7 @@
       "description": "How long changesets will be retained after they have been detached from a batch change.",
       "type": "string",
       "group": "BatchChanges",
-      "examples": [
-        "336h",
-        "48h",
-        "5h30m40s"
-      ]
+      "examples": ["336h", "48h", "5h30m40s"]
     },
     "codeIntelAutoIndexing.enabled": {
       "description": "Enables/disables the code intel auto-indexing feature. Currently experimental.",
@@ -854,17 +772,13 @@
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": [
-        "dev"
-      ]
+      "examples": ["dev"]
     },
     "codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix": {
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (excluding the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": [
-        ""
-      ]
+      "examples": [""]
     },
     "codeIntelRanking.staleResultsAge": {
       "description": "The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.",
@@ -875,9 +789,7 @@
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",
-      "examples": [
-        "https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"
-      ],
+      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"],
       "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",
       "group": "Security"
     },
@@ -917,10 +829,7 @@
       "items": {
         "title": "UpdateIntervalRule",
         "type": "object",
-        "required": [
-          "pattern",
-          "interval"
-        ],
+        "required": ["pattern", "interval"],
         "additionalProperties": false,
         "properties": {
           "pattern": {
@@ -953,9 +862,7 @@
       "description": "DEPRECATED! Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.",
       "type": "boolean",
       "group": "External services",
-      "examples": [
-        true
-      ],
+      "examples": [true],
       "deprecationMessage": "Deprecated because it's no longer supported and hasn't been working for a while."
     },
     "git.cloneURLToRepositoryName": {
@@ -966,10 +873,7 @@
         "description": "Describes a mapping from clone URL to repository name. The `from` field contains a regular expression with named capturing groups. The `to` field contains a template string that references capturing group names. For instance, if `from` is \"^../(?P<name>\\w+)$\" and `to` is \"github.com/user/{name}\", the clone URL \"../myRepository\" would be mapped to the repository name \"github.com/user/myRepository\".",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "from",
-          "to"
-        ],
+        "required": ["from", "to"],
         "properties": {
           "from": {
             "description": "A regular expression that matches a set of clone URLs. The regular expression should use the Go regular expression syntax (https://golang.org/pkg/regexp/) and contain at least one named capturing group. The regular expression matches partially by default, so use \"^...$\" if whole-string matching is desired.",
@@ -1016,37 +920,24 @@
       "title": "SyntaxHighlighting",
       "description": "Syntax highlighting configuration",
       "type": "object",
-      "required": [
-        "engine",
-        "languages"
-      ],
+      "required": ["engine", "languages"],
       "properties": {
         "engine": {
           "title": "SyntaxHighlightingEngine",
           "type": "object",
-          "required": [
-            "default"
-          ],
+          "required": ["default"],
           "properties": {
             "default": {
               "description": "The default syntax highlighting engine to use",
               "type": "string",
-              "enum": [
-                "tree-sitter",
-                "syntect",
-                "scip-syntax"
-              ]
+              "enum": ["tree-sitter", "syntect", "scip-syntax"]
             },
             "overrides": {
               "description": "Manually specify overrides for syntax highlighting engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": [
-                  "tree-sitter",
-                  "syntect",
-                  "scip-syntax"
-                ]
+                "enum": ["tree-sitter", "syntect", "scip-syntax"]
               }
             }
           }
@@ -1054,10 +945,7 @@
         "languages": {
           "title": "SyntaxHighlightingLanguage",
           "type": "object",
-          "required": [
-            "extensions",
-            "patterns"
-          ],
+          "required": ["extensions", "patterns"],
           "properties": {
             "extensions": {
               "description": "Map of extension to language",
@@ -1072,10 +960,7 @@
               "items": {
                 "title": "SyntaxHighlightingLanguagePatterns",
                 "type": "object",
-                "required": [
-                  "pattern",
-                  "language"
-                ],
+                "required": ["pattern", "language"],
                 "properties": {
                   "pattern": {
                     "description": "Regular expression which matches the filepath",
@@ -1095,20 +980,14 @@
           "title": "SymbolConfiguration",
           "description": "Configure symbol generation",
           "type": "object",
-          "required": [
-            "engine"
-          ],
+          "required": ["engine"],
           "properties": {
             "engine": {
               "description": "Manually specify overrides for symbol generation engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": [
-                  "universal-ctags",
-                  "scip-ctags",
-                  "off"
-                ]
+                "enum": ["universal-ctags", "scip-ctags", "off"]
               }
             }
           }
@@ -1181,10 +1060,7 @@
     },
     "scim.identityProvider": {
       "type": "string",
-      "enum": [
-        "STANDARD",
-        "Azure AD"
-      ],
+      "enum": ["STANDARD", "Azure AD"],
       "description": "Identity provider used for SCIM support.  \"STANDARD\" should be used unless a more specific value is available",
       "default": "STANDARD",
       "group": "External services"
@@ -1264,11 +1140,7 @@
         "allow": {
           "description": "Allow or restrict the use of access tokens. The default is \"all-users-create\", which enables all users to create access tokens. Use \"none\" to disable access tokens entirely. Use \"site-admin-create\" to restrict creation of new tokens to admin users (existing tokens will still work until revoked).",
           "type": "string",
-          "enum": [
-            "all-users-create",
-            "site-admin-create",
-            "none"
-          ],
+          "enum": ["all-users-create", "site-admin-create", "none"],
           "default": "all-users-create"
         },
         "allowNoExpiration": {
@@ -1279,27 +1151,13 @@
         "expirationOptionDays": {
           "description": "Options users will see for the number of days until token expiration. The defaultExpirationDays will be added to the list if not already present.",
           "type": "array",
-          "default": [
-            7,
-            14,
-            30,
-            60,
-            90
-          ],
+          "default": [7, 14, 30, 60, 90],
           "items": {
             "type": "integer",
             "maximum": 365,
             "minimum": 1
           },
-          "examples": [
-            [
-              7,
-              14,
-              30,
-              60,
-              90
-            ]
-          ]
+          "examples": [[7, 14, 30, 60, 90]]
         },
         "defaultExpirationDays": {
           "description": "The default duration selection when creating a new access token. This value will be added to the expirationOptionDays if it is not already present",
@@ -1325,38 +1183,20 @@
       "default": {
         "allow": "all-users-create",
         "allowNoExpiration": false,
-        "expirationOptionDays": [
-          7,
-          14,
-          30,
-          60,
-          90
-        ],
+        "expirationOptionDays": [7, 14, 30, 60, 90],
         "defaultExpirationDays": 90
       },
       "examples": [
         {
           "allow": "site-admin-create",
           "allowNoExpiration": true,
-          "expirationOptionDays": [
-            7,
-            14,
-            30,
-            60,
-            90
-          ],
+          "expirationOptionDays": [7, 14, 30, 60, 90],
           "defaultExpirationDays": 90
         },
         {
           "allow": "none",
           "allowNoExpiration": false,
-          "expirationOptionDays": [
-            7,
-            14,
-            30,
-            60,
-            90
-          ],
+          "expirationOptionDays": [7, 14, 30, 60, 90],
           "defaultExpirationDays": 45
         }
       ],
@@ -1377,10 +1217,7 @@
           "items": {
             "type": "string"
           },
-          "examples": [
-            "100.100.100.0/25",
-            "23.34.56.21"
-          ]
+          "examples": ["100.100.100.0/25", "23.34.56.21"]
         },
         "trustedClientIpAddress": {
           "description": "List of trusted client IP addresses that will bypass user IP address check. If empty, nothing can be bypass. This is useful to support access from trusted internal services. It will always permit connection from `127.0.0.1`. You must include the IP range allocated for the Sourcegraph deployment services to allow inter-service communication, e.g., kubernetes pod ip range.",
@@ -1388,10 +1225,7 @@
           "items": {
             "type": "string"
           },
-          "examples": [
-            "100.100.100.0/25",
-            "23.34.56.21"
-          ]
+          "examples": ["100.100.100.0/25", "23.34.56.21"]
         },
         "userIpAddress": {
           "description": "List of user IP addresses to allow. If empty, all IP addresses are allowed.",
@@ -1399,10 +1233,7 @@
           "items": {
             "type": "string"
           },
-          "examples": [
-            "100.100.100.0/25",
-            "23.34.56.21"
-          ]
+          "examples": ["100.100.100.0/25", "23.34.56.21"]
         },
         "userIpRequestHeaders": {
           "description": "An optional list of case-insensitive request header names to use for resolving the callers user IP address. You must ensure that the header is coming from a trusted source. If the header contains multiple IP addresses, the right-most is used. If no IP is found from provided headers, the connected client IP address is used.",
@@ -1410,11 +1241,7 @@
           "items": {
             "type": "string"
           },
-          "examples": [
-            "X-Forwarded-For",
-            "X-Real-IP",
-            "CF-Connecting-IP"
-          ]
+          "examples": ["X-Forwarded-For", "X-Real-IP", "CF-Connecting-IP"]
         },
         "errorMessageTemplate": {
           "description": "A template to customize the error message display to users on unauthorized access.  Available template variables: `{{.Error}}`, `{{.UserIP}}`",
@@ -1451,10 +1278,7 @@
         "bindID": {
           "description": "The type of identifier to identify a user. The default is \"email\", which uses the email address to identify a user. Use \"username\" to identify a user by their username. Changing this setting will erase any permissions created for users that do not yet exist.",
           "type": "string",
-          "enum": [
-            "email",
-            "username"
-          ],
+          "enum": ["email", "username"],
           "default": "email"
         }
       },
@@ -1570,11 +1394,7 @@
       "description": "The SMTP server used to send transactional emails.\nPlease see https://docs.sourcegraph.com/admin/config/email",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "host",
-        "port",
-        "authentication"
-      ],
+      "required": ["host", "port", "authentication"],
       "properties": {
         "host": {
           "description": "The SMTP server host.",
@@ -1595,11 +1415,7 @@
         "authentication": {
           "description": "The type of authentication to use for the SMTP server.",
           "type": "string",
-          "enum": [
-            "none",
-            "PLAIN",
-            "CRAM-MD5"
-          ]
+          "enum": ["none", "PLAIN", "CRAM-MD5"]
         },
         "domain": {
           "description": "The HELO domain to provide to the SMTP server (if needed).",
@@ -1615,10 +1431,7 @@
           "items": {
             "title": "Header",
             "type": "object",
-            "required": [
-              "key",
-              "value"
-            ],
+            "required": ["key", "value"],
             "additionalProperties": false,
             "properties": {
               "key": {
@@ -1657,19 +1470,14 @@
       "type": "string",
       "format": "email",
       "group": "Email",
-      "examples": [
-        "noreply@sourcegraph.example.com"
-      ]
+      "examples": ["noreply@sourcegraph.example.com"]
     },
     "email.senderName": {
       "description": "The name to use in the \"from\" address for emails sent by this server.",
       "type": "string",
       "group": "Email",
       "default": "Sourcegraph",
-      "examples": [
-        "Our Company Sourcegraph",
-        "Example Inc Sourcegraph"
-      ]
+      "examples": ["Our Company Sourcegraph", "Example Inc Sourcegraph"]
     },
     "email.templates": {
       "description": "Configurable templates for some email types sent by Sourcegraph.",
@@ -1701,9 +1509,7 @@
     "executors.frontendURL": {
       "description": "The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.",
       "type": "string",
-      "examples": [
-        "https://sourcegraph.example.com"
-      ]
+      "examples": ["https://sourcegraph.example.com"]
     },
     "executors.srcCLIImage": {
       "description": "The image to use for src-cli in executors. Use this value to pull from a custom image registry.",
@@ -1713,16 +1519,12 @@
     "executors.srcCLIImageTag": {
       "description": "The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": [
-        "4.1.0"
-      ]
+      "examples": ["4.1.0"]
     },
     "executors.lsifGoImage": {
       "description": "The tag to use for the lsif-go image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": [
-        "sourcegraph/lsif-go"
-      ]
+      "examples": ["sourcegraph/lsif-go"]
     },
     "executors.batcheshelperImage": {
       "description": "The image to use for batch changes in executors. Use this value to pull from a custom image registry.",
@@ -1732,17 +1534,13 @@
     "executors.batcheshelperImageTag": {
       "description": "The tag to use for the batcheshelper image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": [
-        "4.1.0"
-      ]
+      "examples": ["4.1.0"]
     },
     "executors.accessToken": {
       "description": "The shared secret between Sourcegraph and executors. The value must contain at least 20 characters.",
       "type": "string",
       "pattern": "^(.{20,}|REDACTED)$",
-      "examples": [
-        "my-super-secret-access-token"
-      ]
+      "examples": ["my-super-secret-access-token"]
     },
     "executors.multiqueue": {
       "description": "The configuration for multiqueue executors.",
@@ -1755,10 +1553,7 @@
             "batches": {
               "description": "The configuration for the batches queue.",
               "type": "object",
-              "required": [
-                "limit",
-                "weight"
-              ],
+              "required": ["limit", "weight"],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1775,10 +1570,7 @@
             "codeintel": {
               "description": "The configuration for the codeintel queue.",
               "type": "object",
-              "required": [
-                "limit",
-                "weight"
-              ],
+              "required": ["limit", "weight"],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1807,9 +1599,7 @@
       },
       "examples": [
         {
-          "*": [
-            "myorg1"
-          ]
+          "*": ["myorg1"]
         }
       ],
       "hide": true
@@ -1874,19 +1664,10 @@
               "deprecationMessage": "No effect, audit logs are always set to SRC_LOG_LEVEL",
               "description": "DEPRECATED: No effect, audit logs are always set to SRC_LOG_LEVEL",
               "type": "string",
-              "enum": [
-                "DEBUG",
-                "INFO",
-                "WARN",
-                "ERROR"
-              ]
+              "enum": ["DEBUG", "INFO", "WARN", "ERROR"]
             }
           },
-          "required": [
-            "internalTraffic",
-            "graphQL",
-            "gitserverAccess"
-          ],
+          "required": ["internalTraffic", "graphQL", "gitserverAccess"],
           "examples": [
             {
               "internalTraffic": false,
@@ -1903,12 +1684,7 @@
             "location": {
               "description": "Where to output the security event log [none, auditlog, database, all] where auditlog is the default logging to stdout with the specified audit log format",
               "type": "string",
-              "enum": [
-                "none",
-                "auditlog",
-                "database",
-                "all"
-              ],
+              "enum": ["none", "auditlog", "database", "all"],
               "default": "auditlog"
             }
           },
@@ -1923,9 +1699,7 @@
     "externalURL": {
       "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.",
       "type": "string",
-      "examples": [
-        "https://sourcegraph.example.com"
-      ]
+      "examples": ["https://sourcegraph.example.com"]
     },
     "observability.client": {
       "description": "EXPERIMENTAL: Configuration for client observability",
@@ -1939,10 +1713,7 @@
             "endpoint": {
               "description": "OpenTelemetry tracing collector endpoint. By default, Sourcegraph's \"/-/debug/otlp\" endpoint forwards data to the configured collector backend.",
               "type": "string",
-              "examples": [
-                "/-/debug/otlp",
-                "https://COLLECTOR_ENDPOINT"
-              ],
+              "examples": ["/-/debug/otlp", "https://COLLECTOR_ENDPOINT"],
               "default": "/-/debug/otlp"
             }
           }
@@ -1968,20 +1739,13 @@
         "sampling": {
           "description": "Determines the conditions under which distributed traces are recorded. \"none\" turns off tracing entirely. \"selective\" (default) sends traces whenever `?trace=1` is present in the URL (though background jobs may still emit traces). \"all\" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. To learn more about additional sampling and traace export configuration with the default tracing type \"opentelemetry\", refer to https://docs.sourcegraph.com/admin/observability/opentelemetry#tracing ",
           "type": "string",
-          "enum": [
-            "selective",
-            "all",
-            "none"
-          ],
+          "enum": ["selective", "all", "none"],
           "default": "selective"
         },
         "type": {
           "description": "Determines what tracing provider to enable. For \"opentelemetry\", the required backend is an OpenTelemetry collector instance (deployed by default with Sourcegraph). For \"jaeger\", a Jaeger instance is required to be configured via Jaeger client environment variables: https://github.com/jaegertracing/jaeger-client-go#environment-variables",
           "type": "string",
-          "enum": [
-            "opentelemetry",
-            "jaeger"
-          ],
+          "enum": ["opentelemetry", "jaeger"],
           "default": "opentelemetry"
         },
         "debug": {
@@ -2020,31 +1784,19 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "level",
-          "notifier"
-        ],
+        "required": ["level", "notifier"],
         "properties": {
           "level": {
             "description": "Sourcegraph alert level to subscribe to notifications for.",
             "type": "string",
-            "enum": [
-              "warning",
-              "critical"
-            ]
+            "enum": ["warning", "critical"]
           },
           "notifier": {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "slack",
-                  "pagerduty",
-                  "webhook",
-                  "email",
-                  "opsgenie"
-                ]
+                "enum": ["slack", "pagerduty", "webhook", "email", "opsgenie"]
               }
             },
             "oneOf": [
@@ -2101,9 +1853,7 @@
           "level": "warning",
           "notifier": {
             "type": "email",
-            "addresses": [
-              "alerts@example.com"
-            ]
+            "addresses": ["alerts@example.com"]
           }
         }
       ]
@@ -2114,39 +1864,25 @@
       "items": {
         "type": "string"
       },
-      "examples": [
-        [
-          "warning_gitserver_disk_space_remaining"
-        ],
-        [
-          "critical_frontend_down",
-          "warning_high_load"
-        ]
-      ]
+      "examples": [["warning_gitserver_disk_space_remaining"], ["critical_frontend_down", "warning_high_load"]]
     },
     "observability.logSlowSearches": {
       "description": "(debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [
-        10000
-      ]
+      "examples": [10000]
     },
     "observability.logSlowGraphQLRequests": {
       "description": "(debug) logs all GraphQL requests slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [
-        10000
-      ]
+      "examples": [10000]
     },
     "observability.captureSlowGraphQLRequestsLimit": {
       "description": "(debug) Set a limit to the amount of captured slow GraphQL requests being stored for visualization. For defining the threshold for a slow GraphQL request, see observability.logSlowGraphQLRequests.",
       "type": "integer",
       "group": "Debug",
-      "examples": [
-        2000
-      ]
+      "examples": [2000]
     },
     "insights.backfill.interruptAfter": {
       "description": "Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.",
@@ -2173,19 +1909,14 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 1,
-      "examples": [
-        10
-      ]
+      "examples": [10]
     },
     "insights.query.worker.rateLimit": {
       "description": "Maximum number of Code Insights queries initiated per second on a worker node.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [
-        10.0,
-        0.5
-      ],
+      "examples": [10.0, 0.5],
       "!go": {
         "pointer": true
       }
@@ -2195,20 +1926,14 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [
-        10,
-        20
-      ]
+      "examples": [10, 20]
     },
     "insights.historical.worker.rateLimit": {
       "description": "Maximum number of historical Code Insights data frames that may be analyzed per second.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [
-        50.0,
-        0.5
-      ],
+      "examples": [50.0, 0.5],
       "!go": {
         "pointer": true
       }
@@ -2218,10 +1943,7 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [
-        10,
-        20
-      ]
+      "examples": [10, 20]
     },
     "insights.aggregations.bufferSize": {
       "description": "The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend",
@@ -2241,11 +1963,7 @@
       "group": "CodeInsights",
       "default": 30,
       "maximum": 90,
-      "examples": [
-        12,
-        24,
-        50
-      ]
+      "examples": [12, 24, 50]
     },
     "own.bestEffortTeamMatching": {
       "description": "The Own service will attempt to match a Team by the last part of its handle if it contains a slash and no match is found for its full handle.",
@@ -2358,29 +2076,14 @@
           "items": {
             "type": "string"
           },
-          "default": [
-            "show",
-            "rev-parse",
-            "log",
-            "diff",
-            "ls-tree"
-          ]
+          "default": ["show", "rev-parse", "log", "diff", "ls-tree"]
         }
       },
       "examples": [
         {
           "size": 1000,
-          "repos": [
-            "github.com/sourcegraph/sourcegraph",
-            "github.com/gorilla/mux"
-          ],
-          "ignoredGitCommands": [
-            "show",
-            "rev-parse",
-            "log",
-            "diff",
-            "ls-tree"
-          ]
+          "repos": ["github.com/sourcegraph/sourcegraph", "github.com/gorilla/mux"],
+          "ignoredGitCommands": ["show", "rev-parse", "log", "diff", "ls-tree"]
         }
       ]
     },
@@ -2434,10 +2137,7 @@
         "srcCliVersionCache": {
           "description": "Configuration related to the src-cli version cache. This should only be used on sourcegraph.com.",
           "type": "object",
-          "required": [
-            "enabled",
-            "github"
-          ],
+          "required": ["enabled", "github"],
           "group": "Sourcegraph.com",
           "properties": {
             "enabled": {
@@ -2448,10 +2148,7 @@
             "github": {
               "description": "GitHub configuration, both for queries and receiving release webhooks.",
               "type": "object",
-              "required": [
-                "token",
-                "webhookSecret"
-              ],
+              "required": ["token", "webhookSecret"],
               "properties": {
                 "repository": {
                   "description": "The repository to get the latest version of.",
@@ -2518,10 +2215,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "key",
-          "message"
-        ],
+        "required": ["key", "message"],
         "properties": {
           "key": {
             "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
@@ -2546,9 +2240,7 @@
       "description": "The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).",
       "type": "array",
       "items": {
-        "required": [
-          "type"
-        ],
+        "required": ["type"],
         "properties": {
           "type": {
             "type": "string",
@@ -2616,9 +2308,7 @@
       "type": "string",
       "description": "The duration of a user session, after which it expires and the user is required to re-authenticate. The default is 90 days. There is typically no need to set this, but some users may have specific internal security requirements.\n\nThe string format is that of the Duration type in the Go time package (https://golang.org/pkg/time/#ParseDuration). E.g., \"720h\", \"43200m\", \"2592000s\" all indicate a timespan of 30 days.\n\nNote: changing this field does not affect the expiration of existing sessions. If you would like to enforce this limit for existing sessions, you must log out currently signed-in users. You can force this by removing all keys beginning with \"session_\" from the Redis store:\n\n* For deployments using `sourcegraph/server`: `docker exec $CONTAINER_ID redis-cli --raw keys 'session_*' | xargs docker exec $CONTAINER_ID redis-cli del`\n* For cluster deployments: \n  ```\n  REDIS_POD=\"$(kubectl get pods -l app=redis-store -o jsonpath={.items[0].metadata.name})\";\n  kubectl exec \"$REDIS_POD\" -- redis-cli --raw keys 'session_*' | xargs kubectl exec \"$REDIS_POD\" -- redis-cli --raw del;\n  ```\n",
       "default": "2160h",
-      "examples": [
-        "168h"
-      ],
+      "examples": ["168h"],
       "group": "Authentication"
     },
     "auth.enableUsernameChanges": {
@@ -2713,17 +2403,10 @@
     },
     "update.channel": {
       "description": "The channel on which to automatically check for Sourcegraph updates.",
-      "type": [
-        "string"
-      ],
-      "enum": [
-        "release",
-        "none"
-      ],
+      "type": ["string"],
+      "enum": ["release", "none"],
       "default": "release",
-      "examples": [
-        "none"
-      ],
+      "examples": ["none"],
       "group": "Misc."
     },
     "productResearchPage.enabled": {
@@ -2826,16 +2509,12 @@
       "!go": {
         "pointer": true
       },
-      "examples": [
-        true
-      ]
+      "examples": [true]
     },
     "organizationInvitations": {
       "description": "Configuration for organization invitations.",
       "type": "object",
-      "required": [
-        "signingKey"
-      ],
+      "required": ["signingKey"],
       "properties": {
         "expiryTime": {
           "description": "Time before the invitation expires, in hours (experimental, not enforced at the moment).",
@@ -2909,11 +2588,7 @@
         "provider": {
           "type": "string",
           "description": "The provider to use for generating embeddings. Defaults to sourcegraph.",
-          "enum": [
-            "openai",
-            "azure-openai",
-            "sourcegraph"
-          ]
+          "enum": ["openai", "azure-openai", "sourcegraph"]
         },
         "endpoint": {
           "type": "string",
@@ -2965,13 +2640,7 @@
               "items": {
                 "type": "string"
               },
-              "examples": [
-                "*.go",
-                "*.ts",
-                "*.md",
-                "src/",
-                "cmd/"
-              ]
+              "examples": ["*.go", "*.ts", "*.md", "src/", "cmd/"]
             },
             "maxFileSizeBytes": {
               "description": "The maximum file size (in bytes) to include in embeddings. Must be between 0 and 100000 (1 MB).",
@@ -3158,11 +2827,7 @@
           "model": "text-embedding-ada-002",
           "accessToken": "your-access-token",
           "url": "https://api.openai.com/v1/embeddings",
-          "excludedFilePathPatterns": [
-            "*.svg",
-            "**/__mocks__/**",
-            "**/test/**"
-          ]
+          "excludedFilePathPatterns": ["*.svg", "**/__mocks__/**", "**/test/**"]
         }
       ]
     },
@@ -3214,14 +2879,7 @@
           "type": "string",
           "description": "The external completions provider. Defaults to 'sourcegraph'.",
           "default": "sourcegraph",
-          "enum": [
-            "anthropic",
-            "openai",
-            "sourcegraph",
-            "azure-openai",
-            "aws-bedrock",
-            "fireworks"
-          ]
+          "enum": ["anthropic", "openai", "sourcegraph", "azure-openai", "aws-bedrock", "fireworks"]
         },
         "endpoint": {
           "type": "string",
@@ -3340,9 +2998,7 @@
       "description": "Configures the builtin username-password authentication provider.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -3359,12 +3015,7 @@
       "description": "Configures the OpenID Connect authentication provider for SSO.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "issuer",
-        "clientID",
-        "clientSecret"
-      ],
+      "required": ["type", "issuer", "clientID", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3423,20 +3074,11 @@
       "description": "Configures the SAML authentication provider for SSO.\n\nNote: if you are using IdP-initiated login, you must have *at most one* SAMLAuthProvider in the `auth.providers` array.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "dependencies": {
-        "serviceProviderCertificate": [
-          "serviceProviderPrivateKey"
-        ],
-        "serviceProviderPrivateKey": [
-          "serviceProviderCertificate"
-        ],
-        "signRequests": [
-          "serviceProviderCertificate",
-          "serviceProviderPrivateKey"
-        ]
+        "serviceProviderCertificate": ["serviceProviderPrivateKey"],
+        "serviceProviderPrivateKey": ["serviceProviderCertificate"],
+        "signRequests": ["serviceProviderCertificate", "serviceProviderPrivateKey"]
       },
       "properties": {
         "type": {
@@ -3547,10 +3189,7 @@
       "description": "Configures the HTTP header authentication provider (which authenticates users by consulting an HTTP request header set by an authentication proxy such as https://github.com/bitly/oauth2_proxy).",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "usernameHeader"
-      ],
+      "required": ["type", "usernameHeader"],
       "properties": {
         "type": {
           "type": "string",
@@ -3559,23 +3198,17 @@
         "usernameHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the username of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": [
-            "X-Forwarded-User"
-          ]
+          "examples": ["X-Forwarded-User"]
         },
         "stripUsernameHeaderPrefix": {
           "description": "The prefix that precedes the username portion of the HTTP header specified in `usernameHeader`. If specified, the prefix will be stripped from the header value and the remainder will be used as the username. For example, if using Google Identity-Aware Proxy (IAP) with Google Sign-In, set this value to `accounts.google.com:`.",
           "type": "string",
-          "examples": [
-            "accounts.google.com:"
-          ]
+          "examples": ["accounts.google.com:"]
         },
         "emailHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the email of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": [
-            "X-App-Email"
-          ]
+          "examples": ["X-App-Email"]
         }
       }
     },
@@ -3583,11 +3216,7 @@
       "description": "Configures the GitHub (or GitHub Enterprise) OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitHub instance: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/. When a user signs into Sourcegraph or links their GitHub account to their existing Sourcegraph account, GitHub will prompt the user for the repo scope.",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "clientID",
-        "clientSecret"
-      ],
+      "required": ["type", "clientID", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3647,13 +3276,8 @@
           },
           "examples": [
             {
-              "orgName": [
-                "team1"
-              ],
-              "anotherOrgName": [
-                "team2",
-                "team3"
-              ]
+              "orgName": ["team1"],
+              "anotherOrgName": ["team2", "team3"]
             }
           ]
         },
@@ -3668,11 +3292,7 @@
       "description": "Configures the GitLab OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitLab instance: https://docs.gitlab.com/ee/integration/oauth_provider.html. The application should have `api` and `read_user` scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/gitlab/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "clientID",
-        "clientSecret"
-      ],
+      "required": ["type", "clientID", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3715,10 +3335,7 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "api",
-          "enum": [
-            "api",
-            "read_api"
-          ]
+          "enum": ["api", "read_api"]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via GitLab authentication. If false, users signing in via GitLab must have an existing Sourcegraph account, which will be linked to their GitLab identity after sign-in.",
@@ -3736,13 +3353,7 @@
             "type": "string",
             "minLength": 1
           },
-          "examples": [
-            [
-              "group",
-              "group/subgroup",
-              "group/subgroup/subgroup"
-            ]
-          ]
+          "examples": [["group", "group/subgroup", "group/subgroup/subgroup"]]
         },
         "tokenRefreshWindowMinutes": {
           "description": "Time in minutes before token expiry when we should attempt to refresh it",
@@ -3763,11 +3374,7 @@
       "description": "Configures the Bitbucket Cloud OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your Bitbucket Cloud workspace: https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/. The application should have account, email, and repository scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/bitbucketcloud/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "clientKey",
-        "clientSecret"
-      ],
+      "required": ["type", "clientKey", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3805,11 +3412,7 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "account,email,repository",
-          "enum": [
-            "account",
-            "email",
-            "repository"
-          ]
+          "enum": ["account", "email", "repository"]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via Bitbucket Cloud authentication. If false, users signing in via Bitbucket Cloud must have an existing Sourcegraph account, which will be linked to their Bitbucket Cloud identity after sign-in.",
@@ -3822,10 +3425,7 @@
       "description": "Gerrit auth provider",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "properties": {
         "type": {
           "type": "string",
@@ -3857,11 +3457,7 @@
       "description": "Azure auth provider for dev.azure.com",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "type",
-        "clientID",
-        "clientSecret"
-      ],
+      "required": ["type", "clientID", "clientSecret"],
       "properties": {
         "type": {
           "type": "string",
@@ -3946,9 +3542,7 @@
     "NotifierSlack": {
       "description": "Slack notifier",
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -3979,10 +3573,7 @@
     "NotifierPagerduty": {
       "description": "PagerDuty notifier",
       "type": "object",
-      "required": [
-        "type",
-        "integrationKey"
-      ],
+      "required": ["type", "integrationKey"],
       "properties": {
         "type": {
           "type": "string",
@@ -4004,10 +3595,7 @@
     "NotifierWebhook": {
       "description": "Webhook notifier",
       "type": "object",
-      "required": [
-        "type",
-        "url"
-      ],
+      "required": ["type", "url"],
       "properties": {
         "type": {
           "type": "string",
@@ -4030,10 +3618,7 @@
     "NotifierEmail": {
       "description": "Email notifier",
       "type": "object",
-      "required": [
-        "type",
-        "address"
-      ],
+      "required": ["type", "address"],
       "properties": {
         "type": {
           "type": "string",
@@ -4048,9 +3633,7 @@
     "NotifierOpsGenie": {
       "description": "OpsGenie notifier",
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -4078,12 +3661,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "team",
-                  "user",
-                  "escalation",
-                  "schedule"
-                ]
+                "enum": ["team", "user", "escalation", "schedule"]
               },
               "id": {
                 "type": "string"
@@ -4097,22 +3675,13 @@
             },
             "oneOf": [
               {
-                "required": [
-                  "type",
-                  "id"
-                ]
+                "required": ["type", "id"]
               },
               {
-                "required": [
-                  "type",
-                  "name"
-                ]
+                "required": ["type", "name"]
               },
               {
-                "required": [
-                  "type",
-                  "username"
-                ]
+                "required": ["type", "username"]
               }
             ]
           }
@@ -4122,18 +3691,11 @@
     "EncryptionKey": {
       "description": "Config for a key",
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "cloudkms",
-            "awskms",
-            "mounted",
-            "noop"
-          ]
+          "enum": ["cloudkms", "awskms", "mounted", "noop"]
         }
       },
       "oneOf": [
@@ -4157,10 +3719,7 @@
     "CloudKMSEncryptionKey": {
       "description": "Google Cloud KMS Encryption Key, used to encrypt data in Google Cloud environments",
       "type": "object",
-      "required": [
-        "type",
-        "keyname"
-      ],
+      "required": ["type", "keyname"],
       "properties": {
         "type": {
           "type": "string",
@@ -4177,10 +3736,7 @@
     "AWSKMSEncryptionKey": {
       "description": "AWS KMS Encryption Key, used to encrypt data in AWS environments",
       "type": "object",
-      "required": [
-        "type",
-        "keyId"
-      ],
+      "required": ["type", "keyId"],
       "properties": {
         "type": {
           "type": "string",
@@ -4200,10 +3756,7 @@
     "MountedEncryptionKey": {
       "description": "This encryption key is mounted from a given file path or an environment variable.",
       "type": "object",
-      "required": [
-        "type",
-        "keyname"
-      ],
+      "required": ["type", "keyname"],
       "properties": {
         "type": {
           "type": "string",
@@ -4226,9 +3779,7 @@
     "NoOpEncryptionKey": {
       "description": "This encryption key is a no op, leaving your data in plaintext (not recommended).",
       "type": "object",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
@@ -4238,10 +3789,7 @@
     },
     "EmailTemplate": {
       "type": "object",
-      "required": [
-        "subject",
-        "html"
-      ],
+      "required": ["subject", "html"],
       "properties": {
         "subject": {
           "description": "Template for email subject header",


### PR DESCRIPTION
Add a setting to limit the number of active access tokens a user can have at a one time, the default value is 25 tokens.  Internal access tokens do not count towards the active limit.  Override of this default is available using the `maxTokensPerUser` setting in the `auth.AccessTokens` section of the site config.

This change does not effect existing tokens, if a user is over the limit no tokens are invalidated however they will not be able to create new tokens without first removing enough to get below the limit. 

closes https://github.com/sourcegraph/sourcegraph/issues/59544
## Test plan
tests add
manual test of access token page and call back page
<img width="513" alt="Screenshot 2024-01-21 at 3 04 46 PM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/3624cc38-0615-4cc8-8176-727fb3e25ee7">
<img width="933" alt="Screenshot 2024-01-21 at 3 05 09 PM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/04d56804-bfef-4e57-a3e9-bddf0680b036">


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
