### PR TITLE
add/v2-telemetry: fuzzy finder prop and mocks update

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.mocks.tsx
@@ -4,6 +4,7 @@ import * as H from 'history'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
 import type { Settings } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import {
@@ -41,6 +42,7 @@ export const FuzzyWrapper: React.FunctionComponent<FuzzyWrapperProps> = props =>
             location={history.location}
             settingsCascade={{ final: { experimentalFeatures: props.experimentalFeatures }, subjects: null }}
             telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
             initialQuery={props.initialQuery}
             userHistory={new UserHistory()}
         />

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -4,6 +4,7 @@ import type * as H from 'history'
 
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { FuzzyModal } from './FuzzyModal'
@@ -14,6 +15,7 @@ const DEFAULT_MAX_RESULTS = 50
 
 export interface FuzzyFinderContainerProps
     extends TelemetryProps,
+        TelemetryV2Props,
         Pick<FuzzyFinderProps, 'location'>,
         SettingsCascadeProps,
         FuzzyTabsProps {
@@ -84,15 +86,17 @@ export const FuzzyFinderContainer: React.FunctionComponent<FuzzyFinderContainerP
     useEffect(() => {
         if (isVisible) {
             props.telemetryService.log('FuzzyFinderViewed', { action: 'shortcut open' })
+            props.telemetryRecorder.recordEvent('fuzzyfinder.shortcut-open', 'viewed')
         }
-    }, [props.telemetryService, isVisible])
+    }, [props.telemetryService, props.telemetryRecorder, isVisible])
 
     const handleItemClick = useCallback(
         (eventName: 'FuzzyFinderResultClicked' | 'FuzzyFinderGoToResultsPageClicked') => {
             props.telemetryService.log(eventName, { activeTab, scope }, { activeTab, scope })
+            props.telemetryRecorder.recordEvent(eventName, 'clicked', { privateMetadata: { activeTab, scope } })
             setIsVisible(false)
         },
-        [props.telemetryService, setIsVisible, activeTab, scope]
+        [props.telemetryService, props.telemetryRecorder, setIsVisible, activeTab, scope]
     )
 
     if (tabs.isAllDisabled()) {


### PR DESCRIPTION
## Background information
See documentation [here](https://docs.sourcegraph.com/dev/background-information/telemetry) on reasoning for transitioning to the new telemetry gateway service.

## Test plan

Run `sg start dotcom` or `sg start`
Verify v2 events are recorded in `event_logs`
Ensure all existing integration tests pass
