### PR TITLE
Expose new Cody Subscriptions API & integrate rate limits with SSC subscription data

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -79,7 +79,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
     const subscription = data?.currentUser?.codySubscription
 
     useEffect(() => {
-        if (enrollPro && data?.currentUser && subscription?.plan !== CodySubscriptionPlan.pro) {
+        if (enrollPro && data?.currentUser && subscription?.plan !== CodySubscriptionPlan.PRO) {
             changeCodyPlan({ variables: { pro: true, id: data?.currentUser?.id } })
         }
     }, [data?.currentUser, changeCodyPlan, enrollPro, subscription])
@@ -98,7 +98,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
     const codeLimitReached = codyCurrentPeriodCodeUsage >= codyCurrentPeriodCodeLimit && codyCurrentPeriodCodeLimit > 0
     const chatLimitReached = codyCurrentPeriodChatUsage >= codyCurrentPeriodChatLimit && codyCurrentPeriodChatLimit > 0
-    const userIsOnProTier = subscription.plan === CodySubscriptionPlan.pro
+    const userIsOnProTier = subscription.plan === CodySubscriptionPlan.PRO
 
     const showUpgradeBanner = !userIsOnProTier && (codeLimitReached || chatLimitReached)
 
@@ -271,12 +271,12 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                     <TrialPeriodIcon />
                                     <div className="mb-2 mt-4">
                                         <Text weight="bold" className={classNames('d-inline mb-0', styles.counter)}>
-                                            {subscription.status === CodySubscriptionStatus.pending
+                                            {subscription.status === CodySubscriptionStatus.PENDING
                                                 ? 'Free trial'
-                                                : subscription.status.toUpperCase()}
+                                                : subscription.status}
                                         </Text>
                                     </div>
-                                    {subscription.status === CodySubscriptionStatus.pending ? (
+                                    {subscription.status === CodySubscriptionStatus.PENDING ? (
                                         <Text className="text-muted mb-0" size="small">
                                             Until Feb 14, 2024
                                         </Text>
@@ -290,7 +290,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                             weight="bold"
                                             className={classNames('d-inline mb-0 text-danger', styles.counter)}
                                         >
-                                            {subscription.status === CodySubscriptionStatus.pending
+                                            {subscription.status === CodySubscriptionStatus.PENDING
                                                 ? 'Free trial ended'
                                                 : subscription.status.toUpperCase()}
                                         </Text>

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -76,11 +76,13 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
     const enrollPro = parameters.get('pro') === 'true'
 
+    const subscription = data?.currentUser?.codySubscription
+
     useEffect(() => {
-        if (enrollPro && data?.currentUser && data?.currentUser?.codySubscription?.plan !== CodySubscriptionPlan.pro) {
+        if (enrollPro && data?.currentUser && subscription?.plan !== CodySubscriptionPlan.pro) {
             changeCodyPlan({ variables: { pro: true, id: data?.currentUser?.id } })
         }
-    }, [data?.currentUser, changeCodyPlan, enrollPro])
+    }, [data?.currentUser, changeCodyPlan, enrollPro, subscription])
 
     const navigate = useNavigate()
 
@@ -90,19 +92,15 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         }
     }, [data, navigate])
 
-    if (!isCodyEnabled() || !isSourcegraphDotCom || !data?.currentUser) {
-        return null
-    }
-
-    const subscription = data.currentUser.codySubscription
-    if (!subscription) {
+    if (!isCodyEnabled() || !isSourcegraphDotCom || !subscription) {
         return null
     }
 
     const codeLimitReached = codyCurrentPeriodCodeUsage >= codyCurrentPeriodCodeLimit && codyCurrentPeriodCodeLimit > 0
     const chatLimitReached = codyCurrentPeriodChatUsage >= codyCurrentPeriodChatLimit && codyCurrentPeriodChatLimit > 0
+    const userIsOnProTier = subscription.plan === CodySubscriptionPlan.pro
 
-    const showUpgradeBanner = subscription.plan !== CodySubscriptionPlan.pro && (codeLimitReached || chatLimitReached)
+    const showUpgradeBanner = !userIsOnProTier && (codeLimitReached || chatLimitReached)
 
     return (
         <>
@@ -144,12 +142,10 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                         <div>
                             <H2>My subscription</H2>
                             <Text className="text-muted mb-0">
-                                You are on the{' '}
-                                {subscription.plan === CodySubscriptionPlan.pro ? CodySubscriptionPlan.pro : 'Free'}{' '}
-                                tier.
+                                You are on the {userIsOnProTier ? 'Pro' : 'Free'} tier.
                             </Text>
                         </div>
-                        {subscription.plan === CodySubscriptionPlan.pro ? (
+                        {userIsOnProTier ? (
                             <div>
                                 <ButtonLink to="/cody/subscription" variant="secondary" outline={true} size="sm">
                                     Manage subscription
@@ -166,7 +162,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                     </div>
                     <div className={classNames('d-flex align-items-center mt-3', styles.responsiveContainer)}>
                         <div className="d-flex flex-column align-items-center flex-grow-1 p-3">
-                            {subscription.plan === CodySubscriptionPlan.pro ? (
+                            {userIsOnProTier ? (
                                 <ProTierIcon />
                             ) : (
                                 <Text className={classNames(styles.planName, 'mb-0')}>Free</Text>
@@ -269,7 +265,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                     </Text>
                                 ))}
                         </div>
-                        {subscription.plan === CodySubscriptionPlan.pro &&
+                        {userIsOnProTier &&
                             (subscription.applyProRateLimits ? (
                                 <div className="d-flex flex-column align-items-center flex-grow-1 p-3 border-left">
                                     <TrialPeriodIcon />

--- a/client/web/src/cody/subscription/CancelProModal.tsx
+++ b/client/web/src/cody/subscription/CancelProModal.tsx
@@ -3,6 +3,7 @@ import { Modal, Button, H2, Text } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
 import type { ChangeCodyPlanResult, ChangeCodyPlanVariables } from '../../graphql-operations'
+import { CodySubscriptionPlan } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
 
@@ -21,7 +22,7 @@ export function CancelProModal({
 
     return (
         <Modal isOpen={true} aria-label="Update to Cody Pro" className={styles.cancelModal} position="center">
-            {data && !data.changeCodyPlan?.codyProEnabled ? (
+            {data && data.changeCodyPlan?.codySubscription?.plan !== CodySubscriptionPlan.pro ? (
                 <div className="d-flex flex-column py-2">
                     <H2>Sorry to see you go.</H2>
 

--- a/client/web/src/cody/subscription/CancelProModal.tsx
+++ b/client/web/src/cody/subscription/CancelProModal.tsx
@@ -22,7 +22,7 @@ export function CancelProModal({
 
     return (
         <Modal isOpen={true} aria-label="Update to Cody Pro" className={styles.cancelModal} position="center">
-            {data && data.changeCodyPlan?.codySubscription?.plan !== CodySubscriptionPlan.pro ? (
+            {data && data.changeCodyPlan?.codySubscription?.plan !== CodySubscriptionPlan.PRO ? (
                 <div className="d-flex flex-column py-2">
                     <H2>Sorry to see you go.</H2>
 

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -40,6 +40,7 @@ interface CodySubscriptionPageProps {
     isSourcegraphDotCom: boolean
     authenticatedUser?: AuthenticatedUser | null
 }
+const MANAGE_SUBSCRIPTION_REDIRECT_URL = 'https://accounts.sourcegraph.com/cody/subscription'
 
 export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageProps> = ({
     isSourcegraphDotCom,
@@ -209,8 +210,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                     }
                                                 )
                                                 if (sscEnabled) {
-                                                    window.location.href =
-                                                        'https://accounts.sourcegraph.com/cody/subscription?pro=true'
+                                                    window.location.href = MANAGE_SUBSCRIPTION_REDIRECT_URL
                                                     return
                                                 }
 
@@ -231,8 +231,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 { tier: 'pro' }
                                             )
                                             if (sscEnabled) {
-                                                window.location.href =
-                                                    'https://accounts.sourcegraph.com/cody/subscription'
+                                                window.location.href = MANAGE_SUBSCRIPTION_REDIRECT_URL
                                                 return
                                             }
 

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -194,7 +194,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                 <Text className="mb-3 text-muted" size="small">
                                     Free until Feb 2024, <strong>no credit card needed</strong>
                                 </Text>
-                                {data.currentUser?.codySubscription?.plan === CodySubscriptionPlan.pro ? (
+                                {data.currentUser?.codySubscription?.plan === CodySubscriptionPlan.PRO ? (
                                     <div>
                                         <Text
                                             className="mb-0 text-muted d-inline cursor-pointer"

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -22,6 +22,8 @@ import {
 import type { AuthenticatedUser } from '../../auth'
 import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
+import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
+import { CodySubscriptionPlan } from '../../graphql-operations'
 import type { UserCodyPlanResult, UserCodyPlanVariables } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
@@ -47,6 +49,8 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
 
     const utm_source = parameters.get('utm_source')
 
+    const [sscEnabled] = useFeatureFlag('use-ssc-for-cody-subscription', false)
+
     useEffect(() => {
         eventLogger.log(EventName.CODY_SUBSCRIPTION_PAGE_VIEWED, { utm_source }, { utm_source })
     }, [utm_source])
@@ -67,8 +71,6 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
     if (!isCodyEnabled() || !isSourcegraphDotCom || !data?.currentUser || !authenticatedUser) {
         return null
     }
-
-    const { codyProEnabled } = data.currentUser
 
     return (
         <>
@@ -191,7 +193,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                 <Text className="mb-3 text-muted" size="small">
                                     Free until Feb 2024, <strong>no credit card needed</strong>
                                 </Text>
-                                {codyProEnabled ? (
+                                {data.currentUser?.codySubscription?.plan === CodySubscriptionPlan.pro ? (
                                     <div>
                                         <Text
                                             className="mb-0 text-muted d-inline cursor-pointer"
@@ -206,10 +208,16 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                         tier: 'free',
                                                     }
                                                 )
+                                                if (sscEnabled) {
+                                                    window.location.href =
+                                                        'https://accounts.sourcegraph.com/cody/subscription?pro=true'
+                                                    return
+                                                }
+
                                                 setShowCancelPro(true)
                                             }}
                                         >
-                                            Cancel
+                                            {sscEnabled ? 'Manage' : 'Cancel'} subscription
                                         </Text>
                                     </div>
                                 ) : (
@@ -222,11 +230,17 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 { tier: 'pro' },
                                                 { tier: 'pro' }
                                             )
+                                            if (sscEnabled) {
+                                                window.location.href =
+                                                    'https://accounts.sourcegraph.com/cody/subscription'
+                                                return
+                                            }
+
                                             setShowUpgradeToPro(true)
                                         }}
                                     >
                                         <Icon svgPath={mdiTrendingUp} className="mr-1" aria-hidden={true} />
-                                        Get Pro trial
+                                        {sscEnabled ? 'Get Pro' : 'Get Pro trial'}
                                     </Button>
                                 )}
                             </div>

--- a/client/web/src/cody/subscription/UpgradeToProModal.tsx
+++ b/client/web/src/cody/subscription/UpgradeToProModal.tsx
@@ -5,6 +5,7 @@ import { useMutation } from '@sourcegraph/http-client'
 import { Button, H1, H2, Icon, Modal, Text } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
+import { CodySubscriptionPlan } from '../../graphql-operations'
 import type { ChangeCodyPlanResult, ChangeCodyPlanVariables } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
@@ -27,7 +28,7 @@ export function UpgradeToProModal({
 
     return (
         <Modal isOpen={true} aria-label="Update to Cody Pro" className={styles.upgradeModal} position="center">
-            {data?.changeCodyPlan?.codyProEnabled ? (
+            {data?.changeCodyPlan?.codySubscription?.plan === CodySubscriptionPlan.pro ? (
                 <div className="d-flex flex-column justify-content-between align-items-center mby-4 py-4">
                     <CodyColorIcon width={40} height={40} className="mb-4" />
                     <H2>Upgraded to Cody Pro 🎉</H2>

--- a/client/web/src/cody/subscription/UpgradeToProModal.tsx
+++ b/client/web/src/cody/subscription/UpgradeToProModal.tsx
@@ -28,7 +28,7 @@ export function UpgradeToProModal({
 
     return (
         <Modal isOpen={true} aria-label="Update to Cody Pro" className={styles.upgradeModal} position="center">
-            {data?.changeCodyPlan?.codySubscription?.plan === CodySubscriptionPlan.pro ? (
+            {data?.changeCodyPlan?.codySubscription?.plan === CodySubscriptionPlan.PRO ? (
                 <div className="d-flex flex-column justify-content-between align-items-center mby-4 py-4">
                     <CodyColorIcon width={40} height={40} className="mb-4" />
                     <H2>Upgraded to Cody Pro 🎉</H2>

--- a/client/web/src/cody/subscription/queries.tsx
+++ b/client/web/src/cody/subscription/queries.tsx
@@ -4,7 +4,13 @@ export const USER_CODY_PLAN = gql`
     query UserCodyPlan {
         currentUser {
             id
-            codyProEnabled
+            codySubscription {
+                status
+                plan
+                applyProRateLimits
+                currentPeriodStartAt
+                currentPeriodEndAt
+            }
         }
     }
 `
@@ -17,8 +23,13 @@ export const USER_CODY_USAGE = gql`
             codyCurrentPeriodCodeUsage
             codyCurrentPeriodChatLimit
             codyCurrentPeriodCodeLimit
-            codyCurrentPeriodStartDate
-            codyCurrentPeriodEndDate
+            codySubscription {
+                status
+                plan
+                applyProRateLimits
+                currentPeriodStartAt
+                currentPeriodEndAt
+            }
         }
     }
 `
@@ -27,7 +38,13 @@ export const CHANGE_CODY_PLAN = gql`
     mutation ChangeCodyPlan($id: ID!, $pro: Boolean!) {
         changeCodyPlan(user: $id, pro: $pro) {
             id
-            codyProEnabled
+            codySubscription {
+                status
+                plan
+                applyProRateLimits
+                currentPeriodStartAt
+                currentPeriodEndAt
+            }
         }
     }
 `

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -38,6 +38,7 @@ export const FEATURE_FLAGS = [
     'opencodegraph',
     'auditlog-expansion',
     'search.newFilters',
+    'use-ssc-for-cody-subscription',
 ] as const
 
 export type FeatureFlagName = typeof FEATURE_FLAGS[number]

--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -324,6 +324,7 @@ go_library(
         "//internal/siteid",
         "//internal/sourcegraphoperator",
         "//internal/src-prometheus",
+        "//internal/ssc",
         "//internal/suspiciousnames",
         "//internal/symbols",
         "//internal/temporarysettings",

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6361,6 +6361,29 @@ type NewUsersConnection implements Connection {
     pageInfo: ConnectionPageInfo!
 }
 
+enum CodySubscriptionStatus {
+    active
+    past_due
+    unpaid
+    canceled
+    trialing
+    pending
+    other
+}
+
+enum CodySubscriptionPlan {
+    free
+    pro
+}
+
+type CodySubscription {
+    status: CodySubscriptionStatus!
+    plan: CodySubscriptionPlan!
+    applyProRateLimits: Boolean!
+    currentPeriodStartAt: DateTime!
+    currentPeriodEndAt: DateTime!
+}
+
 """
 A user.
 """
@@ -6573,17 +6596,14 @@ type User implements Node & SettingsSubject & Namespace {
     """
     codeCompletionsQuotaOverride: Int
     """
+    The Cody subscription details for the user.
+    """
+    codySubscription: CodySubscription
+    """
+    DEPRECATED
     Whether the user has enrolled for Cody Pro.
     """
     codyProEnabled: Boolean!
-    """
-    The start date of current billing period of Cody.
-    """
-    codyCurrentPeriodStartDate: DateTime
-    """
-    The end date of current billing period of Cody.
-    """
-    codyCurrentPeriodEndDate: DateTime
     """
     The count of Cody chats in the current billing period.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6361,6 +6361,9 @@ type NewUsersConnection implements Connection {
     pageInfo: ConnectionPageInfo!
 }
 
+"""
+A status for cody subscription.
+"""
 enum CodySubscriptionStatus {
     active
     past_due
@@ -6371,16 +6374,37 @@ enum CodySubscriptionStatus {
     other
 }
 
+"""
+A plan for cody subscription.
+"""
 enum CodySubscriptionPlan {
     free
     pro
 }
 
+"""
+A subscription for cody.
+"""
 type CodySubscription {
+    """
+    The status for cody subscription.
+    """
     status: CodySubscriptionStatus!
+    """
+    The plan for cody subscription.
+    """
     plan: CodySubscriptionPlan!
+    """
+    Whether pro rate limits are applied for the user.
+    """
     applyProRateLimits: Boolean!
+    """
+    The current billing period start time.
+    """
     currentPeriodStartAt: DateTime!
+    """
+    The current billing period end time.
+    """
     currentPeriodEndAt: DateTime!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6365,21 +6365,21 @@ type NewUsersConnection implements Connection {
 A status for cody subscription.
 """
 enum CodySubscriptionStatus {
-    active
-    past_due
-    unpaid
-    canceled
-    trialing
-    pending
-    other
+    ACTIVE
+    PAST_DUE
+    UNPAID
+    CANCELED
+    TRIALING
+    PENDING
+    OTHER
 }
 
 """
 A plan for cody subscription.
 """
 enum CodySubscriptionPlan {
-    free
-    pro
+    FREE
+    PRO
 }
 
 """
@@ -6403,7 +6403,8 @@ type CodySubscription {
     """
     currentPeriodStartAt: DateTime!
     """
-    The current billing period end time.
+    The current billing period end time. This may be in the past if the
+    subscription is in a canceled state.
     """
     currentPeriodEndAt: DateTime!
 }

--- a/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
+++ b/cmd/frontend/internal/dotcom/productsubscription/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//internal/audit",
         "//internal/auth",
         "//internal/authz",
+        "//internal/cody",
         "//internal/codygateway",
         "//internal/completions/client/fireworks",
         "//internal/completions/types",

--- a/internal/cody/subscription.go
+++ b/internal/cody/subscription.go
@@ -11,8 +11,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const USE_SSC_FEATURE_FLAG = "use-ssc-for-cody-subscription"
-const CODY_PRO_TRIAL_ENDED = "cody-pro-trial-ended"
+// use-ssc-for-cody-subscription is a feature flag that enables the use of SSC as the source of truth for Cody subscription data.
+const USE_SSC_FOR_SUBSCRIPTION_FF = "use-ssc-for-cody-subscription"
+
+// cody-pro-trial-ended is a feature flag that indicates if the Cody Pro Trial has ended.
+const CODY_PRO_TRIAL_ENDED_FF = "cody-pro-trial-ended"
 
 const SAMS_SERVICE_ID = "https://accounts.sgdev.org"
 const SAMS_SERVICE_TYPE = "openidconnect"
@@ -75,13 +78,13 @@ func consolidateSubscriptionDetails(ctx context.Context, user types.User, subscr
 
 	// If the user doesn't have a subscription in the SSC backend, then we need
 	// synthesize one using the data available on dotcom.
-	currentPeriodStartAt, currentPeriodEndAt := PreSSCReleaseCurrentPeriodDateRange(ctx, user)
+	currentPeriodStartAt, currentPeriodEndAt := preSSCReleaseCurrentPeriodDateRange(ctx, user)
 
 	if user.CodyProEnabledAt != nil {
 		return &UserSubscription{
 			Status:               ssc.SubscriptionStatusPending,
 			Plan:                 UserSubscriptionPlanPro,
-			ApplyProRateLimits:   !featureflag.FromContext(ctx).GetBoolOr(CODY_PRO_TRIAL_ENDED, false),
+			ApplyProRateLimits:   !featureflag.FromContext(ctx).GetBoolOr(CODY_PRO_TRIAL_ENDED_FF, false),
 			CurrentPeriodStartAt: currentPeriodStartAt,
 			CurrentPeriodEndAt:   currentPeriodEndAt,
 		}, nil
@@ -127,7 +130,7 @@ func getSubscriptionForUser(ctx context.Context, db database.DB, sscClient ssc.C
 	var subscription *ssc.Subscription
 
 	// Fetch subscription from SSC only if the feature flag is enabled and the user has a SAMS account ID
-	if samsAccountID != "" && featureflag.FromContext(ctx).GetBoolOr(USE_SSC_FEATURE_FLAG, false) {
+	if samsAccountID != "" && featureflag.FromContext(ctx).GetBoolOr(USE_SSC_FOR_SUBSCRIPTION_FF, false) {
 		subscription, err = sscClient.FetchSubscriptionBySAMSAccountID(samsAccountID)
 		if err != nil {
 			return nil, errors.Wrap(err, "error while fetching user subscription from SSC")

--- a/internal/cody/subscription.go
+++ b/internal/cody/subscription.go
@@ -14,7 +14,8 @@ import (
 // use-ssc-for-cody-subscription is a feature flag that enables the use of SSC as the source of truth for Cody subscription data.
 const USE_SSC_FOR_SUBSCRIPTION_FF = "use-ssc-for-cody-subscription"
 
-// cody-pro-trial-ended is a feature flag that indicates if the Cody Pro Trial has ended.
+// cody-pro-trial-ended is a feature flag that indicates if the Cody Pro "Free Trial"  has ended.
+// (Enabling users to use Cody Pro for free for 3-months starting in late Q4'2023.)
 const CODY_PRO_TRIAL_ENDED_FF = "cody-pro-trial-ended"
 
 const SAMS_SERVICE_ID = "https://accounts.sgdev.org"
@@ -23,8 +24,8 @@ const SAMS_SERVICE_TYPE = "openidconnect"
 type UserSubscriptionPlan string
 
 const (
-	UserSubscriptionPlanFree UserSubscriptionPlan = "free"
-	UserSubscriptionPlanPro  UserSubscriptionPlan = "pro"
+	UserSubscriptionPlanFree UserSubscriptionPlan = "FREE"
+	UserSubscriptionPlanPro  UserSubscriptionPlan = "PRO"
 )
 
 type UserSubscription struct {

--- a/internal/cody/subscription_test.go
+++ b/internal/cody/subscription_test.go
@@ -277,7 +277,7 @@ func TestGetSubscriptionForUser(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := actor.WithActor(context.Background(), actor.FromUser(test.user.ID))
 			ctx = withCurrentTimeMock(ctx, test.today)
-			flags := map[string]bool{USE_SSC_FEATURE_FLAG: test.useSSCFeatureFlag, CODY_PRO_TRIAL_ENDED: test.codyProTrialEndedFeatureFlag}
+			flags := map[string]bool{USE_SSC_FOR_SUBSCRIPTION_FF: test.useSSCFeatureFlag, CODY_PRO_TRIAL_ENDED_FF: test.codyProTrialEndedFeatureFlag}
 			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
 
 			db := dbmocks.NewMockDB()

--- a/internal/cody/utils.go
+++ b/internal/cody/utils.go
@@ -22,7 +22,7 @@ func withCurrentTimeMock(ctx context.Context, t time.Time) context.Context {
 	return context.WithValue(ctx, mockCurrentTimeKey, &t)
 }
 
-func PreSSCReleaseCurrentPeriodDateRange(ctx context.Context, user types.User) (time.Time, time.Time) {
+func preSSCReleaseCurrentPeriodDateRange(ctx context.Context, user types.User) (time.Time, time.Time) {
 	// to allow mocking current time during tests
 	currentDate := currentTimeFromCtx(ctx)
 

--- a/internal/cody/utils_test.go
+++ b/internal/cody/utils_test.go
@@ -125,7 +125,7 @@ func TestPreSSCReleaseCurrentPeriodDateRange(t *testing.T) {
 			ctx := actor.WithActor(context.Background(), &actor.Actor{UID: user.ID})
 			ctx = withCurrentTimeMock(ctx, test.today)
 
-			startDate, endDate := PreSSCReleaseCurrentPeriodDateRange(ctx, *user)
+			startDate, endDate := preSSCReleaseCurrentPeriodDateRange(ctx, *user)
 			assert.Equal(t, test.start, startDate, "startDate")
 			assert.Equal(t, test.end, endDate, "endDate")
 		})

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -55,7 +55,7 @@ func newCompletionsHandler(
 	traceFamily string,
 	getModel func(context.Context, types.CodyCompletionRequestParameters, *conftypes.CompletionsConfig) (string, error),
 ) http.Handler {
-	responseHandler := newSwitchingResponseHandler(logger, feature)
+	responseHandler := newSwitchingResponseHandler(logger, db, feature)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -159,8 +159,14 @@ func newCompletionsHandler(
 						http.Error(w, "Internal server error", http.StatusInternalServerError)
 						return
 					}
-					isProUser := user.CodyProEnabledAt != nil
-					respondRateLimited(w, unwrap, isDotcom, isProUser)
+					subscription, err := cody.SubscriptionForUser(ctx, db, *user)
+					if err != nil {
+						l.Error("Error while fetching user's cody subscription", log.Error(err))
+						http.Error(w, "Internal server error", http.StatusInternalServerError)
+						return
+					}
+
+					respondRateLimited(w, unwrap, isDotcom, subscription.ApplyProRateLimits)
 					return
 				}
 				l.Warn("Rate limit error", log.Error(err))
@@ -190,9 +196,9 @@ func respondRateLimited(w http.ResponseWriter, err RateLimitExceededError, isDot
 
 // newSwitchingResponseHandler handles requests to an LLM provider, and wraps the correct
 // handler based on the requestParams.Stream flag.
-func newSwitchingResponseHandler(logger log.Logger, feature types.CompletionsFeature) func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore) {
-	nonStreamer := newNonStreamingResponseHandler(logger, feature)
-	streamer := newStreamingResponseHandler(logger, feature)
+func newSwitchingResponseHandler(logger log.Logger, db database.DB, feature types.CompletionsFeature) func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore) {
+	nonStreamer := newNonStreamingResponseHandler(logger, db, feature)
+	streamer := newStreamingResponseHandler(logger, db, feature)
 	return func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore,
 	) {
 		if requestParams.IsStream(feature) {
@@ -205,7 +211,7 @@ func newSwitchingResponseHandler(logger log.Logger, feature types.CompletionsFea
 
 // newStreamingResponseHandler handles streaming requests to an LLM provider,
 // It writes events to an SSE stream as they come in.
-func newStreamingResponseHandler(logger log.Logger, feature types.CompletionsFeature) func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore) {
+func newStreamingResponseHandler(logger log.Logger, db database.DB, feature types.CompletionsFeature) func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore) {
 	return func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore) {
 		var eventWriter = sync.OnceValue[*streamhttp.Writer](func() *streamhttp.Writer {
 			eventWriter, err := streamhttp.NewWriter(w)
@@ -250,10 +256,17 @@ func newStreamingResponseHandler(logger log.Logger, feature types.CompletionsFea
 						http.Error(w, "Internal server error", http.StatusInternalServerError)
 						return
 					}
-					isProUser := user.CodyProEnabledAt != nil
+
+					subscription, err := cody.SubscriptionForUser(ctx, db, *user)
+					if err != nil {
+						l.Error("Error while fetching user's cody subscription", log.Error(err))
+						http.Error(w, "Internal server error", http.StatusInternalServerError)
+						return
+					}
+
 					isDotcom := envvar.SourcegraphDotComMode()
 					if isDotcom {
-						if isProUser {
+						if subscription.ApplyProRateLimits {
 							w.Header().Set("x-is-cody-pro-user", "true")
 						} else {
 							w.Header().Set("x-is-cody-pro-user", "false")
@@ -292,7 +305,7 @@ func newStreamingResponseHandler(logger log.Logger, feature types.CompletionsFea
 // newNonStreamingResponseHandler handles non-streaming requests to an LLM provider,
 // awaiting the complete response before writing it back in a structured JSON response
 // to the client.
-func newNonStreamingResponseHandler(logger log.Logger, feature types.CompletionsFeature) func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore) {
+func newNonStreamingResponseHandler(logger log.Logger, db database.DB, feature types.CompletionsFeature) func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore) {
 	return func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore) {
 		completion, err := cc.Complete(ctx, feature, requestParams)
 		if err != nil {
@@ -310,10 +323,16 @@ func newNonStreamingResponseHandler(logger log.Logger, feature types.Completions
 						http.Error(w, "Internal server error", http.StatusInternalServerError)
 						return
 					}
-					isProUser := user.CodyProEnabledAt != nil
+					subscription, err := cody.SubscriptionForUser(ctx, db, *user)
+					if err != nil {
+						logger.Error("Error while fetching user's cody subscription", log.Error(err))
+						http.Error(w, "Internal server error", http.StatusInternalServerError)
+						return
+					}
+
 					isDotcom := envvar.SourcegraphDotComMode()
 					if isDotcom {
-						if isProUser {
+						if subscription.ApplyProRateLimits {
 							w.Header().Set("x-is-cody-pro-user", "true")
 						} else {
 							w.Header().Set("x-is-cody-pro-user", "false")

--- a/internal/ssc/ssc.go
+++ b/internal/ssc/ssc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
@@ -70,6 +71,8 @@ func (c *SSCClient) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Sub
 	if err != nil {
 		return nil, err
 	}
+
+	subscription.Status = SubscriptionStatus(strings.ToUpper(subscription.StatusRaw))
 
 	if *code == http.StatusOK {
 		return &subscription, nil

--- a/internal/ssc/types.go
+++ b/internal/ssc/types.go
@@ -11,21 +11,22 @@ const (
 type SubscriptionStatus string
 
 const (
-	SubscriptionStatusActive   SubscriptionStatus = "active"
-	SubscriptionStatusPastDue  SubscriptionStatus = "past_due"
-	SubscriptionStatusUnpaid   SubscriptionStatus = "unpaid"
-	SubscriptionStatusCanceled SubscriptionStatus = "canceled"
-	SubscriptionStatusTrialing SubscriptionStatus = "trialing"
-	SubscriptionStatusOther    SubscriptionStatus = "other"
+	SubscriptionStatusActive   SubscriptionStatus = "ACTIVE"
+	SubscriptionStatusPastDue  SubscriptionStatus = "PAST_DUE"
+	SubscriptionStatusUnpaid   SubscriptionStatus = "UNPAID"
+	SubscriptionStatusCanceled SubscriptionStatus = "CANCELED"
+	SubscriptionStatusTrialing SubscriptionStatus = "TRIALING"
+	SubscriptionStatusOther    SubscriptionStatus = "OTHER"
 	// NOTE: The "pending" status is only temporary, and will be removed after Feb 15 2024.
 	// This is to support the pre-release state where a user has opted for a free Pro trial
 	// but has not put in their cc in SSC yet.
-	SubscriptionStatusPending SubscriptionStatus = "pending"
+	SubscriptionStatusPending SubscriptionStatus = "PENDING"
 )
 
 type Subscription struct {
 	// Status is the current status of the subscription, e.g. "active" or "canceled".
-	Status          SubscriptionStatus `json:"status"`
+	StatusRaw       string             `json:"status"`
+	Status          SubscriptionStatus `json:"-"`
 	BillingInterval BillingInterval    `json:"billingInterval"`
 
 	// CancelAtPeriodEnd flags whether or not a subscription will automatically cancel at the end


### PR DESCRIPTION
Follow-up PR of https://github.com/sourcegraph/sourcegraph/pull/59763

closes: https://github.com/sourcegraph/sourcegraph/issues/58123
closes: https://github.com/sourcegraph/sourcegraph/issues/59622
closes: https://github.com/sourcegraph/sourcegraph/issues/59620
closes: https://github.com/sourcegraph/sourcegraph/issues/59623

The previous PR:
- added a new SSC API client in dotcom to fetch user's subscription info
- added a func `cody.SubscriptionForUser` to be used to find cody subscription info for the user. 
- added unit tests

This PR:
- updates all the graphql resolvers wherever applicable to use the `cody.SubscriptionForUser` function rather than directly checking dotcom's DB for `users.cody_pro_enabled_at` column.
- updated the rate limits logic in `dotcom_user_resolver` to use cody.SubscriptionForUser` function as well. 
- Added the `currentUser.codySubscription` field to graphql api
```graphql
currentUser { 
  codySubscription { 
    status 
    plan 
    applyProRateLimtis 
    currentPeriodStartAt 
    currentPeriodEndAt 
  }
}
```
- Removed the following fields from the graphql API
```graphql
currentUser { 
  codyCurrentPeriodStartDate
  codyCurrentPeriodEndDate
}
```
Both the removed fields are not used by any of the Cody Clients and their usage is updated to follow the new schema for dotcom web. 

## Test plan
Unit tests present

**Manual testing plan**

1. Set up and run SAMS locally.
2. Integrate SAMS as an openidconnect auth provider with dotcom locally.
3. Create a user using the SAMS auth provider.
4. Enable feature flag use-ssc-for-cody-subscription from site admin.
5. Make a graphql API [request](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%7B%5Cn%20%20currentUser%20%7B%5Cn%20%20%20%20codyProEnabled%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D) to confirm false.
6. Visit localhost:9992/cody and go through the subscription flow to sign up for Cody Pro.
7. Make a graphql API [request](https://sourcegraph.test:3443/api/console#%7B%22query%22%3A%22%7B%5Cn%20%20currentUser%20%7B%5Cn%20%20%20%20codyProEnabled%5Cn%20%20%7D%5Cn%7D%5Cn%22%7D) again to confirm true.