### PR TITLE
Search: Add telemetry for keyword and regexp toggles

### DIFF
--- a/client/branded/src/search-ui/input/SearchBox.tsx
+++ b/client/branded/src/search-ui/input/SearchBox.tsx
@@ -200,6 +200,7 @@ export const SearchBox: FC<SearchBoxProps> = props => {
                             navbarSearchQuery={queryState.query}
                             className={styles.searchBoxToggles}
                             structuralSearchDisabled={props.structuralSearchDisabled}
+                            telemetryService={props.telemetryService}
                         />
                     ) : (
                         <LegacyToggles

--- a/client/branded/src/search-ui/input/toggles/Toggles.test.tsx
+++ b/client/branded/src/search-ui/input/toggles/Toggles.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
 import { SearchMode } from '@sourcegraph/shared/src/search'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { Toggles } from './Toggles'
@@ -19,6 +20,7 @@ describe('Toggles', () => {
                     setCaseSensitivity={() => undefined}
                     searchMode={SearchMode.Precise}
                     setSearchMode={() => undefined}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
                 />
             )
 
@@ -35,6 +37,7 @@ describe('Toggles', () => {
                     setCaseSensitivity={() => undefined}
                     searchMode={SearchMode.Precise}
                     setSearchMode={() => undefined}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
                 />
             )
             expect(screen.getAllByRole('checkbox', { name: 'Case sensitivity toggle' })).toMatchSnapshot()
@@ -50,6 +53,7 @@ describe('Toggles', () => {
                     setCaseSensitivity={() => undefined}
                     searchMode={SearchMode.Precise}
                     setSearchMode={() => undefined}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
                 />
             )
             expect(screen.getAllByRole('checkbox', { name: 'Regular expression toggle' })).toMatchSnapshot()

--- a/client/branded/src/search-ui/input/toggles/Toggles.tsx
+++ b/client/branded/src/search-ui/input/toggles/Toggles.tsx
@@ -76,7 +76,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
 
         setPatternType(newPatternType)
         submitOnToggle({ newPatternType })
-        telemetryService.log('ToggleRegexpPatternType', { currentStatus: patternType == SearchPatternType.regexp })
+        telemetryService.log('ToggleRegexpPatternType', { currentStatus: patternType === SearchPatternType.regexp })
     }, [patternType, setPatternType, submitOnToggle, telemetryService])
 
     const toggleStructuralSearch = useCallback((): void => {

--- a/client/branded/src/search-ui/input/toggles/Toggles.tsx
+++ b/client/branded/src/search-ui/input/toggles/Toggles.tsx
@@ -12,6 +12,7 @@ import {
     type SearchPatternTypeProps,
 } from '@sourcegraph/shared/src/search'
 import { findFilter, FilterKind } from '@sourcegraph/shared/src/search/query/query'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { QueryInputToggle } from './QueryInputToggle'
 
@@ -22,6 +23,7 @@ export interface TogglesProps
         SearchPatternTypeMutationProps,
         CaseSensitivityProps,
         SearchModeProps,
+        TelemetryProps,
         Partial<Pick<SubmitSearchProps, 'submitSearch'>> {
     navbarSearchQuery: string
     className?: string
@@ -48,6 +50,7 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
         className,
         submitSearch,
         structuralSearchDisabled,
+        telemetryService,
     } = props
 
     const submitOnToggle = useCallback(
@@ -73,7 +76,8 @@ export const Toggles: React.FunctionComponent<React.PropsWithChildren<TogglesPro
 
         setPatternType(newPatternType)
         submitOnToggle({ newPatternType })
-    }, [patternType, setPatternType, submitOnToggle])
+        telemetryService.log('ToggleRegexpPatternType', { currentStatus: patternType == SearchPatternType.regexp })
+    }, [patternType, setPatternType, submitOnToggle, telemetryService])
 
     const toggleStructuralSearch = useCallback((): void => {
         const newPatternType: SearchPatternType =

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -242,6 +242,7 @@ const NavigationSearchBox: FC<NavigationSearchBoxProps> = props => {
                         setCaseSensitivity={setSearchCaseSensitivity}
                         setSearchMode={setSearchMode}
                         submitSearch={submitSearchOnChange}
+                        telemetryService={telemetryService}
                     />
                 ) : (
                     <LegacyToggles

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -113,6 +113,7 @@ export const SearchNavbarItem: React.FunctionComponent<React.PropsWithChildren<P
                             structuralSearchDisabled={
                                 window.context?.experimentalFeatures?.structuralSearch !== 'enabled'
                             }
+                            telemetryService={props.telemetryService}
                         />
                     ) : (
                         <LegacyToggles

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
@@ -102,7 +102,16 @@ export interface SearchResultsInfoBarProps
  * and a few actions like expand all and save query
  */
 export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
-    const { query, patternType, authenticatedUser, results, options, sourcegraphURL, telemetryService } = props
+    const {
+        query,
+        patternType,
+        authenticatedUser,
+        results,
+        options,
+        sourcegraphURL,
+        onTogglePatternType,
+        telemetryService,
+    } = props
 
     const popoverRef = useRef<HTMLDivElement>(null)
     const navigate = useNavigate()
@@ -195,6 +204,11 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
         setShowSavedSearchModal(false)
         telemetryService.log('SavedQueriesToggleCreating', { queries: { creating: false } })
     }, [telemetryService])
+
+    const handleKeywordSearchToggle = useCallback(() => {
+        telemetryService.log('ToggleKeywordPatternType', { currentStatus: patternType == SearchPatternType.keyword })
+        onTogglePatternType(patternType)
+    }, [onTogglePatternType, patternType, telemetryService])
 
     return (
         <aside
@@ -294,7 +308,7 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
 
                         <Toggle
                             value={props.patternType === SearchPatternType.keyword}
-                            onToggle={() => props.onTogglePatternType(props.patternType)}
+                            onToggle={handleKeywordSearchToggle}
                             title="Enable search language update"
                             className="mr-2"
                         />

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
@@ -206,7 +206,7 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
     }, [telemetryService])
 
     const handleKeywordSearchToggle = useCallback(() => {
-        telemetryService.log('ToggleKeywordPatternType', { currentStatus: patternType == SearchPatternType.keyword })
+        telemetryService.log('ToggleKeywordPatternType', { currentStatus: patternType === SearchPatternType.keyword })
         onTogglePatternType(patternType)
     }, [onTogglePatternType, patternType, telemetryService])
 

--- a/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageInput.tsx
@@ -155,6 +155,7 @@ export const SearchPageInput: FC<SearchPageInputProps> = props => {
                     navbarSearchQuery={queryState.query}
                     submitSearch={submitSearchOnChange}
                     structuralSearchDisabled={window.context?.experimentalFeatures?.structuralSearch !== 'enabled'}
+                    telemetryService={telemetryService}
                 />
             ) : (
                 <LegacyToggles


### PR DESCRIPTION
This adds a telemetry event to track if users hit the keyword search and regexp
toggles. This will help us understand
1. If users are often frustrated/ surprised with the new search syntax
2. Whether we could potentially remove the regexp toggle in a future release

## Test plan

Manual testing with the `eventLogDebug` setting