### PR TITLE
Fix `sg rfc search` 403 failures

### DIFF
--- a/dev/sg/internal/rfc/rfc.go
+++ b/dev/sg/internal/rfc/rfc.go
@@ -367,6 +367,7 @@ func List(ctx context.Context, driveSpec DriveSpec, out *std.Output) error {
 }
 
 func Search(ctx context.Context, query string, driveSpec DriveSpec, out *std.Output) error {
+	driveSpec.OrderBy = "" // fullText queries are always ordered by relevance and fail if an order is specified
 	return queryRFCs(ctx, fmt.Sprintf("(name contains '%[1]s' or fullText contains '%[1]s')", query), driveSpec, rfcTitlesPrinter(out), out)
 }
 


### PR DESCRIPTION
The Google Drive API fails with a 403 if a search specifies both `fullText` and `orderBy` because the results are always ordered by relevance. This breaks `sg rfc search`. Fix the command by not trying to sort these results.

## Test plan

Manually tested:

```
bazel run //dev/sg:sg -- rfc search foo  # does not fail with 403
```
