### PR TITLE
Make SSC SAMS host name configurable

### DIFF
--- a/internal/cody/subscription.go
+++ b/internal/cody/subscription.go
@@ -135,7 +135,7 @@ func getSAMSAccountIDForUser(ctx context.Context, db database.DB, dotcomUserID i
 	oidcAccounts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
 		UserID:      dotcomUserID,
 		ServiceType: "openidconnect",
-		ServiceID:   fmt.Sprintf("https://%s", ssc.SAMSProdHostname),
+		ServiceID:   fmt.Sprintf("https://%s", ssc.GetSAMSHostName()),
 		LimitOffset: &database.LimitOffset{
 			Limit: 1,
 		},

--- a/internal/cody/subscription_test.go
+++ b/internal/cody/subscription_test.go
@@ -299,7 +299,7 @@ func TestGetSubscriptionForUser(t *testing.T) {
 					samsAccountSpec := extsvc.AccountSpec{
 						AccountID:   *test.mockSAMSAccountID,
 						ServiceType: "openidconnect",
-						ServiceID:   fmt.Sprintf("https://%s/", ssc.SAMSProdHostname),
+						ServiceID:   fmt.Sprintf("https://%s/", ssc.GetSAMSHostName()),
 					}
 					return []*extsvc.Account{
 						{

--- a/internal/ssc/ssc.go
+++ b/internal/ssc/ssc.go
@@ -117,6 +117,16 @@ func (c *client) FetchSubscriptionBySAMSAccountID(ctx context.Context, samsAccou
 	}
 }
 
+func GetSAMSHostName() string {
+	sgconf := conf.Get().SiteConfig()
+
+	if sgconf.SscSamsHostName == "" {
+		return SAMSProdHostname
+	}
+
+	return sgconf.SscSamsHostName // [sic] generated code
+}
+
 // NewClient returns a new SSC API client. It is important to avoid creating new
 // API clients if possible, so that it can reuse SAMS access tokens when making
 // requests to SSC. (Otherwise every request would need to create a new token,
@@ -135,7 +145,7 @@ func NewClient() (Client, error) {
 			continue
 		}
 
-		if strings.Contains(oidcInfo.Issuer, SAMSProdHostname) {
+		if strings.Contains(oidcInfo.Issuer, GetSAMSHostName()) {
 			samsConfig = &clientcredentials.Config{
 				ClientID:     oidcInfo.ClientID,
 				ClientSecret: oidcInfo.ClientSecret,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2915,8 +2915,8 @@ type SiteConfiguration struct {
 	SearchLimits *SearchLimits `json:"search.limits,omitempty"`
 	// SscApiBaseUrl description: The base URL of the Self-Serve Cody API.
 	SscApiBaseUrl string `json:"ssc.apiBaseUrl,omitempty"`
-	// SscApiSecret description: The Bearer token for the Self-Serve Cody API.
-	SscApiSecret string `json:"ssc.apiSecret,omitempty"`
+	// SscSamsHostName description: The hostname of SAMS instance to connect.
+	SscSamsHostName string `json:"ssc.samsHostName,omitempty"`
 	// SyntaxHighlighting description: Syntax highlighting configuration
 	SyntaxHighlighting *SyntaxHighlighting `json:"syntaxHighlighting,omitempty"`
 	// UpdateChannel description: The channel on which to automatically check for Sourcegraph updates.
@@ -3090,7 +3090,7 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "search.largeFiles")
 	delete(m, "search.limits")
 	delete(m, "ssc.apiBaseUrl")
-	delete(m, "ssc.apiSecret")
+	delete(m, "ssc.samsHostName")
 	delete(m, "syntaxHighlighting")
 	delete(m, "update.channel")
 	delete(m, "webhook.logging")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -12,10 +12,10 @@
       "default": "https://accounts.sourcegraph.com/cody/api",
       "description": "The base URL of the Self-Serve Cody API."
     },
-    "ssc.apiSecret": {
+    "ssc.samsHostName": {
       "type": "string",
-      "default": "********",
-      "description": "The Bearer token for the Self-Serve Cody API."
+      "default": "accounts.sourcegraph.com",
+      "description": "The hostname of SAMS instance to connect."
     },
     "search.index.symbols.enabled": {
       "description": "Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.",


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/60012

To enable testing, we need to make the SAMS hostname configuration via site config, so that we can connect dotcom staging to sams dev. 

## Test plan
unit tests cover the changes.