### PR TITLE
ctags: ensure that binary has correct featureset

### DIFF
--- a/cmd/symbols/image_test.yaml
+++ b/cmd/symbols/image_test.yaml
@@ -15,8 +15,10 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
-  - name: "universal-ctags has correct features"
-    command: "/usr/bin/universal-ctags --list-features"
+  - name: "ctags has correct features"
+    command: "universal-ctags"
+    args:
+      - --list-features
     expectedOutput: ["interactive", "json"]
 
   # TODO(security): This container should not be running as root

--- a/cmd/symbols/image_test.yaml
+++ b/cmd/symbols/image_test.yaml
@@ -34,4 +34,3 @@ fileExistenceTests:
   uid: 100
   gid: 101
   permissions: 'drwxr-xr-x'
-  

--- a/cmd/symbols/image_test.yaml
+++ b/cmd/symbols/image_test.yaml
@@ -15,6 +15,9 @@ commandTests:
     envVars:
       - key: "SANITY_CHECK"
         value: "true"
+  - name: "universal-ctags has correct features"
+    command: "/usr/bin/universal-ctags --list-features"
+    expectedOutput: ["interactive", "json"]
 
   # TODO(security): This container should not be running as root
   # - name: "not running as root"
@@ -31,6 +34,3 @@ fileExistenceTests:
   uid: 100
   gid: 101
   permissions: 'drwxr-xr-x'
-- name: 'jansson package'
-  path: 'usr/lib/libjansson.la'
-  shouldExist: true

--- a/docker-images/search-indexer/image_test.yaml
+++ b/docker-images/search-indexer/image_test.yaml
@@ -18,12 +18,15 @@ commandTests:
     command: "git"
     args:
       - version
+
   - name: "ctags is runnable"
     command: "universal-ctags"
     args:
       - --version
   - name: "ctags has correct features"
-    command: "universal-ctags --list-features"
+    command: "universal-ctags"
+    args:
+      - "--list-features"
     expectedOutput: ["interactive", "json"]
 
   - name: "not running as root"

--- a/docker-images/search-indexer/image_test.yaml
+++ b/docker-images/search-indexer/image_test.yaml
@@ -22,6 +22,9 @@ commandTests:
     command: "universal-ctags"
     args:
       - --version
+  - name: "ctags has correct features"
+    command: "universal-ctags --list-features"
+    expectedOutput: ["interactive", "json"]
 
   - name: "not running as root"
     command: "/usr/bin/id"
@@ -44,9 +47,6 @@ fileExistenceTests:
   uid: 100
   gid: 101
   permissions: 'drwxr-xr-x'
-- name: 'jansson package'
-  path: 'usr/lib/libjansson.la'
-  shouldExist: true
 
 metadataTest:
   envVars:


### PR DESCRIPTION
Confimed that this test validates that ctags was both built with jansson and that the runtime environment has the correct libs:

```
$ universal-ctags --list-features
#NAME             DESCRIPTION
iconv             can convert input/output encodings
interactive       accepts source code from stdin
json              supports json format output
option-directory  TO BE WRITTEN
optscript         can use the interpreter
packcc            has peg based parser(s)
regex             can use regular expression based pattern matching
wildcards         can use glob matching

# Remove jansson shared libs
rm /usr/lib/libjansson.*

$ universal-ctags --list-features
universal-ctags: error while loading shared libraries: libjansson.so.4: cannot open shared object file: No such file or directory

```

## Test plan

- Local testing
- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
