### PR TITLE
batches: allow refreshing commit signing apps installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- GitHub app installations can now be refreshed from the Batch Changes Site Admin page. [#60125](https://github.com/sourcegraph/sourcegraph/pull/60125)
 
 ### Changed
 

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -3,12 +3,14 @@ import React, { useState } from 'react'
 import { mdiCheckCircleOutline, mdiCheckboxBlankCircleOutline, mdiCogOutline, mdiDelete, mdiOpenInNew } from '@mdi/js'
 import classNames from 'classnames'
 
-import { AnchorLink, Button, ButtonLink, H3, Icon, Link, Text } from '@sourcegraph/wildcard'
+import { AnchorLink, Button, ButtonLink, H3, Icon, Link, Text, LoadingSpinner, ErrorAlert } from '@sourcegraph/wildcard'
 
 import { defaultExternalServices } from '../../../components/externalServices/externalServices'
 import { AppLogo } from '../../../components/gitHubApps/AppLogo'
 import { RemoveGitHubAppModal } from '../../../components/gitHubApps/RemoveGitHubAppModal'
 import type { BatchChangesCodeHostFields } from '../../../graphql-operations'
+
+import { useRefreshGitHubApp } from './backend'
 
 import styles from './CommitSigningIntegrationNode.module.scss'
 
@@ -70,7 +72,7 @@ interface AppDetailsControlsProps {
 
 const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ baseURL, config, refetch }) => {
     const [removeModalOpen, setRemoveModalOpen] = useState<boolean>(false)
-
+    const [refreshGitHubApp, { loading, error }] = useRefreshGitHubApp()
     const createURL = `/site-admin/batch-changes/github-apps/new?baseURL=${encodeURIComponent(baseURL)}`
     return config ? (
         <>
@@ -95,6 +97,14 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
                         View In GitHub <Icon inline={true} svgPath={mdiOpenInNew} aria-hidden={true} />
                     </small>
                 </AnchorLink>
+                <Button
+                    variant="warning"
+                    className="mr-2"
+                    size="sm"
+                    onClick={() => refreshGitHubApp({ variables: { gitHubApp: config.id } })}
+                >
+                    {loading ? <LoadingSpinner inline={true} /> : 'Refresh'}
+                </Button>
                 <ButtonLink
                     className="mr-2"
                     aria-label="Edit"
@@ -113,6 +123,7 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
                     <Icon aria-hidden={true} svgPath={mdiDelete} /> Remove
                 </Button>
             </div>
+            {error && <ErrorAlert error={error} />}
         </>
     ) : (
         <ButtonLink to={createURL} className="ml-auto text-nowrap" variant="success" as={Link} size="sm">

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -75,7 +75,6 @@ interface AppDetailsControlsProps {
 const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ baseURL, config, refetch }) => {
     const [removeModalOpen, setRemoveModalOpen] = useState<boolean>(false)
     const [refreshGitHubApp, { loading, error, data }] = useRefreshGitHubApp()
-    console.log({ data, loading })
     const createURL = `/site-admin/batch-changes/github-apps/new?baseURL=${encodeURIComponent(baseURL)}`
     return config ? (
         <>

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrationNode.tsx
@@ -125,13 +125,9 @@ const AppDetailsControls: React.FunctionComponent<AppDetailsControlsProps> = ({ 
                     <Icon aria-hidden={true} svgPath={mdiDelete} /> Remove
                 </Button>
             </div>
-            {error && (
-                <NodeAlert visible={Boolean(!loading && error)} variant="danger">
-                    {error.message}
-                </NodeAlert>
-            )}
+            {error && <NodeAlert variant="danger">{error.message}</NodeAlert>}
             {!loading && data && (
-                <NodeAlert visible={true} variant="success">
+                <NodeAlert variant="success">
                     Installations for <span className="font-weight-bold">"{config.name}"</span> successfully refreshed.
                 </NodeAlert>
             )}
@@ -168,19 +164,20 @@ const ONE_REM_IN_PX = convertREMToPX(1)
 const APPROX_BANNER_HEIGHT_PX = 40
 
 interface NodeAlertProps {
-    visible: boolean
     variant: 'danger' | 'success'
 }
 
-const NodeAlert: React.FunctionComponent<React.PropsWithChildren<NodeAlertProps>> = ({
-    visible,
-    children,
-    variant,
-}) => {
+const NodeAlert: React.FunctionComponent<React.PropsWithChildren<NodeAlertProps>> = ({ children, variant }) => {
     const ref = useRef<HTMLDivElement>(null)
     const style = useSpring({
-        height: visible ? `${(ref.current?.offsetHeight || APPROX_BANNER_HEIGHT_PX) + ONE_REM_IN_PX}px` : '0px',
-        opacity: visible ? 1 : 0,
+        from: {
+            height: '0px',
+            opacity: 0,
+        },
+        to: {
+            height: `${(ref.current?.offsetHeight || APPROX_BANNER_HEIGHT_PX) + ONE_REM_IN_PX}px`,
+            opacity: 1,
+        },
     })
 
     return (

--- a/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
+++ b/client/web/src/enterprise/batches/settings/CommitSigningIntegrations.tsx
@@ -77,7 +77,11 @@ export const CommitSigningIntegrations: React.FunctionComponent<
                 {error && <ConnectionError errors={[error.message]} />}
                 {loading && !connection && <ConnectionLoading />}
                 {success && !readOnly && (
-                    <DismissibleAlert className="mb-3" variant="success">
+                    <DismissibleAlert
+                        className="mb-3"
+                        variant="success"
+                        partialStorageKey="batch-changes-commit-signing-integration-success"
+                    >
                         GitHub App {appName?.length ? `"${appName}" ` : ''}successfully connected.
                     </DismissibleAlert>
                 )}

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -17,6 +17,8 @@ import type {
     Scalars,
     UserBatchChangesCodeHostsResult,
     UserBatchChangesCodeHostsVariables,
+    RefreshGitHubAppResult,
+    RefreshGitHubAppVariables,
 } from '../../../graphql-operations'
 
 export const CREDENTIAL_FIELDS_FRAGMENT = gql`
@@ -191,3 +193,19 @@ export const CHECK_BATCH_CHANGES_CREDENTIAL = gql`
         }
     }
 `
+
+export const REFRESH_GITHUB_APP = gql`
+    mutation RefreshGitHubApp($gitHubApp: ID!) {
+        refreshGitHubApp(gitHubApp: $gitHubApp) {
+            alwaysNil
+        }
+    }
+`
+
+export const useRefreshGitHubApp = (): MutationTuple<RefreshGitHubAppResult, RefreshGitHubAppVariables> =>
+    useMutation(REFRESH_GITHUB_APP)
+
+//     export const useCreateBatchChangesCredential = (): MutationTuple<
+//     CreateBatchChangesCredentialResult,
+//     CreateBatchChangesCredentialVariables
+// > => useMutation(CREATE_BATCH_CHANGES_CREDENTIAL)

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -204,8 +204,3 @@ export const REFRESH_GITHUB_APP = gql`
 
 export const useRefreshGitHubApp = (): MutationTuple<RefreshGitHubAppResult, RefreshGitHubAppVariables> =>
     useMutation(REFRESH_GITHUB_APP)
-
-//     export const useCreateBatchChangesCredential = (): MutationTuple<
-//     CreateBatchChangesCredentialResult,
-//     CreateBatchChangesCredentialVariables
-// > => useMutation(CREATE_BATCH_CHANGES_CREDENTIAL)

--- a/cmd/frontend/graphqlbackend/githubapps.go
+++ b/cmd/frontend/graphqlbackend/githubapps.go
@@ -25,6 +25,7 @@ type GitHubAppsResolver interface {
 
 	// Mutations
 	DeleteGitHubApp(ctx context.Context, args *DeleteGitHubAppArgs) (*EmptyResponse, error)
+	RefreshGitHubApp(ctx context.Context, args *RefreshGitHubAppArgs) (*EmptyResponse, error)
 }
 
 type GitHubAppConnectionResolver interface {
@@ -50,6 +51,10 @@ type GitHubAppResolver interface {
 }
 
 type DeleteGitHubAppArgs struct {
+	GitHubApp graphql.ID
+}
+
+type RefreshGitHubAppArgs struct {
 	GitHubApp graphql.ID
 }
 

--- a/cmd/frontend/graphqlbackend/githubapps.graphql
+++ b/cmd/frontend/graphqlbackend/githubapps.graphql
@@ -4,6 +4,12 @@ extend type Mutation {
     authentication provider, will be deleted.
     """
     deleteGitHubApp(gitHubApp: ID!): EmptyResponse
+
+    """
+    Refresh a GitHub App. This fetches information about the GitHub app and updates all installations
+    associated with it.
+    """
+    refreshGitHubApp(gitHubApp: ID!): EmptyResponse
 }
 
 extend type Query {

--- a/cmd/frontend/internal/githubapp/resolver.go
+++ b/cmd/frontend/internal/githubapp/resolver.go
@@ -74,6 +74,17 @@ func (r *resolver) DeleteGitHubApp(ctx context.Context, args *graphqlbackend.Del
 	return &graphqlbackend.EmptyResponse{}, nil
 }
 
+func (r *resolver) RefreshGitHubApp(ctx context.Context, args *graphqlbackend.RefreshGitHubAppArgs) (*graphqlbackend.EmptyResponse, error) {
+	// 🚨 SECURITY: Check whether user is site-admin
+	app, err := r.gitHubAppByID(ctx, args.GitHubApp)
+	if err != nil {
+		return nil, err
+	}
+
+	app.syncInstallations()
+	return nil, nil
+}
+
 func (r *resolver) GitHubApps(ctx context.Context, args *graphqlbackend.GitHubAppsArgs) (graphqlbackend.GitHubAppConnectionResolver, error) {
 	// 🚨 SECURITY: Check whether user is site-admin
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {


### PR DESCRIPTION
This gives site admins the ability to refresh a commit signing app, instead of waiting for the periodic worker (which runs every 24 hours) to kick of the installation sync.

![CleanShot 2024-02-14 at 17 51 06@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/c9514bb5-ad13-430c-8f60-8717b5a49fee)

## Test plan

Add a GitHub app on Sourcegraph for Commit Signing.
There should be a `Refresh` button to refresh installations on the app.

If the app is installed on any new org or account, the installations will be added to the database after the `Refresh` operation is done.