### PR TITLE
search input: Add background color to operators/keywords

### DIFF
--- a/'
+++ b/'
@@ -1,6 +1,0 @@
-Merge branch 'rrhyne/dark-mode-keyword-serach' of github.com:sourcegraph/sourcegraph into rrhyne/dark-mode-keyword-serach
-# Please enter a commit message to explain why this merge is necessary,
-# especially if it merges an updated upstream into a topic branch.
-#
-# Lines starting with '#' will be ignored, and an empty message aborts
-# the commit.

--- a/'
+++ b/'
@@ -1,0 +1,6 @@
+Merge branch 'rrhyne/dark-mode-keyword-serach' of github.com:sourcegraph/sourcegraph into rrhyne/dark-mode-keyword-serach
+# Please enter a commit message to explain why this merge is necessary,
+# especially if it merges an updated upstream into a topic branch.
+#
+# Lines starting with '#' will be ignored, and an empty message aborts
+# the commit.

--- a/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
+++ b/client/branded/src/search-ui/input/experimental/codemirror/syntax-highlighting.ts
@@ -10,6 +10,7 @@ import { queryTokens } from '../../codemirror/parsedQuery'
 
 const filter = Decoration.mark({ class: 'sg-query-token sg-query-token-filter' })
 const pattern = Decoration.mark({ class: 'sg-query-token sg-query-token-pattern' })
