### PR TITLE
lib/msp: implement OTEL_SDK_DISABLED

### DIFF
--- a/lib/managedservicesplatform/runtime/contract.go
+++ b/lib/managedservicesplatform/runtime/contract.go
@@ -77,6 +77,7 @@ func newContract(logger log.Logger, env *Env, service ServiceMetadata) Contract 
 				GCPProjectID: pointers.Deref(
 					env.GetOptional("OTEL_GCP_PROJECT_ID", "GCP project ID for OpenTelemetry export"),
 					defaultGCPProjectID),
+				OtelSDKDisabled: env.GetBool("OTEL_SDK_DISABLED", "false", "disable OpenTelemetry SDK"),
 			},
 			sentryDSN: env.GetOptional("SENTRY_DSN", "Sentry error reporting DSN"),
 		},


### PR DESCRIPTION
This change implements the [SDK env var configuration for disabling OpenTelemetry](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration) - this can be useful locally when no collector is set up.

## Test plan

n/a