### PR TITLE
Search Filters: Add apply filters button to the new search filters

### DIFF
--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -62,3 +62,11 @@
         display: none;
     }
 }
+
+.move-icon {
+    --icon-color: var(--body-color);
+
+    margin-left: 0.25rem;
+    fill: none !important;
+    transform: rotateX(-180deg);
+}

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -1,4 +1,5 @@
 .scroll-wrapper {
+    position: relative;
     height: 100%;
     overflow: auto;
     display: flex;
@@ -40,6 +41,24 @@
     }
 }
 
-.footer {
+.footer-content {
     margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    position: sticky;
+    bottom: 0;
+    background-color: var(--code-bg);
+    border-top: 1px solid var(--border-color);
+}
+
+.actions {
+    margin: 0.5rem 0.5rem 0 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    &:empty {
+        display: none;
+    }
 }

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -53,10 +53,10 @@
 }
 
 .actions {
-    margin: 0.5rem 0.5rem 0 0.5rem;
+    margin: 0.75rem 0.5rem 0 0.75rem;
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: 0.5rem;
 
     &:empty {
         display: none;

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -24,7 +24,7 @@ import {
 } from './components/filter-type-list/FilterTypeList'
 import { FiltersDocFooter } from './components/filters-doc-footer/FiltersDocFooter'
 import { ArrowBendIcon } from './components/Icons'
-import { useUrlFilters } from './hooks'
+import { mergeQueryAndFilters, useUrlFilters } from './hooks'
 import { SearchFilterType } from './types'
 
 import styles from './NewSearchFilters.module.scss'
@@ -75,9 +75,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
     }
 
     const handleApplyButtonFilters = (): void => {
-        const filterQuery = selectedFilters.map(f => f.value).join(' ')
-
-        onQueryChange(`${query} ${filterQuery}`.trim())
+        onQueryChange(mergeQueryAndFilters(query, selectedFilters))
     }
 
     return (

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -154,8 +154,8 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
             <div className={styles.footerContent}>
                 <footer className={styles.actions}>
                     {selectedFilters.length > 0 && (
-                        <Button variant="primary" onClick={handleApplyButtonFilters}>
-                            Apply filters to the query
+                        <Button variant="secondary" outline={true} onClick={handleApplyButtonFilters}>
+                            Move filters to the query
                         </Button>
                     )}
 

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -6,7 +6,7 @@ import { scanSearchQuery, succeedScan } from '@sourcegraph/shared/src/search/que
 import type { Filter as QueryFilter } from '@sourcegraph/shared/src/search/query/token'
 import { omitFilter, updateFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
-import { Button } from '@sourcegraph/wildcard'
+import { Button, Icon, Tooltip } from '@sourcegraph/wildcard'
 
 import {
     authorFilter,
@@ -23,6 +23,7 @@ import {
     toSearchSyntaxTypeFilter,
 } from './components/filter-type-list/FilterTypeList'
 import { FiltersDocFooter } from './components/filters-doc-footer/FiltersDocFooter'
+import { ArrowBendIcon } from './components/Icons'
 import { useUrlFilters } from './hooks'
 import { SearchFilterType } from './types'
 
@@ -154,9 +155,15 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
             <div className={styles.footerContent}>
                 <footer className={styles.actions}>
                     {selectedFilters.length > 0 && (
-                        <Button variant="secondary" outline={true} onClick={handleApplyButtonFilters}>
-                            Move filters to the query
-                        </Button>
+                        <Tooltip
+                            placement="right"
+                            content="Moves all your applied filters from this panel into the query bar at the top and resets selected options from this panel."
+                        >
+                            <Button variant="secondary" outline={true} onClick={handleApplyButtonFilters}>
+                                Move filters to the query
+                                <Icon as={ArrowBendIcon} aria-hidden={true} className={styles.moveIcon} />
+                            </Button>
+                        </Tooltip>
                     )}
 
                     {children}

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -6,6 +6,7 @@ import { scanSearchQuery, succeedScan } from '@sourcegraph/shared/src/search/que
 import type { Filter as QueryFilter } from '@sourcegraph/shared/src/search/query/token'
 import { omitFilter, updateFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
+import { Button } from '@sourcegraph/wildcard'
 
 import {
     authorFilter,
@@ -70,6 +71,12 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
                 onQueryChange(updateFilter(newQuery, FilterType.type, toSearchSyntaxTypeFilter(filterType)))
             }
         }
+    }
+
+    const handleApplyButtonFilters = (): void => {
+        const filterQuery = selectedFilters.map(f => f.value).join(' ')
+
+        onQueryChange(`${query} ${filterQuery}`.trim())
     }
 
     return (
@@ -144,9 +151,19 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
                 onSelectedFilterChange={setSelectedFilters}
             />
 
-            <FiltersDocFooter className={styles.footer} />
+            <div className={styles.footerContent}>
+                <footer className={styles.actions}>
+                    {selectedFilters.length > 0 && (
+                        <Button variant="primary" onClick={handleApplyButtonFilters}>
+                            Apply filters to the query
+                        </Button>
+                    )}
 
-            {children}
+                    {children}
+                </footer>
+
+                <FiltersDocFooter />
+            </div>
         </div>
     )
 }

--- a/client/branded/src/search-ui/results/filters/components/Icons.tsx
+++ b/client/branded/src/search-ui/results/filters/components/Icons.tsx
@@ -49,3 +49,43 @@ export const LinkShareIcon: FC<CustomIconProps> = props => (
         />
     </svg>
 )
+
+export const ArrowBendIcon: FC<CustomIconProps> = props => (
+    <svg viewBox="0 0 14 14" height="14" width="14" fill="none" {...props}>
+        <path
+            id="Vector"
+            stroke="var(--icon-color)"
+            strokeWidth="1"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m11.5 10.5 -3 3 -3 -3"
+        />
+        <path
+            id="Vector_2"
+            stroke="var(--icon-color)"
+            strokeWidth="1"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M2.5 0.5h2c1.06087 0 2.07828 0.421427 2.82843 1.17157C8.07857 2.42172 8.5 3.43913 8.5 4.5v9"
+        />
+    </svg>
+)
+
+export const DeleteIcon: FC<CustomIconProps> = props => (
+    <svg fill="none" viewBox="0 0 14 14" height="14" width="14" {...props}>
+        <path
+            stroke="var(--icon-color)"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m13.5 0.5 -13 13"
+            strokeWidth="1"
+        ></path>
+        <path
+            stroke="var(--icon-color)"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m0.5 0.5 13 13"
+            strokeWidth="1"
+        ></path>
+    </svg>
+)

--- a/client/branded/src/search-ui/results/filters/components/Icons.tsx
+++ b/client/branded/src/search-ui/results/filters/components/Icons.tsx
@@ -79,13 +79,13 @@ export const DeleteIcon: FC<CustomIconProps> = props => (
             strokeLinejoin="round"
             d="m13.5 0.5 -13 13"
             strokeWidth="1"
-        ></path>
+        />
         <path
             stroke="var(--icon-color)"
             strokeLinecap="round"
             strokeLinejoin="round"
             d="m0.5 0.5 13 13"
             strokeWidth="1"
-        ></path>
+        />
     </svg>
 )

--- a/client/branded/src/search-ui/results/filters/components/filters-doc-footer/FiltersDocFooter.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/filters-doc-footer/FiltersDocFooter.module.scss
@@ -1,6 +1,5 @@
 .footer {
     padding: 1rem 0.75rem;
-    border-top: 1px solid var(--border-color);
 }
 
 .link {

--- a/client/branded/src/search-ui/results/filters/hooks.ts
+++ b/client/branded/src/search-ui/results/filters/hooks.ts
@@ -1,3 +1,5 @@
+import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
+import { Keyword } from '@sourcegraph/shared/src/search/query/token'
 import { Filter } from '@sourcegraph/shared/src/search/stream'
 import { useSyncedWithURLState } from '@sourcegraph/wildcard'
 
@@ -27,4 +29,26 @@ export function useUrlFilters(): [URLQueryFilter[], (newFilters: URLQueryFilter[
     })
 
     return [filterQuery, setFilterQuery]
+}
+
+export function mergeQueryAndFilters(query: string, filters: URLQueryFilter[]) {
+    const tokens = scanSearchQuery(query)
+
+    // Return original query if it's non-valid query
+    if (tokens.type === 'error') {
+        return query
+    }
+
+    const filterQuery = filters.map(f => f.value).join(' ')
+    const keywords = tokens.term.filter(token => token.type === 'keyword') as Keyword[]
+    const hasAnd = keywords.some(filter => filter.kind === 'and')
+    const hasOr = keywords.some(filter => filter.kind === 'or')
+
+    // Wrap original query with parenthesize if the query has 'or' or 'and'
+    // operators, otherwise simple concatenation may not work for all cases.
+    if (hasOr || hasAnd) {
+        return `(${query}) ${filterQuery}`.trim()
+    }
+
+    return `${query} ${filterQuery}`.trim()
 }

--- a/client/branded/src/search-ui/results/filters/hooks.ts
+++ b/client/branded/src/search-ui/results/filters/hooks.ts
@@ -31,7 +31,7 @@ export function useUrlFilters(): [URLQueryFilter[], (newFilters: URLQueryFilter[
     return [filterQuery, setFilterQuery]
 }
 
-export function mergeQueryAndFilters(query: string, filters: URLQueryFilter[]) {
+export function mergeQueryAndFilters(query: string, filters: URLQueryFilter[]): string {
     const tokens = scanSearchQuery(query)
 
     // Return original query if it's non-valid query

--- a/client/web/src/search/results/SearchResultsCacheProvider.tsx
+++ b/client/web/src/search/results/SearchResultsCacheProvider.tsx
@@ -14,7 +14,7 @@ import { useNavigationType, useLocation } from 'react-router-dom'
 import { merge, of } from 'rxjs'
 import { last, share, tap, throttleTime } from 'rxjs/operators'
 
-import { URLQueryFilter, serializeURLQueryFilters } from '@sourcegraph/branded'
+import { URLQueryFilter, serializeURLQueryFilters, mergeQueryAndFilters } from '@sourcegraph/branded'
 import type { AggregateStreamingSearchResults, StreamSearchOptions } from '@sourcegraph/shared/src/search/stream'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/wildcard'
@@ -87,8 +87,8 @@ export function useCachedSearchResults(props: CachedSearchResultsInput): Aggrega
                 cachedResults.current = { query, options, cache: { ...previousCache, [filterCacheKey]: results } }
             }
 
-            const filterQuery = selectedFilters.map(f => f.value).join(' ')
-            const stream = streamSearch(of(`${query} ${filterQuery}`.trim()), options).pipe(share())
+            const extendQueryWithFilters = mergeQueryAndFilters(query, selectedFilters)
+            const stream = streamSearch(of(extendQueryWithFilters), options).pipe(share())
 
             // If the throttleTime option `trailing` is set, we will return the
             // final value, but it also removes the guarantee that the output events

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.module.scss
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.module.scss
@@ -13,3 +13,11 @@
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
 }
+
+.close-icon {
+    --icon-color: var(--body-color);
+
+    fill: none !important;
+    width: 0.75rem !important;
+    margin-right: 0.25rem;
+}

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.module.scss
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.module.scss
@@ -13,9 +13,3 @@
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
 }
-
-.close-filters {
-    position: sticky;
-    bottom: 0.5rem;
-    margin: 0 0.5rem 0.5rem 0.5rem;
-}

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
@@ -62,7 +62,7 @@ export const SearchFiltersPanel: FC<SearchFiltersPanelProps> = props => {
             onDismiss={() => setFiltersPanel(false)}
         >
             <NewSearchFilters query={query} filters={filters} onQueryChange={onQueryChange}>
-                <Button variant="primary" className={styles.closeFilters} onClick={() => setFiltersPanel(false)}>
+                <Button variant="secondary" onClick={() => setFiltersPanel(false)}>
                     Close filters panel
                 </Button>
             </NewSearchFilters>

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
@@ -62,8 +62,8 @@ export const SearchFiltersPanel: FC<SearchFiltersPanelProps> = props => {
             onDismiss={() => setFiltersPanel(false)}
         >
             <NewSearchFilters query={query} filters={filters} onQueryChange={onQueryChange}>
-                <Button variant="secondary" onClick={() => setFiltersPanel(false)}>
-                    Close filters panel
+                <Button variant="secondary" outline={true} onClick={() => setFiltersPanel(false)}>
+                    Close filters
                 </Button>
             </NewSearchFilters>
         </Modal>

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
@@ -3,8 +3,9 @@ import { FC } from 'react'
 import create from 'zustand'
 
 import { NewSearchFilters, useUrlFilters } from '@sourcegraph/branded'
+import { DeleteIcon } from '@sourcegraph/branded/src/search-ui/results/filters/components/Icons'
 import { Filter } from '@sourcegraph/shared/src/search/stream'
-import { Badge, Button, Modal, Panel, useWindowSize } from '@sourcegraph/wildcard'
+import { Badge, Button, Icon, Modal, Panel, useWindowSize } from '@sourcegraph/wildcard'
 
 import styles from './SearchFiltersPanel.module.scss'
 
@@ -63,6 +64,7 @@ export const SearchFiltersPanel: FC<SearchFiltersPanelProps> = props => {
         >
             <NewSearchFilters query={query} filters={filters} onQueryChange={onQueryChange}>
                 <Button variant="secondary" outline={true} onClick={() => setFiltersPanel(false)}>
+                    <Icon as={DeleteIcon} width={14} height={14} aria-hidden={true} className={styles.closeIcon} />{' '}
                     Close filters
                 </Button>
             </NewSearchFilters>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/59804

Adds "Apply filters to the query" button. 
- You can see it only when you have some selected filters
- As you click it we move all selected filters from the panel to the query and we reset the selected filters in the filter panel (since these filters will be handled by search box query)
- You can go back to prev state with browser history 

| Desktop | Mobile |
| -------- | -------- |
| <img width="1171" alt="Screenshot 2024-01-23 at 13 22 36" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/2d53d05b-61f9-4e64-85d9-18bdfff780cd"> | <img width="1014" alt="Screenshot 2024-01-23 at 13 26 33" src="https://github.com/sourcegraph/sourcegraph/assets/18492575/de5add8d-bd46-423c-8d1c-760c56e7dea3"> |

## Test plan
- Check that this button works as expected
- Check mobile side-panel layout with close filters button 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
