### PR TITLE
Search filters: add approximate count tooltip

### DIFF
--- a/client/branded/src/search-ui/results/filters/components/DynamicFilterBadge.tsx
+++ b/client/branded/src/search-ui/results/filters/components/DynamicFilterBadge.tsx
@@ -2,16 +2,25 @@ import { FC } from 'react'
 
 import classNames from 'classnames'
 
-import { Badge } from '@sourcegraph/wildcard'
+import { Badge, Tooltip } from '@sourcegraph/wildcard'
 
 import styles from './DynamicFilterBadge.module.scss'
 
-export const DynamicFilterBadge: FC<{ exhaustive: boolean; count: number }> = ({ exhaustive, count }) =>
-    count !== 0 ? (
-        <Badge variant="secondary" className={classNames('ml-2', styles.countBadge)}>
-            {exhaustive ? count : `${roundCount(count)}+`}
-        </Badge>
-    ) : null
+export const DynamicFilterBadge: FC<{ exhaustive: boolean; count: number }> = ({ exhaustive, count }) => {
+    const tooltipContent = exhaustive ? null : (
+        <>
+            Result count is approximate because a limit was hit. Increase the limit with the <code>count:</code> filter.
+        </>
+    )
+
+    return (
+        <Tooltip content={tooltipContent}>
+            <Badge ref={null} variant="secondary" className={classNames('ml-2', styles.countBadge)}>
+                {exhaustive ? count : `${roundCount(count)}+`}
+            </Badge>
+        </Tooltip>
+    )
+}
 
 function roundCount(count: number): number {
     const roundNumbers = [10000, 5000, 1000, 500, 100, 50, 10, 5, 1]

--- a/client/branded/src/search-ui/results/filters/components/DynamicFilterBadge.tsx
+++ b/client/branded/src/search-ui/results/filters/components/DynamicFilterBadge.tsx
@@ -9,12 +9,13 @@ import styles from './DynamicFilterBadge.module.scss'
 export const DynamicFilterBadge: FC<{ exhaustive: boolean; count: number }> = ({ exhaustive, count }) => {
     const tooltipContent = exhaustive ? null : (
         <>
-            Result count is approximate because a limit was hit. Increase the limit with the <code>count:</code> filter.
+            This is an approximate count of the results returned because you hit a limit. Try increasing the limit using
+            the <code>count:</code> filter in the search query, or select <code>count:all</code> from the filter list.
         </>
     )
 
     return (
-        <Tooltip content={tooltipContent}>
+        <Tooltip content={tooltipContent} placement="right">
             <Badge ref={null} variant="secondary" className={classNames('ml-2', styles.countBadge)}>
                 {exhaustive ? count : `${roundCount(count)}+`}
             </Badge>

--- a/client/branded/src/search-ui/results/filters/components/DynamicFilterBadge.tsx
+++ b/client/branded/src/search-ui/results/filters/components/DynamicFilterBadge.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 import classNames from 'classnames'
 
-import { Badge, Tooltip } from '@sourcegraph/wildcard'
+import { Badge, Tooltip, Code } from '@sourcegraph/wildcard'
 
 import styles from './DynamicFilterBadge.module.scss'
 
@@ -10,7 +10,7 @@ export const DynamicFilterBadge: FC<{ exhaustive: boolean; count: number }> = ({
     const tooltipContent = exhaustive ? null : (
         <>
             This is an approximate count of the results returned because you hit a limit. Try increasing the limit using
-            the <code>count:</code> filter in the search query, or select <code>count:all</code> from the filter list.
+            the <Code>count:</Code> filter in the search query, or select <Code>count:all</Code> from the filter list.
         </>
     )
 

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -206,7 +206,7 @@ export const repoFilter = (filter: Filter): ReactNode => {
     const { svgPath } = codeHostIcon(filter.label)
 
     return (
-        <Tooltip content={filter.label}>
+        <Tooltip content={filter.label} placement="right">
             <span>
                 <Icon aria-hidden={true} svgPath={svgPath ?? mdiSourceRepository} /> {displayRepoName(filter.label)}
             </span>


### PR DESCRIPTION
We'd talked about this at some point, but I don't remember where we landed on it. It was trivial to implement so I figured we'd just discuss it on a PR to save some time. I am also simultaneously [increasing the default limit](https://github.com/sourcegraph/sourcegraph/pull/60114) so we should hopefully see this even less. 

It might be a little verbose, would appreciate feedback on the copy. 

![CleanShot 2024-02-02 at 17 06 36@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/8a11fec3-9066-4e48-acc9-abc1bad63324)

## Test plan

Hovered over an approximate count and viewed the tooltip.

