### PR TITLE
worker: Fix potential panic on exit

### DIFF
--- a/cmd/worker/internal/codygateway/usageworker.go
+++ b/cmd/worker/internal/codygateway/usageworker.go
@@ -41,12 +41,12 @@ const (
 
 type usageRoutine struct {
 	logger log.Logger
-	ctx    context.Context
 	cancel context.CancelFunc
 }
 
 func (j *usageRoutine) Start() {
-	j.ctx, j.cancel = context.WithCancel(context.Background())
+	var ctx context.Context
+	ctx, j.cancel = context.WithCancel(context.Background())
 
 	goroutine.Go(func() {
 		checkAndStoreLimits := func() {
@@ -57,7 +57,7 @@ func (j *usageRoutine) Start() {
 				return
 			}
 			j.logger.Info("Checking Cody Gateway usage")
-			limits, err := cgc.GetLimits(j.ctx)
+			limits, err := cgc.GetLimits(ctx)
 			if err != nil {
 				j.logger.Error("failed to get cody gateway limits", log.Error(err))
 				return
@@ -93,7 +93,7 @@ func (j *usageRoutine) Start() {
 			select {
 			case <-ticker.C:
 				checkAndStoreLimits()
-			case <-j.ctx.Done():
+			case <-ctx.Done():
 				return
 			}
 		}
@@ -104,6 +104,4 @@ func (j *usageRoutine) Stop() {
 	if j.cancel != nil {
 		j.cancel()
 	}
-	j.ctx = nil
-	j.cancel = nil
 }


### PR DESCRIPTION
This PR fixes a nil access panic on shutdown of worker that I saw locally:

```
[         worker] 2024/01/24 13:08:53 goroutine panic: runtime error: invalid memory address or nil pointer dereference
[         worker] goroutine 980 [running]:
[         worker] runtime/debug.Stack()
[         worker]       /Users/erik/.asdf/installs/golang/1.21.4/go/src/runtime/debug/stack.go:24 +0x64
[         worker] github.com/sourcegraph/sourcegraph/lib/background.Go.func1.1()
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/lib/background/goroutine.go:19 +0x38
[         worker] panic({0x105c12fa0?, 0x1089dc620?})
[         worker]       /Users/erik/.asdf/installs/golang/1.21.4/go/src/runtime/panic.go:914 +0x218
[         worker] github.com/sourcegraph/sourcegraph/cmd/worker/internal/codygateway.(*usageRoutine).Start.func1()
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/cmd/worker/internal/codygateway/usageworker.go:96 +0x80
[         worker] github.com/sourcegraph/sourcegraph/lib/background.Go.func1()
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/lib/background/goroutine.go:24 +0x40
[         worker] created by github.com/sourcegraph/sourcegraph/lib/background.Go in goroutine 917
[         worker]       /Users/erik/Code/sourcegraph/sourcegraph/lib/background/goroutine.go:16 +0x5c
```



## Test plan

No panic observed, although it's not consistently happening.