### PR TITLE
Fix: ensure event.Argument is json

### DIFF
--- a/internal/database/security_event_logs.go
+++ b/internal/database/security_event_logs.go
@@ -112,8 +112,8 @@ type SecurityEvent struct {
 	Timestamp       time.Time
 }
 
-func (e *SecurityEvent) marshalArgumentAsJSON() string {
-	if e.Argument == nil {
+func (e *SecurityEvent) argumentToJSONString() string {
+	if e.Argument == nil || string(e.Argument) == "null" {
 		return "{}"
 	}
 	return string(e.Argument)
@@ -166,7 +166,7 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 		// Add an attribution for Sourcegraph operator to be distinguished in our analytics pipelines
 		if actor.SourcegraphOperator {
 			result, err := jsonc.Edit(
-				event.marshalArgumentAsJSON(),
+				event.argumentToJSONString(),
 				true,
 				EventLogsSourcegraphOperatorKey,
 			)
@@ -197,7 +197,7 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 			event.UserID,
 			event.AnonymousUserID,
 			event.Source,
-			event.marshalArgumentAsJSON(),
+			event.argumentToJSONString(),
 			version.Version(),
 			event.Timestamp.UTC(),
 		)
@@ -221,7 +221,7 @@ func (s *securityEventLogsStore) InsertList(ctx context.Context, events []*Secur
 						log.Uint32("UserID", event.UserID),
 						log.String("AnonymousUserID", event.AnonymousUserID),
 						log.String("source", event.Source),
-						log.String("argument", event.marshalArgumentAsJSON()),
+						log.String("argument", event.argumentToJSONString()),
 						log.String("version", version.Version()),
 						log.String("timestamp", event.Timestamp.UTC().String()),
 					),

--- a/internal/database/security_event_logs_test.go
+++ b/internal/database/security_event_logs_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/sourcegraph/log/logtest"
 
+	sglog "github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
@@ -144,7 +146,7 @@ func assertEventField(t *testing.T, field map[string]any) {
 
 func TestLogSecurityEvent1(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := logtest.Captured(t)
+	logger, exportLogs := logtest.Captured(t)
 
 	db := NewDB(logger, dbtest.NewDB(t))
 
@@ -158,4 +160,14 @@ func TestLogSecurityEvent1(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("sourcegraph operator", func(t *testing.T) {
+		ctx = actor.WithActor(context.Background(), &actor.Actor{UID: 123, SourcegraphOperator: true})
+		err := db.SecurityEventLogs().LogSecurityEvent(ctx, SecurityEventAccessTokenCreated, "http://sourcegraph.com", 123, "AnonymousUserID", "source", nil)
+		require.NoError(t, err)
+
+		logs := exportLogs()
+		for _, log := range logs {
+			require.NotEqual(t, log.Level, sglog.LevelError, "Should not return error: %v", log.Fields["error"])
+		}
+	})
 }


### PR DESCRIPTION
When we pass `nil` to `LogSecurityEvent` `json.Marshal`  turns it into `"null"`, that's why before we edit it with `jsonc.Edit` we need to make sure it's a valid JSON object string instead. We added an additional condition that checks if the argument is `"null"` and return `"{}"` instead.

## Test plan
CI tests, local test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
