### PR TITLE
Search: remove search-phrase-boost feature flag

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -316,7 +316,6 @@ func ToFeatures(flagSet *featureflag.FlagSet, logger log.Logger) *search.Feature
 	return &search.Features{
 		ContentBasedLangFilters: flagSet.GetBoolOr("search-content-based-lang-detection", false),
 		Debug:                   flagSet.GetBoolOr("search-debug", false),
-		PhraseBoost:             flagSet.GetBoolOr("search-boost-phrase", false),
 	}
 }
 

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -388,9 +388,6 @@ type Features struct {
 	// options. This should be used for quick interactive experiments only. An
 	// invalid JSON string or unknown fields will be ignored.
 	ZoektSearchOptionsOverride string
-
-	// PhraseBoost is a feature flag that enables boosting of exact matches.
-	PhraseBoost bool `json:"search-boost-phrase"`
 }
 
 func (f *Features) String() string {


### PR DESCRIPTION
This is no longer used, since we always phrase boost when
`experimentalFeatures.keywordSearch` is enabled.

## Test plan

Covered by CI