### PR TITLE
cmd/gitserver/internal/vcssyncer/perforce.go: set P4CLIENTPATH environment variable for git p4 invocations

### DIFF
--- a/cmd/gitserver/internal/vcssyncer/perforce_test.go
+++ b/cmd/gitserver/internal/vcssyncer/perforce_test.go
@@ -16,7 +16,9 @@ func TestP4DepotSyncer_p4CommandEnv(t *testing.T) {
 		P4Client:                "client",
 		P4Home:                  "p4home",
 	}
-	vars := syncer.p4CommandEnv("host", "username", "password")
+
+	cwd := t.TempDir()
+	vars := syncer.p4CommandEnv(cwd, "host", "username", "password")
 	assertEnv := func(key, value string) {
 		var match string
 		for _, s := range vars {
@@ -44,4 +46,5 @@ func TestP4DepotSyncer_p4CommandEnv(t *testing.T) {
 	assertEnv("P4PORT", "host")
 	assertEnv("P4USER", "username")
 	assertEnv("P4PASSWD", "password")
+	assertEnv("P4CLIENTPATH", cwd)
 }


### PR DESCRIPTION
This PR sets the P4CLIENTPATH environment variable for `git p4` invocations. Since we should be soon switching to p4-fusion anyway, I decided to not expand the `perforce.NewBaseCommand` command to add a `git p4` equivalent. 

See https://sourcegraph.slack.com/archives/C05EMJM2SLR/p1706747362767739?thread_ts=1705621787.809159&cid=C05EMJM2SLR for more context.


## Test plan

CI

