### PR TITLE
msp/monitoring: fixup external healthcheck alert

### DIFF
--- a/dev/managedservicesplatform/stacks/monitoring/service.go
+++ b/dev/managedservicesplatform/stacks/monitoring/service.go
@@ -131,7 +131,7 @@ func createExternalHealthcheckAlert(
 			// there seems to be no way to change this. So we group by the check
 			// target anyway.
 			Trigger:       alertpolicy.TriggerKindAllInViolation,
-			GroupByFields: []string{"host"},
+			GroupByFields: []string{"metric.labels.host"},
 			Reducer:       alertpolicy.MonitoringReduceMean,
 		},
 		NotificationChannels: channels,


### PR DESCRIPTION
Regression from #59848 - I'm not sure how this didn't caught in my testbed testing, but once rolled out it caused the monitoring stacks to fail to apply

## Test plan

Applied in `msp-testbed-robert`