### PR TITLE
Search filters: make repository singular

### DIFF
--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -93,7 +93,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
             />
             <div className={styles.filters}>
                 <SearchDynamicFilter
-                    title="By repositories"
+                    title="By repository"
                     filterKind={FilterKind.Repository}
                     filters={filters}
                     selectedFilters={selectedFilters}


### PR DESCRIPTION
Just a tiny change to change the copy from `By repositories` to the singular `By repository` to be more consistent with the other filter types and so that it correctly completes the sentence "Filter results by repository"

## Test plan

N/A, just a tiny copy edit.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
