### PR TITLE
Fix Cody subscription ends at display logic in UI

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -88,7 +88,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
     const enrollPro = parameters.get('pro') === 'true'
 
-    let subscription = data?.currentUser?.codySubscription
+    const subscription = data?.currentUser?.codySubscription
 
     useEffect(() => {
         if (!arePaymentsEnabled && enrollPro && data?.currentUser && subscription?.plan !== CodySubscriptionPlan.PRO) {
@@ -107,8 +107,6 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
     if (!isCodyEnabled() || !isSourcegraphDotCom || !subscription) {
         return null
     }
-
-    subscription = { ...subscription, cancelAtPeriodEnd: true }
 
     const codeLimitReached = codyCurrentPeriodCodeUsage >= codyCurrentPeriodCodeLimit && codyCurrentPeriodCodeLimit > 0
     const chatLimitReached = codyCurrentPeriodChatUsage >= codyCurrentPeriodChatLimit && codyCurrentPeriodChatLimit > 0


### PR DESCRIPTION
closes: https://sourcegraph.slack.com/archives/C05PC7AKFQV/p1706755128948399

Silly mistake from the previous PR. 

I override the `cancelAtPeriodEnd` property on the frontend to test that state and take a screenshot. I forgot to remove the code. 

![CleanShot 2024-02-01 at 13 31 27@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/65ec5484-b54f-48db-8bd0-b0e8627c81a1)


## Test plan
- Set `use-ssc-for-cody-subscription` and `cody-pro-trial-ended` feature flags to true
- Upgrade to pro
- No subscription end date should be visible on /cody/manage
- Cancel the subscription
- Subscription end date should be visible now