### PR TITLE
build: Use scip-treesitter binary consistently

### DIFF
--- a/cmd/syntactic-code-intel-worker/shared/config.go
+++ b/cmd/syntactic-code-intel-worker/shared/config.go
@@ -33,7 +33,7 @@ func (c *Config) Load() {
 	c.WorkerBudget = int64(c.GetInt("SYNTACTIC_CODE_INTEL_WORKER_BUDGET", "0", "The amount of compressed input data (in bytes) a worker can process concurrently. Zero acts as an infinite budget."))
 	c.MaximumRuntimePerJob = c.GetInterval("SYNTACTIC_CODE_INTEL_WORKER_MAXIMUM_RUNTIME_PER_JOB", "25m", "The maximum time a single repository indexing job can take")
 
-	c.CliPath = c.Get("SCIP_TREESITTER_COMMAND", "scip-treesitter", "TODO: fill in description")
+	c.CliPath = c.Get("SCIP_TREESITTER_PATH", "scip-treesitter", "TODO: fill in description")
 
 	c.ListenAddress = c.GetOptional("SYNTACTIC_CODE_INTEL_WORKER_ADDR", "The address under which the syntactic codeintel worker API listens. Can include a port.")
 	// Fall back to a reasonable default.

--- a/dev/scip-treesitter-dev
+++ b/dev/scip-treesitter-dev
@@ -3,14 +3,14 @@
 # Wrapper for `scip-treesitter` similar to `dev/scip-ctags-dev`.
 #
 # To use an alternate scip-treesitter binary for development, invoke
-# `SCIP_TREESITTER_COMMAND=path/to/scip-treesitter sg start`.
+# `SCIP_TREESITTER_PATH=path/to/scip-treesitter sg start`.
 
 root="$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
 TARGET=$("$root/dev/scip-treesitter-install.sh" which)
 
 if [ ! -f "${TARGET}" ]; then
     echo "scip-treesitter is not installed, please run ./dev/scip-treesitter-install.sh"
-    echo "Alternatively you can use SCIP_TREESITTER_COMMAND=path/to/scip-treesitter to use your own binary."
+    echo "Alternatively you can use SCIP_TREESITTER_PATH=path/to/scip-treesitter to use your own binary."
     exit 1
 else
   ${TARGET} "$@"

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/BUILD.bazel
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/BUILD.bazel
@@ -78,7 +78,7 @@ rust_test(
     env = {
         "INSTA_WORKSPACE_ROOT": ".",
         "RUST_BACKTRACE": "1",
-        "SCIP_CLI_LOCATION": "$(rootpath :scip-treesitter)",
+        "SCIP_TREESITTER_PATH": "$(rootpath :scip-treesitter)",
     },
     deps = all_crate_deps(
         normal = True,

--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/tests/integration_test.rs
@@ -10,9 +10,9 @@ use scip_treesitter_cli::io::read_index_from_file;
 
 lazy_static::lazy_static! {
     static ref BINARY_LOCATION: PathBuf = {
-        match std::env::var("SCIP_CLI_LOCATION") {
+        match std::env::var("SCIP_TREESITTER_PATH") {
             Ok(va) => std::env::current_dir().unwrap().join(va),
-            _ => cargo_bin("scip-treesitter-cli"),
+            _ => cargo_bin("scip-treesitter"),
         }
     };
 }

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -587,7 +587,7 @@ commands:
       - cmd/syntactic-code-intel-worker
       - lib/codeintel
     env:
-      SCIP_TREESITTER_COMMAND: dev/scip-treesitter-dev
+      SCIP_TREESITTER_PATH: dev/scip-treesitter-dev
 
   syntactic-code-intel-worker-0:
     <<: *syntactic_codeintel_worker_template


### PR DESCRIPTION
Use the same environment variable name, and make sure
we use the new binary name for tests.

## Test plan

Covered by existing tests