### PR TITLE
Search results: isolate z-index

### DIFF
--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -1,3 +1,10 @@
+.result-container {
+    // Force the creation of a new stacking context
+    // so the z-index of the result header does not
+    // leak outside of the search results list.
+    isolation: isolate;
+}
+
 .header {
     padding: 0.5rem 0.75rem;
     display: flex;

--- a/client/branded/src/search-ui/components/ResultContainer.tsx
+++ b/client/branded/src/search-ui/components/ResultContainer.tsx
@@ -68,7 +68,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
 
     return (
         <Component
-            className={classNames('test-search-result', className)}
+            className={classNames('test-search-result', className, styles.resultContainer)}
             data-testid="result-container"
             data-result-type={resultType}
             onClick={trackReferencePanelClick}


### PR DESCRIPTION
This fixes an issue with z-index leakage that I introduced in the search results styling update. I didn't really understand what a stacking context was, so I deleted something I thought was no longer relevant.

Fixes https://github.com/sourcegraph/sourcegraph/issues/59903

![CleanShot 2024-01-26 at 11 03 10@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/887a5ff6-caab-40c1-920d-e6ce4bfcfa2e)

## Test plan

See screenshot. Would be nice to add some snapshot tests for this view. Will look into how to do that.