+const keyword = Decoration.mark({ class: 'sg-query-token sg-query-token-keyword' })
 
 function getDecorationForToken(token: Token): Decoration | null {
     switch (token.type) {
@@ -18,6 +19,9 @@ function getDecorationForToken(token: Token): Decoration | null {
         }
         case 'pattern': {
             return pattern
+        }
+        case 'keyword': {
+            return keyword
         }
     }
     return null
@@ -33,19 +37,15 @@ export const filterDecoration = [
             // which is surprising to the user).
             padding: '1px 3px',
         },
+
         '.sg-query-token-pattern': {
-            backgroundColor: '#E6EBF295', // --gray-03 with transparency to make text selection visible
+            backgroundColor: 'var(--search-input-token-pattern)',
         },
         '.sg-query-token-filter': {
-            backgroundColor: '#CCEDFFa0', // --oc-blue-1 with transparency to make text selection visible
+            backgroundColor: 'var(--search-input-token-filter)',
         },
-
-        '.theme-dark & .sg-query-token-pattern': {
-            backgroundColor: '#5E6E8C80', // --gray-08 with transparency to make text selection visible
-        },
-
-        '.theme-dark & .sg-query-token-filter': {
-            backgroundColor: '#074884a0', // --oc-blue-9 with transparency to make text selection visible
+        '.sg-query-token-keyword': {
+            backgroundColor: 'var(--search-input-token-keyword)',
         },
     }),
     EditorView.decorations.compute([queryTokens, 'selection'], state => {

--- a/client/wildcard/src/global-styles/colors.scss
+++ b/client/wildcard/src/global-styles/colors.scss
@@ -15,6 +15,7 @@ $cyan: #72dbe8;
 
 // Exception that's used in $theme-colors.
 $gray-02: #eff2f5;
+$gray-03: #e6ebf2;
 // Exception that's used in [data-reach-dialog-overlay] background.
 $gray-04: #dbe2f0;
 // Exception that's used in $custom-select-indicator as SVG icon fill color.
@@ -52,12 +53,24 @@ $theme-colors: (
     'merged': $merged,
 );
 
+// Brand secondary colors.
+// https://handbook.sourcegraph.com/departments/engineering/design/brand_guidelines/color/#secondary-colors
+$violet-01: #eedfff;
+$violet-02: #e8d1ff;
+$violet-03: #ce9cff;
+$violet-04: #a112ff;
+$violet-05: #820dde;
+$violet-06: #6112a3;
+$violet-07: #270741;
+$violet-08: #160425;
+$violet-09: #5f3dc4;
+
 :root {
     // Gray (blueish) root palette.
     --white: #ffffff;
     --gray-01: #f9fafb;
     --gray-02: #{$gray-02};
-    --gray-03: #e6ebf2;
+    --gray-03: #{$gray-03};
     --gray-04: #{$gray-04};
     --gray-05: #a6b6d9;
     --gray-06: #{$gray-06};
@@ -83,7 +96,6 @@ $theme-colors: (
     --cyan: #{$cyan};
 
     // Brand secondary colors.
-    // https://handbook.sourcegraph.com/departments/engineering/design/brand_guidelines/color/#secondary-colors
     --violet-01: #eedfff;
     --violet-02: #e8d1ff;
     --violet-03: #ce9cff;
@@ -309,6 +321,12 @@ $theme-colors: (
 
     // Header colors
     --result-header-bg: #f5f8fa;
+
+    // Search input "chip" colors
+    // Transparency needs to be added to make the text selection marker visible
+    --search-input-token-pattern: #{rgba($gray-03, 0.6)};
+    --search-input-token-filter: #{rgba($oc-blue-1, 0.6)};
+    --search-input-token-keyword: #{rgba($violet-01, 0.6)};
 }
 
 .theme-dark {
@@ -487,6 +505,12 @@ $theme-colors: (
 
     // Header colors
     --result-header-bg: #22283b;
+
+    // Search input "chip" colors
+    // Transparency needs to be added to make the text selection marker visible
+    --search-input-token-pattern: #{rgba($gray-08, 0.6)};
+    --search-input-token-filter: #{rgba($oc-blue-9, 0.6)};
+    --search-input-token-keyword: #{rgba($violet-05, 0.6)};
 }
 
 // Additional colors global colors.

--- a/client/wildcard/src/global-styles/colors.scss
+++ b/client/wildcard/src/global-styles/colors.scss
@@ -324,7 +324,7 @@ $violet-09: #5f3dc4;
 
     // Search input "chip" colors
     // Transparency needs to be added to make the text selection marker visible
-    --search-input-token-pattern: #{rgba($gray-03, 0.6)};
+    --search-input-token-pattern: #{rgba($gray-04, 0.6)};
     --search-input-token-filter: #{rgba($oc-blue-1, 0.6)};
     --search-input-token-keyword: #{rgba($violet-01, 0.6)};
 }
@@ -508,8 +508,8 @@ $violet-09: #5f3dc4;
 
     // Search input "chip" colors
     // Transparency needs to be added to make the text selection marker visible
-    --search-input-token-pattern: #{rgba($gray-08, 0.6)};
-    --search-input-token-filter: #{rgba($oc-blue-9, 0.6)};
+    --search-input-token-pattern: #{rgba($gray-08, 0.8)};
+    --search-input-token-filter: #{rgba($oc-blue-9, 0.4)};
     --search-input-token-keyword: #{rgba($violet-05, 0.6)};
 }
 

--- a/client/wildcard/src/global-styles/colors.scss
+++ b/client/wildcard/src/global-styles/colors.scss
@@ -15,7 +15,6 @@ $cyan: #72dbe8;
 
 // Exception that's used in $theme-colors.
 $gray-02: #eff2f5;
-$gray-03: #e6ebf2;
 // Exception that's used in [data-reach-dialog-overlay] background.
 $gray-04: #dbe2f0;
 // Exception that's used in $custom-select-indicator as SVG icon fill color.
@@ -70,7 +69,7 @@ $violet-09: #5f3dc4;
     --white: #ffffff;
     --gray-01: #f9fafb;
     --gray-02: #{$gray-02};
-    --gray-03: #{$gray-03};
+    --gray-03: #e6ebf2;
     --gray-04: #{$gray-04};
     --gray-05: #a6b6d9;
     --gray-06: #{$gray-06};


### PR DESCRIPTION
This PR adds a violet background color to keywords. I chose violet-01 for light mode and violet-05 for dark mode.

I also cleaned this up a bit to avoid repeating color values and moved the colors into CSS variables and applied transparency via SCSS. Maybe the alpha value needs to be tweaked.

Light mode: 
![2024-02-02_21-18](https://github.com/sourcegraph/sourcegraph/assets/179026/0b74ceef-879e-4a6b-8864-c7e87f17adbd)

Dark mode:
![2024-02-02_21-18_1](https://github.com/sourcegraph/sourcegraph/assets/179026/3ca3e980-5059-4a68-af28-c3cc03cb9288)

## Test plan

Visual testing
