### PR TITLE
Search: reduce display limit to 500

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -504,7 +504,7 @@ function initiateSearchStream(
         zoektSearchOptions,
         featureOverrides,
         searchMode = SearchMode.Precise,
-        displayLimit = 1500,
+        displayLimit = 500,
         sourcegraphURL = '',
         chunkMatches = false,
     }: StreamSearchOptions,


### PR DESCRIPTION
This reduces the default display limit from 1500 to 500. Note: this is _not_ the same as the default `count:`, so we will still collect and aggregate up to the default `count:` on the backend for the purpose of calculating more exhaustive filters, but we will only send up to 500 results to the client for display. 

Now that our default `count:` is higher and we're streaming larger chunk matches, stream sizes can get unacceptably large. For the purpose of searching code, 500 results should be enough to get an idea of whether your search is refined enough, and our new filters panel will help gently suggest ways to refine it better, so I think reducing the default display limit is an acceptable tradeoff here.

Another option would be to have a separate cutoff where we stream the matched ranges back to the client, but not the actual contents so the client could fetch the contents lazily if someone scrolls down that far. However, that's a significantly larger change, and this seems like a reasonable trade-off for now.

## Test plan

N/A
