### PR TITLE
search jobs: change extension to .jsonl

### DIFF
--- a/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/branded/src/search-ui/results/progress/StreamingProgressSkippedPopover.tsx
@@ -374,7 +374,8 @@ export const ExhaustiveSearchMessage: FC<ExhaustiveSearchMessageProps> = props =
             )}
 
             <Text className={classNames(validationError && 'text-muted', styles.exhaustiveSearchText)}>
-                Search jobs exhaustively return all matches of a query. Results can be downloaded as JSON.
+                Search jobs exhaustively return all matches of a query. Results can be downloaded as JSON Lines text
+                file.
             </Text>
 
             {error && <ErrorAlert error={error} className="mt-3" />}

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -161,7 +161,7 @@ func NewHandler(
 	m.Path("/src-cli/{rest:.*}").Methods("GET").Handler(trace.Route(newSrcCliVersionHandler(logger)))
 	m.Path("/insights/export/{id}").Methods("GET").Handler(trace.Route(handlers.CodeInsightsDataExportHandler))
 	m.Path("/search/stream").Methods("GET").Handler(trace.Route(frontendsearch.StreamHandler(db)))
-	m.Path("/search/export/{id}.json").Methods("GET").Handler(trace.Route(handlers.SearchJobsDataExportHandler))
+	m.Path("/search/export/{id}.jsonl").Methods("GET").Handler(trace.Route(handlers.SearchJobsDataExportHandler))
 	m.Path("/search/export/{id}.log").Methods("GET").Handler(trace.Route(handlers.SearchJobsLogsHandler))
 
 	m.Path("/completions/stream").Methods("POST").Handler(trace.Route(handlers.NewChatCompletionsStreamHandler()))

--- a/cmd/frontend/internal/search/httpapi/export.go
+++ b/cmd/frontend/internal/search/httpapi/export.go
@@ -39,7 +39,7 @@ func ServeSearchJobDownload(logger log.Logger, svc *service.Service) http.Handle
 			return
 		}
 
-		filename := filenamePrefix(jobID) + ".json"
+		filename := filenamePrefix(jobID) + ".jsonl"
 		writeJSON(logger.With(log.Int("jobID", jobID)), w, filename, writerTo)
 	}
 }

--- a/cmd/frontend/internal/search/httpapi/export.go
+++ b/cmd/frontend/internal/search/httpapi/export.go
@@ -77,7 +77,7 @@ func writeCSV(logger log.Logger, w http.ResponseWriter, filenameNoQuotes string,
 }
 
 func writeJSON(logger log.Logger, w http.ResponseWriter, filenameNoQuotes string, writerTo io.WriterTo) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/jsonlines")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filenameNoQuotes))
 	w.WriteHeader(200)
 	n, err := writerTo.WriteTo(w)

--- a/cmd/frontend/internal/search/resolvers/search_job.go
+++ b/cmd/frontend/internal/search/resolvers/search_job.go
@@ -77,7 +77,7 @@ func (r *searchJobResolver) FinishedAt(ctx context.Context) *gqlutil.DateTime {
 
 func (r *searchJobResolver) URL(ctx context.Context) (*string, error) {
 	if r.Job.State == types.JobStateCompleted {
-		exportPath, err := url.JoinPath(conf.Get().ExternalURL, fmt.Sprintf("/.api/search/export/%d.json", r.Job.ID))
+		exportPath, err := url.JoinPath(conf.Get().ExternalURL, fmt.Sprintf("/.api/search/export/%d.jsonl", r.Job.ID))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Search Jobs returns results as line separated JSON, but with a .json extension. This can cause confusion because users might exepect a well formated json file.

This changes the extension to [.jsonl](https://jsonlines.org/) and updates content-type to `application/jsonlines`.

Test plan:
manual testing
