### PR TITLE
Remove embeddings alert from ui

### DIFF
--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -34,9 +34,6 @@ const QUERY = gql`
         site {
             ...SiteFlagFields
         }
-        codeIntelligenceConfigurationPolicies(forEmbeddings: true) {
-            totalCount
-        }
     }
 
     ${siteFlagFieldsFragment}
@@ -63,9 +60,6 @@ export const GlobalAlerts: React.FunctionComponent<Props> = ({ authenticatedUser
                 ({ message }) => !adminOnboardingRemovedAlerts.some(alt => message.includes(alt))
             ) ?? []
     }
-
-    const showNoEmbeddingPoliciesAlert =
-        window.context?.codyEnabled && data?.codeIntelligenceConfigurationPolicies.totalCount === 0
 
     return (
         <div className={classNames('test-global-alert', styles.globalAlerts)}>
@@ -126,22 +120,7 @@ export const GlobalAlerts: React.FunctionComponent<Props> = ({ authenticatedUser
                     .
                 </DismissibleAlert>
             )}
-            {/* Cody app creates a global policy during setup but this alert is flashing during connection to dotcom account */}
-            {showNoEmbeddingPoliciesAlert && authenticatedUser?.siteAdmin && (
-                <DismissibleAlert
-                    key="no-embeddings-policies-alert"
-                    partialStorageKey="no-embeddings-policies-alert"
-                    variant="danger"
-                    className={styles.alert}
-                >
-                    <div>
-                        <strong>Warning!</strong> No embeddings policies have been configured. This will lead to poor
-                        results from Cody, Sourcegraph’s AI assistant. Add an{' '}
-                        <Link to="/site-admin/embeddings/configuration">embedding policy</Link>
-                    </div>
-                    .
-                </DismissibleAlert>
-            )}
+
             <Notices alertClassName={styles.alert} location="top" />
 
             <VerifyEmailNotices authenticatedUser={authenticatedUser} alertClassName={styles.alert} />


### PR DESCRIPTION
Removes the alert about embeddings policies from the UI 
## Test plan
manually tested.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
