### PR TITLE
Search jobs: support boolean patterns

### DIFF
--- a/internal/search/job/jobutil/exhaustive_job.go
+++ b/internal/search/job/jobutil/exhaustive_job.go
@@ -39,12 +39,8 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 	}
 
 	b := inputs.Plan[0]
-	term, ok := b.Pattern.(query.Pattern)
-	if !ok {
-		if b.Pattern == nil {
-			return Exhaustive{}, errors.Errorf("missing pattern")
-		}
-		return Exhaustive{}, errors.Errorf("expected a simple expression (no and/or/etc). Got %v", b.Pattern)
+	if b.Pattern == nil {
+		return Exhaustive{}, errors.Errorf("missing pattern")
 	}
 
 	// We don't support file predicates, such as file:has.content(), because the
@@ -56,8 +52,10 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 	}
 
 	// This is a very weak protection but should be enough to catch simple misuse.
-	if inputs.PatternType == query.SearchTypeRegex && term.Value == ".*" {
-		return Exhaustive{}, errors.Errorf("regex search with .* is not supported")
+	if inputs.PatternType == query.SearchTypeRegex {
+		if term, ok := b.Pattern.(query.Pattern); ok && term.Value == ".*" {
+			return Exhaustive{}, errors.Errorf("regex search with .* is not supported")
+		}
 	}
 
 	repoOptions := toRepoOptions(b, inputs.UserSettings)


### PR DESCRIPTION
This PR adds support for boolean patterns to search jobs. It should be okay in
terms of performance, since we recently updated searcher to handle AND/ OR
patterns natively (https://github.com/sourcegraph/sourcegraph/issues/59038).

This also makes the integration with keyword search a lot nicer. Now when you
have a keyword search with multiple terms and you go to create a search job, it
succeeds. Previously it showed this confusing error:

![Screenshot 2024-02-01 at 11 55 55
AM](https://github.com/sourcegraph/sourcegraph/assets/7461306/f21a6b0b-e1a3-42bd-8415-cbc1f3346ac0)

## Test plan

Updated unit tests, light manual testing