### PR TITLE
Update cody/ssc packages to use SAMS tokens; support multiple SAMS environments

### DIFF
--- a/internal/cody/utils.go
+++ b/internal/cody/utils.go
@@ -2,7 +2,6 @@ package cody
 
 import (
 	"context"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"time"
 )
 
@@ -22,48 +21,25 @@ func withCurrentTimeMock(ctx context.Context, t time.Time) context.Context {
 	return context.WithValue(ctx, mockCurrentTimeKey, &t)
 }
 
-func preSSCReleaseCurrentPeriodDateRange(ctx context.Context, user types.User) (time.Time, time.Time) {
-	// to allow mocking current time during tests
-	currentDate := currentTimeFromCtx(ctx)
+// fakeSubscriptionDateRange returns a fake date range for a Cody subscription.
+// Since this isn't backed by Stripe or anything, the exact dates don't matter.
+//
+// If set, we peg the end date to February 15. (To align with the expected Cody
+// Pro release, when we expect existing free trials to end.) Otherwise the end
+// of the month is chosen.
+func fakeSubscriptionBillingCycle(endOnFeb15 bool) (time.Time, time.Time) {
+	now := time.Now()
+	startOfTheMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 
-	subscriptionStartDate := user.CreatedAt
-	gaReleaseDate := time.Date(2023, 12, 14, 0, 0, 0, 0, subscriptionStartDate.Location())
-
-	if !currentDate.Before(gaReleaseDate) && subscriptionStartDate.Before(gaReleaseDate) {
-		subscriptionStartDate = gaReleaseDate
+	// Peg the end date to 2/15 unless it has already elapsed. (And hopefully
+	// by then we'll be able to delete this function entirely.)
+	feb15th2024 := time.Date(2024, time.February, 15, 12, 0, 0, 0, time.UTC)
+	if endOnFeb15 && now.Before(feb15th2024) {
+		return startOfTheMonth, feb15th2024
 	}
 
-	codyProEnabledAt := user.CodyProEnabledAt
-	if codyProEnabledAt != nil {
-		subscriptionStartDate = *codyProEnabledAt
-	}
-
-	targetDay := subscriptionStartDate.Day()
-	startDayOfTheMonth := targetDay
-	endDayOfTheMonth := targetDay - 1
-	startMonth := currentDate
-	endMonth := currentDate
-
-	if currentDate.Day() < targetDay {
-		// Set to target day of the previous month
-		startMonth = currentDate.AddDate(0, -1, 0)
-	} else {
-		// Set to target day of the next month
-		endMonth = currentDate.AddDate(0, 1, 0)
-	}
-
-	daysInStartingMonth := time.Date(startMonth.Year(), startMonth.Month()+1, 0, 0, 0, 0, 0, startMonth.Location()).Day()
-	if startDayOfTheMonth > daysInStartingMonth {
-		startDayOfTheMonth = daysInStartingMonth
-	}
-
-	daysInEndingMonth := time.Date(endMonth.Year(), endMonth.Month()+1, 0, 0, 0, 0, 0, endMonth.Location()).Day()
-	if endDayOfTheMonth > daysInEndingMonth {
-		endDayOfTheMonth = daysInEndingMonth
-	}
-
-	startDate := time.Date(startMonth.Year(), startMonth.Month(), startDayOfTheMonth, 0, 0, 0, 0, startMonth.Location())
-	endDate := time.Date(endMonth.Year(), endMonth.Month(), endDayOfTheMonth, 23, 59, 59, 59, endMonth.Location())
-
-	return startDate, endDate
+	// This won't be pedantically correct in some situations, but for a stable
+	// fake subscription billing period, it's sufficient.
+	endOfTheMonth := time.Now().AddDate(0, 1, 0).UTC()
+	return startOfTheMonth, endOfTheMonth
 }

--- a/internal/ssc/ssc.go
+++ b/internal/ssc/ssc.go
@@ -1,35 +1,125 @@
 package ssc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
+	"golang.org/x/oauth2/clientcredentials"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// FeatureFlagUseSSCDevInstance, if set, will send requests to the SSC dev environment for dogfooding.
+//
+// IMPORTANT: If this is set, calls to Client.LookupDotcomUserSAMSAccountID return the SAMS account ID
+// for the SAMS dev environment. (Since SSC will be using that for authentication.)
+const FeatureFlagUseSSCDevInstance = "ssc.use-dev-environment"
+
+const (
+	samsProdHostname = "accounts.sourcegraph.com"
+	samsDevHostname  = "accounts.sgdev.org"
 )
 
 // Client is the interface for making requests to the Self-Service Cody backend.
 // This uses a REST API exposed from the service, and not the GraphQL API (which is
 // instead used for user-facing frontend queries.)
 type Client interface {
-	FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Subscription, error)
+	// LookupDotcomUserSAMSAccountID returns the SAMS external account ID for the given dotcom user ID.
+	// Will return "" if the user has no SAMS identity associated with their dotcom user account.
+	//
+	// This will honor the FeatureFlagUseSSCDevInstance. So if set, the returned SAMS account ID
+	// will be from the SAMS dev environment rather than production..
+	LookupDotcomUserSAMSAccountID(ctx context.Context, db database.DB, dotcomUserID int32) (string, error)
+
+	// FetchSubscriptionBySAMSAccountID will return the SSC subscription information associated with
+	// the given SAMS user account. Will return (nil, nil) if the user ID is valid, but has no
+	// SSC subscription information associated with their account.
+	//
+	// In the future, this behavior will change to _ALWAYS_ return subscription data, even for
+	// users that have not converted. But for now, the `cody` package needs to know if the user
+	// has setup their Cody Pro subscription on the SSC backend or not.
+	FetchSubscriptionBySAMSAccountID(ctx context.Context, samsAccountID string) (*Subscription, error)
 }
 
-type SSCClient struct {
+func NewClient() Client {
+	sgconf := conf.Get().SiteConfig()
+	return &client{
+		baseURL: sgconf.SscApiBaseUrl, // [sic] generated code
+	}
+}
+
+type client struct {
 	baseURL     string
 	secretToken string
 }
 
-func (c *SSCClient) sendRequest(method string, url string, body *Subscription) (code *int, err error) {
+// createSAMSToken creates a new SAMS access token for contacting the SSC backend.
+func (c *client) createSAMSToken(ctx context.Context) (string, error) {
+	// The target SSC environment needs to match the SAMS environment being used.
+	useSSCDevInstance := featureflag.FromContext(ctx).GetBoolOr(FeatureFlagUseSSCDevInstance, false)
+
+	var sams *schema.OpenIDConnectAuthProvider
+	for _, provider := range conf.Get().AuthProviders {
+		oidcInfo := provider.Openidconnect
+		if oidcInfo == nil {
+			continue
+		}
+		if useSSCDevInstance {
+			if strings.Contains(oidcInfo.Issuer, samsDevHostname) {
+				sams = oidcInfo
+				break
+			}
+		} else {
+			if strings.Contains(oidcInfo.Issuer, samsProdHostname) {
+				sams = oidcInfo
+				break
+			}
+		}
+	}
+	if sams == nil {
+		return "", errors.New("no appropriate SAMS auth provider found")
+	}
+
+	// BUG: We shouldn't create a new token for every request, and instead use the proper
+	// libraries to cache and refresh automatically. (But that would require that the
+	// SSC client is long-lived, meaning we need to fix that in the cody package first.)
+	clientCreds := &clientcredentials.Config{
+		ClientID:     sams.ClientID,
+		ClientSecret: sams.ClientSecret,
+		TokenURL:     fmt.Sprintf("%s/oauth/token", sams.Issuer),
+
+		// IMPORTANT: The SAMS client must be capable of issuing tokens with the
+		// client.ssc scope.
+		Scopes: []string{"client.ssc"},
+	}
+	token, err := clientCreds.Token(ctx)
+	if err != nil {
+		return "", err
+	}
+	return token.AccessToken, nil
+}
+
+func (c *client) sendRequest(ctx context.Context, method string, url string, body *Subscription) (code *int, err error) {
+	samsToken, err := c.createSAMSToken(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating SAMS token")
+	}
+
+	// Issue the request.
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.secretToken))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", samsToken))
 
 	resp, err := httpcli.UncachedExternalDoer.Do(req)
 	if err != nil {
@@ -54,9 +144,48 @@ func (c *SSCClient) sendRequest(method string, url string, body *Subscription) (
 
 }
 
+// LookupDotcomUserSAMSAccountID attempts to lookup the dotcom user's SAMS account ID from their attached
+// identities. It's possible the user hasn't yet attached a SAMS identity.
+func (c *client) LookupDotcomUserSAMSAccountID(ctx context.Context, db database.DB, dotcomUserID int32) (string, error) {
+	// Fetch all of the user's OpenID Connect identities. We expect a user can have several of these,
+	// such as identities from both the SAMS-dev and SAMS-prod instances.
+	oidcIdentities, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
+		UserID:      dotcomUserID,
+		ServiceType: "openidconnect",
+		LimitOffset: &database.LimitOffset{
+			Limit: 10,
+		},
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "listing external accounts")
+	}
+	if len(oidcIdentities) == 0 {
+		return "", nil
+	}
+
+	// Loop through the available identities and pick out the SAMS identities.
+	var (
+		samsProdAccountID string
+		samsDevAccountID  string
+	)
+	for _, identity := range oidcIdentities {
+		if strings.Contains(identity.URL, samsProdHostname) {
+			samsProdAccountID = identity.AccountID
+		} else if strings.Contains(identity.URL, samsDevHostname) {
+			samsDevAccountID = identity.AccountID
+		}
+	}
+
+	useSSCDevInstance := featureflag.FromContext(ctx).GetBoolOr(FeatureFlagUseSSCDevInstance, false)
+	if useSSCDevInstance {
+		return samsDevAccountID, nil
+	}
+	return samsProdAccountID, nil
+}
+
 // FetchSubscriptionBySAMSAccountID returns the user's Cody subscription for the sams_account_id.
 // It returns nil, nil if the user does not have a Cody Pro subscription.
-func (c *SSCClient) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Subscription, error) {
+func (c *client) FetchSubscriptionBySAMSAccountID(ctx context.Context, samsAccountID string) (*Subscription, error) {
 	if c.baseURL == "" {
 		return nil, errors.New("SSC base url is not set")
 	}
@@ -66,8 +195,8 @@ func (c *SSCClient) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Sub
 	}
 
 	var subscription Subscription
-
-	code, err := c.sendRequest(http.MethodGet, fmt.Sprintf("%s/rest/svc/subscription/%s", c.baseURL, samsAccountID), &subscription)
+	url := fmt.Sprintf("%s/rest/svc/subscription/%s", c.baseURL, samsAccountID)
+	code, err := c.sendRequest(ctx, http.MethodGet, url, &subscription)
 	if err != nil {
 		return nil, err
 	}
@@ -84,13 +213,4 @@ func (c *SSCClient) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Sub
 	}
 
 	return nil, errors.Errorf("unexpected status code %d while fetching user subscription from SSC", *code)
