### PR TITLE
nix: mount /tmp/zig-cache RW in sandbox actions

### DIFF
--- a/dev/nix/shell-hook.sh
+++ b/dev/nix/shell-hook.sh
@@ -45,4 +45,6 @@ build --action_env=PGDATABASE
 build --action_env=PGDATASOURCE
 build --action_env=PGUSER
 build --sandbox_add_mount_pair=/tmp/zig-cache
+build --sandbox_writable_path=/tmp/zig-cache
+build --noincompatible_sandbox_hermetic_tmp
 EOF


### PR DESCRIPTION
Non-hermetic /tmp disabled until we're on bazel 7.0.1
https://github.com/bazelbuild/bazel/issues/20527

## Test plan

`bazel build //:gazelle-buf`
