### PR TITLE
gitserver: Reduce memory usage from new exec

### DIFF
--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -42,7 +42,7 @@ type GitBackend interface {
 	// Exec is a temporary helper to run arbitrary git commands from the exec endpoint.
 	// No new usages of it should be introduced and once the migration is done we will
 	// remove this method.
-	Exec(ctx context.Context, args ...string) (io.ReadCloser, error)
+	Exec(ctx context.Context, stdoutWriter io.Writer, args ...string) error
 }
 
 // GitConfigBackend provides methods for interacting with git configuration.

--- a/cmd/gitserver/internal/server.go
+++ b/cmd/gitserver/internal/server.go
@@ -677,13 +677,7 @@ func (s *Server) Exec(ctx context.Context, req *protocol.ExecRequest, w io.Write
 	}
 
 	cmdStart = time.Now()
-	stdout, err := backend.Exec(ctx, req.Args...)
-	if err != nil {
-		return execStatus{}, err
-	}
-	defer stdout.Close()
-
-	_, execErr = io.Copy(w, stdout)
+	execErr = backend.Exec(ctx, w, req.Args...)
 	if execErr != nil {
 		s.LogIfCorrupt(ctx, repoName, execErr)
 		commandFailedErr := &gitcli.CommandFailedError{}


### PR DESCRIPTION
I was hoping we could use the existing reader implementation of `runGitCommand` to use 100% the same implementation for both native calls and exec calls, but turns out that io.Copy requires to allocate very large buffers. This hopefully addresses some OOM errors I've seen very recently in gitserver.

## Test plan

All the tests still pass. Manually ran an instance.
