### PR TITLE
licensing: ignore redirect check on dotcom

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -352,7 +352,7 @@ func serveHome(db database.DB) handlerFunc {
 		// On non-Sourcegraph.com instances, there is no separate homepage, so redirect to /search.
 		// except if the instance is on a Cody-Only license.
 		redirectURL := "/search"
-		if common.Context.LicenseInfo != nil {
+		if common.Context.LicenseInfo != nil && !envvar.SourcegraphDotComMode() {
 			features := common.Context.LicenseInfo.Features
 			if !features.CodeSearch && features.Cody {
 				redirectURL = "/cody"


### PR DESCRIPTION

## Test plan

Ran `sg start dotcom` and confirmed after login, a user is redirected to the `/search` route.