### PR TITLE
Add .cody/ignore support to remote context 

### DIFF
--- a/cmd/frontend/internal/context/BUILD.bazel
+++ b/cmd/frontend/internal/context/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
         "//cmd/frontend/enterprise",
         "//cmd/frontend/internal/context/resolvers",
         "//internal/codeintel",
-        "//internal/codycontext:context",
+        "//internal/codycontext",
         "//internal/conf/conftypes",
         "//internal/database",
         "//internal/embeddings",

--- a/cmd/frontend/internal/context/init.go
+++ b/cmd/frontend/internal/context/init.go
@@ -35,7 +35,7 @@ func Init(
 		embeddingsClient,
 		searchClient,
 		getQdrantSearcher,
-		gitserver.NewClient("graphql.context.codycontext"),
+		services.GitserverClient.Scoped("codycontext"),
 	)
 	enterpriseServices.CodyContextResolver = resolvers.NewResolver(
 		db,

--- a/cmd/frontend/internal/context/init.go
+++ b/cmd/frontend/internal/context/init.go
@@ -35,7 +35,7 @@ func Init(
 		embeddingsClient,
 		searchClient,
 		getQdrantSearcher,
-		services.GitserverClient.Scoped("codycontext"),
+		codycontext.NewCodyIgnoreFilter(services.GitserverClient.Scoped("codycontext.ignore")),
 	)
 	enterpriseServices.CodyContextResolver = resolvers.NewResolver(
 		db,

--- a/cmd/frontend/internal/context/init.go
+++ b/cmd/frontend/internal/context/init.go
@@ -35,6 +35,7 @@ func Init(
 		embeddingsClient,
 		searchClient,
 		getQdrantSearcher,
+		gitserver.NewClient("graphql.context.codycontext"),
 	)
 	enterpriseServices.CodyContextResolver = resolvers.NewResolver(
 		db,

--- a/cmd/frontend/internal/context/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/context/resolvers/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     visibility = ["//cmd/frontend:__subpackages__"],
     deps = [
         "//cmd/frontend/graphqlbackend",
-        "//internal/codycontext:context",
+        "//internal/codycontext",
         "//internal/database",
         "//internal/gitserver",
         "//internal/trace",
@@ -30,7 +30,7 @@ go_test(
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
         "//internal/api",
-        "//internal/codycontext:context",
+        "//internal/codycontext",
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbtest",

--- a/cmd/frontend/internal/context/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/context/resolvers/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//internal/search/streaming",
         "//internal/types",
         "//lib/errors",
+        "//lib/pointers",
         "//schema",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",

--- a/cmd/frontend/internal/context/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/context/resolvers/BUILD.bazel
@@ -27,7 +27,6 @@ go_test(
         "requires-network",
     ],
     deps = [
-        "//cmd/frontend/envvar",
         "//cmd/frontend/graphqlbackend",
         "//internal/actor",
         "//internal/api",

--- a/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/cmd/frontend/internal/context/resolvers/context_test.go
@@ -115,7 +115,7 @@ func TestContextResolver(t *testing.T) {
 	}
 
 	mockGitserver := gitserver.NewMockClient()
-	mockGitserver.HeadFunc.SetDefaultReturn("abc123", true, nil)
+	mockGitserver.GetDefaultBranchFunc.SetDefaultReturn("main", api.CommitID("abc123"), nil)
 	mockGitserver.StatFunc.SetDefaultHook(func(_ context.Context, repo api.RepoName, _ api.CommitID, fileName string) (fs.FileInfo, error) {
 		return fakeFileInfo{path: fileName}, nil
 	})

--- a/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/cmd/frontend/internal/context/resolvers/context_test.go
@@ -115,6 +115,7 @@ func TestContextResolver(t *testing.T) {
 	}
 
 	mockGitserver := gitserver.NewMockClient()
+	mockGitserver.HeadFunc.SetDefaultReturn("abc123", true, nil)
 	mockGitserver.StatFunc.SetDefaultHook(func(_ context.Context, repo api.RepoName, _ api.CommitID, fileName string) (fs.FileInfo, error) {
 		return fakeFileInfo{path: fileName}, nil
 	})

--- a/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/cmd/frontend/internal/context/resolvers/context_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -42,17 +41,10 @@ func TestContextResolver(t *testing.T) {
 	repo1 := types.Repo{Name: "repo1"}
 	repo2 := types.Repo{Name: "repo2"}
 	truePtr := true
-	envvar.MockSourcegraphDotComMode(true)
-	defer envvar.MockSourcegraphDotComMode(false)
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{
 			CodyEnabled: &truePtr,
 			LicenseKey:  "asdf",
-			Embeddings: &schema.Embeddings{
-				Provider:    "sourcegraph",
-				Enabled:     &truePtr,
-				AccessToken: "123",
-			},
 		},
 	})
 
@@ -105,17 +97,20 @@ func TestContextResolver(t *testing.T) {
 	err = db.Repos().Create(ctx, &repo1, &repo2)
 	require.NoError(t, err)
 
-	_, err = db.ExecContext(ctx, "INSERT INTO repo_embedding_jobs (state, repo_id, revision) VALUES ('completed', $1, 'HEAD');", int32(repo1.ID))
-	require.NoError(t, err)
-
 	files := map[api.RepoName]map[string][]byte{
 		"repo1": {
 			"testcode1.go": []byte("testcode1"),
+			"ignore_me.go": []byte("secret"),
+			"ignore_me.md": []byte("secret"),
 			"testtext1.md": []byte("testtext1"),
+			".cody/ignore": []byte("ignore_me.go\nignore_me.md"),
 		},
 		"repo2": {
 			"testcode2.go": []byte("testcode2"),
+			"ignore_me.go": []byte("secret"),
+			"ignore_me.md": []byte("secret"),
 			"testtext2.md": []byte("testtext2"),
+			".cody/ignore": []byte("ignore_me.go\nignore_me.md"),
 		},
 	}
 
@@ -131,19 +126,7 @@ func TestContextResolver(t *testing.T) {
 	})
 
 	mockEmbeddingsClient := embeddings.NewMockClient()
-	mockEmbeddingsClient.SearchFunc.SetDefaultHook(func(_ context.Context, params embeddings.EmbeddingsSearchParameters) (*embeddings.EmbeddingCombinedSearchResults, error) {
-		require.Equal(t, params.RepoNames, []api.RepoName{"repo1"})
-		require.Equal(t, params.TextResultsCount, 1)
-		require.Equal(t, params.CodeResultsCount, 1)
-		return &embeddings.EmbeddingCombinedSearchResults{
-			CodeResults: embeddings.EmbeddingSearchResults{{
-				FileName: "testcode1.go",
-			}},
-			TextResults: embeddings.EmbeddingSearchResults{{
-				FileName: "testtext1.md",
-			}},
-		}, nil
-	})
+	mockEmbeddingsClient.SearchFunc.SetDefaultReturn(nil, errors.New("embeddings should be disabled"))
 
 	lineRange := func(start, end int) result.ChunkMatches {
 		return result.ChunkMatches{{
@@ -163,13 +146,25 @@ func TestContextResolver(t *testing.T) {
 			stream.Send(streaming.SearchEvent{
 				Results: result.Matches{&result.FileMatch{
 					File: result.File{
-						Path: "testcode2.go",
+						Path: "ignore_me.go",
+						Repo: types.MinimalRepo{ID: repo1.ID, Name: repo1.Name},
+					},
+					ChunkMatches: lineRange(0, 4),
+				}, &result.FileMatch{
+					File: result.File{
+						Path: "ignore_me.go",
 						Repo: types.MinimalRepo{ID: repo2.ID, Name: repo2.Name},
 					},
 					ChunkMatches: lineRange(0, 4),
 				}, &result.FileMatch{
 					File: result.File{
-						Path: "testcode2again.go",
+						Path: "testcode1.go",
+						Repo: types.MinimalRepo{ID: repo1.ID, Name: repo1.Name},
+					},
+					ChunkMatches: lineRange(0, 4),
+				}, &result.FileMatch{
+					File: result.File{
+						Path: "testcode2.go",
 						Repo: types.MinimalRepo{ID: repo2.ID, Name: repo2.Name},
 					},
 					ChunkMatches: lineRange(0, 4),
@@ -178,6 +173,24 @@ func TestContextResolver(t *testing.T) {
 		} else {
 			stream.Send(streaming.SearchEvent{
 				Results: result.Matches{&result.FileMatch{
+					File: result.File{
+						Path: "ignore_me.md",
+						Repo: types.MinimalRepo{ID: repo1.ID, Name: repo1.Name},
+					},
+					ChunkMatches: lineRange(0, 4),
+				}, &result.FileMatch{
+					File: result.File{
+						Path: "ignore_me.md",
+						Repo: types.MinimalRepo{ID: repo2.ID, Name: repo2.Name},
+					},
+					ChunkMatches: lineRange(0, 4),
+				}, &result.FileMatch{
+					File: result.File{
+						Path: "testtext1.md",
+						Repo: types.MinimalRepo{ID: repo1.ID, Name: repo2.Name},
+					},
+					ChunkMatches: lineRange(0, 4),
+				}, &result.FileMatch{
 					File: result.File{
 						Path: "testtext2.md",
 						Repo: types.MinimalRepo{ID: repo2.ID, Name: repo2.Name},
@@ -195,6 +208,7 @@ func TestContextResolver(t *testing.T) {
 		mockEmbeddingsClient,
 		mockSearchClient,
 		nil,
+		mockGitserver,
 	)
 
 	resolver := NewResolver(
@@ -216,7 +230,7 @@ func TestContextResolver(t *testing.T) {
 		paths[i] = result.(*graphqlbackend.FileChunkContextResolver).Blob().Path()
 	}
 	// One code result and text result from each repo
-	expected := []string{"testcode1.go", "testtext1.md", "testcode2.go", "testtext2.md"}
+	expected := []string{"testcode1.go", "testcode2.go", "testtext1.md", "testtext2.md"}
 	sort.Strings(expected)
 	sort.Strings(paths)
 	require.Equal(t, expected, paths)

--- a/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/cmd/frontend/internal/context/resolvers/context_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -45,8 +46,12 @@ func TestContextResolver(t *testing.T) {
 		SiteConfiguration: schema.SiteConfiguration{
 			CodyEnabled: &truePtr,
 			LicenseKey:  "asdf",
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				CodyContextIgnore: pointers.Ptr(true),
+			},
 		},
 	})
+	t.Cleanup(func() { conf.Mock(nil) })
 
 	oldMock := licensing.MockCheckFeature
 	defer func() {

--- a/cmd/frontend/internal/context/resolvers/context_test.go
+++ b/cmd/frontend/internal/context/resolvers/context_test.go
@@ -209,7 +209,7 @@ func TestContextResolver(t *testing.T) {
 		mockEmbeddingsClient,
 		mockSearchClient,
 		nil,
-		mockGitserver,
+		codycontext.NewCodyIgnoreFilter(mockGitserver),
 	)
 
 	resolver := NewResolver(

--- a/internal/codycontext/BUILD.bazel
+++ b/internal/codycontext/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/codycontext",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/actor",
         "//internal/api",
         "//internal/cody",
         "//internal/conf",
@@ -30,6 +31,7 @@ go_library(
         "//lib/errors",
         "//lib/pointers",
         "@com_github_grafana_regexp//:regexp",
+        "@com_github_hashicorp_golang_lru_v2//:golang-lru",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_zoekt//ignore",
@@ -43,9 +45,13 @@ go_test(
     embed = [":codycontext"],
     deps = [
         "//internal/api",
+        "//internal/conf",
         "//internal/gitserver",
         "//internal/types",
         "//lib/errors",
+        "//lib/pointers",
+        "//schema",
+        "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/codycontext/BUILD.bazel
+++ b/internal/codycontext/BUILD.bazel
@@ -1,8 +1,12 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "context",
-    srcs = ["context.go"],
+    srcs = [
+        "context.go",
+        "filter.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/internal/codycontext",
     visibility = ["//:__subpackages__"],
     deps = [
@@ -14,6 +18,7 @@ go_library(
         "//internal/embeddings/db",
         "//internal/embeddings/embed",
         "//internal/featureflag",
+        "//internal/gitserver",
         "//internal/metrics",
         "//internal/observation",
         "//internal/search",
@@ -27,6 +32,20 @@ go_library(
         "@com_github_grafana_regexp//:regexp",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",
+        "@com_github_sourcegraph_zoekt//ignore",
         "@io_opentelemetry_go_otel//attribute",
+    ],
+)
+
+go_test(
+    name = "codycontext_test",
+    srcs = ["filter_test.go"],
+    embed = [":codycontext"],
+    deps = [
+        "//internal/api",
+        "//internal/gitserver",
+        "//internal/types",
+        "//lib/errors",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/codycontext/BUILD.bazel
+++ b/internal/codycontext/BUILD.bazel
@@ -1,8 +1,8 @@
-load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//dev:go_defs.bzl", "go_test")
 
 go_library(
-    name = "context",
+    name = "codycontext",
     srcs = [
         "context.go",
         "filter.go",

--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -124,7 +124,7 @@ func (c *CodyContextClient) GetCodyContext(ctx context.Context, args GetContextA
 
 	// Generating the content filter removes any repos where the filter can not
 	// be determined
-	filterableRepos, contextFilter := c.contentFilter.GetFilter(args.Repos)
+	filterableRepos, contextFilter := c.contentFilter.GetFilter(args.Repos, c.obsCtx.Logger)
 	args.Repos = filterableRepos
 
 	embeddingRepos, keywordRepos, err := c.partitionRepos(ctx, args.Repos)

--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -1,4 +1,4 @@
-package context
+package codycontext
 
 import (
 	"context"

--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -196,7 +196,7 @@ func (c *CodyContextClient) partitionRepos(ctx context.Context, input []types.Re
 	return embedded, notEmbedded, nil
 }
 
-func (c *CodyContextClient) getEmbeddingsContext(ctx context.Context, args GetContextArgs, filter RepoContextFilter) (_ []FileChunkContext, err error) {
+func (c *CodyContextClient) getEmbeddingsContext(ctx context.Context, args GetContextArgs, filter RepoContentFilter) (_ []FileChunkContext, err error) {
 	ctx, _, endObservation := c.getEmbeddingsContextOp.With(ctx, &err, observation.Args{Attrs: args.Attrs()})
 	defer endObservation(1, observation.Args{})
 
@@ -259,7 +259,7 @@ var textFileFilter = func() string {
 }()
 
 // getKeywordContext uses keyword search to find relevant bits of context for Cody
-func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetContextArgs, filter RepoContextFilter) (_ []FileChunkContext, err error) {
+func (c *CodyContextClient) getKeywordContext(ctx context.Context, args GetContextArgs, filter RepoContentFilter) (_ []FileChunkContext, err error) {
 	ctx, _, endObservation := c.getKeywordContextOp.With(ctx, &err, observation.Args{Attrs: args.Attrs()})
 	defer endObservation(1, observation.Args{})
 

--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -122,12 +122,12 @@ func (c *CodyContextClient) GetCodyContext(ctx context.Context, args GetContextA
 		return nil, err
 	}
 
-	embeddingRepos, keywordRepos, err := c.partitionRepos(ctx, args.Repos)
-	if err != nil {
-		return nil, err
-	}
+	// Generating the content filter removes any repos where the filter can not
+	// be determined
+	filterableRepos, contextFilter := c.contentFilter.GetFilter(args.Repos)
+	args.Repos = filterableRepos
 
-	contextFilter, err := c.contentFilter.GetFilter(args.Repos)
+	embeddingRepos, keywordRepos, err := c.partitionRepos(ctx, args.Repos)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (c *CodyContextClient) GetCodyContext(ctx context.Context, args GetContextA
 	// to decide how many results out of our limit should be reserved for
 	// embeddings results. We can't easily compare the scores between embeddings
 	// and keyword search.
-	embeddingsResultRatio := float32(len(embeddingRepos)) / float32(len(args.Repos))
+	embeddingsResultRatio := float32(len(embeddingRepos)) / float32(len(filterableRepos))
 
 	embeddingsArgs := GetContextArgs{
 		Repos:            embeddingRepos,

--- a/internal/codycontext/filter.go
+++ b/internal/codycontext/filter.go
@@ -71,7 +71,7 @@ func (f *repoFilter) GetEnabled() bool {
 }
 
 func (f *repoFilter) GetFilter(repos []types.RepoIDName, logger log.Logger) ([]types.RepoIDName, FileChunkFilterFunc) {
-	if !f.enabled {
+	if !f.GetEnabled() {
 		return repos, func(fcc []FileChunkContext) []FileChunkContext {
 			return fcc
 		}

--- a/internal/codycontext/filter.go
+++ b/internal/codycontext/filter.go
@@ -1,0 +1,65 @@
+package context
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/sourcegraph/zoekt/ignore"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+const codyIgnoreFile = ".cody/ignore"
+
+type filterFunc func(string) bool
+type repoFilter struct {
+	filters map[types.RepoIDName]filterFunc
+}
+
+type RepoContextFilter interface {
+	Filter(chunks []FileChunkContext) []FileChunkContext
+}
+
+// NewCodyIgnoreFilter creates a new Filter that applies .cody/ignore rules from
+// the given repositories to filter file paths. It reads the .cody/ignore file
+// from each repo and parses it into an ignore.Matcher func that is stored in
+// the returned Filter.
+func NewCodyIgnoreFilter(ctx context.Context, client gitserver.Client, repos []types.RepoIDName) (RepoContextFilter, error) {
+	f := &repoFilter{
+		filters: make(map[types.RepoIDName]filterFunc),
+	}
+	for _, repo := range repos {
+		ignoreFile, err := client.ReadFile(ctx, repo.Name, api.CommitID("HEAD"), codyIgnoreFile)
+		if err != nil {
+			// We do not ignore anything if the ignore file does not exist.
+			if strings.Contains(err.Error(), "file does not exist") {
+				continue
+			}
+			return nil, err
+		}
+		ig, err := ignore.ParseIgnoreFile(bytes.NewReader(ignoreFile))
+		if err != nil {
+			return nil, err
+		}
+		f.filters[repo] = ig.Match
+	}
+
+	return f, nil
+}
+
+// Filter applies the ignore rules to the given file chunks,
+// returning only those that do not match any ignore rules.
+func (f *repoFilter) Filter(chunks []FileChunkContext) []FileChunkContext {
+	filtered := make([]FileChunkContext, 0, len(chunks))
+	for _, chunk := range chunks {
+		ignore, ok := f.filters[types.RepoIDName{ID: chunk.RepoID, Name: chunk.RepoName}]
+		if !ok || !ignore(chunk.Path) {
+			filtered = append(filtered, chunk)
+			continue
+		}
+	}
+	return filtered
+}

--- a/internal/codycontext/filter.go
+++ b/internal/codycontext/filter.go
@@ -1,4 +1,4 @@
-package context
+package codycontext
 
 import (
 	"bytes"

--- a/internal/codycontext/filter.go
+++ b/internal/codycontext/filter.go
@@ -6,8 +6,12 @@ import (
 	"io"
 	"os"
 
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sourcegraph/zoekt/ignore"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -15,64 +19,118 @@ import (
 
 const codyIgnoreFile = ".cody/ignore"
 
+var (
+	emptyMatcher ignore.Matcher = ignore.Matcher{}
+
+	ignoreFileCacheHitCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "src",
+		Name:      "cody_ignore_file_cache_hit_count",
+	})
+	ignoreFileCacheMissCount = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "src",
+		Name:      "cody_ignore_file_cache_miss_count",
+	})
+)
+
+type repoRevision struct {
+	Repo   types.RepoIDName
+	Commit api.CommitID
+}
+
 type filterFunc func(string) bool
+type FileChunkFilterFunc func([]FileChunkContext) []FileChunkContext
+type safeCache struct {
+	cache *lru.Cache[repoRevision, ignore.Matcher]
+}
+
+func (c *safeCache) Add(key repoRevision, value ignore.Matcher) (evicted bool) {
+	if c.cache != nil {
+		return c.cache.Add(key, value)
+	}
+	return false
+}
+
+func (c *safeCache) Get(key repoRevision) (ignore.Matcher, bool) {
+	if c.cache != nil {
+		v, ok := c.cache.Get(key)
+		if ok {
+			ignoreFileCacheHitCount.Inc()
+		} else {
+			ignoreFileCacheMissCount.Inc()
+		}
+		return v, ok
+	}
+
+	ignoreFileCacheMissCount.Inc()
+	return ignore.Matcher{}, false
+}
+
 type repoFilter struct {
-	filters map[types.RepoIDName]filterFunc
+	cache  safeCache
+	client gitserver.Client
+}
+
+func (f *repoFilter) GetFilter(repos []types.RepoIDName) (FileChunkFilterFunc, error) {
+	filters := make(map[api.RepoName]filterFunc, len(repos))
+
+	// use the internal actor to ensure access to repo and ignore files
+	ctx := actor.WithInternalActor(context.Background())
+	for _, repo := range repos {
+
+		_, commit, err := f.client.GetDefaultBranch(ctx, repo.Name, true)
+		if err != nil {
+			return nil, err
+		}
+		// No commit signals an empty repo, should be nothing to filter
+		// Also we can't lookup the ignore file without a commit
+		if commit == "" {
+			continue
+		}
+		matcher, err := getIgnoreMatcher(ctx, f.cache, f.client, repo, commit)
+		if err != nil {
+			return nil, err
+		}
+
+		filters[repo.Name] = matcher.Match
+	}
+
+	return func(fcc []FileChunkContext) []FileChunkContext {
+		filtered := make([]FileChunkContext, 0, len(fcc))
+		for _, fc := range fcc {
+			remove, ok := filters[fc.RepoName]
+			if !ok {
+				filtered = append(filtered, fc)
+				continue
+			}
+			if !remove(fc.Path) {
+				filtered = append(filtered, fc)
+			}
+		}
+		return filtered
+	}, nil
 }
 
 type RepoContentFilter interface {
-	Filter(chunks []FileChunkContext) []FileChunkContext
+	GetFilter(repos []types.RepoIDName) (FileChunkFilterFunc, error)
 }
 
 // NewCodyIgnoreFilter creates a new RepoContentFilter that filters out
 // content based on the .cody/ignore file at the head of the default branch
-// for the given repositories. If no .cody/ignore file exists, no filtering is done.
-func NewCodyIgnoreFilter(ctx context.Context, client gitserver.Client, repos []types.RepoIDName) (RepoContentFilter, error) {
-	f := &repoFilter{
-		filters: make(map[types.RepoIDName]filterFunc),
+// for the given repositories.
+func NewCodyIgnoreFilter(client gitserver.Client) RepoContentFilter {
+	c, _ := lru.New[repoRevision, ignore.Matcher](128)
+	return &repoFilter{
+		cache:  safeCache{c},
+		client: client,
 	}
-	for _, repo := range repos {
-		_, commit, err := client.GetDefaultBranch(ctx, repo.Name, true)
-		if err != nil {
-			return nil, err
-		}
-		// this is an empty repo, there won't be anything to filter
-		if commit == "" {
-			continue
-		}
-		ignoreFileBytes, err := getIgnoreFileBytes(ctx, client, repo, commit)
-		if err != nil {
-			// We do not ignore anything if the ignore file does not exist.
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, err
-		}
-		ig, err := ignore.ParseIgnoreFile(bytes.NewReader(ignoreFileBytes))
-		if err != nil {
-			return nil, err
-		}
-		f.filters[repo] = ig.Match
-	}
-
-	return f, nil
 }
 
-// Filter applies the ignore rules to the given file chunks,
-// returning only those that do not match any ignore rules.
-func (f *repoFilter) Filter(chunks []FileChunkContext) []FileChunkContext {
-	filtered := make([]FileChunkContext, 0, len(chunks))
-	for _, chunk := range chunks {
-		ignore, ok := f.filters[types.RepoIDName{ID: chunk.RepoID, Name: chunk.RepoName}]
-		if !ok || !ignore(chunk.Path) {
-			filtered = append(filtered, chunk)
-			continue
-		}
+func getIgnoreMatcher(ctx context.Context, cache safeCache, client gitserver.Client, repo types.RepoIDName, commit api.CommitID) (*ignore.Matcher, error) {
+	cached, ok := cache.Get(repoRevision{Repo: repo, Commit: commit})
+	if ok {
+		return &cached, nil
 	}
-	return filtered
-}
 
-func getIgnoreFileBytes(ctx context.Context, client gitserver.Client, repo types.RepoIDName, commit api.CommitID) ([]byte, error) {
 	fr, err := client.NewFileReader(
 		ctx,
 		repo.Name,
@@ -80,9 +138,23 @@ func getIgnoreFileBytes(ctx context.Context, client gitserver.Client, repo types
 		codyIgnoreFile,
 	)
 	if err != nil {
+		// We do not ignore anything if the ignore file does not exist.
+		if os.IsNotExist(err) {
+			cache.Add(repoRevision{Repo: repo, Commit: commit}, emptyMatcher)
+			return &emptyMatcher, nil
+		}
 		return nil, err
 	}
 	defer fr.Close()
 
-	return io.ReadAll(fr)
+	ignoreFileBytes, err := io.ReadAll(fr)
+	if err != nil {
+		return nil, err
+	}
+	ig, err := ignore.ParseIgnoreFile(bytes.NewReader(ignoreFileBytes))
+	if err != nil {
+		return nil, err
+	}
+	cache.Add(repoRevision{Repo: repo, Commit: commit}, *ig)
+	return ig, nil
 }

--- a/internal/codycontext/filter.go
+++ b/internal/codycontext/filter.go
@@ -32,7 +32,15 @@ func NewCodyIgnoreFilter(ctx context.Context, client gitserver.Client, repos []t
 		filters: make(map[types.RepoIDName]filterFunc),
 	}
 	for _, repo := range repos {
-		ignoreFile, err := client.ReadFile(ctx, repo.Name, api.CommitID("HEAD"), codyIgnoreFile)
+		head, found, err := client.Head(ctx, repo.Name)
+		if err != nil {
+			return nil, err
+		}
+		// this is an empty repo, there won't be anything to filter
+		if !found {
+			continue
+		}
+		ignoreFile, err := client.ReadFile(ctx, repo.Name, api.CommitID(head), codyIgnoreFile)
 		if err != nil {
 			// We do not ignore anything if the ignore file does not exist.
 			if strings.Contains(err.Error(), "file does not exist") {

--- a/internal/codycontext/filter.go
+++ b/internal/codycontext/filter.go
@@ -19,15 +19,14 @@ type repoFilter struct {
 	filters map[types.RepoIDName]filterFunc
 }
 
-type RepoContextFilter interface {
+type RepoContentFilter interface {
 	Filter(chunks []FileChunkContext) []FileChunkContext
 }
 
-// NewCodyIgnoreFilter creates a new Filter that applies .cody/ignore rules from
-// the given repositories to filter file paths. It reads the .cody/ignore file
-// from each repo and parses it into an ignore.Matcher func that is stored in
-// the returned Filter.
-func NewCodyIgnoreFilter(ctx context.Context, client gitserver.Client, repos []types.RepoIDName) (RepoContextFilter, error) {
+// NewCodyIgnoreFilter creates a new RepoContentFilter that filters out
+// content based on the .cody/ignore file at the head of the default branch
+// for the given repositories. If no .cody/ignore file exists, no filtering is done.
+func NewCodyIgnoreFilter(ctx context.Context, client gitserver.Client, repos []types.RepoIDName) (RepoContentFilter, error) {
 	f := &repoFilter{
 		filters: make(map[types.RepoIDName]filterFunc),
 	}

--- a/internal/codycontext/filter_test.go
+++ b/internal/codycontext/filter_test.go
@@ -25,8 +25,7 @@ func TestNewFilter(t *testing.T) {
 		client := gitserver.NewMockClient()
 		client.GetDefaultBranchFunc.SetDefaultReturn("main", api.CommitID("abc123"), nil)
 		client.NewFileReaderFunc.SetDefaultReturn(nil, os.ErrNotExist)
-		f, err := NewCodyIgnoreFilter(context.Background(), client)
-		require.NoError(t, err)
+		f := NewCodyIgnoreFilter(client)
 
 		chunks := []FileChunkContext{
 			{
@@ -55,8 +54,7 @@ func TestNewFilter(t *testing.T) {
 			return nil, os.ErrNotExist
 		})
 
-		f, err := NewCodyIgnoreFilter(context.Background(), client)
-		require.NoError(t, err)
+		f := NewCodyIgnoreFilter(client)
 
 		chunks := []FileChunkContext{
 			{
@@ -100,8 +98,7 @@ func TestNewFilter(t *testing.T) {
 				return nil, os.ErrNotExist
 			}
 		})
-		f, err := NewCodyIgnoreFilter(context.Background(), client)
-		require.NoError(t, err)
+		f := NewCodyIgnoreFilter(client)
 
 		chunks := []FileChunkContext{
 			{
@@ -143,9 +140,8 @@ func TestNewFilter(t *testing.T) {
 			return nil, nil
 		})
 
-		f, err := NewCodyIgnoreFilter(context.Background(), client)
-		require.NoError(t, err)
-		_, err = f.GetFilter(repos)
+		f := NewCodyIgnoreFilter(client)
+		_, err := f.GetFilter(repos)
 		require.NoError(t, err)
 
 	})
@@ -158,9 +154,8 @@ func TestNewFilter(t *testing.T) {
 			return nil, nil
 		})
 
-		f, err := NewCodyIgnoreFilter(context.Background(), client)
-		require.NoError(t, err)
-		_, err = f.GetFilter(repos)
+		f := NewCodyIgnoreFilter(client)
+		_, err := f.GetFilter(repos)
 		require.Error(t, err)
 	})
 
@@ -171,9 +166,8 @@ func TestNewFilter(t *testing.T) {
 			return nil, errors.New("fail")
 		})
 
-		f, err := NewCodyIgnoreFilter(context.Background(), client)
-		require.NoError(t, err)
-		_, err = f.GetFilter(repos)
+		f := NewCodyIgnoreFilter(client)
+		_, err := f.GetFilter(repos)
 		require.Error(t, err)
 	})
 
@@ -181,8 +175,7 @@ func TestNewFilter(t *testing.T) {
 		client := gitserver.NewMockClient()
 		client.GetDefaultBranchFunc.SetDefaultReturn("main", api.CommitID("abc123"), nil)
 		client.NewFileReaderFunc.SetDefaultReturn(io.NopCloser(strings.NewReader("**/file1.go")), nil)
-		f, err := NewCodyIgnoreFilter(context.Background(), client)
-		require.NoError(t, err)
+		f := NewCodyIgnoreFilter(client)
 
 		chunks := []FileChunkContext{
 			{

--- a/internal/codycontext/filter_test.go
+++ b/internal/codycontext/filter_test.go
@@ -39,7 +39,7 @@ func TestNewFilter(t *testing.T) {
 				Path:     "/file2.go",
 			},
 		}
-		filter, _ := f.GetFilter(repos)
+		_, filter := f.GetFilter(repos)
 		filtered := filter(chunks)
 		require.Equal(t, 2, len(filtered))
 	})
@@ -79,7 +79,7 @@ func TestNewFilter(t *testing.T) {
 			},
 		}
 
-		filter, _ := f.GetFilter(repos)
+		_, filter := f.GetFilter(repos)
 		filtered := filter(chunks)
 		require.Equal(t, 1, len(filtered))
 		require.Equal(t, api.RepoName("repo1"), filtered[0].RepoName)
@@ -123,7 +123,7 @@ func TestNewFilter(t *testing.T) {
 			},
 		}
 
-		filter, _ := f.GetFilter(repos)
+		_, filter := f.GetFilter(repos)
 		filtered := filter(chunks)
 		require.Equal(t, 2, len(filtered))
 		require.Equal(t, api.RepoName("repo1"), filtered[0].RepoName)
@@ -141,9 +141,8 @@ func TestNewFilter(t *testing.T) {
 		})
 
 		f := NewCodyIgnoreFilter(client)
-		_, err := f.GetFilter(repos)
-		require.NoError(t, err)
-
+		filterableRepos, _ := f.GetFilter(repos)
+		require.Len(t, filterableRepos, 0)
 	})
 
 	t.Run("errors checking head do error", func(t *testing.T) {
@@ -155,8 +154,8 @@ func TestNewFilter(t *testing.T) {
 		})
 
 		f := NewCodyIgnoreFilter(client)
-		_, err := f.GetFilter(repos)
-		require.Error(t, err)
+		filterableRepos, _ := f.GetFilter(repos)
+		require.Len(t, filterableRepos, 0)
 	})
 
 	t.Run("error reading ignore file causes error", func(t *testing.T) {
@@ -167,8 +166,8 @@ func TestNewFilter(t *testing.T) {
 		})
 
 		f := NewCodyIgnoreFilter(client)
-		_, err := f.GetFilter(repos)
-		require.Error(t, err)
+		filterableRepos, _ := f.GetFilter(repos)
+		require.Len(t, filterableRepos, 0)
 	})
 
 	t.Run("uses cache", func(t *testing.T) {
@@ -190,12 +189,12 @@ func TestNewFilter(t *testing.T) {
 			},
 		}
 		// simulate 1st call
-		filter, _ := f.GetFilter(repos)
+		_, filter := f.GetFilter(repos)
 		filtered := filter(chunks)
 		require.Equal(t, 1, len(filtered))
 
 		//simulate 2nd call
-		filter2, _ := f.GetFilter(repos)
+		_, filter2 := f.GetFilter(repos)
 		filtered2 := filter2(chunks)
 		require.Equal(t, 1, len(filtered2))
 

--- a/internal/codycontext/filter_test.go
+++ b/internal/codycontext/filter_test.go
@@ -8,9 +8,12 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+	"github.com/sourcegraph/sourcegraph/schema"
 
 	"github.com/stretchr/testify/require"
 )
@@ -20,6 +23,14 @@ func TestNewFilter(t *testing.T) {
 		{ID: 1, Name: "repo1"},
 		{ID: 2, Name: "repo2"},
 	}
+	conf.Mock(&conf.Unified{
+		SiteConfiguration: schema.SiteConfiguration{
+			ExperimentalFeatures: &schema.ExperimentalFeatures{
+				CodyContextIgnore: pointers.Ptr(true),
+			},
+		},
+	})
+	t.Cleanup(func() { conf.Mock(nil) })
 
 	t.Run("no ignore files", func(t *testing.T) {
 		client := gitserver.NewMockClient()

--- a/internal/codycontext/filter_test.go
+++ b/internal/codycontext/filter_test.go
@@ -1,4 +1,4 @@
-package context
+package codycontext
 
 import (
 	"context"

--- a/internal/codycontext/filter_test.go
+++ b/internal/codycontext/filter_test.go
@@ -1,0 +1,129 @@
+package context
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFilter(t *testing.T) {
+	repos := []types.RepoIDName{
+		{ID: 1, Name: "repo1"},
+		{ID: 2, Name: "repo2"},
+	}
+
+	t.Run("no ignore files", func(t *testing.T) {
+		client := gitserver.NewMockClient()
+		client.ReadFileFunc.SetDefaultReturn(nil, errors.Errorf("err open .cody/ignore: file does not exist"))
+		f, err := NewCodyIgnoreFilter(context.Background(), client, repos)
+		require.NoError(t, err)
+
+		chunks := []FileChunkContext{
+			{
+				RepoName: "repo1",
+				RepoID:   1,
+				Path:     "/file1.go",
+			},
+			{
+				RepoName: "repo2",
+				RepoID:   2,
+				Path:     "/file2.go",
+			},
+		}
+
+		filtered := f.Filter(chunks)
+		require.Equal(t, 2, len(filtered))
+	})
+
+	t.Run("filters multiple rules in ignore file", func(t *testing.T) {
+		client := gitserver.NewMockClient()
+		client.ReadFileFunc.SetDefaultHook(func(ctx context.Context, repo api.RepoName, commit api.CommitID, name string) ([]byte, error) {
+			if repo == "repo2" { // filter only from repo2
+				return []byte("**/file1.go\nsecret.txt"), nil
+			}
+			return nil, errors.Errorf("err open .cody/ignore: file does not exist")
+		})
+
+		f, err := NewCodyIgnoreFilter(context.Background(), client, repos)
+		require.NoError(t, err)
+
+		chunks := []FileChunkContext{
+			{
+				RepoName: "repo1",
+				RepoID:   1,
+				Path:     "file1.go",
+			},
+			{
+				RepoName: "repo2",
+				RepoID:   2,
+				Path:     "folder1/file1.go",
+			},
+			{
+				RepoName: "repo2",
+				RepoID:   2,
+				Path:     "folder1/folder2/file1.go",
+			},
+			{
+				RepoName: "repo2",
+				RepoID:   2,
+				Path:     "secret.txt",
+			},
+		}
+
+		filtered := f.Filter(chunks)
+		require.Equal(t, 1, len(filtered))
+		require.Equal(t, api.RepoName("repo1"), filtered[0].RepoName)
+	})
+
+	t.Run("uses correct ignore file by repo", func(t *testing.T) {
+		client := gitserver.NewMockClient()
+		client.ReadFileFunc.SetDefaultHook(func(ctx context.Context, repo api.RepoName, commit api.CommitID, name string) ([]byte, error) {
+			if repo == "repo1" { // filter file1 from repo1
+				return []byte("**/file1.go"), nil
+			}
+			if repo == "repo2" { // filter file2 from repo2
+				return []byte("**/file2.go"), nil
+			}
+			return nil, errors.Errorf("err open .cody/ignore: file does not exist")
+		})
+
+		f, err := NewCodyIgnoreFilter(context.Background(), client, repos)
+		require.NoError(t, err)
+
+		chunks := []FileChunkContext{
+			{
+				RepoName: "repo1",
+				RepoID:   1,
+				Path:     "src/file1.go",
+			},
+			{
+				RepoName: "repo1",
+				RepoID:   1,
+				Path:     "src/file2.go",
+			},
+			{
+				RepoName: "repo2",
+				RepoID:   2,
+				Path:     "src/file1.go",
+			},
+			{
+				RepoName: "repo2",
+				RepoID:   2,
+				Path:     "src/file2.go",
+			},
+		}
+
+		filtered := f.Filter(chunks)
+		require.Equal(t, 2, len(filtered))
+		require.Equal(t, api.RepoName("repo1"), filtered[0].RepoName)
+		require.Equal(t, "src/file2.go", filtered[0].Path)
+		require.Equal(t, api.RepoName("repo2"), filtered[1].RepoName)
+		require.Equal(t, "src/file1.go", filtered[1].Path)
+	})
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -911,6 +911,8 @@ type ExpandedGitCommitDescription struct {
 type ExperimentalFeatures struct {
 	// BatchChangesEnablePerforce description: When enabled, batch changes will be executable on Perforce depots.
 	BatchChangesEnablePerforce bool `json:"batchChanges.enablePerforce,omitempty"`
+	// CodyContextIgnore description: Enabled filtering of remote Cody context based on repositories ./cody/ignore file
+	CodyContextIgnore *bool `json:"codyContextIgnore,omitempty"`
 	// CustomGitFetch description: JSON array of configuration that maps from Git clone URL domain/path to custom git fetch command. To enable this feature set environment variable `ENABLE_CUSTOM_GIT_FETCH` as `true` on gitserver.
 	CustomGitFetch []*CustomGitFetchMapping `json:"customGitFetch,omitempty"`
 	// DebugLog description: Turns on debug logging for specific debugging scenarios.
@@ -1006,6 +1008,7 @@ func (v *ExperimentalFeatures) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	delete(m, "batchChanges.enablePerforce")
+	delete(m, "codyContextIgnore")
 	delete(m, "customGitFetch")
 	delete(m, "debug.log")
 	delete(m, "enableGithubInternalRepoVisibility")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -175,6 +175,14 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "codyContextIgnore": {
+          "description": "Enabled filtering of remote Cody context based on repositories ./cody/ignore file",
+          "type": "boolean",
+          "default": false,
+          "!go": {
+            "pointer": true
+          }
+        },
         "searchJobs": {
           "description": "Enables search jobs (long-running exhaustive) search feature and its UI",
           "type": "boolean",


### PR DESCRIPTION
Updates the getCodyContext resolver to filter out context if a `.cody/ignore` file is present and it matches an ignore rule. The behavior is behind an experimental feature in the site config. 

closes https://github.com/sourcegraph/sourcegraph/issues/59682
closes https://github.com/sourcegraph/sourcegraph/issues/59976

## Test plan
updated existing context resolver tests
add new tests for filtering logic

Manual testing 
 - Created a test repo with a main.go file and printed hello world
 - Asked Cody what it printed
<img width="923" alt="Screenshot 2024-01-25 at 10 01 29 AM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/c98408a4-af51-4498-908f-8d0c91590171">

- Added a .cody/ignore file with main.go in it
- waiting for repo sync
- Asked Cody what the program prints - it did not read the file anymore.
<img width="884" alt="Screenshot 2024-01-25 at 9 56 29 AM" src="https://github.com/sourcegraph/sourcegraph/assets/6098507/72742b8b-470a-4659-8584-834a8bd29c58">

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
