### PR TITLE
gitsever: use NewBaseCommand utility in internal/perforce package

### DIFF
--- a/cmd/gitserver/internal/p4exec.go
+++ b/cmd/gitserver/internal/p4exec.go
@@ -66,7 +66,7 @@ func (gs *grpcServer) P4Exec(req *proto.P4ExecRequest, ss proto.GitserverService
 	)
 
 	// Make sure credentials are valid before heavier operation
-	err = perforce.P4TestWithTrust(ss.Context(), p4home, req.GetP4Port(), req.GetP4User(), req.GetP4Passwd()) //nolint:staticcheck
+	err = perforce.P4TestWithTrust(ss.Context(), gs.reposDir, p4home, req.GetP4Port(), req.GetP4User(), req.GetP4Passwd()) //nolint:staticcheck
 	if err != nil {
 		if ctxErr := ss.Context().Err(); ctxErr != nil {
 			return status.FromContextError(ctxErr).Err()

--- a/cmd/gitserver/internal/patch.go
+++ b/cmd/gitserver/internal/patch.go
@@ -449,7 +449,7 @@ func (s *Server) shelveChangelist(ctx context.Context, req protocol.CreateCommit
 	}
 
 	// check to see if there's a changelist for this target branch already
-	cl, err := perforce.GetChangelistByClient(ctx, p4port, p4user, p4passwd, tmpClientDir, p4client)
+	cl, err := perforce.GetChangelistByClient(ctx, p4home, p4port, p4user, p4passwd, tmpClientDir, p4client)
 	if err == nil && cl.ID != "" {
 		return cl.ID, nil
 	}

--- a/cmd/gitserver/internal/perforce/BUILD.bazel
+++ b/cmd/gitserver/internal/perforce/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//cmd/gitserver/internal/common",
         "//cmd/gitserver/internal/executil",
+        "//cmd/gitserver/internal/gitserverfs",
         "//internal/api",
         "//internal/byteutils",
         "//internal/conf",

--- a/cmd/gitserver/internal/perforce/cloneable.go
+++ b/cmd/gitserver/internal/perforce/cloneable.go
@@ -7,9 +7,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func IsDepotPathCloneable(ctx context.Context, p4home, p4port, p4user, p4passwd, depotPath string) error {
+func IsDepotPathCloneable(ctx context.Context, reposDir, p4home, p4port, p4user, p4passwd, depotPath string) error {
 	// start with a test and set up trust if necessary
-	if err := P4TestWithTrust(ctx, p4home, p4port, p4user, p4passwd); err != nil {
+	if err := P4TestWithTrust(ctx, reposDir, p4home, p4port, p4user, p4passwd); err != nil {
 		return errors.Wrap(err, "checking perforce credentials")
 	}
 
@@ -22,7 +22,7 @@ func IsDepotPathCloneable(ctx context.Context, p4home, p4port, p4user, p4passwd,
 	depot := strings.Split(strings.TrimLeft(depotPath, "/"), "/")[0]
 
 	// get a list of depots that match the supplied depot (if it's defined)
-	depots, err := P4Depots(ctx, p4home, p4port, p4user, p4passwd, depot)
+	depots, err := P4Depots(ctx, reposDir, p4home, p4port, p4user, p4passwd, depot)
 	if err != nil {
 		return err
 	}

--- a/cmd/gitserver/internal/perforce/groups.go
+++ b/cmd/gitserver/internal/perforce/groups.go
@@ -4,34 +4,37 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/gitserverfs"
 	"os"
-	"os/exec"
-
-	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/executil"
-	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 // P4GroupMembers returns all usernames that are members of the given group.
-func P4GroupMembers(ctx context.Context, p4home, p4port, p4user, p4passwd, group string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, "p4", "-Mj", "-ztag", "group", "-o", group)
-	cmd.Env = append(os.Environ(),
-		"P4PORT="+p4port,
-		"P4USER="+p4user,
-		"P4PASSWD="+p4passwd,
-		"HOME="+p4home,
-	)
+func P4GroupMembers(ctx context.Context, reposDir, p4home, p4port, p4user, p4passwd, group string) ([]string, error) {
+	options := []P4OptionFunc{
+		WithAuthentication(p4user, p4passwd),
+		WithHost(p4port),
+	}
 
-	out, err := executil.RunCommandCombinedOutput(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd))
+	options = append(options, WithArguments("-Mj", "-ztag", "group", "-o", group))
+
+	scratchDir, err := gitserverfs.TempDir(reposDir, "p4-group-")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create temp dir to invoke 'p4 group'")
+	}
+	defer os.Remove(scratchDir)
+
+	cmd := NewBaseCommand(ctx, p4home, scratchDir, options...)
+	out, err := executil.RunCommandCombinedOutput(ctx, cmd)
 	if err != nil {
 		if ctxerr := ctx.Err(); ctxerr != nil {
 			err = errors.Wrap(ctxerr, "p4 group context error")
 		}
 
 		if len(out) > 0 {
-			err = errors.Wrapf(err, `failed to run command "p4 group" (output follows)\n\n%s`, specifyCommandInErrorMessage(string(out), cmd))
+			err = errors.Wrapf(err, `failed to run command "p4 group" (output follows)\n\n%s`, specifyCommandInErrorMessage(string(out), cmd.Unwrap()))
 		}
 
 		return nil, err

--- a/cmd/gitserver/internal/perforce/users.go
+++ b/cmd/gitserver/internal/perforce/users.go
@@ -3,35 +3,37 @@ package perforce
 import (
 	"context"
 	"encoding/json"
-	"os"
-	"os/exec"
-
-	"github.com/sourcegraph/log"
-
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/executil"
+	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/gitserverfs"
 	"github.com/sourcegraph/sourcegraph/internal/byteutils"
 	"github.com/sourcegraph/sourcegraph/internal/perforce"
-	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"os"
 )
 
 // P4Users returns all of users known to the Perforce server.
-func P4Users(ctx context.Context, p4home, p4port, p4user, p4passwd string) ([]perforce.User, error) {
-	cmd := exec.CommandContext(ctx, "p4", "-Mj", "-ztag", "users")
-	cmd.Env = append(os.Environ(),
-		"P4PORT="+p4port,
-		"P4USER="+p4user,
-		"P4PASSWD="+p4passwd,
-		"HOME="+p4home,
-	)
+func P4Users(ctx context.Context, reposDir, p4home, p4port, p4user, p4passwd string) ([]perforce.User, error) {
+	options := []P4OptionFunc{
+		WithAuthentication(p4user, p4passwd),
+		WithHost(p4port),
+	}
 
-	out, err := executil.RunCommandCombinedOutput(ctx, wrexec.Wrap(ctx, log.NoOp(), cmd))
+	options = append(options, WithArguments("-Mj", "-ztag", "users"))
+
+	scratchDir, err := gitserverfs.TempDir(reposDir, "p4-users-")
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create temp dir to invoke 'p4 users'")
+	}
+	defer os.Remove(scratchDir)
+
+	cmd := NewBaseCommand(ctx, p4home, scratchDir, options...)
+	out, err := executil.RunCommandCombinedOutput(ctx, cmd)
 	if err != nil {
 		if ctxerr := ctx.Err(); ctxerr != nil {
 			err = errors.Wrap(ctxerr, "p4 users context error")
 		}
 		if len(out) > 0 {
-			err = errors.Wrapf(err, `failed to run command "p4 users" (output follows)\n\n%s`, specifyCommandInErrorMessage(string(out), cmd))
+			err = errors.Wrapf(err, `failed to run command "p4 users" (output follows)\n\n%s`, specifyCommandInErrorMessage(string(out), cmd.Unwrap()))
 		}
 		return nil, err
 	}

--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -437,7 +437,7 @@ func (gs *grpcServer) IsPerforcePathCloneable(ctx context.Context, req *proto.Is
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.IsDepotPathCloneable(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.DepotPath)
+	err = perforce.IsDepotPathCloneable(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.DepotPath)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
@@ -452,7 +452,7 @@ func (gs *grpcServer) CheckPerforceCredentials(ctx context.Context, req *proto.C
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -471,7 +471,7 @@ func (gs *grpcServer) PerforceUsers(ctx context.Context, req *proto.PerforceUser
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -487,7 +487,7 @@ func (gs *grpcServer) PerforceUsers(ctx context.Context, req *proto.PerforceUser
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	users, err := perforce.P4Users(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	users, err := perforce.P4Users(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -510,7 +510,7 @@ func (gs *grpcServer) PerforceProtectsForUser(ctx context.Context, req *proto.Pe
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -526,7 +526,7 @@ func (gs *grpcServer) PerforceProtectsForUser(ctx context.Context, req *proto.Pe
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	protects, err := perforce.P4ProtectsForUser(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetUsername())
+	protects, err := perforce.P4ProtectsForUser(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetUsername())
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +548,7 @@ func (gs *grpcServer) PerforceProtectsForDepot(ctx context.Context, req *proto.P
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -564,7 +564,7 @@ func (gs *grpcServer) PerforceProtectsForDepot(ctx context.Context, req *proto.P
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	protects, err := perforce.P4ProtectsForDepot(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetDepot())
+	protects, err := perforce.P4ProtectsForDepot(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetDepot())
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func (gs *grpcServer) PerforceGroupMembers(ctx context.Context, req *proto.Perfo
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -602,7 +602,7 @@ func (gs *grpcServer) PerforceGroupMembers(ctx context.Context, req *proto.Perfo
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	members, err := perforce.P4GroupMembers(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetGroup())
+	members, err := perforce.P4GroupMembers(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetGroup())
 	if err != nil {
 		return nil, err
 	}
@@ -619,7 +619,7 @@ func (gs *grpcServer) IsPerforceSuperUser(ctx context.Context, req *proto.IsPerf
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -628,7 +628,7 @@ func (gs *grpcServer) IsPerforceSuperUser(ctx context.Context, req *proto.IsPerf
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	err = perforce.P4UserIsSuperUser(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4UserIsSuperUser(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -651,7 +651,7 @@ func (gs *grpcServer) PerforceGetChangelist(ctx context.Context, req *proto.Perf
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -667,7 +667,7 @@ func (gs *grpcServer) PerforceGetChangelist(ctx context.Context, req *proto.Perf
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	changelist, err := perforce.GetChangelistByID(ctx, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetChangelistId())
+	changelist, err := perforce.GetChangelistByID(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetChangelistId())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gitserver/internal/vcssyncer/syncer.go
+++ b/cmd/gitserver/internal/vcssyncer/syncer.go
@@ -120,7 +120,7 @@ func NewVCSSyncer(ctx context.Context, opts *NewVCSSyncerOpts) (VCSSyncer, error
 			return nil, err
 		}
 
-		return NewPerforceDepotSyncer(opts.Logger, opts.RecordingCommandFactory, &c, p4Home), nil
+		return NewPerforceDepotSyncer(opts.Logger, opts.RecordingCommandFactory, &c, opts.ReposDir, p4Home), nil
 	case extsvc.TypeJVMPackages:
 		var c schema.JVMPackagesConnection
 		if _, err := extractOptions(&c); err != nil {


### PR DESCRIPTION
This PR uses the `perforce.NewBaseCommand` utility introduced https://github.com/sourcegraph/sourcegraph/pull/59997 throughout the rest of the `internal/perforce` package.

## Test plan

Existing tests in CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
