### PR TITLE
gitserver: Consistently return os.ErrNotExist on subrepo error

### DIFF
--- a/cmd/frontend/internal/httpapi/stream_blame.go
+++ b/cmd/frontend/internal/httpapi/stream_blame.go
@@ -5,6 +5,7 @@ import (
 	"html"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -62,8 +63,8 @@ func handleStreamBlame(logger log.Logger, db database.DB, gitserverClient gitser
 		})
 		if err != nil {
 			tr.SetError(err)
-			if errcode.IsUnauthorized(err) {
-				http.Error(w, err.Error(), http.StatusForbidden)
+			if os.IsNotExist(err) {
+				http.Error(w, err.Error(), http.StatusNotFound)
 				return
 			}
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -77,7 +77,6 @@ go_test(
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/database/dbmocks",
-        "//internal/errcode",
         "//internal/extsvc/gitolite",
         "//internal/gitserver/gitdomain",
         "//internal/gitserver/protocol",

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -838,7 +838,7 @@ func (c *clientImplementor) StreamBlameFile(ctx context.Context, repo api.RepoNa
 
 		if s, ok := status.FromError(err); ok {
 			if s.Code() == codes.PermissionDenied {
-				return nil, errUnauthorizedStreamBlame{Repo: repo}
+				return nil, os.ErrNotExist
 			}
 		}
 

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -2338,7 +2337,7 @@ func TestClient_StreamBlameFile(t *testing.T) {
 
 		_, err := c.StreamBlameFile(context.Background(), "repo", "file", &BlameOptions{})
 		require.Error(t, err)
-		require.True(t, errcode.IsUnauthorized(err))
+		require.True(t, os.IsNotExist(err))
 	})
 }
 


### PR DESCRIPTION
Just to streamline a bit.

## Test plan

Existing test suites for Blame.