### PR TITLE
WIP: Consume Cody Subscription Info from SSC in dotcom

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -76,7 +76,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
     const enrollPro = parameters.get('pro') === 'true'
 
     useEffect(() => {
-        if (enrollPro && data?.currentUser && !data?.currentUser?.codyProEnabled) {
+        if (enrollPro && data?.currentUser && !data?.currentUser?.codySubscription?.isPro) {
             changeCodyPlan({ variables: { pro: true, id: data?.currentUser?.id } })
         }
     }, [data?.currentUser, changeCodyPlan, enrollPro])
@@ -93,12 +93,15 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         return null
     }
 
-    const { codyProEnabled } = data.currentUser
+    const subscription = data.currentUser.codySubscription
+    if (!subscription) {
+        return null
+    }
 
     const codeLimitReached = codyCurrentPeriodCodeUsage >= codyCurrentPeriodCodeLimit && codyCurrentPeriodCodeLimit > 0
     const chatLimitReached = codyCurrentPeriodChatUsage >= codyCurrentPeriodChatLimit && codyCurrentPeriodChatLimit > 0
 
-    const showUpgradeBanner = !codyProEnabled && (codeLimitReached || chatLimitReached)
+    const showUpgradeBanner = !subscription.isPro && (codeLimitReached || chatLimitReached)
 
     return (
         <>
@@ -140,10 +143,10 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                         <div>
                             <H2>My subscription</H2>
                             <Text className="text-muted mb-0">
-                                You are on the {codyProEnabled ? 'Pro' : 'Free'} tier.
+                                You are on the {subscription.isPro ? 'Pro' : 'Free'} tier.
                             </Text>
                         </div>
-                        {codyProEnabled ? (
+                        {subscription.isPro ? (
                             <div>
                                 <ButtonLink to="/cody/subscription" variant="secondary" outline={true} size="sm">
                                     Manage subscription
@@ -160,7 +163,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                     </div>
                     <div className={classNames('d-flex align-items-center mt-3', styles.responsiveContainer)}>
                         <div className="d-flex flex-column align-items-center flex-grow-1 p-3">
-                            {codyProEnabled ? (
+                            {subscription.isPro ? (
                                 <ProTierIcon />
                             ) : (
                                 <Text className={classNames(styles.planName, 'mb-0')}>Free</Text>
@@ -172,7 +175,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                         <div className="d-flex flex-column align-items-center flex-grow-1 p-3 border-left border-right">
                             <AutocompletesIcon />
                             <div className="mb-2 mt-3">
-                                {codyProEnabled ? (
+                                {subscription.isPro ? (
                                     <Text weight="bold" className={classNames('d-inline mb-0', styles.counter)}>
                                         Unlimited
                                     </Text>
@@ -205,10 +208,10 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                             <H4 className={classNames('mb-0', codeLimitReached ? 'text-danger' : 'text-muted')}>
                                 Autocomplete suggestions
                             </H4>
-                            {!codyProEnabled &&
-                                (codeLimitReached && usageData?.currentUser?.codyCurrentPeriodEndDate ? (
+                            {!subscription.isPro &&
+                                (codeLimitReached && subscription.currentPeriodEndAt ? (
                                     <Text className="text-danger mb-0" size="small">
-                                        Renews in <Timestamp date={usageData?.currentUser?.codyCurrentPeriodEndDate} />
+                                        Renews in <Timestamp date={subscription.currentPeriodEndAt} />
                                     </Text>
                                 ) : (
                                     <Text className="text-muted mb-0" size="small">
@@ -219,7 +222,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                         <div className="d-flex flex-column align-items-center flex-grow-1 p-3">
                             <ChatMessagesIcon />
                             <div className="mb-2 mt-3">
-                                {codyProEnabled ? (
+                                {subscription.isPro ? (
                                     <Text weight="bold" className={classNames('d-inline mb-0', styles.counter)}>
                                         Unlimited
                                     </Text>
@@ -252,10 +255,10 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                             <H4 className={classNames('mb-0', chatLimitReached ? 'text-danger' : 'text-muted')}>
                                 Chat messages and commands
                             </H4>
-                            {!codyProEnabled &&
-                                (chatLimitReached && usageData?.currentUser?.codyCurrentPeriodEndDate ? (
+                            {!subscription.isPro &&
+                                (chatLimitReached && subscription.currentPeriodEndAt ? (
                                     <Text className="text-danger mb-0" size="small">
-                                        Renews <Timestamp date={usageData?.currentUser?.codyCurrentPeriodEndDate} />
+                                        Renews <Timestamp date={subscription.currentPeriodEndAt} />
                                     </Text>
                                 ) : (
                                     <Text className="text-muted mb-0" size="small">
@@ -263,7 +266,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                     </Text>
                                 ))}
                         </div>
-                        {codyProEnabled && (
+                        {subscription.isPro && (
                             <div className="d-flex flex-column align-items-center flex-grow-1 p-3 border-left">
                                 <TrialPeriodIcon />
                                 <div className="mb-2 mt-4">

--- a/client/web/src/cody/subscription/CancelProModal.tsx
+++ b/client/web/src/cody/subscription/CancelProModal.tsx
@@ -21,7 +21,7 @@ export function CancelProModal({
 
     return (
         <Modal isOpen={true} aria-label="Update to Cody Pro" className={styles.cancelModal} position="center">
-            {data && !data.changeCodyPlan?.codyProEnabled ? (
+            {data && !data.changeCodyPlan?.codySubscription?.isPro ? (
                 <div className="d-flex flex-column py-2">
                     <H2>Sorry to see you go.</H2>
 

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -22,6 +22,7 @@ import {
 import type { AuthenticatedUser } from '../../auth'
 import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
+import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
 import type { UserCodyPlanResult, UserCodyPlanVariables } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
@@ -47,6 +48,8 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
 
     const utm_source = parameters.get('utm_source')
 
+    const [sscEnabled] = useFeatureFlag('ssc-enabled', false)
+
     useEffect(() => {
         eventLogger.log(EventName.CODY_SUBSCRIPTION_PAGE_VIEWED, { utm_source }, { utm_source })
     }, [utm_source])
@@ -68,7 +71,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
         return null
     }
 
-    const { codyProEnabled } = data.currentUser
+    const isPro = data.currentUser?.codySubscription?.isPro || false
 
     return (
         <>
@@ -191,7 +194,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                 <Text className="mb-3 text-muted" size="small">
                                     Free until Feb 2024, <strong>no credit card needed</strong>
                                 </Text>
-                                {codyProEnabled ? (
+                                {isPro ? (
                                     <div>
                                         <Text
                                             className="mb-0 text-muted d-inline cursor-pointer"
@@ -206,10 +209,17 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                         tier: 'free',
                                                     }
                                                 )
+                                                if (sscEnabled) {
+                                                    window.open(
+                                                        'https://accounts.sourcegraph.com/cody/subscription?pro=true',
+                                                        '_blank'
+                                                    )
+                                                    return
+                                                }
                                                 setShowCancelPro(true)
                                             }}
                                         >
-                                            Cancel
+                                            {sscEnabled ? 'Manage' : 'Cancel'} subscription
                                         </Text>
                                     </div>
                                 ) : (
@@ -222,11 +232,19 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 { tier: 'pro' },
                                                 { tier: 'pro' }
                                             )
+                                            if (sscEnabled) {
+                                                window.open(
+                                                    'https://accounts.sourcegraph.com/cody/subscription',
+                                                    '_blank'
+                                                )
+                                                return
+                                            }
+
                                             setShowUpgradeToPro(true)
                                         }}
                                     >
                                         <Icon svgPath={mdiTrendingUp} className="mr-1" aria-hidden={true} />
-                                        Get Pro trial
+                                        {sscEnabled ? 'Get Pro' : 'Get Pro trial'}
                                     </Button>
                                 )}
                             </div>

--- a/client/web/src/cody/subscription/UpgradeToProModal.tsx
+++ b/client/web/src/cody/subscription/UpgradeToProModal.tsx
@@ -27,7 +27,7 @@ export function UpgradeToProModal({
 
     return (
         <Modal isOpen={true} aria-label="Update to Cody Pro" className={styles.upgradeModal} position="center">
-            {data?.changeCodyPlan?.codyProEnabled ? (
+            {data?.changeCodyPlan?.codySubscription?.isPro ? (
                 <div className="d-flex flex-column justify-content-between align-items-center mby-4 py-4">
                     <CodyColorIcon width={40} height={40} className="mb-4" />
                     <H2>Upgraded to Cody Pro 🎉</H2>

--- a/client/web/src/cody/subscription/queries.tsx
+++ b/client/web/src/cody/subscription/queries.tsx
@@ -4,8 +4,12 @@ export const USER_CODY_PLAN = gql`
     query UserCodyPlan {
         currentUser {
             id
-            codyProEnabled
-            codyProEnabledAt
+            codySubscription {
+                status
+                isPro
+                currentPeriodStartAt
+                currentPeriodEndAt
+            }
         }
     }
 `
@@ -28,8 +32,12 @@ export const CHANGE_CODY_PLAN = gql`
     mutation ChangeCodyPlan($id: ID!, $pro: Boolean!) {
         changeCodyPlan(user: $id, pro: $pro) {
             id
-            codyProEnabled
-            codyProEnabledAt
+            codySubscription {
+                status
+                isPro
+                currentPeriodStartAt
+                currentPeriodEndAt
+            }
         }
     }
 `

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -38,6 +38,7 @@ export const FEATURE_FLAGS = [
     'opencodegraph',
     'auditlog-expansion',
     'search.newFilters',
+    'ssc-enabled',
 ] as const
 
 export type FeatureFlagName = typeof FEATURE_FLAGS[number]

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -324,6 +324,7 @@ go_library(
         "//internal/siteid",
         "//internal/sourcegraphoperator",
         "//internal/src-prometheus",
+        "//internal/ssc",
         "//internal/suspiciousnames",
         "//internal/symbols",
         "//internal/temporarysettings",

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6361,6 +6361,24 @@ type NewUsersConnection implements Connection {
     pageInfo: ConnectionPageInfo!
 }
 
+enum CodySubscriptionStatus {
+    active
+    past_due
+    unpaid
+    canceled
+    trialing
+    pending
+    other
+}
+
+type CodySubscription {
+    status: CodySubscriptionStatus!
+    isPro: Boolean!
+    applyProRateLimits: Boolean!
+    currentPeriodStartAt: DateTime!
+    currentPeriodEndAt: DateTime!
+}
+
 """
 A user.
 """
@@ -6573,18 +6591,26 @@ type User implements Node & SettingsSubject & Namespace {
     """
     codeCompletionsQuotaOverride: Int
     """
+    The Cody subscription details for the user.
+    """
+    codySubscription: CodySubscription
+    """
+    DEPRICATED
     Whether the user has enrolled for Cody Pro.
     """
     codyProEnabled: Boolean!
     """
+    DEPRICATED
     The date when the user enrolled for Cody Pro.
     """
     codyProEnabledAt: DateTime
     """
+    DEPRICATED
     The start date of current billing period of Cody.
     """
     codyCurrentPeriodStartDate: DateTime
     """
+    DEPRICATED
     The end date of current billing period of Cody.
     """
     codyCurrentPeriodEndDate: DateTime

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -12,6 +12,7 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
+	"github.com/sourcegraph/sourcegraph/internal/ssc"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/log"
@@ -79,7 +80,8 @@ type UserResolver struct {
 	// actor containing current user (derived from request context), which lets us
 	// skip fetching actor from context in every resolver function and save DB calls,
 	// because user is fetched in actor only once.
-	actor *actor.Actor
+	actor                 *actor.Actor
+	codySubscriptionCache *ssc.UserCodySubscription
 }
 
 // NewUserResolver returns a new UserResolver with given user object.
@@ -176,22 +178,70 @@ func (r *UserResolver) URL() string {
 
 func (r *UserResolver) SettingsURL() *string { return strptr(r.URL() + "/settings") }
 
+type CodySubscriptionResolver struct {
+	subscription *ssc.UserCodySubscription
+}
+
+func (r *CodySubscriptionResolver) Status() ssc.SubscriptionStatus {
+	return r.subscription.Status
+}
+
+func (r *CodySubscriptionResolver) IsPro() bool {
+	return r.subscription.IsPro
+}
+
+func (r *CodySubscriptionResolver) ApplyProRateLimits() bool {
+	return r.subscription.ApplyProRateLimits
+}
+
+func (r *CodySubscriptionResolver) CurrentPeriodStartAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.subscription.CurrentPeriodStartAt}
+}
+
+func (r *CodySubscriptionResolver) CurrentPeriodEndAt() gqlutil.DateTime {
+	return gqlutil.DateTime{Time: r.subscription.CurrentPeriodEndAt}
+}
+
+func (r *UserResolver) getCodySubscription(ctx context.Context) (*ssc.UserCodySubscription, error) {
+	if r.codySubscriptionCache == nil {
+		subscription, err := ssc.CodySubscriptionForUser(ctx, *r.user)
+		if err != nil {
+			return nil, err
+		}
+
+		r.codySubscriptionCache = subscription
+	}
+
+	return r.codySubscriptionCache, nil
+}
+
+func (r *UserResolver) CodySubscription(ctx context.Context) (*CodySubscriptionResolver, error) {
+	subscription, err := r.getCodySubscription(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CodySubscriptionResolver{subscription: subscription}, nil
+}
+
 func (r *UserResolver) CreatedAt() gqlutil.DateTime {
 	return gqlutil.DateTime{Time: r.user.CreatedAt}
 }
 
+// DEPCREATED: use CodySubscription.CurrentPeriodStartAt instead.
 func (r *UserResolver) CodyProEnabledAt(ctx context.Context) *gqlutil.DateTime {
 	if !envvar.SourcegraphDotComMode() {
 		return nil
 	}
 
-	if r.user.CodyProEnabledAt == nil {
+	if r.user.CodyProOptedAt == nil {
 		return nil
 	}
 
-	return &gqlutil.DateTime{Time: *r.user.CodyProEnabledAt}
+	return &gqlutil.DateTime{Time: *r.user.CodyProOptedAt}
 }
 
+// DEPCREATED: use CodySubscription.IsPro instead.
 func (r *UserResolver) CodyProEnabled(ctx context.Context) bool {
 	return r.CodyProEnabledAt(ctx) != nil
 }
@@ -201,7 +251,7 @@ func (r *UserResolver) CodyCurrentPeriodChatLimit(ctx context.Context) (int32, e
 		return 0, errors.New("this feature is only available on sourcegraph.com")
 	}
 
-	if r.user.CodyProEnabledAt != nil {
+	if r.user.CodyProOptedAt != nil {
 		return 0, nil
 	}
 
@@ -217,7 +267,7 @@ func (r *UserResolver) CodyCurrentPeriodCodeLimit(ctx context.Context) (int32, e
 		return 0, errors.New("this feature is only available on sourcegraph.com")
 	}
 
-	if r.user.CodyProEnabledAt != nil {
+	if r.user.CodyProOptedAt != nil {
 		return 0, nil
 	}
 
@@ -233,7 +283,7 @@ func (r *UserResolver) CodyCurrentPeriodChatUsage(ctx context.Context) (int32, e
 		return 0, errors.New("this feature is only available on sourcegraph.com")
 	}
 
-	currentPeriodStartDate, err := r.CodyCurrentPeriodStartDate(ctx)
+	subscription, err := r.getCodySubscription(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -271,7 +321,7 @@ func (r *UserResolver) CodyCurrentPeriodChatUsage(ctx context.Context) (int32, e
 						)
 					)
 			)
-	`, r.user.ID, currentPeriodStartDate.Time)
+	`, r.user.ID, subscription.CurrentPeriodStartAt)
 
 	count, err := r.db.EventLogs().CountBySQL(ctx, query)
 
@@ -283,7 +333,7 @@ func (r *UserResolver) CodyCurrentPeriodCodeUsage(ctx context.Context) (int32, e
 		return 0, errors.New("this feature is only available on sourcegraph.com")
 	}
 
-	currentPeriodStartDate, err := r.CodyCurrentPeriodStartDate(ctx)
+	subscription, err := r.getCodySubscription(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -295,7 +345,7 @@ func (r *UserResolver) CodyCurrentPeriodCodeUsage(ctx context.Context) (int32, e
 			AND timestamp <= NOW()
 			AND source = 'IDEEXTENSION'
 			AND name LIKE '%%completion:suggested%%'
-	`, r.user.ID, currentPeriodStartDate.Time)
+	`, r.user.ID, subscription.CurrentPeriodStartAt)
 
 	count, err := r.db.EventLogs().CountBySQL(ctx, query)
 
@@ -303,15 +353,21 @@ func (r *UserResolver) CodyCurrentPeriodCodeUsage(ctx context.Context) (int32, e
 }
 
 func (r *UserResolver) CodyCurrentPeriodStartDate(ctx context.Context) (*gqlutil.DateTime, error) {
-	startDate, _, err := r.codyCurrentPeriodDateRange(ctx)
+	subscription, err := r.getCodySubscription(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	return startDate, err
+	return &gqlutil.DateTime{Time: subscription.CurrentPeriodStartAt}, nil
 }
 
 func (r *UserResolver) CodyCurrentPeriodEndDate(ctx context.Context) (*gqlutil.DateTime, error) {
-	_, endDate, err := r.codyCurrentPeriodDateRange(ctx)
+	subscription, err := r.getCodySubscription(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	return endDate, err
+	return &gqlutil.DateTime{Time: subscription.CurrentPeriodEndAt}, nil
 }
 
 type currentTimeCtxKey int
@@ -328,61 +384,6 @@ func currentTimeFromCtx(ctx context.Context) time.Time {
 
 func withCurrentTimeMock(ctx context.Context, t time.Time) context.Context {
 	return context.WithValue(ctx, mockCurrentTimeKey, &t)
-}
-
-func (r *UserResolver) codyCurrentPeriodDateRange(ctx context.Context) (*gqlutil.DateTime, *gqlutil.DateTime, error) {
-	if !envvar.SourcegraphDotComMode() {
-		return nil, nil, errors.New("this feature is only available on sourcegraph.com")
-	}
-
-	// 🚨 SECURITY: Only the user and admins are allowed to access the user's
-	// settings because they may contain secrets or other sensitive data.
-	if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {
-		return nil, nil, err
-	}
-
-	// to allow mocking current time during tests
-	currentDate := currentTimeFromCtx(ctx)
-
-	subscriptionStartDate := r.user.CreatedAt
-	gaReleaseDate := time.Date(2023, 12, 14, 0, 0, 0, 0, subscriptionStartDate.Location())
-
-	if !currentDate.Before(gaReleaseDate) && subscriptionStartDate.Before(gaReleaseDate) {
-		subscriptionStartDate = gaReleaseDate
-	}
-
-	if r.user.CodyProEnabledAt != nil {
-		subscriptionStartDate = *r.user.CodyProEnabledAt
-	}
-
-	targetDay := subscriptionStartDate.Day()
-	startDayOfTheMonth := targetDay
-	endDayOfTheMonth := targetDay - 1
-	startMonth := currentDate
-	endMonth := currentDate
-
-	if currentDate.Day() < targetDay {
-		// Set to target day of the previous month
-		startMonth = currentDate.AddDate(0, -1, 0)
-	} else {
-		// Set to target day of the next month
-		endMonth = currentDate.AddDate(0, 1, 0)
-	}
-
-	daysInStartingMonth := time.Date(startMonth.Year(), startMonth.Month()+1, 0, 0, 0, 0, 0, startMonth.Location()).Day()
-	if startDayOfTheMonth > daysInStartingMonth {
-		startDayOfTheMonth = daysInStartingMonth
-	}
-
-	daysInEndingMonth := time.Date(endMonth.Year(), endMonth.Month()+1, 0, 0, 0, 0, 0, endMonth.Location()).Day()
-	if endDayOfTheMonth > daysInEndingMonth {
-		endDayOfTheMonth = daysInEndingMonth
-	}
-
-	startDate := &gqlutil.DateTime{Time: time.Date(startMonth.Year(), startMonth.Month(), startDayOfTheMonth, 0, 0, 0, 0, startMonth.Location())}
-	endDate := &gqlutil.DateTime{Time: time.Date(endMonth.Year(), endMonth.Month(), endDayOfTheMonth, 23, 59, 59, 59, endMonth.Location())}
-
-	return startDate, endDate, nil
 }
 
 func (r *UserResolver) UpdatedAt() *gqlutil.DateTime {

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -372,7 +372,7 @@ func TestUser_CodyCurrentPeriod(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				user := &types.User{ID: 1}
 				if test.pro {
-					user.CodyProEnabledAt = &test.createdAt
+					user.CodyProOptedAt = &test.createdAt
 				} else {
 					user.CreatedAt = test.createdAt
 				}

--- a/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//internal/productsubscription",
         "//internal/redispool",
         "//internal/slack",
+        "//internal/ssc",
         "//internal/trace",
         "//internal/types",
         "//lib/errors",

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/ssc"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -204,8 +205,13 @@ func getEmbeddingsRateLimit(ctx context.Context, db database.DB, userID int32) (
 			return licensing.CodyGatewayRateLimit{}, err
 		}
 		intervalSeconds = oneMonthInSeconds
-		isProUser := user.CodyProEnabledAt != nil
-		if isProUser {
+
+		subscription, err := ssc.CodySubscriptionForUser(ctx, *user)
+		if err != nil {
+			return licensing.CodyGatewayRateLimit{}, errors.Wrap(err, "error fetching user's cody subscription")
+		}
+
+		if subscription.ApplyProRateLimits {
 			if cfg.PerProUserEmbeddingsMonthlyLimit > 0 {
 				limit = int64(cfg.PerProUserEmbeddingsMonthlyLimit)
 			}
@@ -265,18 +271,17 @@ func getCompletionsRateLimit(ctx context.Context, db database.DB, userID int32, 
 	if err != nil {
 		return licensing.CodyGatewayRateLimit{}, graphqlbackend.CodyGatewayRateLimitSourcePlan, err
 	}
-	isProUser := user.CodyProEnabledAt != nil
-	models := allowedModels(scope, isProUser)
+
+	subscription, err := ssc.CodySubscriptionForUser(ctx, *user)
+	if err != nil {
+		return licensing.CodyGatewayRateLimit{}, graphqlbackend.CodyGatewayRateLimitSourcePlan, errors.Wrap(err, "error fetching user's cody subscription")
+	}
+
+	models := allowedModels(scope, subscription.ApplyProRateLimits)
 	if limit == nil && cfg != nil {
 		source = graphqlbackend.CodyGatewayRateLimitSourcePlan
-		user, err := db.Users().GetByID(ctx, userID)
-		if err != nil {
-			return licensing.CodyGatewayRateLimit{}, graphqlbackend.CodyGatewayRateLimitSourcePlan, err
-		}
-		isProUser := user.CodyProEnabledAt != nil
 		// Update the allowed models based on the user's plan.
-		models = allowedModels(scope, isProUser)
-		intervalSeconds, limit, err = getSelfServeUsageLimits(scope, isProUser, *cfg)
+		intervalSeconds, limit, err = getSelfServeUsageLimits(scope, subscription.ApplyProRateLimits, *cfg)
 		if err != nil {
 			return licensing.CodyGatewayRateLimit{}, graphqlbackend.CodyGatewayRateLimitSourcePlan, err
 		}

--- a/internal/completions/httpapi/BUILD.bazel
+++ b/internal/completions/httpapi/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//internal/redispool",
         "//internal/requestclient",
         "//internal/search/streaming/http",
+        "//internal/ssc",
         "//internal/telemetry",
         "//internal/telemetry/telemetryrecorder",
         "//internal/trace",

--- a/internal/completions/httpapi/chat.go
+++ b/internal/completions/httpapi/chat.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/ssc"
 
 	"github.com/sourcegraph/log"
 
@@ -40,8 +41,13 @@ func NewChatCompletionsStreamHandler(logger log.Logger, db database.DB) http.Han
 				if err != nil {
 					return "", err
 				}
-				isProUser := user.CodyProEnabledAt != nil
-				if isAllowedCustomChatModel(requestParams.Model, isProUser) {
+
+				subscription, err := ssc.CodySubscriptionForUser(ctx, *user)
+				if err != nil {
+					return "", err
+				}
+
+				if isAllowedCustomChatModel(requestParams.Model, subscription.ApplyProRateLimits) {
 					return requestParams.Model, nil
 				}
 			}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1346,7 +1346,7 @@ SELECT u.id,
 	u.tos_accepted,
 	u.completed_post_signup,
 	EXISTS (SELECT 1 FROM user_external_accounts WHERE service_type = 'scim' AND user_id = u.id AND deleted_at IS NULL) AS scim_controlled,
-	u.cody_pro_enabled_at
+	u.cody_pro_enabled_at as cody_pro_opted_as
 FROM users u %s`, query)
 	rows, err := u.Query(ctx, q)
 	if err != nil {
@@ -1358,7 +1358,7 @@ FROM users u %s`, query)
 	for rows.Next() {
 		var u types.User
 		var displayName, avatarURL sql.NullString
-		err := rows.Scan(&u.ID, &u.Username, &displayName, &avatarURL, &u.CreatedAt, &u.UpdatedAt, &u.SiteAdmin, &u.BuiltinAuth, &u.InvalidatedSessionsAt, &u.TosAccepted, &u.CompletedPostSignup, &u.SCIMControlled, &u.CodyProEnabledAt)
+		err := rows.Scan(&u.ID, &u.Username, &displayName, &avatarURL, &u.CreatedAt, &u.UpdatedAt, &u.SiteAdmin, &u.BuiltinAuth, &u.InvalidatedSessionsAt, &u.TosAccepted, &u.CompletedPostSignup, &u.SCIMControlled, &u.CodyProOptedAt)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "ssc",
+    srcs = [
+        "ssc.go",
+        "types.go",
+        "utils.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/ssc",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/featureflag",
+        "//internal/httpcli",
+        "//internal/types",
+        "//lib/errors",
+    ],
+)

--- a/internal/ssc/ssc.go
+++ b/internal/ssc/ssc.go
@@ -1,0 +1,134 @@
+package ssc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+const SSC_API_BASE_URL = "http://127.0.0.1:9982/cody"
+const SSC_ADMINISTRATIVE_SECRET_TOKEN = "naman"
+
+// FetchSubscriptionBySAMSAccountID returns the user's Cody subscription for the sams_account_id
+func FetchSubscriptionBySAMSAccountID(samsAccountID string) (*SSCSubscription, error) {
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/rest/svc/subscription/%s", SSC_API_BASE_URL, samsAccountID), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", SSC_ADMINISTRATIVE_SECRET_TOKEN))
+
+	resp, err := httpcli.UncachedExternalDoer.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		var subscription SSCSubscription
+		err = json.Unmarshal(body, &subscription)
+		if err != nil {
+			return nil, err
+		}
+
+		subscription.SAMSAccountID = samsAccountID
+
+		return &subscription, nil
+	}
+
+	// 204 response indicates that the user does not have a Cody Pro subscription
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
+	return nil, errors.Errorf("unexpected status code %d while fetching user subscription from SSC", resp.StatusCode)
+}
+
+var febReleaseDate = time.Date(2024, 02, 15, 0, 0, 0, 0, time.Now().Location())
+
+func ConsolidateSubscriptionDetails(ctx context.Context, user types.User, subscription *SSCSubscription) (*UserCodySubscription, error) {
+	isBeforeFebReleaseDate := time.Now().Before(febReleaseDate)
+
+	// The user has put in their cc and signed up for Cody Pro on SSC
+	if subscription != nil {
+		currentPeriodStart, err := time.Parse(time.RFC3339, subscription.CurrentPeriodStart)
+		if err != nil {
+			return nil, err
+		}
+
+		currentPeriodEnd, err := time.Parse(time.RFC3339, subscription.CurrentPeriodEnd)
+		if err != nil {
+			return nil, err
+		}
+
+		applyProRateLimits := subscription.Status == SubscriptionStatusActive || subscription.Status == SubscriptionStatusPastDue || subscription.Status == SubscriptionStatusTrialing
+
+		return &UserCodySubscription{
+			Status:               subscription.Status,
+			IsPro:                true,
+			ApplyProRateLimits:   applyProRateLimits,
+			CurrentPeriodStartAt: currentPeriodStart,
+			CurrentPeriodEndAt:   currentPeriodEnd,
+		}, nil
+	}
+
+	currentPeriodStartAt, currentPeriodEndAt, err := preSSCCurrentPeriodDateRange(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+
+	// The user opted for Cody Pro Trial on dotcom but have not put in their cc on SSC
+	if user.CodyProOptedAt != nil {
+		if currentPeriodEndAt.After(febReleaseDate) {
+			currentPeriodEndAt = febReleaseDate
+		}
+
+		return &UserCodySubscription{
+			Status:               SubscriptionStatusPending,
+			IsPro:                true,
+			ApplyProRateLimits:   isBeforeFebReleaseDate,
+			CurrentPeriodStartAt: currentPeriodStartAt,
+			CurrentPeriodEndAt:   currentPeriodEndAt,
+		}, nil
+	}
+
+	// The user neither opted for Cody Pro on dotcom nor have put in their cc on SSC
+	return &UserCodySubscription{
+		Status:               SubscriptionStatusPending,
+		IsPro:                false,
+		ApplyProRateLimits:   false,
+		CurrentPeriodStartAt: currentPeriodStartAt,
+		CurrentPeriodEndAt:   currentPeriodEndAt,
+	}, nil
+}
+
+func CodySubscriptionForUser(ctx context.Context, user types.User) (*UserCodySubscription, error) {
+	// TODO (naman): get account_id from user_external_services table
+	// based on a feature flag swtich between accounts.sourcegraph.com and accounts.sgdev.org
+	sams_account_id := "018d18a8-55e8-7d2f-b902-4d29c308565f"
+
+	var subscription *SSCSubscription
+	var err error
+
+	if featureflag.FromContext(ctx).GetBoolOr("ssc-enabled", false) {
+		subscription, err = FetchSubscriptionBySAMSAccountID(sams_account_id)
+		if err != nil {
+			return nil, errors.Wrap(err, "error while fetching user subscription from SSC")
+		}
+	}
+
+	return ConsolidateSubscriptionDetails(ctx, user, subscription)
+}

--- a/internal/ssc/types.go
+++ b/internal/ssc/types.go
@@ -1,0 +1,49 @@
+package ssc
+
+import (
+	"time"
+)
+
+type BillingInterval string
+
+const (
+	BillingIntervalDaily   BillingInterval = "daily"
+	BillingIntervalMonthly BillingInterval = "monthly"
+	BillingIntervalYearly  BillingInterval = "yearly"
+)
+
+type SubscriptionStatus string
+
+const (
+	SubscriptionStatusActive   SubscriptionStatus = "active"
+	SubscriptionStatusPastDue  SubscriptionStatus = "past_due"
+	SubscriptionStatusUnpaid   SubscriptionStatus = "unpaid"
+	SubscriptionStatusCanceled SubscriptionStatus = "canceled"
+	SubscriptionStatusTrialing SubscriptionStatus = "trialing"
+	SubscriptionStatusPending  SubscriptionStatus = "pending"
+	SubscriptionStatusOther    SubscriptionStatus = "other"
+)
+
+type SSCSubscription struct {
+	SAMSAccountID string
+	// Status is the current status of the subscription, e.g. "active" or "canceled".
+	Status          SubscriptionStatus `json:"status"`
+	BillingInterval BillingInterval    `json:"billingInterval"`
+
+	// CancelAtPeriodEnd flags whether or not a subscription will automatically cancel at the end
+	// of the current billing cycle, or if it will renew.
+	CancelAtPeriodEnd bool `json:"cancelAtPeriodEnd"`
+
+	// Billing cycle anchors are times represented as an ISO-8601 string.
+	// e.g. "2024-01-17T13:18:05−07:00"
+	CurrentPeriodStart string `json:"currentPeriodStart"`
+	CurrentPeriodEnd   string `json:"currentPeriodEnd"`
+}
+
+type UserCodySubscription struct {
+	Status               SubscriptionStatus
+	IsPro                bool
+	ApplyProRateLimits   bool
+	CurrentPeriodStartAt time.Time
+	CurrentPeriodEndAt   time.Time
+}

--- a/internal/ssc/utils.go
+++ b/internal/ssc/utils.go
@@ -1,0 +1,69 @@
+package ssc
+
+import (
+	"context"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"time"
+)
+
+type currentTimeCtxKey int
+
+const mockCurrentTimeKey currentTimeCtxKey = iota
+
+func currentTimeFromCtx(ctx context.Context) time.Time {
+	t, ok := ctx.Value(mockCurrentTimeKey).(*time.Time)
+	if !ok || t == nil {
+		return time.Now()
+	}
+	return *t
+}
+
+func withCurrentTimeMock(ctx context.Context, t time.Time) context.Context {
+	return context.WithValue(ctx, mockCurrentTimeKey, &t)
+}
+
+func preSSCCurrentPeriodDateRange(ctx context.Context, user types.User) (time.Time, time.Time, error) {
+	// to allow mocking current time during tests
+	currentDate := currentTimeFromCtx(ctx)
+
+	subscriptionStartDate := user.CreatedAt
+	gaReleaseDate := time.Date(2023, 12, 14, 0, 0, 0, 0, subscriptionStartDate.Location())
+
+	if !currentDate.Before(gaReleaseDate) && subscriptionStartDate.Before(gaReleaseDate) {
+		subscriptionStartDate = gaReleaseDate
+	}
+
+	codyProOptedAt := user.CodyProOptedAt
+	if codyProOptedAt != nil {
+		subscriptionStartDate = *codyProOptedAt
+	}
+
+	targetDay := subscriptionStartDate.Day()
+	startDayOfTheMonth := targetDay
+	endDayOfTheMonth := targetDay - 1
+	startMonth := currentDate
+	endMonth := currentDate
+
+	if currentDate.Day() < targetDay {
+		// Set to target day of the previous month
+		startMonth = currentDate.AddDate(0, -1, 0)
+	} else {
+		// Set to target day of the next month
+		endMonth = currentDate.AddDate(0, 1, 0)
+	}
+
+	daysInStartingMonth := time.Date(startMonth.Year(), startMonth.Month()+1, 0, 0, 0, 0, 0, startMonth.Location()).Day()
+	if startDayOfTheMonth > daysInStartingMonth {
+		startDayOfTheMonth = daysInStartingMonth
+	}
+
+	daysInEndingMonth := time.Date(endMonth.Year(), endMonth.Month()+1, 0, 0, 0, 0, 0, endMonth.Location()).Day()
+	if endDayOfTheMonth > daysInEndingMonth {
+		endDayOfTheMonth = daysInEndingMonth
+	}
+
+	startDate := time.Date(startMonth.Year(), startMonth.Month(), startDayOfTheMonth, 0, 0, 0, 0, startMonth.Location())
+	endDate := time.Date(endMonth.Year(), endMonth.Month(), endDayOfTheMonth, 23, 59, 59, 59, endMonth.Location())
+
+	return startDate, endDate, nil
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -855,7 +855,7 @@ type User struct {
 	TosAccepted           bool
 	CompletedPostSignup   bool
 	SCIMControlled        bool
-	CodyProEnabledAt      *time.Time
+	CodyProOptedAt        *time.Time
 }
 
 // Name returns a name for the user. If the user has a display name,


### PR DESCRIPTION
In-Progress

Make a request to SSC from dotcom with the SAMS account_id to fetch user's subscription info. Combine the SSC subscription details with the Cody Pro trial opted info from dotcom based on `users.cody_pro_enabled_at` to expose a new `user.codySubscription` graphql API which can be consumed by Cody Clients and Cody Management dashboard. 

This PR also makes dotcom's rate limit resolver consumed by the SSC API to fetch user's subscription.

## Test plan
TODO