### PR TITLE
gomod: update zoekt for query.Boost in proto

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5755,8 +5755,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:xfQ+hpwxBMb4Dvy3djTCheq/kt7LGxhe3SywvebgPXY=",
-        version = "v0.0.0-20240129113324-340c5f85f0b7",
+        sum = "h1:tVSzsnax+PF5rrWj91qVZyTR8YGGbtu0BW48t+1PizY=",
+        version = "v0.0.0-20240129144758-19fa44cea9eb",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -568,7 +568,7 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20231018142932-e00da332dac5
 	github.com/sourcegraph/sourcegraph/monitoring v0.0.0-20230124144931-b2d81b1accb6
-	github.com/sourcegraph/zoekt v0.0.0-20240129113324-340c5f85f0b7
+	github.com/sourcegraph/zoekt v0.0.0-20240129144758-19fa44cea9eb
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1673,8 +1673,8 @@ github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc h1:o+eq0cjVV3B5
 github.com/sourcegraph/scip v0.3.1-0.20230627154934-45df7f6d33fc/go.mod h1:7ZKAtLIUmiMvOIgG5LMcBxdtBXVa0v2GWC4Hm1ASYQ0=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20240129113324-340c5f85f0b7 h1:xfQ+hpwxBMb4Dvy3djTCheq/kt7LGxhe3SywvebgPXY=
-github.com/sourcegraph/zoekt v0.0.0-20240129113324-340c5f85f0b7/go.mod h1:PdSaENu0p/FIBJnN/qEBDXAlZCz5oN699Nt5TdbQmOk=
+github.com/sourcegraph/zoekt v0.0.0-20240129144758-19fa44cea9eb h1:tVSzsnax+PF5rrWj91qVZyTR8YGGbtu0BW48t+1PizY=
+github.com/sourcegraph/zoekt v0.0.0-20240129144758-19fa44cea9eb/go.mod h1:PdSaENu0p/FIBJnN/qEBDXAlZCz5oN699Nt5TdbQmOk=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
Small changes we noticed while testing with sourcegraph integration.

https://github.com/sourcegraph/zoekt/compare/340c5f85f0b7...19fa44cea9eb

- https://github.com/sourcegraph/zoekt/commit/dbe1d4b397 fix: prune boostMatchTree if child is pruned
- https://github.com/sourcegraph/zoekt/commit/19fa44cea9 add query.Boost to protobuf

Test Plan: tested on zoekt CI and here.
