### PR TITLE
Search results color tweaks

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -12,6 +12,7 @@
     padding: 0.75rem;
 
     &:focus-within {
+
         // Show suggestion if there is any focused element withing container
         .suggestions {
             display: block;

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -12,7 +12,6 @@
     padding: 0.75rem;
 
     &:focus-within {
-
         // Show suggestion if there is any focused element withing container
         .suggestions {
             display: block;

--- a/client/web/src/nav/GlobalNavbar.module.scss
+++ b/client/web/src/nav/GlobalNavbar.module.scss
@@ -33,7 +33,8 @@
     z-index: 2;
     width: 100%;
     padding: 0.75rem 1rem;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color-2);
+    background-color: var(--color-bg-1);
 }
 
 .list {

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.module.scss
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.module.scss
@@ -41,7 +41,8 @@
 
 .new-filters {
     grid-area: new-filters;
-    border-right: 1px solid var(--border-color);
+    border-right: 1px solid var(--border-color-2);
+    background-color: var(--color-bg-1);
 }
 
 .filters {
@@ -119,6 +120,7 @@
     padding: 0.3rem 0.5rem;
     border-bottom: 1px solid var(--border-color-2);
     min-height: 41px;
+    background-color: var(--result-header-bg);
 }
 
 .content {


### PR DESCRIPTION
This updates the colors a little further on the search results page. This is my first (albeit super simple) commit. As a result, please thoroughly check the changes visually.

## Screenshots

### Before
<img width="1345" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/e541b31d-8627-4529-b6b1-584a82fcdb99">

### After
<img width="1355" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/960a4f96-742e-4849-9c7a-27707bac2c9d">

## Test plan
- Manually tested