### PR TITLE
search: Disable 'jump to suggestion' behavior in secondary query inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Long lines now wrap correctly in the diff view. [#58138](https://github.com/sourcegraph/sourcegraph/pull/58138)
 - Fixed an issue in the search input where pressing Enter after selecting a suggestion would sometimes insert another suggestions instead of submitting the query. [#58186](https://github.com/sourcegraph/sourcegraph/pull/58186)
 - Fixed an issue where having sub-repo permissions enabled could cause repositories with a large number of files in directories to become unviewable. [#59420](https://github.com/sourcegraph/sourcegraph/pull/59420)
+- On the search context, code monitoring, code insights, saved searches or notebook pages, when selecting a repository or file suggestion in the query input with Enter the suggestion is now properly appended to the query instead of navigating away to the corresponding repository or file page.
 
 ### Removed
 

--- a/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/CodeMirrorQueryInput.tsx
@@ -40,6 +40,13 @@ export interface CodeMirrorQueryInputFacadeProps extends QueryInputProps {
      * search history.
      */
     onSelectSearchFromHistory?: () => void
+
+    /**
+     * When enabled, eligible suggestions will become "jump targets" which means
+     * when a suggestion is selected, pressing enter will navigate to the suggestion
+     * instead of inserting it into the query input.
+     */
+    enableJumpToSuggestion?: boolean
 }
 
 /**
@@ -78,6 +85,7 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
     // Used by the VSCode extension (which doesn't use this component directly,
     // but added for future compatibility)
     fetchStreamSuggestions = defaultFetchStreamSuggestions,
+    enableJumpToSuggestion = false,
 }) => {
     const editorRef = useRef<EditorView | null>(null)
     const focusSearchBarShortcut = useKeyboardShortcut('focusSearch')
@@ -130,9 +138,16 @@ export const CodeMirrorMonacoFacade: React.FunctionComponent<CodeMirrorQueryInpu
                     fetchSuggestions: query =>
                         fetchStreamSuggestions(appendContextFilter(query, selectedSearchContextSpecRef.current)),
                     isSourcegraphDotCom,
+                    enableJumpToSuggestion,
                     navigate,
                 }),
-            [isSourcegraphDotCom, navigate, fetchStreamSuggestions, selectedSearchContextSpecRef]
+            [
+                isSourcegraphDotCom,
+                enableJumpToSuggestion,
+                navigate,
+                fetchStreamSuggestions,
+                selectedSearchContextSpecRef,
+            ]
         )
     )
 

--- a/client/branded/src/search-ui/input/SearchBox.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.tsx
@@ -188,6 +188,7 @@ export const SearchBox: FC<SearchBoxProps> = props => {
                         selectedSearchContextSpec={props.selectedSearchContextSpec}
                         searchHistory={recentSearchesWithoutSearchContext}
                         onSelectSearchFromHistory={onInlineSearchHistorySelect}
+                        enableJumpToSuggestion={true}
                     />
                     {showKeywordSearchToggle ? (
                         <Toggles

--- a/client/branded/src/search-ui/input/codemirror/completion.ts
+++ b/client/branded/src/search-ui/input/codemirror/completion.ts
@@ -154,7 +154,11 @@ const theme = EditorView.theme({
  * searchQueryAutocompletion registers extensions for automcompletion, using the
  * provided suggestion sources.
  */
-export function searchQueryAutocompletion(sources: StandardSuggestionSource[], navigate?: NavigateFunction): Extension {
+export function searchQueryAutocompletion(
+    sources: StandardSuggestionSource[],
+    enableJumpToSuggestion: boolean,
+    navigate?: NavigateFunction
+): Extension {
     const override: CompletionSource[] = sources.map(source => context => {
         const position = context.pos
         const query = context.state.facet(queryTokens)
@@ -172,7 +176,7 @@ export function searchQueryAutocompletion(sources: StandardSuggestionSource[], n
         {
             render(completion) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-                if ((completion as any)?.url) {
+                if (enableJumpToSuggestion && navigate && (completion as any)?.url) {
                     return createSVGIcon(mdiLightningBoltCircle, '')
                 }
                 const icon = createSVGIcon(
@@ -263,7 +267,7 @@ export function searchQueryAutocompletion(sources: StandardSuggestionSource[], n
                         const selected = selectedCompletion(view.state)
                         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
                         const url = (selected as any)?.url
-                        if (navigate && typeof url === 'string') {
+                        if (enableJumpToSuggestion && navigate && typeof url === 'string') {
                             navigate(url)
                             return true
                         }

--- a/client/branded/src/search-ui/input/codemirror/index.ts
+++ b/client/branded/src/search-ui/input/codemirror/index.ts
@@ -33,6 +33,12 @@ export const changeListener = (callback: (value: string) => void): Extension =>
 
 interface CreateDefaultSuggestionsOptions extends Omit<DefaultSuggestionSourcesOptions, 'fetchSuggestions'> {
     fetchSuggestions: (query: string) => Observable<SearchMatch[]>
+    /**
+     * If enabled, pressing Enter will navigate to the URL associated with the
+     * selected suggestion, if available. In this case `navigate` must be provided as well.
+     * Defaults to false.
+     */
+    enableJumpToSuggestion?: boolean
     navigate?: NavigateFunction
 }
 
@@ -46,6 +52,7 @@ export const createDefaultSuggestions = ({
     disableFilterCompletion,
     disableSymbolCompletion,
     navigate,
+    enableJumpToSuggestion = false,
     showWhenEmpty,
 }: CreateDefaultSuggestionsOptions): Extension => [
     searchQueryAutocompletion(
@@ -56,6 +63,7 @@ export const createDefaultSuggestions = ({
             disableFilterCompletion,
             showWhenEmpty,
         }),
+        enableJumpToSuggestion,
         navigate
     ),
     loadingIndicator(),


### PR DESCRIPTION
This has been an issue for a while and has recently been reported again internally ([Slack](https://sourcegraph.slack.com/archives/C05R619V4F8/p1706519009598839)).

The "old" search input is still used in places other than the search and repository pages (i.e. everywhere that's not the main search input). These places are solely used for entering a query, not for navigating around, and so "jump to suggestion" for repositories and files should be disabled.


## Test plan

Selecting a repository by pressing Enter in the search context query input updates the input instead of navigating to the repo page.