-}
-
-func NewClient() *SSCClient {
-	sgconf := conf.Get().SiteConfig()
-
-	return &SSCClient{
-		baseURL:     sgconf.SscApiBaseUrl,
-		secretToken: sgconf.SscApiSecret,
-	}
 }


### PR DESCRIPTION
We are trying to introduce the ability for dotcom to pull Cody subscription information from the SSC service, as part of eventually having it be the source of truth for this information.


https://github.com/sourcegraph/sourcegraph/pull/59763 was the first step towards this. It introduced a `cody` package to be the sole location where we fetch Cody subscription information. And then as an implementation detail, that package referred to an `ssc` package with an API client for contacting the SSC backend.

The next step is to update the SSC client to use SAMS access tokens for authorization. As it is configured today, it is using a "shared secret" which is no longer supported on the SSC backend. Nor has it ever been configured for the live dotcom environment. (https://github.com/sourcegraph/sourcegraph/pull/59783/files was a prototype showing how to do that.)

This PR updates the SSC client to use SAMS tokens. But also does it in such a way that dotcom can support TWO versions of SAMS (`-dev` and `-prod`) concurrently. In order to facilitate end-to-end testing and dogfooding of Cody, and without a Sourcegraph.com test environment, we need to expose a per-user feature flag to enable a user having their subscription information pulled from a lower SSC environment.

... and to authenticate requests to that SSC-dev environment, we need to use a SAMS token for the SAMS-dev environment. (Yes that is confusing. But fortunately the two services share a hostname. So that's nice.)

> **Why is it important to support BOTH -dev and -prod SAMS instance concurrently?**
> Otherwise, we aren't able to test Cody :'( See https://docs.google.com/document/d/1IIdeJqQ_Xwkgw8m0dydCYJTRMByowoymFXzth3fqRoI/edit.

I also did a bunch of cleanup and refactoring to just get my bearings for how the code was supposed to work. But can tease that out if it seems too risky or would make this more difficult to review.

## Questions for Reviewers

I'm assuming that lookups to get the status of a feature flag are essentially free, since the flag set is part of the `context.Context`. Is that correct?

Needing every SSC request to first hit the database to look up the user's attached identities, doesn't seem great. But this is only done as part of GraphQL queries that fetch the user's subscription information. (So presumably not exactly on the critical path.) But what options are available for making this faster? Initializing the SAMS configuration lazily, but keeping them in a package-level variable?

I am renaming some feature flags to (arguably) make them easier to understand. But how bad of an idea is this? e.g. does having orphaned feature flags cause major problems?

## Test plan

Not yet. I want to confirm that he approach is sound before updating the tests.