### PR TITLE
Control SAMS origin via feature flag for testing

### DIFF
--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -40,7 +40,16 @@ interface CodySubscriptionPageProps {
     isSourcegraphDotCom: boolean
     authenticatedUser?: AuthenticatedUser | null
 }
-const MANAGE_SUBSCRIPTION_REDIRECT_URL = 'https://accounts.sourcegraph.com/cody/subscription'
+
+const useManageSubscriptionRedirectURL = (pro: boolean): string => {
+    const [useSAMSTestInstance] = useFeatureFlag('use-sams-test-instance', false)
+
+    if (useSAMSTestInstance) {
+        return 'https://accounts.sgdev.org/cody/subscription' + (pro ? '?pro=true' : '')
+    }
+
+    return 'https://accounts.sourcegraph.com/cody/subscription' + (pro ? '?pro=true' : '')
+}
 
 export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageProps> = ({
     isSourcegraphDotCom,
@@ -51,7 +60,6 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
     const utm_source = parameters.get('utm_source')
 
     const [sscEnabled] = useFeatureFlag('use-ssc-for-cody-subscription', false)
-
     useEffect(() => {
         eventLogger.log(EventName.CODY_SUBSCRIPTION_PAGE_VIEWED, { utm_source }, { utm_source })
     }, [utm_source])
@@ -60,6 +68,10 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
 
     const [showUpgradeToPro, setShowUpgradeToPro] = useState<boolean>(false)
     const [showCancelPro, setShowCancelPro] = useState<boolean>(false)
+
+    const manageSubscriptionRedirestURL = useManageSubscriptionRedirectURL(
+        data?.currentUser?.codySubscription?.plan === CodySubscriptionPlan.PRO
+    )
 
     const navigate = useNavigate()
 
@@ -210,7 +222,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                     }
                                                 )
                                                 if (sscEnabled) {
-                                                    window.location.href = MANAGE_SUBSCRIPTION_REDIRECT_URL
+                                                    window.location.href = manageSubscriptionRedirestURL
                                                     return
                                                 }
 
@@ -231,7 +243,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 { tier: 'pro' }
                                             )
                                             if (sscEnabled) {
-                                                window.location.href = MANAGE_SUBSCRIPTION_REDIRECT_URL
+                                                window.location.href = manageSubscriptionRedirestURL
                                                 return
                                             }
 

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -38,6 +38,7 @@ export const FEATURE_FLAGS = [
     'auditlog-expansion',
     'search.newFilters',
     'use-ssc-for-cody-subscription',
+    'use-sams-test-instance',
 ] as const
 
 export type FeatureFlagName = typeof FEATURE_FLAGS[number]

--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/conf",
+        "//internal/featureflag",
         "//internal/httpcli",
         "//lib/errors",
     ],

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2913,10 +2913,18 @@ type SiteConfiguration struct {
 	SearchLargeFiles []string `json:"search.largeFiles,omitempty"`
 	// SearchLimits description: Limits that search applies for number of repositories searched and timeouts.
 	SearchLimits *SearchLimits `json:"search.limits,omitempty"`
-	// SscApiBaseUrl description: The base URL of the Self-Serve Cody API.
-	SscApiBaseUrl string `json:"ssc.apiBaseUrl,omitempty"`
+	// SscApiBaseURL description: The base URL of the Self-Serve Cody API.
+	SscApiBaseURL string `json:"ssc.api.baseURL,omitempty"`
 	// SscApiSecret description: The Bearer token for the Self-Serve Cody API.
-	SscApiSecret string `json:"ssc.apiSecret,omitempty"`
+	SscApiSecret string `json:"ssc.api.secret,omitempty"`
+	// SscSamsServiceID description: The service ID for SAMS external service.
+	SscSamsServiceID string `json:"ssc.sams.serviceID,omitempty"`
+	// SscTestApiBaseURL description: The base URL of the Self-Serve Cody test API.
+	SscTestApiBaseURL string `json:"ssc.test.api.baseURL,omitempty"`
+	// SscTestApiSecret description: The Bearer token for the Self-Serve Cody test API.
+	SscTestApiSecret string `json:"ssc.test.api.secret,omitempty"`
+	// SscTestSamsServiceID description: The service ID for SAMS test external service.
+	SscTestSamsServiceID string `json:"ssc.test.sams.serviceID,omitempty"`
 	// SyntaxHighlighting description: Syntax highlighting configuration
 	SyntaxHighlighting *SyntaxHighlighting `json:"syntaxHighlighting,omitempty"`
 	// UpdateChannel description: The channel on which to automatically check for Sourcegraph updates.
@@ -3089,8 +3097,12 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "search.index.symbols.enabled")
 	delete(m, "search.largeFiles")
 	delete(m, "search.limits")
-	delete(m, "ssc.apiBaseUrl")
-	delete(m, "ssc.apiSecret")
+	delete(m, "ssc.api.baseURL")
+	delete(m, "ssc.api.secret")
+	delete(m, "ssc.sams.serviceID")
+	delete(m, "ssc.test.api.baseURL")
+	delete(m, "ssc.test.api.secret")
+	delete(m, "ssc.test.sams.serviceID")
 	delete(m, "syntaxHighlighting")
 	delete(m, "update.channel")
 	delete(m, "webhook.logging")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -7,15 +7,29 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
-    "ssc.apiBaseUrl": {
+    "ssc.api.baseURL": {
       "type": "string",
-      "default": "https://accounts.sourcegraph.com/cody/api",
       "description": "The base URL of the Self-Serve Cody API."
     },
-    "ssc.apiSecret": {
+    "ssc.api.secret": {
       "type": "string",
-      "default": "********",
       "description": "The Bearer token for the Self-Serve Cody API."
+    },
+    "ssc.sams.serviceID": {
+      "type": "string",
+      "description": "The service ID for SAMS external service."
+    },
+    "ssc.test.api.baseURL": {
+      "type": "string",
+      "description": "The base URL of the Self-Serve Cody test API."
+    },
+    "ssc.test.api.secret": {
+      "type": "string",
+      "description": "The Bearer token for the Self-Serve Cody test API."
+    },
+    "ssc.test.sams.serviceID": {
+      "type": "string",
+      "description": "The service ID for SAMS test external service."
     },
     "search.index.symbols.enabled": {
       "description": "Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.",


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/59786

This PR enables site admins to control if cody subscription flow for a particular user will utilise `accounts.sourcegraph.com` or `accounts.sgdev.org` using a feature flag. 

This will enable us to test the complete SSC flow, even before SAMS is fully deployed and migrated to. 

loom: https://www.loom.com/share/efd9c3dbda1249288627234d7092ba86

## Test plan
Unit testes added
Follow the loom demo for manual testing: https://www.loom.com/share/efd9c3dbda1249288627234d7092ba86
