### PR TITLE
Update SSC client to use SAMS access tokens

### DIFF
--- a/internal/cody/subscription.go
+++ b/internal/cody/subscription.go
@@ -2,6 +2,7 @@ package cody
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -11,15 +12,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-// use-ssc-for-cody-subscription is a feature flag that enables the use of SSC as the source of truth for Cody subscription data.
-const USE_SSC_FOR_SUBSCRIPTION_FF = "use-ssc-for-cody-subscription"
+// featureFlagUseSCCForSubscription determines if we should attempt to lookup subscription data from SSC.
+const featureFlagUseSCCForSubscription = "use-ssc-for-cody-subscription"
 
-// cody-pro-trial-ended is a feature flag that indicates if the Cody Pro "Free Trial"  has ended.
+// featureFlagCodyProTrialEnded indicates if the Cody Pro "Free Trial"  has ended.
 // (Enabling users to use Cody Pro for free for 3-months starting in late Q4'2023.)
-const CODY_PRO_TRIAL_ENDED_FF = "cody-pro-trial-ended"
-
-const SAMS_SERVICE_ID = "https://accounts.sgdev.org"
-const SAMS_SERVICE_TYPE = "openidconnect"
+const featureFlagCodyProTrialEnded = "cody-pro-trial-ended"
 
 type UserSubscriptionPlan string
 
@@ -81,11 +79,14 @@ func consolidateSubscriptionDetails(ctx context.Context, user types.User, subscr
 	// synthesize one using the data available on dotcom.
 	currentPeriodStartAt, currentPeriodEndAt := preSSCReleaseCurrentPeriodDateRange(ctx, user)
 
+	// Whether or not the Cody Pro free trial offer is still running.
+	codyProTrialEnded := featureflag.FromContext(ctx).GetBoolOr(featureFlagCodyProTrialEnded, false)
+
 	if user.CodyProEnabledAt != nil {
 		return &UserSubscription{
 			Status:               ssc.SubscriptionStatusPending,
 			Plan:                 UserSubscriptionPlanPro,
-			ApplyProRateLimits:   !featureflag.FromContext(ctx).GetBoolOr(CODY_PRO_TRIAL_ENDED_FF, false),
+			ApplyProRateLimits:   !codyProTrialEnded,
 			CurrentPeriodStartAt: currentPeriodStartAt,
 			CurrentPeriodEndAt:   currentPeriodEndAt,
 		}, nil
@@ -100,41 +101,47 @@ func consolidateSubscriptionDetails(ctx context.Context, user types.User, subscr
 	}, nil
 }
 
-// getSAMSAccountIDForUser returns the user's SAMS account ID from users_external_accounts table.
-func getSAMSAccountIDForUser(ctx context.Context, db database.DB, user types.User) (string, error) {
-	// TODO(sourcegraph#59786): make service_id configurable between accounts.sourcegraph.com and accounts.sgdev.org using a feature flag for testing.
+// getSAMSAccountIDForUser returns the user's SAMS account ID if available.
+//
+// If the user has not associated a SAMS identity with their dotcom user account,
+// will return ("", nil). After we migrate all dotcom user accounts to SAMS, that
+// should no longer be possible.
+func getSAMSAccountIDForUser(ctx context.Context, db database.DB, dotcomUserID int32) (string, error) {
+	// TODO(sourcegraph#59786): Support pulling a user's SAMS-dev identity so we can
+	// fetch subscription information from SSC-dev, for dogfooding.
 	accounts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
-		UserID:      user.ID,
-		ServiceType: SAMS_SERVICE_TYPE,
-		ServiceID:   SAMS_SERVICE_ID,
+		UserID:      dotcomUserID,
+		ServiceID:   "https://accounts.sgdev.org", // SAMS-prod
+		ServiceType: "openidconnect",
 		LimitOffset: &database.LimitOffset{
 			Limit: 1,
 		},
 	})
 	if err != nil {
-		return "", errors.Wrap(err, "error while fetching user's external account")
+		return "", errors.Wrap(err, "listing external accounts")
 	}
 
 	if len(accounts) > 0 {
 		return accounts[0].AccountID, nil
 	}
-
 	return "", nil
 }
 
