### PR TITLE
fix: Use repoId instead of array for rockskip_symbols delete

### DIFF
--- a/internal/rockskip/postgres.go
+++ b/internal/rockskip/postgres.go
@@ -230,7 +230,7 @@ func tryDeleteOldestRepo(ctx context.Context, db *sql.Conn, maxRepos int, thread
 	if err != nil {
 		return false, err
 	}
-	_, err = tx.ExecContext(ctx, "DELETE FROM rockskip_symbols WHERE repo_id = $1;", pg.Array([]int{repoId}))
+	_, err = tx.ExecContext(ctx, "DELETE FROM rockskip_symbols WHERE repo_id = $1;", repoId)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Closes #60110

Changed the DELETE statement for the rockskip_symbols table to use the `repoId` variable directly instead of wrapping it in a PostgreSQL array. Using an int array caused an error because [repo_id is an integer in the schema](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@e0a774243cf61a83063eb8eea13d37b1764b4483/-/blob/internal/database/schema.codeintel.json?L1320-1323).

` t=2024-02-01T21:05:07+0000 lvl=eror msg="Failed to delete old repos" error="ERROR: invalid input syntax for type integer: \"{11}\" (SQLSTATE 22P02)"`



## Test plan
Manually tested

tryDeleteOldestRepo deletes repos to stay under max_repos: 2.


https://github.com/sourcegraph/sourcegraph/assets/69164745/303075ba-f6c1-462e-a91a-c7c089af9cfc



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
