### PR TITLE
Prevent some error log spam from subrepo perms

### DIFF
--- a/internal/search/job/jobutil/sub_repo_perms_job.go
+++ b/internal/search/job/jobutil/sub_repo_perms_job.go
@@ -95,7 +95,9 @@ func applySubRepoFiltering(ctx context.Context, checker authz.SubRepoPermissionC
 		enabled, err := authz.SubRepoEnabledForRepoID(ctx, checker, m.RepoName().ID)
 		if err != nil {
 			// If an error occurs while checking sub-repo perms, we omit it from the results
-			logger.Error("Could not determine if sub-repo permissions are enabled for repo, skipping", log.Error(err), log.String("repoName", string(m.RepoName().Name)))
+			if err != ctx.Err() {
+				logger.Error("Could not determine if sub-repo permissions are enabled for repo, skipping", log.Error(err), log.String("repoName", string(m.RepoName().Name)))
+			}
 			errCache[m.RepoName().Name] = struct{}{}
 			continue
 		}


### PR DESCRIPTION
If the context is canceled which can happen frequently for searches, this is not an actionable error IMO, so let's skip throwing a big red line to stdout.

## Test plan

n/a, simple change.