### PR TITLE
Icons: Add attribution license comment for the core-line icon set

### DIFF
--- a/client/branded/src/search-ui/results/filters/components/Icons.tsx
+++ b/client/branded/src/search-ui/results/filters/components/Icons.tsx
@@ -2,7 +2,7 @@ import { FC, SVGProps } from 'react'
 
 interface CustomIconProps extends SVGProps<SVGSVGElement> {}
 
-// This file contains core-line icons by https://streamlinehq.com. It is licensed under CC BY 4.0
+// This file contains core-line icons by https://www.streamlinehq.com. It is licensed under CC BY 4.0
 // Original source of icon set - https://www.streamlinehq.com/icons/core-line-free
 
 export const OpenBookIcon: FC<CustomIconProps> = props => (

--- a/client/branded/src/search-ui/results/filters/components/Icons.tsx
+++ b/client/branded/src/search-ui/results/filters/components/Icons.tsx
@@ -2,6 +2,9 @@ import { FC, SVGProps } from 'react'
 
 interface CustomIconProps extends SVGProps<SVGSVGElement> {}
 
+// This file contains core-line icons by https://streamlinehq.com. It is licensed under CC BY 4.0
+// Original source of icon set - https://www.streamlinehq.com/icons/core-line-free
+
 export const OpenBookIcon: FC<CustomIconProps> = props => (
     <svg width="18" height="18" viewBox="0 0 18 18" fill="transparent" {...props}>
         <path


### PR DESCRIPTION
Originally, new icons were added in this PR https://github.com/sourcegraph/sourcegraph, this PR simply adds some attribution comment for the CC 4.0 license of these icons. 


## Test plan
- None

