### PR TITLE
msp/monitoring: add alerting spec for environment Opsgenie enablement

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -79,6 +79,9 @@ type EnvironmentSpec struct {
 	// Resources configures additional resources that a service may depend on.
 	Resources *EnvironmentResourcesSpec `yaml:"resources,omitempty"`
 
+	// Alerting configures alerting and notifications for the environment.
+	Alerting *EnvironmentAlertingSpec `yaml:"alerting,omitempty"`
+
 	// AllowDestroys, if false, configures Terraform lifecycle guards against
 	// deletion of potentially critical resources. This includes things like the
 	// environment project and databases, and also guards against the deletion
@@ -719,4 +722,9 @@ func (s *EnvironmentResourceBigQueryDatasetSpec) LoadSchemas(dir string) error {
 // LoadSchemas will ensure that each table has a corresponding schema file.
 func (s *EnvironmentResourceBigQueryDatasetSpec) GetSchema(tableID string) []byte {
 	return s.rawSchemaFiles[tableID]
+}
+
+type EnvironmentAlertingSpec struct {
+	// Opsgenie, if true, disables suppression of Opsgenie alerts.
+	Opsgenie *bool `yaml:"opsgenie,omitempty"`
 }

--- a/dev/managedservicesplatform/stacks/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/stacks/monitoring/monitoring.go
@@ -85,7 +85,10 @@ type Variables struct {
 	EnvironmentCategory spec.EnvironmentCategory
 	// EnvironmentID is the name of the service environment.
 	EnvironmentID string
-	Monitoring    spec.MonitoringSpec
+	// Alerting configuration for the environment.
+	Alerting spec.EnvironmentAlertingSpec
+	// Monitoring spec.
+	Monitoring spec.MonitoringSpec
 	// MaxInstanceCount informs service scaling alerts.
 	MaxInstanceCount *int
 	// ExternalDomain informs external health checks on the service domain.
@@ -181,11 +184,10 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 				// Let the team own the integration.
 				OwnerTeamId: team.Id(),
 
-				// Supress all notifications if opsgenieAlerts is disabled -
+				// Supress all notifications if Alerting.Opsgenie is false -
 				// this allows us to see the alerts, but not necessarily get
 				// paged by it.
-				// TODO: Enable after we dogfood the alerts for a while.
-				SuppressNotifications: pointers.Ptr(true),
+				SuppressNotifications: !pointers.DerefZero(vars.Alerting.Opsgenie),
 
 				// Point alerts sent through this integration at the Opsgenie team.
 				Responders: []*opsgenieintegration.ApiIntegrationResponders{{


### PR DESCRIPTION
Previously these were universally suppressed as we were in development only.

## Test plan

Applied on sams-dev