### PR TITLE
code-search: update new global navigation bar to conform to navbar update

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -226,6 +226,7 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                 <>
                     {newSearchNavigation ? (
                         <NewGlobalNavigationBar
+                            routes={props.routes}
                             showSearchBox={showNavigationSearchBox}
                             authenticatedUser={props.authenticatedUser}
                             isSourcegraphDotCom={props.isSourcegraphDotCom}

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`GlobalNavbar > code search only license 1`] = `
         >
           <a
             class="link"
-            href="/cody/chat"
+            href="/cody"
           >
             <span
               class="linkContent"
@@ -235,7 +235,7 @@ exports[`GlobalNavbar > cody only license 1`] = `
         >
           <a
             class="link"
-            href="/cody/chat"
+            href="/cody"
           >
             <span
               class="linkContent"
@@ -384,7 +384,7 @@ exports[`GlobalNavbar > default 1`] = `
         >
           <a
             class="link"
-            href="/cody/chat"
+            href="/cody"
           >
             <span
               class="linkContent"

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
@@ -1,11 +1,11 @@
-import { Decorator, Meta, StoryFn } from '@storybook/react'
+import type { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { updateJSContextBatchChangesLicense } from '@sourcegraph/shared/src/testing/batches'
 
-import { AuthenticatedUser } from '../../auth'
+import type { AuthenticatedUser } from '../../auth'
 import { WebStory } from '../../components/WebStory'
-import { GlobalNavbar, GlobalNavbarProps } from '../GlobalNavbar'
+import type { GlobalNavbar, GlobalNavbarProps } from '../GlobalNavbar'
 
 import { NewGlobalNavigationBar } from './NewGlobalNavigationBar'
 
@@ -24,6 +24,7 @@ export default config
 
 export const NewGlobalNavigationBarDemo: StoryFn = () => (
     <NewGlobalNavigationBar
+        routes={[]}
         isSourcegraphDotCom={true}
         ownEnabled={true}
         notebooksEnabled={true}

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -1,10 +1,10 @@
-import { FC, useCallback, useState, ComponentType, PropsWithChildren } from 'react'
+import { type FC, useCallback, useState, type ComponentType, type PropsWithChildren } from 'react'
 
 import { mdiClose, mdiMenu } from '@mdi/js'
 import classNames from 'classnames'
 import BarChartIcon from 'mdi-react/BarChartIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
-import { NavLink, RouteObject, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
+import { NavLink, type RouteObject, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import shallow from 'zustand/shallow'
 
 import { LegacyToggles } from '@sourcegraph/branded'
@@ -66,7 +66,6 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
     } = props
 
     const isLightTheme = useIsLightTheme()
-    const location = useLocation()
     const [params] = useSearchParams()
     const [isSideMenuOpen, setSideMenuOpen] = useState(false)
     const routeMatch = useRoutesMatch(props.routes)

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -145,6 +145,7 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
                     showBatchChanges={showBatchChanges}
                     showCodeInsights={showCodeInsights}
                     isSourcegraphDotCom={isSourcegraphDotCom}
+                    authenticatedUser={authenticatedUser}
                     onClose={() => setSideMenuOpen(false)}
                 />
             )}
@@ -307,6 +308,7 @@ interface SidebarNavigationProps {
     showBatchChanges: boolean
     showCodeInsights: boolean
     onClose: () => void
+    authenticatedUser: AuthenticatedUser | null
 }
 
 const SidebarNavigation: FC<SidebarNavigationProps> = props => {
@@ -320,6 +322,7 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
         showBatchChanges,
         showCodeInsights,
         isSourcegraphDotCom,
+        authenticatedUser,
         onClose,
     } = props
 
@@ -389,11 +392,13 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
                         Cody AI
                     </NavItemLink>
 
-                    <ul className={classNames(styles.sidebarNavigationList, styles.sidebarNavigationListNested)}>
-                        <NavItemLink url={PageRoutes.CodyChat} onClick={handleNavigationClick}>
-                            Web Chat
-                        </NavItemLink>
-                    </ul>
+                    {authenticatedUser && (
+                        <ul className={classNames(styles.sidebarNavigationList, styles.sidebarNavigationListNested)}>
+                            <NavItemLink url={PageRoutes.CodyChat} onClick={handleNavigationClick}>
+                                Web Chat
+                            </NavItemLink>
+                        </ul>
+                    )}
 
                     {showBatchChanges && (
                         <NavItemLink url="/batch-changes" icon={BatchChangesIconNav} onClick={handleNavigationClick}>

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -3,25 +3,24 @@ import { FC, useCallback, useState, ComponentType, PropsWithChildren } from 'rea
 import { mdiClose, mdiMenu } from '@mdi/js'
 import classNames from 'classnames'
 import BarChartIcon from 'mdi-react/BarChartIcon'
-import BookOutlineIcon from 'mdi-react/BookOutlineIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
-import { NavLink, useLocation, useNavigate } from 'react-router-dom'
+import { NavLink, RouteObject, useLocation, useNavigate } from 'react-router-dom'
 import shallow from 'zustand/shallow'
 
 import { LegacyToggles } from '@sourcegraph/branded'
 import { Toggles } from '@sourcegraph/branded/src/search-ui/input/toggles/Toggles'
-import { SearchQueryState, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
-import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import type { SearchQueryState, SubmitSearchParameters } from '@sourcegraph/shared/src/search'
+import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Text, Icon, Button, Modal, Link, ProductStatusBadge, ButtonLink } from '@sourcegraph/wildcard'
 
-import { AuthenticatedUser } from '../../auth'
+import type { AuthenticatedUser } from '../../auth'
 import { BatchChangesIconNav } from '../../batches/icons'
-import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { CodyLogo } from '../../cody/components/CodyLogo'
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { DeveloperSettingsGlobalNavItem } from '../../devsettings/DeveloperSettingsGlobalNavItem'
 import { useFeatureFlag, useKeywordSearch } from '../../featureFlags/useFeatureFlag'
+import { useRoutesMatch } from '../../hooks'
 import { PageRoutes } from '../../routes.constants'
 import { isSearchJobsEnabled } from '../../search-jobs/utility'
 import { LazyV2SearchInput } from '../../search/input/LazyV2SearchInput'
@@ -43,6 +42,7 @@ interface NewGlobalNavigationBar extends TelemetryProps {
     showSearchBox: boolean
     selectedSearchContextSpec?: string
     showFeedbackModal: () => void
+    routes: RouteObject[]
 }
 
 /**
@@ -67,6 +67,7 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
 
     const isLightTheme = useIsLightTheme()
     const [isSideMenuOpen, setSideMenuOpen] = useState(false)
+    const routeMatch = useRoutesMatch(props.routes)
 
     // Features enablement flags and conditions
     const isLicensed = !!window.context?.licenseInfo
@@ -107,7 +108,7 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
                         showSearchContext={showSearchContext}
                         showOwn={showOwn}
                         showCodySearch={showCodySearch}
-                        showCodyDropdown={false}
+                        authenticatedUser={authenticatedUser}
                         showSearchJobs={showSearchJobs}
                         showSearchNotebook={showSearchNotebook}
                         showCodeMonitoring={showCodeMonitoring}
@@ -115,6 +116,7 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
                         showCodeInsights={showCodeInsights}
                         isSourcegraphDotCom={isSourcegraphDotCom}
                         className={styles.inlineNavigationList}
+                        routeMatch={routeMatch}
                     />
                 )}
 
@@ -359,6 +361,17 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
                                 </NavItemLink>
                             )}
                             {showOwn && <NavItemLink url={PageRoutes.Own}>Code ownership</NavItemLink>}
+                            {showSearchNotebook && (
+                                <NavItemLink url={PageRoutes.Notebooks} onClick={handleNavigationClick}>
+                                    Notebooks
+                                </NavItemLink>
+                            )}
+
+                            {showCodeMonitoring && (
+                                <NavItemLink url="/code-monitoring" onClick={handleNavigationClick}>
+                                    Code Monitoring
+                                </NavItemLink>
+                            )}
                             {showCodySearch && (
                                 <NavItemLink url={PageRoutes.CodySearch} onClick={handleNavigationClick}>
                                     Natural language search <ProductStatusBadge status="experimental" />
@@ -372,21 +385,15 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
                         </ul>
                     </li>
 
-                    <NavItemLink url={PageRoutes.CodyChat} icon={CodyLogo} onClick={handleNavigationClick}>
-                        Cody
+                    <NavItemLink url={PageRoutes.Cody} icon={CodyLogo} onClick={handleNavigationClick}>
+                        Cody AI
                     </NavItemLink>
 
-                    {showSearchNotebook && (
-                        <NavItemLink url={PageRoutes.Notebooks} icon={BookOutlineIcon} onClick={handleNavigationClick}>
-                            Notebooks
+                    <ul className={classNames(styles.sidebarNavigationList, styles.sidebarNavigationListNested)}>
+                        <NavItemLink url={PageRoutes.CodyChat} onClick={handleNavigationClick}>
+                            Web Chat
                         </NavItemLink>
-                    )}
-
-                    {showCodeMonitoring && (
-                        <NavItemLink url="/code-monitoring" icon={CodeMonitoringLogo} onClick={handleNavigationClick}>
-                            Code Monitoring
-                        </NavItemLink>
-                    )}
+                    </ul>
 
                     {showBatchChanges && (
                         <NavItemLink url="/batch-changes" icon={BatchChangesIconNav} onClick={handleNavigationClick}>

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -4,7 +4,7 @@ import { mdiClose, mdiMenu } from '@mdi/js'
 import classNames from 'classnames'
 import BarChartIcon from 'mdi-react/BarChartIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
-import { NavLink, RouteObject, useLocation, useNavigate } from 'react-router-dom'
+import { NavLink, RouteObject, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import shallow from 'zustand/shallow'
 
 import { LegacyToggles } from '@sourcegraph/branded'
@@ -66,6 +66,8 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
     } = props
 
     const isLightTheme = useIsLightTheme()
+    const location = useLocation()
+    const [params] = useSearchParams()
     const [isSideMenuOpen, setSideMenuOpen] = useState(false)
     const routeMatch = useRoutesMatch(props.routes)
 
@@ -79,18 +81,23 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
     const showCodeMonitoring = codeMonitoringEnabled && !isSourcegraphDotCom
     const showBatchChanges = batchChangesEnabled && isLicensed && !isSourcegraphDotCom
     const showCodeInsights = codeInsightsEnabled && !isSourcegraphDotCom
+    // We only show the hamburger icon on a repo page and search results page
+    const showHamburger =
+        routeMatch === PageRoutes.RepoContainer || (routeMatch === PageRoutes.Search && params.get('q'))
 
     return (
         <>
             <nav aria-label="Main" className={styles.nav}>
-                <Button
-                    variant="secondary"
-                    outline={true}
-                    className={styles.menuButton}
-                    onClick={() => setSideMenuOpen(true)}
-                >
-                    <Icon svgPath={mdiMenu} aria-label="Navigation menu" />
-                </Button>
+                {showHamburger && (
+                    <Button
+                        variant="secondary"
+                        outline={true}
+                        className={styles.menuButton}
+                        onClick={() => setSideMenuOpen(true)}
+                    >
+                        <Icon svgPath={mdiMenu} aria-label="Navigation menu" />
+                    </Button>
+                )}
 
                 <NavLink to={PageRoutes.Search}>
                     <BrandLogo variant="symbol" isLightTheme={isLightTheme} className={styles.logo} />


### PR DESCRIPTION
This PR updates the NewGlobalNavigationBar so that it conforms to some of the updates we've been making to the NavBar as regards the licensing work.

![CleanShot 2024-01-30 at 23 55 22](https://github.com/sourcegraph/sourcegraph/assets/25608335/e5797ec4-90c1-4143-b38a-7d2dff62f982)
![CleanShot 2024-01-30 at 23 54 36](https://github.com/sourcegraph/sourcegraph/assets/25608335/fe3885b5-1ea4-4411-a62b-c7790453ce27)


## Test plan

* Manual testing