### PR TITLE
Keyword search: temporarily add feature flag

### DIFF
--- a/client/branded/src/search-ui/input/SearchBox.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.tsx
@@ -13,7 +13,6 @@ import {
 import { getGlobalSearchContextFilter } from '@sourcegraph/shared/src/search/query/query'
 import { omitFilter } from '@sourcegraph/shared/src/search/query/transformer'
 import type { fetchStreamSuggestions as defaultFetchStreamSuggestions } from '@sourcegraph/shared/src/search/suggestions'
-import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import type { RecentSearch } from '@sourcegraph/shared/src/settings/temporary/recentSearches'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -59,6 +58,7 @@ export interface SearchBoxProps
     showSearchHistory?: boolean
 
     recentSearches?: RecentSearch[]
+    showKeywordSearchToggle: boolean
 }
 
 export const SearchBox: FC<SearchBoxProps> = props => {
@@ -118,8 +118,6 @@ export const SearchBox: FC<SearchBoxProps> = props => {
             return search
         })
     }, [recentSearches, selectedSearchContextSpec])
-
-    const showKeywordSearchToggle = useExperimentalFeatures(features => features.keywordSearch)
 
     return (
         <div
@@ -190,7 +188,7 @@ export const SearchBox: FC<SearchBoxProps> = props => {
                         onSelectSearchFromHistory={onInlineSearchHistorySelect}
                         enableJumpToSuggestion={true}
                     />
-                    {showKeywordSearchToggle ? (
+                    {props.showKeywordSearchToggle ? (
                         <Toggles
                             patternType={props.patternType}
                             setPatternType={props.setPatternType}

--- a/client/branded/src/search-ui/input/SearchBox.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.tsx
@@ -58,7 +58,7 @@ export interface SearchBoxProps
     showSearchHistory?: boolean
 
     recentSearches?: RecentSearch[]
-    showKeywordSearchToggle: boolean
+    showKeywordSearchToggle?: boolean
 }
 
 export const SearchBox: FC<SearchBoxProps> = props => {

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
@@ -120,7 +120,6 @@ export const CommunitySearchContextPage: React.FunctionComponent<
                     setQueryState={setQueryState}
                     hardCodedSearchContextSpec={props.communitySearchContextMetadata.spec}
                     simpleSearch={false}
-                    showKeywordSearchToggle={false}
                 />
             </div>
             {!props.communitySearchContextMetadata.lowProfile && (

--- a/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
+++ b/client/web/src/communitySearchContexts/CommunitySearchContextPage.tsx
@@ -120,6 +120,7 @@ export const CommunitySearchContextPage: React.FunctionComponent<
                     setQueryState={setQueryState}
                     hardCodedSearchContextSpec={props.communitySearchContextMetadata.spec}
                     simpleSearch={false}
+                    showKeywordSearchToggle={false}
                 />
             </div>
             {!props.communitySearchContextMetadata.lowProfile && (

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -32,6 +32,7 @@ export const FEATURE_FLAGS = [
     'search-boost-phrase',
     'search-content-based-lang-detection',
     'search-debug',
+    'search-keyword',
     'search-input-show-history',
     'search-results-keyboard-navigation',
     'search-simple',

--- a/client/web/src/featureFlags/useFeatureFlag.ts
+++ b/client/web/src/featureFlags/useFeatureFlag.ts
@@ -1,5 +1,6 @@
 import { logger } from '@sourcegraph/common'
 import { getDocumentNode, gql, useQuery } from '@sourcegraph/http-client'
+import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 
 import type { EvaluateFeatureFlagResult, EvaluateFeatureFlagVariables } from '../graphql-operations'
 
@@ -114,4 +115,10 @@ export function useFeatureFlag(
     const status = error ? 'error' : data ? 'loaded' : 'initial'
 
     return [value, status, error?.networkError]
+}
+
+export function useKeywordSearch(): boolean {
+    const [flagEnabled] = useFeatureFlag('search-keyword')
+    const settingEnabled = !!useExperimentalFeatures(features => features.keywordSearch)
+    return flagEnabled || settingEnabled
 }

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -35,7 +35,7 @@ import { CodyLogo } from '../cody/components/CodyLogo'
 import { BrandLogo } from '../components/branding/BrandLogo'
 import { useFuzzyFinderFeatureFlags } from '../components/fuzzyFinder/FuzzyFinderFeatureFlag'
 import { DeveloperSettingsGlobalNavItem } from '../devsettings/DeveloperSettingsGlobalNavItem'
-import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
+import { useFeatureFlag, useKeywordSearch } from '../featureFlags/useFeatureFlag'
 import { useRoutesMatch } from '../hooks'
 import type { CodeInsightsProps } from '../insights/types'
 import type { NotebookProps } from '../notebooks'
@@ -175,6 +175,8 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
 
     const developerMode = useDeveloperSettings(settings => settings.enabled) || process.env.NODE_ENV === 'development'
 
+    const showKeywordSearchToggle = useKeywordSearch()
+
     return (
         <>
             <NavBar
@@ -268,6 +270,7 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         searchContextsEnabled={searchContextsEnabled}
                         isRepositoryRelatedPage={isRepositoryRelatedPage}
+                        showKeywordSearchToggle={showKeywordSearchToggle}
                     />
                 </div>
             )}

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -11,7 +11,6 @@ import shallow from 'zustand/shallow'
 import { LegacyToggles } from '@sourcegraph/branded'
 import { Toggles } from '@sourcegraph/branded/src/search-ui/input/toggles/Toggles'
 import { SearchQueryState, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
-import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Text, Icon, Button, Modal, Link, ProductStatusBadge, ButtonLink } from '@sourcegraph/wildcard'
@@ -22,7 +21,7 @@ import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { CodyLogo } from '../../cody/components/CodyLogo'
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { DeveloperSettingsGlobalNavItem } from '../../devsettings/DeveloperSettingsGlobalNavItem'
-import { useFeatureFlag } from '../../featureFlags/useFeatureFlag'
+import { useFeatureFlag, useKeywordSearch } from '../../featureFlags/useFeatureFlag'
 import { PageRoutes } from '../../routes.constants'
 import { isSearchJobsEnabled } from '../../search-jobs/utility'
 import { LazyV2SearchInput } from '../../search/input/LazyV2SearchInput'
@@ -184,7 +183,7 @@ const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
     const navigate = useNavigate()
     const location = useLocation()
 
-    const showKeywordSearchToggle = useExperimentalFeatures(features => features.keywordSearch)
+    const showKeywordSearchToggle = useKeywordSearch()
 
     const [isFocused, setFocused] = useState(false)
     const { searchMode, queryState, searchPatternType, searchCaseSensitivity, setQueryState, submitSearch } =

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -7,7 +7,7 @@ import { SearchBox, LegacyToggles } from '@sourcegraph/branded'
 import { Toggles } from '@sourcegraph/branded/src/search-ui/input/toggles/Toggles'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SearchContextInputProps, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
-import { useExperimentalFeatures, type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { type SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Form } from '@sourcegraph/wildcard'
 
@@ -28,6 +28,7 @@ interface Props
     isSourcegraphDotCom: boolean
     isSearchAutoFocusRequired?: boolean
     isRepositoryRelatedPage?: boolean
+    showKeywordSearchToggle?: boolean
 }
 
 const selectQueryState = ({
@@ -78,8 +79,6 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
         submitSearchOnChangeRef.current()
     }, [])
 
-    const showKeywordSearchToggle = useExperimentalFeatures(features => features.keywordSearch)
-
     // TODO (#48103): Remove/simplify when new search input is released
     if (v2QueryInput) {
         return (
@@ -101,7 +100,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                     selectedSearchContextSpec={props.selectedSearchContextSpec}
                     className="flex-grow-1"
                 >
-                    {showKeywordSearchToggle ? (
+                    {props.showKeywordSearchToggle ? (
                         <Toggles
                             patternType={searchPatternType}
                             caseSensitive={searchCaseSensitivity}
@@ -160,6 +159,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                 hideHelpButton={false}
                 showSearchHistory={true}
                 recentSearches={recentSearches}
+                showKeywordSearchToggle={props.showKeywordSearchToggle}
             />
         </Form>
     )

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
@@ -37,12 +37,13 @@ import {
     PathMatch,
     StreamSearchOptions,
 } from '@sourcegraph/shared/src/search/stream'
-import { SettingsCascadeProps, useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { NOOP_TELEMETRY_SERVICE, TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { Button, Icon, H2, H4, useScrollManager, Panel, useLocalStorage, Link } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../../auth'
+import { useKeywordSearch } from '../../../../featureFlags/useFeatureFlag'
 import { fetchBlob } from '../../../../repo/blob/backend'
 import type { SearchPanelConfig } from '../../../../repo/blob/codemirror/search'
 import { SearchPanelViewMode } from '../../../../repo/blob/codemirror/types'
@@ -178,7 +179,7 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
         [onSearchSubmit]
     )
 
-    const showKeywordSearchToggle = useExperimentalFeatures(features => features.keywordSearch)
+    const showKeywordSearchToggle = useKeywordSearch()
 
     return (
         <div className={classNames(styles.root, { [styles.rootWithNewFilters]: newFiltersEnabled })}>

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -11,7 +11,7 @@ import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Label, Tooltip, useLocalStorage } from '@sourcegraph/wildcard'
 
 import { BrandLogo } from '../../../components/branding/BrandLogo'
-import { useFeatureFlag } from '../../../featureFlags/useFeatureFlag'
+import { useFeatureFlag, useKeywordSearch } from '../../../featureFlags/useFeatureFlag'
 import { useLegacyContext_onlyInStormRoutes } from '../../../LegacyRouteContext'
 import { useV2QueryInput } from '../../../search/useV2QueryInput'
 import { useNavbarQueryState } from '../../../stores'
@@ -72,6 +72,8 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
 
     const patternType = useNavbarQueryState.getState().searchPatternType
 
+    const showKeywordSearchToggle = useKeywordSearch()
+
     return (
         <div className={classNames('d-flex flex-column align-items-center px-3', styles.searchPage)}>
             <BrandLogo className={styles.logo} isLightTheme={isLightTheme} variant="logo" />
@@ -110,6 +112,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                                     simpleSearch={false}
                                     queryState={queryState}
                                     setQueryState={setQueryState}
+                                    showKeywordSearchToggle={showKeywordSearchToggle}
                                 />
                             </div>
                         </Tooltip>
@@ -121,6 +124,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                             simpleSearch={simpleSearch && simpleSearchEnabled}
                             queryState={queryState}
                             setQueryState={setQueryState}
+                            showKeywordSearchToggle={showKeywordSearchToggle}
                         />
                         {authenticatedUser && showOnboardingTour && (
                             <GettingStartedTour

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -50,7 +50,7 @@ interface SearchPageInputProps {
     setQueryState: (newState: QueryState) => void
     hardCodedSearchContextSpec?: string
     simpleSearch: boolean
-    showKeywordSearchToggle: boolean
+    showKeywordSearchToggle?: boolean
 }
 
 export const SearchPageInput: FC<SearchPageInputProps> = props => {

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -16,7 +16,6 @@ import {
     type SearchModeProps,
     getUserSearchContextNamespaces,
 } from '@sourcegraph/shared/src/search'
-import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { Form } from '@sourcegraph/wildcard'
 
 import { Notices } from '../../../global/Notices'
@@ -51,6 +50,7 @@ interface SearchPageInputProps {
     setQueryState: (newState: QueryState) => void
     hardCodedSearchContextSpec?: string
     simpleSearch: boolean
+    showKeywordSearchToggle: boolean
 }
 
 export const SearchPageInput: FC<SearchPageInputProps> = props => {
@@ -128,8 +128,6 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
         [setQueryState]
     )
 
-    const showKeywordSearchToggle = useExperimentalFeatures(features => features.keywordSearch)
-
     // TODO (#48103): Remove/simplify when new search input is released
     const input = v2QueryInput ? (
         <LazyV2SearchInput
@@ -146,7 +144,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
             selectedSearchContextSpec={selectedSearchContextSpec}
             className="flex-grow-1"
         >
-            {showKeywordSearchToggle ? (
+            {props.showKeywordSearchToggle ? (
                 <Toggles
                     patternType={patternType}
                     caseSensitive={caseSensitive}
@@ -199,6 +197,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
             structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch !== 'enabled'}
             showSearchHistory={true}
             recentSearches={recentSearches}
+            showKeywordSearchToggle={props.showKeywordSearchToggle}
         />
     )
     return (


### PR DESCRIPTION
In #59779 we cleaned up the config for keyword search, removing the feature
flag in favor of a user setting. This PR temporarily re-introduces the feature
flag to make it easier to run users tests.

Now, the feature can be enabled simply by adding the URL parameter
`&feat=search-keyword`.

## Test plan

Manual testing 
