### PR TITLE
highlighter: Rename PackedRange -> Range

### DIFF
--- a/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/evaluate.rs
+++ b/docker-images/syntax-highlighter/crates/scip-treesitter-cli/src/evaluate.rs
@@ -12,7 +12,7 @@ use colored::{ColoredString, Colorize};
 use scip::types::Index;
 use serde::Serializer;
 use string_interner::{symbol::SymbolU32, StringInterner, Symbol};
-use syntax_analysis::range::PackedRange;
+use syntax_analysis::range::Range;
 
 use crate::{io::read_index_from_file, progress::*};
 
@@ -86,7 +86,7 @@ struct SymbolPair {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 struct LocationInFile {
-    rng: PackedRange,
+    rng: Range,
     path_id: PathId,
 }
 
@@ -97,7 +97,7 @@ pub struct SymbolOccurrence {
 }
 
 impl SymbolOccurrence {
-    fn range(&self) -> &PackedRange {
+    fn range(&self) -> &Range {
         &self.location.rng
     }
 }
@@ -751,7 +751,7 @@ impl Evaluator {
             let path_id = self.path_formatter.make_path_id(&doc.relative_path);
             out.reserve(doc.occurrences.len());
             for occ in &doc.occurrences {
-                let rng = PackedRange::from_vec(&occ.range).unwrap();
+                let rng = Range::from_vec(&occ.range).unwrap();
                 let sym_id: SymbolId<T>;
                 if let Some(prefix) = occ.symbol.strip_prefix("local ") {
                     sym_id = self.symbol_formatter.make_symbol_id(&format!(

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/globals.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/globals.rs
@@ -1,4 +1,4 @@
-use crate::range::PackedRange;
+use crate::range::Range;
 use anyhow::Result;
 use bitvec::prelude::*;
 use protobuf::Enum;
@@ -8,8 +8,8 @@ use crate::languages::TagConfiguration;
 
 #[derive(Debug)]
 pub struct Scope {
-    pub ident_range: PackedRange,
-    pub scope_range: PackedRange,
+    pub ident_range: Range,
+    pub scope_range: Range,
     pub globals: Vec<Global>,
     pub children: Vec<Scope>,
     pub descriptors: Vec<Descriptor>,
@@ -18,8 +18,8 @@ pub struct Scope {
 
 #[derive(Debug)]
 pub struct Global {
-    pub range: PackedRange,
-    pub enclosing: Option<PackedRange>,
+    pub range: Range,
+    pub enclosing: Option<Range>,
     pub descriptors: Vec<Descriptor>,
     pub kind: symbol_information::Kind,
 }

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
@@ -10,7 +10,7 @@ use tree_sitter_highlight::{
 };
 
 use crate::highlighting::SourcegraphQuery;
-use crate::range::PackedRange;
+use crate::range::Range;
 
 macro_rules! include_scip_query {
     ($lang: expr, $query: literal) => {
@@ -277,7 +277,7 @@ pub fn index_language_with_config(
                 // certain builds fail or something to test this out better (but
                 // not have syntax highlighting completely fall apart from one
                 // bad range)
-                let local_range = match PackedRange::from_vec(&local.range) {
+                let local_range = match Range::from_vec(&local.range) {
                     Some(range) => range,
                     None => continue,
                 };

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/range.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/range.rs
@@ -1,14 +1,14 @@
 use tree_sitter::Node;
 
 #[derive(Debug, PartialEq, Eq, Default, Hash, Copy, Clone)]
-pub struct PackedRange {
+pub struct Range {
     pub start_line: i32,
     pub start_col: i32,
     pub end_line: i32,
     pub end_col: i32,
 }
 
-impl PackedRange {
+impl Range {
     // TODO: I don't know how much I love just returning an error here...
     //       Maybe we should make an infallible version too. It's just a bit annoying
     //       to pack and unpack all of these for effectively no reason.
@@ -40,7 +40,7 @@ impl PackedRange {
     }
 
     /// Checks if the range is equal to the given vector.
-    /// If the other vector is not a valid PackedRange then it returns false
+    /// If the other vector is not a valid Range then it returns false
     pub fn eq_vec(&self, v: &[i32]) -> bool {
         match v.len() {
             3 => {
@@ -59,7 +59,7 @@ impl PackedRange {
         }
     }
 
-    pub fn contains(&self, other: &PackedRange) -> bool {
+    pub fn contains(&self, other: &Range) -> bool {
         other.start_line >= self.start_line
             && other.end_line <= self.end_line
             && (other.start_line != self.start_line || other.start_col >= self.start_col)
@@ -67,13 +67,13 @@ impl PackedRange {
     }
 }
 
-impl PartialOrd for PackedRange {
+impl PartialOrd for Range {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for PackedRange {
+impl Ord for Range {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         (self.start_line, self.end_line, self.start_col).cmp(&(
             other.start_line,
@@ -83,7 +83,7 @@ impl Ord for PackedRange {
     }
 }
 
-impl<'a> From<Node<'a>> for PackedRange {
+impl<'a> From<Node<'a>> for Range {
     fn from(node: Node<'a>) -> Self {
         let start = node.start_position();
         let end = node.end_position();
@@ -98,39 +98,39 @@ impl<'a> From<Node<'a>> for PackedRange {
 
 #[cfg(test)]
 mod tests {
-    use super::PackedRange;
+    use super::Range;
 
     #[test]
     fn test_packed_range_contains() {
-        let outer = PackedRange {
+        let outer = Range {
             start_line: 1,
             start_col: 1,
             end_line: 4,
             end_col: 4,
         };
 
-        let inner = PackedRange {
+        let inner = Range {
             start_line: 2,
             start_col: 2,
             end_line: 3,
             end_col: 3,
         };
 
-        let overlapping = PackedRange {
+        let overlapping = Range {
             start_line: 3,
             start_col: 3,
             end_line: 5,
             end_col: 5,
         };
 
-        let outside = PackedRange {
+        let outside = Range {
             start_line: 5,
             start_col: 5,
             end_line: 6,
             end_col: 6,
         };
 
-        let same = PackedRange {
+        let same = Range {
             start_line: 1,
             start_col: 1,
             end_line: 4,

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/snapshot.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/snapshot.rs
@@ -6,7 +6,7 @@ use scip::types::{
     symbol_information, Document, Occurrence, SymbolInformation, SymbolRole, SyntaxKind,
 };
 
-use crate::range::PackedRange;
+use crate::range::Range;
 
 #[derive(Debug, Clone, Default)]
 pub struct SnapshotRange {
@@ -51,7 +51,7 @@ pub fn dump_document_with_config(
     opts: SnapshotOptions,
 ) -> Result<String> {
     let mut occurrences = doc.occurrences.clone();
-    occurrences.sort_by_key(|o| PackedRange::from_vec(&o.range).unwrap_or_default());
+    occurrences.sort_by_key(|o| Range::from_vec(&o.range).unwrap_or_default());
     let mut occurrences = VecDeque::from(occurrences);
 
     let mut result = String::new();
@@ -80,7 +80,7 @@ pub fn dump_document_with_config(
                 _ => &occ.range,
             };
 
-            let range = match PackedRange::from_vec(range) {
+            let range = match Range::from_vec(range) {
                 Some(range) => range,
                 None => continue,
             };


### PR DESCRIPTION
`Packed` doesn't make sense as a prefix as the value is actually unpacked
(we'll duplicate the line number in the common case)

## Test plan

n/a