### PR TITLE
truncate commit message in commit view if necessary

### DIFF
--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -21,6 +21,7 @@ import { GitCommitNodeByline } from './GitCommitNodeByline'
 
 import styles from './GitCommitNode.module.scss'
 
+const TRUNCATED_COMMIT_MESSAGE_LENGTH = 240
 export interface GitCommitNodeProps {
     node: GitCommitFields
 
@@ -158,25 +159,30 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
         </div>
     )
 
-    const handleTruncate = () => setTruncateCommitMessage(!truncateCommitMessage)
-    const showCommitMessage = expandCommitMessageBody || showCommitMessageBody
-    const commitContent =
-        truncateCommitMessage && node.body && node.body.length > 240 ? `${node.body.slice(0, 240)}...` : node.body
-    const truncationNeeded = commitContent && commitContent.length > 240
+    const commitMessage = node.body ?? ''
+    const truncationNeeded = commitMessage.length > TRUNCATED_COMMIT_MESSAGE_LENGTH
+    const truncatedCommitMessage =
+        truncateCommitMessage && truncationNeeded
+            ? `${commitMessage.slice(0, TRUNCATED_COMMIT_MESSAGE_LENGTH)}...`
+            : commitMessage
 
-    const commitMessageBody =
-        showCommitMessage && commitContent ? (
-            <div className="w-100">
-                <pre className={styles.messageBody}>
-                    <Linkified input={commitContent} externalURLs={node.externalURLs} />
-                    {truncationNeeded && (
-                        <Button variant="link" size="sm" display="inline" onClick={handleTruncate}>
-                            {truncateCommitMessage ? 'see more' : 'see less'}
-                        </Button>
-                    )}
-                </pre>
-            </div>
-        ) : undefined
+    const commitMessageBody = (
+        <div className="w-100">
+            <pre className={styles.messageBody}>
+                <Linkified input={truncatedCommitMessage} externalURLs={node.externalURLs} />
+                {truncationNeeded && (
+                    <Button
+                        variant="link"
+                        size="sm"
+                        display="inline"
+                        onClick={() => setTruncateCommitMessage(!truncateCommitMessage)}
+                    >
+                        {truncateCommitMessage ? 'see more' : 'see less'}
+                    </Button>
+                )}
+            </pre>
+        </div>
+    )
 
     const bylineElement = (
         <GitCommitNodeByline

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -158,37 +158,28 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
         </div>
     )
 
