### PR TITLE
Remove `cody.codebase` setting from VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,6 +72,5 @@
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "cody.codebase": "github.com/sourcegraph/sourcegraph",
   "rust-analyzer.linkedProjects": ["docker-images/syntax-highlighter/Cargo.toml"]
 }


### PR DESCRIPTION
With the introduction of multi-repo search for Enterprise, chat context detects the relevant codebase from the current file. Hard-coding `cody.codebase` in the VSCode settings file overrides that mechanism. Let's stop doing that, and instead dogfood a configuration closer to the default our customers experience.

If individual people want to set `cody.codebase`, naturally they can do that with user settings.

## Test plan

Manually tested with VSCode and Cody Insiders v1.3.1706726270