+// Returns the subscription data for the given user. (And reconciling the data between both
+// the dotcom database and the SSC backend.
 func getSubscriptionForUser(ctx context.Context, db database.DB, sscClient ssc.Client, user types.User) (*UserSubscription, error) {
-	samsAccountID, err := getSAMSAccountIDForUser(ctx, db, user)
+	samsAccountID, err := getSAMSAccountIDForUser(ctx, db, user.ID)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching user's SAMS account ID")
 	}
 
+	// While developing the SSC backend, we only fetch subscription data for users based on a flag.
 	var subscription *ssc.Subscription
-
-	// Fetch subscription from SSC only if the feature flag is enabled and the user has a SAMS account ID
-	if samsAccountID != "" && featureflag.FromContext(ctx).GetBoolOr(USE_SSC_FOR_SUBSCRIPTION_FF, false) {
-		subscription, err = sscClient.FetchSubscriptionBySAMSAccountID(samsAccountID)
+	useSCCForSubscriptionData := featureflag.FromContext(ctx).GetBoolOr(featureFlagUseSCCForSubscription, false)
+	if samsAccountID != "" && useSCCForSubscriptionData {
+		subscription, err = sscClient.FetchSubscriptionBySAMSAccountID(ctx, samsAccountID)
 		if err != nil {
-			return nil, errors.Wrap(err, "error while fetching user subscription from SSC")
+			return nil, errors.Wrap(err, "fetching subscription from SSC")
 		}
 	}
 
@@ -143,5 +150,13 @@ func getSubscriptionForUser(ctx context.Context, db database.DB, sscClient ssc.C
 
 // SubscriptionForUser returns the user's Cody subscription details.
 func SubscriptionForUser(ctx context.Context, db database.DB, user types.User) (*UserSubscription, error) {
-	return getSubscriptionForUser(ctx, db, ssc.NewClient(), user)
+	sscClient := getSSCClient()
+	return getSubscriptionForUser(ctx, db, sscClient, user)
 }
+
+// getSSCClient returns a self-service Cody API client. We only do this once so that the stateless client
+// can persist in memory longer, so we can benefit from the underlying HTTP client only needing to reissue
+// SAMS access tokens when needed, rather than minting a new token for every request.
+var getSSCClient = sync.OnceValue[ssc.Client](func() ssc.Client {
+	return ssc.NewClient()
+})

--- a/internal/cody/subscription_test.go
+++ b/internal/cody/subscription_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
@@ -12,8 +14,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/ssc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/stretchr/testify/assert"
 )
+
+// TODO: Update all of this.
 
 type mockSSCClient struct {
 	t                     *testing.T
@@ -277,7 +280,10 @@ func TestGetSubscriptionForUser(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := actor.WithActor(context.Background(), actor.FromUser(test.user.ID))
 			ctx = withCurrentTimeMock(ctx, test.today)
-			flags := map[string]bool{USE_SSC_FOR_SUBSCRIPTION_FF: test.useSSCFeatureFlag, CODY_PRO_TRIAL_ENDED_FF: test.codyProTrialEndedFeatureFlag}
+			flags := map[string]bool{
+				featureFlagUseSCCForSubscription: test.useSSCFeatureFlag,
+				featureFlagCodyProTrialEnded:     test.codyProTrialEndedFeatureFlag,
+			}
 			ctx = featureflag.WithFlags(ctx, featureflag.NewMemoryStore(flags, flags, flags))
 
 			db := dbmocks.NewMockDB()

--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//internal/conf",
         "//internal/httpcli",
+        "//internal/trace",
         "//lib/errors",
     ],
 )

--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/conf",
-        "//internal/httpcli",
         "//internal/trace",
         "//lib/errors",
         "@io_opentelemetry_go_otel//attribute",

--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/ssc",
     visibility = ["//:__subpackages__"],
     deps = [
+        "go.opentelemetry.io/otel/attribute",
+        "golang.org/x/oauth2/clientcredentials",
         "//internal/conf",
         "//internal/httpcli",
         "//internal/trace",

--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -9,11 +9,11 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/ssc",
     visibility = ["//:__subpackages__"],
     deps = [
-        "go.opentelemetry.io/otel/attribute",
-        "golang.org/x/oauth2/clientcredentials",
         "//internal/conf",
         "//internal/httpcli",
         "//internal/trace",
         "//lib/errors",
+        "@io_opentelemetry_go_otel//attribute",
+        "@org_golang_x_oauth2//clientcredentials",
     ],
 )

--- a/internal/ssc/ssc.go
+++ b/internal/ssc/ssc.go
@@ -1,96 +1,145 @@
 package ssc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
+	"golang.org/x/oauth2/clientcredentials"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
+
+// SAMSProdHostname is the hostname for the SAMS production instance.
+const SAMSProdHostname = "accounts.sourcegraph.com"
 
 // Client is the interface for making requests to the Self-Service Cody backend.
 // This uses a REST API exposed from the service, and not the GraphQL API (which is
 // instead used for user-facing frontend queries.)
 type Client interface {
-	FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Subscription, error)
+	// FetchSubscriptionBySAMSAccountID will return the SSC subscription information associated with
+	// the given SAMS user account. Will return (nil, nil) if the user ID is valid, but has no
+	// SSC subscription information associated with their account. Or an error if the SAMS account
+	// ID is unrecognized.
+	//
+	// In the future, this behavior will change to _ALWAYS_ return subscription data, even for
+	// users that have not converted. But for now, the `cody` package needs to know if the user
+	// has setup their Cody Pro subscription on the SSC backend or not.
+	FetchSubscriptionBySAMSAccountID(ctx context.Context, samsAccountID string) (*Subscription, error)
 }
 
