### PR TITLE
search: Auto focus search input on homepage without showing suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Structural Search is now disabled by default. To enable it, set `experimentalFeatures.structuralSearch: "enabled"` in the site configuration. [#57584](https://github.com/sourcegraph/sourcegraph/pull/57584)
 - Search Jobs switches the format of downloaded results from CSV to JSON. [#59619](https://github.com/sourcegraph/sourcegraph/pull/59619)
 - [Search Jobs](https://docs.sourcegraph.com/code_search/how-to/search-jobs) is now in beta and enabled by default. It can be disabled in the site configuration by setting `experimentalFeatures.searchJobs: false`.
+- The search input on the search homepage is now automatically focused when the page loads.
 
 ### Fixed
 

--- a/client/web/src/search/input/V2SearchInput.tsx
+++ b/client/web/src/search/input/V2SearchInput.tsx
@@ -185,6 +185,7 @@ export const V2SearchInput: FC<PropsWithChildren<V2SearchInputProps>> = ({
 
     return (
         <CodeMirrorQueryInputWrapper
+            autoFocus={inputProps.autoFocus}
             interpretComments={false}
             placeholder="Search for code or files..."
             patternType={inputProps.patternType}

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -133,6 +133,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
     // TODO (#48103): Remove/simplify when new search input is released
     const input = v2QueryInput ? (
         <LazyV2SearchInput
+            autoFocus={!isTouchOnlyDevice}
             telemetryService={telemetryService}
             patternType={patternType}
             interpretComments={false}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/59174

This PR adds autofocus to the search page but doesn't show suggestions until the user interacts with the input (either by moving the cursor or changing the input).

## Test plan

- Opened the search home page -> search input is focused
  - Moved cursor with keyboard, moved cursor with mouse, entered text -> suggestion show up
- Opened search results page and repo page -> search input is not focused
