### PR TITLE
search: fix typo in defaultPatternType

### DIFF
--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -403,7 +403,7 @@
     "search.defaultPatternType": {
       "description": "The default pattern type that search queries will be intepreted as. `lucky` is an experimental mode that will interpret the query in multiple ways.",
       "type": "string",
-      "pattern": "standard|literal|regexp|lucky|keyword/codycontext"
+      "pattern": "standard|literal|regexp|lucky|keyword|codycontext"
     },
     "search.defaultCaseSensitive": {
       "description": "Whether query patterns are treated case sensitively. Patterns are case insensitive by default.",


### PR DESCRIPTION
Fixes a typo introduced in #59686

Test plan:
Verified locally that the default "keyword" is now respected