### PR TITLE
Search filters: Polish filters panel

### DIFF
--- a/client/branded/BUILD.bazel
+++ b/client/branded/BUILD.bazel
@@ -127,6 +127,7 @@ ts_project(
         "src/search-ui/results/StreamingSearchResultsFooter.tsx",
         "src/search-ui/results/StreamingSearchResultsList.tsx",
         "src/search-ui/results/filters/NewSearchFilters.tsx",
+        "src/search-ui/results/filters/components/Icons.tsx",
         "src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx",
         "src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx",
         "src/search-ui/results/filters/components/filters-doc-footer/FiltersDocFooter.tsx",

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from 'react'
+import { FC, ReactNode, useMemo } from 'react'
 
 import { FilterType, resolveFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { findFilters } from '@sourcegraph/shared/src/search/query/query'
@@ -31,9 +31,10 @@ interface NewSearchFiltersProps {
     query: string
     filters?: Filter[]
     onQueryChange: (nextQuery: string) => void
+    children?: ReactNode
 }
 
-export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, onQueryChange }) => {
+export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, onQueryChange, children }) => {
     const [selectedFilters, setSelectedFilters] = useUrlFilters()
 
     const type = useMemo(() => {
@@ -144,6 +145,8 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
             />
 
             <FiltersDocFooter className={styles.footer} />
+
+            {children}
         </div>
     )
 }

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -86,28 +86,6 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
                 />
             )}
 
-            {(type === SearchFilterType.Commits || type === SearchFilterType.Diffs) && (
-                <>
-                    <SearchDynamicFilter
-                        title="By author"
-                        filterKind="author"
-                        filters={filters}
-                        selectedFilters={selectedFilters}
-                        renderItem={authorFilter}
-                        onSelectedFilterChange={setSelectedFilters}
-                    />
-
-                    <SearchDynamicFilter
-                        title="By commit date"
-                        filterKind="commit date"
-                        filters={filters}
-                        selectedFilters={selectedFilters}
-                        renderItem={commitDateFilter}
-                        onSelectedFilterChange={setSelectedFilters}
-                    />
-                </>
-            )}
-
             <SearchDynamicFilter
                 title="By language"
                 filterKind="lang"
@@ -117,6 +95,17 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
                 onSelectedFilterChange={setSelectedFilters}
             />
 
+            {(type === SearchFilterType.Commits || type === SearchFilterType.Diffs) && (
+                <SearchDynamicFilter
+                    title="By author"
+                    filterKind="author"
+                    filters={filters}
+                    selectedFilters={selectedFilters}
+                    renderItem={authorFilter}
+                    onSelectedFilterChange={setSelectedFilters}
+                />
+            )}
+
             <SearchDynamicFilter
                 title="By repositories"
                 filterKind="repo"
@@ -125,6 +114,17 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
                 renderItem={repoFilter}
                 onSelectedFilterChange={setSelectedFilters}
             />
+
+            {(type === SearchFilterType.Commits || type === SearchFilterType.Diffs) && (
+                <SearchDynamicFilter
+                    title="By commit date"
+                    filterKind="commit date"
+                    filters={filters}
+                    selectedFilters={selectedFilters}
+                    renderItem={commitDateFilter}
+                    onSelectedFilterChange={setSelectedFilters}
+                />
+            )}
 
             <SearchDynamicFilter
                 title="By file"

