### PR TITLE
bazel: fix prechecks annotations

### DIFF
--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -15,7 +15,6 @@ function generate_diff_artifact() {
   if [[ $SKIP_GEN_DIFF -eq 1 ]]; then
     exit $EXIT_CODE
   fi
-  # only generate the diff if we have a non-zero exit code and the exit code does not indicate a critical failure
   if [[ $EXIT_CODE -ne 0 ]]; then
     temp=$(mktemp -d -t "buildkite-$BUILDKITE_BUILD_NUMBER-XXXXXXXX")
     trap 'rm -rf -- "$temp"' EXIT

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -42,10 +42,10 @@ bazel "${bazelrc[@]}" configure || EXIT_CODE=$?
 # tooling does not handle go 1.21 on the host which is why it is exiting with 110
 if [[ $EXIT_CODE -eq 110 ]]; then
   echo "[WARN] bazel configure exited with code 110 which we are ignoring for now as it is due to the host go version."
-else if [[ $EXIT_CODE -ne 0 ]]; then
+elif [[ $EXIT_CODE -ne 0 ]]; then
   echo ":x: bazel configure exited with code $EXIT_CODE - please look at the output above for more information or reach out to #discuss-dev-infra"
   SKIP_GEN_DIFF=1
-  exit "$EXIT_CODE
+  exit "$EXIT_CODE"
 fi
 
 echo "--- Checking if BUILD.bazel files were updated"

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -31,7 +31,11 @@ function generate_diff_artifact() {
 trap generate_diff_artifact EXIT
 
 echo "--- :bazel: Running bazel configure"
-bazel "${bazelrc[@]}" configure
+bazel "${bazelrc[@]}" configure || EXIT_CODE=$?
+if [[ $EXIT_CODE -ne 110 && $EXIT_CODE -ne 0 ]]; then
+  echo ":x: bazel configure exited unexpected exit code ${EXIT_CODE}! Please check the output or ask in #discuss-dev-infra"
+  exit "$EXIT_CODE"
+fi
 
 echo "--- Checking if BUILD.bazel files were updated"
 # Account for the possibility of a BUILD.bazel to be totally new, and thus untracked.

--- a/dev/ci/bazel-prechecks.sh
+++ b/dev/ci/bazel-prechecks.sh
@@ -33,7 +33,7 @@ trap generate_diff_artifact EXIT
 echo "--- :bazel: Running bazel configure"
 bazel "${bazelrc[@]}" configure || EXIT_CODE=$?
 if [[ $EXIT_CODE -ne 110 && $EXIT_CODE -ne 0 ]]; then
-  echo ":x: bazel configure exited unexpected exit code ${EXIT_CODE}! Please check the output or ask in #discuss-dev-infra"
+  echo ":x: bazel configure exited with unexpected exit code ${EXIT_CODE}! Please check the output or ask in #discuss-dev-infra"
   exit "$EXIT_CODE"
 fi
 


### PR DESCRIPTION
`bazel configure` exits with 110 due to it have some issues with the host go version, even though it executed successfully. So we add a check for the exit code and also print a message informing the user

Closes https://github.com/sourcegraph/devx-support/issues/561
## Test plan
Tested locally
