### PR TITLE
search: Don't trigger git fetch in symbol search job

### DIFF
--- a/internal/search/searcher/symbol_search_job.go
+++ b/internal/search/searcher/symbol_search_job.go
@@ -97,7 +97,7 @@ func searchInRepo(ctx context.Context, gitserverClient gitserver.Client, repoRev
 	// backend.{GitRepo,Repos.ResolveRev}) because that would slow this operation
 	// down by a lot (if we're looping over many repos). This means that it'll fail if a
 	// repo is not on gitserver.
-	commitID, err := gitserverClient.ResolveRevision(ctx, repoRevs.GitserverRepo(), inputRev, gitserver.ResolveRevisionOptions{})
+	commitID, err := gitserverClient.ResolveRevision(ctx, repoRevs.GitserverRepo(), inputRev, gitserver.ResolveRevisionOptions{NoEnsureRevision: true})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is in line with other jobs, and makes more sense IMO wrt. the comment right above.

Let me know if this assessment is wrong.

## Test plan

CI.
