### PR TITLE
client: Re-enable file nav related hovers for C and C++

### DIFF
--- a/client/shared/src/codeintel/scip.ts
+++ b/client/shared/src/codeintel/scip.ts
@@ -244,7 +244,7 @@ export enum SyntaxKind {
     PunctuationBracket = 3,
 
     // `if`, `else`, `return`, `class`, etc.
-    IdentifierKeyword = 4,
+    Keyword = 4,
 
     // `+`, `*`, etc.
     IdentifierOperator = 5,

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -32,7 +32,6 @@ const INTERACTIVE_OCCURRENCE_KINDS = new Set([
     // a comment or a keyword.
     SyntaxKind.Keyword,
     SyntaxKind.Comment,
-
 ])
 
 export const isInteractiveOccurrence = (occurrence: Occurrence): boolean => {

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -11,6 +11,7 @@ import { type HighlightIndex, syntaxHighlight } from './highlight'
 const INTERACTIVE_OCCURRENCE_KINDS = new Set([
     SyntaxKind.Identifier,
     SyntaxKind.IdentifierBuiltin,
+    SyntaxKind.IdentifierBuiltinType,
     SyntaxKind.IdentifierConstant,
     SyntaxKind.IdentifierMutableGlobal,
     SyntaxKind.IdentifierParameter,

--- a/client/web/src/repo/blob/codemirror/occurrence-utils.ts
+++ b/client/web/src/repo/blob/codemirror/occurrence-utils.ts
@@ -23,6 +23,15 @@ const INTERACTIVE_OCCURRENCE_KINDS = new Set([
     SyntaxKind.IdentifierMacroDefinition,
     SyntaxKind.IdentifierType,
     SyntaxKind.IdentifierAttribute,
+    // In #include "foo.h", "foo.h" gets marked as a string literal
+    SyntaxKind.StringLiteral,
+    // For C and C++, scip-clang emits an occurrence for the very
+    // first token in the source file to support 'Go to def' and
+    // 'Find refs' for header files. This first token is usually
+    // a comment or a keyword.
+    SyntaxKind.Keyword,
+    SyntaxKind.Comment,
+
 ])
 
 export const isInteractiveOccurrence = (occurrence: Occurrence): boolean => {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/59733

## Test plan

Manually checked the hovers start showing up at the start of the file,
and when hovering over the header path in the `#include`.

![](https://github.com/sourcegraph/sourcegraph/assets/93103176/c3b4e0d3-83ff-4cd5-86d3-51d01ad7bccf)
![](https://github.com/sourcegraph/sourcegraph/assets/93103176/d3fe94c4-ce0c-4e49-a389-c6cc138e3662)

