### PR TITLE
Add Self Serve Cody API client to dotcom

### DIFF
--- a/client/web/src/cody/subscription/queries.tsx
+++ b/client/web/src/cody/subscription/queries.tsx
@@ -5,7 +5,6 @@ export const USER_CODY_PLAN = gql`
         currentUser {
             id
             codyProEnabled
-            codyProEnabledAt
         }
     }
 `
@@ -29,7 +28,6 @@ export const CHANGE_CODY_PLAN = gql`
         changeCodyPlan(user: $id, pro: $pro) {
             id
             codyProEnabled
-            codyProEnabledAt
         }
     }
 `

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6577,10 +6577,6 @@ type User implements Node & SettingsSubject & Namespace {
     """
     codyProEnabled: Boolean!
     """
-    The date when the user enrolled for Cody Pro.
-    """
-    codyProEnabledAt: DateTime
-    """
     The start date of current billing period of Cody.
     """
     codyCurrentPeriodStartDate: DateTime

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
-	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -226,167 +224,6 @@ func TestUser_LatestSettings(t *testing.T) {
 				got := fmt.Sprintf("%v", err)
 				want := "must be authenticated as user with id 1"
 				assert.Equal(t, want, got)
-			})
-		}
-	})
-}
-
-func TestUser_CodyCurrentPeriod(t *testing.T) {
-	db := dbmocks.NewMockDB()
-
-	orig := envvar.SourcegraphDotComMode()
-	envvar.MockSourcegraphDotComMode(true)
-	t.Cleanup(func() {
-		envvar.MockSourcegraphDotComMode(orig)
-	})
-
-	t.Run("allowed by same user or site admin", func(t *testing.T) {
-		users := dbmocks.NewMockUserStore()
-		db.UsersFunc.SetDefaultReturn(users)
-		now := time.Now()
-
-		tests := []struct {
-			name    string
-			ctx     context.Context
-			success bool
-		}{
-			{
-				name:    "same user",
-				ctx:     actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
-				success: true,
-			},
-			{
-				name:    "another user",
-				ctx:     actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
-				success: false,
-			},
-			{
-				name:    "another user, but site admin",
-				ctx:     actor.WithActor(context.Background(), actor.FromActualUser(&types.User{ID: 2, SiteAdmin: true})),
-				success: true,
-			},
-		}
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				user := &types.User{ID: 1, CreatedAt: now}
-				users.GetByIDFunc.SetDefaultReturn(user, nil)
-
-				date, _ := NewUserResolver(test.ctx, db, user).CodyCurrentPeriodStartDate(test.ctx)
-
-				assert.Equal(t, test.success, date != nil, "CodyCurrentPeriodStartDate")
-			})
-		}
-	})
-
-	t.Run("success", func(t *testing.T) {
-		users := dbmocks.NewMockUserStore()
-		db.UsersFunc.SetDefaultReturn(users)
-		now := time.Now()
-
-		tests := []struct {
-			name      string
-			user      *types.User
-			today     time.Time
-			createdAt time.Time
-			pro       bool
-			start     time.Time
-			end       time.Time
-		}{
-			{
-				name:      "before release for community user created before december 14th",
-				createdAt: time.Date(2023, 10, 5, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2023, 12, 1, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2023, 11, 5, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2023, 12, 4, 23, 59, 59, 59, now.Location()),
-			},
-			{
-				name:      "after release for community user created before december 14th",
-				createdAt: time.Date(2023, 11, 5, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2023, 12, 25, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2023, 12, 14, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2024, 1, 13, 23, 59, 59, 59, now.Location()),
-			},
-			{
-				name:      "community user created before current day",
-				createdAt: time.Date(2024, 9, 5, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2025, 1, 15, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2025, 1, 5, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2025, 2, 4, 23, 59, 59, 59, now.Location()),
-			},
-			{
-				name:      "community user created after current day",
-				createdAt: time.Date(2024, 9, 25, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2025, 1, 15, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2024, 12, 25, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2025, 1, 24, 23, 59, 59, 59, now.Location()),
-			},
-			{
-				name:      "community user created on 31st Jan",
-				createdAt: time.Date(2025, 1, 31, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2025, 2, 15, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2025, 1, 31, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2025, 2, 28, 23, 59, 59, 59, now.Location()),
-			},
-			{
-				name:      "before release for pro user subscribed before december 14th",
-				createdAt: time.Date(2022, 9, 5, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2023, 1, 15, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2023, 1, 5, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2023, 2, 4, 23, 59, 59, 59, now.Location()),
-				pro:       true,
-			},
-			{
-				name:      "after release for community user subscribed before december 14th",
-				createdAt: time.Date(2022, 9, 5, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2023, 1, 15, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2023, 1, 5, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2023, 2, 4, 23, 59, 59, 59, now.Location()),
-				pro:       true,
-			},
-			{
-				name:      "pro user subscribed before current day",
-				createdAt: time.Date(2024, 9, 5, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2025, 1, 15, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2025, 1, 5, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2025, 2, 4, 23, 59, 59, 59, now.Location()),
-				pro:       true,
-			},
-			{
-				name:      "pro user subscribed after current day",
-				createdAt: time.Date(2024, 9, 25, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2025, 1, 15, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2024, 12, 25, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2025, 1, 24, 23, 59, 59, 59, now.Location()),
-				pro:       true,
-			},
-			{
-				name:      "pro user subscribed on 31st Jan",
-				createdAt: time.Date(2025, 1, 31, 0, 0, 0, 0, now.Location()),
-				today:     time.Date(2025, 2, 15, 0, 0, 0, 0, now.Location()),
-				start:     time.Date(2025, 1, 31, 0, 0, 0, 0, now.Location()),
-				end:       time.Date(2025, 2, 28, 23, 59, 59, 59, now.Location()),
-				pro:       true,
-			},
-		}
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				user := &types.User{ID: 1}
-				if test.pro {
-					user.CodyProEnabledAt = &test.createdAt
-				} else {
-					user.CreatedAt = test.createdAt
-				}
-
-				users.GetByIDFunc.SetDefaultReturn(test.user, nil)
-
-				ctx := actor.WithActor(context.Background(), &actor.Actor{UID: user.ID})
-				ctx = withCurrentTimeMock(ctx, test.today)
-
-				startDate, _ := NewUserResolver(ctx, db, user).CodyCurrentPeriodStartDate(ctx)
-				assert.Equal(t, &gqlutil.DateTime{Time: test.start}, startDate, "CodyCurrentPeriodStartDate")
-
-				endDate, _ := NewUserResolver(ctx, db, user).CodyCurrentPeriodEndDate(ctx)
-				assert.Equal(t, &gqlutil.DateTime{Time: test.end}, endDate, "CodyCurrentPeriodEndDate")
 			})
 		}
 	})

--- a/internal/cody/BUILD.bazel
+++ b/internal/cody/BUILD.bazel
@@ -3,7 +3,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "cody",
-    srcs = ["feature_flag.go"],
+    srcs = [
+        "feature_flag.go",
+        "subscription.go",
+        "utils.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/cody",
     visibility = ["//:__subpackages__"],
     deps = [
@@ -17,6 +21,8 @@ go_library(
         "//internal/featureflag",
         "//internal/licensing",
         "//internal/rbac",
+        "//internal/ssc",
+        "//internal/types",
         "//lib/errors",
         "@com_github_sourcegraph_log//:log",
     ],
@@ -24,17 +30,25 @@ go_library(
 
 go_test(
     name = "cody_test",
-    srcs = ["feature_flag_test.go"],
+    srcs = [
+        "feature_flag_test.go",
+        "subscription_test.go",
+        "utils_test.go",
+    ],
     embed = [":cody"],
     deps = [
+        "//cmd/frontend/envvar",
         "//internal/actor",
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbmocks",
+        "//internal/extsvc",
         "//internal/featureflag",
         "//internal/licensing",
         "//internal/rbac/types",
+        "//internal/ssc",
         "//internal/types",
         "//schema",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/internal/cody/subscription.go
+++ b/internal/cody/subscription.go
@@ -1,0 +1,147 @@
+package cody
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/ssc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+const USE_SSC_FEATURE_FLAG = "use-ssc-for-cody-subscription"
+
+type UserSubscriptionPlan string
+
+const (
+	UserSubscriptionPlanFree UserSubscriptionPlan = "free"
+	UserSubscriptionPlanPro  UserSubscriptionPlan = "pro"
+)
+
+type UserSubscription struct {
+	// Status is the current status of the subscription. "pending" means the user has no Cody Pro subscription.
+	// "pending" subscription will be removed post Feb 15, 2024. It is required to support users who have opted for
+	// Cody Pro Trial on dotcom.
+	Status ssc.SubscriptionStatus
+	// Plan is the plan the user is subscribed to. "free" or "pro".
+	Plan UserSubscriptionPlan
+	// ApplyProRateLimits is true if the user has a valid subscription status.
+	ApplyProRateLimits bool
+	// CurrentPeriodStartAt is the start date of the current billing cycle.
+	CurrentPeriodStartAt time.Time
+	// CurrentPeriodEndAt is the end date of the current billing cycle.
+	CurrentPeriodEndAt time.Time
+}
+
+// consolidateSubscriptionDetails consolidates the subscription details from dotcom and SSC.
+// Post Feb 15, 2024, this function will be removed and the logic will be simplified to us the SSC info only.
+func consolidateSubscriptionDetails(ctx context.Context, user types.User, subscription *ssc.Subscription) (*UserSubscription, error) {
+	now := currentTimeFromCtx(ctx)
+	febReleaseDate := time.Date(2024, 02, 14, 23, 59, 59, 59, now.Location())
+	isAfterFebReleaseDate := now.After(febReleaseDate)
+
+	// The user has put in their cc and signed up for Cody Pro on SSC
+	if subscription != nil {
+		currentPeriodStart, err := time.ParseInLocation(time.RFC3339, subscription.CurrentPeriodStart, now.Location())
+		if err != nil {
+			return nil, err
+		}
+
+		currentPeriodEnd, err := time.ParseInLocation(time.RFC3339, subscription.CurrentPeriodEnd, now.Location())
+		if err != nil {
+			return nil, err
+		}
+
+		applyProRateLimits := subscription.Status == ssc.SubscriptionStatusActive || subscription.Status == ssc.SubscriptionStatusPastDue || subscription.Status == ssc.SubscriptionStatusTrialing
+
+		return &UserSubscription{
+			Status:               subscription.Status,
+			Plan:                 UserSubscriptionPlanPro,
+			ApplyProRateLimits:   applyProRateLimits,
+			CurrentPeriodStartAt: currentPeriodStart,
+			CurrentPeriodEndAt:   currentPeriodEnd,
+		}, nil
+	}
+
+	currentPeriodStartAt, currentPeriodEndAt := PreSSCReleaseCurrentPeriodDateRange(ctx, user)
+
+	// after the release, all the users will be on the free plan if they have no subscription on SSC
+	if isAfterFebReleaseDate || user.CodyProEnabledAt == nil {
+		return &UserSubscription{
+			Status:               ssc.SubscriptionStatusPending,
+			Plan:                 UserSubscriptionPlanFree,
+			ApplyProRateLimits:   false,
+			CurrentPeriodStartAt: currentPeriodStartAt,
+			CurrentPeriodEndAt:   currentPeriodEndAt,
+		}, nil
+	}
+
+	// NOTE: The following code is only temporary, and will be removed after Feb 15 2024.
+	// After the release, the only source of truth for the subscription details will be SSC.
+	// This will also allow us the remove the "pending" status from the SubscriptionStatus enum.
+
+	// currentPeriodEndAt should not be after the release date for pro opted users without SSC subscription
+	if currentPeriodEndAt.After(febReleaseDate) {
+		currentPeriodEndAt = febReleaseDate
+	}
+
+	return &UserSubscription{
+		Status:               ssc.SubscriptionStatusPending,
+		Plan:                 UserSubscriptionPlanPro,
+		ApplyProRateLimits:   true,
+		CurrentPeriodStartAt: currentPeriodStartAt,
+		CurrentPeriodEndAt:   currentPeriodEndAt,
+	}, nil
+}
+
+// getSAMSAccountIDForUser returns the user's SAMS account ID from users_external_accounts table.
+func getSAMSAccountIDForUser(ctx context.Context, db database.DB, user types.User) (string, error) {
+	// TODO: make service_id configurable between accounts.sourcegraph.com and accounts.sgdev.org using a feature flag for testing.
+	accounts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
+		UserID:      user.ID,
+		ServiceType: "openidconnect",
+		ServiceID:   "https://accounts.sourcegraph.com",
+		LimitOffset: &database.LimitOffset{
+			Limit: 1,
+		},
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "error while fetching user's external account")
+	}
+
+	if len(accounts) > 0 {
+		return accounts[0].AccountID, nil
+	}
+
+	return "", nil
+}
+
+type SSCClient interface {
+	FetchSubscriptionBySAMSAccountID(samsAccountID string) (*ssc.Subscription, error)
+}
+
+func getSubscriptionForUser(ctx context.Context, db database.DB, sscClient SSCClient, user types.User) (*UserSubscription, error) {
+	samsAccountID, err := getSAMSAccountIDForUser(ctx, db, user)
+	if err != nil {
+		return nil, err
+	}
+
+	var subscription *ssc.Subscription
+
+	// Fetch subscription from SSC only if the feature flag is enabled and the user has a SAMS account ID
+	if samsAccountID != "" && featureflag.FromContext(ctx).GetBoolOr(USE_SSC_FEATURE_FLAG, false) {
+		subscription, err = sscClient.FetchSubscriptionBySAMSAccountID(samsAccountID)
+		if err != nil {
+			return nil, errors.Wrap(err, "error while fetching user subscription from SSC")
+		}
+	}
+
+	return consolidateSubscriptionDetails(ctx, user, subscription)
+}
+
+// SubscriptionForUser returns the user's Cody subscription details.
+func SubscriptionForUser(ctx context.Context, db database.DB, user types.User) (*UserSubscription, error) {
+	return getSubscriptionForUser(ctx, db, ssc.NewClient(), user)
+}

--- a/internal/cody/subscription_test.go
+++ b/internal/cody/subscription_test.go
@@ -1,0 +1,307 @@
+package cody
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+	"github.com/sourcegraph/sourcegraph/internal/ssc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockSSCClient struct {
+	t                     *testing.T
+	expectedSAMSAccountID *string
+	mockSSCSubscription   *ssc.Subscription
+	shouldBeCalled        bool
+	Called                bool
+}
+
+func (m mockSSCClient) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*ssc.Subscription, error) {
+	if !m.shouldBeCalled {
+		m.t.Error("FetchSubscriptionBySAMSAccountID should not have be called")
+	}
+	assert.NotNil(m.t, m.expectedSAMSAccountID)
+	assert.Equal(m.t, *m.expectedSAMSAccountID, samsAccountID)
+
+	m.Called = true
+
+	return m.mockSSCSubscription, nil
+}
+
+func toTimePtr(t time.Time) *time.Time {
+	return &t
+}
+
+func TestGetSubscriptionForUser(t *testing.T) {
+	testSAMSAccountID := "123"
+
+	tests := []struct {
+		name                 string
+		user                 types.User
+		today                time.Time
+		mockSSCSubscription  *ssc.Subscription
+		mockSAMSAccountID    *string
+		featureFlagEnabled   bool
+		expectedSubscription UserSubscription
+	}{
+		{
+			name: "free user without SAMS account & SSC subscription",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: nil,
+			},
+			today:               time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: nil,
+			mockSAMSAccountID:   nil,
+			featureFlagEnabled:  true,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusPending,
+				Plan:                 UserSubscriptionPlanFree,
+				ApplyProRateLimits:   false,
+				CurrentPeriodStartAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC),
+			},
+		},
+		{
+			name: "free user with SAMS account without SSC subscription",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: nil,
+			},
+			today:               time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: nil,
+			mockSAMSAccountID:   &testSAMSAccountID,
+			featureFlagEnabled:  true,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusPending,
+				Plan:                 UserSubscriptionPlanFree,
+				ApplyProRateLimits:   false,
+				CurrentPeriodStartAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC),
+			},
+		},
+		{
+			// possible when the user opted for Pro only after the feb release
+			name: "free user with SAMS account & SSC subscription",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: nil,
+			},
+			today: time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: &ssc.Subscription{
+				Status:             ssc.SubscriptionStatusActive,
+				BillingInterval:    ssc.BillingIntervalMonthly,
+				CancelAtPeriodEnd:  false,
+				CurrentPeriodStart: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+				CurrentPeriodEnd:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC).Format(time.RFC3339Nano),
+			},
+			mockSAMSAccountID:  &testSAMSAccountID,
+			featureFlagEnabled: true,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusActive,
+				Plan:                 UserSubscriptionPlanPro,
+				ApplyProRateLimits:   true,
+				CurrentPeriodStartAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC),
+			},
+		},
+		{
+			// possible when the user opted for Pro only after the feb release
+			name: "free user with SAMS account & SSC subscription but feature flag disabled",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: nil,
+			},
+			today: time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: &ssc.Subscription{
+				Status:             ssc.SubscriptionStatusActive,
+				BillingInterval:    ssc.BillingIntervalMonthly,
+				CancelAtPeriodEnd:  false,
+				CurrentPeriodStart: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+				CurrentPeriodEnd:   time.Date(2025, 1, 31, 23, 59, 59, 59, time.UTC).Format(time.RFC3339Nano),
+			},
+			mockSAMSAccountID:  &testSAMSAccountID,
+			featureFlagEnabled: false,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusPending,
+				Plan:                 UserSubscriptionPlanFree,
+				ApplyProRateLimits:   false,
+				CurrentPeriodStartAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC),
+			},
+		},
+		{
+			name: "pro user without SAMS account & SSC subscription before release",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: toTimePtr(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			today:               time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: nil,
+			mockSAMSAccountID:   nil,
+			featureFlagEnabled:  true,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusPending,
+				Plan:                 UserSubscriptionPlanPro,
+				ApplyProRateLimits:   true,
+				CurrentPeriodStartAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC),
+			},
+		},
+		{
+			name: "pro user without SAMS account & SSC subscription after release",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: toTimePtr(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			today:               time.Date(2024, 2, 16, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: nil,
+			mockSAMSAccountID:   nil,
+			featureFlagEnabled:  true,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusPending,
+				Plan:                 UserSubscriptionPlanFree,
+				ApplyProRateLimits:   false,
+				CurrentPeriodStartAt: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 2, 29, 23, 59, 59, 59, time.UTC),
+			},
+		},
+		{
+			name: "pro user with SAMS account without SSC subscription before release",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: toTimePtr(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			today:               time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: nil,
+			mockSAMSAccountID:   &testSAMSAccountID,
+			featureFlagEnabled:  true,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusPending,
+				Plan:                 UserSubscriptionPlanPro,
+				ApplyProRateLimits:   true,
+				CurrentPeriodStartAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC),
+			},
+		},
+		{
+			name: "pro user with SAMS account without SSC subscription after release",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: toTimePtr(time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			today:               time.Date(2024, 2, 16, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: nil,
+			mockSAMSAccountID:   &testSAMSAccountID,
+			featureFlagEnabled:  true,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusPending,
+				Plan:                 UserSubscriptionPlanFree,
+				ApplyProRateLimits:   false,
+				CurrentPeriodStartAt: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 2, 29, 23, 59, 59, 59, time.UTC),
+			},
+		},
+		{
+			name: "pro user with SAMS account & SSC subscription",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: toTimePtr(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			today: time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: &ssc.Subscription{
+				Status:             ssc.SubscriptionStatusActive,
+				BillingInterval:    ssc.BillingIntervalMonthly,
+				CancelAtPeriodEnd:  false,
+				CurrentPeriodStart: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+				CurrentPeriodEnd:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC).Format(time.RFC3339Nano),
+			},
+			mockSAMSAccountID:  &testSAMSAccountID,
+			featureFlagEnabled: true,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusActive,
+				Plan:                 UserSubscriptionPlanPro,
+				ApplyProRateLimits:   true,
+				CurrentPeriodStartAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC),
+			},
+		},
+		{
+			// possible when the user opted for Pro only after the feb release
+			name: "pro user with SAMS account & SSC subscription but feature flag disabled before release",
+			user: types.User{
+				ID:               1,
+				CreatedAt:        time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				CodyProEnabledAt: toTimePtr(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+			},
+			today: time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+			mockSSCSubscription: &ssc.Subscription{
+				Status:             ssc.SubscriptionStatusActive,
+				BillingInterval:    ssc.BillingIntervalMonthly,
+				CancelAtPeriodEnd:  false,
+				CurrentPeriodStart: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+				CurrentPeriodEnd:   time.Date(2025, 1, 31, 23, 59, 59, 59, time.UTC).Format(time.RFC3339Nano),
+			},
+			mockSAMSAccountID:  &testSAMSAccountID,
+			featureFlagEnabled: false,
+			expectedSubscription: UserSubscription{
+				Status:               ssc.SubscriptionStatusPending,
+				Plan:                 UserSubscriptionPlanPro,
+				ApplyProRateLimits:   true,
+				CurrentPeriodStartAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				CurrentPeriodEndAt:   time.Date(2024, 1, 31, 23, 59, 59, 59, time.UTC),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := actor.WithActor(context.Background(), actor.FromUser(test.user.ID))
+			ctx = withCurrentTimeMock(ctx, test.today)
+			flags := map[string]bool{USE_SSC_FEATURE_FLAG: test.featureFlagEnabled}
+			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
+
+			db := dbmocks.NewMockDB()
+			userExternalAccount := dbmocks.NewMockUserExternalAccountsStore()
+			userExternalAccount.ListFunc.SetDefaultHook(func(ctx context.Context, opts database.ExternalAccountsListOptions) ([]*extsvc.Account, error) {
+				assert.Equal(t, test.user.ID, opts.UserID)
+
+				if test.mockSAMSAccountID != nil {
+					return []*extsvc.Account{{AccountSpec: extsvc.AccountSpec{AccountID: *test.mockSAMSAccountID}}}, nil
+				}
+
+				return []*extsvc.Account{}, nil
+			})
+			db.UserExternalAccountsFunc.SetDefaultReturn(userExternalAccount)
+
+			sscClient := mockSSCClient{
+				t:                     t,
+				expectedSAMSAccountID: test.mockSAMSAccountID,
+				mockSSCSubscription:   test.mockSSCSubscription,
+				shouldBeCalled:        test.featureFlagEnabled && test.mockSAMSAccountID != nil,
+			}
+
+			actualSubscription, err := getSubscriptionForUser(ctx, db, sscClient, test.user)
+
+			assert.Nil(t, err)
+			assert.NotNil(t, actualSubscription)
+			assert.Equal(t, test.expectedSubscription, *actualSubscription)
+		})
+	}
+}

--- a/internal/cody/utils.go
+++ b/internal/cody/utils.go
@@ -1,0 +1,69 @@
+package cody
+
+import (
+	"context"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"time"
+)
+
+type currentTimeCtxKey int
+
+const mockCurrentTimeKey currentTimeCtxKey = iota
+
+func currentTimeFromCtx(ctx context.Context) time.Time {
+	t, ok := ctx.Value(mockCurrentTimeKey).(*time.Time)
+	if !ok || t == nil {
+		return time.Now()
+	}
+	return *t
+}
+
+func withCurrentTimeMock(ctx context.Context, t time.Time) context.Context {
+	return context.WithValue(ctx, mockCurrentTimeKey, &t)
+}
+
+func PreSSCReleaseCurrentPeriodDateRange(ctx context.Context, user types.User) (time.Time, time.Time) {
+	// to allow mocking current time during tests
+	currentDate := currentTimeFromCtx(ctx)
+
+	subscriptionStartDate := user.CreatedAt
+	gaReleaseDate := time.Date(2023, 12, 14, 0, 0, 0, 0, subscriptionStartDate.Location())
+
+	if !currentDate.Before(gaReleaseDate) && subscriptionStartDate.Before(gaReleaseDate) {
+		subscriptionStartDate = gaReleaseDate
+	}
+
+	codyProEnabledAt := user.CodyProEnabledAt
+	if codyProEnabledAt != nil {
+		subscriptionStartDate = *codyProEnabledAt
+	}
+
+	targetDay := subscriptionStartDate.Day()
+	startDayOfTheMonth := targetDay
+	endDayOfTheMonth := targetDay - 1
+	startMonth := currentDate
+	endMonth := currentDate
+
+	if currentDate.Day() < targetDay {
+		// Set to target day of the previous month
+		startMonth = currentDate.AddDate(0, -1, 0)
+	} else {
+		// Set to target day of the next month
+		endMonth = currentDate.AddDate(0, 1, 0)
+	}
+
+	daysInStartingMonth := time.Date(startMonth.Year(), startMonth.Month()+1, 0, 0, 0, 0, 0, startMonth.Location()).Day()
+	if startDayOfTheMonth > daysInStartingMonth {
+		startDayOfTheMonth = daysInStartingMonth
+	}
+
+	daysInEndingMonth := time.Date(endMonth.Year(), endMonth.Month()+1, 0, 0, 0, 0, 0, endMonth.Location()).Day()
+	if endDayOfTheMonth > daysInEndingMonth {
+		endDayOfTheMonth = daysInEndingMonth
+	}
+
+	startDate := time.Date(startMonth.Year(), startMonth.Month(), startDayOfTheMonth, 0, 0, 0, 0, startMonth.Location())
+	endDate := time.Date(endMonth.Year(), endMonth.Month(), endDayOfTheMonth, 23, 59, 59, 59, endMonth.Location())
+
+	return startDate, endDate
+}

--- a/internal/cody/utils_test.go
+++ b/internal/cody/utils_test.go
@@ -1,0 +1,133 @@
+package cody
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestPreSSCReleaseCurrentPeriodDateRange(t *testing.T) {
+	db := dbmocks.NewMockDB()
+
+	orig := envvar.SourcegraphDotComMode()
+	envvar.MockSourcegraphDotComMode(true)
+	t.Cleanup(func() {
+		envvar.MockSourcegraphDotComMode(orig)
+	})
+
+	users := dbmocks.NewMockUserStore()
+	db.UsersFunc.SetDefaultReturn(users)
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		user      *types.User
+		today     time.Time
+		createdAt time.Time
+		pro       bool
+		start     time.Time
+		end       time.Time
+	}{
+		{
+			name:      "before release for community user created before december 14th",
+			createdAt: time.Date(2023, 10, 5, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2023, 12, 1, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2023, 11, 5, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2023, 12, 4, 23, 59, 59, 59, now.Location()),
+		},
+		{
+			name:      "after release for community user created before december 14th",
+			createdAt: time.Date(2023, 11, 5, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2023, 12, 25, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2023, 12, 14, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2024, 1, 13, 23, 59, 59, 59, now.Location()),
+		},
+		{
+			name:      "community user created before current day",
+			createdAt: time.Date(2024, 9, 5, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2025, 1, 15, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2025, 1, 5, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2025, 2, 4, 23, 59, 59, 59, now.Location()),
+		},
+		{
+			name:      "community user created after current day",
+			createdAt: time.Date(2024, 9, 25, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2025, 1, 15, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2024, 12, 25, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2025, 1, 24, 23, 59, 59, 59, now.Location()),
+		},
+		{
+			name:      "community user created on 31st Jan",
+			createdAt: time.Date(2025, 1, 31, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2025, 2, 15, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2025, 1, 31, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2025, 2, 28, 23, 59, 59, 59, now.Location()),
+		},
+		{
+			name:      "before release for pro user subscribed before december 14th",
+			createdAt: time.Date(2022, 9, 5, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2023, 1, 15, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2023, 1, 5, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2023, 2, 4, 23, 59, 59, 59, now.Location()),
+			pro:       true,
+		},
+		{
+			name:      "after release for community user subscribed before december 14th",
+			createdAt: time.Date(2022, 9, 5, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2023, 1, 15, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2023, 1, 5, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2023, 2, 4, 23, 59, 59, 59, now.Location()),
+			pro:       true,
+		},
+		{
+			name:      "pro user subscribed before current day",
+			createdAt: time.Date(2024, 9, 5, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2025, 1, 15, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2025, 1, 5, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2025, 2, 4, 23, 59, 59, 59, now.Location()),
+			pro:       true,
+		},
+		{
+			name:      "pro user subscribed after current day",
+			createdAt: time.Date(2024, 9, 25, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2025, 1, 15, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2024, 12, 25, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2025, 1, 24, 23, 59, 59, 59, now.Location()),
+			pro:       true,
+		},
+		{
+			name:      "pro user subscribed on 31st Jan",
+			createdAt: time.Date(2025, 1, 31, 0, 0, 0, 0, now.Location()),
+			today:     time.Date(2025, 2, 15, 0, 0, 0, 0, now.Location()),
+			start:     time.Date(2025, 1, 31, 0, 0, 0, 0, now.Location()),
+			end:       time.Date(2025, 2, 28, 23, 59, 59, 59, now.Location()),
+			pro:       true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			user := &types.User{ID: 1}
+			if test.pro {
+				user.CodyProEnabledAt = &test.createdAt
+			} else {
+				user.CreatedAt = test.createdAt
+			}
+
+			users.GetByIDFunc.SetDefaultReturn(test.user, nil)
+
+			ctx := actor.WithActor(context.Background(), &actor.Actor{UID: user.ID})
+			ctx = withCurrentTimeMock(ctx, test.today)
+
+			startDate, endDate := PreSSCReleaseCurrentPeriodDateRange(ctx, *user)
+			assert.Equal(t, test.start, startDate, "startDate")
+			assert.Equal(t, test.end, endDate, "endDate")
+		})
+	}
+}

--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "ssc",
+    srcs = [
+        "ssc.go",
+        "types.go",
+    ],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/ssc",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/conf",
+        "//internal/httpcli",
+        "//lib/errors",
+    ],
+)

--- a/internal/ssc/ssc.go
+++ b/internal/ssc/ssc.go
@@ -11,23 +11,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-type Client struct {
-	baseUrl     string
+// Client is the interface for making requests to the Self-Service Cody backend.
+// This uses a REST API exposed from the service, and not the GraphQL API (which is
+// instead used for user-facing frontend queries.)
+type Client interface {
+	FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Subscription, error)
+}
+
+type SSCClient struct {
+	baseURL     string
 	secretToken string
 }
 
-// FetchSubscriptionBySAMSAccountID returns the user's Cody subscription for the sams_account_id.
-// It returns nil, nil if the user does not have a Cody Pro subscription.
-func (c *Client) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Subscription, error) {
-	if c.baseUrl == "" {
-		return nil, errors.New("SSC base url is not set")
-	}
-
-	if c.secretToken == "" {
-		return nil, errors.New("SSC secret token is not set")
-	}
-
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/svc/subscription/%s", c.baseUrl, samsAccountID), nil)
+func (c *SSCClient) sendRequest(method string, url string, body *Subscription) (code *int, err error) {
+	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -41,33 +38,56 @@ func (c *Client) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Subscr
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
+		bytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return &resp.StatusCode, err
+		}
+
+		err = json.Unmarshal(bytes, body)
 		if err != nil {
 			return nil, err
 		}
+	}
 
-		var subscription Subscription
-		err = json.Unmarshal(body, &subscription)
-		if err != nil {
-			return nil, err
-		}
+	return &resp.StatusCode, nil
 
+}
+
+// FetchSubscriptionBySAMSAccountID returns the user's Cody subscription for the sams_account_id.
+// It returns nil, nil if the user does not have a Cody Pro subscription.
+func (c *SSCClient) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Subscription, error) {
+	if c.baseURL == "" {
+		return nil, errors.New("SSC base url is not set")
+	}
+
+	if c.secretToken == "" {
+		return nil, errors.New("SSC secret token is not set")
+	}
+
+	var subscription Subscription
+
+	code, err := c.sendRequest(http.MethodGet, fmt.Sprintf("%s/rest/svc/subscription/%s", c.baseURL, samsAccountID), &subscription)
+	if err != nil {
+		return nil, err
+	}
+
+	if *code == http.StatusOK {
 		return &subscription, nil
 	}
 
 	// 204 response indicates that the user does not have a Cody Pro subscription
-	if resp.StatusCode == http.StatusNoContent {
+	if *code == http.StatusNoContent {
 		return nil, nil
 	}
 
-	return nil, errors.Errorf("unexpected status code %d while fetching user subscription from SSC", resp.StatusCode)
+	return nil, errors.Errorf("unexpected status code %d while fetching user subscription from SSC", *code)
 }
 
-func NewClient() *Client {
+func NewClient() *SSCClient {
 	sgconf := conf.Get().SiteConfig()
 
-	return &Client{
-		baseUrl:     sgconf.SscApiBaseUrl,
+	return &SSCClient{
+		baseURL:     sgconf.SscApiBaseUrl,
 		secretToken: sgconf.SscApiSecret,
 	}
 }

--- a/internal/ssc/ssc.go
+++ b/internal/ssc/ssc.go
@@ -1,0 +1,73 @@
+package ssc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+type Client struct {
+	baseUrl     string
+	secretToken string
+}
+
+// FetchSubscriptionBySAMSAccountID returns the user's Cody subscription for the sams_account_id.
+// It returns nil, nil if the user does not have a Cody Pro subscription.
+func (c *Client) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Subscription, error) {
+	if c.baseUrl == "" {
+		return nil, errors.New("SSC base url is not set")
+	}
+
+	if c.secretToken == "" {
+		return nil, errors.New("SSC secret token is not set")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/svc/subscription/%s", c.baseUrl, samsAccountID), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.secretToken))
+
+	resp, err := httpcli.UncachedExternalDoer.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		var subscription Subscription
+		err = json.Unmarshal(body, &subscription)
+		if err != nil {
+			return nil, err
+		}
+
+		return &subscription, nil
+	}
+
+	// 204 response indicates that the user does not have a Cody Pro subscription
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+
+	return nil, errors.Errorf("unexpected status code %d while fetching user subscription from SSC", resp.StatusCode)
+}
+
+func NewClient() *Client {
+	sgconf := conf.Get().SiteConfig()
+
+	return &Client{
+		baseUrl:     sgconf.SscApiBaseUrl,
+		secretToken: sgconf.SscApiSecret,
+	}
+}

--- a/internal/ssc/types.go
+++ b/internal/ssc/types.go
@@ -1,0 +1,39 @@
+package ssc
+
+type BillingInterval string
+
+const (
+	BillingIntervalDaily   BillingInterval = "daily"
+	BillingIntervalMonthly BillingInterval = "monthly"
+	BillingIntervalYearly  BillingInterval = "yearly"
+)
+
+type SubscriptionStatus string
+
+const (
+	SubscriptionStatusActive   SubscriptionStatus = "active"
+	SubscriptionStatusPastDue  SubscriptionStatus = "past_due"
+	SubscriptionStatusUnpaid   SubscriptionStatus = "unpaid"
+	SubscriptionStatusCanceled SubscriptionStatus = "canceled"
+	SubscriptionStatusTrialing SubscriptionStatus = "trialing"
+	SubscriptionStatusOther    SubscriptionStatus = "other"
+	// NOTE: The "pending" status is only temporary, and will be removed after Feb 15 2024.
+	// This is to support the pre-release state where a user has opted for a free Pro trial
+	// but has not put in their cc in SSC yet.
+	SubscriptionStatusPending SubscriptionStatus = "pending"
+)
+
+type Subscription struct {
+	// Status is the current status of the subscription, e.g. "active" or "canceled".
+	Status          SubscriptionStatus `json:"status"`
+	BillingInterval BillingInterval    `json:"billingInterval"`
+
+	// CancelAtPeriodEnd flags whether or not a subscription will automatically cancel at the end
+	// of the current billing cycle, or if it will renew.
+	CancelAtPeriodEnd bool `json:"cancelAtPeriodEnd"`
+
+	// Billing cycle anchors are times represented as an ISO-8601 string.
+	// e.g. "2024-01-17T13:18:05−07:00"
+	CurrentPeriodStart string `json:"currentPeriodStart"`
+	CurrentPeriodEnd   string `json:"currentPeriodEnd"`
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2900,6 +2900,10 @@ type SiteConfiguration struct {
 	SearchLargeFiles []string `json:"search.largeFiles,omitempty"`
 	// SearchLimits description: Limits that search applies for number of repositories searched and timeouts.
 	SearchLimits *SearchLimits `json:"search.limits,omitempty"`
+	// SscApiBaseUrl description: The base URL of the Self-Serve Cody API.
+	SscApiBaseUrl string `json:"ssc.apiBaseUrl,omitempty"`
+	// SscApiSecret description: The Bearer token for the Self-Serve Cody API.
+	SscApiSecret string `json:"ssc.apiSecret,omitempty"`
 	// SyntaxHighlighting description: Syntax highlighting configuration
 	SyntaxHighlighting *SyntaxHighlighting `json:"syntaxHighlighting,omitempty"`
 	// UpdateChannel description: The channel on which to automatically check for Sourcegraph updates.
@@ -3072,6 +3076,8 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "search.index.symbols.enabled")
 	delete(m, "search.largeFiles")
 	delete(m, "search.limits")
+	delete(m, "ssc.apiBaseUrl")
+	delete(m, "ssc.apiSecret")
 	delete(m, "syntaxHighlighting")
 	delete(m, "update.channel")
 	delete(m, "webhook.logging")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -7,6 +7,16 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
+    "ssc.apiBaseUrl": {
+      "type": "string",
+      "default": "https://accounts.sourcegraph.com/cody/api",
+      "description": "The base URL of the Self-Serve Cody API."
+    },
+    "ssc.apiSecret": {
+      "type": "string",
+      "default": "********",
+      "description": "The Bearer token for the Self-Serve Cody API."
+    },
     "search.index.symbols.enabled": {
       "description": "Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.",
       "type": "boolean",


### PR DESCRIPTION
This PR is the first of many to fetch Cody's subscription data from SSC (Self-Serve Cody) into dotcom and integrate at the required places. This PR only takes care of the "fetching" part. 

Right now, we know if the user has opted for a pro trial by looking at the `users.cody_pro_enabled_at` column in the dotcom database. 

From Feb 1st, tentatively, we will be allowing users to put in their credit cards on SSC, which will create a `trialling` subscription for them on SSC. We will need the combined info of dotcom and SSC to support the UI.

After the Feb 15th release, SSC will be the only source of truth for the user's Cody subscription. Part of the code, added as part of this PR, will be removed after the release.

Cody Clients and Cody Management page on dotcom uses dotcom's API to know about the user's Cody subscription info. To support that, we need to fetch subscription info from SSC into dotcom.

**As part of this PR, we are:**
1. Introducing SSC client in `/internal/ssc`, which allows us to fetch the user's Cody Subscription from SSC.
2. Consolidating data from dotcom & SSC to figure out the user's subscription in `internal/cody/subscription`.
3. Make fetching info from SSC controlled by a feature flag: `use-ssc-for-cody-subscription`.
4. Updating `user.codyProEnabled` in graphql API to use `internal/cody/subscription`, which integrates it with subscription data from SSC.
5. Removing `user.codyProEnabledAt` from graphql API. It is a redundant field and not used by any Cody Clients or the web. Confirmed by this [search](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/*+codyProEnabledAt&patternType=standard&sm=1) and double checking locally.
6. Adding unit tests.

**Next steps as part of follow-up PRs:**
1. Expose subscription status info from the graphql API. 
2. Update rate-limit logic at various places to use `interna/cody/subscription` for the user's SSC subscription info rather than dotcom's DB.

The above 2 next steps will make the PLG flow functional from the dotcom side. As a follow-up, we will also work on creating a whole new actor source for Cody Gateway to reach SSC for rate limit info directly.

## Test plan

Unit tests are added as part of this PR.

**Manual Testing Plan**
1. Set up and run SAMS locally.
4. Integrate SAMS as an openidconnect auth provider with dotcom locally. 
5. Create a user using the SAMS auth provider.
6. Enable feature flag `use-ssc-for-cody-subscription` from site admin.
7. Make a graphql API [request](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%7B%5Cn%20%20currentUser%20%7B%5Cn%20%20%20%20codyProEnabled%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D) to confirm `false`. 
8. Visit `localhost:9992/cody` and go through the subscription flow to sign up for Cody Pro.
9. Make a graphql API [request](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%7B%5Cn%20%20currentUser%20%7B%5Cn%20%20%20%20codyProEnabled%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D) again to confirm `true`. 