-type SSCClient struct {
-	baseURL     string
-	secretToken string
+type client struct {
+	baseURL string
+
+	// httpClient to use for making requests to SSC. It will have a transport configured
+	// to automatically issue or reuse SAMS access tokens as needed.
+	httpClient *http.Client
 }
 
-func (c *SSCClient) sendRequest(method string, url string, body *Subscription) (code *int, err error) {
-	req, err := http.NewRequest(method, url, nil)
+// Validate inspects the client configuration and ensures it is valid.
+func (c *client) Validate() error {
+	if c.baseURL == "" {
+		return errors.New("no SCC base URL provided")
+	}
+	if c.httpClient == nil {
+		return errors.New("no HTTP client found")
+	}
+	return nil
+}
+
+// sendRequest issues an HTTP request to SSC. If supplied, the response will be unmarshalled into outBody as JSON.
+func (c *client) sendRequest(ctx context.Context, method string, url string, outBody *Subscription) (code *int, err error) {
+	// Build and send the request.
+	req, err := http.NewRequest(method, url, nil /* body */)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.secretToken))
-
-	resp, err := httpcli.UncachedExternalDoer.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "calling SSC")
 	}
-
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusOK {
-		bytes, err := io.ReadAll(resp.Body)
+	if outBody != nil {
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return &resp.StatusCode, err
+			return &resp.StatusCode, errors.Wrap(err, "reading response")
 		}
 
-		err = json.Unmarshal(bytes, body)
+		err = json.Unmarshal(bodyBytes, outBody)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "unmarshalling response")
 		}
 	}
 
 	return &resp.StatusCode, nil
-
 }
 