+    const commitContent = truncatedCommitMessage && node.body ? `${node.body.slice(0, 240)}...` : node.body
+
     const commitMessageBody =
         expandCommitMessageBody || showCommitMessageBody ? (
             <div className="w-100">
-                {truncatedCommitMessage ? (
+                {commitContent && node.body && (
                     <pre className={styles.messageBody}>
-                        {node.body && (
-                            <Linkified input={`${node.body.slice(0, 240)}...`} externalURLs={node.externalURLs} />
+                        <Linkified
+                            input={node.body.length < 240 ? node.body : commitContent}
+                            externalURLs={node.externalURLs}
+                        />
+                        {node.body.length > 240 && (
+                            <Button
+                                variant="link"
+                                size="sm"
+                                display="inline"
+                                onClick={() => setTruncatedCommitMessage(!truncatedCommitMessage)}
+                            >
+                                {truncatedCommitMessage ? 'see more' : 'see less'}
+                            </Button>
                         )}
-                        <Button
-                            variant="link"
-                            size="sm"
-                            display="inline"
-                            onClick={() => setTruncatedCommitMessage(false)}
-                        >
-                            see more
-                        </Button>
                     </pre>
-                ) : (
-                    <>
-                        <pre className={styles.messageBody}>
-                            {node.body && <Linkified input={node.body} externalURLs={node.externalURLs} />}
-                        </pre>
-                        <Button
-                            variant="link"
-                            size="sm"
-                            display="inline"
-                            onClick={() => setTruncatedCommitMessage(true)}
-                        >
-                            see less
-                        </Button>
-                    </>
                 )}
             </div>
         ) : undefined

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -163,19 +163,17 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
             <div className="w-100">
                 {truncatedCommitMessage ? (
                     <pre className={styles.messageBody}>
-                        <>
-                            {node.body && (
-                                <Linkified input={`${node.body.slice(0, 240)}...`} externalURLs={node.externalURLs} />
-                            )}
-                            <Button
-                                variant="link"
-                                size="sm"
-                                display="inline"
-                                onClick={() => setTruncatedCommitMessage(false)}
-                            >
-                                see more
-                            </Button>
-                        </>
+                        {node.body && (
+                            <Linkified input={`${node.body.slice(0, 240)}...`} externalURLs={node.externalURLs} />
+                        )}
+                        <Button
+                            variant="link"
+                            size="sm"
+                            display="inline"
+                            onClick={() => setTruncatedCommitMessage(false)}
+                        >
+                            see more
+                        </Button>
                     </pre>
                 ) : (
                     <>

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -83,6 +83,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     wrapperElement: WrapperElement = 'div',
 }) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
+    const [truncatedCommitMessage, setTruncatedCommitMessage] = useState<boolean>(true)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
 
     const sourceType = node.perforceChangelist ? RepositoryType.PERFORCE_DEPOT : RepositoryType.GIT_REPOSITORY
@@ -160,9 +161,37 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     const commitMessageBody =
         expandCommitMessageBody || showCommitMessageBody ? (
             <div className="w-100">
-                <pre className={styles.messageBody}>
-                    {node.body && <Linkified input={node.body} externalURLs={node.externalURLs} />}
-                </pre>
+                {truncatedCommitMessage ? (
+                    <pre className={styles.messageBody}>
+                        <>
+                            {node.body && (
+                                <Linkified input={`${node.body.slice(0, 240)}...`} externalURLs={node.externalURLs} />
+                            )}
+                            <Button
+                                variant="link"
+                                size="sm"
+                                display="inline"
+                                onClick={() => setTruncatedCommitMessage(false)}
+                            >
+                                see more
+                            </Button>
+                        </>
+                    </pre>
+                ) : (
+                    <>
+                        <pre className={styles.messageBody}>
+                            {node.body && <Linkified input={node.body} externalURLs={node.externalURLs} />}
+                        </pre>
+                        <Button
+                            variant="link"
+                            size="sm"
+                            display="inline"
+                            onClick={() => setTruncatedCommitMessage(true)}
+                        >
+                            see less
+                        </Button>
+                    </>
+                )}
             </div>
         ) : undefined
 

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -158,29 +158,25 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
         </div>
     )
 
+    const handleTruncate = () => setTruncatedCommitMessage(!truncatedCommitMessage)
     const showCommitMessage = expandCommitMessageBody || showCommitMessageBody
-    const commitContent = truncatedCommitMessage && node.body ? `${node.body.slice(0, 240)}` : node.body
+    const commitContent =
+        truncatedCommitMessage && node.body && node.body.length > 240 ? `${node.body.slice(0, 240)}...` : node.body
+    const truncationNeeded = commitContent && commitContent.length > 240
 
-    const commitMessageBody = showCommitMessage && commitContent ? (
-        <div className="w-100">
-            <pre className={styles.messageBody}>
-                <Linkified
-                    input={commitContent}
-                    externalURLs={node.externalURLs}
-                />
-                {commitContent.length >= 240 &&
-                    <Button
-                        variant="link"
-                        size="sm"
-                        display="inline"
-                        onClick={() => setTruncatedCommitMessage(!truncatedCommitMessage)}
-                    >
-                        {truncatedCommitMessage ? '... see more' : 'see less'}
-                    </Button>
-                }
-            </pre>
-        </div>
-    ) : undefined
+    const commitMessageBody =
+        showCommitMessage && commitContent ? (
+            <div className="w-100">
+                <pre className={styles.messageBody}>
+                    <Linkified input={commitContent} externalURLs={node.externalURLs} />
+                    {truncationNeeded && (
+                        <Button variant="link" size="sm" display="inline" onClick={handleTruncate}>
+                            {truncatedCommitMessage ? 'see more' : 'see less'}
+                        </Button>
+                    )}
+                </pre>
+            </div>
+        ) : undefined
 
     const bylineElement = (
         <GitCommitNodeByline

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -83,7 +83,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     wrapperElement: WrapperElement = 'div',
 }) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
-    const [truncatedCommitMessage, setTruncatedCommitMessage] = useState<boolean>(true)
+    const [truncateCommitMessage, setTruncateCommitMessage] = useState<boolean>(true)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
 
     const sourceType = node.perforceChangelist ? RepositoryType.PERFORCE_DEPOT : RepositoryType.GIT_REPOSITORY
@@ -158,10 +158,10 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
         </div>
     )
 
-    const handleTruncate = () => setTruncatedCommitMessage(!truncatedCommitMessage)
+    const handleTruncate = () => setTruncateCommitMessage(!truncateCommitMessage)
     const showCommitMessage = expandCommitMessageBody || showCommitMessageBody
     const commitContent =
-        truncatedCommitMessage && node.body && node.body.length > 240 ? `${node.body.slice(0, 240)}...` : node.body
+        truncateCommitMessage && node.body && node.body.length > 240 ? `${node.body.slice(0, 240)}...` : node.body
     const truncationNeeded = commitContent && commitContent.length > 240
 
     const commitMessageBody =
@@ -171,7 +171,7 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
                     <Linkified input={commitContent} externalURLs={node.externalURLs} />
                     {truncationNeeded && (
                         <Button variant="link" size="sm" display="inline" onClick={handleTruncate}>
-                            {truncatedCommitMessage ? 'see more' : 'see less'}
+                            {truncateCommitMessage ? 'see more' : 'see less'}
                         </Button>
                     )}
                 </pre>

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -158,31 +158,29 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
         </div>
     )
 
