### PR TITLE
Test for jansson shared library rather than .la file

### DIFF
--- a/cmd/symbols/image_test.yaml
+++ b/cmd/symbols/image_test.yaml
@@ -32,5 +32,5 @@ fileExistenceTests:
   gid: 101
   permissions: 'drwxr-xr-x'
 - name: 'jansson package'
-  path: 'usr/lib/libjansson.la'
+  path: 'usr/lib/libjansson.so.4'
   shouldExist: true

--- a/docker-images/search-indexer/image_test.yaml
+++ b/docker-images/search-indexer/image_test.yaml
@@ -45,7 +45,7 @@ fileExistenceTests:
   gid: 101
   permissions: 'drwxr-xr-x'
 - name: 'jansson package'
-  path: 'usr/lib/libjansson.la'
+  path: 'usr/lib/libjansson.so.4'
   shouldExist: true
 
 metadataTest:


### PR DESCRIPTION
Our image tests looked for the presence of a libarchive file. This isn't present in newer versions of the package - presumably as it isn't required at runtime so has been stripped. Replace the test with the actual shared library file.

## Test plan

- CI build

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
