### PR TITLE
Stops updating lsif-rust docker image

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
+++ b/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
@@ -27,7 +27,6 @@ var defaultIndexers = map[string]string{
 // To update, run `DOCKER_USER=... DOCKER_PASS=... ./update-shas.sh`
 var defaultIndexerSHAs = map[string]string{
 	"sourcegraph/scip-go":         "sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc",
-	"sourcegraph/lsif-rust":       "sha256:83cb769788987eb52f21a18b62d51ebb67c9436e1b0d2e99904c70fef424f9d1",
 	"sourcegraph/scip-rust":       "sha256:adf0047fc3050ba4f7be71302b42c74b49901f38fb40916d94ac5fc9181ac078",
 	"sourcegraph/scip-java":       "sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702",
 	"sourcegraph/scip-python":     "sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d",

--- a/internal/codeintel/autoindexing/internal/inference/libs/update-shas.sh
+++ b/internal/codeintel/autoindexing/internal/inference/libs/update-shas.sh
@@ -16,7 +16,7 @@ fi
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 # No scip-clang as that doesn't have a Docker image
-for indexer in scip-go lsif-rust scip-rust scip-java scip-python scip-typescript scip-ruby; do
+for indexer in scip-go scip-rust scip-java scip-python scip-typescript scip-ruby; do
   tag="latest"
   if [[ "${indexer}" = "scip-python" ]] || [[ "${indexer}" = "scip-typescript" || "${indexer}" = "scip-ruby" ]]; then
     tag="autoindex"

--- a/internal/codeintel/autoindexing/internal/store/enqueuer_test.go
+++ b/internal/codeintel/autoindexing/internal/store/enqueuer_test.go
@@ -143,9 +143,9 @@ func TestInsertIndexes(t *testing.T) {
 			},
 			LocalSteps:  nil,
 			Root:        "/baz",
-			Indexer:     "sourcegraph/lsif-rust:15",
+			Indexer:     "sourcegraph/scip-rust:15",
 			IndexerArgs: []string{"-v"},
-			Outfile:     "dump.lsif",
+			Outfile:     "out.scip",
 			ExecutionLogs: []executor.ExecutionLogEntry{
 				{Command: []string{"op", "1"}, Out: "Done with 1.\n"},
 				{Command: []string{"op", "2"}, Out: "Done with 2.\n"},
@@ -207,9 +207,9 @@ func TestInsertIndexes(t *testing.T) {
 			},
 			LocalSteps:  []string{},
 			Root:        "/baz",
-			Indexer:     "sourcegraph/lsif-rust:15",
+			Indexer:     "sourcegraph/scip-rust:15",
 			IndexerArgs: []string{"-v"},
-			Outfile:     "dump.lsif",
+			Outfile:     "out.scip",
 			ExecutionLogs: []executor.ExecutionLogEntry{
 				{Command: []string{"op", "1"}, Out: "Done with 1.\n"},
 				{Command: []string{"op", "2"}, Out: "Done with 2.\n"},


### PR DESCRIPTION
We're not actually using this anywhere, as the default autoindexing config for Rust uses `scip-rust` instead.

## Test plan

n/a