### PR TITLE
nix: mount /tmp/zig-cache in sandbox actions

### DIFF
--- a/dev/nix/shell-hook.sh
+++ b/dev/nix/shell-hook.sh
@@ -28,6 +28,11 @@ build --extra_toolchains=@zig_sdk//toolchain:linux_amd64_gnu.2.34
 EOF
 fi
 
+# without this, zig cc is forced to rebuild on every sandboxed GoLink action, which
+# adds ~1m of time to GoLink actions. The reason it's on _every_ GoLink action is
+# because sandboxes are ephemeral and don't persist non-mounted paths between actions.
+mkdir -p /tmp/zig-cache
+
 # We run this check afterwards so we can read the values exported by the
 # start-*.sh scripts. We need to smuggle in these envvars for tests on both
 # linux and darwin.
@@ -39,4 +44,5 @@ build --action_env=PGDATA
 build --action_env=PGDATABASE
 build --action_env=PGDATASOURCE
 build --action_env=PGUSER
+build --sandbox_add_mount_pair=/tmp/zig-cache
 EOF

--- a/shell.nix
+++ b/shell.nix
@@ -146,5 +146,5 @@ mkShell.override { stdenv = if hostPlatform.isMacOS then pkgs.clang11Stdenv else
   # https://sourcegraph.com/github.com/bazelbuild/bazel@1a4da7f331c753c92e2c91efcad434dc29d10d43/-/blob/scripts/packages/bazel.sh?L23-28
   USE_BAZEL_VERSION = if hostPlatform.isMacOS then "" else pkgs.bazel_7.version;
 
-  LIBTOOL = if hostPlatform.isMacOS then "${pkgs.libtool}" else "";
+  LIBTOOL = if hostPlatform.isMacOS then "/usr/bin/libtool" else "";
 }


### PR DESCRIPTION
As detailed in the shell hook:
Without this, zig cc is forced to rebuild on every sandboxed GoLink action, which adds ~1m of time to GoLink actions. The reason it's on _every_ GoLink action is because sandboxes are ephemeral and don't persist non-mounted paths between actions.

We're already doing this for `darwin-docker` config, so this only affects us nixos users

--- 

Smuggling in a libtool fix for macos that would otherwise yield the following error when building rust with bazel:

<details>
<summary>Details</summary>

```
cargo:rerun-if-env-changed=AR_aarch64-apple-darwin
AR_aarch64-apple-darwin = None
cargo:rerun-if-env-changed=AR_aarch64_apple_darwin
AR_aarch64_apple_darwin = None
cargo:rerun-if-env-changed=HOST_AR
HOST_AR = None
cargo:rerun-if-env-changed=AR
AR = Some("/nix/store/42yck6r7y2jhcrd0ay0glz30w6pw4wzh-libtool-2.4.7")
cargo:rerun-if-env-changed=ARFLAGS_aarch64-apple-darwin
ARFLAGS_aarch64-apple-darwin = None
cargo:rerun-if-env-changed=ARFLAGS_aarch64_apple_darwin
ARFLAGS_aarch64_apple_darwin = None
cargo:rerun-if-env-changed=HOST_ARFLAGS
HOST_ARFLAGS = None
cargo:rerun-if-env-changed=ARFLAGS
ARFLAGS = None
running: ZERO_AR_DATE="1" "/nix/store/42yck6r7y2jhcrd0ay0glz30w6pw4wzh-libtool-2.4.7" "cq" "/private/var/tmp/_bazel_noah/dcf2fbfa8ce2981c9fc4201fa6327d3b/sandbox/darwin-sandbox/6091/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/external/crate_index__tree-sitter-kotlin-0.2.11/tree-sitter-kotlin_build_script.out_dir/libparser.a" "/private/var/tmp/_bazel_noah/dcf2fbfa8ce2981c9fc4201fa6327d3b/sandbox/darwin-sandbox/6091/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/external/crate_index__tree-sitter-kotlin-0.2.11/tree-sitter-kotlin_build_script.out_dir/src/parser.o" "/private/var/tmp/_bazel_noah/dcf2fbfa8ce2981c9fc4201fa6327d3b/sandbox/darwin-sandbox/6091/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/external/crate_index__tree-sitter-kotlin-0.2.11/tree-sitter-kotlin_build_script.out_dir/src/scanner.o"

--stderr:


error occurred: Command ZERO_AR_DATE="1" "/nix/store/42yck6r7y2jhcrd0ay0glz30w6pw4wzh-libtool-2.4.7" "cq" "/private/var/tmp/_bazel_noah/dcf2fbfa8ce2981c9fc4201fa6327d3b/sandbox/darwin-sandbox/6091/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/external/crate_index__tree-sitter-kotlin-0.2.11/tree-sitter-kotlin_build_script.out_dir/libparser.a" "/private/var/tmp/_bazel_noah/dcf2fbfa8ce2981c9fc4201fa6327d3b/sandbox/darwin-sandbox/6091/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/external/crate_index__tree-sitter-kotlin-0.2.11/tree-sitter-kotlin_build_script.out_dir/src/parser.o" "/private/var/tmp/_bazel_noah/dcf2fbfa8ce2981c9fc4201fa6327d3b/sandbox/darwin-sandbox/6091/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/external/crate_index__tree-sitter-kotlin-0.2.11/tree-sitter-kotlin_build_script.out_dir/src/scanner.o" with args "" failed to start: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
```

</details>

## Test plan

Observing `bazel build //dev/sg` times
