### PR TITLE
licensing: cleanup logic for conditonally mounting route

### DIFF
--- a/client/web/src/LegacyRouteContext.tsx
+++ b/client/web/src/LegacyRouteContext.tsx
@@ -87,7 +87,12 @@ export interface LegacyLayoutRouteContext
     extends StaticAppConfig,
         StaticSourcegraphWebAppContext,
         DynamicSourcegraphWebAppContext,
-        StaticLegacyRouteContext {}
+        StaticLegacyRouteContext {
+    licenseFeatures: {
+        codeSearchEnabled: boolean
+        codyEnabled: boolean
+    }
+}
 
 interface LegacyRouteProps {
     render: (props: LegacyLayoutRouteContext) => JSX.Element
@@ -162,6 +167,10 @@ export const LegacyRouteContextProvider: FC<PropsWithChildren<LegacyRouteContext
         ...injections,
         ...computedContextFields,
         ...context,
+        licenseFeatures: {
+            codeSearchEnabled: Boolean(window.context.licenseInfo?.features.codeSearch),
+            codyEnabled: Boolean(window.context.licenseInfo?.features.cody),
+        },
     } satisfies LegacyLayoutRouteContext
 
     return <LegacyRouteContext.Provider value={legacyContext}>{children}</LegacyRouteContext.Provider>

--- a/client/web/src/LegacyRouteContext.tsx
+++ b/client/web/src/LegacyRouteContext.tsx
@@ -27,6 +27,7 @@ import type { SearchStreamingProps } from './search'
 import type { StaticSourcegraphWebAppContext, DynamicSourcegraphWebAppContext } from './SourcegraphWebApp'
 import type { StaticAppConfig } from './staticAppConfig'
 import { eventLogger } from './tracking/eventLogger'
+import { getLicenseFeatures } from './util/license'
 
 export interface StaticLegacyRouteContext extends LegacyRouteComputedContext, LegacyRouteStaticInjections {}
 
@@ -89,8 +90,8 @@ export interface LegacyLayoutRouteContext
         DynamicSourcegraphWebAppContext,
         StaticLegacyRouteContext {
     licenseFeatures: {
-        codeSearchEnabled: boolean
-        codyEnabled: boolean
+        isCodeSearchEnabled: boolean
+        isCodyEnabled: boolean
     }
 }
 
@@ -167,10 +168,7 @@ export const LegacyRouteContextProvider: FC<PropsWithChildren<LegacyRouteContext
         ...injections,
         ...computedContextFields,
         ...context,
-        licenseFeatures: {
-            codeSearchEnabled: Boolean(window.context.licenseInfo?.features.codeSearch),
-            codyEnabled: Boolean(window.context.licenseInfo?.features.cody),
-        },
+        licenseFeatures: getLicenseFeatures(),
     } satisfies LegacyLayoutRouteContext
 
     return <LegacyRouteContext.Provider value={legacyContext}>{children}</LegacyRouteContext.Provider>

--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -57,6 +57,7 @@ import { setQueryStateFromSettings, useDeveloperSettings, useNavbarQueryState } 
 import { TelemetryRecorderProvider } from './telemetry'
 import { eventLogger } from './tracking/eventLogger'
 import { UserSessionStores } from './UserSessionStores'
+import { getLicenseFeatures } from './util/license'
 import { siteSubjectNoAdmin, viewerSubjectFromSettings } from './util/settings'
 
 interface LegacySourcegraphWebAppState extends SettingsCascadeProps {
@@ -249,6 +250,7 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
                             updateSearchContext={updateSearchContext}
                             deleteSearchContext={deleteSearchContext}
                             streamSearch={aggregateStreamingSearch}
+                            licenseFeatures={getLicenseFeatures()}
                         />
                     }
                 />

--- a/client/web/src/components/legacyLayoutRouteContext.mock.ts
+++ b/client/web/src/components/legacyLayoutRouteContext.mock.ts
@@ -73,4 +73,8 @@ export const legacyLayoutRouteContextMock = {
     ...dynamicWebAppConfig,
     ...legacyRouteComputedContext,
     ...legacyRouteInjectedContext,
+    licenseFeatures: {
+        isCodeSearchEnabled: true,
+        isCodyEnabled: true,
+    },
 } satisfies LegacyLayoutRouteContext

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -82,8 +82,6 @@ const PassThroughToServer: React.FC = () => {
     return null
 }
 
