### PR TITLE
msp/cloudsql: make max_connections configurable

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -607,6 +607,8 @@ type EnvironmentResourcePostgreSQLSpec struct {
 	// Defaults to 4 (to meet CloudSQL minimum). You must request 0.9 to 6.5 GB
 	// per vCPU.
 	MemoryGB *int `yaml:"memoryGB,omitempty"`
+	// Defaults to whatever CloudSQL provides. Must be between 14 and 262143.
+	MaxConnections *int `yaml:"maxConnections,omitempty"`
 }
 
 func (EnvironmentResourcePostgreSQLSpec) ResourceKind() string { return "PostgreSQL instance" }


### PR DESCRIPTION
In SAMS we are exploring horizontal scaling options, and naturally this requires higher database connections. In the future maybe we can intelligently configure this based on Cloud Run scaling configurations.

## Test plan

Click-ops the increase