### PR TITLE
search: revert to single space phrase boosting

### DIFF
--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -644,7 +644,7 @@ func ExperimentalPhraseBoost(logger sglog.Logger, originalQuery string) BasicPas
 			phrase := ""
 			for _, child := range n.Operands {
 				c, isPattern := child.(Pattern)
-				if !isPattern || c.Negated {
+				if !isPattern || c.Negated || c.Annotation.Labels.IsSet(Regexp) {
 					return basic
 				}
 

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"math"
 	"strconv"
 	"strings"
 
@@ -642,42 +641,23 @@ func ExperimentalPhraseBoost(logger sglog.Logger, originalQuery string) BasicPas
 				return basic
 			}
 
-			first := math.MaxInt
-			last := math.MinInt
-			// Check if all operands are patterns and not negated.
+			phrase := ""
 			for _, child := range n.Operands {
 				c, isPattern := child.(Pattern)
 				if !isPattern || c.Negated {
 					return basic
 				}
 
-				if c.Annotation.Range.Start.Column < first {
-					first = c.Annotation.Range.Start.Column
-				}
-
-				if c.Annotation.Range.End.Column > last {
-					last = c.Annotation.Range.End.Column
-				}
+				phrase += c.Value + " "
 			}
-
-			// To get here, we must have found several non-negated patterns. Assuming the
-			// ranges are set correctly, this statement should always be false.
-			if first > last {
-				logger.Error(
-					"encountered invalid range during phrase boost",
-					sglog.Int("first", first),
-					sglog.Int("last", last),
-					sglog.String("query", originalQuery),
-				)
-				return basic
-			}
+			phrase = strings.TrimSpace(phrase)
 
 			basic.Pattern = Operator{
 				Kind: Or,
 				Operands: []Node{
 					Pattern{
-						Value:      originalQuery[first:last],
-						Annotation: Annotation{Labels: Boost},
+						Value:      phrase,
+						Annotation: Annotation{Labels: Boost | Literal | QuotesAsLiterals | Standard},
 					},
 					n,
 				},

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -23,11 +23,8 @@ func TestExperimentalPhraseBoost(t *testing.T) {
 
 	// expect phrase query
 	autogold.Expect(`(or "foo bar bas" (and "foo" "bar" "bas"))`).Equal(t, test("foo bar bas", SearchTypeKeyword))
-
-	// respect whitespace
-	autogold.Expect(`(or "foo   bar  bas" (and "foo" "bar" "bas"))`).Equal(t, test("foo   bar  bas", SearchTypeKeyword))
-	autogold.Expect(`(or "foo\tbar:  bas" (and "foo" "bar:" "bas"))`).Equal(t, test("foo\tbar:  bas ", SearchTypeKeyword))
-	autogold.Expect(`(or "いい お天気 です" (and "いい" "お天気" "です"))`).Equal(t, test("いい お天気 です", SearchTypeKeyword))
+	autogold.Expect(`(or "foo bar bas" (and "foo" "bar" "bas"))`).Equal(t, test("(foo and bar) and bas", SearchTypeKeyword))
+	autogold.Expect(`(or "* int func(" (and "*" "int" "func("))`).Equal(t, test("* int func(", SearchTypeKeyword))
 
 	// expect no phrase query
 	autogold.Expect(`"foo"`).Equal(t, test("foo", SearchTypeKeyword))

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -25,8 +25,11 @@ func TestExperimentalPhraseBoost(t *testing.T) {
 	autogold.Expect(`(or "foo bar bas" (and "foo" "bar" "bas"))`).Equal(t, test("foo bar bas", SearchTypeKeyword))
 	autogold.Expect(`(or "foo bar bas" (and "foo" "bar" "bas"))`).Equal(t, test("(foo and bar) and bas", SearchTypeKeyword))
 	autogold.Expect(`(or "* int func(" (and "*" "int" "func("))`).Equal(t, test("* int func(", SearchTypeKeyword))
+	autogold.Expect(`(or "foo bar bas qux" (and "foo bar" "bas" "qux"))`).Equal(t, test(`"foo bar" bas qux`, SearchTypeKeyword))
 
 	// expect no phrase query
+	autogold.Expect(`"foo bar bas"`).Equal(t, test("/foo bar bas/", SearchTypeKeyword))
+	autogold.Expect(`(and "foo" "bar" "ba.*")`).Equal(t, test("foo bar /ba.*/", SearchTypeKeyword))
 	autogold.Expect(`"foo"`).Equal(t, test("foo", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" "bar")`).Equal(t, test("foo bar", SearchTypeKeyword))
 	autogold.Expect(`(and "foo" "bar")`).Equal(t, test("foo and bar", SearchTypeKeyword))


### PR DESCRIPTION
Relates to #59974

We revert the logic to a much simpler join by " ".

During manual testing we noticed that queries that include reserved keywords, such as `(foo and bar) and bas` led to undesired phrase queries. For the case of `(foo and bar) and bas` we would search the phrase `foo and bar) and bas`. In hindsight this is an obvious flaw of using the character range of the terms from the original query. 

I also fix another bug which was caused by missing parser flags. Essentially, the missing flags led to parser errors if specials characters were used in the phrase.

Test plan:
- updated unit test
- I tested manually queries such "* func = Function" or "(foo and bar) and bas" and confirmed the results are as expected. 