### PR TITLE
dev: rename trace to Plan

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -89,7 +89,7 @@ func (s *searchClient) Plan(
 	protocol search.Protocol,
 	contextLines *int32,
 ) (_ *search.Inputs, err error) {
-	tr, ctx := trace.New(ctx, "NewSearchInputs", attribute.String("query", searchQuery))
+	tr, ctx := trace.New(ctx, "Plan", attribute.String("query", searchQuery))
 	defer tr.EndWithErr(&err)
 
 	searchType, err := detectSearchType(version, patternType)


### PR DESCRIPTION
While looking at our traces I noticed that the name "NewSearchInputs" is probably a remnant from earlier code.

"Plan" is the better name, given that we also use "Execute" for the next stage.

<img width="1164" alt="Pasted image 20240201113358" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/6a773625-9801-4fb2-899d-86b9274cdd68">


Test plan:
local testing