--- a/client/branded/src/search-ui/results/filters/components/Icons.tsx
+++ b/client/branded/src/search-ui/results/filters/components/Icons.tsx
@@ -1,0 +1,48 @@
+import { FC, SVGProps } from 'react'
+
+interface CustomIconProps extends SVGProps<SVGSVGElement> {}
+
+export const OpenBookIcon: FC<CustomIconProps> = props => (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="transparent" {...props}>
+        <path
+            d="M8.99988 16.4284C7.32587 14.5854 5.05564 13.3916 2.58846 13.057C2.30763 13.0259 2.04827 12.8919 1.86044 12.6809C1.6726 12.4698 1.5696 12.1967 1.57131 11.9141V2.71413C1.5713 2.54906 1.60705 2.38594 1.6761 2.23599C1.74515 2.08606 1.84586 1.95286 1.97131 1.84556C2.09455 1.74021 2.23879 1.66229 2.39446 1.61697C2.55011 1.57165 2.71364 1.55997 2.87417 1.5827C5.23336 1.97425 7.39156 3.14999 8.99988 4.91985V16.4284Z"
+            stroke="var(--icon-color)"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+        <path
+            d="M9 16.4284C10.674 14.5854 12.9442 13.3916 15.4114 13.057C15.6922 13.0259 15.9517 12.8919 16.1394 12.6809C16.3273 12.4698 16.4303 12.1967 16.4286 11.9141V2.71413C16.4286 2.54906 16.3928 2.38594 16.3238 2.23599C16.2547 2.08606 16.1541 1.95286 16.0286 1.84556C15.9054 1.74021 15.7611 1.66229 15.6055 1.61697C15.4497 1.57165 15.2863 1.55997 15.1257 1.5827C12.7665 1.97425 10.6083 3.14999 9 4.91985V16.4284Z"
+            stroke="var(--icon-color)"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+    </svg>
+)
+
+export const LinkShareIcon: FC<CustomIconProps> = props => (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" {...props}>
+        <path
+            d="M10.0001 7.85714V11.7143C10.0001 11.9416 9.9098 12.1597 9.74908 12.3204C9.58837 12.4811 9.37033 12.5714 9.143 12.5714H2.28585C2.05852 12.5714 1.84051 12.4811 1.67976 12.3204C1.51902 12.1597 1.42871 11.9416 1.42871 11.7143V4.85714C1.42871 4.62981 1.51902 4.4118 1.67976 4.25105C1.84051 4.09031 2.05852 4 2.28585 4H6.143"
+            stroke="var(--icon-color)"
+            strokeWidth="1.25"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+        <path
+            d="M9.57178 1.42859H12.5718V4.42859"
+            stroke="var(--icon-color)"
+            strokeWidth="1.25"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+        <path
+            d="M12.5717 1.42859L7.85742 6.14287"
+            stroke="var(--icon-color)"
+            strokeWidth="1.25"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+    </svg>
+)

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
@@ -67,6 +67,6 @@
 }
 
 .description {
-    margin: 0 0.65rem -.25rem 0.65rem;
+    margin: 0 0.65rem -0.25rem 0.65rem;
     color: var(--text-muted);
 }

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
@@ -6,7 +6,7 @@
 }
 
 .heading {
-    margin: 0;
+    margin: 0 0 0.25rem 0;
 }
 
 .list {
@@ -64,4 +64,9 @@
     &::after {
         display: none;
     }
+}
+
+.description {
+    margin: 0 0.65rem -.25rem 0.65rem;
+    color: var(--text-muted);
 }

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -40,7 +40,7 @@ interface SearchDynamicFilterProps {
     filters?: Filter[]
 
     /** Exposes render API to render some custom filter item in the list */
-    renderItem?: (filter: Filter) => ReactNode
+    renderItem?: (filter: Filter, selected: boolean) => ReactNode
 
     /**
      * It's called whenever user changes (pick/reset) any filters in the filter panel.
@@ -147,7 +147,7 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
 interface DynamicFilterItemProps {
     filter: Filter
     selected: boolean
-    renderItem?: (filter: Filter) => ReactNode
+    renderItem?: (filter: Filter, selected: boolean) => ReactNode
     onClick: (filter: URLQueryFilter, remove?: boolean) => void
 }
 
@@ -162,7 +162,7 @@ const DynamicFilterItem: FC<DynamicFilterItemProps> = props => {
                 className={classNames(styles.item, { [styles.itemSelected]: selected })}
                 onClick={() => onClick(filter, selected)}
             >
-                <span className={styles.itemText}>{renderItem ? renderItem(filter) : filter.label}</span>
+                <span className={styles.itemText}>{renderItem ? renderItem(filter, selected) : filter.label}</span>
                 {filter.count !== 0 && (
                     <Badge variant="secondary" className="ml-2">
                         {filter.exhaustive ? filter.count : `${roundCount(filter.count)}+`}
@@ -207,10 +207,10 @@ export const repoFilter = (filter: Filter): ReactNode => {
     )
 }
 
-export const commitDateFilter = (filter: Filter): ReactNode => (
+export const commitDateFilter = (filter: Filter, selected: boolean): ReactNode => (
     <span className={styles.commitDate}>
         {filter.label}
-        <Code>{filter.value}</Code>
+        <Code className={!selected ? 'text-muted' : ''}>{filter.value}</Code>
     </span>
 )
 

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -15,7 +15,8 @@ import { URLQueryFilter } from '../../hooks'
 
 import styles from './SearchDynamicFilter.module.scss'
 
-const MAX_FILTERS_NUMBER = 5
+const DEFAULT_FILTERS_NUMBER = 5
+const MAX_FILTERS_NUMBER = 10
 
 interface SearchDynamicFilterProps {
     /** Name title of the filter section */
@@ -61,7 +62,7 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
     onSelectedFilterChange,
 }) => {
     const [searchTerm, setSearchTerm] = useState<string>('')
-    const [visibleFilters, setVisibleFilters] = useState<number>(MAX_FILTERS_NUMBER)
+    const [showMoreFilters, setShowMoreFilters] = useState<boolean>(false)
 
     const relevantSelectedFilters = selectedFilters.filter(sf => sf.kind === filterKind)
     const relevantFilters = filters?.filter(f => f.kind === filterKind) ?? []
@@ -91,27 +92,9 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
 
     const lowerSearchTerm = searchTerm.toLowerCase()
     const filteredFilters = mergedFilters.filter(filter => filter.label.toLowerCase().includes(lowerSearchTerm))
-    const filtersToShow =
-        filteredFilters.length <= visibleFilters ? filteredFilters : filteredFilters.slice(0, visibleFilters)
-    const allFiltersDisplayed = visibleFilters >= filteredFilters.length
-
-    const moreOrLessFilters = (): void => {
-        const filtersDisplayed = visibleFilters + MAX_FILTERS_NUMBER
-
-        if (allFiltersDisplayed) {
-            // setAllFiltersDisplayed(false)
-            setVisibleFilters(MAX_FILTERS_NUMBER)
-            return
-        }
-
-        if (filteredFilters.length <= filtersDisplayed) {
-            setVisibleFilters(filtersDisplayed)
-            // setAllFiltersDisplayed(true)
-            return
-        }
-
-        setVisibleFilters(filtersDisplayed)
-    }
+    const filtersToShow = showMoreFilters
+        ? filteredFilters.slice(0, MAX_FILTERS_NUMBER)
+        : filteredFilters.slice(0, DEFAULT_FILTERS_NUMBER)
 
     return (
         <div className={styles.root}>
@@ -119,7 +102,7 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
                 {title}
             </H4>
 
-            {mergedFilters.length > MAX_FILTERS_NUMBER && (
+            {mergedFilters.length > DEFAULT_FILTERS_NUMBER && (
                 <Input
                     value={searchTerm}
                     placeholder={`Filter ${filterKind}`}
@@ -138,10 +121,18 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
                     />
                 ))}
             </ul>
-            {filteredFilters.length > MAX_FILTERS_NUMBER && (
-                <Button variant="link" size="sm" onClick={() => moreOrLessFilters()}>
-                    {allFiltersDisplayed ? `Show less ${filterKind}s` : `Show more ${filterKind}s`}
-                </Button>
+            {filteredFilters.length > DEFAULT_FILTERS_NUMBER && (
+                <>
+                    {showMoreFilters && filteredFilters.length > MAX_FILTERS_NUMBER && (
+                        <small className={styles.description}>
+                            There are {filteredFilters.length - MAX_FILTERS_NUMBER} other filters, use search to see
+                            more
+                        </small>
+                    )}
+                    <Button variant="link" size="sm" onClick={() => setShowMoreFilters(!showMoreFilters)}>
+                        {showMoreFilters ? `Show less ${filterKind}s` : `Show more ${filterKind}s`}
+                    </Button>
+                </>
             )}
         </div>
     )

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -120,6 +120,12 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
                         onClick={handleFilterClick}
                     />
                 ))}
+
+                {filtersToShow.length === 0 && (
+                    <small className={styles.description}>
+                        There are no {filterKind}s to show, try to use different search value
+                    </small>
+                )}
             </ul>
             {filteredFilters.length > DEFAULT_FILTERS_NUMBER && (
                 <>

--- a/client/branded/src/search-ui/results/filters/components/filters-doc-footer/FiltersDocFooter.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/filters-doc-footer/FiltersDocFooter.module.scss
@@ -1,11 +1,11 @@
 .footer {
-    padding: 1rem 0.5rem;
+    padding: 1rem 0.75rem;
     border-top: 1px solid var(--border-color);
 }
 
 .link {
     display: flex;
-    gap: 0.25rem;
+    gap: 0.5rem;
     color: var(--text-muted);
 
     &-text {
@@ -16,6 +16,11 @@
     }
 
     &-icon {
-        margin-top: 0.1rem;
+        margin-top: 0.15rem;
+        fill: none !important;
+    }
+
+    &:hover {
+        --icon-color: var(--primary);
     }
 }

--- a/client/branded/src/search-ui/results/filters/components/filters-doc-footer/FiltersDocFooter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/filters-doc-footer/FiltersDocFooter.tsx
@@ -1,9 +1,10 @@
 import { FC } from 'react'
 
-import { mdiBook, mdiLink } from '@mdi/js'
 import classNames from 'classnames'
 
 import { Icon, Link, H4 } from '@sourcegraph/wildcard'
+
+import { LinkShareIcon, OpenBookIcon } from '../Icons'
 
 import styles from './FiltersDocFooter.module.scss'
 
@@ -14,14 +15,14 @@ interface FiltersDocFooterProps {
 export const FiltersDocFooter: FC<FiltersDocFooterProps> = ({ className }) => (
     <footer className={classNames(styles.footer, className)}>
         <Link target="_blank" rel="noopener" to="/help/code_search/reference/queries" className={styles.link}>
-            <Icon svgPath={mdiBook} aria-hidden={true} className={styles.linkIcon} />
+            <Icon as={OpenBookIcon} aria-hidden={true} className={styles.linkIcon} />
             <span className={styles.linkText}>
                 <H4 as="span" className="m-0">
                     Need more advanced filters?
                 </H4>
                 <small>Explore the query syntax docs</small>
             </span>
-            <Icon svgPath={mdiLink} aria-hidden={true} className={styles.linkIcon} />
+            <Icon as={LinkShareIcon} aria-hidden={true} className={styles.linkIcon} />
         </Link>
     </footer>
 )

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.module.scss
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.module.scss
@@ -13,3 +13,10 @@
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
 }
+
+
+.close-filters {
+    position: sticky;
+    bottom: 0.5rem;
+    margin: 0 0.5rem 0.5rem 0.5rem;
+}

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.module.scss
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.module.scss
@@ -14,7 +14,6 @@
     border-bottom-left-radius: 0;
 }
 
-
 .close-filters {
     position: sticky;
     bottom: 0.5rem;

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
@@ -61,7 +61,11 @@ export const SearchFiltersPanel: FC<SearchFiltersPanelProps> = props => {
             className={styles.modal}
             onDismiss={() => setFiltersPanel(false)}
         >
-            <NewSearchFilters query={query} filters={filters} onQueryChange={onQueryChange} />
+            <NewSearchFilters query={query} filters={filters} onQueryChange={onQueryChange}>
+                <Button variant="primary" className={styles.closeFilters} onClick={() => setFiltersPanel(false)}>
+                    Close filters panel
+                </Button>
+            </NewSearchFilters>
         </Modal>
     )
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/59440
Fixes https://github.com/sourcegraph/sourcegraph/issues/59385

Note: That `count:all` filter will be added on the backend (probably under utility section), after this FE logic will use them as other filters without changes. 

## Test plan
- Check that filters panel has close button on the mobile
- Check that filters has right show/hide more filters logic 
- Check that filters section has zero state if your inline search produces zero matches
- Check that icons in the footer are right

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
