### PR TITLE
Keyword search: add feedback modal

### DIFF
--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.module.scss
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.module.scss
@@ -80,6 +80,12 @@
     max-width: 20rem;
 }
 
+.feedback-button {
+    color: var(--link-color);
+    padding: 0;
+    margin: 0;
+}
+
 .cody-feedback-alert {
     overflow: unset;
 }

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
@@ -2,7 +2,7 @@ import { FC, useCallback, useMemo, useRef, useState } from 'react'
 
 import { mdiChevronDoubleDown, mdiChevronDoubleUp, mdiOpenInNew, mdiThumbDown, mdiThumbUp } from '@mdi/js'
 import classNames from 'classnames'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useMatches, useNavigate } from 'react-router-dom'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
@@ -15,6 +15,7 @@ import {
     Alert,
     Button,
     createRectangle,
+    FeedbackPrompt,
     H3,
     Icon,
     Link,
@@ -32,6 +33,7 @@ import {
     NO_ACCESS_BATCH_CHANGES_WRITE,
     NO_ACCESS_SOURCEGRAPH_COM,
 } from '../../../../batches/utils'
+import { useHandleSubmitFeedback, useRoutesMatch } from '../../../../hooks'
 import { SavedSearchModal } from '../../../../savedSearches/SavedSearchModal'
 import { eventLogger } from '../../../../tracking/eventLogger'
 import { DOTCOM_URL } from '../../../../tracking/util'
@@ -210,6 +212,14 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
         onTogglePatternType(patternType)
     }, [onTogglePatternType, patternType, telemetryService])
 
+    const [feedbackModalOpen, setFeedbackModalOpen] = useState(false)
+
+    const routeMatches = useMatches()
+    const { handleSubmitFeedback } = useHandleSubmitFeedback({
+        routeMatch: routeMatches && routeMatches.length > 0 ? routeMatches.at(-1)!.pathname : undefined,
+        textPrefix: '[Source: keyword search] ',
+    })
+
     return (
         <aside
             role="region"
@@ -217,6 +227,22 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
             className={classNames(props.className, styles.searchResultsInfoBar)}
             data-testid="results-info-bar"
         >
+            {feedbackModalOpen ? (
+                <FeedbackPrompt
+                    onSubmit={handleSubmitFeedback}
+                    modal={true}
+                    openByDefault={true}
+                    authenticatedUser={
+                        props.authenticatedUser
+                            ? {
+                                  username: props.authenticatedUser.username || '',
+                                  email: props.authenticatedUser.emails.find(email => email.isPrimary)?.email || '',
+                              }
+                            : null
+                    }
+                    onClose={() => setFeedbackModalOpen(false)}
+                />
+            ) : null}
             {refFromCodySearch && codySearchInput.input && codySearchInput.translatedQuery === props.query ? (
                 <Alert variant="info" className={styles.codyFeedbackAlert}>
                     Sourcegraph converted "<strong>{codySearchInput.input}</strong>" to "
@@ -302,6 +328,7 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
                                         </Link>{' '}
                                         to learn more.
                                     </Text>
+                                    <Button onClick={() => setFeedbackModalOpen(true)}>Send feedback</Button>
                                 </div>
                             </PopoverContent>
                         </Popover>

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
@@ -328,7 +328,12 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
                                         </Link>{' '}
                                         to learn more.
                                     </Text>
-                                    <Button onClick={() => setFeedbackModalOpen(true)}>Send feedback</Button>
+                                    <Button
+                                        className={styles.feedbackButton}
+                                        onClick={() => setFeedbackModalOpen(true)}
+                                    >
+                                        Send feedback
+                                    </Button>
                                 </div>
                             </PopoverContent>
                         </Popover>

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
@@ -33,7 +33,7 @@ import {
     NO_ACCESS_BATCH_CHANGES_WRITE,
     NO_ACCESS_SOURCEGRAPH_COM,
 } from '../../../../batches/utils'
-import { useHandleSubmitFeedback, useRoutesMatch } from '../../../../hooks'
+import { useHandleSubmitFeedback } from '../../../../hooks'
 import { SavedSearchModal } from '../../../../savedSearches/SavedSearchModal'
 import { eventLogger } from '../../../../tracking/eventLogger'
 import { DOTCOM_URL } from '../../../../tracking/util'

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
@@ -2,7 +2,7 @@ import { FC, useCallback, useMemo, useRef, useState } from 'react'
 
 import { mdiChevronDoubleDown, mdiChevronDoubleUp, mdiOpenInNew, mdiThumbDown, mdiThumbUp } from '@mdi/js'
 import classNames from 'classnames'
-import { useLocation, useMatches, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
@@ -214,9 +214,8 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
 
     const [feedbackModalOpen, setFeedbackModalOpen] = useState(false)
 
-    const routeMatches = useMatches()
     const { handleSubmitFeedback } = useHandleSubmitFeedback({
-        routeMatch: routeMatches && routeMatches.length > 0 ? routeMatches.at(-1)!.pathname : undefined,
+        routeMatch: location.pathname,
         textPrefix: '[Source: keyword search] ',
     })
 


### PR DESCRIPTION
This PR adds a "Send feedback" button to the keyword search popover that pulls
up our feedback modal. It prefixes the feedback with "[Source: keyword search]"
so we know it's about keyword search.

## Test plan

Manual testing