### PR TITLE
refactor: replace `errors.New(fmt.Sprintf` with `errors.Newf`

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -155,7 +155,7 @@ func (s *repositoriesConnectionStore) MarshalCursor(node *RepositoryResolver, or
 		}
 		value = strconv.FormatInt(int64(*size), 10)
 	default:
-		return nil, errors.New(fmt.Sprintf("invalid OrderBy.Field. Expected: one of (name, created_at, gr.repo_size_bytes). Actual: %s", column))
+		return nil, errors.Newf("invalid OrderBy.Field. Expected: one of (name, created_at, gr.repo_size_bytes). Actual: %s", column)
 	}
 
 	cursor := MarshalRepositoryCursor(
@@ -180,12 +180,12 @@ func (s *repositoriesConnectionStore) UnmarshalCursor(cursor string, orderBy dat
 
 	column := orderBy[0].Field
 	if repoCursor.Column != column {
-		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected: %s Actual: %s", column, repoCursor.Column))
+		return nil, errors.Newf("Invalid cursor. Expected: %s Actual: %s", column, repoCursor.Column)
 	}
 
 	values := strings.Split(repoCursor.Value, "@")
 	if len(values) != 2 {
-		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, repoCursor.Value))
+		return nil, errors.Newf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, repoCursor.Value)
 	}
 
 	repoID, err := strconv.Atoi(values[1])

