### PR TITLE
Update migrator schemas to 5.2.7

### DIFF
--- a/tools/release/schema_deps.bzl
+++ b/tools/release/schema_deps.bzl
@@ -8,6 +8,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def schema_deps():
     http_file(
         name = "schemas_archive",
-        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.2.3.tar.gz"],
-        sha256 = "c5aec72d528c0b3803070ccba58049c42f9b2618c9dba367dffe106d30f8f6fe",
+        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.2.7.tar.gz"],
+        sha256 = "f54994171850e3475a9b446c29e4db4c1ea0ea039ce1cc5355f71f5b4725b117",
     )


### PR DESCRIPTION
@keegancsmith the release is still running the previous iteration of how we handle database schemas in the migrator. I'll make sure it's correct for when you start running the legacy release tooling, as this part isn't automated over there, as I initially thought we'd be done by then (but in the meantime we found a better way of doing it). 

If for some reason, you were the one to handle this manually and I'm not there (and also because the way to use this the _old way_ is slightly different that what the README explains, which is made for RFC795, so it has a notion of schemas being avail but not yet published).   

```
# assuming you're running inside sg/sg 

bazel run //tools/release:upload_current_schemas -- v5.3.0 
bazel run //tools/release:generate_schemas_archive -- v5.3.0 fetch-current-schemas $(pwd)/
```

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
