### PR TITLE
Uses an actual Path in FileInfo and avoids an unnecessary clone

### DIFF
--- a/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
+++ b/docker-images/syntax-highlighter/crates/syntax-analysis/src/highlighting.rs
@@ -167,7 +167,7 @@ impl<'a> SublimeLanguageName<'a> {
             x if x == "Rust Enhanced".to_lowercase() => "rust",
             x if x == "JS Custom - React".to_lowercase() => "javascript",
             x if x == "TypeScriptReact".to_lowercase() => {
-                if file_info.path.ends_with(".tsx") {
+                if file_info.extension() == Some("tsx") {
                     "tsx"
                 } else {
                     "typescript"


### PR DESCRIPTION
Sorry, I couldn't let it rest so I had to try to make the change. I still think this makes more sense as the only non-path usage is to check whether the string is empty, which is just as easy with `self.path.to_string_lossy().is_empty()`.

Feel free to close this PR and go with the String one if you disagree

## Test plan

CI

