### PR TITLE
[Cody Gateway] add refresh token endpoint with sams authenticator

### DIFF
--- a/cmd/cody-gateway/internal/auth/sams.go
+++ b/cmd/cody-gateway/internal/auth/sams.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/response"
+	"github.com/sourcegraph/sourcegraph/internal/authbearer"
+	"github.com/sourcegraph/sourcegraph/internal/sams"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// SAMSAuthenticator provides an auth middleware that uses SAMS service-to-service tokens to authenticate the requests.
+type SAMSAuthenticator struct {
+	Logger     log.Logger
+	SAMSClient sams.Client
+}
+
+func (a *SAMSAuthenticator) Middleware(requiredScopes []sams.Scope, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := trace.Logger(r.Context(), a.Logger)
+		token, err := authbearer.ExtractBearer(r.Header)
+		if err != nil {
+			response.JSONError(logger, w, http.StatusBadRequest, err)
+			return
+		}
+
+		introspectionResponse, err := a.SAMSClient.IntrospectToken(r.Context(), token)
+		if err != nil {
+			logger.Error("error introspecting token", log.Error(err))
+			response.JSONError(logger, w, http.StatusInternalServerError, err)
+			return
+		}
+
+		if !introspectionResponse.Active {
+			logger.Error(
+				"attempt to authenticate with inactive SAMS token",
+				log.String("client", introspectionResponse.ClientID))
+			response.JSONError(logger, w, http.StatusUnauthorized, errors.New("inactive token"))
+			return
+		}
+
+		gotScopes := strings.Split(introspectionResponse.Scope, " ")
+		for _, requiredScope := range requiredScopes {
+			if !slices.Contains(gotScopes, requiredScope) {
+				logger.Error(
+					"attempt to authenticate using SAMS token without required scope",
+					log.Strings("gotScopes", gotScopes),
+					log.String("requiredScope", requiredScope))
+				response.JSONError(logger, w, http.StatusForbidden, errors.New("missing required scope"))
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -2,16 +2,12 @@ package graphqlbackend
 
 import (
 	"context"
-	"encoding/hex"
-	"fmt"
-	"net/http"
 	"net/url"
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
-	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
 	"github.com/sourcegraph/sourcegraph/internal/cody"
 	"github.com/sourcegraph/sourcegraph/internal/ssc"
 
@@ -26,13 +22,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
-	"github.com/sourcegraph/sourcegraph/internal/hashutil"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/suspiciousnames"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -538,47 +531,13 @@ func (r *schemaResolver) ChangeCodyPlan(ctx context.Context, args *changeCodyPla
 		return nil, err
 	}
 
-	if err := r.refreshGatewayRateLimits(ctx); err != nil {
+	if err := cody.RefreshGatewayRateLimits(ctx, userID, r.db); err != nil {
 		// We intentionally don't fail the upgrade flow here, Gateway will pickup
 		// the new limits automatically. (Just later than we'd like.)
 		r.logger.Warn("refresh gateway limits", log.Error(err))
 	}
 
 	return UserByIDInt32(ctx, r.db, userID)
-}
-
-// refreshGatewayRateLimits refreshes the rate limits for the user on Cody Gateway.
-func (r *schemaResolver) refreshGatewayRateLimits(ctx context.Context) error {
-	completionsConfig := conf.GetCompletionsConfig(conf.Get().SiteConfig())
-	// We don't need to do anything if the target is not Cody Gateway, but it's not an error either.
-	if completionsConfig.Provider != conftypes.CompletionsProviderNameSourcegraph {
-		return nil
-	}
-
-	a := actor.FromContext(ctx)
-	apiTokenSha256, err := r.db.AccessTokens().GetOrCreateInternalToken(ctx, a.UID, []string{"user:all"})
-	if err != nil {
-		return errors.Wrap(err, "getting internal access token")
-	}
-	gatewayToken := accesstoken.DotcomUserGatewayAccessTokenPrefix + hex.EncodeToString(hashutil.ToSHA256Bytes(apiTokenSha256))
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, completionsConfig.Endpoint+"/v1/limits/refresh", nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", gatewayToken))
-
-	resp, err := httpcli.UncachedExternalDoer.Do(req)
-	defer func() { _ = resp.Body.Close() }()
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("non-200 response refreshing Gateway limits: %d", resp.StatusCode)
-	}
-
-	return nil
 }
 
 // CurrentUser returns the authenticated user if any. If there is no authenticated user, it returns

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -37,6 +37,12 @@ func AccessTokenAuthMiddleware(db database.DB, baseLogger log.Logger, next http.
 			return
 		}
 
+		// Temporary(sourcegraph#59625) SSC API uses SAMS auth token.
+		if strings.HasPrefix(r.URL.Path, "/.api/ssc/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// The license check handler uses a Bearer token and request body which
 		// is checked in `productsubscription/license_check_handler.go`
 		if envvar.SourcegraphDotComMode() && strings.HasPrefix(r.URL.Path, "/.api/license/check") {

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"context"
+	"fmt"
 	"log" //nolint:logging // TODO move all logging to sourcegraph/log
 	"net/http"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"github.com/gorilla/schema"
 	"github.com/graph-gophers/graphql-go"
 	sglog "github.com/sourcegraph/log"
+	"golang.org/x/oauth2/clientcredentials"
 	"google.golang.org/grpc"
 
 	zoektProto "github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver/protos/sourcegraph/zoekt/configuration/v1"
@@ -30,10 +32,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	confProto "github.com/sourcegraph/sourcegraph/internal/api/internalapi/v1"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/sams"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -179,6 +183,32 @@ func NewHandler(
 			Methods(http.MethodGet, http.MethodPost).
 			Name("updatecheck").
 			Handler(updatecheckHandler)
+
+		dotcomConf := conf.Get().Dotcom
+
+		samsClient := sams.NewClient(
+			dotcomConf.SamsServer,
+			clientcredentials.Config{
+				ClientID:     dotcomConf.SamsClientID,
+				ClientSecret: dotcomConf.SamsClientSecret,
+				TokenURL:     fmt.Sprintf("%s/oauth/token", dotcomConf.SamsServer),
+				Scopes:       []string{"openid", "profile", "email"},
+			},
+		)
+
+		samsAuthenticator := sams.Authenticator{
+			Logger:     logger.Scoped("sams.Authenticator"),
+			SAMSClient: samsClient,
+		}
+
+		// API endpoint for ssc to trigger cody's rate limit refresh for a user
+		// TODO(sourcegraph#59625) remove this as part of adding SAMSActor source
+		m.Path("/ssc/users/{samsUserID}/cody/limits/refresh").Methods("POST").Handler(
+			samsAuthenticator.RequireAuth(
+				[]sams.Scope{sams.ScopeDotcom},
+				newSSCRefreshCodyRateLimitHandler(logger, db),
+			),
+		)
 	}
 
 	// repo contains routes that are NOT specific to a revision. In these routes, the URL may not contain a revspec after the repo (that is, no "github.com/foo/bar@myrevspec").

--- a/cmd/frontend/internal/httpapi/ssc.go
+++ b/cmd/frontend/internal/httpapi/ssc.go
@@ -1,0 +1,57 @@
+package httpapi
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/sourcegraph/log"
+	"github.com/sourcegraph/sourcegraph/internal/cody"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/ssc"
+)
+
+// newSSCRefreshCodyRateLimitHandler returns an http.Handler to trigger cody's rate limit refresh for a user
+// TODO(sourcegraph#59625) remove as part of adding SAMSActor source
+func newSSCRefreshCodyRateLimitHandler(logger log.Logger, db database.DB) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		samsUserID := mux.Vars(r)["samsUserID"]
+		if samsUserID == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("missing uuid"))
+			return
+		}
+
+		oidcAccounts, err := db.UserExternalAccounts().List(ctx, database.ExternalAccountsListOptions{
+			AccountID:   samsUserID,
+			ServiceType: "openidconnect",
+			ServiceID:   fmt.Sprintf("https://%s", ssc.GetSAMSHostName()),
+			LimitOffset: &database.LimitOffset{
+				Limit: 1,
+			},
+		})
+		if err != nil {
+			logger.Error("error getting oidc accounts", log.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		if len(oidcAccounts) == 0 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		userID := oidcAccounts[0].UserID
+
+		if err := cody.RefreshGatewayRateLimits(ctx, userID, db); err != nil {
+			logger.Error("error refreshing gateway rate limits", log.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/internal/cody/rate_limits.go
+++ b/internal/cody/rate_limits.go
@@ -1,0 +1,49 @@
+package cody
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/hashutil"
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+)
+
+// RefreshGatewayRateLimits refreshes the rate limits for the user on Cody Gateway.
+func RefreshGatewayRateLimits(ctx context.Context, userID int32, db database.DB) error {
+	completionsConfig := conf.GetCompletionsConfig(conf.Get().SiteConfig())
+	// We don't need to do anything if the target is not Cody Gateway, but it's not an error either.
+	if completionsConfig.Provider != conftypes.CompletionsProviderNameSourcegraph {
+		return nil
+	}
+
+	apiTokenSha256, err := db.AccessTokens().GetOrCreateInternalToken(ctx, userID, []string{"user:all"})
+	if err != nil {
+		return errors.Wrap(err, "getting internal access token")
+	}
+	gatewayToken := accesstoken.DotcomUserGatewayAccessTokenPrefix + hex.EncodeToString(hashutil.ToSHA256Bytes(apiTokenSha256))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, completionsConfig.Endpoint+"/v1/limits/refresh", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", gatewayToken))
+
+	resp, err := httpcli.UncachedExternalDoer.Do(req)
+	defer func() { _ = resp.Body.Close() }()
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("non-200 response refreshing Gateway limits: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/sams/BUILD.bazel
+++ b/internal/sams/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sams",
+    srcs = ["client.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/internal/sams",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//lib/errors",
+        "@org_golang_x_oauth2//:oauth2",
+        "@org_golang_x_oauth2//clientcredentials",
+    ],
+)

--- a/internal/sams/auth.go
+++ b/internal/sams/auth.go
@@ -1,0 +1,63 @@
+package sams
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/sourcegraph/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/authbearer"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+// Authenticator provides an auth middleware that uses SAMS service-to-service tokens to authenticate the requests.
+type Authenticator struct {
+	Logger     log.Logger
+	SAMSClient Client
+}
+
+func (a *Authenticator) RequireAuth(requiredScopes []Scope, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger := trace.Logger(r.Context(), a.Logger)
+		token, err := authbearer.ExtractBearer(r.Header)
+		if err != nil {
+			logger.Error("error extracting bearer token", log.Error(err))
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		introspectionResponse, err := a.SAMSClient.IntrospectToken(r.Context(), token)
+		if err != nil {
+			logger.Error("error introspecting token", log.Error(err))
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		if !introspectionResponse.Active {
+			logger.Error(
+				"attempt to authenticate with inactive SAMS token",
+				log.String("client", introspectionResponse.ClientID))
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("inactive token"))
+			return
+		}
+
+		gotScopes := strings.Split(introspectionResponse.Scope, " ")
+		for _, requiredScope := range requiredScopes {
+			if !slices.Contains(gotScopes, requiredScope) {
+				logger.Error(
+					"attempt to authenticate using SAMS token without required scope",
+					log.Strings("gotScopes", gotScopes),
+					log.String("requiredScope", requiredScope))
+				w.WriteHeader(http.StatusForbidden)
+				w.Write([]byte("missing required scope"))
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/sams/client.go
+++ b/internal/sams/client.go
@@ -1,0 +1,102 @@
+package sams
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+type Scope = string
+
+const (
+	ScopeDotcom Scope = "client.dotcom"
+	// more granualar scopes can be added here later if required
+)
+
+// tokenIntrospection is the response from the OAuth spec. More information
+// can be found at: https://www.oauth.com/oauth2-servers/token-introspection-endpoint/
+type TokenIntrospection struct {
+	// This is a boolean value of whether or not the presented token is
+	// currently active. The value should be “true” if the token has been
+	// issued by this authorization server, has not been revoked by the user,
+	// and has not expired.
+	Active bool `json:"active"`
+
+	// A space-separated list of scopes associated with this token.
+	Scope string `json:"scope"`
+
+	// The client identifier for the OAuth 2.0 client that the token was issued to.
+	ClientID string `json:"client_id"`
+
+	// A human-readable identifier for the user who authorized this token.
+	Username string `json:"username"`
+
+	// The unix timestamp (integer timestamp, number of seconds since January 1, 1970 UTC)
+	// indicating when this token will expire.
+	Expiration int64 `json:"exp"`
+}
+
+type Client interface {
+	IntrospectToken(ctx context.Context, token string) (*TokenIntrospection, error)
+}
+
+type samsClient struct {
+	server                  string
+	clientCredentialsConfig clientcredentials.Config
+}
+
+func (c *samsClient) IntrospectToken(ctx context.Context, token string) (*TokenIntrospection, error) {
+	// https://www.oauth.com/oauth2-servers/token-introspection-endpoint/
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("%s/oauth/introspect", c.server),
+		strings.NewReader("token="+token),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "create introspection request")
+	}
+
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// Create the OAuth2 HTTP client. This will handle setting up the HTTP headers based on the token source.
+	// (And potentially issue a new token as needed.)
+	tokenSource := c.clientCredentialsConfig.TokenSource(ctx)
+	httpClient := oauth2.NewClient(ctx, tokenSource)
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return nil, errors.Wrap(err, "calling SSC")
+	}
+
+	defer response.Body.Close()
+
+	bodyBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading response")
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("unexpected status code %d from SAMS", response.StatusCode)
+	}
+
+	var introspectionResponse TokenIntrospection
+	err = json.Unmarshal(bodyBytes, &introspectionResponse)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse introspection response body")
+	}
+	return &introspectionResponse, nil
+}
+
+func NewClient(samsServer string, clientCredentialsConfig clientcredentials.Config) Client {
+	return &samsClient{
+		server:                  samsServer,
+		clientCredentialsConfig: clientCredentialsConfig,
+	}
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -698,6 +698,12 @@ type Dotcom struct {
 	MinimumExternalAccountAge int `json:"minimumExternalAccountAge,omitempty"`
 	// MinimumExternalAccountAgeExemptList description: A list of email addresses that are allowed to be exempted from the minimumExternalAccountAge requirement.
 	MinimumExternalAccountAgeExemptList []string `json:"minimumExternalAccountAgeExemptList,omitempty"`
+	// SamsClientID description: The clientID for SAMS instance.
+	SamsClientID string `json:"sams.clientID,omitempty"`
+	// SamsClientSecret description: The clientSecret for SAMS instance.
+	SamsClientSecret string `json:"sams.clientSecret,omitempty"`
+	// SamsServer description: The server URL for SAMS instance.
+	SamsServer string `json:"sams.server,omitempty"`
 	// SlackLicenseAnomallyWebhook description: Slack webhook for when there is an anomaly detected with license key usage.
 	SlackLicenseAnomallyWebhook string `json:"slackLicenseAnomallyWebhook,omitempty"`
 	// SlackLicenseCreationWebhook description: Slack webhook for when a license key is created.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -24,13 +24,17 @@
         "pointer": true
       },
       "group": "Search",
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "search.index.shardConcurrency": {
       "description": "The number of threads each indexserver should use to index shards. If not set, indexserver will use the number of available CPUs. This is exposed as a safeguard and should usually not require being set.",
       "type": "integer",
       "group": "Search",
-      "examples": ["10"]
+      "examples": [
+        "10"
+      ]
     },
     "search.largeFiles": {
       "description": "A list of file glob patterns where matching files will be indexed and searched regardless of their size. Files still need to be valid utf-8 to be indexed. The glob pattern syntax can be found here: https://github.com/bmatcuk/doublestar#patterns.",
@@ -39,13 +43,21 @@
         "type": "string"
       },
       "group": "Search",
-      "examples": [["go.sum", "package-lock.json", "**/*.thrift"]]
+      "examples": [
+        [
+          "go.sum",
+          "package-lock.json",
+          "**/*.thrift"
+        ]
+      ]
     },
     "debug.search.symbolsParallelism": {
       "description": "(debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.",
       "type": "integer",
       "group": "Debug",
-      "examples": ["20"]
+      "examples": [
+        "20"
+      ]
     },
     "cloneProgress.log": {
       "description": "Whether clone progress should be logged to a file. If enabled, logs are written to files in the OS default path for temporary files.",
@@ -199,7 +211,10 @@
         "eventLogging": {
           "description": "Enables user event logging inside of the Sourcegraph instance. This will allow admins to have greater visibility of user activity, such as frequently viewed pages, frequent searches, and more. These event logs (and any specific user actions) are only stored locally, and never leave this Sourcegraph instance.",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "enabled"
         },
         "passwordPolicy": {
@@ -250,62 +265,92 @@
         "structuralSearch": {
           "description": "Enables structural search.",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "perforce": {
           "description": "Allow adding Perforce code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "enabled",
           "deprecationMessage": "Deprecated, Perforce is always enabled, setting is no longer used."
         },
         "perforceChangelistMapping": {
           "description": "Allow mapping of Perforce changelists to their commit SHAs in the DB",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "goPackages": {
           "description": "Allow adding Go package host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "jvmPackages": {
           "description": "Allow adding JVM package host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "npmPackages": {
           "description": "Allow adding npm package code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "pythonPackages": {
           "description": "Allow adding Python package code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "rustPackages": {
           "description": "Allow adding Rust package code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "rubyPackages": {
           "description": "Allow adding Ruby package host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "pagure": {
           "description": "Allow adding Pagure code host connections",
           "type": "string",
-          "enum": ["enabled", "disabled"],
+          "enum": [
+            "enabled",
+            "disabled"
+          ],
           "default": "disabled"
         },
         "subRepoPermissions": {
@@ -347,7 +392,9 @@
               "items": {
                 "type": "string",
                 "pattern": "^-----BEGIN CERTIFICATE-----\n",
-                "examples": ["-----BEGIN CERTIFICATE-----\n..."]
+                "examples": [
+                  "-----BEGIN CERTIFICATE-----\n..."
+                ]
               }
             }
           }
@@ -360,7 +407,10 @@
             "description": "Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.",
             "type": "object",
             "additionalProperties": false,
-            "required": ["domainPath", "fetch"],
+            "required": [
+              "domainPath",
+              "fetch"
+            ],
             "properties": {
               "domainPath": {
                 "description": "Git clone URL domain/path",
@@ -393,10 +443,14 @@
             "type": "object",
             "title": "SearchIndexRevisionsRule",
             "additionalProperties": false,
-            "required": ["revisions"],
+            "required": [
+              "revisions"
+            ],
             "anyOf": [
               {
-                "required": ["name"]
+                "required": [
+                  "name"
+                ]
               }
             ],
             "properties": {
@@ -419,7 +473,11 @@
             [
               {
                 "name": "^github.com/org/.*",
-                "revisions": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"]
+                "revisions": [
+                  "3.17",
+                  "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
+                  "v3.17.1"
+                ]
               }
             ]
           ]
@@ -436,8 +494,14 @@
           },
           "examples": [
             {
-              "github.com/sourcegraph/sourcegraph": ["3.17", "f6ca985c27486c2df5231ea3526caa4a4108ffb6", "v3.17.1"],
-              "name/of/repo": ["develop"]
+              "github.com/sourcegraph/sourcegraph": [
+                "3.17",
+                "f6ca985c27486c2df5231ea3526caa4a4108ffb6",
+                "v3.17.1"
+              ],
+              "name/of/repo": [
+                "develop"
+              ]
             }
           ]
         },
@@ -591,13 +655,18 @@
         "languageDetection": {
           "description": "Setting for customizing language detection behavior",
           "type": "object",
-          "required": ["graphQL"],
+          "required": [
+            "graphQL"
+          ],
           "additionalProperties": false,
           "properties": {
             "graphQL": {
               "description": "What to take into account for computing 'languages' for the GraphQL API. This setting indirectly affects client-side code attempting to determine languages, such as search-based code navigation and the files sidebar.",
               "type": "string",
-              "enum": ["useFileContents", "useFileNamesOnly"],
+              "enum": [
+                "useFileContents",
+                "useFileNamesOnly"
+              ],
               "default": "useFileContents"
             }
           }
@@ -618,7 +687,9 @@
         },
         {
           "tls.external": {
-            "certificates": ["-----BEGIN CERTIFICATE-----\n..."],
+            "certificates": [
+              "-----BEGIN CERTIFICATE-----\n..."
+            ],
             "insecureSkipVerify": true
           }
         }
@@ -665,7 +736,9 @@
       "items": {
         "title": "BatchChangeRolloutWindow",
         "type": "object",
-        "required": ["rate"],
+        "required": [
+          "rate"
+        ],
         "additionalProperties": false,
         "properties": {
           "rate": {
@@ -702,13 +775,18 @@
           }
         },
         "dependencies": {
-          "start": ["end"]
+          "start": [
+            "end"
+          ]
         }
       },
       "examples": [
         {
           "rate": "10/hour",
-          "days": ["saturday", "sunday"],
+          "days": [
+            "saturday",
+            "sunday"
+          ],
           "start": "06:00",
           "end": "20:00"
         }
@@ -724,7 +802,11 @@
       "description": "How long changesets will be retained after they have been detached from a batch change.",
       "type": "string",
       "group": "BatchChanges",
-      "examples": ["336h", "48h", "5h30m40s"]
+      "examples": [
+        "336h",
+        "48h",
+        "5h30m40s"
+      ]
     },
     "codeIntelAutoIndexing.enabled": {
       "description": "Enables/disables the code intel auto-indexing feature. Currently experimental.",
@@ -790,13 +872,17 @@
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (including the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": ["dev"]
+      "examples": [
+        "dev"
+      ]
     },
     "codeIntelRanking.documentReferenceCountsDerivativeGraphKeyPrefix": {
       "description": "An arbitrary identifier used to group calculated rankings from SCIP data (excluding the SCIP export).",
       "type": "string",
       "group": "Code intelligence",
-      "examples": [""]
+      "examples": [
+        ""
+      ]
     },
     "codeIntelRanking.staleResultsAge": {
       "description": "The interval at which to run the reduce job that computes document reference counts. Default is 24hrs.",
@@ -807,7 +893,9 @@
     "corsOrigin": {
       "description": "Required when using any of the native code host integrations for Phabricator, GitLab, or Bitbucket Server. It is a space-separated list of allowed origins for cross-origin HTTP requests which should be the base URL for your Phabricator, GitLab, or Bitbucket Server instance.",
       "type": "string",
-      "examples": ["https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"],
+      "examples": [
+        "https://my-phabricator.example.com https://my-bitbucket.example.com https://my-gitlab.example.com"
+      ],
       "pattern": "^((https?:\\/\\/[\\w-\\.]+)( https?:\\/\\/[\\w-\\.]+)*)|\\*$",
       "group": "Security"
     },
@@ -847,7 +935,10 @@
       "items": {
         "title": "UpdateIntervalRule",
         "type": "object",
-        "required": ["pattern", "interval"],
+        "required": [
+          "pattern",
+          "interval"
+        ],
         "additionalProperties": false,
         "properties": {
           "pattern": {
@@ -880,7 +971,9 @@
       "description": "DEPRECATED! Disable redirects to sourcegraph.com when visiting public repositories that can't exist on this server.",
       "type": "boolean",
       "group": "External services",
-      "examples": [true],
+      "examples": [
+        true
+      ],
       "deprecationMessage": "Deprecated because it's no longer supported and hasn't been working for a while."
     },
     "git.cloneURLToRepositoryName": {
@@ -891,7 +984,10 @@
         "description": "Describes a mapping from clone URL to repository name. The `from` field contains a regular expression with named capturing groups. The `to` field contains a template string that references capturing group names. For instance, if `from` is \"^../(?P<name>\\w+)$\" and `to` is \"github.com/user/{name}\", the clone URL \"../myRepository\" would be mapped to the repository name \"github.com/user/myRepository\".",
         "type": "object",
         "additionalProperties": false,
-        "required": ["from", "to"],
+        "required": [
+          "from",
+          "to"
+        ],
         "properties": {
           "from": {
             "description": "A regular expression that matches a set of clone URLs. The regular expression should use the Go regular expression syntax (https://golang.org/pkg/regexp/) and contain at least one named capturing group. The regular expression matches partially by default, so use \"^...$\" if whole-string matching is desired.",
@@ -938,24 +1034,37 @@
       "title": "SyntaxHighlighting",
       "description": "Syntax highlighting configuration",
       "type": "object",
-      "required": ["engine", "languages"],
+      "required": [
+        "engine",
+        "languages"
+      ],
       "properties": {
         "engine": {
           "title": "SyntaxHighlightingEngine",
           "type": "object",
-          "required": ["default"],
+          "required": [
+            "default"
+          ],
           "properties": {
             "default": {
               "description": "The default syntax highlighting engine to use",
               "type": "string",
-              "enum": ["tree-sitter", "syntect", "scip-syntax"]
+              "enum": [
+                "tree-sitter",
+                "syntect",
+                "scip-syntax"
+              ]
             },
             "overrides": {
               "description": "Manually specify overrides for syntax highlighting engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": ["tree-sitter", "syntect", "scip-syntax"]
+                "enum": [
+                  "tree-sitter",
+                  "syntect",
+                  "scip-syntax"
+                ]
               }
             }
           }
@@ -963,7 +1072,10 @@
         "languages": {
           "title": "SyntaxHighlightingLanguage",
           "type": "object",
-          "required": ["extensions", "patterns"],
+          "required": [
+            "extensions",
+            "patterns"
+          ],
           "properties": {
             "extensions": {
               "description": "Map of extension to language",
@@ -978,7 +1090,10 @@
               "items": {
                 "title": "SyntaxHighlightingLanguagePatterns",
                 "type": "object",
-                "required": ["pattern", "language"],
+                "required": [
+                  "pattern",
+                  "language"
+                ],
                 "properties": {
                   "pattern": {
                     "description": "Regular expression which matches the filepath",
@@ -998,14 +1113,20 @@
           "title": "SymbolConfiguration",
           "description": "Configure symbol generation",
           "type": "object",
-          "required": ["engine"],
+          "required": [
+            "engine"
+          ],
           "properties": {
             "engine": {
               "description": "Manually specify overrides for symbol generation engine per language",
               "type": "object",
               "additionalProperties": {
                 "type": "string",
-                "enum": ["universal-ctags", "scip-ctags", "off"]
+                "enum": [
+                  "universal-ctags",
+                  "scip-ctags",
+                  "off"
+                ]
               }
             }
           }
@@ -1078,7 +1199,10 @@
     },
     "scim.identityProvider": {
       "type": "string",
-      "enum": ["STANDARD", "Azure AD"],
+      "enum": [
+        "STANDARD",
+        "Azure AD"
+      ],
       "description": "Identity provider used for SCIM support.  \"STANDARD\" should be used unless a more specific value is available",
       "default": "STANDARD",
       "group": "External services"
@@ -1158,7 +1282,11 @@
         "allow": {
           "description": "Allow or restrict the use of access tokens. The default is \"all-users-create\", which enables all users to create access tokens. Use \"none\" to disable access tokens entirely. Use \"site-admin-create\" to restrict creation of new tokens to admin users (existing tokens will still work until revoked).",
           "type": "string",
-          "enum": ["all-users-create", "site-admin-create", "none"],
+          "enum": [
+            "all-users-create",
+            "site-admin-create",
+            "none"
+          ],
           "default": "all-users-create"
         },
         "allowNoExpiration": {
@@ -1169,13 +1297,27 @@
         "expirationOptionDays": {
           "description": "Options users will see for the number of days until token expiration. The defaultExpirationDays will be added to the list if not already present.",
           "type": "array",
-          "default": [7, 14, 30, 60, 90],
+          "default": [
+            7,
+            14,
+            30,
+            60,
+            90
+          ],
           "items": {
             "type": "integer",
             "maximum": 365,
             "minimum": 1
           },
-          "examples": [[7, 14, 30, 60, 90]]
+          "examples": [
+            [
+              7,
+              14,
+              30,
+              60,
+              90
+            ]
+          ]
         },
         "defaultExpirationDays": {
           "description": "The default duration selection when creating a new access token. This value will be added to the expirationOptionDays if it is not already present",
@@ -1201,20 +1343,38 @@
       "default": {
         "allow": "all-users-create",
         "allowNoExpiration": false,
-        "expirationOptionDays": [7, 14, 30, 60, 90],
+        "expirationOptionDays": [
+          7,
+          14,
+          30,
+          60,
+          90
+        ],
         "defaultExpirationDays": 90
       },
       "examples": [
         {
           "allow": "site-admin-create",
           "allowNoExpiration": true,
-          "expirationOptionDays": [7, 14, 30, 60, 90],
+          "expirationOptionDays": [
+            7,
+            14,
+            30,
+            60,
+            90
+          ],
           "defaultExpirationDays": 90
         },
         {
           "allow": "none",
           "allowNoExpiration": false,
-          "expirationOptionDays": [7, 14, 30, 60, 90],
+          "expirationOptionDays": [
+            7,
+            14,
+            30,
+            60,
+            90
+          ],
           "defaultExpirationDays": 45
         }
       ],
@@ -1235,7 +1395,10 @@
           "items": {
             "type": "string"
           },
-          "examples": ["100.100.100.0/25", "23.34.56.21"]
+          "examples": [
+            "100.100.100.0/25",
+            "23.34.56.21"
+          ]
         },
         "trustedClientIpAddress": {
           "description": "List of trusted client IP addresses that will bypass user IP address check. If empty, nothing can be bypass. This is useful to support access from trusted internal services. It will always permit connection from `127.0.0.1`. You must include the IP range allocated for the Sourcegraph deployment services to allow inter-service communication, e.g., kubernetes pod ip range.",
@@ -1243,7 +1406,10 @@
           "items": {
             "type": "string"
           },
-          "examples": ["100.100.100.0/25", "23.34.56.21"]
+          "examples": [
+            "100.100.100.0/25",
+            "23.34.56.21"
+          ]
         },
         "userIpAddress": {
           "description": "List of user IP addresses to allow. If empty, all IP addresses are allowed.",
@@ -1251,7 +1417,10 @@
           "items": {
             "type": "string"
           },
-          "examples": ["100.100.100.0/25", "23.34.56.21"]
+          "examples": [
+            "100.100.100.0/25",
+            "23.34.56.21"
+          ]
         },
         "userIpRequestHeaders": {
           "description": "An optional list of case-insensitive request header names to use for resolving the callers user IP address. You must ensure that the header is coming from a trusted source. If the header contains multiple IP addresses, the right-most is used. If no IP is found from provided headers, the connected client IP address is used.",
@@ -1259,7 +1428,11 @@
           "items": {
             "type": "string"
           },
-          "examples": ["X-Forwarded-For", "X-Real-IP", "CF-Connecting-IP"]
+          "examples": [
+            "X-Forwarded-For",
+            "X-Real-IP",
+            "CF-Connecting-IP"
+          ]
         },
         "errorMessageTemplate": {
           "description": "A template to customize the error message display to users on unauthorized access.  Available template variables: `{{.Error}}`, `{{.UserIP}}`",
@@ -1296,7 +1469,10 @@
         "bindID": {
           "description": "The type of identifier to identify a user. The default is \"email\", which uses the email address to identify a user. Use \"username\" to identify a user by their username. Changing this setting will erase any permissions created for users that do not yet exist.",
           "type": "string",
-          "enum": ["email", "username"],
+          "enum": [
+            "email",
+            "username"
+          ],
           "default": "email"
         }
       },
@@ -1412,7 +1588,11 @@
       "description": "The SMTP server used to send transactional emails.\nPlease see https://docs.sourcegraph.com/admin/config/email",
       "type": "object",
       "additionalProperties": false,
-      "required": ["host", "port", "authentication"],
+      "required": [
+        "host",
+        "port",
+        "authentication"
+      ],
       "properties": {
         "host": {
           "description": "The SMTP server host.",
@@ -1433,7 +1613,11 @@
         "authentication": {
           "description": "The type of authentication to use for the SMTP server.",
           "type": "string",
-          "enum": ["none", "PLAIN", "CRAM-MD5"]
+          "enum": [
+            "none",
+            "PLAIN",
+            "CRAM-MD5"
+          ]
         },
         "domain": {
           "description": "The HELO domain to provide to the SMTP server (if needed).",
@@ -1449,7 +1633,10 @@
           "items": {
             "title": "Header",
             "type": "object",
-            "required": ["key", "value"],
+            "required": [
+              "key",
+              "value"
+            ],
             "additionalProperties": false,
             "properties": {
               "key": {
@@ -1488,14 +1675,19 @@
       "type": "string",
       "format": "email",
       "group": "Email",
-      "examples": ["noreply@sourcegraph.example.com"]
+      "examples": [
+        "noreply@sourcegraph.example.com"
+      ]
     },
     "email.senderName": {
       "description": "The name to use in the \"from\" address for emails sent by this server.",
       "type": "string",
       "group": "Email",
       "default": "Sourcegraph",
-      "examples": ["Our Company Sourcegraph", "Example Inc Sourcegraph"]
+      "examples": [
+        "Our Company Sourcegraph",
+        "Example Inc Sourcegraph"
+      ]
     },
     "email.templates": {
       "description": "Configurable templates for some email types sent by Sourcegraph.",
@@ -1527,7 +1719,9 @@
     "executors.frontendURL": {
       "description": "The URL where Sourcegraph executors can reach the Sourcegraph instance. If not set, defaults to externalURL. URLs with a path (other than `/`) are not allowed. For Docker executors, the special hostname `host.docker.internal` can be used to refer to the Docker container's host.",
       "type": "string",
-      "examples": ["https://sourcegraph.example.com"]
+      "examples": [
+        "https://sourcegraph.example.com"
+      ]
     },
     "executors.srcCLIImage": {
       "description": "The image to use for src-cli in executors. Use this value to pull from a custom image registry.",
@@ -1537,12 +1731,16 @@
     "executors.srcCLIImageTag": {
       "description": "The tag to use for the src-cli image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": ["4.1.0"]
+      "examples": [
+        "4.1.0"
+      ]
     },
     "executors.lsifGoImage": {
       "description": "The tag to use for the lsif-go image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": ["sourcegraph/lsif-go"]
+      "examples": [
+        "sourcegraph/lsif-go"
+      ]
     },
     "executors.batcheshelperImage": {
       "description": "The image to use for batch changes in executors. Use this value to pull from a custom image registry.",
@@ -1552,13 +1750,17 @@
     "executors.batcheshelperImageTag": {
       "description": "The tag to use for the batcheshelper image in executors. Use this value to use a custom tag. Sourcegraph by default uses the best match, so use this setting only if you really need to overwrite it and make sure to keep it updated.",
       "type": "string",
-      "examples": ["4.1.0"]
+      "examples": [
+        "4.1.0"
+      ]
     },
     "executors.accessToken": {
       "description": "The shared secret between Sourcegraph and executors. The value must contain at least 20 characters.",
       "type": "string",
       "pattern": "^(.{20,}|REDACTED)$",
-      "examples": ["my-super-secret-access-token"]
+      "examples": [
+        "my-super-secret-access-token"
+      ]
     },
     "executors.multiqueue": {
       "description": "The configuration for multiqueue executors.",
@@ -1571,7 +1773,10 @@
             "batches": {
               "description": "The configuration for the batches queue.",
               "type": "object",
-              "required": ["limit", "weight"],
+              "required": [
+                "limit",
+                "weight"
+              ],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1588,7 +1793,10 @@
             "codeintel": {
               "description": "The configuration for the codeintel queue.",
               "type": "object",
-              "required": ["limit", "weight"],
+              "required": [
+                "limit",
+                "weight"
+              ],
               "properties": {
                 "limit": {
                   "description": "The maximum number of dequeues allowed within the expiration window.",
@@ -1617,7 +1825,9 @@
       },
       "examples": [
         {
-          "*": ["myorg1"]
+          "*": [
+            "myorg1"
+          ]
         }
       ],
       "hide": true
@@ -1682,10 +1892,19 @@
               "deprecationMessage": "No effect, audit logs are always set to SRC_LOG_LEVEL",
               "description": "DEPRECATED: No effect, audit logs are always set to SRC_LOG_LEVEL",
               "type": "string",
-              "enum": ["DEBUG", "INFO", "WARN", "ERROR"]
+              "enum": [
+                "DEBUG",
+                "INFO",
+                "WARN",
+                "ERROR"
+              ]
             }
           },
-          "required": ["internalTraffic", "graphQL", "gitserverAccess"],
+          "required": [
+            "internalTraffic",
+            "graphQL",
+            "gitserverAccess"
+          ],
           "examples": [
             {
               "internalTraffic": false,
@@ -1702,7 +1921,12 @@
             "location": {
               "description": "Where to output the security event log [none, auditlog, database, all] where auditlog is the default logging to stdout with the specified audit log format",
               "type": "string",
-              "enum": ["none", "auditlog", "database", "all"],
+              "enum": [
+                "none",
+                "auditlog",
+                "database",
+                "all"
+              ],
               "default": "auditlog"
             }
           },
@@ -1717,7 +1941,9 @@
     "externalURL": {
       "description": "The externally accessible URL for Sourcegraph (i.e., what you type into your browser). Previously called `appURL`. Only root URLs are allowed.",
       "type": "string",
-      "examples": ["https://sourcegraph.example.com"]
+      "examples": [
+        "https://sourcegraph.example.com"
+      ]
     },
     "observability.client": {
       "description": "EXPERIMENTAL: Configuration for client observability",
@@ -1731,7 +1957,10 @@
             "endpoint": {
               "description": "OpenTelemetry tracing collector endpoint. By default, Sourcegraph's \"/-/debug/otlp\" endpoint forwards data to the configured collector backend.",
               "type": "string",
-              "examples": ["/-/debug/otlp", "https://COLLECTOR_ENDPOINT"],
+              "examples": [
+                "/-/debug/otlp",
+                "https://COLLECTOR_ENDPOINT"
+              ],
               "default": "/-/debug/otlp"
             }
           }
@@ -1757,13 +1986,20 @@
         "sampling": {
           "description": "Determines the conditions under which distributed traces are recorded. \"none\" turns off tracing entirely. \"selective\" (default) sends traces whenever `?trace=1` is present in the URL (though background jobs may still emit traces). \"all\" sends traces on every request. Note that this only affects the behavior of the distributed tracing client. To learn more about additional sampling and traace export configuration with the default tracing type \"opentelemetry\", refer to https://docs.sourcegraph.com/admin/observability/opentelemetry#tracing ",
           "type": "string",
-          "enum": ["selective", "all", "none"],
+          "enum": [
+            "selective",
+            "all",
+            "none"
+          ],
           "default": "selective"
         },
         "type": {
           "description": "Determines what tracing provider to enable. For \"opentelemetry\", the required backend is an OpenTelemetry collector instance (deployed by default with Sourcegraph). For \"jaeger\", a Jaeger instance is required to be configured via Jaeger client environment variables: https://github.com/jaegertracing/jaeger-client-go#environment-variables",
           "type": "string",
-          "enum": ["opentelemetry", "jaeger"],
+          "enum": [
+            "opentelemetry",
+            "jaeger"
+          ],
           "default": "opentelemetry"
         },
         "debug": {
@@ -1802,19 +2038,31 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["level", "notifier"],
+        "required": [
+          "level",
+          "notifier"
+        ],
         "properties": {
           "level": {
             "description": "Sourcegraph alert level to subscribe to notifications for.",
             "type": "string",
-            "enum": ["warning", "critical"]
+            "enum": [
+              "warning",
+              "critical"
+            ]
           },
           "notifier": {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["slack", "pagerduty", "webhook", "email", "opsgenie"]
+                "enum": [
+                  "slack",
+                  "pagerduty",
+                  "webhook",
+                  "email",
+                  "opsgenie"
+                ]
               }
             },
             "oneOf": [
@@ -1871,7 +2119,9 @@
           "level": "warning",
           "notifier": {
             "type": "email",
-            "addresses": ["alerts@example.com"]
+            "addresses": [
+              "alerts@example.com"
+            ]
           }
         }
       ]
@@ -1882,25 +2132,39 @@
       "items": {
         "type": "string"
       },
-      "examples": [["warning_gitserver_disk_space_remaining"], ["critical_frontend_down", "warning_high_load"]]
+      "examples": [
+        [
+          "warning_gitserver_disk_space_remaining"
+        ],
+        [
+          "critical_frontend_down",
+          "warning_high_load"
+        ]
+      ]
     },
     "observability.logSlowSearches": {
       "description": "(debug) logs all search queries (issued by users, code intelligence, or API requests) slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [10000]
+      "examples": [
+        10000
+      ]
     },
     "observability.logSlowGraphQLRequests": {
       "description": "(debug) logs all GraphQL requests slower than the specified number of milliseconds.",
       "type": "integer",
       "group": "Debug",
-      "examples": [10000]
+      "examples": [
+        10000
+      ]
     },
     "observability.captureSlowGraphQLRequestsLimit": {
       "description": "(debug) Set a limit to the amount of captured slow GraphQL requests being stored for visualization. For defining the threshold for a slow GraphQL request, see observability.logSlowGraphQLRequests.",
       "type": "integer",
       "group": "Debug",
-      "examples": [2000]
+      "examples": [
+        2000
+      ]
     },
     "insights.backfill.interruptAfter": {
       "description": "Set the number of seconds an insight series will spend backfilling before being interrupted. Series are interrupted to prevent long running insights from exhausting all of the available workers. Interrupted series will be placed back in the queue and retried based on their priority.",
@@ -1927,14 +2191,19 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 1,
-      "examples": [10]
+      "examples": [
+        10
+      ]
     },
     "insights.query.worker.rateLimit": {
       "description": "Maximum number of Code Insights queries initiated per second on a worker node.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10.0, 0.5],
+      "examples": [
+        10.0,
+        0.5
+      ],
       "!go": {
         "pointer": true
       }
@@ -1944,14 +2213,20 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10, 20]
+      "examples": [
+        10,
+        20
+      ]
     },
     "insights.historical.worker.rateLimit": {
       "description": "Maximum number of historical Code Insights data frames that may be analyzed per second.",
       "type": "number",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [50.0, 0.5],
+      "examples": [
+        50.0,
+        0.5
+      ],
       "!go": {
         "pointer": true
       }
@@ -1961,7 +2236,10 @@
       "type": "integer",
       "group": "CodeInsights",
       "default": 20,
-      "examples": [10, 20]
+      "examples": [
+        10,
+        20
+      ]
     },
     "insights.aggregations.bufferSize": {
       "description": "The size of the buffer for aggregations ran in-memory. A higher limit might strain memory for the frontend",
@@ -1981,7 +2259,11 @@
       "group": "CodeInsights",
       "default": 30,
       "maximum": 90,
-      "examples": [12, 24, 50]
+      "examples": [
+        12,
+        24,
+        50
+      ]
     },
     "own.bestEffortTeamMatching": {
       "description": "The Own service will attempt to match a Team by the last part of its handle if it contains a slash and no match is found for its full handle.",
@@ -2094,14 +2376,29 @@
           "items": {
             "type": "string"
           },
-          "default": ["show", "rev-parse", "log", "diff", "ls-tree"]
+          "default": [
+            "show",
+            "rev-parse",
+            "log",
+            "diff",
+            "ls-tree"
+          ]
         }
       },
       "examples": [
         {
           "size": 1000,
-          "repos": ["github.com/sourcegraph/sourcegraph", "github.com/gorilla/mux"],
-          "ignoredGitCommands": ["show", "rev-parse", "log", "diff", "ls-tree"]
+          "repos": [
+            "github.com/sourcegraph/sourcegraph",
+            "github.com/gorilla/mux"
+          ],
+          "ignoredGitCommands": [
+            "show",
+            "rev-parse",
+            "log",
+            "diff",
+            "ls-tree"
+          ]
         }
       ]
     },
@@ -2125,6 +2422,18 @@
       "description": "Configuration options for Sourcegraph.com only.",
       "type": "object",
       "properties": {
+        "sams.server": {
+          "type": "string",
+          "description": "The server URL for SAMS instance."
+        },
+        "sams.clientID": {
+          "type": "string",
+          "description": "The clientID for SAMS instance."
+        },
+        "sams.clientSecret": {
+          "type": "string",
+          "description": "The clientSecret for SAMS instance."
+        },
         "minimumExternalAccountAge": {
           "description": "The minimum amount of days a Github or GitLab account must exist, before being allowed on Sourcegraph.com.",
           "type": "integer",
@@ -2155,7 +2464,10 @@
         "srcCliVersionCache": {
           "description": "Configuration related to the src-cli version cache. This should only be used on sourcegraph.com.",
           "type": "object",
-          "required": ["enabled", "github"],
+          "required": [
+            "enabled",
+            "github"
+          ],
           "group": "Sourcegraph.com",
           "properties": {
             "enabled": {
@@ -2166,7 +2478,10 @@
             "github": {
               "description": "GitHub configuration, both for queries and receiving release webhooks.",
               "type": "object",
-              "required": ["token", "webhookSecret"],
+              "required": [
+                "token",
+                "webhookSecret"
+              ],
               "properties": {
                 "repository": {
                   "description": "The repository to get the latest version of.",
@@ -2233,7 +2548,10 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["key", "message"],
+        "required": [
+          "key",
+          "message"
+        ],
         "properties": {
           "key": {
             "description": "e.g. '2023-03-10-my-key'; MUST START WITH YYYY-MM-DD; a globally unique key used to track whether the message has been dismissed.",
@@ -2258,7 +2576,9 @@
       "description": "The authentication providers to use for identifying and signing in users. See instructions below for configuring SAML, OpenID Connect (including Google Workspace), and HTTP authentication proxies. Multiple authentication providers are supported (by specifying multiple elements in this array).",
       "type": "array",
       "items": {
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "properties": {
           "type": {
             "type": "string",
@@ -2326,7 +2646,9 @@
       "type": "string",
       "description": "The duration of a user session, after which it expires and the user is required to re-authenticate. The default is 90 days. There is typically no need to set this, but some users may have specific internal security requirements.\n\nThe string format is that of the Duration type in the Go time package (https://golang.org/pkg/time/#ParseDuration). E.g., \"720h\", \"43200m\", \"2592000s\" all indicate a timespan of 30 days.\n\nNote: changing this field does not affect the expiration of existing sessions. If you would like to enforce this limit for existing sessions, you must log out currently signed-in users. You can force this by removing all keys beginning with \"session_\" from the Redis store:\n\n* For deployments using `sourcegraph/server`: `docker exec $CONTAINER_ID redis-cli --raw keys 'session_*' | xargs docker exec $CONTAINER_ID redis-cli del`\n* For cluster deployments: \n  ```\n  REDIS_POD=\"$(kubectl get pods -l app=redis-store -o jsonpath={.items[0].metadata.name})\";\n  kubectl exec \"$REDIS_POD\" -- redis-cli --raw keys 'session_*' | xargs kubectl exec \"$REDIS_POD\" -- redis-cli --raw del;\n  ```\n",
       "default": "2160h",
-      "examples": ["168h"],
+      "examples": [
+        "168h"
+      ],
       "group": "Authentication"
     },
     "auth.enableUsernameChanges": {
@@ -2421,10 +2743,17 @@
     },
     "update.channel": {
       "description": "The channel on which to automatically check for Sourcegraph updates.",
-      "type": ["string"],
-      "enum": ["release", "none"],
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "release",
+        "none"
+      ],
       "default": "release",
-      "examples": ["none"],
+      "examples": [
+        "none"
+      ],
       "group": "Misc."
     },
     "productResearchPage.enabled": {
@@ -2527,12 +2856,16 @@
       "!go": {
         "pointer": true
       },
-      "examples": [true]
+      "examples": [
+        true
+      ]
     },
     "organizationInvitations": {
       "description": "Configuration for organization invitations.",
       "type": "object",
-      "required": ["signingKey"],
+      "required": [
+        "signingKey"
+      ],
       "properties": {
         "expiryTime": {
           "description": "Time before the invitation expires, in hours (experimental, not enforced at the moment).",
@@ -2607,7 +2940,11 @@
         "provider": {
           "type": "string",
           "description": "The provider to use for generating embeddings. Defaults to sourcegraph.",
-          "enum": ["openai", "azure-openai", "sourcegraph"]
+          "enum": [
+            "openai",
+            "azure-openai",
+            "sourcegraph"
+          ]
         },
         "endpoint": {
           "type": "string",
@@ -2659,7 +2996,13 @@
               "items": {
                 "type": "string"
               },
-              "examples": ["*.go", "*.ts", "*.md", "src/", "cmd/"]
+              "examples": [
+                "*.go",
+                "*.ts",
+                "*.md",
+                "src/",
+                "cmd/"
+              ]
             },
             "maxFileSizeBytes": {
               "description": "The maximum file size (in bytes) to include in embeddings. Must be between 0 and 100000 (1 MB).",
@@ -2846,7 +3189,11 @@
           "model": "text-embedding-ada-002",
           "accessToken": "your-access-token",
           "url": "https://api.openai.com/v1/embeddings",
-          "excludedFilePathPatterns": ["*.svg", "**/__mocks__/**", "**/test/**"]
+          "excludedFilePathPatterns": [
+            "*.svg",
+            "**/__mocks__/**",
+            "**/test/**"
+          ]
         }
       ]
     },
@@ -2898,7 +3245,14 @@
           "type": "string",
           "description": "The external completions provider. Defaults to 'sourcegraph'.",
           "default": "sourcegraph",
-          "enum": ["anthropic", "openai", "sourcegraph", "azure-openai", "aws-bedrock", "fireworks"]
+          "enum": [
+            "anthropic",
+            "openai",
+            "sourcegraph",
+            "azure-openai",
+            "aws-bedrock",
+            "fireworks"
+          ]
         },
         "endpoint": {
           "type": "string",
@@ -3034,7 +3388,9 @@
       "description": "Configures the builtin username-password authentication provider.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3051,7 +3407,12 @@
       "description": "Configures the OpenID Connect authentication provider for SSO.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "issuer", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "issuer",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3110,11 +3471,20 @@
       "description": "Configures the SAML authentication provider for SSO.\n\nNote: if you are using IdP-initiated login, you must have *at most one* SAMLAuthProvider in the `auth.providers` array.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "dependencies": {
-        "serviceProviderCertificate": ["serviceProviderPrivateKey"],
-        "serviceProviderPrivateKey": ["serviceProviderCertificate"],
-        "signRequests": ["serviceProviderCertificate", "serviceProviderPrivateKey"]
+        "serviceProviderCertificate": [
+          "serviceProviderPrivateKey"
+        ],
+        "serviceProviderPrivateKey": [
+          "serviceProviderCertificate"
+        ],
+        "signRequests": [
+          "serviceProviderCertificate",
+          "serviceProviderPrivateKey"
+        ]
       },
       "properties": {
         "type": {
@@ -3225,7 +3595,10 @@
       "description": "Configures the HTTP header authentication provider (which authenticates users by consulting an HTTP request header set by an authentication proxy such as https://github.com/bitly/oauth2_proxy).",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "usernameHeader"],
+      "required": [
+        "type",
+        "usernameHeader"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3234,17 +3607,23 @@
         "usernameHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the username of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": ["X-Forwarded-User"]
+          "examples": [
+            "X-Forwarded-User"
+          ]
         },
         "stripUsernameHeaderPrefix": {
           "description": "The prefix that precedes the username portion of the HTTP header specified in `usernameHeader`. If specified, the prefix will be stripped from the header value and the remainder will be used as the username. For example, if using Google Identity-Aware Proxy (IAP) with Google Sign-In, set this value to `accounts.google.com:`.",
           "type": "string",
-          "examples": ["accounts.google.com:"]
+          "examples": [
+            "accounts.google.com:"
+          ]
         },
         "emailHeader": {
           "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the email of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
           "type": "string",
-          "examples": ["X-App-Email"]
+          "examples": [
+            "X-App-Email"
+          ]
         }
       }
     },
@@ -3252,7 +3631,11 @@
       "description": "Configures the GitHub (or GitHub Enterprise) OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitHub instance: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/. When a user signs into Sourcegraph or links their GitHub account to their existing Sourcegraph account, GitHub will prompt the user for the repo scope.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3312,8 +3695,13 @@
           },
           "examples": [
             {
-              "orgName": ["team1"],
-              "anotherOrgName": ["team2", "team3"]
+              "orgName": [
+                "team1"
+              ],
+              "anotherOrgName": [
+                "team2",
+                "team3"
+              ]
             }
           ]
         },
@@ -3328,7 +3716,11 @@
       "description": "Configures the GitLab OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your GitLab instance: https://docs.gitlab.com/ee/integration/oauth_provider.html. The application should have `api` and `read_user` scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/gitlab/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3371,7 +3763,10 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "api",
-          "enum": ["api", "read_api"]
+          "enum": [
+            "api",
+            "read_api"
+          ]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via GitLab authentication. If false, users signing in via GitLab must have an existing Sourcegraph account, which will be linked to their GitLab identity after sign-in.",
@@ -3389,7 +3784,13 @@
             "type": "string",
             "minLength": 1
           },
-          "examples": [["group", "group/subgroup", "group/subgroup/subgroup"]]
+          "examples": [
+            [
+              "group",
+              "group/subgroup",
+              "group/subgroup/subgroup"
+            ]
+          ]
         },
         "tokenRefreshWindowMinutes": {
           "description": "Time in minutes before token expiry when we should attempt to refresh it",
@@ -3410,7 +3811,11 @@
       "description": "Configures the Bitbucket Cloud OAuth authentication provider for SSO. In addition to specifying this configuration object, you must also create a OAuth App on your Bitbucket Cloud workspace: https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/. The application should have account, email, and repository scopes and the callback URL set to the concatenation of your Sourcegraph instance URL and \"/.auth/bitbucketcloud/callback\".",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientKey", "clientSecret"],
+      "required": [
+        "type",
+        "clientKey",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3448,7 +3853,11 @@
           "type": "string",
           "description": "The OAuth API scope that should be used",
           "default": "account,email,repository",
-          "enum": ["account", "email", "repository"]
+          "enum": [
+            "account",
+            "email",
+            "repository"
+          ]
         },
         "allowSignup": {
           "description": "Allows new visitors to sign up for accounts via Bitbucket Cloud authentication. If false, users signing in via Bitbucket Cloud must have an existing Sourcegraph account, which will be linked to their Bitbucket Cloud identity after sign-in.",
@@ -3461,7 +3870,10 @@
       "description": "Gerrit auth provider",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3493,7 +3905,11 @@
       "description": "Azure auth provider for dev.azure.com",
       "type": "object",
       "additionalProperties": false,
-      "required": ["type", "clientID", "clientSecret"],
+      "required": [
+        "type",
+        "clientID",
+        "clientSecret"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3578,7 +3994,9 @@
     "NotifierSlack": {
       "description": "Slack notifier",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3609,7 +4027,10 @@
     "NotifierPagerduty": {
       "description": "PagerDuty notifier",
       "type": "object",
-      "required": ["type", "integrationKey"],
+      "required": [
+        "type",
+        "integrationKey"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3631,7 +4052,10 @@
     "NotifierWebhook": {
       "description": "Webhook notifier",
       "type": "object",
-      "required": ["type", "url"],
+      "required": [
+        "type",
+        "url"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3654,7 +4078,10 @@
     "NotifierEmail": {
       "description": "Email notifier",
       "type": "object",
-      "required": ["type", "address"],
+      "required": [
+        "type",
+        "address"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3669,7 +4096,9 @@
     "NotifierOpsGenie": {
       "description": "OpsGenie notifier",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3697,7 +4126,12 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["team", "user", "escalation", "schedule"]
+                "enum": [
+                  "team",
+                  "user",
+                  "escalation",
+                  "schedule"
+                ]
               },
               "id": {
                 "type": "string"
@@ -3711,13 +4145,22 @@
             },
             "oneOf": [
               {
-                "required": ["type", "id"]
+                "required": [
+                  "type",
+                  "id"
+                ]
               },
               {
-                "required": ["type", "name"]
+                "required": [
+                  "type",
+                  "name"
+                ]
               },
               {
-                "required": ["type", "username"]
+                "required": [
+                  "type",
+                  "username"
+                ]
               }
             ]
           }
@@ -3727,11 +4170,18 @@
     "EncryptionKey": {
       "description": "Config for a key",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["cloudkms", "awskms", "mounted", "noop"]
+          "enum": [
+            "cloudkms",
+            "awskms",
+            "mounted",
+            "noop"
+          ]
         }
       },
       "oneOf": [
@@ -3755,7 +4205,10 @@
     "CloudKMSEncryptionKey": {
       "description": "Google Cloud KMS Encryption Key, used to encrypt data in Google Cloud environments",
       "type": "object",
-      "required": ["type", "keyname"],
+      "required": [
+        "type",
+        "keyname"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3772,7 +4225,10 @@
     "AWSKMSEncryptionKey": {
       "description": "AWS KMS Encryption Key, used to encrypt data in AWS environments",
       "type": "object",
-      "required": ["type", "keyId"],
+      "required": [
+        "type",
+        "keyId"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3792,7 +4248,10 @@
     "MountedEncryptionKey": {
       "description": "This encryption key is mounted from a given file path or an environment variable.",
       "type": "object",
-      "required": ["type", "keyname"],
+      "required": [
+        "type",
+        "keyname"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3815,7 +4274,9 @@
     "NoOpEncryptionKey": {
       "description": "This encryption key is a no op, leaving your data in plaintext (not recommended).",
       "type": "object",
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "properties": {
         "type": {
           "type": "string",
@@ -3825,7 +4286,10 @@
     },
     "EmailTemplate": {
       "type": "object",
-      "required": ["subject", "html"],
+      "required": [
+        "subject",
+        "html"
+      ],
       "properties": {
         "subject": {
           "description": "Template for email subject header",


### PR DESCRIPTION
This is the first of many upcoming PRs to enable refreshing user's rate limits on Cody Gateway when a subscription change happens on SSC.

Issue: https://github.com/sourcegraph/accounts.sourcegraph.com/issues/363
Related SAMS PR: https://github.com/sourcegraph/accounts.sourcegraph.com/pull/418

**The whole plan is as follows (given we do not have SAMSActor on Gateway yet):**
- On every subscription change, SSC will make a request to Cody Gateway to refresh the rate limits for the user, the same as dotcom does right now.
- SSC will send dotcom_user_id with the request, which it will get from the user's metadata from SAMS. 
- Dotcom will expose a new graphql resolver which provides rate limits for user ID. Right now, it provides one, but for a dotcom access token.
- Gateway will make a call to dotcom to fetch the limits for the dotcom_user_id using the new API. It does the same now but for dotcom's per_user_access_token.

**How will it look when we have SAMSActor & SSCSource on Gateway?**
Same as above, but with a few changes:
- SSC will send SAMS user_access_token in place of dotcom_user_id with the request.
- SSC will expose a graphql resolver which provides rate limits for SAMS user_access_token.
- Gateway will use SAMS user_access_token to fetch rate limits directly from SSC.

**What does this PR handle?**
1. It implements a new SAMS client.
2. It implements a new SAMS auth middleware, which allows auth using service-to-service tokens utilizing the SAMS client.
3. It exposes a new dummy API endpoint, `/v1/sams/limits/refresh`, which utilises the new SAMS auth middleware. To note, the `/v1/limits/refresh` endpoint already exists, but it uses the present auth. 

**What does this PR NOT handle? (TODOs for upcoming PRs)**
1. The actual implementation of the new API endpoint is pending and will be addressed in upcoming PRs. 
2. It doesn't update the dotcom graphql API either, which will be addressed in upcoming PRs.

## Test plan
- Checkout SAMS local on https://github.com/sourcegraph/accounts.sourcegraph.com/pull/418
- Run SAMS locally under the 9982 port. Otherwise, it will conflict with Gateway running on 9992.
- Create client ID and client secrets using: 
![CleanShot 2024-02-01 at 21 53 45@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/02afcdd9-5da4-4590-ac4e-e7a37a68f3d4)
- Update scopes to include `cody.gateway` in the DB directly `psql -U sourcegraph accounts` `update idp_clients set scopes = '["openid", "profile", "email", "offline_access", "cody.gateway", "cody.ssc"]';`
- Update `sg.config.overwrite.yaml` in sg repo to include the client secret and id similar to this: 
![CleanShot 2024-02-01 at 21 56 08@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/88ad7867-7f4e-46eb-b186-c091a79a27f1)
- Update `.envrc` in accounts repo to include include the client secret, id and gateway URL similar to this: 
![CleanShot 2024-02-01 at 21 57 19@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/28476635-3bbc-45be-864b-9b3e5c2d8416)
- Search for codyAdminAccountIDs in accounts repo and copy the admin account id hard coded. Update  your the `users.external_id` and `users.accounts_external_id` in accounts and cody_management DB respectively, which the admin account id. 
- Visit `localhost:9982` in the browser. Make sure you are logged in with the account you set as admin above. 
- Make the following request from the console to test the flow: 
```
await (await fetch(`${window.location.href}cody/api/rest/user/{put the external_id here}/limits/refresh`, { method: 'POST' })).json()
```
