### PR TITLE
search: encode streaming SSE with gzip

### DIFF
--- a/cmd/frontend/internal/search/BUILD.bazel
+++ b/cmd/frontend/internal/search/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//internal/types",
         "//lib/errors",
         "//lib/pointers",
+        "@com_github_nytimes_gziphandler//:gziphandler",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",


### PR DESCRIPTION
We have noticed large response payloads on dotcom which are not gzipped compressed. This should help make a dent in the amount of data a client needs to download over the wire.

Alternatively I considered upgrading all uses of StreamWriter to support gzip. I was surprised but happy to see StreamWriter now has multiple consumers outside of search (completions and blame). However, this was relatively complicated so targetting just our main streaming endpoint.

Test Plan: Added unit tests. Additionally debugged why the middleware wasn't working before and how to make it work with https://gist.github.com/keegancsmith/4e133d976f7042f0b56b6f1f062dae7b
