### PR TITLE
gomod: update zoekt

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5741,8 +5741,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:TB4KxGtcJm98TfyDHhSkbffngM+EVlTu0epG3SxUU0U=",
-        version = "v0.0.0-20240110094557-7487a0d53131",
+        sum = "h1:CumaleyciZzwsNOf1ewSC2hgKdFaBuO0yzTeIUcp64Y=",
+        version = "v0.0.0-20240122093209-b82a981f8240",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -567,7 +567,7 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20231018142932-e00da332dac5
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20240110094557-7487a0d53131
+	github.com/sourcegraph/zoekt v0.0.0-20240122093209-b82a981f8240
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1670,8 +1670,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20240110094557-7487a0d53131 h1:TB4KxGtcJm98TfyDHhSkbffngM+EVlTu0epG3SxUU0U=
-github.com/sourcegraph/zoekt v0.0.0-20240110094557-7487a0d53131/go.mod h1:DA42q8CujJGj9zLcJfgvVV3VI6rykt/VrjkLaGdmNp4=
+github.com/sourcegraph/zoekt v0.0.0-20240122093209-b82a981f8240 h1:CumaleyciZzwsNOf1ewSC2hgKdFaBuO0yzTeIUcp64Y=
+github.com/sourcegraph/zoekt v0.0.0-20240122093209-b82a981f8240/go.mod h1:DA42q8CujJGj9zLcJfgvVV3VI6rykt/VrjkLaGdmNp4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
https://github.com/sourcegraph/zoekt/compare/7487a0d53131...b82a981f8240

There are quite a few changes, but most are internal e2e test changes. Here are the commits which change behaviour. Only the scoring change will have a minor effect on users in rare cases:

- https://github.com/sourcegraph/zoekt/commit/7e44ea78f6 all: adjust field order for match structs
- https://github.com/sourcegraph/zoekt/commit/7dcc7979f6 api: implement succinct output for SearchOptions.String
- https://github.com/sourcegraph/zoekt/commit/1adab43b4c score: remove ZOEKT_NOVELTY_DISABLE
- https://github.com/sourcegraph/zoekt/commit/18b6999367 api: JSON omitempty on optional fields in FileMatch
- https://github.com/sourcegraph/zoekt/commit/b82a981f82 score: do scoring on candidateMatches

And below are the e2e test changes:

- https://github.com/sourcegraph/zoekt/commit/155050eb98 zoekt-archive-index: split out ranking tests and archive indexing
- https://github.com/sourcegraph/zoekt/commit/344e33ae3c e2e: introduce optional shard cache
- https://github.com/sourcegraph/zoekt/commit/6463096a03 e2e: recall and visual indication of ranks
- https://github.com/sourcegraph/zoekt/commit/b35d8a202d e2e: add ranking tests for atom boosting
- https://github.com/sourcegraph/zoekt/commit/4be2929fd0 e2e: add a ranking test case for "zoekt searcher"

Test Plan: tested in zoekt repo and this CI
