### PR TITLE
search: up display limit to 1500

### DIFF
--- a/client/shared/src/search/stream.ts
+++ b/client/shared/src/search/stream.ts
@@ -504,7 +504,7 @@ function initiateSearchStream(
         zoektSearchOptions,
         featureOverrides,
         searchMode = SearchMode.Precise,
-        displayLimit = 500,
+        displayLimit = 1500,
         sourcegraphURL = '',
         chunkMatches = false,
     }: StreamSearchOptions,


### PR DESCRIPTION
This helps alleviate an issue where we often do not show enough results on the first page due to a single file containing lots of matches. However, there are some searches which match files which contain long lines. That we are tackling right now. In the mean time though I think its better to solve the single file issue over the specific searches being slow.

Test Plan: CI