### PR TITLE
auth: be fully compatible with our creative redirect params

### DIFF
--- a/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/cmd/frontend/internal/auth/oauth/middleware.go
@@ -83,8 +83,13 @@ func newOAuthFlowHandler(serviceType string) http.Handler {
 		id := r.URL.Query().Get("pc")
 		p := GetProvider(serviceType, id)
 		if p == nil {
+			redirect := r.URL.Query().Get("redirect")
+			if redirect == "" {
+				redirect = r.URL.Query().Get("returnTo")
+			}
+
 			log15.Warn("no OAuth provider found with ID and service type", "id", id, "serviceType", serviceType)
-			http.Redirect(w, r, "/sign-in?returnTo="+r.URL.Query().Get("returnTo"), http.StatusFound)
+			http.Redirect(w, r, "/sign-in?returnTo="+redirect, http.StatusFound)
 			return
 		}
 		p.Login(p.OAuth2Config()).ServeHTTP(w, r)

--- a/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/cmd/frontend/internal/auth/oauth/middleware.go
@@ -83,6 +83,12 @@ func newOAuthFlowHandler(serviceType string) http.Handler {
 		id := r.URL.Query().Get("pc")
 		p := GetProvider(serviceType, id)
 		if p == nil {
+			// NOTE: Within the Sourcegraph application, we have been using both the
+			// "redirect" and "returnTo" query parameters inconsistently, and some of the
+			// usages are also on the client side (Cody clients). If we ever settle on one
+			// and updated all usages on both server and client side, we need to make sure
+			// to have a grace period (e.g. 3 months) for the client side because we have no
+			// control over when users will actually upgrade their clients.
 			redirect := r.URL.Query().Get("redirect")
 			if redirect == "" {
 				redirect = r.URL.Query().Get("returnTo")

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -123,6 +123,12 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimPrefix(r.URL.Path, authPrefix) {
 		case "/login": // Endpoint that starts the Authentication Request Code Flow.
+			// NOTE: Within the Sourcegraph application, we have been using both the
+			// "redirect" and "returnTo" query parameters inconsistently, and some of the
+			// usages are also on the client side (Cody clients). If we ever settle on one
+			// and updated all usages on both server and client side, we need to make sure
+			// to have a grace period (e.g. 3 months) for the client side because we have no
+			// control over when users will actually upgrade their clients.
 			redirect := r.URL.Query().Get("redirect")
 			if redirect == "" {
 				redirect = r.URL.Query().Get("returnTo")

--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -123,19 +123,20 @@ func authHandler(db database.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimPrefix(r.URL.Path, authPrefix) {
 		case "/login": // Endpoint that starts the Authentication Request Code Flow.
+			redirect := r.URL.Query().Get("redirect")
+			if redirect == "" {
+				redirect = r.URL.Query().Get("returnTo")
+			}
+
 			p, safeErrMsg, err := GetProviderAndRefresh(r.Context(), r.URL.Query().Get("pc"), GetProvider)
 			if errors.Is(err, errNoSuchProvider) {
 				log15.Warn("Failed to get provider.", "error", err)
-				http.Redirect(w, r, "/sign-in?returnTo="+r.URL.Query().Get("returnTo"), http.StatusFound)
+				http.Redirect(w, r, "/sign-in?returnTo="+redirect, http.StatusFound)
 				return
 			} else if err != nil {
 				log15.Error("Failed to get provider.", "error", err)
 				http.Error(w, safeErrMsg, http.StatusInternalServerError)
 				return
-			}
-			redirect := r.URL.Query().Get("redirect")
-			if redirect == "" {
-				redirect = r.URL.Query().Get("returnTo")
 			}
 			RedirectToAuthRequest(w, r, p, redirect)
 			return


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/59986 does not _fully_ work, so here is the follow-up.

## Test plan

```zsh
→ curl https://sourcegraph.test:3443/.auth/openidconnect/login?pc=404&returnTo=%2Fsearch
<a href="/sign-in?returnTo=/search">Found</a>.

→ curl https://sourcegraph.test:3443/.auth/github/login?pc=404&returnTo=%2Fsearch
<a href="/sign-in?returnTo=/search">Found</a>.

→ curl https://sourcegraph.test:3443/.auth/openidconnect/login?pc=404&redirect=%2Fsearch
<a href="/sign-in?returnTo=/search">Found</a>.

→ curl https://sourcegraph.test:3443/.auth/github/login?pc=404&redirect=%2Fsearch
<a href="/sign-in?returnTo=/search">Found</a>.
```