### PR TITLE
sg/msp: fix monitoring config struct always being zero value

### DIFF
--- a/dev/managedservicesplatform/spec/monitoring.go
+++ b/dev/managedservicesplatform/spec/monitoring.go
@@ -31,7 +31,7 @@ type MonitoringAlertsSpec struct {
 type ResponseCodeRatioAlertSpec struct {
 	ID           string   `yaml:"id"`
 	Name         string   `yaml:"name"`
-	Description  *string  `yaml:"description,omitempty"`
+	Description  string   `yaml:"description,omitempty"`
 	Code         *int     `yaml:"code,omitempty"`
 	CodeClass    *string  `yaml:"codeClass,omitempty"`
 	ExcludeCodes []string `yaml:"excludeCodes,omitempty"`

--- a/dev/managedservicesplatform/spec/spec.go
+++ b/dev/managedservicesplatform/spec/spec.go
@@ -116,7 +116,9 @@ func parse(data []byte) (*Spec, error) {
 	}
 
 	// Assign zero value for top-level monitoring spec for covenience
-	s.Monitoring = &MonitoringSpec{}
+	if s.Monitoring == nil {
+		s.Monitoring = &MonitoringSpec{}
+	}
 
 	if validationErrs := s.Validate(); len(validationErrs) > 0 {
 		return nil, errors.Append(nil, validationErrs...)

--- a/dev/managedservicesplatform/stacks/monitoring/response_codes.go
+++ b/dev/managedservicesplatform/stacks/monitoring/response_codes.go
@@ -22,6 +22,7 @@ func createResponseCodeAlerts(
 			ID:           config.ID,
 			ProjectID:    vars.ProjectID,
 			Name:         config.Name,
+			Description:  config.Description,
 			ResourceName: vars.Service.ID,
 			ResourceKind: alertpolicy.CloudRunService,
 			ResponseCodeMetric: &alertpolicy.ResponseCodeMetric{


### PR DESCRIPTION
Adding response code ratio alerts to the service spec was not generating the cdktf. The code was always setting the monitoring spec to empty struct.

The fix is to only set to empty struct if it parsed as nil (was not provided)

Noticed when experimenting for https://github.com/sourcegraph/accounts.sourcegraph.com/issues/291
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
- CI
- locally-tested