### PR TITLE
Don't send users access token created email when creation fails

### DIFF
--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -113,6 +113,9 @@ func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAcce
 
 	uid := actor.FromContext(ctx).UID
 	id, token, err := r.db.AccessTokens().Create(ctx, userID, args.Scopes, args.Note, uid, expiresAt)
+	if err != nil {
+		return nil, err
+	}
 	logger := r.logger.Scoped("CreateAccessToken").
 		With(log.Int32("userID", uid))
 


### PR DESCRIPTION
The error from creation of access tokens was unchecked with caused emails to be sent when creation of the access token failed.  This becomes a more common situation after https://github.com/sourcegraph/sourcegraph/pull/59731 which adds a limit to the number of access tokens a user may have.
## Test plan
manually tested 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