-    const commitContent = truncatedCommitMessage && node.body ? `${node.body.slice(0, 240)}...` : node.body
+    const showCommitMessage = expandCommitMessageBody || showCommitMessageBody
+    const commitContent = truncatedCommitMessage && node.body ? `${node.body.slice(0, 240)}` : node.body
 
-    const commitMessageBody =
-        expandCommitMessageBody || showCommitMessageBody ? (
-            <div className="w-100">
-                {commitContent && node.body && (
-                    <pre className={styles.messageBody}>
-                        <Linkified
-                            input={node.body.length < 240 ? node.body : commitContent}
-                            externalURLs={node.externalURLs}
-                        />
-                        {node.body.length > 240 && (
-                            <Button
-                                variant="link"
-                                size="sm"
-                                display="inline"
-                                onClick={() => setTruncatedCommitMessage(!truncatedCommitMessage)}
-                            >
-                                {truncatedCommitMessage ? 'see more' : 'see less'}
-                            </Button>
-                        )}
-                    </pre>
-                )}
-            </div>
-        ) : undefined
+    const commitMessageBody = showCommitMessage && commitContent ? (
+        <div className="w-100">
+            <pre className={styles.messageBody}>
+                <Linkified
+                    input={commitContent}
+                    externalURLs={node.externalURLs}
+                />
+                {commitContent.length >= 240 &&
+                    <Button
+                        variant="link"
+                        size="sm"
+                        display="inline"
+                        onClick={() => setTruncatedCommitMessage(!truncatedCommitMessage)}
+                    >
+                        {truncatedCommitMessage ? '... see more' : 'see less'}
+                    </Button>
+                }
+            </pre>
+        </div>
+    ) : undefined
 
     const bylineElement = (
         <GitCommitNodeByline


### PR DESCRIPTION
Before, we showed the full commit message on the commit view. Now, we give the user the option to see more, or less of the commit message.

## Test plan
Previewed locally. Passing CI/CD.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
