### PR TITLE
search: respect whitespace for phrase boost

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -122,6 +122,12 @@ func (s *searchClient) Plan(
 	if err != nil {
 		return nil, &QueryError{Query: searchQuery, Err: err}
 	}
+
+	if searchType == query.SearchTypeKeyword {
+		plan = query.MapPlan(plan, query.ExperimentalPhraseBoost(s.runtimeClients.Logger, searchQuery))
+		tr.AddEvent("applied phrase boost")
+	}
+
 	tr.AddEvent("parsing done")
 
 	var finalContextLines int32

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -72,7 +72,11 @@ func NewPlanJob(inputs *search.Inputs, plan query.Plan) (job.Job, error) {
 func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 
 	if inputs.Features != nil && inputs.Features.PhraseBoost {
-		b.Pattern = query.ExperimentalPhraseBoost(b.Pattern)
+		newPattern, err := query.ExperimentalPhraseBoost(b.Pattern, inputs.OriginalQuery)
+		if err != nil {
+			return nil, err
+		}
+		b.Pattern = newPattern
 	}
 
 	var children []job.Job

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -71,14 +71,6 @@ func NewPlanJob(inputs *search.Inputs, plan query.Plan) (job.Job, error) {
 // NewBasicJob converts a query.Basic into its job tree representation.
 func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 
-	if inputs.Features != nil && inputs.Features.PhraseBoost {
-		newPattern, err := query.ExperimentalPhraseBoost(b.Pattern, inputs.OriginalQuery)
-		if err != nil {
-			return nil, err
-		}
-		b.Pattern = newPattern
-	}
-
 	var children []job.Job
 	addJob := func(j job.Job) {
 		children = append(children, j)

--- a/internal/search/query/BUILD.bazel
+++ b/internal/search/query/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "@com_github_go_enry_go_enry_v2//data",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_grafana_regexp//syntax",
+        "@com_github_sourcegraph_log//:log",
         "@com_github_tj_go_naturaldate//:go-naturaldate",
     ],
 )
@@ -62,6 +63,7 @@ go_test(
         "@com_github_grafana_regexp//:regexp",
         "@com_github_grafana_regexp//syntax",
         "@com_github_hexops_autogold_v2//:autogold",
+        "@com_github_sourcegraph_log//:log",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/grafana/regexp"
+	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -619,61 +620,70 @@ func ToBasicQuery(nodes []Node) (Basic, error) {
 	return Basic{Parameters: parameters, Pattern: pattern}, nil
 }
 
-// ExperimentalPhraseBoost appends a phrase query to the original query but only
-// if the original query consists of a single top-level AND expression. The
-// purpose is to improve ranking of exact matches by adding a phrase
-// query for the entire query string.
+// ExperimentalPhraseBoost returns a transformation on basic queries that
+// appends a phrase query to the original query but only if the original query
+// consists of a single top-level AND expression. The purpose is to improve
+// ranking of exact matches by adding a phrase query for the entire query
+// string.
 //
 // Example:
 //
 //	foo bar bas -> (or (and foo bar bas) ("foo bar bas"))
-func ExperimentalPhraseBoost(node Node, originalQuery string) (Node, error) {
-	if node == nil {
-		return nil, nil
-	}
-
-	if n, ok := node.(Operator); ok && n.Kind == And {
-		// Gate on the number of operands. We don't want to add a phrase query for very
-		// short queries.
-		if len(n.Operands) < 3 {
-			return n, nil
+func ExperimentalPhraseBoost(logger sglog.Logger, originalQuery string) BasicPass {
+	return func(basic Basic) Basic {
+		if basic.Pattern == nil {
+			return basic
 		}
 
-		first := math.MaxInt
-		last := math.MinInt
-		// Check if all operands are patterns and not negated.
-		for _, child := range n.Operands {
-			c, isPattern := child.(Pattern)
-			if !isPattern || c.Negated {
-				return n, nil
+		if n, ok := basic.Pattern.(Operator); ok && n.Kind == And {
+			// Gate on the number of operands. We don't want to add a phrase query for very
+			// short queries.
+			if len(n.Operands) < 3 {
+				return basic
 			}
 
-			if c.Annotation.Range.Start.Column < first {
-				first = c.Annotation.Range.Start.Column
+			first := math.MaxInt
+			last := math.MinInt
+			// Check if all operands are patterns and not negated.
+			for _, child := range n.Operands {
+				c, isPattern := child.(Pattern)
+				if !isPattern || c.Negated {
+					return basic
+				}
+
+				if c.Annotation.Range.Start.Column < first {
+					first = c.Annotation.Range.Start.Column
+				}
+
+				if c.Annotation.Range.End.Column > last {
+					last = c.Annotation.Range.End.Column
+				}
 			}
 
-			if c.Annotation.Range.End.Column > last {
-				last = c.Annotation.Range.End.Column
+			// To get here, we must have found several non-negated patterns. Assuming the
+			// ranges are set correctly, this statement should always be false.
+			if first > last {
+				logger.Error(
+					"encountered invalid range during phrase boost",
+					sglog.Int("first", first),
+					sglog.Int("last", last),
+					sglog.String("query", originalQuery),
+				)
+				return basic
 			}
-		}
 
-		// To get here, we must have found several non-negated patterns. Assuming the
-		// ranges are set correctly, this statement should always be false.
-		if first > last {
-			return n, errors.Errorf("phrase boost: invalid range %d > %d for query %s", first, last, originalQuery)
-		}
-
-		return Operator{
-			Kind: Or,
-			Operands: []Node{
-				Pattern{
-					Value:      originalQuery[first:last],
-					Annotation: Annotation{Labels: Boost},
+			basic.Pattern = Operator{
+				Kind: Or,
+				Operands: []Node{
+					Pattern{
+						Value:      originalQuery[first:last],
+						Annotation: Annotation{Labels: Boost},
+					},
+					n,
 				},
-				n,
-			},
-		}, nil
-	}
+			}
+		}
 
-	return node, nil
+		return basic
+	}
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -18,26 +18,25 @@ func TestExperimentalPhraseBoost(t *testing.T) {
 
 		plan = MapPlan(plan, ExperimentalPhraseBoost(sglog.NoOp(), input))
 
-		json, _ := ToJSON(plan.ToQ())
-		return json
+		return plan.ToQ().String()
 	}
 
 	// expect phrase query
-	autogold.Expect(`[{"or":[{"value":"foo bar bas","negated":false,"labels":null,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}},{"and":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":4},"end":{"line":0,"column":7}}},{"value":"bas","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":8},"end":{"line":0,"column":11}}}]}]}]`).Equal(t, test("foo bar bas", SearchTypeKeyword))
+	autogold.Expect(`(or "foo bar bas" (and "foo" "bar" "bas"))`).Equal(t, test("foo bar bas", SearchTypeKeyword))
 
 	// respect whitespace
-	autogold.Expect(`[{"or":[{"value":"foo   bar  bas","negated":false,"labels":null,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}},{"and":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":6},"end":{"line":0,"column":9}}},{"value":"bas","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":11},"end":{"line":0,"column":14}}}]}]}]`).Equal(t, test("foo   bar  bas", SearchTypeKeyword))
-	autogold.Expect(`[{"or":[{"value":"foo\tbar:  bas","negated":false,"labels":null,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}},{"and":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar:","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":4},"end":{"line":0,"column":8}}},{"value":"bas","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":10},"end":{"line":0,"column":13}}}]}]}]`).Equal(t, test("foo\tbar:  bas ", SearchTypeKeyword))
-	autogold.Expect(`[{"or":[{"value":"いい　お天気　です","negated":false,"labels":null,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}},{"and":[{"value":"いい","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}},{"value":"お天気","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":9},"end":{"line":0,"column":18}}},{"value":"です","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":21},"end":{"line":0,"column":27}}}]}]}]`).Equal(t, test("いい　お天気　です", SearchTypeKeyword))
+	autogold.Expect(`(or "foo   bar  bas" (and "foo" "bar" "bas"))`).Equal(t, test("foo   bar  bas", SearchTypeKeyword))
+	autogold.Expect(`(or "foo\tbar:  bas" (and "foo" "bar:" "bas"))`).Equal(t, test("foo\tbar:  bas ", SearchTypeKeyword))
+	autogold.Expect(`(or "いい お天気 です" (and "いい" "お天気" "です"))`).Equal(t, test("いい お天気 です", SearchTypeKeyword))
 
 	// expect no phrase query
-	autogold.Expect(`[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}}]`).Equal(t, test("foo", SearchTypeKeyword))
-	autogold.Expect(`[{"and":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":4},"end":{"line":0,"column":7}}}]}]`).Equal(t, test("foo bar", SearchTypeKeyword))
-	autogold.Expect(`[{"and":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":8},"end":{"line":0,"column":11}}}]}]`).Equal(t, test("foo and bar", SearchTypeKeyword))
-	autogold.Expect(`[{"and":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar","negated":true,"labels":["Literal"],"range":{"start":{"line":0,"column":4},"end":{"line":0,"column":11}}}]}]`).Equal(t, test("foo not bar", SearchTypeKeyword))
-	autogold.Expect(`[{"and":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":4},"end":{"line":0,"column":7}}},{"value":"bas","negated":true,"labels":["Literal"],"range":{"start":{"line":0,"column":8},"end":{"line":0,"column":15}}},{"value":"quz","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":16},"end":{"line":0,"column":19}}}]}]`).Equal(t, test("foo bar not bas quz", SearchTypeKeyword))
-	autogold.Expect(`[{"or":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":7},"end":{"line":0,"column":10}}},{"value":"bas","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":14},"end":{"line":0,"column":17}}}]}]`).Equal(t, test("foo or bar or bas", SearchTypeKeyword))
-	autogold.Expect(`[{"or":[{"and":[{"value":"foo","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":3}}},{"value":"bar","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":8},"end":{"line":0,"column":11}}}]},{"and":[{"value":"quz","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":16},"end":{"line":0,"column":19}}},{"value":"biz","negated":false,"labels":["Literal"],"range":{"start":{"line":0,"column":24},"end":{"line":0,"column":27}}}]}]}]`).Equal(t, test("foo and bar or (quz and biz)", SearchTypeKeyword))
+	autogold.Expect(`"foo"`).Equal(t, test("foo", SearchTypeKeyword))
+	autogold.Expect(`(and "foo" "bar")`).Equal(t, test("foo bar", SearchTypeKeyword))
+	autogold.Expect(`(and "foo" "bar")`).Equal(t, test("foo and bar", SearchTypeKeyword))
+	autogold.Expect(`(and "foo" (not "bar"))`).Equal(t, test("foo not bar", SearchTypeKeyword))
+	autogold.Expect(`(and "foo" "bar" (not "bas") "quz")`).Equal(t, test("foo bar not bas quz", SearchTypeKeyword))
+	autogold.Expect(`(or "foo" "bar" "bas")`).Equal(t, test("foo or bar or bas", SearchTypeKeyword))
+	autogold.Expect(`(or (and "foo" "bar") (and "quz" "biz"))`).Equal(t, test("foo and bar or (quz and biz)", SearchTypeKeyword))
 }
 
 func TestSubstituteAliases(t *testing.T) {


### PR DESCRIPTION
Terms in phrases might be separated by more than one whitespace. With this change we respect the original query when we construct the phrase query. Before, we always joined terms with " ".  

Additionally we couple this feature to keyword search instead of having it as a feature flag.

<img width="1013" alt="Screenshot 2024-01-30 at 14 23 43" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/d367f941-de6b-4e81-9539-fab4979b2775">

Note: The transformation now happens during the planning stage instead of the executing stage. I think this is a more obvious spot as it happens next to other transformations on the query plan.

Test plan:
updated unit test
