### PR TITLE
Auto-redirect to SAMS

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -78,6 +78,28 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
     }
 
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
+    // If there is only one auth provider on dotcom, we want to redirect to it directly.
+    if (
+        context.sourcegraphDotComMode &&
+        thirdPartyAuthProviders.length === 1 &&
+        !thirdPartyAuthProviders[0].isBuiltin
+    ) {
+        window.location.replace(thirdPartyAuthProviders[0].authenticationURL)
+        return (
+            <>
+                <PageTitle title="Signing in..." />
+                <AuthPageWrapper
+                    title="Redirecting to sign in..."
+                    sourcegraphDotComMode={context.sourcegraphDotComMode}
+                    className={styles.wrapper}
+                >
+                    <Alert className="mt-3" variant="info">
+                        You are being redirected to sign in with {thirdPartyAuthProviders[0].displayName}.
+                    </Alert>
+                </AuthPageWrapper>
+            </>
+        )
+    }
     const primaryProviders = thirdPartyAuthProviders.slice(0, context.primaryLoginProvidersCount)
     const moreProviders = thirdPartyAuthProviders.slice(context.primaryLoginProvidersCount)
 


### PR DESCRIPTION
- Fixes #59634

Notes:
- I've used an "if dotcom" check to avoid affecting enterprise or cloud instances.
- It redirects to any single non-built-in provider, but practically, this will only be SAMS on dotcom.
- I created a simple custom redirect note to make the UX nice.

## Test plan

See me testing this (except operators) in this [1-min Loom](https://www.loom.com/share/64499f7dd0c848e595a35eadb98f78c2)

Tested it with:
- ✅ several auth methods enabled → the sign-in page shows up
- ✅ a single auth provider enabled → I got auto-redirected
- ✅ a single auth provider plus Sourcegraph Operators enabled → I got auto-redirected
- ✅ a single auth provider plus Sourcegraph Operators enabled with the `sourcegraph-operators` query attribute set → the sign-in page shows up