-// FetchSubscriptionBySAMSAccountID returns the user's Cody subscription for the sams_account_id.
-// It returns nil, nil if the user does not have a Cody Pro subscription.
-func (c *SSCClient) FetchSubscriptionBySAMSAccountID(samsAccountID string) (*Subscription, error) {
-	if c.baseURL == "" {
-		return nil, errors.New("SSC base url is not set")
-	}
-
-	if c.secretToken == "" {
-		return nil, errors.New("SSC secret token is not set")
+func (c *client) FetchSubscriptionBySAMSAccountID(ctx context.Context, samsAccountID string) (*Subscription, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
 	}
 
 	var subscription Subscription
-
-	code, err := c.sendRequest(http.MethodGet, fmt.Sprintf("%s/rest/svc/subscription/%s", c.baseURL, samsAccountID), &subscription)
+	url := fmt.Sprintf("%s/rest/svc/subscription/%s", c.baseURL, samsAccountID)
+	code, err := c.sendRequest(ctx, http.MethodGet, url, &subscription)
 	if err != nil {
 		return nil, err
 	}
 
 	subscription.Status = SubscriptionStatus(strings.ToUpper(subscription.StatusRaw))
 
-	if *code == http.StatusOK {
+	switch *code {
+	case http.StatusOK:
+		// User has an SSC subscription.
 		return &subscription, nil
-	}
-
-	// 204 response indicates that the user does not have a Cody Pro subscription
-	if *code == http.StatusNoContent {
+	case http.StatusNoContent:
+		// User is valid, but does not have an SSC subscription.
 		return nil, nil
+	default:
+		return nil, errors.Errorf("unexpected status code %d", *code)
 	}
-
-	return nil, errors.Errorf("unexpected status code %d while fetching user subscription from SSC", *code)
 }
 
-func NewClient() *SSCClient {
+// NewClient returns a new SSC API client. It is important to avoid creating new
+// API clients if possible, so that it can reuse SAMS access tokens when making
+// requests to SSC. (Otherwise every request would need to create a new token,
+// adding unnecessary latency.)
+//
+// If no SAMS authorization provider is configured, this function will not panic,
+// but instead will return an error on every call.
+func NewClient() Client {
 	sgconf := conf.Get().SiteConfig()
 
-	return &SSCClient{
-		baseURL:     sgconf.SscApiBaseUrl,
-		secretToken: sgconf.SscApiSecret,
+	// Fetch the SAMS configuration data.
+	var samsConfig *clientcredentials.Config
+	for _, provider := range conf.Get().AuthProviders {
+		oidcInfo := provider.Openidconnect
+		if oidcInfo == nil {
+			continue
+		}
+
+		if strings.Contains(oidcInfo.Issuer, SAMSProdHostname) {
+			samsConfig = &clientcredentials.Config{
+				ClientID:     oidcInfo.ClientID,
+				ClientSecret: oidcInfo.ClientSecret,
+				TokenURL:     fmt.Sprintf("%s/oauth/token", oidcInfo.Issuer),
+				Scopes:       []string{"client.ssc"},
+			}
+			break
+		}
+	}
+
+	// Create a long-lived HTTP client for all dotcom<->SSC requests, using
+	// the samsConfig credentials as needed.
+	httpClient := samsConfig.Client(context.Background())
+
+	return &client{
+		baseURL:    sgconf.SscApiBaseUrl, // [sic] generated code
+		httpClient: httpClient,
 	}
 }


### PR DESCRIPTION
Update the `ssc.Client` code to use SAMS access tokens for authentication rather than a shared secret. (Having SSC use the shared secret for auth was only going to be a temporary solution, and SAMS apparently supports OAuth clients and issuing tokens well enough to use this now(*).)

(*) Using the SSC client is behind a feature flag while the system is under development, but also because I do not believe the dotcom instance actually has the SAMS-prod identity provider wired up. (So if this were enabled, I don't think it would actually work on Sourcegraph.com as-is.)

This PR also performs some minor stylistic cleanups, adds some comments, and fixes a bug in the unit tests that should have been caught by the linter in CI (❗❓) .

> Re: bugs, the issue was that since `mockSSCClient.FetchSubscriptionBySAMSAccountID` was on a non-pointer receiver, assignment to `m.Called` would have been visible. My IDE identified this, and is easy enough to fix.
>
> I'm surprised that it got through CI. Do we need to opt-in to Golang linting or something? If I run `golangci-lint run` locally it... has some problems with the repo. Is this expected for the `sourcegraph/sourcegraph` repo?

## Test plan

None (⚠️) I haven't ran this locally. I will try to get my local setup running and configured to work with SAMS running locally. (I'll update the PR description when I do.)

I would love to have unit tests for the SSC client, but I don't know if it makes sense to mock out all the layers of the HTTP client, its transport, just to confirm the `clientcredentials.Config` type works as expected. (Since that's all outside of our control.)