### PR TITLE
Use long lived oauth2.TokenSource, not http.Client

### DIFF
--- a/internal/ssc/BUILD.bazel
+++ b/internal/ssc/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//internal/trace",
         "//lib/errors",
         "@io_opentelemetry_go_otel//attribute",
+        "@org_golang_x_oauth2//:oauth2",
         "@org_golang_x_oauth2//clientcredentials",
     ],
 )


### PR DESCRIPTION
When we wrote the code for `ssc.client`, we wanted to use an existing OAuth library to automate reissuing access tokens when they expire. So we would only need to generate a new SAMS access token every hour or so, rather than on every request.

I had thought that the `*http.Client` returned from `clientcredentials.Config::Client(...)` would do just that. However, in practice that did not appear to be the case. (The HTTP client was returning tokens that had long expired, i.e. not refreshing them when needed.)

After looking closer at the source code, a few things stood out. For example, by having the `*http.Client` be long lived, it runs afoul of the doc comment on top of `oauth2.NewClient` (which `client credentials.Config::Client` calls).

> The returned client is not valid beyond the lifetime of the context.

So this PR adjusts things to instead only `clientcredentials.Config::TokenSource(context.Background())` function. This will create a reusable token source that will generate new tokens on-demand. (via `client credentials.tokenSource::Token`.)

This still doesn't quite explain why `clientcredentials.Config::Client` wasn't working in the first place, but conceptually this makes a little more sense. As the "long lived thing" is only the `TokenSource`, and not the `*http.Client`. (That seems like an improvement because there are a lot more nuances to how the `http.Client` and its `Transport` and connections are all handled... 🤷 )

## Test plan

I don't have my local machine configured to run Sourcegraph locally, or this integration point with SAMS/SSC. So regrettably, the test plan is "check it in, and try this out on https://cody-services-dev.sgdev.dev".