### PR TITLE
Search Filters: Add count:all client filter

### DIFF
--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.story.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.story.tsx
@@ -16,4 +16,6 @@ const config: Meta = {
 
 export default config
 
-export const FiltersStore = () => <NewSearchFilters query="" filters={[]} onQueryChange={() => {}} />
+export const FiltersStore = () => (
+    <NewSearchFilters query="" filters={[]} onQueryChange={() => {}} withCountAllFilter={false} />
+)

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -137,6 +137,8 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
                 onSelectedFilterChange={setSelectedFilters}
             />
 
+            <SyntheticCountFilter query={query} onQueryChange={onQueryChange} />
+
             <div className={styles.footerContent}>
                 <footer className={styles.actions}>
                     {selectedFilters.length > 0 && (
@@ -157,6 +159,75 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
                 <FiltersDocFooter />
             </div>
         </div>
+    )
+}
+
+const STATIC_COUNT_FILTER: Filter[] = [
+    {
+        // Since backend filters don't support count filter
+        // this means that Filter type doesn't have this as possible kind value
+        // It's okay to cast it since it's handled in one place below in SyntheticCountFilter
+        kind: 'count' as any,
+        label: 'Show all matches',
+        count: 0,
+        exhaustive: true,
+        value: 'count:all',
+    },
+]
+
+interface SyntheticCountFilterProps {
+    query: string
+    onQueryChange: (query: string) => void
+}
+
+/**
+ * Client-based count filter, usually filters are generated on the backend
+ * based on a given query and results, count filter isn't supported by our
+ * backend at the moment, so it's synthetically included on the client.
+ *
+ * It scans original search query and detects count filter if it catches
+ * count:all filter. As user enables this filter in the filter panel it
+ * changes the original query by adding count:all to the end.
+ */
+const SyntheticCountFilter: FC<SyntheticCountFilterProps> = props => {
+    const { query, onQueryChange } = props
+
+    const selectedCountFilter = useMemo<Filter[]>(() => {
+        const tokens = scanSearchQuery(query)
+
+        if (tokens.type === 'success') {
+            const filters = tokens.term.filter((token): token is QueryFilter => token.type === 'filter')
+            const countFilters = filters.filter(filter => resolveFilter(filter.field.value)?.type === 'count')
+
+            if (countFilters.length === 0 || countFilters.length > 1) {
+                return []
+            }
+
+            return STATIC_COUNT_FILTER
+        }
+
+        return []
+    }, [query])
+
+    const handleCountAllFilter = (countFilters: URLQueryFilter[]): void => {
+        if (countFilters.length > 0) {
+            onQueryChange(`${query} count:all`)
+        } else {
+            const filters = findFilters(succeedScan(query), FilterType.count)
+            const nextQuery = filters.reduce((query, filter) => omitFilter(query, filter), query)
+
+            onQueryChange(nextQuery)
+        }
+    }
+
+    return (
+        <SearchDynamicFilter
+            filterKind={FiltersType.Count as any}
+            filters={STATIC_COUNT_FILTER}
+            selectedFilters={selectedCountFilter}
+            renderItem={commitDateFilter}
+            onSelectedFilterChange={handleCountAllFilter}
+        />
     )
 }
 

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -44,7 +44,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
     onQueryChange,
     children,
 }) => {
-    const [selectedFilters, setSelectedFilters, serilizeFiltersURL] = useUrlFilters()
+    const [selectedFilters, setSelectedFilters, serializeFiltersURL] = useUrlFilters()
 
     const type = useMemo(() => {
         const tokens = scanSearchQuery(query)
@@ -71,11 +71,11 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
         // extra entries with completely internal locations update,
         // Setting filters shouldn't be in the history since onQueryChange
         // changes URL itself.
-        onQueryChange(newQuery, serilizeFiltersURL(newSelectedFilters))
+        onQueryChange(newQuery, serializeFiltersURL(newSelectedFilters))
     }
 
     const handleApplyButtonFilters = (): void => {
-        onQueryChange(mergeQueryAndFilters(query, selectedFilters), serilizeFiltersURL([]))
+        onQueryChange(mergeQueryAndFilters(query, selectedFilters), serializeFiltersURL([]))
     }
 
     return (

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -68,7 +68,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
     }
 
     const handleApplyButtonFilters = (): void => {
-        onQueryChange(mergeQueryAndFilters(query, selectedFilters))
+        onQueryChange(mergeQueryAndFilters(query, selectedFilters), serilizeFiltersURL([]))
     }
 
     return (

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -32,11 +32,18 @@ import styles from './NewSearchFilters.module.scss'
 interface NewSearchFiltersProps {
     query: string
     filters?: Filter[]
+    withCountAllFilter: boolean
     onQueryChange: (nextQuery: string, updatedSearchURLQuery?: string) => void
     children?: ReactNode
 }
 
-export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, onQueryChange, children }) => {
+export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
+    query,
+    filters,
+    withCountAllFilter,
+    onQueryChange,
+    children,
+}) => {
     const [selectedFilters, setSelectedFilters, serilizeFiltersURL] = useUrlFilters()
 
     const type = useMemo(() => {
@@ -137,7 +144,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({ query, filters, on
                 onSelectedFilterChange={setSelectedFilters}
             />
 
-            <SyntheticCountFilter query={query} onQueryChange={onQueryChange} />
+            <SyntheticCountFilter query={query} isLimitHit={withCountAllFilter} onQueryChange={onQueryChange} />
 
             <div className={styles.footerContent}>
                 <footer className={styles.actions}>
@@ -177,6 +184,7 @@ const STATIC_COUNT_FILTER: Filter[] = [
 
 interface SyntheticCountFilterProps {
     query: string
+    isLimitHit: boolean
     onQueryChange: (query: string) => void
 }
 
@@ -190,7 +198,7 @@ interface SyntheticCountFilterProps {
  * changes the original query by adding count:all to the end.
  */
 const SyntheticCountFilter: FC<SyntheticCountFilterProps> = props => {
-    const { query, onQueryChange } = props
+    const { query, isLimitHit, onQueryChange } = props
 
     const selectedCountFilter = useMemo<Filter[]>(() => {
         const tokens = scanSearchQuery(query)
@@ -218,6 +226,11 @@ const SyntheticCountFilter: FC<SyntheticCountFilterProps> = props => {
 
             onQueryChange(nextQuery)
         }
+    }
+
+    // Hide count all filter if search is already exhaustive
+    if (selectedCountFilter.length === 0 && !isLimitHit) {
+        return null
     }
 
     return (

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -20,7 +20,7 @@ const MAX_FILTERS_NUMBER = 10
 
 interface SearchDynamicFilterProps {
     /** Name title of the filter section */
-    title: string
+    title?: string
 
     /**
      * Specifies which type filter we want to render in this particular
@@ -101,9 +101,11 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
 
     return (
         <div className={styles.root}>
-            <H4 as={H2} className={styles.heading}>
-                {title}
-            </H4>
+            {title && (
+                <H4 as={H2} className={styles.heading}>
+                    {title}
+                </H4>
+            )}
 
             {mergedFilters.length > DEFAULT_FILTERS_NUMBER && (
                 <Input
@@ -211,6 +213,13 @@ export const repoFilter = (filter: Filter): ReactNode => {
 }
 
 export const commitDateFilter = (filter: Filter, selected: boolean): ReactNode => (
+    <span className={styles.commitDate}>
+        {filter.label}
+        <Code className={!selected ? 'text-muted' : ''}>{filter.value}</Code>
+    </span>
+)
+
+export const countAllFilter = (filter: Filter, selected: boolean): ReactNode => (
     <span className={styles.commitDate}>
         {filter.label}
         <Code className={!selected ? 'text-muted' : ''}>{filter.value}</Code>

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -64,17 +64,20 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
     const [searchTerm, setSearchTerm] = useState<string>('')
     const [showMoreFilters, setShowMoreFilters] = useState<boolean>(false)
 
-    const relevantSelectedFilters = selectedFilters.filter(sf => sf.kind === filterKind)
     const relevantFilters = filters?.filter(f => f.kind === filterKind) ?? []
+    const relevantSelectedFilters = selectedFilters.filter(sf => sf.kind === filterKind)
+
     const isSelected = (filter: Filter): boolean =>
         relevantSelectedFilters.find(sf => filtersEqual(filter, sf)) !== undefined
 
     const mergedFilters = [
-        // Selected filters come first, but we want to map them to the backend filters to get the relevant count and exhaustiveness
+        // Selected filters come first, but we want to map them to the backend filters
+        // to get the relevant count and exhaustiveness
         ...relevantSelectedFilters.map(
             sf => filters?.find(f => filtersEqual(f, sf)) ?? { ...sf, count: 0, exhaustive: true }
         ),
-        // Followed by filters from the backend, but excluding the ones we already listed
+        // Followed by filters from the backend, but excluding the ones we
+        // already listed
         ...relevantFilters.filter(f => relevantSelectedFilters.find(sf => filtersEqual(f, sf)) === undefined),
     ]
 

--- a/client/branded/src/search-ui/results/filters/hooks.ts
+++ b/client/branded/src/search-ui/results/filters/hooks.ts
@@ -1,8 +1,9 @@
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { Keyword } from '@sourcegraph/shared/src/search/query/token'
 import { Filter } from '@sourcegraph/shared/src/search/stream'
-import { useSyncedWithURLState } from '@sourcegraph/wildcard'
+import { SetStateResult, useSyncedWithURLState } from '@sourcegraph/wildcard'
 
+export const FILTERS_URL_KEY = 'filters'
 export type URLQueryFilter = Pick<Filter, 'kind' | 'label' | 'value'>
 
 export function serializeURLQueryFilters(filters: URLQueryFilter[]): string | null {
@@ -20,15 +21,13 @@ export function deserializeURLQueryFilters(serialized: string | null): URLQueryF
     return parsed.map(([kind, label, value]) => ({ kind, label, value }))
 }
 
-export function useUrlFilters(): [URLQueryFilter[], (newFilters: URLQueryFilter[]) => void] {
-    const [filterQuery, setFilterQuery] = useSyncedWithURLState<URLQueryFilter[], string>({
-        urlKey: 'filters',
+export function useUrlFilters(): SetStateResult<URLQueryFilter[]> {
+    return useSyncedWithURLState<URLQueryFilter[], string>({
+        urlKey: FILTERS_URL_KEY,
         serializer: serializeURLQueryFilters,
         deserializer: deserializeURLQueryFilters,
         replace: false,
     })
-
-    return [filterQuery, setFilterQuery]
 }
 
 export function mergeQueryAndFilters(query: string, filters: URLQueryFilter[]): string {

--- a/client/branded/src/search-ui/results/filters/types.ts
+++ b/client/branded/src/search-ui/results/filters/types.ts
@@ -6,3 +6,56 @@ export enum SearchFilterType {
     Commits = 'Commits',
     Diffs = 'Diffs',
 }
+
+export enum FiltersType {
+    SymbolKind = 'symbol type',
+    Language = 'lang',
+    Author = 'author',
+    Repository = 'repo',
+    CommitDate = 'commit date',
+    File = 'file',
+    Utility = 'utility',
+
+    // Synthetic filter, lives only on the client
+    Count = 'count',
+}
+
+export const SEARCH_TYPES_TO_FILTER_TYPES: Record<SearchFilterType, `${FiltersType}`[]> = {
+    [SearchFilterType.Code]: [
+        FiltersType.Language,
+        FiltersType.Repository,
+        FiltersType.File,
+        FiltersType.Utility,
+        FiltersType.Count,
+    ],
+    [SearchFilterType.Repositories]: [FiltersType.Repository, FiltersType.Utility, FiltersType.Count],
+    [SearchFilterType.Paths]: [
+        FiltersType.Language,
+        FiltersType.Repository,
+        FiltersType.File,
+        FiltersType.Utility,
+        FiltersType.Count,
+    ],
+    [SearchFilterType.Symbols]: [
+        FiltersType.SymbolKind,
+        FiltersType.Language,
+        FiltersType.Repository,
+        FiltersType.File,
+        FiltersType.Utility,
+        FiltersType.Count,
+    ],
+    [SearchFilterType.Commits]: [
+        FiltersType.Author,
+        FiltersType.Repository,
+        FiltersType.CommitDate,
+        FiltersType.Utility,
+        FiltersType.Count,
+    ],
+    [SearchFilterType.Diffs]: [
+        FiltersType.Author,
+        FiltersType.Repository,
+        FiltersType.CommitDate,
+        FiltersType.Utility,
+        FiltersType.Count,
+    ],
+}

--- a/client/branded/src/search-ui/results/filters/types.ts
+++ b/client/branded/src/search-ui/results/filters/types.ts
@@ -1,3 +1,7 @@
+import { Filter } from '@sourcegraph/shared/out/src/search/stream'
+
+import { URLQueryFilter } from './hooks'
+
 export enum SearchFilterType {
     Code = 'Code',
     Repositories = 'Repositories',

--- a/client/branded/src/search-ui/results/filters/types.ts
+++ b/client/branded/src/search-ui/results/filters/types.ts
@@ -1,7 +1,3 @@
-import { Filter } from '@sourcegraph/shared/out/src/search/stream'
-
-import { URLQueryFilter } from './hooks'
-
 export enum SearchFilterType {
     Code = 'Code',
     Repositories = 'Repositories',

--- a/client/shared/src/search/searchQueryState.tsx
+++ b/client/shared/src/search/searchQueryState.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from 'react'
+import React, { createContext } from 'react'
 
 import type { StoreApi, UseBoundStore } from 'zustand'
 
@@ -30,14 +30,6 @@ export const SearchQueryStateStoreProvider: React.FunctionComponent<
         {children}
     </SearchQueryStateStoreContext.Provider>
 )
-
-export const useSearchQueryStateStoreContext = (): SearchQueryStateStore => {
-    const context = useContext(SearchQueryStateStoreContext)
-    if (context === null) {
-        throw new Error('useSearchQueryStateStoreContext must be used within a SearchQueryStateStoreProvider')
-    }
-    return context
-}
 
 /**
  * Describes where settings have been loaded from when the app loads. Higher

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -1,4 +1,4 @@
-import { FILTERS_URL_KEY } from '@sourcegraph/branded'
+import { FILTERS_URL_KEY } from '@sourcegraph/branded/src/search-ui/results/filters/hooks'
 import { compatNavigate } from '@sourcegraph/common'
 import type { SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'

--- a/client/web/src/search/helpers.tsx
+++ b/client/web/src/search/helpers.tsx
@@ -1,3 +1,4 @@
+import { FILTERS_URL_KEY } from '@sourcegraph/branded'
 import { compatNavigate } from '@sourcegraph/common'
 import type { SubmitSearchParameters } from '@sourcegraph/shared/src/search'
 import { appendContextFilter } from '@sourcegraph/shared/src/search/query/transformer'
@@ -12,7 +13,13 @@ import { AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY } from './results
  * This breaks all functionality that is built on top of URL query params and history
  * state. This list of query keys will be preserved between searches.
  */
-const PRESERVED_QUERY_PARAMETERS = ['feat', 'trace', AGGREGATION_MODE_URL_KEY, AGGREGATION_UI_MODE_URL_KEY]
+const PRESERVED_QUERY_PARAMETERS = [
+    'feat',
+    'trace',
+    AGGREGATION_MODE_URL_KEY,
+    AGGREGATION_UI_MODE_URL_KEY,
+    FILTERS_URL_KEY,
+]
 
 /**
  * Returns a URL query string with only the parameters in PRESERVED_QUERY_PARAMETERS.

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -144,19 +144,20 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
          * Example use-case: search-aggregation result bar click where we first update the URL
          * by settings the `groupBy` search param to `null` and then synchronously call `submitSearch`.
          */
-        (updates: QueryUpdate[], updatedSearchQuery?: string) =>
+        (updates: QueryUpdate[], updatedSearchQuery?: string) => {
             submitQuerySearch(
                 {
-                    selectedSearchContextSpec: props.selectedSearchContextSpec,
+                    source: 'filter',
                     historyOrNavigate: navigate,
+                    selectedSearchContextSpec: props.selectedSearchContextSpec,
                     location: {
                         ...location,
                         search: updatedSearchQuery || location.search,
                     },
-                    source: 'filter',
                 },
                 updates
-            ),
+            )
+        },
         [submitQuerySearch, props.selectedSearchContextSpec, navigate, location]
     )
 

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -73,16 +73,11 @@ const aggregationModeDeserializer = (
  * ULR query param {@link AGGREGATION_MODE_URL_KEY}
  */
 export const useAggregationSearchMode = (): SetStateResult<SearchAggregationMode | null> => {
-    const [aggregationMode, setAggregationMode] = useSyncedWithURLState<
-        SearchAggregationMode | null,
-        SerializedAggregationMode
-    >({
+    return useSyncedWithURLState<SearchAggregationMode | null, SerializedAggregationMode>({
         urlKey: AGGREGATION_MODE_URL_KEY,
         serializer: aggregationModeSerializer,
         deserializer: aggregationModeDeserializer,
     })
-
-    return [aggregationMode, setAggregationMode]
 }
 
 /**
@@ -121,13 +116,11 @@ const aggregationUIModeDeserializer = (serializedValue: SerializedAggregationUIM
  * ULR query param {@link AGGREGATION_UI_MODE_URL_KEY}
  */
 export const useAggregationUIMode = (): SetStateResult<AggregationUIMode> => {
-    const [aggregationMode, setAggregationMode] = useSyncedWithURLState({
+    return useSyncedWithURLState({
         urlKey: AGGREGATION_UI_MODE_URL_KEY,
         serializer: aggregationUIModeSerializer,
         deserializer: aggregationUIModeDeserializer,
     })
-
-    return [aggregationMode, setAggregationMode]
 }
 
 export const AGGREGATION_SEARCH_QUERY = gql`

--- a/client/web/src/search/results/components/aggregation/hooks.ts
+++ b/client/web/src/search/results/components/aggregation/hooks.ts
@@ -72,13 +72,12 @@ const aggregationModeDeserializer = (
  * Shared state hook for syncing aggregation type state between different UI trough
  * ULR query param {@link AGGREGATION_MODE_URL_KEY}
  */
-export const useAggregationSearchMode = (): SetStateResult<SearchAggregationMode | null> => {
-    return useSyncedWithURLState<SearchAggregationMode | null, SerializedAggregationMode>({
+export const useAggregationSearchMode = (): SetStateResult<SearchAggregationMode | null> =>
+    useSyncedWithURLState<SearchAggregationMode | null, SerializedAggregationMode>({
         urlKey: AGGREGATION_MODE_URL_KEY,
         serializer: aggregationModeSerializer,
         deserializer: aggregationModeDeserializer,
     })
-}
 
 /**
  * Serialized UI mode values
@@ -115,13 +114,12 @@ const aggregationUIModeDeserializer = (serializedValue: SerializedAggregationUIM
  * Shared state hook for syncing aggregation UI mode state between different UI trough
  * ULR query param {@link AGGREGATION_UI_MODE_URL_KEY}
  */
-export const useAggregationUIMode = (): SetStateResult<AggregationUIMode> => {
-    return useSyncedWithURLState({
+export const useAggregationUIMode = (): SetStateResult<AggregationUIMode> =>
+    useSyncedWithURLState({
         urlKey: AGGREGATION_UI_MODE_URL_KEY,
         serializer: aggregationUIModeSerializer,
         deserializer: aggregationUIModeDeserializer,
     })
-}
 
 export const AGGREGATION_SEARCH_QUERY = gql`
     fragment SearchAggregationModeAvailability on AggregationModeAvailability {

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
@@ -22,6 +22,7 @@ export const useSearchFiltersStore = create<SearchFiltersStore>(set => ({
 export interface SearchFiltersPanelProps {
     query: string
     filters: Filter[] | undefined
+    withCountAllFilter: boolean
     className?: string
     onQueryChange: (nextQuery: string, updatedSearchURLQuery?: string) => void
 }
@@ -35,7 +36,7 @@ export interface SearchFiltersPanelProps {
  * as it is, use consumer agnostic NewSearchFilters component instead.
  */
 export const SearchFiltersPanel: FC<SearchFiltersPanelProps> = props => {
-    const { query, filters, className, onQueryChange } = props
+    const { query, filters, withCountAllFilter, className, onQueryChange } = props
 
     const { isOpen, setFiltersPanel } = useSearchFiltersStore()
     const uiMode = useSearchFiltersPanelUIMode()
@@ -50,7 +51,12 @@ export const SearchFiltersPanel: FC<SearchFiltersPanelProps> = props => {
                 ariaLabel="Filters sidebar"
                 className={className}
             >
-                <NewSearchFilters query={query} filters={filters} onQueryChange={onQueryChange} />
+                <NewSearchFilters
+                    query={query}
+                    filters={filters}
+                    withCountAllFilter={withCountAllFilter}
+                    onQueryChange={onQueryChange}
+                />
             </Panel>
         )
     }
@@ -62,7 +68,12 @@ export const SearchFiltersPanel: FC<SearchFiltersPanelProps> = props => {
             className={styles.modal}
             onDismiss={() => setFiltersPanel(false)}
         >
-            <NewSearchFilters query={query} filters={filters} onQueryChange={onQueryChange}>
+            <NewSearchFilters
+                query={query}
+                filters={filters}
+                withCountAllFilter={withCountAllFilter}
+                onQueryChange={onQueryChange}
+            >
                 <Button variant="secondary" outline={true} onClick={() => setFiltersPanel(false)}>
                     <Icon as={DeleteIcon} width={14} height={14} aria-hidden={true} className={styles.closeIcon} />{' '}
                     Close filters

--- a/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
+++ b/client/web/src/search/results/components/filters-panel/SearchFiltersPanel.tsx
@@ -23,7 +23,7 @@ export interface SearchFiltersPanelProps {
     query: string
     filters: Filter[] | undefined
     className?: string
-    onQueryChange: (nextQuery: string) => void
+    onQueryChange: (nextQuery: string, updatedSearchURLQuery?: string) => void
 }
 
 /**

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
@@ -172,8 +172,8 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
     )
 
     const handleFilterPanelQueryChange = useCallback(
-        (updatedQuery: string): void => {
-            onSearchSubmit([{ type: 'replaceQuery', value: updatedQuery }])
+        (updatedQuery: string, updatedSearchURLQuery?: string): void => {
+            onSearchSubmit([{ type: 'replaceQuery', value: updatedQuery }], updatedSearchURLQuery)
         },
         [onSearchSubmit]
     )

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
@@ -186,8 +186,9 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                 <SearchFiltersPanel
                     query={submittedURLQuery}
                     filters={results?.filters}
-                    onQueryChange={handleFilterPanelQueryChange}
+                    withCountAllFilter={isSearchLimitHit(results)}
                     className={styles.newFilters}
+                    onQueryChange={handleFilterPanelQueryChange}
                 />
             )}
 
@@ -338,6 +339,14 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
             )}
         </div>
     )
+}
+
+const isSearchLimitHit = (results?: AggregateStreamingSearchResults): boolean => {
+    if (results?.state !== 'complete') {
+        return false
+    }
+
+    return results?.progress.skipped.some(skipped => skipped.reason.includes('-limit'))
 }
 
 interface NewSearchSidebarWrapper extends HTMLAttributes<HTMLElement> {

--- a/client/web/src/stores/navbarSearchQueryState.ts
+++ b/client/web/src/stores/navbarSearchQueryState.ts
@@ -50,10 +50,18 @@ export const useNavbarQueryState = create<NavbarQueryState>((set, get) => ({
             searchPatternType: patternType,
             searchMode: searchMode,
         } = get()
+
         const query = parameters.query ?? queryState.query
         const updatedQuery = updateQuery(query, updates)
+
         if (canSubmitSearch(query, parameters.selectedSearchContextSpec)) {
-            submitSearch({ ...parameters, query: updatedQuery, caseSensitive, patternType, searchMode })
+            submitSearch({
+                ...parameters,
+                query: updatedQuery,
+                caseSensitive,
+                patternType,
+                searchMode,
+            })
         }
     },
 }))

--- a/client/wildcard/src/hooks/useSyncedWithUrlState.ts
+++ b/client/wildcard/src/hooks/useSyncedWithUrlState.ts
@@ -68,7 +68,7 @@ export function useSyncedWithURLState<State, SerializedState>(
 
             return `?${urlSearchParameters.toString()}`
         },
-        [navigate, serializer, urlKey, urlSearchParameters, replace]
+        [serializer, urlKey, urlSearchParameters]
     )
 
     return [queryParameter, setNextState, serializeURL]

--- a/client/wildcard/src/hooks/useSyncedWithUrlState.ts
+++ b/client/wildcard/src/hooks/useSyncedWithUrlState.ts
@@ -18,7 +18,7 @@ export interface UpdateSearchQueryOptions {
 export type SetStateResult<State> = [
     state: State,
     dispatch: (state: State, options?: UpdateSearchQueryOptions) => UpdatedSearchQuery,
-    serilize: (state: State) => UpdatedSearchQuery
+    serialize: (state: State) => UpdatedSearchQuery
 ]
 
 /**

--- a/client/wildcard/src/hooks/useSyncedWithUrlState.ts
+++ b/client/wildcard/src/hooks/useSyncedWithUrlState.ts
@@ -10,7 +10,16 @@ export interface URLStateOptions<State, SerializedState> {
 }
 
 export type UpdatedSearchQuery = string
-export type SetStateResult<State> = [state: State, dispatch: (state: State) => UpdatedSearchQuery]
+
+export interface UpdateSearchQueryOptions {
+    replace: boolean
+}
+
+export type SetStateResult<State> = [
+    state: State,
+    dispatch: (state: State, options?: UpdateSearchQueryOptions) => UpdatedSearchQuery,
+    serilize: (state: State) => UpdatedSearchQuery
+]
 
 /**
  * React hook analog standard react useState hook but with synced value with URL
@@ -30,7 +39,7 @@ export function useSyncedWithURLState<State, SerializedState>(
     )
 
     const setNextState = useCallback(
-        (nextState: State) => {
+        (nextState: State, options?: UpdateSearchQueryOptions) => {
             const serializedValue = serializer(nextState)
 
             if (serializedValue === null) {
@@ -40,12 +49,27 @@ export function useSyncedWithURLState<State, SerializedState>(
             }
 
             const search = `?${urlSearchParameters.toString()}`
-            navigate({ search }, { replace })
+            navigate({ search }, { replace: options?.replace ?? replace })
 
             return search
         },
         [navigate, serializer, urlKey, urlSearchParameters, replace]
     )
 
-    return [queryParameter, setNextState]
+    const serializeURL = useCallback(
+        (nextState: State) => {
+            const serializedValue = serializer(nextState)
+
+            if (serializedValue === null) {
+                urlSearchParameters.delete(urlKey)
+            } else {
+                urlSearchParameters.set(urlKey, serializedValue)
+            }
+
+            return `?${urlSearchParameters.toString()}`
+        },
+        [navigate, serializer, urlKey, urlSearchParameters, replace]
+    )
+
+    return [queryParameter, setNextState, serializeURL]
 }


### PR DESCRIPTION
Support behaviour from https://github.com/sourcegraph/sourcegraph/issues/59593

Quick facts about `count:all` filter
- It isn't supported on the backend, so client should extend backend generated filters with new count kind
- `Count:all` filter should change the original query, we do not store anything in filters query param about count:all filters
- Since `count:all` will change the query we should support filter preservation as we change the query (prior to this PR any changes about the query reset filters completely) 
- Filter preservation tries to be a bit smart and resets filters if they no longer makes sense with new query, for example if you're picked Paths type in the filter panel and then select `Exclude go vendor` filter and then switch to the repository type, this filter will be reseted, because there is no such filter as exclude go vendor with repositories types
- This smart logic won't catch all cases, so sometimes there will be some empty state
- Because of possible empty states we no longer have any logic about show/hide filters in different filter types, if we have selected filter we will show it to you in any filter type. This is our safe way to reset filters if they don't make sense anymore.
- Browser history catches all changes as it was before.
- We show `count:all` filter unconditionally, because conditions for this might be very tricky (don't show if search limit wasn't hit may work but I found it very difficult to figure out from user point of view, we probably should apply this show/hide logic when we have more visible limit hit UI in the progress info header cc @taiyab)

## Test plan
- Check that `count:all` filter works as you expect it.
- Check that smart logic about preservation filters value works as you think it should work (any feedback is welcome)
- Check that browser history catches all filter and query change and there is neither trash or skipped states in browser history 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
