### PR TITLE
Search Results: new styling

### DIFF
--- a/client/branded/src/search-ui/components/CommitSearchResultMatch.module.scss
+++ b/client/branded/src/search-ui/components/CommitSearchResultMatch.module.scss
@@ -26,7 +26,7 @@
 }
 
 .code-excerpt {
-    padding: 0.5rem;
+    padding: 0.75rem;
     color: var(--body-color);
 
     table {

--- a/client/branded/src/search-ui/components/CommitSearchResultMatch.module.scss
+++ b/client/branded/src/search-ui/components/CommitSearchResultMatch.module.scss
@@ -26,7 +26,7 @@
 }
 
 .code-excerpt {
-    padding: 0 0.5rem;
+    padding: 0.5rem;
     color: var(--body-color);
 
     table {

--- a/client/branded/src/search-ui/components/CopyPathAction.module.scss
+++ b/client/branded/src/search-ui/components/CopyPathAction.module.scss
@@ -1,5 +1,5 @@
 .button {
-    padding: 0.5rem;
+    padding: 0 0.5rem;
 }
 
 .copy-icon {

--- a/client/branded/src/search-ui/components/FileMatchChildren.module.scss
+++ b/client/branded/src/search-ui/components/FileMatchChildren.module.scss
@@ -1,6 +1,5 @@
 .file-match-children {
     background-color: var(--code-bg);
-    border-radius: var(--border-radius);
     padding: 0.25rem 0;
     position: relative;
 

--- a/client/branded/src/search-ui/components/FilePathSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FilePathSearchResult.tsx
@@ -65,6 +65,6 @@ export const FilePathSearchResult: FC<FilePathSearchResult & TelemetryProps> = (
             className={classNames(styles.copyButtonContainer, containerClassName)}
             repoLastFetched={result.repoLastFetched}
             actions={<SearchResultPreviewButton result={result} />}
-        ></ResultContainer>
+        />
     )
 }

--- a/client/branded/src/search-ui/components/FilePathSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FilePathSearchResult.tsx
@@ -65,10 +65,6 @@ export const FilePathSearchResult: FC<FilePathSearchResult & TelemetryProps> = (
             className={classNames(styles.copyButtonContainer, containerClassName)}
             repoLastFetched={result.repoLastFetched}
             actions={<SearchResultPreviewButton result={result} />}
-        >
-            <div className={classNames(styles.searchResultMatch, 'p-2')}>
-                <small>{result.pathMatches ? 'Path match' : 'File contains matching content'}</small>
-            </div>
-        </ResultContainer>
+        ></ResultContainer>
     )
 }

--- a/client/branded/src/search-ui/components/RepoSearchResult.tsx
+++ b/client/branded/src/search-ui/components/RepoSearchResult.tsx
@@ -78,8 +78,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     const tags = [
         ...(metadata
             ? Object.entries(metadata).map(([key, value]) =>
-                  metadataToTag({ key, value }, queryState, false, buildSearchURLQueryFromQueryState)
-              )
+                metadataToTag({ key, value }, queryState, false, buildSearchURLQueryFromQueryState)
+            )
             : []),
         ...(topics ? topics.map(topic => topicToTag(topic, queryState, false, buildSearchURLQueryFromQueryState)) : []),
     ]
@@ -101,7 +101,7 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
             {(showExtraInfo || description || showRepoMetadata) && (
                 <div
                     data-testid="search-repo-result"
-                    className={classNames(styles.searchResultMatch, styles.gap1, 'p-2 flex-column')}
+                    className={classNames(styles.searchResultMatch, styles.gap1, 'p-3 flex-column')}
                 >
                     {showExtraInfo && (
                         <div className={classNames('d-flex', styles.dividerBetween)}>

--- a/client/branded/src/search-ui/components/RepoSearchResult.tsx
+++ b/client/branded/src/search-ui/components/RepoSearchResult.tsx
@@ -78,8 +78,8 @@ export const RepoSearchResult: React.FunctionComponent<RepoSearchResultProps> = 
     const tags = [
         ...(metadata
             ? Object.entries(metadata).map(([key, value]) =>
-                metadataToTag({ key, value }, queryState, false, buildSearchURLQueryFromQueryState)
-            )
+                  metadataToTag({ key, value }, queryState, false, buildSearchURLQueryFromQueryState)
+              )
             : []),
         ...(topics ? topics.map(topic => topicToTag(topic, queryState, false, buildSearchURLQueryFromQueryState)) : []),
     ]

--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -3,7 +3,10 @@
     display: flex;
     align-items: center;
     flex-wrap: wrap;
+
     position: sticky;
+    top: 0;
+
     z-index: 1; // Show on top of search result contents
 
     border-bottom: 1px solid var(--border-color);

--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -1,18 +1,18 @@
-.result-container {
+li.result-container {
     &:last-child {
         border-bottom-width: 1px;
     }
 
-    &:not(:last-of-type) {
-        // Prevents the sticky items below from affecting
-        // anything outside of the result container.
-        isolation: isolate;
-        margin-bottom: 1rem;
-    }
+    // &:not(:last-of-type) {
+    //     // Prevents the sticky items below from affecting
+    //     // anything outside of the result container.
+    //     isolation: isolate;
+    //     margin-bottom: 0.75rem;
+    // }
 }
 
 .header {
-    padding: 0.5rem 0.5rem 0.25rem 0;
+    padding: 0.5rem 0.75rem;
     display: flex;
     align-items: center;
     flex-wrap: wrap;
@@ -22,7 +22,15 @@
     // header and top of the scrolling block
     top: -1px;
     z-index: 1; // Show on top of search result contents
-    background-color: var(--body-bg);
+    border-bottom: 1px solid var(--border-color);
+
+    // TODO(taiyab): this needs to be fit into the design system
+    :global(.theme-light) & {
+        background-color: #f4f7f9;
+    }
+    :global(.theme-dark) & {
+        background-color: #090909;
+    }
 
     &-title {
         flex: 1 1 auto;
@@ -34,9 +42,9 @@
         margin-bottom: 0;
     }
 
-    &:not(:only-of-type) {
-        border-bottom: none;
-    }
+    // &:not(:only-of-type) {
+    //     border-bottom: none;
+    // }
 
     :global(.match-highlight) {
         color: var(--text-muted-highlighted);
@@ -44,9 +52,8 @@
 }
 
 .result {
-    border-radius: var(--border-radius);
-    border: 1px solid var(--border-color);
-    margin-top: 0.25rem;
+    // border-radius: var(--border-radius);
+    border-bottom: 1px solid var(--border-color);
 
     &:hover {
         border-color: var(--border-color-2);

--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -13,7 +13,7 @@
 
     // TODO(taiyab): this needs to be fit into the design system
     :global(.theme-light) & {
-        background-color: #f4f7f9;
+        background-color: #f5f8fa;
     }
     :global(.theme-dark) & {
         background-color: #22283b;

--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -2,13 +2,6 @@ li.result-container {
     &:last-child {
         border-bottom-width: 1px;
     }
-
-    // &:not(:last-of-type) {
-    //     // Prevents the sticky items below from affecting
-    //     // anything outside of the result container.
-    //     isolation: isolate;
-    //     margin-bottom: 0.75rem;
-    // }
 }
 
 .header {
@@ -29,7 +22,7 @@ li.result-container {
         background-color: #f4f7f9;
     }
     :global(.theme-dark) & {
-        background-color: #090909;
+        background-color: #22283b;
     }
 
     &-title {
@@ -42,17 +35,12 @@ li.result-container {
         margin-bottom: 0;
     }
 
-    // &:not(:only-of-type) {
-    //     border-bottom: none;
-    // }
-
     :global(.match-highlight) {
         color: var(--text-muted-highlighted);
     }
 }
 
 .result {
-    // border-radius: var(--border-radius);
     border-bottom: 1px solid var(--border-color);
 
     &:hover {

--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -1,20 +1,11 @@
-li.result-container {
-    &:last-child {
-        border-bottom-width: 1px;
-    }
-}
-
 .header {
     padding: 0.5rem 0.75rem;
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     position: sticky;
-    // With 0 value there is a rendering bug in Safari where this block
-    // doesn't fit tight enough and hence it's leaving a gap between sticky
-    // header and top of the scrolling block
-    top: -1px;
     z-index: 1; // Show on top of search result contents
+
     border-bottom: 1px solid var(--border-color);
 
     // TODO(taiyab): this needs to be fit into the design system
@@ -31,10 +22,6 @@ li.result-container {
         flex-wrap: wrap;
     }
 
-    p {
-        margin-bottom: 0;
-    }
-
     :global(.match-highlight) {
         color: var(--text-muted-highlighted);
     }
@@ -42,10 +29,6 @@ li.result-container {
 
 .result {
     border-bottom: 1px solid var(--border-color);
-
-    &:hover {
-        border-color: var(--border-color-2);
-    }
 }
 
 .header:focus-within + .highlight-result.result,

--- a/client/branded/src/search-ui/components/ResultContainer.tsx
+++ b/client/branded/src/search-ui/components/ResultContainer.tsx
@@ -68,7 +68,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
 
     return (
         <Component
-            className={classNames('test-search-result', styles.resultContainer, className)}
+            className={classNames('test-search-result', className)}
             data-testid="result-container"
             data-result-type={resultType}
             onClick={trackReferencePanelClick}

--- a/client/branded/src/search-ui/components/SearchResult.module.scss
+++ b/client/branded/src/search-ui/components/SearchResult.module.scss
@@ -5,7 +5,6 @@
     overflow-x: auto;
     overflow-y: hidden;
     background-color: var(--code-bg);
-    border-radius: var(--border-radius);
     padding: 0.25rem 0;
     position: relative;
 

--- a/client/branded/src/search-ui/components/SearchResult.module.scss
+++ b/client/branded/src/search-ui/components/SearchResult.module.scss
@@ -5,7 +5,6 @@
     overflow-x: auto;
     overflow-y: hidden;
     background-color: var(--code-bg);
-    padding: 0.25rem 0;
     position: relative;
 
     &:hover {

--- a/client/branded/src/search-ui/components/SearchResult.module.scss
+++ b/client/branded/src/search-ui/components/SearchResult.module.scss
@@ -93,10 +93,11 @@
     text-align: left;
     border: none;
     padding: 0.25rem 0.5rem;
-    background-color: var(--border-color);
+    border-top: 1px solid var(--border-color);
+    background-color: var(--code-bg);
     border-bottom-left-radius: var(--border-radius);
     border-bottom-right-radius: var(--border-radius);
-    color: var(--collapse-results-color);
+    color: var(--text-disabled);
 
     // When expanded, stick collapse button to the bottom of the
     // screen if there are enough search results to cause scrolling.
@@ -108,6 +109,10 @@
     &-text {
         margin-left: 0.125rem;
     }
+}
+
+.toggle-matches-button:hover {
+    color: var(--text-muted);
 }
 
 .copy-button {

--- a/client/branded/src/search-ui/components/SearchResultPreviewButton.tsx
+++ b/client/branded/src/search-ui/components/SearchResultPreviewButton.tsx
@@ -26,7 +26,7 @@ export const SearchResultPreviewButton: FC<SearchResultPreviewButtonProps> = pro
     }
 
     return (
-        <Button variant="link" className="py-1 px-0 mr-2" onClick={handleClick}>
+        <Button variant="link" className="py-0 px-0 mr-2" onClick={handleClick}>
             {isActive ? 'Hide preview' : 'Preview'}
         </Button>
     )

--- a/client/branded/src/search-ui/components/SearchResultPreviewButton.tsx
+++ b/client/branded/src/search-ui/components/SearchResultPreviewButton.tsx
@@ -26,7 +26,7 @@ export const SearchResultPreviewButton: FC<SearchResultPreviewButtonProps> = pro
     }
 
     return (
-        <Button variant="link" className="py-0 px-0 mr-2" onClick={handleClick}>
+        <Button variant="link" className="p-0 mr-2" onClick={handleClick}>
             {isActive ? 'Hide preview' : 'Preview'}
         </Button>
     )

--- a/client/branded/src/search-ui/components/SymbolSearchResult.module.scss
+++ b/client/branded/src/search-ui/components/SymbolSearchResult.module.scss
@@ -7,22 +7,18 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    background-color: var(--body-bg) !important;
-    padding: 0.25rem 0;
+    background-color: var(--code-bg);
+    border-bottom: 1px solid var(--border-color);
+    padding: 0.25rem;
 }
 
 .symbol {
     display: flex;
     align-items: center;
     width: 100%;
-    background-color: var(--color-bg-2);
+    background-color: var(--code-bg);
     padding: 0.25rem;
-    border-radius: var(--border-radius);
     cursor: pointer;
-
-    &:not(:last-child) {
-        margin-bottom: 0.5rem;
-    }
 
     &-code-excerpt {
         :global(.code) {

--- a/client/branded/src/search-ui/components/SymbolSearchResult.module.scss
+++ b/client/branded/src/search-ui/components/SymbolSearchResult.module.scss
@@ -8,8 +8,6 @@
     display: flex;
     flex-direction: column;
     background-color: var(--code-bg);
-    border-bottom: 1px solid var(--border-color);
-    padding: 0.25rem;
 }
 
 .symbol {
@@ -17,8 +15,9 @@
     align-items: center;
     width: 100%;
     background-color: var(--code-bg);
-    padding: 0.25rem;
+    padding: 0.5rem;
     cursor: pointer;
+    border-bottom: 1px solid var(--border-color);
 
     &-code-excerpt {
         :global(.code) {

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -34,7 +34,6 @@ import { StreamingSearchResultFooter } from './StreamingSearchResultsFooter'
 import { useItemsToShow } from './use-items-to-show'
 import { useSearchResultsKeyboardNavigation } from './useSearchResultsKeyboardNavigation'
 
-import resultContainerStyles from '../components/ResultContainer.module.scss'
 import styles from './StreamingSearchResultsList.module.scss'
 
 export interface StreamingSearchResultsListProps

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -133,10 +133,6 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                                 filePath={result.path}
                                 revision={getRevision(result.branches, result.commit)}
                                 repoName={result.repository}
-                                // PrefetchableFile adds an extra wrapper, so we lift the <li> up and match the ResultContainer styles.
-                                // Better approach would be to use `as` to avoid wrapping, but that requires a larger refactor of the
-                                // child components than is worth doing right now for this experimental feature
-                                className={resultContainerStyles.resultContainer}
                                 as="li"
                             >
                                 {result.type === 'content' && (

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -267,7 +267,8 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             <VirtualList<SearchMatch>
                 as="ol"
                 aria-label="Search results"
-                className={classNames('mt-2 mb-0', styles.list)}
+                // TODO: is this the source of the extra style application?
+                className={classNames(styles.list)}
                 itemsToShow={itemsToShow}
                 onShowMoreItems={handleBottomHit}
                 items={results?.results || []}

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -267,7 +267,6 @@ export const StreamingSearchResultsList: React.FunctionComponent<
             <VirtualList<SearchMatch>
                 as="ol"
                 aria-label="Search results"
-                // TODO: is this the source of the extra style application?
                 className={classNames(styles.list)}
                 itemsToShow={itemsToShow}
                 onShowMoreItems={handleBottomHit}

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.module.scss
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.module.scss
@@ -125,7 +125,6 @@
 .content {
     grid-area: contents;
     overflow: auto;
-    padding: 0 0.5rem 0.5rem 0.5rem;
 
     &::-webkit-scrollbar {
         width: 0.5rem;

--- a/client/wildcard/src/global-styles/colors.scss
+++ b/client/wildcard/src/global-styles/colors.scss
@@ -222,7 +222,6 @@ $theme-colors: (
     --modal-bg: #{rgba($gray-04, 0.5)};
     --sidebar-bg: var(--color-bg-1);
     --sidebar-border-color: var(--border-color-2);
-    --collapse-results-color: var(--gray-08);
     // Chroma rules, for rendered markdown blocks
     --chroma-error-fg: #a61717;
     --chroma-error-bg: #e3d2d2;
@@ -318,7 +317,7 @@ $theme-colors: (
     --secondary: var(--gray-08);
     --secondary-2: #242936;
     --secondary-3: #1f232e;
-    --secondary-4: #545967;
+    --secondary-4: #1e222f;
     --success-2: #156724;
     --success-3: #237332;
     --success-4: #054410;


### PR DESCRIPTION
This updates the styling of the search results to match the designs. As it turns out, there wasn't a ton to do other than styling and spacing tweaks that we needed to do anyways.

<table>
<th>
<td>Light</td>
<td>Dark</td>
</th>
<tr>
<td>Content</td>
<td>

![CleanShot 2024-01-24 at 16 45 39@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/407c6f2c-0f5d-4d59-ab64-e3d305e204eb)

</td>
<td>

![CleanShot 2024-01-24 at 16 45 48@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/d4e38d65-dc89-476b-8c1b-941239925bd4)

</td>

</td>
</tr>
<tr>
<td>Repo</td>
<td>


![CleanShot 2024-01-24 at 16 46 31@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/b734c07f-6fae-4bef-a611-9cba0c8f3172)


</td>
<td>


![CleanShot 2024-01-24 at 16 46 23@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/d3c1b964-6abd-4fd8-b5f1-2f7617a3b1fb)


</td>
</tr>
<tr>
<td>Path</td>
<td>

![CleanShot 2024-01-24 at 16 46 54@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/a7600329-0977-4072-b22a-cad6432215bb)


</td>
<td>

![CleanShot 2024-01-24 at 16 47 00@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/137e4d87-4a2b-43b7-88d6-b59a30a9c6f6)

</td>
</tr>
<tr>
<td>Symbol</td>
<td>

![CleanShot 2024-01-24 at 16 47 34@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/5f9a7036-e1b8-4f4f-a549-3840146004ad)


</td>
<td>

![CleanShot 2024-01-24 at 16 47 27@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/e6273b2b-df31-4cfc-bb05-a87861fa9c8e)

</td>

</tr>
<tr>
<tr>
<td>Commit</td>
<td>

![CleanShot 2024-01-24 at 16 48 27@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/2fff2199-5844-4f78-b815-28d809ff5d5d)


</td>
<td>

![CleanShot 2024-01-24 at 16 48 33@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/e412e57a-9547-45bf-b377-1c6c50001cb7)

</td>
</tr>
<tr>
<td>Diff</td>
<td>

![CleanShot 2024-01-24 at 16 49 07@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/09216e82-93b8-4188-b0f8-763a3328b6a1)

</td>
<td>

![CleanShot 2024-01-24 at 16 49 02@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/d80c5d44-06cf-417c-bf14-6a7debee553d)

</td>
</tr>
</table>

A video of scroll behavior. Notice that the first header does not move when scrolled.

https://github.com/sourcegraph/sourcegraph/assets/12631702/feb598cc-6ba9-4a72-9602-bb19a4fadaa2

@taiyab The header color for dark mode looks nice, but does not contrast well with the border color:

![CleanShot 2024-01-24 at 16 19 18@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/bca0db54-c9c7-4e82-a9b7-8581918367f5)

## Test plan

Lots and lots of manual visual testing and tweaking. There should be no changes in behavior, only in style. I'll be doing an audit of the other places we display search results as well to make sure nothing surprising broke there before merge, but right now it's dinner time.