--- a/cmd/frontend/internal/insights/resolvers/admin_resolver.go
+++ b/cmd/frontend/internal/insights/resolvers/admin_resolver.go
@@ -500,7 +500,7 @@ func (a *adminBackfillQueueConnectionStore) MarshalCursor(node *graphqlbackend.B
 	switch scheduler.BackfillQueueColumn(column) {
 	case scheduler.State, scheduler.QueuePosition:
 	default:
-		return nil, errors.New(fmt.Sprintf("invalid OrderBy.Field. Expected: one of (STATE, QUEUE_POSITION). Actual: %s", column))
+		return nil, errors.Newf("invalid OrderBy.Field. Expected: one of (STATE, QUEUE_POSITION). Actual: %s", column)
 	}
 
 	// In cursor Column is the what to sort by and the Value is the backfillID

--- a/cmd/frontend/internal/own/resolvers/resolvers.go
+++ b/cmd/frontend/internal/own/resolvers/resolvers.go
@@ -826,7 +826,7 @@ func unmarshalAssignOwnerArgs(args graphqlbackend.AssignOwnerOrTeamInput, unmars
 		return nil, unmarshalError
 	}
 	if userOrTeamID == 0 {
-		return nil, errors.New(fmt.Sprintf("assigned %s ID should not be 0", unmarshalMode))
+		return nil, errors.Newf("assigned %s ID should not be 0", unmarshalMode)
 	}
 	repoID, err := graphqlbackend.UnmarshalRepositoryID(args.RepoID)
 	if err != nil {

--- a/cmd/frontend/internal/search/resolvers/resolver.go
+++ b/cmd/frontend/internal/search/resolvers/resolver.go
@@ -166,7 +166,7 @@ func (s *searchJobsConnectionStore) MarshalCursor(node graphqlbackend.SearchJobR
 	case "query":
 		value = node.Query()
 	default:
-		return nil, errors.New(fmt.Sprintf("invalid OrderBy.Field. Expected one of (created_at, agg_state, query). Actual: %s", column))
+		return nil, errors.Newf("invalid OrderBy.Field. Expected one of (created_at, agg_state, query). Actual: %s", column)
 	}
 
 	id, err := UnmarshalSearchJobID(node.ID())
@@ -184,7 +184,7 @@ func (s *searchJobsConnectionStore) MarshalCursor(node graphqlbackend.SearchJobR
 
 func (s *searchJobsConnectionStore) UnmarshalCursor(cursor string, orderBy database.OrderBy) ([]any, error) {
 	if kind := relay.UnmarshalKind(graphql.ID(cursor)); kind != searchJobsCursorKind {
-		return nil, errors.New(fmt.Sprintf("expected a %q cursor, got %q", searchJobsCursorKind, kind))
+		return nil, errors.Newf("expected a %q cursor, got %q", searchJobsCursorKind, kind)
 	}
 	var spec *types.Cursor
 	if err := relay.UnmarshalSpec(graphql.ID(cursor), &spec); err != nil {
@@ -196,12 +196,12 @@ func (s *searchJobsConnectionStore) UnmarshalCursor(cursor string, orderBy datab
 	}
 	column := orderBy[0].Field
 	if spec.Column != column {
-		return nil, errors.New(fmt.Sprintf("expected a %q cursor, got %q", column, spec.Column))
+		return nil, errors.Newf("expected a %q cursor, got %q", column, spec.Column)
 	}
 
 	i := strings.LastIndex(spec.Value, "@")
 	if i == -1 {
-		return nil, errors.New(fmt.Sprintf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, spec.Value))
+		return nil, errors.Newf("Invalid cursor. Expected Value: <%s>@<id> Actual Value: %s", column, spec.Value)
 	}
 
 	values := []string{spec.Value[0:i], spec.Value[i+1:]}

--- a/dev/sg/internal/wolfi/base-image.go
+++ b/dev/sg/internal/wolfi/base-image.go
@@ -111,7 +111,7 @@ func (c PackageRepoConfig) LoadBaseImage(name string) error {
 func (c PackageRepoConfig) CleanupBaseImageBuild(name string) error {
 	imageDir := c.ImageDir
 	if !strings.HasSuffix(imageDir, "/wolfi-images/local-images") {
-		return errors.New(fmt.Sprintf("directory '%s' does not look like the image output directory - not cleaning up", imageDir))
+		return errors.Newf("directory '%s' does not look like the image output directory - not cleaning up", imageDir)
 	}
 
 	if err := os.RemoveAll(imageDir); err != nil {

--- a/dev/sg/sg_rfc.go
+++ b/dev/sg/sg_rfc.go
@@ -126,7 +126,7 @@ sg rfc --private create --type <type> "title"
 					}
 				}
 				if template.Name == "" {
-					return errors.New(fmt.Sprintf("Unknown RFC type: %s", rfcType))
+					return errors.Newf("Unknown RFC type: %s", rfcType)
 				}
 
 				if c.Args().Len() == 0 {

--- a/internal/github_apps/store/store.go
+++ b/internal/github_apps/store/store.go
@@ -115,7 +115,7 @@ func (s *gitHubAppsStore) Create(ctx context.Context, app *ghtypes.GitHubApp) (i
 
 	baseURL, err := url.Parse(app.BaseURL)
 	if err != nil {
-		return -1, errors.New(fmt.Sprintf("unable to parse base URL: %s", baseURL.String()))
+		return -1, errors.Newf("unable to parse base URL: %s", baseURL.String())
 	}
 	baseURL = extsvc.NormalizeBaseURL(baseURL)
 	domain := app.Domain

--- a/internal/security/gsm/gsm_test.go
+++ b/internal/security/gsm/gsm_test.go
@@ -39,7 +39,7 @@ func TestFetchGSM(t *testing.T) {
 			name: "Test cannot find secret returns empty secret",
 			client: &mockClient{
 				AccessFunc: func(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
-					return nil, errors.New(fmt.Sprintf("rpc error: code = NotFound desc = Secret [%s] not found or has no versions", req.Name))
+					return nil, errors.Newf("rpc error: code = NotFound desc = Secret [%s] not found or has no versions", req.Name)
 				},
 				CloseFunc: func() error { return nil },
 			},

--- a/lib/batches/template/templating.go
+++ b/lib/batches/template/templating.go
@@ -80,7 +80,7 @@ func ValidateBatchSpecTemplate(spec string) (bool, error) {
 		// to provide a clearer message.
 		errorRe := regexp.MustCompile(`(?i)function "(?P<key>[^"]+)" not defined`)
 		if matches := errorRe.FindStringSubmatch(err.Error()); len(matches) > 0 {
-			return false, errors.New(fmt.Sprintf("validating batch spec template: unknown templating variable: '%s'", matches[1]))
+			return false, errors.Newf("validating batch spec template: unknown templating variable: '%s'", matches[1])
 		}
 		// If we couldn't give a more specific error, fall back on the one from text/template.
 		return false, errors.Wrap(err, "validating batch spec template")
@@ -92,7 +92,7 @@ func ValidateBatchSpecTemplate(spec string) (bool, error) {
 		// to provide a clearer message.
 		errorRe := regexp.MustCompile(`(?i)at <(?P<outer>[^>]+)>:.*for key "(?P<inner>[^"]+)"`)
 		if matches := errorRe.FindStringSubmatch(err.Error()); len(matches) > 0 {
-			return false, errors.New(fmt.Sprintf("validating batch spec template: unknown templating variable: '%s.%s'", matches[1], matches[2]))
+			return false, errors.Newf("validating batch spec template: unknown templating variable: '%s.%s'", matches[1], matches[2])
 		}
 		// If we couldn't give a more specific error, fall back on the one from text/template.
 		return false, errors.Wrap(err, "validating batch spec template")

--- a/lib/codeintel/tools/lsif-index-tester/main.go
+++ b/lib/codeintel/tools/lsif-index-tester/main.go
@@ -164,7 +164,7 @@ func testDirectory(ctx context.Context, logger log.Logger, indexer []string, dir
 	}
 
 	if !successful {
-		return errors.New(fmt.Sprintf("'%s' Failed.", directory))
+		return errors.Newf("'%s' Failed.", directory)
 	}
 
 	return nil

--- a/lib/codeintel/tools/lsif-validate/validate.go
+++ b/lib/codeintel/tools/lsif-validate/validate.go
@@ -35,7 +35,7 @@ func validate(indexFile *os.File) error {
 	}
 
 	if len(ctx.Errors) > 0 {
-		return errors.New(fmt.Sprintf("Detected %d errors", len(ctx.Errors)))
+		return errors.Newf("Detected %d errors", len(ctx.Errors))
 	}
 
 	return nil


### PR DESCRIPTION
This PR replaces `errors.New(fmt.Sprintf(...))` statements with [`errors.Newf`](https://github.com/sourcegraph/sourcegraph/blob/a9df350def08fd71f31e6c52f458821cf0b760f6/lib/errors/cockroach.go#L24) because it's shorter. These functions are the same.

## Test plan

Existing test suites.