### PR TITLE
Build and push candidate images in parallel

### DIFF
--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -68,12 +68,8 @@ func publishFinalDockerImage(c Config, app string) operations.Operation {
 }
 
 // Used in default run type
-func bazelPushImagesCandidates(version string, isAspectBuild bool) func(*bk.Pipeline) {
-	depKey := "bazel-tests"
-	if isAspectBuild {
-		depKey = "__main__::test"
-	}
-	return bazelPushImagesCmd(version, true, depKey)
+func bazelPushImagesCandidates(version string) func(*bk.Pipeline) {
+	return bazelPushImagesCmd(version, true, "pipeline-gen")
 }
 
 // Used in default run type

--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -69,7 +69,7 @@ func publishFinalDockerImage(c Config, app string) operations.Operation {
 
 // Used in default run type
 func bazelPushImagesCandidates(version string) func(*bk.Pipeline) {
-	return bazelPushImagesCmd(version, true, "pipeline-gen")
+	return bazelPushImagesCmd(version, true)
 }
 
 // Used in default run type
@@ -78,15 +78,15 @@ func bazelPushImagesFinal(version string, isAspectBuild bool) func(*bk.Pipeline)
 	if isAspectBuild {
 		depKey = "__main__::test"
 	}
-	return bazelPushImagesCmd(version, false, depKey)
+	return bazelPushImagesCmd(version, false, bk.DependsOn(depKey))
 }
 
 // Used in CandidateNoTest run type
 func bazelPushImagesNoTest(version string) func(*bk.Pipeline) {
-	return bazelPushImagesCmd(version, false, "pipeline-gen")
+	return bazelPushImagesCmd(version, false)
 }
 
-func bazelPushImagesCmd(version string, isCandidate bool, depKey string) func(*bk.Pipeline) {
+func bazelPushImagesCmd(version string, isCandidate bool, opts ...bk.StepOpt) func(*bk.Pipeline) {
 	stepName := ":bazel::docker: Push final images"
 	stepKey := "bazel-push-images"
 	candidate := ""
@@ -99,14 +99,15 @@ func bazelPushImagesCmd(version string, isCandidate bool, depKey string) func(*b
 
 	return func(pipeline *bk.Pipeline) {
 		pipeline.AddStep(stepName,
-			bk.Agent("queue", "bazel"),
-			bk.DependsOn(depKey),
-			bk.Key(stepKey),
-			bk.Env("PUSH_VERSION", version),
-			bk.Env("CANDIDATE_ONLY", candidate),
-			bazelApplyPrecheckChanges(),
-			bk.Cmd(bazelStampedCmd(`build $$(bazel query 'kind("oci_push rule", //...)')`)),
-			bk.Cmd("./dev/ci/push_all.sh"),
+			append(opts,
+				bk.Agent("queue", "bazel"),
+				bk.Key(stepKey),
+				bk.Env("PUSH_VERSION", version),
+				bk.Env("CANDIDATE_ONLY", candidate),
+				bazelApplyPrecheckChanges(),
+				bk.Cmd(bazelStampedCmd(`build $$(bazel query 'kind("oci_push rule", //...)')`)),
+				bk.Cmd("./dev/ci/push_all.sh"),
+			)...,
 		)
 	}
 }

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -167,11 +167,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			))
 		}
 
-		// Publish candidate images to dev registry
-		publishOpsDev := operations.NewNamedSet("Publish candidate images")
-		publishOpsDev.Append(bazelPushImagesCandidates(c.Version))
-		ops.Merge(publishOpsDev)
-
 	case runtype.ReleaseNightly:
 		ops.Append(triggerReleaseBranchHealthchecks(minimumUpgradeableVersion))
 

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -167,6 +167,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			))
 		}
 
+		// Publish candidate images to dev registry
+		publishOpsDev := operations.NewNamedSet("Publish candidate images")
+		publishOpsDev.Append(bazelPushImagesCandidates(c.Version, isAspectWorkflowBuild))
+		ops.Merge(publishOpsDev)
+
 	case runtype.ReleaseNightly:
 		ops.Append(triggerReleaseBranchHealthchecks(minimumUpgradeableVersion))
 

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -169,7 +169,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		// Publish candidate images to dev registry
 		publishOpsDev := operations.NewNamedSet("Publish candidate images")
-		publishOpsDev.Append(bazelPushImagesCandidates(c.Version, isAspectWorkflowBuild))
+		publishOpsDev.Append(bazelPushImagesCandidates(c.Version))
 		ops.Merge(publishOpsDev)
 
 	case runtype.ReleaseNightly:
@@ -314,7 +314,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		// Publish candidate images to dev registry
 		publishOpsDev := operations.NewNamedSet("Publish candidate images")
-		publishOpsDev.Append(bazelPushImagesCandidates(c.Version, isAspectWorkflowBuild))
+		publishOpsDev.Append(bazelPushImagesCandidates(c.Version))
 		ops.Merge(publishOpsDev)
 
 		// End-to-end tests


### PR DESCRIPTION
This removes the constraint on candidate images requiring tests to have run. I tested this with a dependency on the test step, then without, then with again, to see if caching was having an impact, but it seems like no, they all took about the same amount of time, and running it without the constraint saved about 3 minutes.

## Test plan
Ran it in CI
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
