### PR TITLE
search: remove V4

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -262,10 +262,8 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 			searchType = query.SearchTypeLiteral
 		case "V3":
 			searchType = query.SearchTypeStandard
-		case "V4":
-			searchType = query.SearchTypeKeyword
 		default:
-			return -1, errors.Errorf("unrecognized version: want \"V1\", \"V2\", \"V3\", or \"V4\", got %q", version)
+			return -1, errors.Errorf("unrecognized version: want \"V1\", \"V2\", or \"V3\", got %q", version)
 		}
 	}
 	return searchType, nil

--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -262,10 +262,10 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 			searchType = query.SearchTypeLiteral
 		case "V3":
 			searchType = query.SearchTypeStandard
-		case "V4-rc1":
+		case "V4":
 			searchType = query.SearchTypeKeyword
 		default:
-			return -1, errors.Errorf("unrecognized version: want \"V1\", \"V2\", \"V3\", or \"V4-rc1\", got %q", version)
+			return -1, errors.Errorf("unrecognized version: want \"V1\", \"V2\", \"V3\", or \"V4\", got %q", version)
 		}
 	}
 	return searchType, nil

--- a/internal/search/client/client_test.go
+++ b/internal/search/client/client_test.go
@@ -30,7 +30,7 @@ func TestDetectSearchType(t *testing.T) {
 		{"V1, no pattern type", "V1", nil, "", query.SearchTypeRegex},
 		{"V2, no pattern type", "V2", nil, "", query.SearchTypeLiteral},
 		{"V3, no pattern type", "V3", nil, "", query.SearchTypeStandard},
-		{"V4-rc1, no pattern type", "V4-rc1", nil, "", query.SearchTypeKeyword},
+		{"V4, no pattern type", "V4", nil, "", query.SearchTypeKeyword},
 		{"V2, no pattern type, input does not produce parse error", "V2", nil, "/-/godoc", query.SearchTypeLiteral},
 		{"V1, regexp pattern type", "V1", &typeRegexp, "", query.SearchTypeRegex},
 		{"V2, regexp pattern type", "V2", &typeRegexp, "", query.SearchTypeRegex},
@@ -70,7 +70,7 @@ func TestDetectSearchType(t *testing.T) {
 		}, {
 			version:     "V99",
 			patternType: nil,
-			errorString: "unrecognized version: want \"V1\", \"V2\", \"V3\", or \"V4-rc1\", got \"V99\"",
+			errorString: "unrecognized version: want \"V1\", \"V2\", \"V3\", or \"V4\", got \"V99\"",
 		}}
 
 		for _, tc := range cases {

--- a/internal/search/client/client_test.go
+++ b/internal/search/client/client_test.go
@@ -30,7 +30,6 @@ func TestDetectSearchType(t *testing.T) {
 		{"V1, no pattern type", "V1", nil, "", query.SearchTypeRegex},
 		{"V2, no pattern type", "V2", nil, "", query.SearchTypeLiteral},
 		{"V3, no pattern type", "V3", nil, "", query.SearchTypeStandard},
-		{"V4, no pattern type", "V4", nil, "", query.SearchTypeKeyword},
 		{"V2, no pattern type, input does not produce parse error", "V2", nil, "/-/godoc", query.SearchTypeLiteral},
 		{"V1, regexp pattern type", "V1", &typeRegexp, "", query.SearchTypeRegex},
 		{"V2, regexp pattern type", "V2", &typeRegexp, "", query.SearchTypeRegex},
@@ -70,7 +69,7 @@ func TestDetectSearchType(t *testing.T) {
 		}, {
 			version:     "V99",
 			patternType: nil,
-			errorString: "unrecognized version: want \"V1\", \"V2\", \"V3\", or \"V4\", got \"V99\"",
+			errorString: "unrecognized version: want \"V1\", \"V2\", or \"V3\", got \"V99\"",
 		}}
 
 		for _, tc := range cases {


### PR DESCRIPTION
We don't need V4 for the next release. We always send the pattern type if keyword search is active. 

Test plan:
CI