### PR TITLE
Cody context: handle empty queries

### DIFF
--- a/internal/search/codycontext/job.go
+++ b/internal/search/codycontext/job.go
@@ -17,7 +17,8 @@ func NewSearchJob(plan query.Plan, newJob func(query.Basic) (job.Job, error)) (j
 		return nil, errors.New("The 'codycontext' patterntype does not support multiple clauses")
 	}
 
-	q, err := transformBasicQuery(plan[0])
+	basicQuery := plan[0].ToParseTree()
+	q, err := queryStringToKeywordQuery(query.StringHuman(basicQuery))
 	if err != nil || q == nil {
 		return nil, err
 	}

--- a/internal/search/codycontext/query_transformer_test.go
+++ b/internal/search/codycontext/query_transformer_test.go
@@ -67,6 +67,11 @@ func TestQueryStringToKeywordQuery(t *testing.T) {
 			wantPatterns: autogold.Expect([]string{"cluster", "python"}),
 		},
 		{
+			query:        "context:global the who",
+			wantQuery:    autogold.Expect("type:file context:global"),
+			wantPatterns: autogold.Expect([]string{}),
+		},
+		{
 			query:     `outer content:"inner {with} (special) ^characters$ and keywords like file or repo"`,
 			wantQuery: autogold.Expect("type:file (special OR ^characters$ OR keyword OR file OR repo OR outer)"),
 			wantPatterns: autogold.Expect([]string{

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -48,7 +48,7 @@ func NewPlanJob(inputs *search.Inputs, plan query.Plan) (job.Job, error) {
 
 	if inputs.PatternType == query.SearchTypeCodyContext {
 		if inputs.SearchMode == search.SmartSearch {
-			return nil, errors.New("The 'keyword' patterntype is not compatible with Smart Search")
+			return nil, errors.New("The 'codycontext' patterntype is not compatible with Smart Search")
 		}
 
 		newJobTree, err := codycontext.NewSearchJob(plan, newJob)


### PR DESCRIPTION
If a cody context query contains only stopwords, then query processing returns
a list of empty terms, causing a panic. Now, we just return an empty query
which matches no files.

Fixes #60090

## Test plan

Added new unit test