### PR TITLE
licensing: disable features in JSContext based on license

### DIFF
--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -321,7 +321,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 	// server. Including secret fields here is OK if it is based on the user's
 	// authentication above, but do not include e.g. hard-coded secrets about
 	// the server instance here as they would be sent to anonymous users.
-	return JSContext{
+	context := JSContext{
 		ExternalURL:         globals.ExternalURL().String(),
 		XHRHeaders:          headers,
 		UserAgentIsBot:      isBot(req.UserAgent()),
@@ -407,6 +407,20 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 		RunningOnMacOS: runningOnMacOS,
 	}
+
+	if !licenseInfo.Features.CodeSearch {
+		context.BatchChangesEnabled = false
+		context.CodeInsightsEnabled = false
+		context.ExecutorsEnabled = false
+		context.CodeInsightsEnabled = false
+	}
+
+	if !licenseInfo.Features.Cody {
+		context.CodyEnabled = false
+		context.CodyEnabledForCurrentUser = false
+		context.EmbeddingsEnabled = false
+	}
+	return context
 }
 
 // createCurrentUser creates CurrentUser object which contains of types.User

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -408,6 +408,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		RunningOnMacOS: runningOnMacOS,
 	}
 
+	// If the license a Sourcegraph instance is running under does not support Code Search features
+	// we force disable related features (executors, batch-changes, executors, code-insights).
 	if !licenseInfo.Features.CodeSearch {
 		context.BatchChangesEnabled = false
 		context.CodeInsightsEnabled = false
@@ -415,6 +417,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		context.CodeInsightsEnabled = false
 	}
 
+	// If the license a Sourcegraph instance is running under does not support Cody features
+	// we force disable related features (embeddings etc).
 	if !licenseInfo.Features.Cody {
 		context.CodyEnabled = false
 		context.CodyEnabledForCurrentUser = false

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -408,21 +408,23 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		RunningOnMacOS: runningOnMacOS,
 	}
 
-	// If the license a Sourcegraph instance is running under does not support Code Search features
-	// we force disable related features (executors, batch-changes, executors, code-insights).
-	if !licenseInfo.Features.CodeSearch {
-		context.BatchChangesEnabled = false
-		context.CodeInsightsEnabled = false
-		context.ExecutorsEnabled = false
-		context.CodeInsightsEnabled = false
-	}
+	if licenseInfo != nil {
+		// If the license a Sourcegraph instance is running under does not support Code Search features
+		// we force disable related features (executors, batch-changes, executors, code-insights).
+		if licenseInfo.Features.CodeSearch {
+			context.BatchChangesEnabled = false
+			context.CodeInsightsEnabled = false
+			context.ExecutorsEnabled = false
+			context.CodeInsightsEnabled = false
+		}
 
-	// If the license a Sourcegraph instance is running under does not support Cody features
-	// we force disable related features (embeddings etc).
-	if !licenseInfo.Features.Cody {
-		context.CodyEnabled = false
-		context.CodyEnabledForCurrentUser = false
-		context.EmbeddingsEnabled = false
+		// If the license a Sourcegraph instance is running under does not support Cody features
+		// we force disable related features (embeddings etc).
+		if !licenseInfo.Features.Cody {
+			context.CodyEnabled = false
+			context.CodyEnabledForCurrentUser = false
+			context.EmbeddingsEnabled = false
+		}
 	}
 	return context
 }


### PR DESCRIPTION
This PR disables Features in JSContext if the license the Sourcegraph instance is running on doesn't support them. 

For example, features like Embeddings and Cody depends on the license supporting `FeatureCody`, however if this isn't the case, we can hardcode false for the context variables. 

This makes checks on the frontend easy to do.

## Test plan

* Manual testing on my local instance.