### PR TITLE
msp/monitoring: relax CPU alerts

### DIFF
--- a/dev/managedservicesplatform/stacks/monitoring/common.go
+++ b/dev/managedservicesplatform/stacks/monitoring/common.go
@@ -38,8 +38,9 @@ func createCommonAlerts(
 				Filters:   map[string]string{"metric.type": "run.googleapis.com/container/cpu/utilizations"},
 				Aligner:   alertpolicy.MonitoringAlignPercentile99,
 				Reducer:   alertpolicy.MonitoringReduceMax,
-				Period:    "300s",
-				Threshold: 0.8,
+				Period:    "60s",
+				Duration:  "600s",
+				Threshold: 0.9,
 			},
 		},
 		{


### PR DESCRIPTION
This is only really a critical problem if we are pegged at high usage for a long time.

## Test plan

n/a