### PR TITLE
Correct discrepancy between "subscription end" and "trial end" on Cody Management Page

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -142,7 +142,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
     // change its value accordingly.
     const freeTrialEndString = 'Until Feb 14, 2024'
     if (!hasTrialEnded && userIsOnProTier) {
-        codyProSubscriptionEndTime = new Date(2024, 2, 14, 12, 0, 0)
+        codyProSubscriptionEndTime = (new Date(2024, 2, 14, 12, 0, 0)).toISOString()
     }
 
     return (

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -114,6 +114,37 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         subscription.plan === CodySubscriptionPlan.PRO &&
         !(subscription.status === CodySubscriptionStatus.TRIALING && subscription.cancelAtPeriodEnd)
 
+    // Flag usage limits as resetting based on the current subscription's billing cycle.
+    //
+    // BUG: The usage limit refresh should be independent of a user's subscription data.
+    //      e.g. if we offered an annual billing plan, we'd want to reset usage more often.
+    //      sourcegraph#59990 is related, and required for the times to line up with the
+    //      behavior from Cody Gateway.
+    //
+    // BUG: If the subscription is canceled, this will be in the past and therefore invalid.
+    //      This data should be fetched from the SSC backend, and like above, separeate
+    //      from the user's subscription billing cycle.
+    const usageRefreshTime = subscription.currentPeriodEndAt
+
+    // Time when the user's current subscription will end.
+    //
+    // BUG: If the subscription is in the canceled state, this will be in the past. We need
+    //      to update the UI to simply say "subscription canceled" or "you are on the free"
+    //      plan, you don't have any subscription billing cycle anchors".
+    //
+    let codyProSubscriptionEndTime = subscription.currentPeriodEndAt
+
+    // Correct the situation where the user is on a Cody Pro free trial, but hasn't entered
+    // any subscription information into the SSC frontend. This would mean that their free
+    // trial is coming to an end on ~2/15. We need the UI to reflect this, however, because
+    // we are overloading `currentPeriodEnd` for usageRefreshTime, we do not return the
+    // correct value from the backend. So we separate it out into a separate variable and
+    // change its value accordingly.
+    const freeTrialEndString = 'Until Feb 14, 2024'
+    if (!hasTrialEnded && userIsOnProTier) {
+        codyProSubscriptionEndTime = new Date(2024, 2, 14, 12, 0, 0)
+    }
+
     return (
         <>
             <Page className={classNames('d-flex flex-column')}>
@@ -184,7 +215,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                             </Text>
                             {userIsOnProTier && subscription.cancelAtPeriodEnd && (
                                 <Text className="text-muted mb-0 mt-4" size="small">
-                                    Subscription ends <Timestamp date={subscription.currentPeriodEndAt} />
+                                    Subscription ends <Timestamp date={codyProSubscriptionEndTime} />
                                 </Text>
                             )}
                         </div>
@@ -227,7 +258,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                             {!subscription.applyProRateLimits &&
                                 (codeLimitReached ? (
                                     <Text className="text-danger mb-0" size="small">
-                                        Renews in <Timestamp date={subscription.currentPeriodEndAt} />
+                                        Renews in <Timestamp date={usageRefreshTime} />
                                     </Text>
                                 ) : (
                                     <Text className="text-muted mb-0" size="small">
@@ -274,7 +305,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                             {!subscription.applyProRateLimits &&
                                 (chatLimitReached && subscription.currentPeriodEndAt ? (
                                     <Text className="text-danger mb-0" size="small">
-                                        Renews <Timestamp date={subscription.currentPeriodEndAt} />
+                                        Renews <Timestamp date={usageRefreshTime} />
                                     </Text>
                                 ) : (
                                     <Text className="text-muted mb-0" size="small">
@@ -291,7 +322,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                     </Text>
                                 </div>
                                 <Text className="text-muted mb-0" size="small">
-                                    Until Feb 14, 2024
+                                    {freeTrialEndString}
                                 </Text>
                             </div>
                         )}

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -142,7 +142,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
     // change its value accordingly.
     const freeTrialEndString = 'Until Feb 14, 2024'
     if (!hasTrialEnded && userIsOnProTier) {
-        codyProSubscriptionEndTime = (new Date(2024, 2, 14, 12, 0, 0)).toISOString()
+        codyProSubscriptionEndTime = new Date(2024, 2, 14, 12, 0, 0).toISOString()
     }
 
     return (


### PR DESCRIPTION
You can be in a situation where the `/cody/management` page is showing you inconsistent/confusing data. Unfortunately there are several reasons for this, and some we won't be able to fix for another few weeks.

![image](https://github.com/sourcegraph/sourcegraph/assets/4029847/46d9aa6b-cf63-459e-9332-9efc3ace4019)

This PR introduces some new local variables to tease apart different uses of the `cancelAtPeriodEnd` field. And adds a boat load of comments to clarify what things need to change and how, as we iterate on this page and the larger SSC integration.

> @thenamankumar , as always I reserve the right to be totally wrong. Feel free to make any changes to the comments if they are factually incorrect. Otherwise, if things look good please go ahead and merge it so we can get this deployed ASAP. 🙏 

Fixes #60071 

## Test plan

I did no testing for this. We definitely should have unit tests for the `CodyManagementPage.tsx` (since this is only the tip of the iceberg in terms of annoying complexity and nuance to subscription statuses and their interpretation).

But I'm going to feign ignorance for the time being in not knowing how to create said unit tests for a React component in a reasonable amount of time.