### PR TITLE
executor: Add audit log mode

### DIFF
--- a/cmd/executor/internal/config/config.go
+++ b/cmd/executor/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 
 	FrontendURL                                    string
 	FrontendAuthorizationToken                     string
+	EnableJobAuditLogging                          bool
 	QueueName                                      string
 	QueueNamesStr                                  string
 	QueueNames                                     []string
@@ -113,6 +114,7 @@ type Config struct {
 func (c *Config) Load() {
 	c.FrontendURL = c.Get("EXECUTOR_FRONTEND_URL", "", "The external URL of the sourcegraph instance.")
 	c.FrontendAuthorizationToken = c.Get("EXECUTOR_FRONTEND_PASSWORD", c.defaultFrontendPassword, "The authorization token supplied to the frontend.")
+	c.EnableJobAuditLogging = c.GetBool("EXECUTOR_ENABLE_JOB_AUDIT_LOGGING", "false", "Enables logging of the job payload to the executor logs. Note that this mode might contain secret information and logs very verbosely.")
 	c.QueueName = c.GetOptional("EXECUTOR_QUEUE_NAME", "The name of the queue to listen to.")
 	c.QueueNamesStr = c.GetOptional("EXECUTOR_QUEUE_NAMES", "The names of multiple queues to listen to, comma-separated.")
 	c.QueuePollInterval = c.GetInterval("EXECUTOR_QUEUE_POLL_INTERVAL", "1s", "Interval between dequeue requests.")

--- a/cmd/executor/internal/config/config_test.go
+++ b/cmd/executor/internal/config/config_test.go
@@ -40,6 +40,8 @@ func TestConfig_Load(t *testing.T) {
 			return "10"
 		case "EXECUTOR_MAX_ACTIVE_TIME":
 			return "1h"
+		case "EXECUTOR_ENABLE_JOB_AUDIT_LOGGING":
+			return "true"
 		case "EXECUTOR_KUBERNETES_CONFIG_PATH":
 			return "/foo/bar"
 		case "EXECUTOR_KUBERNETES_NODE_NAME":
@@ -82,6 +84,7 @@ func TestConfig_Load(t *testing.T) {
 
 	assert.Equal(t, "EXECUTOR_FRONTEND_URL", cfg.FrontendURL)
 	assert.Equal(t, "EXECUTOR_FRONTEND_PASSWORD", cfg.FrontendAuthorizationToken)
+	assert.True(t, cfg.EnableJobAuditLogging)
 	assert.Equal(t, "EXECUTOR_QUEUE_NAME", cfg.QueueName)
 	assert.Equal(t, "EXECUTOR_QUEUE_NAMES", cfg.QueueNamesStr)
 	assert.Equal(t, 10*time.Second, cfg.QueuePollInterval)
@@ -192,6 +195,7 @@ func TestConfig_Load_Defaults(t *testing.T) {
 
 	assert.Empty(t, cfg.FrontendURL)
 	assert.Empty(t, cfg.FrontendAuthorizationToken)
+	assert.False(t, cfg.EnableJobAuditLogging)
 	assert.Empty(t, cfg.QueueName)
 	assert.Empty(t, cfg.QueueNamesStr)
 	assert.Equal(t, time.Second, cfg.QueuePollInterval)

--- a/cmd/executor/internal/run/util.go
+++ b/cmd/executor/internal/run/util.go
@@ -83,6 +83,7 @@ func apiWorkerOptions(c *config.Config, queueTelemetryOptions queue.TelemetryOpt
 
 		NodeExporterEndpoint:               c.NodeExporterURL,
 		DockerRegistryNodeExporterEndpoint: c.DockerRegistryNodeExporterURL,
+		EnableJobAuditLogging:              c.EnableJobAuditLogging,
 	}
 }
 

--- a/cmd/executor/internal/worker/BUILD.bazel
+++ b/cmd/executor/internal/worker/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//cmd/executor/internal/worker/runner",
         "//cmd/executor/internal/worker/runtime",
         "//cmd/executor/internal/worker/workspace",
+        "//internal/binary",
         "//internal/executor/types",
         "//internal/executor/util",
         "//internal/goroutine",

--- a/cmd/executor/internal/worker/cmdlogger/logger_test.go
+++ b/cmd/executor/internal/worker/cmdlogger/logger_test.go
@@ -2,6 +2,7 @@ package cmdlogger
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/sourcegraph/log/logtest"
@@ -22,7 +23,7 @@ func TestLogger(t *testing.T) {
 
 	job := types.Job{}
 	internalLogger := logtest.Scoped(t)
-	l := NewLogger(internalLogger, s, job, map[string]string{})
+	l := NewLogger(internalLogger, s, job, strings.NewReplacer())
 
 	e := l.LogEntry("the_key", []string{"cmd", "arg1"})
 
@@ -68,7 +69,7 @@ func TestLogger_Failure(t *testing.T) {
 
 	job := types.Job{}
 	internalLogger := logtest.Scoped(t)
-	l := NewLogger(internalLogger, s, job, map[string]string{})
+	l := NewLogger(internalLogger, s, job, strings.NewReplacer())
 
 	e := l.LogEntry("the_key", []string{"cmd", "arg1"})
 

--- a/cmd/executor/internal/worker/command/command.go
+++ b/cmd/executor/internal/worker/command/command.go
@@ -68,6 +68,7 @@ func (c *RealCommand) Run(ctx context.Context, cmdLogger cmdlogger.Logger, spec 
 		"Running command",
 		log.String("key", spec.Key),
 		log.String("workingDir", spec.Dir),
+		log.String("image", spec.Image),
 	)
 
 	// Check if we can even run the command.

--- a/cmd/executor/internal/worker/worker.go
+++ b/cmd/executor/internal/worker/worker.go
@@ -73,6 +73,10 @@ type Options struct {
 	// DockerRegistryNodeExporterEndpoint is the URL of the intermediary caching docker registry,
 	// for scraping and forwarding metrics.
 	DockerRegistryNodeExporterEndpoint string
+
+	// EnableJobAuditLogging enables logging of the job payload to the executor logs.
+	// Note that this mode might contain secret information and logs very verbosely.
+	EnableJobAuditLogging bool
 }
 
 // NewWorker creates a worker that polls a remote job queue API for work.


### PR DESCRIPTION
Adds a mode on request of a customer that logs ALL the things the executor does. Essentially, we're dumping the whole job payload, which contains all the relevant information to be able to replicate what users did.
We're attempting to redact any secret values, but there's no 100% guarantee (especially if a user uses a non-redacted secret directly). 

Here's an example:

```
[batches-exe...r] WARN executor_processor.Handle worker/handler.go:151 Received new job to process {
  "handle": {
    "jobID": 7,
    "repositoryName": "github.com/k3s-io/k3s",
    "commit": "6d77b7a9204ebe40c53425ce4bc82c1df456e911",
    "job": {
      "id": 7,
      "version": 2,
      "queueName": "",
      "repositoryName": "github.com/k3s-io/k3s",
      "repositoryDirectory": "repository",
      "commit": "6d77b7a9204ebe40c53425ce4bc82c1df456e911",
      "fetchTags": false,
      "shallowClone": true,
      "sparseCheckout": [],
      "redactedValueReplacements": [],
      "dockerAuthConfigEntries": 0,
      "virtualMachineFiles": {
        "input.json": {
          "content": "{\"BatchChangeAttributes\":{\"Name\":\"test-logs\",\"Description\":\"Add Hello World to READMEs\"},\"repository\":{\"id\":\"UmVwb3NpdG9yeToxMw==\",\"name\":\"github.com/k3s-io/k3s\"},\"branch\":{\"name\":\"refs/heads/master\",\"target\":{\"oid\":\"6d77b7a9204ebe40c53425ce4bc82c1df456e911\"}},\"path\":\"\",\"onlyFetchWorkspace\":false,\"steps\":[{\"run\":\"echo I am evil | tee -a $(find -name README.md)\",\"container\":\"ubuntu:18.04\",\"env\":{}}],\"searchResultPaths\":[\"README.md\"],\"cachedStepResultFound\":false,\"cachedStepResult\":{\"changedFiles\":{\"modified\":null,\"added\":null,\"deleted\":null,\"renamed\":null},\"stdout\":\"\",\"stderr\":\"\",\"stepIndex\":0,\"diff\":\"\",\"outputs\":null},\"skippedSteps\":{}}"
        }
      },
      "dockerSteps": {},
      "cliSteps": {
        "step0": {
          "key": "batch-exec",
          "command": [
            "batch",
            "exec",
            "-f",
            "input.json",
            "-repo",
            "repository",
            "-tmp",
            ".src-tmp",
            "-binaryDiffs"
          ],
          "dir": ".",
          "env": []
        }
      }
    }
  }
}
```

## Test plan

Manual.

