### PR TITLE
search jobs: graduate from EAP to beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to Sourcegraph are documented in this file.
   - For `size` the supported units are `B`, `b`, `kB`, `KB`, `kiB`, `KiB`, `MiB`, `MB`, `GiB`, `GB`. No decimals points are supported.
 - Structural Search is now disabled by default. To enable it, set `experimentalFeatures.structuralSearch: "enabled"` in the site configuration. [#57584](https://github.com/sourcegraph/sourcegraph/pull/57584)
 - Search Jobs switches the format of downloaded results from CSV to JSON. [#59619](https://github.com/sourcegraph/sourcegraph/pull/59619)
+- [Search Jobs](https://docs.sourcegraph.com/code_search/how-to/search-jobs) is now in beta and enabled by default. It can be disabled in the site configuration by setting `experimentalFeatures.searchJobs: "disabled"`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ All notable changes to Sourcegraph are documented in this file.
   - For `size` the supported units are `B`, `b`, `kB`, `KB`, `kiB`, `KiB`, `MiB`, `MB`, `GiB`, `GB`. No decimals points are supported.
 - Structural Search is now disabled by default. To enable it, set `experimentalFeatures.structuralSearch: "enabled"` in the site configuration. [#57584](https://github.com/sourcegraph/sourcegraph/pull/57584)
 - Search Jobs switches the format of downloaded results from CSV to JSON. [#59619](https://github.com/sourcegraph/sourcegraph/pull/59619)
-- [Search Jobs](https://docs.sourcegraph.com/code_search/how-to/search-jobs) is now in beta and enabled by default. It can be disabled in the site configuration by setting `experimentalFeatures.searchJobs: "disabled"`.
+- [Search Jobs](https://docs.sourcegraph.com/code_search/how-to/search-jobs) is now in beta and enabled by default. It can be disabled in the site configuration by setting `experimentalFeatures.searchJobs: false`.
 
 ### Fixed
 

--- a/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.tsx
@@ -364,7 +364,7 @@ export const ExhaustiveSearchMessage: FC<ExhaustiveSearchMessageProps> = props =
         <section className={styles.exhaustiveSearch}>
             <header className={styles.exhaustiveSearchHeader}>
                 <Text className="m-0">Create a search job:</Text>
-                <ProductStatusBadge status="experimental" />
+                <ProductStatusBadge status="beta" />
             </header>
 
             {validationError && (

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.tsx
@@ -181,7 +181,7 @@ export const SearchJobsPage: FC<SearchJobsPageProps> = props => {
         <Page>
             <PageTitle title="Search jobs" />
             <PageHeader
-                annotation={<FeedbackBadge status="experimental" feedback={{ mailto: 'support@sourcegraph.com' }} />}
+                annotation={<FeedbackBadge status="beta" feedback={{ mailto: 'support@sourcegraph.com' }} />}
                 path={[{ icon: LayersSearchOutlineIcon, text: 'Search Jobs' }]}
                 description={
                     <>

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -327,7 +327,7 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
                 path: PageRoutes.SearchJobs,
                 content: (
                     <>
-                        Search Jobs <ProductStatusBadge className="ml-2" status="experimental" />
+                        Search Jobs <ProductStatusBadge className="ml-2" status="beta" />
                     </>
                 ),
             },

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -354,7 +354,7 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
                             )}
                             {showSearchJobs && (
                                 <NavItemLink url={PageRoutes.SearchJobs} onClick={handleNavigationClick}>
-                                    Search Jobs <ProductStatusBadge className="ml-2" status="experimental" />
+                                    Search Jobs <ProductStatusBadge className="ml-2" status="beta" />
                                 </NavItemLink>
                             )}
                         </ul>

--- a/client/web/src/search-jobs/utility.ts
+++ b/client/web/src/search-jobs/utility.ts
@@ -6,4 +6,4 @@
  * It's on for all users on the instance, or it's off for all users.
  * Only admins can turn it on/off in the site configuration page.
  */
-export const isSearchJobsEnabled = (): boolean => window.context?.experimentalFeatures?.searchJobs ?? false
+export const isSearchJobsEnabled = (): boolean => window.context?.experimentalFeatures?.searchJobs ?? true

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -292,9 +292,13 @@ describe('StreamingSearchResults', () => {
                 userEvent.click(check, undefined, { skipPointerEventsCheck: true })
             }
 
-            userEvent.click(await screen.findByText(/search again/i, { selector: 'button[type=submit]' }), undefined, {
-                skipPointerEventsCheck: true,
-            })
+            userEvent.click(
+                await screen.findByText(/modify and re-run/i, { selector: 'button[type=submit]' }),
+                undefined,
+                {
+                    skipPointerEventsCheck: true,
+                }
+            )
 
             expect(helpers.submitSearch).toBeCalledTimes(index + 1)
             const args = submitSearchMock.mock.calls[index][0]

--- a/internal/search/exhaustive/service/service.go
+++ b/internal/search/exhaustive/service/service.go
@@ -480,5 +480,5 @@ func isEnabled() bool {
 	if experimentalFeatures := conf.SiteConfig().ExperimentalFeatures; experimentalFeatures != nil {
 		return experimentalFeatures.SearchJobs != nil && *experimentalFeatures.SearchJobs
 	}
-	return false
+	return true
 }


### PR DESCRIPTION
Relates to #59352 

This updates the badges from "experimental" to "beta" and enables search jobs by default.

## Test plan
Just a change of defaults. I checked the badges in the Navbar and on the Search Jobs page manually

<img width="434" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/05ea9d12-d208-4f24-86ca-54d184c1f007">

<img width="834" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/ae744623-7000-441d-812e-c17d03eac5d9">
