### PR TITLE
Match chainguard's updated grafana versioning

### DIFF
--- a/wolfi-images/server.yaml
+++ b/wolfi-images/server.yaml
@@ -39,7 +39,7 @@ contents:
     - p4cli@sourcegraph
     - p4-fusion-sg@sourcegraph
     - s3proxy@sourcegraph
-    - grafana@chainguard
+    - grafana-7@chainguard
 
 accounts:
   groups:


### PR DESCRIPTION
In the latest release Chainguard are now using `grafana-7` rather than `grafana`.

## Test plan

- CI
- Manual testing of CI-built image

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
