### PR TITLE
change(httpapi): extend max request duration

### DIFF
--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -36,8 +36,8 @@ import (
 )
 
 // maxRequestDuration is the maximum amount of time a request can take before
-// being cancelled.
-const maxRequestDuration = time.Minute
+// being cancelled as DeadlineExceeded.
+const maxRequestDuration = 2 * time.Minute
 
 var timeToFirstEventMetrics = metrics.NewREDMetrics(
 	prometheus.DefaultRegisterer,


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1706116514736789

Work with https://github.com/sourcegraph/cody/pull/2902

- Increased the maximum request duration for HTTP API calls in the `internal/completions/httpapi` handler from 1 minute to 2 minutes to accommodate longer processing times for slower chat model.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->

Connect instance. to Cody and try using Chat GPT 4 model that has a slower response time, and confirm any streaming response did not get cut off at 1 minute.