### PR TITLE
search: factor out display limit logic into displayFilter struct

### DIFF
--- a/cmd/frontend/internal/search/BUILD.bazel
+++ b/cmd/frontend/internal/search/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "search",
     srcs = [
+        "display.go",
         "event_writer.go",
         "init.go",
         "metadata.go",

--- a/cmd/frontend/internal/search/display.go
+++ b/cmd/frontend/internal/search/display.go
@@ -1,0 +1,46 @@
+package search
+
+import "github.com/sourcegraph/sourcegraph/internal/search/result"
+
+// displayFilter mutates event matches before sending them to the end user
+// (after all statistics/etc have been calculated).
+//
+// In particular displayFilter is responsible for ensuring we only send
+// display limit results (?display URL parameter).
+//
+// Note: this is different to the search limit (MaxResults). Search limit
+// decides when to stop searching, this decides when to stop sending the
+// actual matches to the user.
+type displayFilter struct {
+	// MatchLimit is the computed display limit (?display URL parameter).
+	// After MatchLimit results have been sent to the user we stop streaming
+	// more matches.
+	MatchLimit int
+
+	matchesRemaining int
+}
+
+// newDisplayFilter returns the displayFilter for args. maxResults is the
+// maximum results we are allowed to search. This is used to bound the display
+// limit.
+func newDisplayFilter(args *args, maxResults int) *displayFilter {
+	// Display is the number of results we send down. If display is < 0 we
+	// want to send everything we find before hitting a limit. Otherwise we
+	// can only send up to limit results.
+	displayLimit := args.Display
+	if displayLimit < 0 || displayLimit > maxResults {
+		displayLimit = maxResults
+	}
+
+	return &displayFilter{
+		MatchLimit:       displayLimit,
+		matchesRemaining: displayLimit,
+	}
+}
+
+// Limit will limit m to enforce the display limits.
+//
+// Note: this should only be called after aggregating statistics.
+func (d *displayFilter) Limit(m *result.Matches) {
+	d.matchesRemaining = m.Limit(d.matchesRemaining)
+}


### PR DESCRIPTION
We are going to make this logic more complicated. This is a first step to better document and isolate the logic from the core http streaming logic.

The intention is to add limiter (or possibly mutators) based on ChunkMatch.Content sizes.

Test Plan: go test