### PR TITLE
oidc: support pass along "prompt_auth" to IdP

### DIFF
--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -430,5 +430,12 @@ func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, 
 	//
 	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
 	// OIDC spec.
-	http.Redirect(w, r, p.oauth2Config().AuthCodeURL(oidcState, oidc.Nonce(oidcState)), http.StatusFound)
+	authURL := p.oauth2Config().AuthCodeURL(oidcState, oidc.Nonce(oidcState))
+	// Pass along the prompt_auth to OP for the specific type of authentication to
+	// use, e.g. "github", "gitlab", "google".
+	promptAuth := r.URL.Query().Get("prompt_auth")
+	if promptAuth != "" {
+		authURL += "&prompt_auth=" + promptAuth
+	}
+	http.Redirect(w, r, authURL, http.StatusFound)
 }


### PR DESCRIPTION
Client-side/sister PR of https://github.com/sourcegraph/accounts.sourcegraph.com/pull/375. This allows SG clients (e.g. Cody clients) to instruct which authentication provider to use when gets redirected to SAMS.

## Why do we need this?

Dotcom accounts are migrating to SAMS but in order to make SAMS as the only sign-in option, we need to remove all other options but VSCode clients hardcodes the URL that blindly assumes those options will still exist, which results in a dead-end page for users.

But we do want to keep the benefit of "Sign in with [provider]" initiated from the clients, so with this PR, the VSCode client only need to update its link to something like (line break for readability):

```
https://sourcegraph.com/.auth/openidconnect/login?
prompt_auth={google,github,gitlab}&
pc=xSZLq_V7qzT9tU0-lHh98w&
redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=CODY
```

To achieve the same result.


The code logic does nothing if `prompt_auth` is not present.

## Test plan



https://github.com/sourcegraph/sourcegraph/assets/2946214/d5e56c8f-7b52-4da3-a9c7-f4287a7c9c17

