### PR TITLE
oidc: add prompt login option

### DIFF
--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -432,9 +432,11 @@ func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, 
 	// validating the response to the ID Token request. We re-use the Authn request
 	// state as the nonce.
 	//
+	// The "prompt=login" asks the OP to prompt the user for re-authentication.
+	//
 	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
 	// OIDC spec.
-	authURL := p.oauth2Config().AuthCodeURL(oidcState, oidc.Nonce(oidcState))
+	authURL := p.oauth2Config().AuthCodeURL(oidcState, oidc.Nonce(oidcState)) + "&prompt=login"
 	// Pass along the prompt_auth to OP for the specific type of authentication to
 	// use, e.g. "github", "gitlab", "google".
 	promptAuth := r.URL.Query().Get("prompt_auth")


### PR DESCRIPTION
This is the client/sister PR of the https://github.com/sourcegraph/accounts.sourcegraph.com/pull/388

## Why do we need this?

Have you ever encounter a scenario that... you thought (and you did) signed out of a service to switch accounts, but clicking on sign in never again prompt to choose which GitHub/GitLab/Google to continue. Only to realize you need to manually sign out of the IdP as well?

This PR is for this exact UX improvement. Because there is no safe to automatically signs out users from IdP when signing out of a service (and in general it just shouldn't), force re-authentication it a nice way to have an illusion of integrated UX that now the user can the exact same sign-in options as if the user had never signed in.

## Enterprise impact

1. If their IdP/SSO support `prompt=login` per standard, the improved UX still hold.
2. If their IdP/SSO does not support, then they would just ignore it.

## Test plan



https://github.com/sourcegraph/sourcegraph/assets/2946214/740af714-4db0-487c-9f0b-b96393c66251

