### PR TITLE
Revert "truncate commit message in commit view if necessary"

### DIFF
--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -21,7 +21,6 @@ import { GitCommitNodeByline } from './GitCommitNodeByline'
 
 import styles from './GitCommitNode.module.scss'
 
-const TRUNCATED_COMMIT_MESSAGE_LENGTH = 240
 export interface GitCommitNodeProps {
     node: GitCommitFields
 
@@ -84,7 +83,6 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     wrapperElement: WrapperElement = 'div',
 }) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
-    const [truncateCommitMessage, setTruncateCommitMessage] = useState<boolean>(true)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
 
     const sourceType = node.perforceChangelist ? RepositoryType.PERFORCE_DEPOT : RepositoryType.GIT_REPOSITORY
@@ -159,30 +157,14 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
         </div>
     )
 
-    const commitMessage = node.body ?? ''
-    const truncationNeeded = commitMessage.length > TRUNCATED_COMMIT_MESSAGE_LENGTH
-    const truncatedCommitMessage =
-        truncateCommitMessage && truncationNeeded
-            ? `${commitMessage.slice(0, TRUNCATED_COMMIT_MESSAGE_LENGTH)}...`
-            : commitMessage
-
-    const commitMessageBody = (
-        <div className="w-100">
-            <pre className={styles.messageBody}>
-                <Linkified input={truncatedCommitMessage} externalURLs={node.externalURLs} />
-                {truncationNeeded && (
-                    <Button
-                        variant="link"
-                        size="sm"
-                        display="inline"
-                        onClick={() => setTruncateCommitMessage(!truncateCommitMessage)}
-                    >
-                        {truncateCommitMessage ? 'see more' : 'see less'}
-                    </Button>
-                )}
-            </pre>
-        </div>
-    )
+    const commitMessageBody =
+        expandCommitMessageBody || showCommitMessageBody ? (
+            <div className="w-100">
+                <pre className={styles.messageBody}>
+                    {node.body && <Linkified input={node.body} externalURLs={node.externalURLs} />}
+                </pre>
+            </div>
+        ) : undefined
 
     const bylineElement = (
         <GitCommitNodeByline


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#59766 since it inadvertantly expanded the commit message at the top of the blob view

# Test Plan
N/A