### PR TITLE
gitserver: Don't buffer stdout

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/clibackend.go
+++ b/cmd/gitserver/internal/git/gitcli/clibackend.go
@@ -128,7 +128,6 @@ type cmdReader struct {
 	ctx      context.Context
 	cmd      wrexec.Cmder
 	stderr   *bytes.Buffer
-	buf      bytes.Buffer
 	logger   log.Logger
 	git      git.GitBackend
 	repoName api.RepoName
@@ -137,7 +136,6 @@ type cmdReader struct {
 
 func (rc *cmdReader) Read(p []byte) (n int, err error) {
 	n, err = rc.ReadCloser.Read(p)
-	writtenN, writeErr := rc.buf.Write(p[:n])
 	if err == io.EOF {
 		rc.ReadCloser.Close()
 		rc.closed = true
@@ -148,9 +146,6 @@ func (rc *cmdReader) Read(p []byte) (n int, err error) {
 			}
 			return n, commandFailedError(rc.ctx, err, rc.cmd, rc.stderr.Bytes())
 		}
-	}
-	if err == nil && writeErr != nil {
-		return writtenN, writeErr
 	}
 	return n, err
 }


### PR DESCRIPTION
No idea how this snuck in, but we've accidentally accumulated the whole stdout in memory for no good reason? I'm not sure why this is in here tbh, but it was me.

Thanks GCloud Profiler!

## Test plan

None of the tests break.
