### PR TITLE
soap: add support for site config allowlist

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -252,6 +252,7 @@ go_library(
         "//internal/authz/permssync",
         "//internal/binary",
         "//internal/cloneurls",
+        "//internal/cloud",
         "//internal/codeintel/dependencies",
         "//internal/codeintel/dependencies/shared",
         "//internal/codeintel/resolvers",

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/cloud"
 	"github.com/sourcegraph/sourcegraph/internal/cody"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
@@ -315,6 +316,13 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 	unredacted, err := conf.UnredactSecrets(args.Input, prev)
 	if err != nil {
 		return false, errors.Errorf("error unredacting secrets: %s", err)
+	}
+
+	cloudSiteConfig := cloud.SiteConfig()
+	if cloudSiteConfig.SiteConfigAllowlistEnabled() && !actor.FromContext(ctx).SourcegraphOperator {
+		if p, ok := allowEdit(prev.Site, unredacted, cloudSiteConfig.SiteConfigAllowlist.Paths); !ok {
+			return false, cloudSiteConfig.SiteConfigAllowlistOnError(p)
+		}
 	}
 
 	prev.Site = unredacted
@@ -646,4 +654,17 @@ func (c *codyLLMConfigurationResolver) CompletionModelMaxTokens() *int32 {
 		return &max
 	}
 	return nil
+}
+
+func allowEdit(before, after string, allowlist []string) ([]string, bool) {
+	var notAllowed []string
+	changes := conf.Diff(before, after)
+	for key := range changes {
+		for _, p := range allowlist {
+			if key != p {
+				notAllowed = append(notAllowed, key)
+			}
+		}
+	}
+	return notAllowed, len(notAllowed) == 0
 }

--- a/internal/conf/diff.go
+++ b/internal/conf/diff.go
@@ -5,8 +5,21 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
+
+func Diff(before, after string) (fields map[string]struct{}) {
+	beforeCfg, err := ParseConfig(conftypes.RawUnified{Site: before})
+	if err != nil {
+		return nil
+	}
+	afterCfg, err := ParseConfig(conftypes.RawUnified{Site: after})
+	if err != nil {
+		return nil
+	}
+	return diff(beforeCfg, afterCfg)
+}
 
 // diff returns names of the Go fields that have different values between the
 // two configurations.


### PR DESCRIPTION
Part of https://github.com/sourcegraph/customer/issues/2747

Closes https://github.com/sourcegraph/customer/issues/2750

On Cloud, site config is a mixed of Cloud-managed and customer-managed fields. Sometime customer may touch things that they're not supposed to. Either it broke the instance or they're surprised these values are overridden by Cloud later on.

@unknwon proposed the idea of reusing SOAP to implement an allowlist approach to solve this problem.

## Test plan

Follow https://handbook.sourcegraph.com/departments/cloud/technical-docs/oidc_site_admin/#how-to-enable-soap-locally to set up dev environment

```
{
  "authProviders": {
    "sourcegraphOperator": {
      "clientID": "<>",
      "clientSecret": "<>",
      "issuer": "<>",
      "lifecycleDuration": 60
    }
  },
  "siteConfigAllowlist": {
    "paths": ["externalURL"]
  }
}
```

Login as a regular admin

Tries to edit the site config with `  "codeIntelAutoIndexing.enabled": false,`, you should see

![CleanShot 2024-01-25 at 16 15 18](https://github.com/sourcegraph/sourcegraph/assets/8373004/813b7d1d-15c4-465b-8b31-a31dc014c88f)

Then, log in as a SOAP admin

Edit the site config again, it should work.

