### PR TITLE
sg monitoring: fix dashboard arguments

### DIFF
--- a/dev/sg/sg_monitoring.go
+++ b/dev/sg/sg_monitoring.go
@@ -158,7 +158,7 @@ func dashboardsFromArgs(args cli.Args) (dashboards definitions.Dashboards, err e
 		dashboards = definitions.Default()
 	} else {
 		for _, arg := range args.Slice() {
-			d := definitions.Default().GetByName(args.First())
+			d := definitions.Default().GetByName(arg)
 			if d == nil {
 				return nil, errors.Newf("Dashboard %q not found", arg)
 			}


### PR DESCRIPTION
Allows you to list metrics from multiple dashboards, e.g. `sg monitoring metrics frontend gitserver`. Previously, we only used the first argument (incorrectly)

## Test plan

```sh
sg monitoring metrics frontend
# ...
  Found 160 metrics in use.  
sg monitoring metrics frontend gitserver
# ...
  Found 216 metrics in use.
```