### PR TITLE
highlighter: De-couple server code from highlighting

### DIFF
--- a/docker-images/syntax-highlighter/BUILD.bazel
+++ b/docker-images/syntax-highlighter/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
@@ -16,6 +16,27 @@ rust_binary(
     deps = all_crate_deps(
         normal = True,
     ) + [
+        ":syntect_server_lib",
+        "//docker-images/syntax-highlighter/crates/syntax-analysis",
+        "//docker-images/syntax-highlighter/crates/tree-sitter-all-languages",
+    ],
+)
+
+rust_library(
+    name = "syntect_server_lib",
+    srcs = glob(
+        ["src/**/*.rs"],
+        allow_empty = False,
+        exclude = [
+            "src/main.rs",
+            "src/bin/**/*.rs",
+        ],
+    ),
+    aliases = aliases(),
+    crate_name = "syntect_server",
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+    visibility = ["//docker-images/syntax-highlighter:__subpackages__"],
+    deps = all_crate_deps(normal = True) + [
         "//docker-images/syntax-highlighter/crates/syntax-analysis",
         "//docker-images/syntax-highlighter/crates/tree-sitter-all-languages",
     ],

--- a/docker-images/syntax-highlighter/Cargo.Bazel.lock
+++ b/docker-images/syntax-highlighter/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "98ae077c1070b8536f3312447aab51ecb51b454dd723fb009d8651aa36b00fcc",
+  "checksum": "918bd96be703b8b273b10ab59b6ed914bf280077f6f1f001cbab4524d0debaeb",
   "crates": {
     "addr2line 0.20.0": {
       "name": "addr2line",
@@ -11533,10 +11533,6 @@
               "target": "regex"
             },
             {
-              "id": "rocket 0.5.0-rc.3",
-              "target": "rocket"
-            },
-            {
               "id": "rustc-hash 1.1.0",
               "target": "rustc_hash"
             },
@@ -11722,14 +11718,28 @@
       "name": "syntect_server",
       "version": "1.0.1",
       "repository": null,
-      "targets": [],
-      "library_target_name": null,
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "syntect_server",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "syntect_server",
       "common_attrs": {
         "compile_data_glob": [
           "**"
         ],
         "deps": {
           "common": [
+            {
+              "id": "anyhow 1.0.75",
+              "target": "anyhow"
+            },
             {
               "id": "base64 0.13.1",
               "target": "base64"
@@ -11781,6 +11791,10 @@
             {
               "id": "syntect 4.7.0",
               "target": "syntect"
+            },
+            {
+              "id": "tree-sitter-highlight 0.20.1",
+              "target": "tree_sitter_highlight"
             }
           ],
           "selects": {}

--- a/docker-images/syntax-highlighter/Cargo.lock
+++ b/docker-images/syntax-highlighter/Cargo.lock
@@ -2096,7 +2096,6 @@ dependencies = [
  "pretty_assertions",
  "protobuf",
  "regex",
- "rocket",
  "rustc-hash",
  "scip",
  "serde",
@@ -2134,6 +2133,7 @@ dependencies = [
 name = "syntect_server"
 version = "1.0.1"
 dependencies = [
+ "anyhow",
  "base64 0.13.1",
  "clap 4.3.23",
  "criterion",
@@ -2150,6 +2150,7 @@ dependencies = [
  "syntax-analysis",
  "syntect",
  "tree-sitter-all-languages",
+ "tree-sitter-highlight",
 ]
 
 [[package]]

--- a/docker-images/syntax-highlighter/Cargo.toml
+++ b/docker-images/syntax-highlighter/Cargo.toml
@@ -9,13 +9,15 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
+anyhow.workspace = true
 clap.workspace = true
+protobuf.workspace = true
 rocket.workspace = true
 scip.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 syntect.workspace = true
-protobuf.workspace = true
+tree-sitter-highlight.workspace = true
 
 rustyline = "9.1.2"
 base64 = "0.13.0"

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/Cargo.toml
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/Cargo.toml
@@ -12,7 +12,6 @@ itertools.workspace = true
 lazy_static.workspace = true
 paste.workspace = true
 protobuf.workspace = true
-rocket.workspace = true
 scip.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
@@ -361,10 +361,7 @@ mod test {
 
     #[test]
     fn test_syntect_lang_detection() {
-        let cases = [
-            ("foo.cls", "%", "TeX"),
-            ("foo.cls", "/**", "Apex"),
-        ];
+        let cases = [("foo.cls", "%", "TeX"), ("foo.cls", "/**", "Apex")];
 
         for (path, content, lang) in cases {
             test_syntect_lang_detection_impl(path, content, lang);

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
@@ -14,9 +14,14 @@ use crate::highlighting::syntect_html::ClassedTableGenerator;
 
 #[derive(Default)]
 pub struct FileInfo<'a> {
-    // This is kept as a String instead of a PathBuf as
-    // we don't really care about OS-level operations, but
-    // using String is much more convenient.
+    // This is kept as a String instead of a PathBuf because:
+    // 1. Sourcegraph doesn't support non-UTF-8 values in paths.
+    // 2. The input received from the network is UTF-8.
+    // 3. We're not using this path to call any OS APIs
+    //    which would require Path.
+    // 4. It avoids extra conversions when interacting with
+    //    syntect or in the ad-hoc language detection code that
+    //    we currently have.
     path: String,
     pub contents: &'a str,
     pub language: Option<&'a str>,

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
@@ -1,329 +1,397 @@
-use std::path::Path;
+pub mod syntect_html;
+pub mod syntect_scip;
 
+use anyhow::anyhow;
 use protobuf::Message;
-use rocket::serde::json::{json, Value as JsonValue};
-use serde::Deserialize;
-use syntect::{
-    html::ClassStyle,
-    parsing::{SyntaxReference, SyntaxSet},
-};
+use std::fmt::{Debug, Display, Formatter};
+use std::path::Path;
+use syntect::html::ClassStyle;
+
+use syntect::parsing::{SyntaxReference, SyntaxSet};
 
 pub mod tree_sitter;
-pub use tree_sitter::{
-    index_language as treesitter_index, index_language_with_config as treesitter_index_with_config,
-    jsonify_err, lsif_highlight,
-};
+use crate::highlighting::syntect_html::ClassedTableGenerator;
 
-mod syntect_html;
-use self::syntect_html::ClassedTableGenerator;
-use tree_sitter_highlight::Error;
-
-use self::tree_sitter::treesitter_language;
-
-mod syntect_scip;
-
-thread_local! {
-    pub(crate) static SYNTAX_SET: SyntaxSet = SyntaxSet::load_defaults_newlines();
+#[derive(Default)]
+pub struct FileInfo<'a> {
+    // This is kept as a String instead of a PathBuf as
+    // we don't really care about OS-level operations, but
+    // using String is much more convenient.
+    path: String,
+    pub contents: &'a str,
+    pub language: Option<&'a str>,
 }
 
-/// Struct from: internal/gosyntect/gosyntect.go
-///
-/// Keep in sync with that struct.
-#[derive(Deserialize, Default, Debug)]
-pub struct SourcegraphQuery {
-    // Deprecated field with a default empty string value, kept for backwards
-    // compatability with old clients.
-    //
-    // TODO: Can I just delete this because this image will only run for a particular sourcegraph
-    // version... so they can't be out of sync anymore, which is pretty cool
-    #[serde(default)]
-    pub extension: String,
-
-    // Contents of the file
-    pub code: String,
-
-    // default empty string value for backwards compat with clients who do not specify this field.
-    #[serde(default)]
-    pub filepath: String,
-
-    // The language defined by the server. Required to tree-sitter to use for the filetype name.
-    // default empty string value for backwards compat with clients who do not specify this field.
-    pub filetype: Option<String>,
-
-    // line_length_limit is ignored if css is false
-    pub line_length_limit: Option<usize>,
-}
-
-// NOTE: Keep in sync: internal/gosyntect/gosyntect.go
-#[derive(Deserialize, Default, Debug, PartialEq, Eq)]
-pub enum SyntaxEngine {
-    /// Returns highlighting data only via syntect in SCIP format
-    #[default]
-    #[serde(rename = "syntect")]
-    Syntect,
-
-    /// Returns highlighting data only via Tree-sitter in SCIP format
-    #[serde(rename = "tree-sitter")]
-    TreeSitter,
-
-    /// Returns highlighting data and optionally locals data via Tree-sitter in SCIP format
-    ///
-    /// This name is preserved for backwards compatibility. The web client
-    /// makes use of locals data for code navigation, so it doesn't make
-    /// sense to omit locals data if it is available.
-    #[serde(rename = "scip-syntax")]
-    ScipSyntax,
-}
-
-#[derive(Deserialize, Default, Debug)]
-pub struct ScipHighlightQuery {
-    // Which highlighting engine to use.
-    pub engine: SyntaxEngine,
-
-    // Contents of the file
-    pub code: String,
-
-    // filepath is only used if language is None.
-    pub filepath: String,
-
-    // The language defined by the server. Required to tree-sitter to use for the filetype name.
-    // default empty string value for backwards compat with clients who do not specify this field.
-    pub filetype: Option<String>,
-
-    // line_length_limit is used to limit syntect problems when
-    // parsing very long lines
-    pub line_length_limit: Option<usize>,
-}
-
-pub fn determine_filetype(q: &SourcegraphQuery) -> String {
-    let filetype = SYNTAX_SET.with(|syntax_set| match determine_language(q, syntax_set) {
-        Ok(language) => language.name.clone(),
-        Err(_) => "".to_owned(),
-    });
-
-    if filetype.is_empty() || filetype.to_lowercase() == "plain text" {
-        #[allow(clippy::single_match)]
-        match q.extension.as_str() {
-            "ncl" => return "nickel".to_string(),
-            _ => {}
-        };
+impl<'a> FileInfo<'a> {
+    pub fn new<'b>(path: &str, contents: &'b str, language: Option<&'b str>) -> FileInfo<'b> {
+        FileInfo {
+            path: path.to_string(),
+            contents,
+            language,
+        }
     }
 
-    // Normalize all the filenames here
-    match filetype.as_str() {
-        "Rust Enhanced" => "rust",
-        "C++" => "cpp",
-        "C#" => "c_sharp",
-        "JS Custom - React" => "javascript",
-        "TypeScriptReact" => {
-            if q.filepath.ends_with(".tsx") {
-                "tsx"
-            } else {
-                "typescript"
+    pub fn new_from_extension<'b>(extension: &str, contents: &'b str, language: Option<&'b str>) -> FileInfo<'b> {
+        FileInfo {
+            path: format!("__highlighter_synthetic__{}{}",
+                if extension.starts_with('.') { "" } else { "." },
+                extension),
+            contents,
+            language
+        }
+    }
+
+    fn extension(&self) -> Option<&str> {
+        for (i, c) in self.path.bytes().enumerate().rev() {
+            if c == b'/' {
+                return None
             }
-        }
-        filetype => filetype,
-    }
-    .to_lowercase()
-}
-
-pub fn determine_language<'a>(
-    q: &SourcegraphQuery,
-    syntax_set: &'a SyntaxSet,
-) -> Result<&'a SyntaxReference, JsonValue> {
-    // If filetype is passed, we should choose that if possible.
-    if let Some(filetype) = &q.filetype {
-        // This is `find_syntax_by_name` except that it doesn't care about
-        // case sensitivity or anything like that.
-        //
-        // This makes it just a lost simpler to move between frontend and backend.
-        // At some point, we need a definitive list for this.
-        if let Some(language) = syntax_set
-            .syntaxes()
-            .iter()
-            .rev()
-            .find(|&s| filetype == &s.name.to_lowercase())
-        {
-            return Ok(language);
-        }
-    }
-
-    if q.filepath.is_empty() {
-        // Legacy codepath, kept for backwards-compatability with old clients.
-        return match syntax_set.find_syntax_by_extension(&q.extension) {
-            Some(v) => Ok(v),
-            // Fall back: Determine syntax definition by first line.
-            None => match syntax_set.find_syntax_by_first_line(&q.code) {
-                Some(v) => Ok(v),
-                None => Err(json!({"error": "invalid extension"})),
-            },
-        };
-    }
-
-    // Split the input path ("foo/myfile.go") into file name
-    // ("myfile.go") and extension ("go").
-    let path = Path::new(&q.filepath);
-    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    let extension = path.extension().and_then(|x| x.to_str()).unwrap_or("");
-
-    // Override syntect's language detection for conflicting file extensions because
-    // it's impossible to express this logic in a syntax definition.
-    struct Override {
-        extension: &'static str,
-        prefix_langs: Vec<(&'static str, &'static str)>,
-        default: &'static str,
-    }
-    let overrides = vec![
-        Override {
-            extension: "cls",
-            prefix_langs: vec![("%", "TeX"), ("\\", "TeX")],
-            default: "Apex",
-        },
-        Override {
-            extension: "xlsg",
-            prefix_langs: vec![],
-            default: "xlsg",
-        },
-    ];
-
-    if let Some(Override {
-        prefix_langs,
-        default,
-        ..
-    }) = overrides.iter().find(|o| o.extension == extension)
-    {
-        let name = match prefix_langs
-            .iter()
-            .find(|(prefix, _)| q.code.starts_with(prefix))
-        {
-            Some((_, lang)) => lang,
-            None => default,
-        };
-        return Ok(syntax_set
-            .find_syntax_by_name(name)
-            .unwrap_or_else(|| syntax_set.find_syntax_plain_text()));
-    }
-
-    Ok(syntax_set
-        // First try to find a syntax whose "extension" matches our file
-        // name. This is done due to some syntaxes matching an "extension"
-        // that is actually a whole file name (e.g. "Dockerfile" or "CMakeLists.txt")
-        // see https://github.com/trishume/syntect/pull/170
-        .find_syntax_by_extension(file_name)
-        .or_else(|| syntax_set.find_syntax_by_extension(extension))
-        .or_else(|| syntax_set.find_syntax_by_first_line(&q.code))
-        .unwrap_or_else(|| syntax_set.find_syntax_plain_text()))
-}
-
-pub fn list_features() {
-    // List supported file extensions.
-    SYNTAX_SET.with(|syntax_set| {
-        println!("## Supported file extensions:");
-        println!();
-        for sd in syntax_set.syntaxes() {
-            println!("- {} (`{}`)", sd.name, sd.file_extensions.join("`, `"));
-        }
-        println!();
-    });
-}
-
-pub fn syntect_highlight(q: SourcegraphQuery) -> JsonValue {
-    SYNTAX_SET.with(|syntax_set| {
-        // Determine syntax definition by extension.
-        let syntax_def = match determine_language(&q, syntax_set) {
-            Ok(v) => v,
-            Err(e) => return e,
-        };
-
-        let output = ClassedTableGenerator::new(
-            syntax_set,
-            syntax_def,
-            &q.code,
-            q.line_length_limit,
-            ClassStyle::SpacedPrefixed { prefix: "hl-" },
-        )
-        .generate();
-
-        json!({ "data": output, "plaintext": syntax_def.name == "Plain Text", })
-    })
-}
-
-pub fn scip_highlight(q: ScipHighlightQuery) -> Result<JsonValue, JsonValue> {
-    match q.engine {
-        SyntaxEngine::Syntect => SYNTAX_SET.with(|ss| {
-            let sg_query = SourcegraphQuery {
-                extension: "".to_string(),
-                filepath: q.filepath.clone(),
-                filetype: q.filetype.clone(),
-                line_length_limit: None,
-                code: q.code.clone(),
-            };
-
-            let language = determine_language(&sg_query, ss).map_err(jsonify_err)?;
-            let document = syntect_scip::DocumentGenerator::new(
-                ss,
-                language,
-                q.code.as_str(),
-                q.line_length_limit,
-            )
-            .generate();
-            let encoded = document.write_to_bytes().map_err(jsonify_err)?;
-            Ok(json!({"scip": base64::encode(encoded), "plaintext": false}))
-        }),
-        SyntaxEngine::TreeSitter | SyntaxEngine::ScipSyntax => {
-            let language = q
-                .filetype
-                .ok_or_else(|| json!({"error": "Must pass a language for /scip" }))?
-                .to_lowercase();
-
-            let include_locals = q.engine == SyntaxEngine::ScipSyntax;
-
-            match treesitter_index(treesitter_language(&language), &q.code, include_locals) {
-                Ok(document) => {
-                    let encoded = document.write_to_bytes().map_err(jsonify_err)?;
-
-                    Ok(json!({"scip": base64::encode(encoded), "plaintext": false}))
+            if c == b'.' {
+                if i == 0 {
+                    return None
                 }
-                Err(Error::InvalidLanguage) => Err(json!({
-                    "error": format!("{} is not a valid filetype for treesitter", language)
-                })),
-                Err(err) => Err(jsonify_err(err)),
+                let prev = self.path.as_bytes().get(i - 1)
+                    .expect("i > 0 so indexing with 'i - 1' should've succeeded");
+                if *prev == b'/' {
+                    return None
+                }
+                return Some(self.path.get(i + 1..).unwrap())
             }
+        }
+        None
+    }
+}
+
+// Language names as used by syntect & Sublime grammars
+struct SublimeLanguageName {
+    raw: String,
+}
+
+impl SublimeLanguageName {
+    fn into_tree_sitter_name(self, file_info: &FileInfo<'_>) -> TreeSitterLanguageName {
+        if self.raw.is_empty() || self.raw.to_lowercase() == "plain text" {
+            #[allow(clippy::single_match)]
+            match file_info.extension() {
+                Some("ncl") => return TreeSitterLanguageName::new("nickel"),
+                _ => {}
+            };
+        }
+
+        // Written in an unusual style so that we can:
+        // 1. Avoid case-sensitive comparison
+        // 2. We can look up corresponding Sublime Grammars easily
+        //    when using case-sensitive text search
+        let normalized_name = self.raw.as_str().to_lowercase();
+        let normalized_name = match normalized_name {
+            x if x == "Rust Enhanced".to_lowercase() => "rust",
+            x if x == "JS Custom - React".to_lowercase() => "javascript",
+            x if x == "TypeScriptReact".to_lowercase() => {
+                if file_info.path.ends_with(".tsx") {
+                    "tsx"
+                } else {
+                    "typescript"
+                }
+            }
+            _ => &normalized_name,
+        };
+        // TODO: When https://github.com/sourcegraph/sourcegraph/issues/56376
+        // is fixed, we should be able to detect the language without
+        // using syntect. We can directly then map Linguist/enry names
+        // to the data that we have instead of separately maintaining
+        // another set of names for Tree-sitter.
+        TreeSitterLanguageName::new(normalized_name)
+    }
+}
+
+// Somewhat ad-hoc set of names based on existing Tree-sitter grammars.
+pub struct TreeSitterLanguageName {
+    raw: String,
+}
+
+impl Display for TreeSitterLanguageName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
+impl TreeSitterLanguageName {
+    pub fn new(s: &str) -> TreeSitterLanguageName {
+        let mut s = s.to_lowercase();
+        if &s == "c++" {
+            s = "cpp".to_string();
+        } else if &s == "c#" {
+            s = "c_sharp".to_string();
+        }
+        TreeSitterLanguageName { raw: s }
+    }
+}
+
+impl<'a> FileInfo<'a> {
+    pub fn determine_language(
+        &self,
+        syntax_set: &SyntaxSet,
+    ) -> Result<TreeSitterLanguageName, LanguageDetectionError> {
+        let name = SublimeLanguageName {
+            raw: match self.find_matching_syntax_reference(syntax_set) {
+                Ok(language) => language.name.clone(),
+                Err(e) => return Err(e),
+            },
+        }
+        .into_tree_sitter_name(self);
+        Ok(name)
+    }
+
+    pub(crate) fn find_matching_syntax_reference<'s>(
+        &self,
+        syntax_set: &'s SyntaxSet,
+    ) -> Result<&'s SyntaxReference, LanguageDetectionError> {
+        // If filetype is passed, we should choose that if possible.
+        if let Some(filetype) = self.language {
+            // This is `find_syntax_by_name` except that it doesn't care about
+            // case sensitivity or anything like that.
+            //
+            // This makes it just a lost simpler to move between frontend and backend.
+            // At some point, we need a definitive list for this.
+            if let Some(language) = syntax_set
+                .syntaxes()
+                .iter()
+                .rev()
+                .find(|&s| filetype == s.name.to_lowercase())
+            {
+                return Ok(language);
+            }
+        }
+
+        if self.path.is_empty() {
+            // Legacy codepath, kept for backwards-compatability with old clients.
+            return match syntax_set.find_syntax_by_extension(self.extension().unwrap_or("")) {
+                Some(v) => Ok(v),
+                // Fall back: Determine syntax definition by first line.
+                None => match syntax_set.find_syntax_by_first_line(self.contents) {
+                    Some(v) => Ok(v),
+                    None => Err(LanguageDetectionError::InvalidExtension),
+                },
+            };
+        }
+
+        // Split the input path ("foo/myfile.go") into file name
+        // ("myfile.go") and extension ("go").
+        let path = Path::new(&self.path);
+        let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        let extension = path.extension().and_then(|x| x.to_str()).unwrap_or("");
+
+        // Override syntect's language detection for conflicting file extensions because
+        // it's impossible to express this logic in a syntax definition.
+        struct Override {
+            extension: &'static str,
+            prefix_langs: Vec<(&'static str, &'static str)>,
+            default: &'static str,
+        }
+        let overrides = vec![
+            Override {
+                extension: "cls",
+                prefix_langs: vec![("%", "TeX"), ("\\", "TeX")],
+                default: "Apex",
+            },
+            Override {
+                extension: "xlsg",
+                prefix_langs: vec![],
+                default: "xlsg",
+            },
+        ];
+
+        if let Some(Override {
+            prefix_langs,
+            default,
+            ..
+        }) = overrides.iter().find(|o| o.extension == extension)
+        {
+            let name = match prefix_langs
+                .iter()
+                .find(|(prefix, _)| self.contents.starts_with(prefix))
+            {
+                Some((_, lang)) => lang,
+                None => default,
+            };
+            return Ok(syntax_set
+                .find_syntax_by_name(name)
+                .unwrap_or_else(|| syntax_set.find_syntax_plain_text()));
+        }
+
+        Ok(syntax_set
+            // First try to find a syntax whose "extension" matches our file
+            // name. This is done due to some syntaxes matching an "extension"
+            // that is actually a whole file name (e.g. "Dockerfile" or "CMakeLists.txt")
+            // see https://github.com/trishume/syntect/pull/170
+            .find_syntax_by_extension(file_name)
+            .or_else(|| syntax_set.find_syntax_by_extension(extension))
+            .or_else(|| syntax_set.find_syntax_by_first_line(self.contents))
+            .unwrap_or_else(|| syntax_set.find_syntax_plain_text()))
+    }
+}
+
+pub enum HighlightingBackend<'a> {
+    SyntectHtml {
+        syntax_set: &'a SyntaxSet,
+        line_length_limit: Option<usize>,
+    },
+    SyntectScip {
+        syntax_set: &'a SyntaxSet,
+        line_length_limit: Option<usize>,
+    },
+    TreeSitter {
+        include_locals: bool,
+    },
+}
+
+pub struct HighlightedText {
+    pub payload: String,
+    pub kind: PayloadKind,
+    pub grammar: String,
+}
+
+#[derive(PartialEq, Eq)]
+pub enum PayloadKind {
+    Html,
+    Base64EncodedScip,
+}
+
+impl<'b> HighlightingBackend<'b> {
+    /// The result is HTML for SyntectHtml and base64-encoded SCIP data for
+    /// other backends.
+    pub fn highlight(&self, file_info: &FileInfo<'_>) -> anyhow::Result<HighlightedText> {
+        match self {
+            HighlightingBackend::SyntectHtml {
+                syntax_set,
+                line_length_limit,
+            } => {
+                let syntax_ref = file_info.find_matching_syntax_reference(syntax_set)?;
+                Ok(HighlightedText {
+                    payload: ClassedTableGenerator::new(
+                        syntax_set,
+                        syntax_ref,
+                        file_info.contents,
+                        *line_length_limit,
+                        ClassStyle::SpacedPrefixed { prefix: "hl-" },
+                    )
+                    .generate(),
+                    kind: PayloadKind::Html,
+                    grammar: format!("Sublime {}", syntax_ref.name),
+                })
+            }
+            HighlightingBackend::SyntectScip {
+                syntax_set,
+                line_length_limit,
+            } => {
+                let syntax_ref = file_info.find_matching_syntax_reference(syntax_set)?;
+                let document = syntect_scip::DocumentGenerator::new(
+                    syntax_set,
+                    syntax_ref,
+                    file_info.contents,
+                    *line_length_limit,
+                )
+                .generate();
+                Ok(HighlightedText {
+                    payload: base64::encode(document.write_to_bytes()?),
+                    kind: PayloadKind::Base64EncodedScip,
+                    grammar: format!("Sublime {}", syntax_ref.name),
+                })
+            }
+            HighlightingBackend::TreeSitter { include_locals } => {
+                let language = match file_info.language {
+                    None => {
+                        return Err(anyhow!(
+                            "Tree-sitter backend requires a language to be specified"
+                        ))
+                    }
+                    Some(s) => SublimeLanguageName { raw: s.to_string() },
+                };
+                let language = language.into_tree_sitter_name(file_info);
+                match language.highlight_document(file_info.contents, *include_locals) {
+                    Ok(document) => match document.write_to_bytes() {
+                        Err(e) => Err(anyhow!("failed to serialize document {:?}", e)),
+                        Ok(doc) => Ok(HighlightedText {
+                            payload: base64::encode(doc),
+                            kind: PayloadKind::Base64EncodedScip,
+                            grammar: format!("Tree-sitter {}", language),
+                        }),
+                    },
+                    Err(tree_sitter_highlight::Error::InvalidLanguage) => Err(anyhow!(
+                        "{} is not a valid filetype for Tree-sitter",
+                        language
+                    )),
+                    Err(err) => Err(anyhow!("highlighting failed: {}", err)),
+                }
+            }
+        }
+    }
+}
+
+pub enum LanguageDetectionError {
+    InvalidExtension,
+}
+
+impl Debug for LanguageDetectionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        (&self as &dyn Display).fmt(f)
+    }
+}
+
+impl std::error::Error for LanguageDetectionError {}
+
+impl Display for LanguageDetectionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LanguageDetectionError::InvalidExtension => f.write_str("invalid extension"),
         }
     }
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use syntect::parsing::SyntaxSet;
 
     use super::*;
 
-    #[test]
-    fn cls_tex() {
-        let syntax_set = SyntaxSet::load_defaults_newlines();
-        let query = SourcegraphQuery {
-            filepath: "foo.cls".to_string(),
-            filetype: None,
-            code: "%".to_string(),
-            line_length_limit: None,
-            extension: String::new(),
-        };
-        let result = determine_language(&query, &syntax_set);
-        assert_eq!(result.unwrap().name, "TeX");
+    // Local to tests as this crate takes the syntax set as an input argument.
+    thread_local! {
+        pub(crate) static SYNTAX_SET: SyntaxSet = SyntaxSet::load_defaults_newlines();
+    }
+
+    fn test_syntect_lang_detection_impl(path: &str, content: &str, expected_language: &str) {
+        let file_info = FileInfo::new(path, content, None);
+        SYNTAX_SET.with(|syntax_set| {
+            let result = file_info.find_matching_syntax_reference(syntax_set);
+            assert_eq!(&result.unwrap().name, expected_language);
+        })
     }
 
     #[test]
-    fn cls_apex() {
-        let syntax_set = SyntaxSet::load_defaults_newlines();
-        let query = SourcegraphQuery {
-            filepath: "foo.cls".to_string(),
-            filetype: None,
-            code: "/**".to_string(),
-            line_length_limit: None,
-            extension: String::new(),
-        };
-        let result = determine_language(&query, &syntax_set);
-        assert_eq!(result.unwrap().name, "Apex");
+    fn test_syntect_lang_detection() {
+        let cases = [
+            ("foo.cls", "%", "TeX"),
+            ("foo.cls", "/**", "Apex"),
+        ];
+
+        for (path, content, lang) in cases {
+            test_syntect_lang_detection_impl(path, content, lang);
+        }
+    }
+
+    #[test]
+    fn test_extension() {
+        let mapping = [
+            ("foo", None),
+            ("foo.x", Some("x")),
+            ("foo.x.y", Some("y")),
+            (".abc", None),
+            ("a/.abc", None),
+            ("a.c/b.d", Some("d")),
+            ("a.c/b", None),
+        ];
+
+        for (path, expected_ext) in mapping {
+            assert_eq!(FileInfo::new(path, "", None).extension(), expected_ext);
+        }
     }
 }

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_html.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_html.rs
@@ -234,16 +234,27 @@ impl<'a> fmt::Display for Escape<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::highlighting::{FileInfo, HighlightingBackend};
     use crate::highlighting::test::SYNTAX_SET;
+    use crate::highlighting::{FileInfo, HighlightingBackend};
 
-    fn test_css_table_highlight(file_info: &FileInfo<'_>, line_length_limit: Option<usize>, expected: &str) {
+    fn test_css_table_highlight(
+        file_info: &FileInfo<'_>,
+        line_length_limit: Option<usize>,
+        expected: &str,
+    ) {
         let output = SYNTAX_SET.with(|syntax_set| {
-            HighlightingBackend::SyntectHtml { syntax_set, line_length_limit }
-                .highlight(file_info)
-                .unwrap()
+            HighlightingBackend::SyntectHtml {
+                syntax_set,
+                line_length_limit,
+            }
+            .highlight(file_info)
+            .unwrap()
         });
-        assert_eq!(expected, &output.payload, "used grammar: {}", output.grammar);
+        assert_eq!(
+            expected, &output.payload,
+            "used grammar: {}",
+            output.grammar
+        );
     }
 
     #[test]
@@ -305,7 +316,7 @@ mod tests {
         let file_info = FileInfo::new(
             "test.java",
             "package com.lwl.boot.model;\n\npublic class Item implements Serializable {}",
-            None
+            None,
         );
         let expected = "<table>\
                             <tbody>\

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_html.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_html.rs
@@ -234,23 +234,21 @@ impl<'a> fmt::Display for Escape<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::highlighting::{syntect_highlight, SourcegraphQuery};
-    use rocket::serde::json::json;
+    use crate::highlighting::{FileInfo, HighlightingBackend};
+    use crate::highlighting::test::SYNTAX_SET;
 
-    fn test_css_table_highlight(q: SourcegraphQuery, expected: &str) {
-        let result = syntect_highlight(q);
-        assert_eq!(json!({"data": expected, "plaintext": false}), result);
+    fn test_css_table_highlight(file_info: &FileInfo<'_>, line_length_limit: Option<usize>, expected: &str) {
+        let output = SYNTAX_SET.with(|syntax_set| {
+            HighlightingBackend::SyntectHtml { syntax_set, line_length_limit }
+                .highlight(file_info)
+                .unwrap()
+        });
+        assert_eq!(expected, &output.payload, "used grammar: {}", output.grammar);
     }
 
     #[test]
     fn simple_css() {
-        let query = SourcegraphQuery {
-            filepath: "test.go".to_string(),
-            filetype: None,
-            code: "package main\n".to_string(),
-            line_length_limit: None,
-            extension: String::new(),
-        };
+        let file_info = FileInfo::new("test.go", "package main\n", None);
         let expected = "<table>\
                             <tbody>\
                                 <tr>\
@@ -266,19 +264,13 @@ mod tests {
                                 </tr>\
                             </tbody>\
                         </table>";
-        test_css_table_highlight(query, expected)
+        test_css_table_highlight(&file_info, None, expected)
     }
 
     // See https://github.com/sourcegraph/sourcegraph/issues/20537
     #[test]
     fn long_line_gets_escaped() {
-        let query = SourcegraphQuery {
-            filepath: "test.html".to_string(),
-            filetype: None,
-            code: "<div>test</div>".to_string(),
-            line_length_limit: Some(10),
-            extension: String::new(),
-        };
+        let file_info = FileInfo::new("test.html", "<div>test</div>", None);
         let expected = "<table>\
                             <tbody>\
                                 <tr>\
@@ -289,18 +281,12 @@ mod tests {
                                 </tr>\
                             </tbody>\
                         </table>";
-        test_css_table_highlight(query, expected)
+        test_css_table_highlight(&file_info, Some(10), expected)
     }
 
     #[test]
     fn no_highlight_long_line() {
-        let query = SourcegraphQuery {
-            filepath: "test.go".to_string(),
-            filetype: None,
-            code: "package main\n".to_string(),
-            line_length_limit: Some(5),
-            extension: String::new(),
-        };
+        let file_info = FileInfo::new("test.go", "package main\n", None);
         let expected = "<table>\
                             <tbody>\
                                 <tr>\
@@ -311,19 +297,16 @@ mod tests {
                                 </tr>\
                             </tbody>\
                         </table>";
-        test_css_table_highlight(query, expected)
+        test_css_table_highlight(&file_info, Some(5), expected)
     }
 
     #[test]
     fn multi_line_java() {
-        let query = SourcegraphQuery {
-            filepath: "test.java".to_string(),
-            filetype: None,
-            code: "package com.lwl.boot.model;\n\npublic class Item implements Serializable {}"
-                .to_string(),
-            line_length_limit: None,
-            extension: String::new(),
-        };
+        let file_info = FileInfo::new(
+            "test.java",
+            "package com.lwl.boot.model;\n\npublic class Item implements Serializable {}",
+            None
+        );
         let expected = "<table>\
                             <tbody>\
                                 <tr>\
@@ -386,26 +369,23 @@ mod tests {
                                 </tr>\
                             </tbody>\
                         </table>";
-        test_css_table_highlight(query, expected)
+        test_css_table_highlight(&file_info, None, expected)
     }
 
     #[test]
     fn multi_line_matlab() {
-        let query = SourcegraphQuery {
-            filepath: "test.m".to_string(),
-            filetype: Option::Some("matlab".to_string()),
-            code: "function setupPythonIfNeeded()\n
+        let file_info = FileInfo::new(
+            "test.m",
+            "function setupPythonIfNeeded()\n
             % Python setup is only supported in R2019a (ver 9.6) and later\n
             if verLessThan('matlab','9.6')\n
             error(\"setupPythonIfNeeded:unsupportedVersion\",\"Only version R2019a and later are supported\")\n
             end\n
-            end"
-                .to_string(),
-            line_length_limit: None,
-            extension: String::new(),
-        };
+            end",
+            Some("matlab"),
+        );
 
         let expected = "<table><tbody><tr><td class=\"line\" data-line=\"1\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\"><span class=\"hl-keyword hl-other hl-matlab\">function</span><span class=\"hl-meta hl-function hl-parameters hl-matlab\"> <span class=\"hl-entity hl-name hl-function hl-matlab\">setupPythonIfNeeded</span><span class=\"hl-punctuation hl-section hl-parens hl-begin hl-matlab\">(</span><span class=\"hl-punctuation hl-section hl-parens hl-end hl-matlab\">)</span></span>\n</span></div></td></tr><tr><td class=\"line\" data-line=\"2\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"3\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-comment hl-line hl-percentage hl-matlab\"><span class=\"hl-punctuation hl-definition hl-comment hl-matlab\">%</span> Python setup is only supported in R2019a (ver 9.6) and later\n</span></span></div></td></tr><tr><td class=\"line\" data-line=\"4\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"5\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-keyword hl-control hl-matlab\">if</span> <span class=\"hl-keyword hl-desktop hl-matlab\">verLessThan</span><span class=\"hl-meta hl-parens hl-matlab\"><span class=\"hl-punctuation hl-section hl-parens hl-begin hl-matlab\">(</span><span class=\"hl-string hl-quoted hl-single hl-matlab\"><span class=\"hl-punctuation hl-definition hl-string hl-begin hl-matlab\">&#39;</span>matlab<span class=\"hl-punctuation hl-definition hl-string hl-end hl-matlab\">&#39;</span></span>,<span class=\"hl-string hl-quoted hl-single hl-matlab\"><span class=\"hl-punctuation hl-definition hl-string hl-begin hl-matlab\">&#39;</span>9.6<span class=\"hl-punctuation hl-definition hl-string hl-end hl-matlab\">&#39;</span></span><span class=\"hl-punctuation hl-section hl-parens hl-end hl-matlab\">)</span></span>\n</span></div></td></tr><tr><td class=\"line\" data-line=\"6\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"7\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-keyword hl-other hl-matlab\">error</span><span class=\"hl-meta hl-parens hl-matlab\"><span class=\"hl-punctuation hl-section hl-parens hl-begin hl-matlab\">(</span><span class=\"hl-string hl-quoted hl-double hl-matlab\"><span class=\"hl-punctuation hl-definition hl-string hl-begin hl-matlab\">&quot;</span>setupPythonIfNeeded:unsupportedVersion<span class=\"hl-punctuation hl-definition hl-string hl-end hl-matlab\">&quot;</span></span>,<span class=\"hl-string hl-quoted hl-double hl-matlab\"><span class=\"hl-punctuation hl-definition hl-string hl-begin hl-matlab\">&quot;</span>Only version R2019a and later are supported<span class=\"hl-punctuation hl-definition hl-string hl-end hl-matlab\">&quot;</span></span><span class=\"hl-punctuation hl-section hl-parens hl-end hl-matlab\">)</span></span>\n</span></div></td></tr><tr><td class=\"line\" data-line=\"8\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"9\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-keyword hl-control hl-matlab\">end</span>\n</span></div></td></tr><tr><td class=\"line\" data-line=\"10\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">\n</span></div></td></tr><tr><td class=\"line\" data-line=\"11\"/><td class=\"code\"><div><span class=\"hl-source hl-matlab\">            <span class=\"hl-keyword hl-control hl-matlab\">end</span></span></div></td></tr></tbody></table>";
-        test_css_table_highlight(query, expected);
+        test_css_table_highlight(&file_info, None, expected);
     }
 }

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_scip.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_scip.rs
@@ -551,27 +551,26 @@ mod test {
     }
 
     use super::*;
-    use crate::highlighting::{determine_language, SourcegraphQuery};
+    use crate::highlighting::{test::SYNTAX_SET, FileInfo};
+
+    fn make_scip_doc_via_syntect(file_info: &FileInfo<'_>) -> Document {
+        SYNTAX_SET.with(|syntax_set| {
+            let syntax_ref = file_info.find_matching_syntax_reference(syntax_set).unwrap();
+            DocumentGenerator::new(syntax_set, syntax_ref, file_info.contents, None).generate()
+        })
+    }
 
     #[test]
     fn test_generates_empty_file() {
-        let syntax_set = SyntaxSet::load_defaults_newlines();
-        let q = SourcegraphQuery {
-            filetype: Some("go".to_string()),
-            code: "".to_string(),
+        let output = make_scip_doc_via_syntect(&FileInfo {
+            language: Some("go"),
             ..Default::default()
-        };
-
-        let syntax_def = determine_language(&q, &syntax_set).unwrap();
-        let output = DocumentGenerator::new(&syntax_set, syntax_def, &q.code, q.line_length_limit)
-            .generate();
-
+        });
         assert_eq!(Document::default(), output);
     }
 
     #[test]
     fn test_all_files() -> Result<(), std::io::Error> {
-        let ss = SyntaxSet::load_defaults_newlines();
         let mut failed = vec![];
 
         let crate_root: std::path::PathBuf = std::env::var("CARGO_MANIFEST_DIR").unwrap().into();
@@ -601,15 +600,8 @@ mod test {
             let mut contents = String::new();
             file.read_to_string(&mut contents)?;
 
-            let q = SourcegraphQuery {
-                extension: filepath.extension().unwrap().to_str().unwrap().to_string(),
-                filepath: filepath.to_str().unwrap().to_string(),
-                filetype: None,
-                line_length_limit: None,
-                code: contents.clone(),
-            };
-            let syntax_def = determine_language(&q, &ss).unwrap();
-            let document = DocumentGenerator::new(&ss, syntax_def, &q.code, None).generate();
+            let file_info = FileInfo::new(filepath.to_str().unwrap(), &contents, None);
+            let document = make_scip_doc_via_syntect(&file_info);
 
             // As far as I can tell, there is no "matches_snapshot" or similar for `insta`.
             // So we'll just catch the panic for now, push the results and then panic at the end

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_scip.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/syntect_scip.rs
@@ -555,7 +555,9 @@ mod test {
 
     fn make_scip_doc_via_syntect(file_info: &FileInfo<'_>) -> Document {
         SYNTAX_SET.with(|syntax_set| {
-            let syntax_ref = file_info.find_matching_syntax_reference(syntax_set).unwrap();
+            let syntax_ref = file_info
+                .find_matching_syntax_reference(syntax_set)
+                .unwrap();
             DocumentGenerator::new(syntax_set, syntax_ref, file_info.contents, None).generate()
         })
     }

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
@@ -488,7 +488,7 @@ SELECT * FROM my_table
             let language = &crate::highlighting::test::SYNTAX_SET
                 .with(|syntax_set| {
                     FileInfo::new(filepath.to_string_lossy().as_ref(), &contents, None)
-                    .determine_language(syntax_set)
+                        .determine_language(syntax_set)
                 })
                 .unwrap();
 
@@ -540,7 +540,7 @@ SELECT * FROM my_table
             let language = crate::highlighting::test::SYNTAX_SET
                 .with(|syntax_set| {
                     FileInfo::new(filepath.to_string_lossy().as_ref(), &contents, None)
-                    .determine_language(syntax_set)
+                        .determine_language(syntax_set)
                 })
                 .unwrap();
 

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
@@ -1,15 +1,11 @@
-use anyhow::Result;
 use paste::paste;
-use protobuf::Message;
-use rocket::serde::json::{serde_json::json, Value as JsonValue};
 use scip::types::{Document, Occurrence, SyntaxKind};
 use std::collections::HashMap;
 use tree_sitter_all_languages::ParserId;
 use tree_sitter_highlight::{
-    Error, Highlight, HighlightConfiguration, HighlightEvent, Highlighter as TSHighlighter,
+    Highlight, HighlightConfiguration, HighlightEvent, Highlighter as TSHighlighter,
 };
 
-use crate::highlighting::SourcegraphQuery;
 use crate::range::Range;
 
 macro_rules! include_scip_query {
@@ -24,22 +20,19 @@ macro_rules! include_scip_query {
         ))
     };
 }
+use crate::highlighting::TreeSitterLanguageName;
 pub(crate) use include_scip_query;
 
 #[rustfmt::skip]
-// Table of (@CaptureGroup, SyntaxKind) mapping.
+// This table serves two purposes.
 //
-// Any capture defined in a query will be mapped to the following SyntaxKind via the highlighter.
+// 1. It serves as the list of all captures that we
+//    recognize in highlighting queries specified in
+//    highlights.scm files. The list of captures is
+//    the union across all languages.
+// 2. It describes the capture -> syntax kind mapping.
 //
-// To extend what types of captures are included, simply add a line below that takes a particular
-// match group that you're interested in and map it to a new SyntaxKind.
-//
-// We can also define our own new capture types that we want to use and add to queries to provide
-// particular highlights if necessary.
-//
-// (I can also add per-language mappings for these if we want, but you could also just do that with
-//  unique match groups. For example `@rust-bracket`, or similar. That doesn't need any
-//  particularly new rust code to be written. You can just modify queries for that)
+// Client-side code will convert the syntax kinds into actual colors.
 const MATCHES_TO_SYNTAX_KINDS: &[(&str, SyntaxKind)] = &[
     ("boolean",                 SyntaxKind::BooleanLiteral),
     ("character",               SyntaxKind::CharacterLiteral),
@@ -156,9 +149,6 @@ macro_rules! create_configurations {
 
 lazy_static::lazy_static! {
     pub static ref CONFIGURATIONS: HashMap<ParserId, HighlightConfiguration> = {
-        // NOTE: typescript/tsx crates are included, even though not listed below.
-
-        // You can add any new crate::parsers::Parser variants here.
         create_configurations!(
             (C, "c"),
             (Cpp, "cpp"),
@@ -177,132 +167,112 @@ lazy_static::lazy_static! {
             (Rust, "rust"),
             (Scala, "scala"),
             (Sql, "sql"),
+            // Skipping TypeScript and TSX here as they're handled
+            // specially inside the macro implementation.
             (Xlsg, "xlsg"),
             (Zig, "zig")
         )
     };
 }
 
-fn get_highlighting_configuration(filetype: &str) -> Option<&'static HighlightConfiguration> {
-    ParserId::from_name(filetype).and_then(|parser| CONFIGURATIONS.get(&parser))
-}
-
 fn get_syntax_kind_for_hl(hl: Highlight) -> SyntaxKind {
     MATCHES_TO_SYNTAX_KINDS[hl.0].1
 }
 
-// Handle special cases where syntect language names don't match treesitter names.
-pub(crate) fn treesitter_language(syntect_language: &str) -> &str {
-    match syntect_language {
-        "c++" => "cpp",
-        _ => syntect_language,
-    }
-}
-
-pub fn jsonify_err(e: impl ToString) -> JsonValue {
-    json!({"error": e.to_string()})
-}
-
-// TODO(cleanup_lsif): Remove this when we remove /lsif endpoint
-// Currently left unchanged
-pub fn lsif_highlight(q: SourcegraphQuery) -> Result<JsonValue, JsonValue> {
-    let filetype = q
-        .filetype
-        .ok_or_else(|| json!({"error": "Must pass a filetype for /lsif" }))?
-        .to_lowercase();
-
-    match index_language(&filetype, &q.code, false) {
-        Ok(document) => {
-            let encoded = document.write_to_bytes().map_err(jsonify_err)?;
-
-            Ok(json!({"data": base64::encode(encoded), "plaintext": false}))
+impl TreeSitterLanguageName {
+    pub fn highlight_document(
+        &self,
+        code: &str,
+        include_locals: bool,
+    ) -> Result<Document, tree_sitter_highlight::Error> {
+        match self.highlighting_configuration() {
+            Some(lang_config) => {
+                self.highlight_document_with_config(code, include_locals, lang_config)
+            }
+            None => Err(tree_sitter_highlight::Error::InvalidLanguage),
         }
-        Err(Error::InvalidLanguage) => Err(json!({
-            "error": format!("{} is not a valid filetype for treesitter", filetype)
-        })),
-        Err(err) => Err(jsonify_err(err)),
     }
-}
 
-pub fn index_language(filetype: &str, code: &str, include_locals: bool) -> Result<Document, Error> {
-    match get_highlighting_configuration(filetype) {
-        Some(lang_config) => {
-            index_language_with_config(filetype, code, lang_config, include_locals)
-        }
-        None => Err(Error::InvalidLanguage),
+    fn parser_id(&self) -> Option<ParserId> {
+        ParserId::from_name(&self.raw)
     }
-}
 
-pub fn index_language_with_config(
-    filetype: &str,
-    code: &str,
-    lang_config: &HighlightConfiguration,
-    include_locals: bool,
-) -> Result<Document, Error> {
-    // Normalize string to be always only \n endings.
-    //  We don't care that the byte offsets are "incorrect" now for this
-    //  because we are using a line,col based approach
-    let code = code.replace("\r\n", "\n");
+    fn highlighting_configuration(&self) -> Option<&'static HighlightConfiguration> {
+        self.parser_id()
+            .and_then(|parser| CONFIGURATIONS.get(&parser))
+    }
 
-    // TODO: We should automatically apply no highlights when we are
-    // in an injected piece of code.
-    //
-    // Unfortunately, that information isn't currently available when
-    // we are iterating in the higlighter.
-    let mut highlighter = TSHighlighter::new();
-    let highlights = highlighter.highlight(lang_config, code.as_bytes(), None, |l| {
-        get_highlighting_configuration(l)
-    })?;
+    pub fn highlight_document_with_config(
+        &self,
+        code: &str,
+        include_locals: bool,
+        lang_config: &HighlightConfiguration,
+    ) -> Result<Document, tree_sitter_highlight::Error> {
+        // Normalize string to be always only \n endings.
+        //  We don't care that the byte offsets are "incorrect" now for this
+        //  because we are using a line,col based approach
+        let code = code.replace("\r\n", "\n");
 
-    let mut emitter = ScipEmitter::new();
-    let mut doc = emitter.render(highlights, &code)?;
-    doc.occurrences.sort_by_key(|a| (a.range[0], a.range[1]));
+        // TODO: We should automatically apply no highlights when we are
+        // in an injected piece of code.
+        //
+        // Unfortunately, that information isn't currently available when
+        // we are iterating in the higlighter.
+        let mut highlighter = TSHighlighter::new();
+        let highlights = highlighter.highlight(lang_config, code.as_bytes(), None, |l| {
+            TreeSitterLanguageName::new(l).highlighting_configuration()
+        })?;
 
-    if include_locals {
-        let parser = tree_sitter_all_languages::ParserId::from_name(filetype);
-        if let Some(parser) = parser {
-            // TODO: Could probably write this in a much better way.
-            let mut local_occs = crate::get_locals(parser, code.as_bytes()).unwrap_or_default();
+        let mut emitter = ScipEmitter::new();
+        let mut doc = emitter.render(highlights, &code)?;
+        doc.occurrences.sort_by_key(|a| (a.range[0], a.range[1]));
 
-            // Get ranges in reverse order, because we're going to pop off the back of the list.
-            //  (that's why we're sorting the opposite way of the document occurrences above).
-            local_occs.sort_by_key(|a| (-a.range[0], -a.range[1]));
+        if include_locals {
+            let parser = self.parser_id();
+            if let Some(parser) = parser {
+                // TODO: Could probably write this in a much better way.
+                let mut local_occs = crate::get_locals(parser, code.as_bytes()).unwrap_or_default();
 
-            let mut next_doc_idx = 0;
-            while let Some(local) = local_occs.pop() {
-                // We *should* be able to assume that all these ranges are valid ranges
-                // but for now we'll skip if they aren't.
-                //
-                // We can add some observability stuff to this later, and/or make
-                // certain builds fail or something to test this out better (but
-                // not have syntax highlighting completely fall apart from one
-                // bad range)
-                let local_range = match Range::from_vec(&local.range) {
-                    Some(range) => range,
-                    None => continue,
-                };
+                // Get ranges in reverse order, because we're going to pop off the back of the list.
+                //  (that's why we're sorting the opposite way of the document occurrences above).
+                local_occs.sort_by_key(|a| (-a.range[0], -a.range[1]));
 
-                let (matching_idx, matching_occ) = match doc
-                    .occurrences
-                    .iter_mut()
-                    .enumerate()
-                    .skip(next_doc_idx)
-                    .find(|(_, occ)| local_range.eq_vec(&occ.range))
-                {
-                    Some(found) => found,
-                    None => continue,
-                };
+                let mut next_doc_idx = 0;
+                while let Some(local) = local_occs.pop() {
+                    // We *should* be able to assume that all these ranges are valid ranges
+                    // but for now we'll skip if they aren't.
+                    //
+                    // We can add some observability stuff to this later, and/or make
+                    // certain builds fail or something to test this out better (but
+                    // not have syntax highlighting completely fall apart from one
+                    // bad range)
+                    let local_range = match Range::from_vec(&local.range) {
+                        Some(range) => range,
+                        None => continue,
+                    };
 
-                next_doc_idx = matching_idx;
+                    let (matching_idx, matching_occ) = match doc
+                        .occurrences
+                        .iter_mut()
+                        .enumerate()
+                        .skip(next_doc_idx)
+                        .find(|(_, occ)| local_range.eq_vec(&occ.range))
+                    {
+                        Some(found) => found,
+                        None => continue,
+                    };
 
-                // Update occurrence with new information from locals
-                matching_occ.symbol = local.symbol;
-                matching_occ.symbol_roles = local.symbol_roles;
+                    next_doc_idx = matching_idx;
+
+                    // Update occurrence with new information from locals
+                    matching_occ.symbol = local.symbol;
+                    matching_occ.symbol_roles = local.symbol_roles;
+                }
             }
         }
-    }
 
-    Ok(doc)
+        Ok(doc)
+    }
 }
 
 struct OffsetManager {
@@ -433,7 +403,7 @@ mod test {
     };
 
     use super::*;
-    use crate::highlighting::determine_filetype;
+    use crate::highlighting::FileInfo;
     use crate::snapshot::{self, dump_document_with_config};
 
     fn snapshot_treesitter_syntax_kinds(doc: &Document, source: &str) -> String {
@@ -463,16 +433,16 @@ mod test {
     }
 
     #[test]
-    fn test_highlights_one_comment() -> Result<(), Error> {
+    fn test_highlights_one_comment() -> anyhow::Result<()> {
         let src = "// Hello World";
-        let document = index_language("go", src, false)?;
+        let document = TreeSitterLanguageName::new("go").highlight_document(src, false)?;
         insta::assert_snapshot!(snapshot_treesitter_syntax_kinds(&document, src));
 
         Ok(())
     }
 
     #[test]
-    fn test_highlights_a_sql_query_within_go() -> Result<(), Error> {
+    fn test_highlights_a_sql_query_within_go() -> anyhow::Result<()> {
         let src = r#"package main
 
 const MySqlQuery = `
@@ -480,16 +450,16 @@ SELECT * FROM my_table
 `
 "#;
 
-        let document = index_language("go", src, false)?;
+        let document = TreeSitterLanguageName::new("go").highlight_document(src, false)?;
         insta::assert_snapshot!(snapshot_treesitter_syntax_kinds(&document, src));
 
         Ok(())
     }
 
     #[test]
-    fn test_highlight_csharp_file() -> Result<(), Error> {
+    fn test_highlight_csharp_file() -> anyhow::Result<()> {
         let src = "using System;";
-        let document = index_language("c_sharp", src, false)?;
+        let document = TreeSitterLanguageName::new("c_sharp").highlight_document(src, false)?;
         insta::assert_snapshot!(snapshot_treesitter_syntax_kinds(&document, src));
 
         Ok(())
@@ -515,21 +485,14 @@ SELECT * FROM my_table
             let mut contents = String::new();
             file.read_to_string(&mut contents)?;
 
-            let filetype = &determine_filetype(&SourcegraphQuery {
-                extension: filepath.extension().unwrap().to_str().unwrap().to_string(),
-                filepath: filepath.to_str().unwrap().to_string(),
-                filetype: None,
-                line_length_limit: None,
-                code: contents.clone(),
-            });
+            let language = &crate::highlighting::test::SYNTAX_SET
+                .with(|syntax_set| {
+                    FileInfo::new(filepath.to_string_lossy().as_ref(), &contents, None)
+                    .determine_language(syntax_set)
+                })
+                .unwrap();
 
-            let indexed = index_language(filetype, &contents, true);
-            if indexed.is_err() {
-                // assert failure
-                panic!("unknown filetype {:?}", filetype);
-            }
-            let document = indexed.unwrap();
-
+            let document = language.highlight_document(&contents, true).unwrap();
             // TODO: I'm not sure if there's a better way to run the snapshots without
             // panicing and then catching, but this will do for now.
             match std::panic::catch_unwind(|| {
@@ -574,20 +537,14 @@ SELECT * FROM my_table
             let mut contents = String::new();
             file.read_to_string(&mut contents)?;
 
-            let filetype = &determine_filetype(&SourcegraphQuery {
-                extension: filepath.extension().unwrap().to_str().unwrap().to_string(),
-                filepath: filepath.to_str().unwrap().to_string(),
-                filetype: None,
-                line_length_limit: None,
-                code: contents.clone(),
-            });
+            let language = crate::highlighting::test::SYNTAX_SET
+                .with(|syntax_set| {
+                    FileInfo::new(filepath.to_string_lossy().as_ref(), &contents, None)
+                    .determine_language(syntax_set)
+                })
+                .unwrap();
 
-            let indexed = index_language(filetype, &contents, true);
-            if indexed.is_err() {
-                // assert failure
-                panic!("unknown filetype {:?}", filetype);
-            }
-            let document = indexed.unwrap();
+            let document = language.highlight_document(&contents, true).unwrap();
 
             // TODO: I'm not sure if there's a better way to run the snapshots without
             // panicing and then catching, but this will do for now.

--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting/tree_sitter.rs
@@ -198,8 +198,7 @@ impl TreeSitterLanguageName {
     }
 
     fn highlighting_configuration(&self) -> Option<&'static HighlightConfiguration> {
-        self.parser_id()
-            .and_then(|parser| CONFIGURATIONS.get(&parser))
+        CONFIGURATIONS.get(&self.parser_id()?)
     }
 
     pub fn highlight_document_with_config(

--- a/docker-images/syntax-highlighter/src/bin/scip-dump-response.rs
+++ b/docker-images/syntax-highlighter/src/bin/scip-dump-response.rs
@@ -1,8 +1,8 @@
 use std::{fs, path::Path};
 
 use clap::Parser;
-use syntect::parsing::SyntaxSet;
 use syntax_analysis::highlighting::FileInfo;
+use syntect::parsing::SyntaxSet;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -40,12 +40,20 @@ fn main() -> Result<(), std::io::Error> {
 
     let file_info = FileInfo::new(path.to_string_lossy().as_ref(), &contents, None);
 
-    let language = file_info.determine_language(&SyntaxSet::load_defaults_newlines())
+    let language = file_info
+        .determine_language(&SyntaxSet::load_defaults_newlines())
         .expect("failed to determine language");
     println!("  language: {:?}", language.to_string());
 
-    let document = language.highlight_document(&contents, args.include_locals)
-        .unwrap_or_else(|e| panic!("failed to run Tree-sitter for file '{}': {:?}", path.to_string_lossy(), e));
+    let document = language
+        .highlight_document(&contents, args.include_locals)
+        .unwrap_or_else(|e| {
+            panic!(
+                "failed to run Tree-sitter for file '{}': {:?}",
+                path.to_string_lossy(),
+                e
+            )
+        });
     println!("  highlighted document");
 
     scip::write_message_to_file(output, document).expect("writes document");

--- a/docker-images/syntax-highlighter/src/bin/scip-dump-response.rs
+++ b/docker-images/syntax-highlighter/src/bin/scip-dump-response.rs
@@ -1,6 +1,8 @@
 use std::{fs, path::Path};
 
 use clap::Parser;
+use syntect::parsing::SyntaxSet;
+use syntax_analysis::highlighting::FileInfo;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -36,27 +38,15 @@ fn main() -> Result<(), std::io::Error> {
     let contents = fs::read_to_string(path)?;
     println!("  read {} bytes", contents.len());
 
-    let filetype = syntax_analysis::highlighting::determine_filetype(
-        &syntax_analysis::highlighting::SourcegraphQuery {
-            extension: path
-                .extension()
-                .expect("extension")
-                .to_str()
-                .expect("valid utf-8 path")
-                .to_string(),
-            code: contents.clone(),
-            filepath: "".to_string(),
-            filetype: None,
-            line_length_limit: None,
-        },
-    );
+    let file_info = FileInfo::new(path.to_string_lossy().as_ref(), &contents, None);
 
-    println!("  filetype: {:?}", filetype);
+    let language = file_info.determine_language(&SyntaxSet::load_defaults_newlines())
+        .expect("failed to determine language");
+    println!("  language: {:?}", language.to_string());
 
-    let document =
-        syntax_analysis::highlighting::treesitter_index(&filetype, &contents, args.include_locals)
-            .expect("parse document");
-    println!("  parsed document");
+    let document = language.highlight_document(&contents, args.include_locals)
+        .unwrap_or_else(|e| panic!("failed to run Tree-sitter for file '{}': {:?}", path.to_string_lossy(), e));
+    println!("  highlighted document");
 
     scip::write_message_to_file(output, document).expect("writes document");
     println!("  wrote document to {:?}", output);

--- a/docker-images/syntax-highlighter/src/lib.rs
+++ b/docker-images/syntax-highlighter/src/lib.rs
@@ -1,9 +1,7 @@
 use anyhow::Context;
 use rocket::serde::json::{json, Value as JsonValue};
 use serde::Deserialize;
-use syntax_analysis::highlighting::{
-    FileInfo, HighlightingBackend, PayloadKind,
-};
+use syntax_analysis::highlighting::{FileInfo, HighlightingBackend, PayloadKind};
 use syntect::parsing::SyntaxSet;
 
 thread_local! {
@@ -130,10 +128,12 @@ pub fn syntect_highlight(q: SourcegraphQuery) -> JsonValue {
 // TODO(cleanup_lsif): Remove this when we remove /lsif endpoint
 // Currently left unchanged
 pub fn lsif_highlight(q: SourcegraphQuery) -> Result<JsonValue, JsonValue> {
-    let output = HighlightingBackend::TreeSitter { include_locals: false }
-        .highlight(&q.file_info())
-        .context("/lsif endpoint")
-        .map_err(jsonify_err)?;
+    let output = HighlightingBackend::TreeSitter {
+        include_locals: false,
+    }
+    .highlight(&q.file_info())
+    .context("/lsif endpoint")
+    .map_err(jsonify_err)?;
     debug_assert!(output.kind == PayloadKind::Base64EncodedScip);
     Ok(json!({"data": output.payload, "plaintext": false}))
 }
@@ -141,14 +141,13 @@ pub fn lsif_highlight(q: SourcegraphQuery) -> Result<JsonValue, JsonValue> {
 pub fn scip_highlight(q: ScipHighlightQuery) -> Result<JsonValue, JsonValue> {
     SYNTAX_SET.with(|syntax_set| {
         let backend = match q.engine {
-            SyntaxEngine::Syntect =>
-                HighlightingBackend::SyntectScip {
-                    syntax_set,
-                    line_length_limit: q.line_length_limit,
-                },
+            SyntaxEngine::Syntect => HighlightingBackend::SyntectScip {
+                syntax_set,
+                line_length_limit: q.line_length_limit,
+            },
             SyntaxEngine::TreeSitter | SyntaxEngine::ScipSyntax => {
                 HighlightingBackend::TreeSitter {
-                    include_locals: q.engine == SyntaxEngine::ScipSyntax
+                    include_locals: q.engine == SyntaxEngine::ScipSyntax,
                 }
             }
         };

--- a/docker-images/syntax-highlighter/src/lib.rs
+++ b/docker-images/syntax-highlighter/src/lib.rs
@@ -1,0 +1,162 @@
+use anyhow::Context;
+use rocket::serde::json::{json, Value as JsonValue};
+use serde::Deserialize;
+use syntax_analysis::highlighting::{
+    FileInfo, HighlightingBackend, PayloadKind,
+};
+use syntect::parsing::SyntaxSet;
+
+thread_local! {
+    pub(crate) static SYNTAX_SET: SyntaxSet = SyntaxSet::load_defaults_newlines();
+}
+
+pub fn list_features() {
+    // List supported file extensions.
+    SYNTAX_SET.with(|syntax_set| {
+        println!("## Supported file extensions:");
+        println!();
+        for sd in syntax_set.syntaxes() {
+            println!("- {} (`{}`)", sd.name, sd.file_extensions.join("`, `"));
+        }
+        println!();
+    });
+}
+
+/// Struct from: internal/gosyntect/gosyntect.go
+///
+/// Keep in sync with that struct.
+#[derive(Deserialize, Default, Debug)]
+pub struct SourcegraphQuery {
+    // Deprecated field with a default empty string value, kept for backwards
+    // compatability with old clients.
+    //
+    // TODO: Can I just delete this because this image will only run for a particular sourcegraph
+    // version... so they can't be out of sync anymore, which is pretty cool
+    #[serde(default)]
+    pub extension: String,
+
+    // Contents of the file
+    pub code: String,
+
+    // default empty string value for backwards compat with clients who do not specify this field.
+    #[serde(default)]
+    pub filepath: String,
+
+    // The language defined by the server. Required to tree-sitter to use for the filetype name.
+    // default empty string value for backwards compat with clients who do not specify this field.
+    pub filetype: Option<String>,
+
+    // line_length_limit is ignored if css is false
+    pub line_length_limit: Option<usize>,
+}
+
+impl SourcegraphQuery {
+    fn file_info(&self) -> FileInfo<'_> {
+        if self.filepath.is_empty() {
+            FileInfo::new_from_extension(&self.extension, &self.code, self.filetype.as_deref())
+        } else {
+            FileInfo::new(&self.filepath, &self.code, self.filetype.as_deref())
+        }
+    }
+}
+
+// NOTE: Keep in sync: internal/gosyntect/gosyntect.go
+#[derive(Deserialize, Default, Debug, PartialEq, Eq)]
+pub enum SyntaxEngine {
+    /// Returns highlighting data only via syntect in SCIP format
+    #[default]
+    #[serde(rename = "syntect")]
+    Syntect,
+
+    /// Returns highlighting data only via Tree-sitter in SCIP format
+    #[serde(rename = "tree-sitter")]
+    TreeSitter,
+
+    /// Returns highlighting data and optionally locals data via Tree-sitter in SCIP format
+    ///
+    /// This name is preserved for backwards compatibility. The web client
+    /// makes use of locals data for code navigation, so it doesn't make
+    /// sense to omit locals data if it is available.
+    #[serde(rename = "scip-syntax")]
+    ScipSyntax,
+}
+
+#[derive(Deserialize, Default, Debug)]
+pub struct ScipHighlightQuery {
+    // Which highlighting engine to use.
+    pub engine: SyntaxEngine,
+
+    // Contents of the file
+    pub code: String,
+
+    // filepath is only used if language is None.
+    pub filepath: String,
+
+    // The language defined by the server. Required to tree-sitter to use for the filetype name.
+    // default empty string value for backwards compat with clients who do not specify this field.
+    pub filetype: Option<String>,
+
+    // line_length_limit is used to limit syntect problems when
+    // parsing very long lines
+    pub line_length_limit: Option<usize>,
+}
+
+impl ScipHighlightQuery {
+    fn file_info(&self) -> FileInfo<'_> {
+        FileInfo::new(&self.filepath, &self.code, self.filetype.as_deref())
+    }
+}
+
+pub fn jsonify_err(e: impl ToString) -> JsonValue {
+    json!({"error": e.to_string()})
+}
+
+pub fn syntect_highlight(q: SourcegraphQuery) -> JsonValue {
+    SYNTAX_SET.with(|syntax_set| {
+        let backend = HighlightingBackend::SyntectHtml {
+            syntax_set,
+            line_length_limit: q.line_length_limit,
+        };
+        let output = match backend.highlight(&q.file_info()) {
+            Ok(output) => output,
+            Err(e) => return jsonify_err(e),
+        };
+
+        debug_assert!(output.kind == PayloadKind::Html);
+        json!({ "data": output.payload, "plaintext": &output.grammar == "Plain Text", })
+    })
+}
+
+// TODO(cleanup_lsif): Remove this when we remove /lsif endpoint
+// Currently left unchanged
+pub fn lsif_highlight(q: SourcegraphQuery) -> Result<JsonValue, JsonValue> {
+    let output = HighlightingBackend::TreeSitter { include_locals: false }
+        .highlight(&q.file_info())
+        .context("/lsif endpoint")
+        .map_err(jsonify_err)?;
+    debug_assert!(output.kind == PayloadKind::Base64EncodedScip);
+    Ok(json!({"data": output.payload, "plaintext": false}))
+}
+
+pub fn scip_highlight(q: ScipHighlightQuery) -> Result<JsonValue, JsonValue> {
+    SYNTAX_SET.with(|syntax_set| {
+        let backend = match q.engine {
+            SyntaxEngine::Syntect =>
+                HighlightingBackend::SyntectScip {
+                    syntax_set,
+                    line_length_limit: q.line_length_limit,
+                },
+            SyntaxEngine::TreeSitter | SyntaxEngine::ScipSyntax => {
+                HighlightingBackend::TreeSitter {
+                    include_locals: q.engine == SyntaxEngine::ScipSyntax
+                }
+            }
+        };
+        let output = backend
+            .highlight(&q.file_info())
+            .context("/scip endpoint")
+            .map_err(jsonify_err)?;
+        debug_assert!(output.kind == PayloadKind::Base64EncodedScip);
+        Ok(json!({"scip": output.payload, "plaintext": false}))
+    })
+}

--- a/docker-images/syntax-highlighter/src/main.rs
+++ b/docker-images/syntax-highlighter/src/main.rs
@@ -4,7 +4,7 @@
 extern crate rocket;
 
 use rocket::serde::json::{json, Json, Value as JsonValue};
-use syntax_analysis::highlighting::{ScipHighlightQuery, SourcegraphQuery};
+use syntect_server::{ScipHighlightQuery, SourcegraphQuery};
 
 #[post("/", format = "application/json", data = "<q>")]
 fn syntect(q: Json<SourcegraphQuery>) -> JsonValue {
@@ -13,7 +13,7 @@ fn syntect(q: Json<SourcegraphQuery>) -> JsonValue {
     // will require some non-trivial work upstream:
     // https://github.com/trishume/syntect/issues/98
     let result = std::panic::catch_unwind(|| {
-        syntax_analysis::highlighting::syntect_highlight(q.into_inner())
+        syntect_server::syntect_highlight(q.into_inner())
     });
     match result {
         Ok(v) => v,
@@ -26,7 +26,7 @@ fn syntect(q: Json<SourcegraphQuery>) -> JsonValue {
 // for now, since I'm working on doing that.
 #[post("/lsif", format = "application/json", data = "<q>")]
 fn lsif(q: Json<SourcegraphQuery>) -> JsonValue {
-    match syntax_analysis::highlighting::lsif_highlight(q.into_inner()) {
+    match syntect_server::lsif_highlight(q.into_inner()) {
         Ok(v) => v,
         Err(err) => err,
     }
@@ -34,7 +34,7 @@ fn lsif(q: Json<SourcegraphQuery>) -> JsonValue {
 
 #[post("/scip", format = "application/json", data = "<q>")]
 fn scip(q: Json<ScipHighlightQuery>) -> JsonValue {
-    match syntax_analysis::highlighting::scip_highlight(q.into_inner()) {
+    match syntect_server::scip_highlight(q.into_inner()) {
         Ok(v) => v,
         Err(err) => err,
     }
@@ -78,7 +78,7 @@ fn rocket() -> _ {
     // Only list features if QUIET != "true"
     match std::env::var("QUIET") {
         Ok(v) if v == "true" => {}
-        _ => syntax_analysis::highlighting::list_features(),
+        _ => syntect_server::list_features(),
     };
 
     rocket::build()

--- a/docker-images/syntax-highlighter/src/main.rs
+++ b/docker-images/syntax-highlighter/src/main.rs
@@ -12,9 +12,7 @@ fn syntect(q: Json<SourcegraphQuery>) -> JsonValue {
     // and instead Syntect would return Result types when failures occur. This
     // will require some non-trivial work upstream:
     // https://github.com/trishume/syntect/issues/98
-    let result = std::panic::catch_unwind(|| {
-        syntect_server::syntect_highlight(q.into_inner())
-    });
+    let result = std::panic::catch_unwind(|| syntect_server::syntect_highlight(q.into_inner()));
     match result {
         Ok(v) => v,
         Err(_) => json!({"error": "panic while highlighting code", "code": "panic"}),


### PR DESCRIPTION
Makes partial progress towards https://github.com/sourcegraph/sourcegraph/issues/59792

Addresses feedback from https://github.com/sourcegraph/sourcegraph/pull/59890

- `*Query` types are now moved to the server code.
- syntax-analysis crate no longer depends on Rocket (web server).
  Instead, it just takes a FileInfo struct for highlighting,
  and the server code converts a query into a FileInfo value.
- syntax-analysis crate doesn't depend on JSON for highlighting.
  There is still JSON usage in the ctags bit, but we can
  separate that out in a different PR as this is already quite big.

As part of this, I've introduced different types for the different
grammar names (Syntect/Sublime vs Tree-sitter) so that the code is
easier to follow. For simplicity, we do not eagerly validate
the grammar names on construction, but return an error as part of
highlighting if there is no match found. This matches the old
behavior. In the future, we could clean this up to be more
'correct by construction'.

## Test plan

- [x] Existing tests are passing
- [x] Test manually by spinning up syntax-highlighter and making sure
      there aren't any issues.
