### PR TITLE
gitserver: Remove CloneableLimiter

### DIFF
--- a/cmd/gitserver/internal/server_test.go
+++ b/cmd/gitserver/internal/server_test.go
@@ -322,7 +322,6 @@ func makeTestServer(ctx context.Context, t *testing.T, repoDir, remote string, d
 		ctx:                     ctx,
 		Locker:                  NewRepositoryLocker(),
 		cloneLimiter:            limiter.NewMutable(1),
-		cloneableLimiter:        limiter.NewMutable(1),
 		RPSLimiter:              ratelimit.NewInstrumentedLimiter("GitserverTest", rate.NewLimiter(rate.Inf, 10)),
 		RecordingCommandFactory: wrexec.NewRecordingCommandFactory(nil, 0),
 		Perforce:                perforce.NewService(ctx, obctx, logger, db, list.New()),

--- a/doc/admin/observability/alerts.md
+++ b/doc/admin/observability/alerts.md
@@ -1474,39 +1474,6 @@ Generated query for warning alert: `max((sum(src_gitserver_clone_queue)) >= 25)`
 
 <br />
 
-## gitserver: repository_existence_check_queue_size
-
-<p class="subtitle">repository existence check queue size</p>
-
-**Descriptions**
-
-- <span class="badge badge-warning">warning</span> gitserver: 25+ repository existence check queue size
-
-**Next steps**
-
-- **Check the code host status indicator for errors:** on the Sourcegraph app homepage, when signed in as an admin click the cloud icon in the top right corner of the page.
-- **Check if the issue continues to happen after 30 minutes**, it may be temporary.
-- **Check the gitserver logs for more information.**
-- Learn more about the related dashboard panel in the [dashboards reference](./dashboards.md#gitserver-repository-existence-check-queue-size).
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_gitserver_repository_existence_check_queue_size"
-]
-```
-
-<sub>*Managed by the [Sourcegraph Source team](https://handbook.sourcegraph.com/departments/engineering/teams/source).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Generated query for warning alert: `max((sum(src_gitserver_lsremote_queue)) >= 25)`
-
-</details>
-
-<br />
-
 ## gitserver: gitserver_site_configuration_duration_since_last_successful_update_by_instance
 
 <p class="subtitle">maximum duration since last successful site configuration update (all "gitserver" instances)</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -5671,25 +5671,6 @@ Query: `sum(src_gitserver_clone_queue)`
 
 <br />
 
-#### gitserver: repository_existence_check_queue_size
-
-<p class="subtitle">Repository existence check queue size</p>
-
-Refer to the [alerts reference](./alerts.md#gitserver-repository-existence-check-queue-size) for 1 alert related to this panel.
-
-To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100071` on your Sourcegraph instance.
-
-<sub>*Managed by the [Sourcegraph Source team](https://handbook.sourcegraph.com/departments/engineering/teams/source).*</sub>
-
-<details>
-<summary>Technical details</summary>
-
-Query: `sum(src_gitserver_lsremote_queue)`
-
-</details>
-
-<br />
-
 #### gitserver: echo_command_duration_test
 
 <p class="subtitle">Echo test command duration</p>
@@ -5704,7 +5685,7 @@ If this value is consistently high, consider the following:
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100080` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100071` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Source team](https://handbook.sourcegraph.com/departments/engineering/teams/source).*</sub>
 
@@ -5727,7 +5708,7 @@ It does not indicate any problems with the instance.
 
 This panel has no related alerts.
 
-To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100090` on your Sourcegraph instance.
+To see this panel, visit `/-/debug/grafana/d/gitserver/gitserver?viewPanel=100072` on your Sourcegraph instance.
 
 <sub>*Managed by the [Sourcegraph Source team](https://handbook.sourcegraph.com/departments/engineering/teams/source).*</sub>
 

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -235,21 +235,6 @@ func GitServer() *monitoring.Dashboard {
 							`,
 						},
 						{
-							Name:        "repository_existence_check_queue_size",
-							Description: "repository existence check queue size",
-							Query:       "sum(src_gitserver_lsremote_queue)",
-							Warning:     monitoring.Alert().GreaterOrEqual(25),
-							Panel:       monitoring.Panel().LegendFormat("queue size"),
-							Owner:       monitoring.ObservableOwnerSource,
-							NextSteps: `
-								- **Check the code host status indicator for errors:** on the Sourcegraph app homepage, when signed in as an admin click the cloud icon in the top right corner of the page.
-								- **Check if the issue continues to happen after 30 minutes**, it may be temporary.
-								- **Check the gitserver logs for more information.**
-							`,
-						},
-					},
-					{
-						{
 							Name:        "echo_command_duration_test",
 							Description: "echo test command duration",
 							Query:       "max(src_gitserver_echo_duration_seconds)",
@@ -266,8 +251,6 @@ func GitServer() *monitoring.Dashboard {
 								- **Kubernetes and Docker Compose:** Check that you are running a similar number of git server replicas and that their CPU/memory limits are allocated according to what is shown in the [Sourcegraph resource estimator](../deploy/resource_estimator.md).
 							`,
 						},
-					},
-					{
 						{
 							Name:          "src_gitserver_repo_count",
 							Description:   "number of repositories on gitserver",


### PR DESCRIPTION
IMO, this is an unnecessary optimization that increases complexity and in the current implementation locks for longer than it needs to, because the lock in Blocking clone mode is only returned when the clone has completed, limiting the concurrency more than desired. There are also the clone limiter AND RPS limiter still in place, so we got more than enough rate limiters in place here, IMO.

Please prove me wrong :) 

## Test plan

Existing test suites and code reviews.

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@es/cloneablelimiter-rm)