### PR TITLE
Search results: use `--border-color-2` on header

### DIFF
--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -9,7 +9,7 @@
 
     z-index: 1; // Show on top of search result contents
 
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color-2);
 
     // TODO(taiyab): this needs to be fit into the design system
     :global(.theme-light) & {
@@ -31,7 +31,7 @@
 }
 
 .result {
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color-2);
 }
 
 .header:focus-within + .highlight-result.result,

--- a/client/branded/src/search-ui/components/SymbolSearchResult.module.scss
+++ b/client/branded/src/search-ui/components/SymbolSearchResult.module.scss
@@ -8,6 +8,7 @@
     display: flex;
     flex-direction: column;
     background-color: var(--code-bg);
+    border-bottom: 1px solid var(--border-color-2);
 }
 
 .symbol {
@@ -17,7 +18,10 @@
     background-color: var(--code-bg);
     padding: 0.5rem;
     cursor: pointer;
-    border-bottom: 1px solid var(--border-color);
+
+    &:not(:first-child) {
+        border-top: 1px solid var(--border-color);
+    }
 
     &-code-excerpt {
         :global(.code) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/59882

This just updates the borders on the search results headers to be `--border-color-2` for higher contrast. The borders separating the file chunks and individual symbol matches stay at `--border-color` because those have darker backgrounds, so the higher contrast is not needed. Additionally, I think it helps with visual hierarchy.

<table>
<tr><th>Light</th><th>Dark</th></tr>
<tr>
<td>

![CleanShot 2024-01-26 at 10 45 47@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/9b91faca-7309-451b-9e45-8e8cf762894e)

</td>
<td>

![CleanShot 2024-01-26 at 10 47 10@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/b9c84786-2567-4a9e-91f9-0a96bca38945)


</td>

</tr>
<tr>
<td>

![CleanShot 2024-01-26 at 10 45 56@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/97e622f0-e679-4704-a331-e9adbfc0ef2a)

</td>
<td>

![CleanShot 2024-01-26 at 10 46 59@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/ee5c068b-95fd-4479-9852-063b338d8ea7)


</td>
</table>


## Test plan

Visual testing.