### PR TITLE
msp/cloudrun: expose execution environment

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -325,6 +325,10 @@ type EnvironmentInstancesResourcesSpec struct {
 	// Memory specifies the memory available to each instance. Must be between
 	// 512MiB and 32GiB.
 	Memory string `yaml:"memory"`
+	// CloudRunGeneration is either 1 or 2, corresponding to the generations
+	// outlined in https://cloud.google.com/run/docs/about-execution-environments.
+	// By default, we use the Cloud Run default.
+	CloudRunGeneration *int
 }
 
 func (s *EnvironmentInstancesResourcesSpec) Validate() []error {

--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
@@ -98,6 +98,16 @@ func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variable
 		vars.Environment.Instances.Scaling = &spec.EnvironmentInstancesScalingSpec{}
 	}
 
+	var executionEnvironment *string
+	if generation := vars.Environment.Instances.Resources.CloudRunGeneration; generation != nil {
+		switch *generation {
+		case 1:
+			executionEnvironment = pointers.Ptr("EXECUTION_ENVIRONMENT_GEN1")
+		case 2:
+			executionEnvironment = pointers.Ptr("EXECUTION_ENVIRONMENT_GEN2")
+		}
+	}
+
 	name, err := vars.Name()
 	if err != nil {
 		return nil, err
@@ -144,6 +154,7 @@ func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variable
 				MaxInstanceCount: pointers.Float64(
 					pointers.Deref(vars.Environment.Instances.Scaling.MaxCount, builder.DefaultMaxInstances)),
 			},
+			ExecutionEnvironment: executionEnvironment,
 
 			// Configuration for the single service container.
 			Containers: []*cloudrunv2service.CloudRunV2ServiceTemplateContainers{{


### PR DESCRIPTION
SAMS is _very_ compute-heavy it turns out, so we want to be able to use the 2nd-generation Cloud Run environment: https://cloud.google.com/run/docs/about-execution-environments

## Test plan

n/a