### PR TITLE
sg msp: add 'fleet' command for summaries

### DIFF
--- a/dev/sg/msp/BUILD.bazel
+++ b/dev/sg/msp/BUILD.bazel
@@ -31,5 +31,6 @@ go_library(
         "//lib/pointers",
         "@com_github_sourcegraph_run//:run",
         "@com_github_urfave_cli_v2//:cli",
+        "@org_golang_x_exp//maps",
     ],
 )


### PR DESCRIPTION
Saves some time for #progress posts so that I'm not constantly counting these by hand 😁 

## Test plan

Note that a lot of soon-to-be-prod environments are actually still in the `test` category for convenience

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/9470dd85-7c86-48ef-adbb-3428bb5d0c79)
