### PR TITLE
all: use stdlib slices package

### DIFF
--- a/cmd/cody-gateway/internal/actor/productsubscription/BUILD.bazel
+++ b/cmd/cody-gateway/internal/actor/productsubscription/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "@com_github_vektah_gqlparser_v2//gqlerror",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_trace//:trace",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
+++ b/cmd/cody-gateway/internal/actor/productsubscription/productsubscription.go
@@ -3,6 +3,7 @@ package productsubscription
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/dotcom"

--- a/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/completions/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel//codes",
         "@io_opentelemetry_go_otel_trace//:trace",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -15,7 +16,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/events"

--- a/cmd/cody-gateway/internal/httpapi/embeddings/BUILD.bazel
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_trace//:trace",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/events"

--- a/cmd/cody-gateway/internal/httpapi/embeddings/models.go
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/models.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"

--- a/cmd/frontend/internal/authz/resolvers/BUILD.bazel
+++ b/cmd/frontend/internal/authz/resolvers/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "@com_github_graph_gophers_graphql_go//relay",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_x_exp//maps",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -2,13 +2,13 @@ package resolvers
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/log"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/actor"

--- a/cmd/frontend/internal/executorqueue/handler/BUILD.bazel
+++ b/cmd/frontend/internal/executorqueue/handler/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
         "@com_github_sourcegraph_log//:log",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/cmd/frontend/internal/executorqueue/handler/multihandler.go
+++ b/cmd/frontend/internal/executorqueue/handler/multihandler.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/sourcegraph/log"
-	"golang.org/x/exp/slices"
 
 	"github.com/mroth/weightedrand/v2"
 

--- a/cmd/gitserver/internal/vcssyncer/BUILD.bazel
+++ b/cmd/gitserver/internal/vcssyncer/BUILD.bazel
@@ -107,7 +107,6 @@ go_test(
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
         "@org_golang_x_mod//module",
     ],
 )

