### PR TITLE
honeycomb: remove database-batch from emitting to honeycomb

### DIFF
--- a/internal/database/batch/BUILD.bazel
+++ b/internal/database/batch/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//internal/database/basestore",
         "//internal/database/dbconn",
         "//internal/database/dbutil",
-        "//internal/honey",
         "//internal/metrics",
         "//internal/observation",
         "//lib/errors",

--- a/internal/database/batch/observability.go
+++ b/internal/database/batch/observability.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sourcegraph/log"
 
-	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -43,10 +42,7 @@ var (
 
 func getOperations(logger log.Logger) *operations {
 	opsOnce.Do(func() {
-		observationCtx := observation.NewContext(logger, observation.Honeycomb(&honey.Dataset{
-			Name:       "database-batch",
-			SampleRate: 20,
-		}))
+		observationCtx := observation.NewContext(logger)
 
 		ops = newOperations(observationCtx)
 	})


### PR DESCRIPTION
Doesn't appear to be used by anyone anymore, so we can save some quota

## Test plan

N/A
