### PR TITLE
Symbol search: fix panic on empty query

### DIFF
--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -628,7 +628,7 @@ func mapSlice(values []string, f func(string) string) []string {
 }
 
 func toSymbolSearchRequest(f query.Flat) (*searcher.SymbolSearchRequest, error) {
-	if f.Pattern.Negated {
+	if f.Pattern != nil && f.Pattern.Negated {
 		return nil, &query.UnsupportedError{
 			Msg: "symbol search does not support negation.",
 		}

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -1067,6 +1067,9 @@ func TestToSymbolSearchRequest(t *testing.T) {
 		input:  `repo:go-diff patterntype:literal type:symbol HunkNoChunksize select:symbol -file:^README\.md `,
 		output: autogold.Expect(`{"RegexpPattern":"HunkNoChunksize","IsCaseSensitive":false,"IncludePatterns":null,"ExcludePattern":"^README\\.md"}`),
 	}, {
+		input:  `repo:go-diff type:symbol`,
+		output: autogold.Expect(`{"RegexpPattern":"","IsCaseSensitive":false,"IncludePatterns":null,"ExcludePattern":""}`),
+	}, {
 		input:   `type:symbol NOT option`,
 		output:  autogold.Expect("null"),
 		wantErr: true,
@@ -1079,14 +1082,12 @@ func TestToSymbolSearchRequest(t *testing.T) {
 		}
 
 		b := plan[0]
-		var pattern query.Pattern
+		var pattern *query.Pattern
 		if p, ok := b.Pattern.(query.Pattern); ok {
-			pattern = p
-		} else {
-			t.Fatal(err)
+			pattern = &p
 		}
 
-		f := query.Flat{Parameters: b.Parameters, Pattern: &pattern}
+		f := query.Flat{Parameters: b.Parameters, Pattern: pattern}
 		return toSymbolSearchRequest(f)
 	}
 


### PR DESCRIPTION
This fixes an issue we introduced recently where empty symbol searches could
panic. The bug is unreleased.

## Test plan

Added new unit test