### PR TITLE
Keyword search: support patterntype in other features

### DIFF
--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -271,8 +271,9 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
         placeholder: '"content"',
     },
     [FilterType.patterntype]: {
-        discreteValues: () => ['regexp', 'structural', 'literal', 'standard'].map(value => ({ label: value })),
-        description: 'The pattern type (standard, regexp, literal, structural) in use',
+        discreteValues: () =>
+            ['keyword', 'literal', 'regexp', 'standard', 'structural'].map(value => ({ label: value })),
+        description: 'The pattern type (standard, keyword, regexp, literal) in use',
         singular: true,
     },
     [FilterType.repo]: {

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -28,7 +28,7 @@ interface TriggerAreaProps {
 }
 
 const isDiffOrCommit = (value: string): boolean => value === 'diff' || value === 'commit'
-const isLiteralOrRegexp = (value: string): boolean => value === 'literal' || value === 'regexp'
+const isValidPatternType = (value: string): boolean => value === 'keyword' || value === 'literal' || value === 'regexp'
 
 const ValidQueryChecklistItem: React.FunctionComponent<
     React.PropsWithChildren<{
@@ -170,7 +170,7 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                         filter.type === 'filter' &&
                         resolveFilter(filter.field.value)?.type === FilterType.patterntype &&
                         filter.value &&
-                        isLiteralOrRegexp(filter.value.value)
+                        isValidPatternType(filter.value.value)
                 )
         }
 
@@ -268,7 +268,7 @@ export const FormTriggerArea: React.FunctionComponent<React.PropsWithChildren<Tr
                                     hint="Code monitors support literal and regex search. Searches are literal by default."
                                     dataTestid="patterntype-checkbox"
                                 >
-                                    Is <Code>patternType:literal</Code> or <Code>patternType:regexp</Code>
+                                    Is <Code>patternType:keyword</Code>, <Code>literal</Code> or <Code>regexp</Code>
                                 </ValidQueryChecklistItem>
                             </li>
                             <li>

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/components/search-query-checks/SearchQueryChecks.tsx
@@ -30,10 +30,10 @@ export const SearchQueryChecks: FC<SearchQueryChecksProps> = ({ checks }) => (
             expression boolean operators can still be used)
         </CheckListItem>
         <CheckListItem
-            errorMessage="shouldn't contain patternType:literal or patternType:structural"
+            errorMessage="shouldn't contain 'keyword', 'literal', or 'structural' patterntype"
             valid={checks?.isValidPatternType}
         >
-            Does not contain <Code>patternType:literal</Code> or <Code>patternType:structural</Code>
+            Does not contain a <Code>patternType:keyword</Code>, <Code>literal</Code>, or <Code>structural</Code>{' '}
         </CheckListItem>
         <CheckListItem errorMessage="shouldn't contain repo filter" valid={checks?.isNotRepo}>
             Does not contain <Code>repo:</Code> filter

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/utils/search-query-validator.ts
@@ -33,15 +33,12 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
         const hasOr = keywords.some(filter => filter.kind === 'or')
         const hasNot = keywords.some(filter => filter.kind === 'not')
 
-        const hasLiteralPattern = filters.some(
-            filter =>
-                resolveFilter(filter.field.value)?.type === FilterType.patterntype && filter.value?.value === 'literal'
-        )
-
-        const hasStructuralPattern = filters.some(
+        const hasInvalidPatternType = filters.some(
             filter =>
                 resolveFilter(filter.field.value)?.type === FilterType.patterntype &&
-                filter.value?.value === 'structural'
+                (filter.value?.value === 'literal' ||
+                    filter.value?.value === 'structural' ||
+                    filter.value?.value === 'keyword')
         )
 
         const hasRepo = filters.some(
@@ -66,7 +63,7 @@ export const searchQueryValidator = (value: string | undefined): Checks => {
 
         return {
             isValidOperator: !hasAnd && !hasOr && !hasNot,
-            isValidPatternType: !hasLiteralPattern && !hasStructuralPattern,
+            isValidPatternType: !hasInvalidPatternType,
             isNotRepo: !hasRepo,
             isNotContext: !hasContext,
             isNotCommitOrDiff: !hasCommit && !hasDiff,

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -327,10 +327,10 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 	return &EmptyResponse{}, nil
 }
 
-var patternType = lazyregexp.New(`(?i)\bpatternType:(literal|regexp|structural|standard)\b`)
+var patternType = lazyregexp.New(`(?i)\bpatternType:(literal|regexp|structural|standard|keyword)\b`)
 
 func queryHasPatternType(query string) bool {
 	return patternType.Match([]byte(query))
 }
 
-var errMissingPatternType = errors.New("a `patternType:` filter is required in the query for all saved searches. `patternType` can be \"standard\", \"literal\", \"regexp\" or \"structural\"")
+var errMissingPatternType = errors.New("a `patternType:` filter is required in the query for all saved searches. `patternType` can be \"keyword\", \"standard\", \"literal\", or \"regexp\"")


### PR DESCRIPTION
This PR fixes several issues when you perform a keyword search, then select Actions -> ...
* Code monitoring now allows `patterntype:keyword`
* Saved searches now accept `keyword`
* Insights already allowed `keyword` for "Track changes", now it correctly rejects it for "Detect and track patterns"
* The keyword patterntype no longer has these red squiggly lines in various search inputs:

![Screenshot 2024-02-01 at 12 04 49 PM](https://github.com/sourcegraph/sourcegraph/assets/7461306/2c720bb2-2d87-4d47-a323-0ac7616cf544)

## Test plan

Manual testing. Also tested searches within Notebooks and Batch changes, and `keyword` is already allowed.