### PR TITLE
gitserver: introduce abstraction around p4 exec

### DIFF
--- a/cmd/gitserver/internal/perforce/BUILD.bazel
+++ b/cmd/gitserver/internal/perforce/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "changelist.go",
         "cloneable.go",
+        "command.go",
         "depots.go",
         "groups.go",
         "login.go",
@@ -40,6 +41,7 @@ go_test(
     name = "perforce_test",
     srcs = [
         "changelist_test.go",
+        "command_test.go",
         "groups_test.go",
         "perforce_test.go",
         "protects_test.go",

--- a/cmd/gitserver/internal/perforce/command.go
+++ b/cmd/gitserver/internal/perforce/command.go
@@ -1,0 +1,159 @@
+package perforce
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/wrexec"
+)
+
+// p4Options holds configuration options for executing Perforce commands.
+type p4Options struct {
+	arguments []string // arguments to pass to the command
+
+	overrideEnvironment map[string]string // these environment variables will override any existing environment variables with the same name
+	environment         []string          // these environment variables will be set for the command
+
+	stdin  io.Reader // alternative stdin for the command
+	stdout io.Writer // alternative stdout for the command
+	stderr io.Writer // alternative stderr for the command
+
+	logger log.Logger // logger to use for the command
+}
+
+type P4OptionFunc func(*p4Options)
+
+// WithArguments sets the given arguments to the command arguments.
+func WithArguments(args ...string) P4OptionFunc {
+	return func(o *p4Options) {
+		o.arguments = args
+	}
+}
+
+// WithHost specifies the host to use for the Perforce command.
+//
+// Example: WithHost("ssl:perforce.example.com:1666")
+func WithHost(p4port string) P4OptionFunc {
+	return func(o *p4Options) {
+		if o.overrideEnvironment == nil {
+			o.overrideEnvironment = make(map[string]string)
+		}
+
+		o.overrideEnvironment["P4PORT"] = p4port
+	}
+}
+
+// WithAuthentication specifies the user and password to use for the Perforce command.
+//
+// Example: WithAuthentication("alice", "hunter2")
+func WithAuthentication(user, password string) P4OptionFunc {
+	return func(o *p4Options) {
+		if o.overrideEnvironment == nil {
+			o.overrideEnvironment = make(map[string]string)
+		}
+
+		o.overrideEnvironment["P4USER"] = user
+		o.overrideEnvironment["P4PASSWD"] = password
+	}
+}
+
+// WithEnvironment specifies the environment variables to set for the Perforce command.
+// Each string should be in the form "key=value".
+//
+// If multiple environment variables with the same key are provided, only the last one will be used.
+//
+// If no environment variables are provided, the command will inherit the current process's environment.
+//
+// Example: WithEnvironment("CONFIG_DIR=/etc/perforce", "P4CONFIG=.p4config")
+func WithEnvironment(env ...string) P4OptionFunc {
+	return func(o *p4Options) {
+		o.environment = append(o.environment, env...)
+	}
+}
+
+// WithClient specifies the client to use for the Perforce command.
+//
+// Example: WithClient("alice-client")
+func WithClient(client string) P4OptionFunc {
+	return func(o *p4Options) {
+		if o.overrideEnvironment == nil {
+			o.overrideEnvironment = make(map[string]string)
+		}
+
+		o.overrideEnvironment["P4CLIENT"] = client
+	}
+}
+
+// WithStderr specifies the writer to use for the command's stderr output.
+func WithStderr(stderr io.Writer) P4OptionFunc {
+	return func(o *p4Options) {
+		o.stderr = stderr
+	}
+}
+
+// WithStdin specifies the reader to use for the command's stdin input.
+func WithStdin(stdin io.Reader) P4OptionFunc {
+	return func(o *p4Options) {
+		o.stdin = stdin
+	}
+}
+
+// WithStdout specifies the writer to use for the command's stdout output.
+func WithStdout(stdout io.Writer) P4OptionFunc {
+	return func(o *p4Options) {
+		o.stdout = stdout
+	}
+}
+
+func NewBaseCommand(ctx context.Context, homeDir, cwd string, options ...P4OptionFunc) wrexec.Cmder {
+	opts := p4Options{}
+
+	// Apply options
+	for _, option := range options {
+		option(&opts)
+	}
+
+	c := exec.CommandContext(ctx, "p4", opts.arguments...)
+
+	c.Env = os.Environ()
+
+	// Apply environment variables if specified
+	if opts.environment != nil {
+		c.Env = opts.environment
+	}
+
+	// Make sure that the override environment variables
+	// take precedence over any duplicates in existing environment variables.
+	for k, v := range opts.overrideEnvironment {
+		c.Env = append(c.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	c.Env = append(c.Env,
+		fmt.Sprintf("P4CLIENTPATH=%s", cwd),
+		fmt.Sprintf("HOME=%s", homeDir),
+	)
+
+	// Apply alternate stdin, stdout, and stderr if specified
+
+	if opts.stdin != nil {
+		c.Stdin = opts.stdin
+	}
+
+	if opts.stdout != nil {
+		c.Stdout = opts.stdout
+	}
+
+	if opts.stderr != nil {
+		c.Stderr = opts.stderr
+	}
+
+	// Set the working directory
+	c.Dir = cwd
+
+	return wrexec.Wrap(ctx, log.NoOp(), c)
+}

--- a/cmd/gitserver/internal/perforce/command_test.go
+++ b/cmd/gitserver/internal/perforce/command_test.go
@@ -1,0 +1,312 @@
+package perforce
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithEnvironment(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	t.Run("basic", func(t *testing.T) {
+
+		opts := []P4OptionFunc{
+			WithEnvironment("KEY1=value1"),
+			WithEnvironment("KEY2=value2"),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		require.Contains(t, c.Env, "KEY1=value1")
+		require.Contains(t, c.Env, "KEY2=value2")
+	})
+
+	t.Run("use existing environment if not specified", func(t *testing.T) {
+		t.Setenv("baseKey", "baseValue")
+
+		var opts []P4OptionFunc
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		require.Contains(t, c.Env, "baseKey=baseValue")
+	})
+
+	t.Run("replaces existing environment if specified", func(t *testing.T) {
+		oldValue, newValue := "oldBaseValue", "newBaseValue"
+
+		t.Setenv("baseKey", oldValue)
+
+		opts := []P4OptionFunc{
+			WithEnvironment(fmt.Sprintf("baseKey=%s", newValue)),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		require.Contains(t, c.Env, fmt.Sprintf("baseKey=%s", newValue))
+		require.NotContains(t, c.Env, fmt.Sprintf("baseKey=%s", oldValue))
+	})
+}
+
+func TestWithAuthentication(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	t.Run("overrides base environment", func(t *testing.T) {
+		fakeUser, fakePass := "fakeUser", "fakePass"
+		realUser, realPass := "realUser", "realPass"
+
+		opts := []P4OptionFunc{
+			WithAuthentication(realUser, realPass),
+			WithEnvironment("P4USER="+fakeUser, "P4PASSWD="+fakePass),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		fakeUserIndex := slices.Index(c.Env, "P4USER="+fakeUser)
+		fakePassIndex := slices.Index(c.Env, "P4PASSWD="+fakePass)
+		realUserIndex := slices.Index(c.Env, "P4USER="+realUser)
+		realPassIndex := slices.Index(c.Env, "P4PASSWD="+realPass)
+
+		// Ensure that all environment variables are set
+		require.GreaterOrEqual(t, fakeUserIndex, 0)
+		require.GreaterOrEqual(t, fakePassIndex, 0)
+		require.GreaterOrEqual(t, realUserIndex, 0)
+		require.GreaterOrEqual(t, realPassIndex, 0)
+
+		// Ensure that the override environment variables take precedence over
+		// any duplicates in existing environment variables.
+		require.Greater(t, realUserIndex, fakeUserIndex)
+		require.Greater(t, realPassIndex, fakePassIndex)
+	})
+
+	t.Run("last option overrides previous options", func(t *testing.T) {
+		oldUser, oldPass := "oldUser", "oldPass"
+		newUser, newPass := "newUser", "newPass"
+
+		opts := []P4OptionFunc{
+			WithAuthentication(oldUser, oldPass),
+			WithAuthentication(newUser, newPass),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		require.NotContains(t, c.Env, "P4USER="+oldUser)
+		require.NotContains(t, c.Env, "P4PASSWD="+oldPass)
+
+		require.Contains(t, c.Env, "P4USER="+newUser)
+		require.Contains(t, c.Env, "P4PASSWD="+newPass)
+	})
+}
+
+func TestWithClient(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	t.Run("overrides base environment", func(t *testing.T) {
+		fakeClient := "fakeClient"
+		realClient := "realClient"
+
+		opts := []P4OptionFunc{
+			WithClient(realClient),
+			WithEnvironment("P4CLIENT=" + fakeClient),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		fakeClientIndex := slices.Index(c.Env, "P4CLIENT="+fakeClient)
+		realClientIndex := slices.Index(c.Env, "P4CLIENT="+realClient)
+
+		// Ensure that all environment variables are set
+		require.GreaterOrEqual(t, fakeClientIndex, 0)
+		require.GreaterOrEqual(t, realClientIndex, 0)
+
+		// Ensure that the override environment variables take precedence over
+		// any duplicates in existing environment variables.
+		require.Greater(t, realClientIndex, fakeClientIndex)
+	})
+
+	t.Run("last option overrides previous options", func(t *testing.T) {
+		oldClient := "oldClient"
+		newClient := "newClient"
+
+		opts := []P4OptionFunc{
+			WithClient(oldClient),
+			WithClient(newClient),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		require.NotContains(t, c.Env, "P4CLIENT="+oldClient)
+		require.Contains(t, c.Env, "P4CLIENT="+newClient)
+	})
+}
+
+func TestHomeDir(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	t.Run("basic", func(t *testing.T) {
+		var opts []P4OptionFunc
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		require.Contains(t, c.Environ(), fmt.Sprintf("HOME=%s", homeDir))
+	})
+
+	t.Run("overrides base environment", func(t *testing.T) {
+		fakeHomeDir := t.TempDir()
+		realHomeDir := t.TempDir()
+
+		opts := []P4OptionFunc{
+			WithEnvironment("HOME=" + fakeHomeDir),
+		}
+
+		c := NewBaseCommand(ctx, realHomeDir, cwd, opts...).Unwrap()
+
+		require.Contains(t, c.Environ(), fmt.Sprintf("HOME=%s", realHomeDir))
+		require.NotContains(t, c.Environ(), fmt.Sprintf("HOME=%s", fakeHomeDir))
+	})
+}
+
+func TestWithHost(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	t.Run("overrides base environment", func(t *testing.T) {
+		fakeHost := "ssl:fakeHost:1666"
+		realHost := "ssl:realHost:1666"
+
+		opts := []P4OptionFunc{
+			WithHost(realHost),
+			WithEnvironment("P4PORT=" + fakeHost),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		fakeHostIndex := slices.Index(c.Env, "P4PORT="+fakeHost)
+		realHostIndex := slices.Index(c.Env, "P4PORT="+realHost)
+
+		// Ensure that all environment variables are set
+		require.GreaterOrEqual(t, fakeHostIndex, 0)
+		require.GreaterOrEqual(t, realHostIndex, 0)
+		// Ensure that the override environment variables take precedence over
+		// any duplicates in existing environment variables.
+		require.Greater(t, realHostIndex, fakeHostIndex)
+	})
+
+	t.Run("last option overrides previous options", func(t *testing.T) {
+		oldHost := "ssl:oldHost:1666"
+		newHost := "ssl:newHost:1666"
+
+		opts := []P4OptionFunc{
+			WithHost(oldHost),
+			WithHost(newHost),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+		require.NotContains(t, c.Env, "P4PORT="+oldHost)
+		require.Contains(t, c.Env, "P4PORT="+newHost)
+	})
+}
+
+func TestWithArguments(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	t.Run("basic usage", func(t *testing.T) {
+		opts := []P4OptionFunc{
+			WithArguments("arg1", "arg2"),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+		require.Equal(t, []string{"arg1", "arg2"}, c.Args[1:])
+	})
+
+	t.Run("last option overrides previous options", func(t *testing.T) {
+		oldArgs := []string{"oldArg1", "oldArg2"}
+		newArgs := []string{"newArg1", "newArg2"}
+
+		opts := []P4OptionFunc{
+			WithArguments(oldArgs...),
+			WithArguments(newArgs...),
+		}
+
+		c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+		require.Equal(t, newArgs, c.Args[1:])
+	})
+}
+
+func TestWithStdin(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	fakeReader := bytes.NewReader(nil)
+
+	stdin := fakeReader
+	opts := []P4OptionFunc{
+		WithStdin(fakeReader),
+	}
+
+	c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+	require.Equal(t, stdin, c.Stdin)
+}
+
+func TestWithStdout(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	fakeWriter := bytes.NewBuffer(nil)
+
+	stdout := fakeWriter
+	opts := []P4OptionFunc{
+		WithStdout(fakeWriter),
+	}
+
+	c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+	require.Equal(t, stdout, c.Stdout)
+}
+
+func TestWithStderr(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	fakeWriter := bytes.NewBuffer(nil)
+
+	stderr := fakeWriter
+	opts := []P4OptionFunc{
+		WithStderr(fakeWriter),
+	}
+
+	c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+	require.Equal(t, stderr, c.Stderr)
+}
+
+func TestP4CLIENTPath(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	var opts []P4OptionFunc
+	c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+	require.Contains(t, c.Env, "P4CLIENTPATH="+cwd)
+}
+
+func TestCWD(t *testing.T) {
+	ctx := context.Background()
+	homeDir, cwd := t.TempDir(), t.TempDir()
+
+	var opts []P4OptionFunc
+	c := NewBaseCommand(ctx, homeDir, cwd, opts...).Unwrap()
+
+	require.Equal(t, cwd, c.Dir)
+}


### PR DESCRIPTION
This PR introduces an abstraction in the `cmd/gitserver/internal/perforce` package that controls how perforce commands are instructed. A new API, `perforce.NewBaseCommand` encapsulates the construction of the `exec.Cmd` for the `p4` cli so that people are generally prevented from accessing the underlying `exec.Cmd` fields.

See https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1706747362767739?thread_ts=1705621787.809159&cid=C05EMJM2SLR for more context on this change.

## Test plan

Some rote CI tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
