### PR TITLE
build: resolved deprecation warning for aspect config.yaml tasks style

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,7 +1,7 @@
 ---
 bazel:
   rcfiles:
-      - ".aspect/bazelrc/ci.sourcegraph.bazelrc"
+    - ".aspect/bazelrc/ci.sourcegraph.bazelrc"
   flags:
     # This flag is required because otherwise the integration tests fail with `fcmod` Operation not permitted
     # which is probably related to the launced containers writing to mapped in directories as root and then
@@ -15,25 +15,25 @@ bazel:
     - --experimental_profile_include_target_label
     - --noslim_profile
 env:
-    REDIS_CACHE_ENDPOINT: ":6379"
-    GIT_PAGER: ''
+  REDIS_CACHE_ENDPOINT: ":6379"
+  GIT_PAGER: ""
 tasks:
-    # Checks that BUILD files are formatted
-    buildifier:
-        queue: aspect-small
-    # Checks that BUILD file content is up-to-date with sources
-    gazelle:
-        queue: aspect-small
-        target: //:configure
-        fix_target: //:configure
-    # Checks that all tests are passing
-    test:
+  # Checks that BUILD files are formatted
+  - buildifier:
+      queue: aspect-small
+  # Checks that BUILD file content is up-to-date with sources
+  - gazelle:
+      queue: aspect-small
+      target: //:configure
+      fix_target: //:configure
+  # Checks that all tests are passing
+  - test:
       include_eternal_tests: true
       targets:
-          - //...
-          # This target should only really run when on main which we aren't handling. For the time being while we
-          # evaluate Aspect Workflows it is ok
-          # TODO(burmudar): Let this only run on main branch
-          - //testing:codeintel_integration_test
-    finalization:
-        queue: aspect-small
+        - //...
+        # This target should only really run when on main which we aren't handling. For the time being while we
+        # evaluate Aspect Workflows it is ok
+        # TODO(burmudar): Let this only run on main branch
+        - //testing:codeintel_integration_test
+  - finalization:
+      queue: aspect-small


### PR DESCRIPTION
Resolves the following warning in Aspect Workflows 5.9 for the deprecated non-list task style in the `.aspect/workflows/config.yaml`:

```

(02:52:02) [ASPECT] [WARN]
--
  | • tasks: Deprecated configuration: Tasks are migrating to a list, see documentation for details
```

Also, white space was inconsistent in the file so I ran it through a formatter.

## Test plan

CI