### PR TITLE
Allow sg wolfi image opentelemetry-collector to work

### DIFF
--- a/dev/sg/internal/wolfi/base-image.go
+++ b/dev/sg/internal/wolfi/base-image.go
@@ -52,7 +52,6 @@ func (c PackageRepoConfig) DoBaseImageBuild(name string, buildDir string) error 
 		"-e", fmt.Sprintf("SOURCE_DATE_EPOCH=%d", time.Now().Unix()),
 		"-w", "/work",
 		"cgr.dev/chainguard/apko", "build",
-		"--debug",
 		"--arch", "x86_64",
 		"--repository-append", "@local /packages",
 		"--keyring-append", fmt.Sprintf("/keys/%s.pub", c.KeyFilename),


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/60069

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
CI 

`sg wolfi image opentelemetry-collector` works
