### PR TITLE
Updated pre-commit regex for new token format

### DIFF
--- a/dev/check-tokens.sh
+++ b/dev/check-tokens.sh
@@ -20,9 +20,16 @@ files=$(git diff --name-only --staged --diff-filter ACMR)
 function check() {
   local file="$1"
 
-  if ! grep -qE "(?:(?:\/\/)|(?:#)|(?:--)) ?pre-commit:ignore_sourcegraph_token$" "$file" && grep -qE "s(?:g[psd]|lk)_[0-9a-fA-F]{40,}" "$file" ; then
-    echo "Found a Sourcegraph token in git staged file: $file. Please remove it."
-    exit 1
+  if ! grep -qE "(?:(?:\/\/)|(?:#)|(?:--)) ?pre-commit:ignore_sourcegraph_token$" "$file"; then
+    if grep -qE "s(?:g[psd]|lk)_[0-9a-fA-F]{40,}" "$file"; then
+      echo "Found a Sourcegraph token in git staged file: $file. Please remove it."
+      exit 1
+    fi
+
+    if grep -qE "sgph_[a-f0-9]{16}_[a-f0-9]{40}" "$file"; then
+      echo "Found a Sourcegraph token in git staged file: $file. Please remove it."
+      exit 1
+    fi
   fi
   if grep -qE "gh[pousr]_[0-9a-zA-Z]{36}" "$file"; then
     echo "Found a GitHub token in git staged file: $file. Please remove it."


### PR DESCRIPTION
As title. This doesn't actually allow us to remove the pragma from any files because every file that contains a local token also contains a real looking token. 

However, weren't actually catching any files that contained new tokens because the regex we had would only catch old-style tokens, so this is actually necessary
## Test plan
Manually tried to commit various local, old style and new style tokens to verify pre-commit caught them.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