--- a/cmd/gitserver/internal/vcssyncer/packages_syncer_test.go
+++ b/cmd/gitserver/internal/vcssyncer/packages_syncer_test.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/cmd/worker/internal/auth/BUILD.bazel
+++ b/cmd/worker/internal/auth/BUILD.bazel
@@ -42,6 +42,5 @@ go_test(
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/cmd/worker/internal/auth/sourcegraph_operator_cleaner_test.go
+++ b/cmd/worker/internal/auth/sourcegraph_operator_cleaner_test.go
@@ -2,13 +2,13 @@ package auth
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/cloud"

--- a/cmd/worker/internal/permissions/BUILD.bazel
+++ b/cmd/worker/internal/permissions/BUILD.bazel
@@ -80,6 +80,5 @@ go_test(
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_log//logtest",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/cmd/worker/internal/permissions/bitbucket_projects_test.go
+++ b/cmd/worker/internal/permissions/bitbucket_projects_test.go
@@ -4,10 +4,10 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/log/logtest"
 

--- a/dev/managedservicesplatform/internal/imageupdater/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/imageupdater/BUILD.bazel
@@ -11,6 +11,5 @@ go_library(
         "@com_github_google_go_containerregistry//pkg/name",
         "@com_github_google_go_containerregistry//pkg/v1/google",
         "@com_github_google_go_containerregistry//pkg/v1/remote",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/dev/managedservicesplatform/internal/imageupdater/imageupdater.go
+++ b/dev/managedservicesplatform/internal/imageupdater/imageupdater.go
@@ -2,13 +2,13 @@ package imageupdater
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/google"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )

--- a/dev/managedservicesplatform/stacks/cloudrun/BUILD.bazel
+++ b/dev/managedservicesplatform/stacks/cloudrun/BUILD.bazel
@@ -38,6 +38,5 @@ go_library(
         "@com_github_sourcegraph_managed_services_platform_cdktf_gen_sentry//key",
         "@com_github_sourcegraph_managed_services_platform_cdktf_gen_sentry//project",
         "@org_golang_x_exp//maps",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/dev/managedservicesplatform/stacks/cloudrun/cloudrun.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/cloudrun.go
@@ -3,12 +3,12 @@ package cloudrun
 import (
 	"bytes"
 	"html/template"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
 

--- a/dev/sg/BUILD.bazel
+++ b/dev/sg/BUILD.bazel
@@ -117,7 +117,6 @@ go_library(
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_x_exp//maps",
-        "@org_golang_x_exp//slices",
         "@org_golang_x_mod//semver",
         "@org_golang_x_oauth2//:oauth2",
         "@org_golang_x_text//cases",

--- a/dev/sg/sg_bazel.go
+++ b/dev/sg/sg_bazel.go
@@ -1,14 +1,15 @@
 package main
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/urfave/cli/v2"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/category"
 	"github.com/sourcegraph/sourcegraph/dev/sg/internal/std"
@@ -106,8 +107,8 @@ If no categories are referenced, then 'builds' is assumed as the default.`,
 					}
 				}
 
-				slices.SortFunc(categories, func(a, b bzlgenTarget) bool {
-					return a.order < b.order
+				slices.SortFunc(categories, func(a, b bzlgenTarget) int {
+					return cmp.Compare(a.order, b.order)
 				})
 
 				std.Out.WriteLine(output.Emojif(output.EmojiAsterisk, "Invoking the following Bazel generating categories: %s", strings.Join(categoryNames, ", ")))

--- a/internal/authz/providers/github/BUILD.bazel
+++ b/internal/authz/providers/github/BUILD.bazel
@@ -59,6 +59,5 @@ go_test(
         "@com_github_gregjones_httpcache//:httpcache",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/internal/authz/providers/github/github_test.go
+++ b/internal/authz/providers/github/github_test.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gregjones/httpcache"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -41,7 +41,7 @@ func mockClientFunc(mockClient client) func() (client, error) {
 }
 
 func stableSortRepoID(v []extsvc.RepoID) {
-	slices.SortStableFunc(v, func(a, b extsvc.RepoID) bool { return strings.Compare(string(a), string(b)) < 1 })
+	slices.Sort(v)
 }
 
 // newMockClientWithTokenMock is used to keep the behaviour of WithToken function mocking

--- a/internal/codeintel/codenav/BUILD.bazel
+++ b/internal/codeintel/codenav/BUILD.bazel
@@ -39,7 +39,6 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_scip//bindings/go/scip",
         "@io_opentelemetry_go_otel//attribute",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -2,15 +2,16 @@ package codenav
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/scip/bindings/go/scip"
 	"go.opentelemetry.io/otel/attribute"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -923,8 +924,8 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 			// 	documentation = strings.TrimSpace(documentation)
 			// 	writeDocumentation(&b, documentation, prefix, false)
 			// }
-			slices.SortFunc(info.Relationships, func(a, b *scip.Relationship) bool {
-				return a.Symbol < b.Symbol
+			slices.SortFunc(info.Relationships, func(a, b *scip.Relationship) int {
+				return cmp.Compare(a.Symbol, b.Symbol)
 			})
 			for _, relationship := range info.Relationships {
 				var b strings.Builder

--- a/internal/codeintel/dependencies/internal/store/BUILD.bazel
+++ b/internal/codeintel/dependencies/internal/store/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_lib_pq//:pq",
         "@io_opentelemetry_go_otel//attribute",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/internal/codeintel/dependencies/internal/store/store.go
+++ b/internal/codeintel/dependencies/internal/store/store.go
@@ -1,17 +1,18 @@
 package store
 
 import (
+	"cmp"
 	"context"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgconn"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 	"go.opentelemetry.io/otel/attribute"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/dependencies/shared"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
@@ -218,12 +219,12 @@ func (s *store) InsertPackageRepoRefs(ctx context.Context, deps []shared.Minimal
 		return
 	}
 
-	slices.SortStableFunc(deps, func(a, b shared.MinimalPackageRepoRef) bool {
+	slices.SortStableFunc(deps, func(a, b shared.MinimalPackageRepoRef) int {
 		if a.Scheme != b.Scheme {
-			return a.Scheme < b.Scheme
+			return cmp.Compare(a.Scheme, b.Scheme)
 		}
 
-		return a.Name < b.Name
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	// first reduce

--- a/internal/database/BUILD.bazel
+++ b/internal/database/BUILD.bazel
@@ -332,7 +332,6 @@ go_test(
         "@org_golang_google_protobuf//types/known/structpb",
         "@org_golang_google_protobuf//types/known/timestamppb",
         "@org_golang_x_exp//maps",
-        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/internal/database/authz_test.go
+++ b/internal/database/authz_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/internal/database/perms_store_test.go
+++ b/internal/database/perms_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 	"testing"
@@ -17,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/log/logtest"

--- a/internal/gitserver/BUILD.bazel
+++ b/internal/gitserver/BUILD.bazel
@@ -53,7 +53,6 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/binary"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 
 	"github.com/sourcegraph/log"

--- a/internal/grpc/example/weather/v1/BUILD.bazel
+++ b/internal/grpc/example/weather/v1/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
 proto_library(
     name = "grpc_example_weather_v1_proto",
     srcs = ["weather.proto"],
+    strip_import_prefix = "/internal",
     visibility = ["//:__subpackages__"],
     deps = ["@com_google_protobuf//:timestamp_proto"],
 )

--- a/internal/grpc/example/weather/v1/BUILD.bazel
+++ b/internal/grpc/example/weather/v1/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
 proto_library(
     name = "grpc_example_weather_v1_proto",
     srcs = ["weather.proto"],
-    strip_import_prefix = "/internal",
     visibility = ["//:__subpackages__"],
     deps = ["@com_google_protobuf//:timestamp_proto"],
 )

--- a/internal/grpc/testprotos/news/v1/BUILD.bazel
+++ b/internal/grpc/testprotos/news/v1/BUILD.bazel
@@ -5,6 +5,7 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "news_proto",
     srcs = ["news.proto"],
+    strip_import_prefix = "/internal",
     visibility = ["//:__subpackages__"],
     deps = ["@com_google_protobuf//:timestamp_proto"],
 )

--- a/internal/grpc/testprotos/news/v1/BUILD.bazel
+++ b/internal/grpc/testprotos/news/v1/BUILD.bazel
@@ -5,7 +5,6 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 proto_library(
     name = "news_proto",
     srcs = ["news.proto"],
-    strip_import_prefix = "/internal",
     visibility = ["//:__subpackages__"],
     deps = ["@com_google_protobuf//:timestamp_proto"],
 )

--- a/internal/licensing/BUILD.bazel
+++ b/internal/licensing/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "@com_github_gomodule_redigo//redis",
         "@com_github_sourcegraph_log//:log",
         "@org_golang_x_crypto//ssh",
-        "@org_golang_x_exp//slices",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/internal/licensing/codygateway.go
+++ b/internal/licensing/codygateway.go
@@ -1,7 +1,7 @@
 package licensing
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 // CodyGatewayRateLimit indicates rate limits for Sourcegraph's managed Cody Gateway service.

--- a/internal/licensing/telemetryexport.go
+++ b/internal/licensing/telemetryexport.go
@@ -2,11 +2,11 @@ package licensing
 
 import (
 	"os"
+	"slices"
 	"time"
 
 	"go.uber.org/atomic"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"

--- a/internal/oobmigration/BUILD.bazel
+++ b/internal/oobmigration/BUILD.bazel
@@ -41,7 +41,6 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@in_gopkg_yaml_v3//:yaml_v3",
         "@io_opentelemetry_go_otel//attribute",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/internal/oobmigration/store.go
+++ b/internal/oobmigration/store.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"github.com/jackc/pgconn"
 	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 
 	"github.com/sourcegraph/sourcegraph/internal/collections"

--- a/internal/search/backend/BUILD.bazel
+++ b/internal/search/backend/BUILD.bazel
@@ -45,7 +45,6 @@ go_library(
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//types/known/timestamppb",
-        "@org_golang_x_exp//slices",
     ],
 )
 

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -1,10 +1,12 @@
 package backend
 
 import (
+	"cmp"
+	"slices"
+
 	"github.com/grafana/regexp"
 	"github.com/inconshreveable/log15" //nolint:logging // TODO move all logging to sourcegraph/log
 	"github.com/sourcegraph/zoekt"
-	"golang.org/x/exp/slices"
 
 	proto "github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver/protos/sourcegraph/zoekt/configuration/v1"
 
@@ -265,12 +267,14 @@ func getIndexOptions(
 		})
 	}
 
-	slices.SortFunc(o.Branches, func(a, b zoekt.RepositoryBranch) bool {
+	slices.SortFunc(o.Branches, func(a, b zoekt.RepositoryBranch) int {
 		// Zoekt treats first branch as default branch, so put HEAD first
-		if a.Name == "HEAD" || b.Name == "HEAD" {
-			return a.Name == "HEAD"
+		if a.Name == "HEAD" {
+			return -1
+		} else if b.Name == "HEAD" {
+			return 1
 		}
-		return a.Name < b.Name
+		return cmp.Compare(a.Name, b.Name)
 	})
 
 	// If the first branch is not HEAD, do not index anything. This should

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -268,13 +268,19 @@ func getIndexOptions(
 	}
 
 	slices.SortFunc(o.Branches, func(a, b zoekt.RepositoryBranch) int {
-		// Zoekt treats first branch as default branch, so put HEAD first
-		if a.Name == "HEAD" {
-			return -1
-		} else if b.Name == "HEAD" {
-			return 1
+		aName := a.Name
+		bName := b.Name
+
+		// Zoekt treats first branch as default branch, so put HEAD first. We
+		// do this by making the string empty, which is a bottom.
+		if aName == "HEAD" {
+			aName = ""
 		}
-		return cmp.Compare(a.Name, b.Name)
+		if bName == "HEAD" {
+			bName = ""
+		}
+
+		return cmp.Compare(aName, bName)
 	})
 
 	// If the first branch is not HEAD, do not index anything. This should

--- a/internal/search/exhaustive/service/BUILD.bazel
+++ b/internal/search/exhaustive/service/BUILD.bazel
@@ -74,6 +74,5 @@ go_test(
         "@com_github_sourcegraph_log//logtest",
         "@com_github_sourcegraph_zoekt//:zoekt",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/internal/search/exhaustive/service/searcher_test.go
+++ b/internal/search/exhaustive/service/searcher_test.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -12,7 +14,6 @@ import (
 	"github.com/sourcegraph/log/logtest"
 	"github.com/sourcegraph/zoekt"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -237,8 +238,8 @@ func mockGitserver(repoMocks []repoMock) *gitserver.MockClient {
 				CommitID: api.CommitID(commit),
 			})
 		}
-		slices.SortFunc(refs, func(a, b gitdomain.Ref) bool {
-			return a.Name < b.Name
+		slices.SortFunc(refs, func(a, b gitdomain.Ref) int {
+			return cmp.Compare(a.Name, b.Name)
 		})
 		return refs, nil
 	})

--- a/internal/search/job/jobutil/BUILD.bazel
+++ b/internal/search/job/jobutil/BUILD.bazel
@@ -64,7 +64,6 @@ go_library(
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_zoekt//query",
         "@io_opentelemetry_go_otel//attribute",
-        "@org_golang_x_exp//slices",
         "@org_uber_go_atomic//:atomic",
     ],
 )
@@ -124,7 +123,6 @@ go_test(
         "@com_github_sourcegraph_log//logtest",
         "@com_github_sourcegraph_zoekt//query",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp/syntax" //nolint:depguard // using the grafana fork of regexp clashes with zoekt, which uses the std regexp/syntax.
+	"slices"
 	"testing"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	zoektquery "github.com/sourcegraph/zoekt/query"
@@ -1400,7 +1400,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	for i, match := range matches {
 		matchKeys[i] = match.Key()
 	}
-	slices.SortFunc(matchKeys, result.Key.Less)
+	slices.SortFunc(matchKeys, result.Key.Compare)
 
 	wantResultKeys := []result.Key{
 		{Repo: "foo", Commit: "branch3", Path: "main.go"},

--- a/internal/search/query/repo_revs.go
+++ b/internal/search/query/repo_revs.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"cmp"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -32,19 +33,18 @@ func (r1 RevisionSpecifier) String() string {
 	return r1.RevSpec
 }
 
-// Less compares two revspecOrRefGlob entities, suitable for use
-// with sort.Slice()
+// Compare r1 to r2, suitable for use with sort.Slice().
 //
 // possibly-undesired: this results in treating an entity with
 // no revspec, but a refGlob, as "earlier" than any revspec.
-func (r1 RevisionSpecifier) Less(r2 RevisionSpecifier) bool {
-	if r1.RevSpec != r2.RevSpec {
-		return r1.RevSpec < r2.RevSpec
+func (r1 RevisionSpecifier) Compare(r2 RevisionSpecifier) int {
+	if v := cmp.Compare(r1.RevSpec, r2.RevSpec); v != 0 {
+		return v
 	}
-	if r1.RefGlob != r2.RefGlob {
-		return r1.RefGlob < r2.RefGlob
+	if v := cmp.Compare(r1.RefGlob, r2.RefGlob); v != 0 {
+		return v
 	}
-	return r1.ExcludeRefGlob < r2.ExcludeRefGlob
+	return cmp.Compare(r1.ExcludeRefGlob, r2.ExcludeRefGlob)
 }
 
 func (r1 RevisionSpecifier) HasRefGlob() bool {

--- a/internal/search/repos/BUILD.bazel
+++ b/internal/search/repos/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "@com_github_sourcegraph_zoekt//:zoekt",
         "@com_github_sourcegraph_zoekt//query",
         "@io_opentelemetry_go_otel//attribute",
-        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
     ],
 )
@@ -81,6 +80,5 @@ go_test(
         "@com_github_sourcegraph_zoekt//:zoekt",
         "@com_github_sourcegraph_zoekt//query",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/internal/search/repos/repos.go
+++ b/internal/search/repos/repos.go
@@ -3,6 +3,7 @@ package repos
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,7 +17,6 @@ import (
 	"github.com/sourcegraph/zoekt"
 	zoektquery "github.com/sourcegraph/zoekt/query"
 	"go.opentelemetry.io/otel/attribute"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -1047,7 +1047,7 @@ func getRevsForMatchedRepo(repo api.RepoName, pats []patternRevspec) (matched []
 				matched = append(matched, rev)
 			}
 		}
-		slices.SortFunc(matched, query.RevisionSpecifier.Less)
+		slices.SortFunc(matched, query.RevisionSpecifier.Compare)
 		return
 	}
 
@@ -1056,7 +1056,7 @@ func getRevsForMatchedRepo(repo api.RepoName, pats []patternRevspec) (matched []
 		clashing = append(clashing, rev)
 	}
 	// ensure that lists are always returned in sorted order.
-	slices.SortFunc(clashing, query.RevisionSpecifier.Less)
+	slices.SortFunc(clashing, query.RevisionSpecifier.Compare)
 	return
 }
 

--- a/internal/search/repos/repos_test.go
+++ b/internal/search/repos/repos_test.go
@@ -1,11 +1,13 @@
 package repos
 
 import (
+	stdcmp "cmp"
 	"context"
 	"flag"
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -14,7 +16,6 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/sourcegraph/zoekt"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/log/logtest"
 
@@ -537,11 +538,11 @@ func TestResolverIterateRepoRevs(t *testing.T) {
 			var want []RepoRevSpecs
 			want = append(want, tc.want...)
 
-			less := func(a, b RepoRevSpecs) bool {
-				return a.Repo.ID < b.Repo.ID
+			compare := func(a, b RepoRevSpecs) int {
+				return stdcmp.Compare(a.Repo.ID, b.Repo.ID)
 			}
-			slices.SortFunc(got, less)
-			slices.SortFunc(want, less)
+			slices.SortFunc(got, compare)
+			slices.SortFunc(want, compare)
 
 			if diff := cmp.Diff(got, want); diff != "" {
 				t.Errorf("unexpected (-have, +want):\n%s", diff)

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -1,6 +1,7 @@
 package result
 
 import (
+	"cmp"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -86,31 +87,36 @@ type Key struct {
 
 // Less compares one key to another for sorting
 func (k Key) Less(other Key) bool {
-	if k.Repo != other.Repo {
-		return k.Repo < other.Repo
+	return k.Compare(other) < 0
+}
+
+// Compare k to other for sorting
+func (k Key) Compare(other Key) int {
+	if v := cmp.Compare(k.Repo, other.Repo); v != 0 {
+		return v
 	}
 
-	if k.Rev != other.Rev {
-		return k.Rev < other.Rev
+	if v := cmp.Compare(k.Rev, other.Rev); v != 0 {
+		return v
 	}
 
-	if !k.AuthorDate.Equal(other.AuthorDate) {
-		return k.AuthorDate.Before(other.AuthorDate)
+	if v := k.AuthorDate.Compare(other.AuthorDate); v != 0 {
+		return v
 	}
 
-	if k.Commit != other.Commit {
-		return k.Commit < other.Commit
+	if v := cmp.Compare(k.Commit, other.Commit); v != 0 {
+		return v
 	}
 
-	if k.Path != other.Path {
-		return k.Path < other.Path
+	if v := cmp.Compare(k.Path, other.Path); v != 0 {
+		return v
 	}
 
-	if k.OwnerMetadata != other.OwnerMetadata {
-		return k.OwnerMetadata < other.OwnerMetadata
+	if v := cmp.Compare(k.OwnerMetadata, other.OwnerMetadata); v != 0 {
+		return v
 	}
 
-	return k.TypeRank < other.TypeRank
+	return cmp.Compare(k.TypeRank, other.TypeRank)
 }
 
 // Matches implements sort.Interface

--- a/internal/search/result/range.go
+++ b/internal/search/result/range.go
@@ -2,6 +2,7 @@ package result
 
 import (
 	"bufio"
+	"cmp"
 	"encoding/json"
 	"sort"
 	"strings"
@@ -84,6 +85,11 @@ func (l Location) Sub(o Location) Location {
 		Line:   l.Line - o.Line,
 		Column: l.Column - o.Column,
 	}
+}
+
+// Compare compares the Offset of l and o.
+func (l Location) Compare(o Location) int {
+	return cmp.Compare(l.Offset, o.Offset)
 }
 
 // MarshalJSON provides a custom JSON serialization to reduce

--- a/internal/search/streaming/client/BUILD.bazel
+++ b/internal/search/streaming/client/BUILD.bazel
@@ -17,6 +17,5 @@ go_library(
         "//internal/types",
         "//lib/pointers",
         "@com_github_sourcegraph_log//:log",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/internal/search/streaming/client/progress.go
+++ b/internal/search/streaming/client/progress.go
@@ -1,9 +1,8 @@
 package client
 
 import (
+	"slices"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	sgapi "github.com/sourcegraph/sourcegraph/internal/api"
 	searchshared "github.com/sourcegraph/sourcegraph/internal/search"

--- a/internal/search/zoekt/BUILD.bazel
+++ b/internal/search/zoekt/BUILD.bazel
@@ -70,6 +70,5 @@ go_test(
         "@com_github_sourcegraph_zoekt//:zoekt",
         "@com_github_sourcegraph_zoekt//query",
         "@com_github_stretchr_testify//require",
-        "@org_golang_x_exp//slices",
     ],
 )

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -1,10 +1,11 @@
 package zoekt
 
 import (
+	"cmp"
+	"slices"
 	"testing"
 
 	"github.com/hexops/autogold/v2"
-	"golang.org/x/exp/slices"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -154,17 +155,17 @@ func queryEqual(a, b zoekt.Q) bool {
 	sortChildren := func(q zoekt.Q) zoekt.Q {
 		switch s := q.(type) {
 		case *zoekt.And:
-			slices.SortFunc(s.Children, zoektQStringLess)
+			slices.SortFunc(s.Children, zoektQStringCompare)
 		case *zoekt.Or:
-			slices.SortFunc(s.Children, zoektQStringLess)
+			slices.SortFunc(s.Children, zoektQStringCompare)
 		}
 		return q
 	}
 	return zoekt.Map(a, sortChildren).String() == zoekt.Map(b, sortChildren).String()
 }
 
-func zoektQStringLess(a, b zoekt.Q) bool {
-	return a.String() < b.String()
+func zoektQStringCompare(a, b zoekt.Q) int {
+	return cmp.Compare(a.String(), b.String())
 }
 
 func computeResultTypes(types []string, b query.Basic, searchType query.SearchType) result.Types {


### PR DESCRIPTION
This is a bigger change than I want, but the version of exp/slices we used had a change from taking a Less func for SortFunc to a Compare. To update a vulnerability we also bring in a new version of exp/slices, so I seperated out this change.

All our uses of exp/slices are now covered by the stdlib, so I migrate all our uses to it. In particular this mostly meant updating custom Less functions to using the stdlib cmp.Compare.

The only functional change was a potential bug I found in filter_file_contains.go. The comment for the sort says sort by Start offset, but the code was incorrectly comparing the end offset for the 2nd argument. This makes sort's Less function break the expected invariants, so the code was quite wrong. I expect in practice we didn't notice it since most ranges did not overlap. This fix makes the compare function respect the expected invariants and just seems correct.

Test Plan: CI and grep returns nothing for "golang.org/x/exp/slices" in go files.