### PR TITLE
Misc: retain URL params on redirect

### DIFF
--- a/cmd/frontend/internal/handlerutil/repo.go
+++ b/cmd/frontend/internal/handlerutil/repo.go
@@ -80,6 +80,11 @@ func RedirectToNewRepoName(w http.ResponseWriter, r *http.Request, newRepoName a
 		return err
 	}
 
-	http.Redirect(w, r, destURL.String(), http.StatusMovedPermanently)
+	// Update the old request with the new path, retaining any additional
+	// query params and fragments.
+	origURLCopy := *r.URL
+	origURLCopy.Path = destURL.Path
+
+	http.Redirect(w, r, origURLCopy.String(), http.StatusMovedPermanently)
 	return nil
 }


### PR DESCRIPTION
When a repo is renamed, we redirect to the new name so old links still work. However, we currently strip any query params or fragments from the request on redirect. This makes the redirect only update the path, maintaining the original query params.

This should fix an issue reported where "open in sourcegraph" links stopped working.

## Test plan

Renamed a repo, tested that the redirect kept `?trace=1`. I'd write an automated test, but the way we set up routing would make that really finnicky and not very valuable