### PR TITLE
msp-example: use version.Version for more interesting images

### DIFF
--- a/cmd/msp-example/internal/example/BUILD.bazel
+++ b/cmd/msp-example/internal/example/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//lib/managedservicesplatform/example:__subpackages__",
     ],
     deps = [
+        "//internal/version",
         "//lib/background",
         "//lib/errors",
         "//lib/managedservicesplatform/runtime",

--- a/cmd/msp-example/internal/example/example.go
+++ b/cmd/msp-example/internal/example/example.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/version"
 	"github.com/sourcegraph/sourcegraph/lib/background"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 	"github.com/sourcegraph/sourcegraph/lib/managedservicesplatform/runtime"
@@ -28,7 +29,7 @@ type Service struct{}
 var _ runtime.Service[Config] = Service{}
 
 func (s Service) Name() string    { return "example" }
-func (s Service) Version() string { return "dev" }
+func (s Service) Version() string { return version.Version() }
 func (s Service) Initialize(
 	ctx context.Context,
 	logger log.Logger,


### PR DESCRIPTION
Otherwise, it seems all our images are the same. Having a diff makes it easier to test deploying changes, e.g. #59956 

## Test plan

Builds locally