### PR TITLE
msp/monitoring: only use Opsgenie for critical alerts, make external_health_check the only critical alert

### DIFF
--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -742,6 +742,9 @@ func (s *EnvironmentResourceBigQueryDatasetSpec) GetSchema(tableID string) []byt
 }
 
 type EnvironmentAlertingSpec struct {
-	// Opsgenie, if true, disables suppression of Opsgenie alerts.
+	// Opsgenie, if true, disables suppression of Opsgenie alerts. Note that
+	// only critical alerts are delivered to Opsgenie - this is a curated set
+	// of alerts that are considered high-signal indicators that something is
+	// definitely wrong with your service.
 	Opsgenie *bool `yaml:"opsgenie,omitempty"`
 }

--- a/dev/managedservicesplatform/stacks/monitoring/cloudsql.go
+++ b/dev/managedservicesplatform/stacks/monitoring/cloudsql.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
-	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringnotificationchannel"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
@@ -14,7 +13,7 @@ func createCloudSQLAlerts(
 	stack cdktf.TerraformStack,
 	id resourceid.ID,
 	vars Variables,
-	channels []monitoringnotificationchannel.MonitoringNotificationChannel,
+	channels alertpolicy.NotificationChannels,
 ) error {
 	cloudSQLResourceName := fmt.Sprintf("%s:%s",
 		vars.ProjectID, *vars.CloudSQLInstanceID)

--- a/dev/managedservicesplatform/stacks/monitoring/common.go
+++ b/dev/managedservicesplatform/stacks/monitoring/common.go
@@ -2,7 +2,6 @@ package monitoring
 
 import (
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
-	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringnotificationchannel"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
@@ -13,7 +12,7 @@ func createCommonAlerts(
 	stack cdktf.TerraformStack,
 	id resourceid.ID,
 	vars Variables,
-	channels []monitoringnotificationchannel.MonitoringNotificationChannel,
+	channels alertpolicy.NotificationChannels,
 ) error {
 	// Convert a spec.ServiceKind into a alertpolicy.ServiceKind
 	serviceKind := alertpolicy.CloudRunService

--- a/dev/managedservicesplatform/stacks/monitoring/job.go
+++ b/dev/managedservicesplatform/stacks/monitoring/job.go
@@ -2,7 +2,6 @@ package monitoring
 
 import (
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
-	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringnotificationchannel"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
@@ -12,7 +11,7 @@ func createJobAlerts(
 	stack cdktf.TerraformStack,
 	id resourceid.ID,
 	vars Variables,
-	channels []monitoringnotificationchannel.MonitoringNotificationChannel,
+	channels alertpolicy.NotificationChannels,
 ) error {
 	// Alert whenever a Cloud Run Job fails
 	if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{

--- a/dev/managedservicesplatform/stacks/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/stacks/monitoring/monitoring.go
@@ -16,6 +16,7 @@ import (
 	slackconversation "github.com/sourcegraph/managed-services-platform-cdktf/gen/slack/conversation"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/googlesecretsmanager"
+	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/gsmsecret"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/random"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
@@ -149,7 +150,10 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 
 	// Prepare GCP monitoring channels on which to notify on when an alert goes
 	// off.
-	var channels []monitoringnotificationchannel.MonitoringNotificationChannel
+	channels := make(map[alertpolicy.ServerityLevel][]monitoringnotificationchannel.MonitoringNotificationChannel)
+	addChannel := func(level alertpolicy.ServerityLevel, c monitoringnotificationchannel.MonitoringNotificationChannel) {
+		channels[level] = append(channels[level], c)
+	}
 
 	// Configure opsgenie channels
 	// TODO: Enable after we dogfood the alerts for a while.
@@ -211,7 +215,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 				}},
 			})
 
-		channels = append(channels,
+		addChannel(alertpolicy.SeverityLevelCritical,
 			monitoringnotificationchannel.NewMonitoringNotificationChannel(stack,
 				id.TerraformID("notification_channel"),
 				&monitoringnotificationchannel.MonitoringNotificationChannelConfig{
@@ -291,26 +295,28 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 			}
 		}
 
-		channels = append(channels,
-			monitoringnotificationchannel.NewMonitoringNotificationChannel(stack,
-				id.TerraformID("notification_channel"),
-				&monitoringnotificationchannel.MonitoringNotificationChannelConfig{
-					Project:     &vars.ProjectID,
-					DisplayName: pointers.Stringf("Slack - %s", channel.Name),
-					Type:        pointers.Ptr("slack"),
-					Labels: &map[string]*string{
-						"channel_name": &channel.Name,
-					},
-					SensitiveLabels: &monitoringnotificationchannel.MonitoringNotificationChannelSensitiveLabels{
-						AuthToken: &slackToken.Value,
-					},
-					DependsOn: func() *[]cdktf.ITerraformDependable {
-						if slackChannel != nil {
-							return pointers.Ptr([]cdktf.ITerraformDependable{slackChannel})
-						}
-						return nil
-					}(),
-				}))
+		slackNotifications := monitoringnotificationchannel.NewMonitoringNotificationChannel(stack,
+			id.TerraformID("notification_channel"),
+			&monitoringnotificationchannel.MonitoringNotificationChannelConfig{
+				Project:     &vars.ProjectID,
+				DisplayName: pointers.Stringf("Slack - %s", channel.Name),
+				Type:        pointers.Ptr("slack"),
+				Labels: &map[string]*string{
+					"channel_name": &channel.Name,
+				},
+				SensitiveLabels: &monitoringnotificationchannel.MonitoringNotificationChannelSensitiveLabels{
+					AuthToken: &slackToken.Value,
+				},
+				DependsOn: func() *[]cdktf.ITerraformDependable {
+					if slackChannel != nil {
+						return pointers.Ptr([]cdktf.ITerraformDependable{slackChannel})
+					}
+					return nil
+				}(),
+			})
+
+		addChannel(alertpolicy.SeverityLevelWarning, slackNotifications)
+		addChannel(alertpolicy.SeverityLevelCritical, slackNotifications)
 	}
 
 	// Set up alerts, configuring each with all our notification channels

--- a/dev/managedservicesplatform/stacks/monitoring/redis.go
+++ b/dev/managedservicesplatform/stacks/monitoring/redis.go
@@ -2,7 +2,6 @@ package monitoring
 
 import (
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
-	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringnotificationchannel"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
@@ -12,7 +11,7 @@ func createRedisAlerts(
 	stack cdktf.TerraformStack,
 	id resourceid.ID,
 	vars Variables,
-	channels []monitoringnotificationchannel.MonitoringNotificationChannel,
+	channels alertpolicy.NotificationChannels,
 ) error {
 	// Iterate over a list of Redis alert configurations. Custom struct defines
 	// the field we expect to vary between each.

--- a/dev/managedservicesplatform/stacks/monitoring/response_codes.go
+++ b/dev/managedservicesplatform/stacks/monitoring/response_codes.go
@@ -2,7 +2,6 @@ package monitoring
 
 import (
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
-	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringnotificationchannel"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
@@ -12,7 +11,7 @@ func createResponseCodeAlerts(
 	stack cdktf.TerraformStack,
 	id resourceid.ID,
 	vars Variables,
-	channels []monitoringnotificationchannel.MonitoringNotificationChannel,
+	channels alertpolicy.NotificationChannels,
 ) error {
 	for _, config := range vars.Monitoring.Alerts.ResponseCodeRatios {
 		if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{

--- a/dev/managedservicesplatform/stacks/monitoring/service.go
+++ b/dev/managedservicesplatform/stacks/monitoring/service.go
@@ -110,11 +110,14 @@ func createExternalHealthcheckAlert(
 	if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{
 		Service:       vars.Service,
 		EnvironmentID: vars.EnvironmentID,
+		ProjectID:     vars.ProjectID,
 
 		ID:          "external_health_check",
 		Name:        "External Uptime Check",
 		Description: fmt.Sprintf("Service is failing to repond on https://%s - this may be expected if the service was recently provisioned or if its external domain has changed.", externalDNS),
-		ProjectID:   vars.ProjectID,
+
+		// If a service is not reachable, it's definitely a problem.
+		Severity: alertpolicy.SeverityLevelCritical,
 
 		ResourceKind: alertpolicy.URLUptime,
 		ResourceName: *uptimeCheck.UptimeCheckId(),

--- a/dev/managedservicesplatform/stacks/monitoring/service.go
+++ b/dev/managedservicesplatform/stacks/monitoring/service.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
-	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringnotificationchannel"
 	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringuptimecheckconfig"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
@@ -17,7 +16,7 @@ func createServiceAlerts(
 	stack cdktf.TerraformStack,
 	id resourceid.ID,
 	vars Variables,
-	channels []monitoringnotificationchannel.MonitoringNotificationChannel,
+	channels alertpolicy.NotificationChannels,
 ) error {
 	// Only provision if MaxCount is specified greater or equal 5 (the default).
 	// If nil, it doesn't matter
@@ -61,7 +60,7 @@ func createExternalHealthcheckAlert(
 	stack cdktf.TerraformStack,
 	id resourceid.ID,
 	vars Variables,
-	channels []monitoringnotificationchannel.MonitoringNotificationChannel,
+	channels alertpolicy.NotificationChannels,
 ) error {
 	var (
 		healthcheckPath    = "/"


### PR DESCRIPTION
Closes https://github.com/sourcegraph/managed-services/issues/469 - allow us to subscribe to pages without unintentionally being paged by potentially flakey alerts. At launch we'll have close eyes on things so this is fine - as we gain confidence in alerts we make promote them to critical ones.

Related: https://github.com/sourcegraph/managed-services/issues/385

## Test plan

On sams-prod:

```
        "display_name": "External Uptime Check",
        "documentation": {
          "content": "Service is failing to repond on https://accounts.sourcegraph.com - this may be expected if the service was recently provisioned or if its external domain has changed.\n\nSee https://handbook.sourcegraph.com/departments/engineering/managed-services/sams#prod for service and infrastructure access details.\nIf you need additional assistance, reach out to #discuss-core-services.",
          "mime_type": "text/markdown",
          "subject": "Sourcegraph Accounts (prod): External Uptime Check"
        },
        "notification_channels": [
          "${google_monitoring_notification_channel.monitoring-opsgenie_owner_0-notification_channel.id}",
          "${google_monitoring_notification_channel.monitoring-slack_alerts-msp-notification_channel.id}",
          "${google_monitoring_notification_channel.monitoring-slack_alerts-sams-prod-notification_channel.id}"
        ],
```

Other alerts don't have the opsgenie alerts:

```
      "display_name": "High Ratio of 403 Responses",
        "documentation": {
          "content": "403 (forbidden) responses coming from the application. Does NOT include requests that did not reach the instance,  e.g. if no host is available to receive a request - check GCP logs and error reports instead.\n\n\nSee https://handbook.sourcegraph.com/departments/engineering/managed-services/sams#prod for service and infrastructure access details.\nIf you need additional assistance, reach out to #discuss-core-services.",
          "mime_type": "text/markdown"
        },
        "notification_channels": [
          "${google_monitoring_notification_channel.monitoring-slack_alerts-msp-notification_channel.id}",
          "${google_monitoring_notification_channel.monitoring-slack_alerts-sams-prod-notification_channel.id}"
        ],
        "project": "${data.terraform_remote_state.cross-stack-reference-input-project.outputs.cross-stack-output-google_projectsams-prod-projectproject_id}"
      },
```