-const codyRoutes: readonly RouteObject[] = []
-
 /**
  * Holds all top-level routes for the app because both the navbar and the main content area need to
  * switch over matched path.
@@ -401,7 +399,8 @@ function SearchConsolePageOrRedirect(props: LegacyLayoutRouteContext): JSX.Eleme
 }
 
 function SearchPageOrUpsellPage(props: LegacyLayoutRouteContext): JSX.Element {
-    if (disableCodeSearchFeatures) {
+    const { isCodyEnabled, isCodeSearchEnabled } = props.licenseFeatures
+    if (isCodyEnabled && !isCodeSearchEnabled) {
         return <SearchUpsellPage />
     }
     return <SearchPageWrapper {...props} />

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -159,7 +159,7 @@ export const routes: RouteObject[] = [
                         telemetryService={props.telemetryService}
                     />
                 )}
-                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled && isSearchJobsEnabled()}
+                condition={isSearchJobsEnabled}
             />
         ),
     },

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -137,7 +137,7 @@ export const routes: RouteObject[] = [
             <LegacyRoute
                 render={props => <GlobalCodeMonitoringArea {...props} />}
                 condition={({ isSourcegraphDotCom, licenseFeatures }) =>
-                    !isSourcegraphDotCom && licenseFeatures.codeSearchEnabled
+                    !isSourcegraphDotCom && licenseFeatures.isCodeSearchEnabled
                 }
             />
         ),
@@ -161,7 +161,7 @@ export const routes: RouteObject[] = [
                         telemetryService={props.telemetryService}
                     />
                 )}
-                condition={({ licenseFeatures }) => licenseFeatures.codeSearchEnabled && isSearchJobsEnabled()}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled && isSearchJobsEnabled()}
             />
         ),
     },
@@ -170,7 +170,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <SearchContextsListPage {...props} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codeSearchEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),
     },
@@ -179,7 +179,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <CreateSearchContextPage {...props} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codeSearchEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),
     },
@@ -188,7 +188,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <EditSearchContextPage {...props} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codeSearchEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),
     },
@@ -197,7 +197,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <SearchContextPage {...props} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codeSearchEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),
     },
@@ -210,7 +210,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <GlobalNotebooksArea {...props} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codeSearchEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),
     },
@@ -219,7 +219,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={() => <OwnPage />}
-                condition={({ licenseFeatures }) => licenseFeatures.codeSearchEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),
     },
@@ -228,7 +228,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <SearchConsolePageOrRedirect {...props} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codeSearchEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),
     },
@@ -306,7 +306,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <CodySearchPage {...props} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codyEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
             />
         ),
     },
@@ -326,7 +326,7 @@ export const routes: RouteObject[] = [
                     return <div />
                 }}
                 condition={({ licenseFeatures }) =>
-                    !window.location.pathname.startsWith('/cody/chat') && licenseFeatures.codyEnabled
+                    !window.location.pathname.startsWith('/cody/chat') && licenseFeatures.isCodyEnabled
                 }
             />
         ),
@@ -336,7 +336,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <CodyChatPage {...props} context={window.context} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codyEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
             />
         ),
     },
@@ -345,7 +345,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <CodyManagementPage {...props} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codyEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
             />
         ),
     },
@@ -354,7 +354,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => <CodySubscriptionPage {...props} />}
-                condition={({ licenseFeatures }) => licenseFeatures.codyEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
             />
         ),
     },
@@ -364,7 +364,7 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={() => <CodyUpsellPage />}
-                condition={({ licenseFeatures }) => !licenseFeatures.codyEnabled}
+                condition={({ licenseFeatures }) => !licenseFeatures.isCodyEnabled}
             />
         ),
     },
@@ -379,7 +379,7 @@ export const routes: RouteObject[] = [
                         <RepoContainer {...props} />
                     </CodySidebarStoreProvider>
                 )}
-                condition={({ licenseFeatures }) => licenseFeatures.codeSearchEnabled}
+                condition={({ licenseFeatures }) => licenseFeatures.isCodeSearchEnabled}
             />
         ),
         // In RR6, the useMatches hook will only give you the location that is matched

--- a/client/web/src/search/upsell/SearchUpsellPage.tsx
+++ b/client/web/src/search/upsell/SearchUpsellPage.tsx
@@ -116,15 +116,15 @@ export const SearchUpsellPage: FC = () => {
 
             <section className={styles.footer}>
                 <Text className={styles.footerText}>Code Search also works great with...</Text>
-                <Link to="/">
+                <Link to="/help/code_monitoring">
                     Code Monitoring{' '}
-                    <Icon className="pl-2" svgPath={mdiOpenInNew} inline={false} aria-label="Copy snippet" />
+                    <Icon svgPath={mdiOpenInNew} inline={false} aria-label="Learn more about Code Monitoring" />
                 </Link>
-                <Link to="/">
-                    Insights <Icon className="pl-2" svgPath={mdiOpenInNew} inline={false} aria-label="Copy snippet" />
+                <Link to="/help/code_insights">
+                    Insights <Icon svgPath={mdiOpenInNew} inline={false} aria-label="Learn more about Code Insights" />
                 </Link>
-                <Link to="/">
-                    Notebooks <Icon className="pl-2" svgPath={mdiOpenInNew} inline={false} aria-label="Copy snippet" />
+                <Link to="/help/notebooks">
+                    Notebooks <Icon svgPath={mdiOpenInNew} inline={false} aria-label="Learn more about Notebooks" />
                 </Link>
             </section>
         </div>


### PR DESCRIPTION
Closes #60105

The previous implementaiton had lots of ternaries - I discovered recently that the `<LegacyRoute>` component had a `condition` prop that uses a boolean logic to mount a route or display a 404, so I'm moving the logic to use that instead as it's cleaner and easier to understand.

## Test plan

On a full license, all routes will work as is.

On a Code Search only license, only code-search features will show up.
On a Cody only license, only cody related features will show up.
