### PR TITLE
User Menu: Connect feedback button with feedback menu option in new navigation

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -235,6 +235,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                             codeMonitoringEnabled={props.codeMonitoringEnabled}
                             batchChangesEnabled={props.batchChangesEnabled}
                             codeInsightsEnabled={props.codeInsightsEnabled ?? false}
+                            showFeedbackModal={showFeedbackModal}
                             selectedSearchContextSpec={props.selectedSearchContextSpec}
                             telemetryService={props.telemetryService}
                         />

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
@@ -52,5 +52,6 @@ export const NewGlobalNavigationBarDemo: StoryFn = () => (
         }
         selectedSearchContextSpec=""
         telemetryService={NOOP_TELEMETRY_SERVICE}
+        showFeedbackModal={() => {}}
     />
 )

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -42,6 +42,7 @@ interface NewGlobalNavigationBar extends TelemetryProps {
     codeInsightsEnabled: boolean
     showSearchBox: boolean
     selectedSearchContextSpec?: string
+    showFeedbackModal: () => void
 }
 
 /**
@@ -60,6 +61,7 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
         authenticatedUser,
         selectedSearchContextSpec,
         showSearchBox,
+        showFeedbackModal,
         telemetryService,
     } = props
 
@@ -120,7 +122,7 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
                     <UserNavItem
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         authenticatedUser={authenticatedUser}
-                        showFeedbackModal={() => {}}
+                        showFeedbackModal={showFeedbackModal}
                         className="ml-auto"
                         showKeyboardShortcutsHelp={() => {}}
                         telemetryService={telemetryService}


### PR DESCRIPTION
Prior to this fix feedback option in the user menu did nothing, this PR connects it with feedback modal 

## Test plan
- Check that you can open feedback panel from user menu when new navigation is enabled

