### PR TITLE
Search filters: increase backend limits on dynamic filters

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -47,7 +47,7 @@ func StreamHandler(db database.DB) http.Handler {
 		logger:              logger,
 		db:                  db,
 		searchClient:        client.New(logger, db, gitserver.NewClient("http.search.stream")),
-		flushTickerInternal: 100 * time.Millisecond,
+		flushTickerInternal: 200 * time.Millisecond,
 		pingTickerInterval:  5 * time.Second,
 	})
 }

--- a/internal/search/streaming/search_filters.go
+++ b/internal/search/streaming/search_filters.go
@@ -254,7 +254,7 @@ func (s *SearchFilters) Update(event SearchEvent) {
 func (s *SearchFilters) Compute() []*Filter {
 	s.Dirty = false
 	return s.filters.Compute(computeOpts{
-		MaxRepos: 40,
-		MaxOther: 40,
+		MaxRepos: 1000,
+		MaxOther: 1000,
 	})
 }


### PR DESCRIPTION
This dramatically increases the limits on the number of dynamic filters sent back to the client. Right now, we send a maximum of 40 filters back, which is problematic when a user wants to search for a repository in the sidebar to filter down their results. Since these are small payloads, I've increased the max number to 1000. It should be rare that we get more filters than that given that we generate at most one filter per result.

I've also increased the flush interval from 100ms to 200ms to offset the small potential payload size increase. It's practically not useful to get that many updates per second anyways, and we can probably push this even further since this also forces a re-render of a bunch of things for each event, but for now I'm happy with just doubling it.

## Test plan

I tested that the search functionality in the sidebar still feels snappy even with 1000 entries. I also checked that the payload size wasn't going to be problematic. Even with the full 1000 entries, it's still only 80kb of data, which compresses to 8kb now that we're gzipping the stream. I will keep an eye on the search blitz metrics as well to ensure there are no weird corner cases.