### PR TITLE
search: default keyword search to on

### DIFF
--- a/client/web/src/featureFlags/useFeatureFlag.ts
+++ b/client/web/src/featureFlags/useFeatureFlag.ts
@@ -118,7 +118,5 @@ export function useFeatureFlag(
 }
 
 export function useKeywordSearch(): boolean {
-    const [flagEnabled] = useFeatureFlag('search-keyword')
-    const settingEnabled = !!useExperimentalFeatures(features => features.keywordSearch)
-    return flagEnabled || settingEnabled
+    return useExperimentalFeatures<boolean | undefined>(features => features.keywordSearch) !== false
 }

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -353,9 +353,7 @@ describe('Search', () => {
                     await driver.page.click('.test-case-sensitivity-toggle')
                     await editor.focus()
                     await driver.page.keyboard.press(Key.Enter)
-                    await driver.assertWindowLocation(
-                        '/search?q=context:global+test&patternType=standard&case=yes&sm=1'
-                    )
+                    await driver.assertWindowLocation('/search?q=context:global+test&patternType=keyword&case=yes&sm=0')
                 })
 
                 test('Clicking toggle turns off case sensitivity and removes case= URL parameter', async () => {
@@ -384,7 +382,9 @@ describe('Search', () => {
                 beforeEach(() => {
                     testContext.overrideGraphQL({
                         ...commonSearchGraphQLResults,
-                        ...createViewerSettingsGraphQLOverride({ user: applySettings() }),
+                        ...createViewerSettingsGraphQLOverride({
+                            user: applySettings({ experimentalFeatures: { keywordSearch: false } }),
+                        }),
                     })
                     testContext.overrideJsContext({ experimentalFeatures: { structuralSearch: 'enabled' } })
                 })

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -30,14 +30,18 @@ export function viewerSubjectFromSettings(
     return siteSubjectNoAdmin()
 }
 
+function isKeywordSearchEnabled(settingsCascade: SettingsCascadeOrError): boolean {
+    const features = getFromSettings(settingsCascade, 'experimentalFeatures') as SettingsExperimentalFeatures
+    return features?.keywordSearch !== false
+}
+
 /**
  * Returns the user-configured default search mode or undefined if not
  * configured by the user.
  */
 export function defaultSearchModeFromSettings(settingsCascade: SettingsCascadeOrError): SearchMode | undefined {
     // When the 'keyword search' language update is enabled, make sure to disable smart search
-    const features = getFromSettings(settingsCascade, 'experimentalFeatures') as SettingsExperimentalFeatures
-    if (features?.keywordSearch !== false) {
+    if (isKeywordSearchEnabled(settingsCascade)) {
         return SearchMode.Precise
     }
 
@@ -58,8 +62,7 @@ export function defaultSearchModeFromSettings(settingsCascade: SettingsCascadeOr
  */
 export function defaultPatternTypeFromSettings(settingsCascade: SettingsCascadeOrError): SearchPatternType | undefined {
     // When the 'keyword search' language update is enabled, default to the 'keyword' patterntype
-    const features = getFromSettings(settingsCascade, 'experimentalFeatures') as SettingsExperimentalFeatures
-    if (features?.keywordSearch !== false) {
+    if (isKeywordSearchEnabled(settingsCascade)) {
         return SearchPatternType.keyword
     }
 

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -37,7 +37,7 @@ export function viewerSubjectFromSettings(
 export function defaultSearchModeFromSettings(settingsCascade: SettingsCascadeOrError): SearchMode | undefined {
     // When the 'keyword search' language update is enabled, make sure to disable smart search
     const features = getFromSettings(settingsCascade, 'experimentalFeatures') as SettingsExperimentalFeatures
-    if (features?.keywordSearch) {
+    if (features?.keywordSearch !== false) {
         return SearchMode.Precise
     }
 
@@ -59,7 +59,7 @@ export function defaultSearchModeFromSettings(settingsCascade: SettingsCascadeOr
 export function defaultPatternTypeFromSettings(settingsCascade: SettingsCascadeOrError): SearchPatternType | undefined {
     // When the 'keyword search' language update is enabled, default to the 'keyword' patterntype
     const features = getFromSettings(settingsCascade, 'experimentalFeatures') as SettingsExperimentalFeatures
-    if (features?.keywordSearch) {
+    if (features?.keywordSearch !== false) {
         return SearchPatternType.keyword
     }
 

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -226,7 +226,7 @@
         "keywordSearch": {
           "description": "Whether to enable the 'keyword search' language improvement",
           "type": "boolean",
-          "default": false
+          "default": true
         }
       },
       "group": "Experimental"


### PR DESCRIPTION
This switches the default from off to on. To disable keyword search completely, customers have to set
`experimentalFeatures.keywordSearch: false` in site settings.

## Test plan
Tested manually
