### PR TITLE
auth: redirect to "/sign-in" when auth provider not found

### DIFF
--- a/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/cmd/frontend/internal/auth/oauth/middleware.go
@@ -83,9 +83,8 @@ func newOAuthFlowHandler(serviceType string) http.Handler {
 		id := r.URL.Query().Get("pc")
 		p := GetProvider(serviceType, id)
 		if p == nil {
-			log15.Error("no OAuth provider found with ID and service type", "id", id, "serviceType", serviceType)
-			msg := fmt.Sprintf("Misconfigured %s auth provider.", serviceType)
-			http.Error(w, msg, http.StatusInternalServerError)
+			log15.Warn("no OAuth provider found with ID and service type", "id", id, "serviceType", serviceType)
+			http.Redirect(w, r, "/sign-in?returnTo="+r.URL.Query().Get("returnTo"), http.StatusFound)
 			return
 		}
 		p.Login(p.OAuth2Config()).ServeHTTP(w, r)

--- a/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/cmd/frontend/internal/auth/openidconnect/config.go
@@ -41,6 +41,8 @@ func GetProvider(id string) *Provider {
 	return nil
 }
 
+var errNoSuchProvider = errors.New("no such authentication provider")
+
 // GetProviderAndRefresh retrieves the authentication provider with the given
 // type and ID, and refreshes the token used by the provider.
 func GetProviderAndRefresh(ctx context.Context, id string, getProvider func(id string) *Provider) (p *Provider, safeErrMsg string, err error) {
@@ -48,7 +50,7 @@ func GetProviderAndRefresh(ctx context.Context, id string, getProvider func(id s
 	if p == nil {
 		return nil,
 			"Misconfigured authentication provider.",
-			errors.Errorf("no authentication provider found with ID %q", id)
+			errNoSuchProvider
 	}
 	if p.config.Issuer == "" {
 		return nil,

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -124,7 +124,11 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimPrefix(r.URL.Path, authPrefix) {
 		case "/login": // Endpoint that starts the Authentication Request Code Flow.
 			p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), r.URL.Query().Get("pc"), GetProvider)
-			if err != nil {
+			if errors.Is(err, errNoSuchProvider) {
+				log15.Warn("Failed to get provider.", "error", err)
+				http.Redirect(w, r, "/sign-in?returnTo="+r.URL.Query().Get("returnTo"), http.StatusFound)
+				return
+			} else if err != nil {
 				log15.Error("Failed to get provider.", "error", err)
 				http.Error(w, safeErrMsg, http.StatusInternalServerError)
 				return


### PR DESCRIPTION
When there is no matching auth provider, there is almost always something more fucky going on. Although this PR is made specifically for VSCode Cody client, i.e. when users click on the "Sign in with X" button that links to a non-existent auth provider, it is generally more helpful to the end user to get back to the `/sign-in` page then a raw screen with a opaque error message.

## Test plan

```zsh
→ curl https://sourcegraph.test:3443/.auth/openidconnect/login?pc=404&returnTo=%2Fsearch
<a href="/sign-in?returnTo=/search">Found</a>.

→ curl https://sourcegraph.test:3443/.auth/github/login?pc=404&returnTo=%2Fsearch
<a href="/sign-in?returnTo=/search">Found</a>.
```
