### PR TITLE
repo: Add back link to commits page

### DIFF
--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -8,6 +8,7 @@ import {
     mdiHistory,
     mdiPackageVariantClosed,
     mdiSourceBranch,
+    mdiSourceCommit,
     mdiSourceFork,
     mdiSourceRepository,
     mdiTag,
@@ -269,6 +270,18 @@ export const TreePage: FC<Props> = ({
             </div>
             <div className={styles.menu}>
                 <ButtonGroup>
+                    <Tooltip content="Git commits">
+                        <Button
+                            className="flex-shrink-0"
+                            to={`/${encodeURIPathComponent(repoName)}/-/commits`}
+                            variant="secondary"
+                            outline={true}
+                            as={Link}
+                        >
+                            <Icon aria-hidden={true} svgPath={mdiSourceCommit} />{' '}
+                            <span className={styles.text}>Commits</span>
+                        </Button>
+                    </Tooltip>
                     {!isPackage && (
                         <Tooltip content="Git branches">
                             <Button


### PR DESCRIPTION
Now that we don't show a commits panel anymore there is no link to navigating to the commits page. This PR adds back the link to the "repo header".

![2024-02-02_13-29](https://github.com/sourcegraph/sourcegraph/assets/179026/cb345d92-8993-41b8-b969-c5b3aac8a8e5)


## Test plan

Visual testing
