### PR TITLE
codemirror: Fix text selection color in search input and blob

### DIFF
--- a/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.tsx
@@ -9,6 +9,7 @@ import { useMergeRefs } from 'use-callback-ref'
 import { TraceSpanProvider } from '@sourcegraph/observability-client'
 import { useCodeMirror, useCompartment } from '@sourcegraph/shared/src/components/CodeMirrorEditor'
 import type { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 
 import {
     type QueryInputEventHandlers,
@@ -144,6 +145,7 @@ export const BaseCodeMirrorQueryInput = memo(
         const containerRef = useRef<HTMLDivElement | null>(null)
         const localEditorRef = useRef<EditorView | null>(null)
         const editorRef = useMergeRefs([ref, localEditorRef])
+        const isLightTheme = useIsLightTheme()
         // We need to expliclity remove line breaks when multiLine is set, to ensure
         // that the initial value is properly formatted. The corresponding CodeMirror
         // extension only affects changes made after initialization.
@@ -170,6 +172,10 @@ export const BaseCodeMirrorQueryInput = memo(
             editorRef,
             useMemo(() => multiline(multiLine), [multiLine])
         )
+        const themeExtension = useCompartment(
+            editorRef,
+            useMemo(() => EditorView.darkTheme.of(!isLightTheme), [isLightTheme])
+        )
         const externalExtension = useCompartment(editorRef, extension)
         const allExtensions = useMemo(
             () => [
@@ -178,6 +184,7 @@ export const BaseCodeMirrorQueryInput = memo(
                 eventHandlers,
                 multiLineExtension,
                 readOnlyExtension,
+                themeExtension,
                 staticExtensions,
             ],
             [eventHandlers, parsedQueryExtension, readOnlyExtension, multiLineExtension, externalExtension]

--- a/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.tsx
@@ -187,7 +187,14 @@ export const BaseCodeMirrorQueryInput = memo(
                 themeExtension,
                 staticExtensions,
             ],
-            [eventHandlers, parsedQueryExtension, readOnlyExtension, multiLineExtension, externalExtension]
+            [
+                eventHandlers,
+                parsedQueryExtension,
+                readOnlyExtension,
+                multiLineExtension,
+                externalExtension,
+                themeExtension,
+            ]
         )
 
         useCodeMirror(editorRef, containerRef, normalizedValue, allExtensions)

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -28,7 +28,7 @@ import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TemporarySettingsSchema } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { Theme, useTheme } from '@sourcegraph/shared/src/theme'
+import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
     parseQueryAndHash,
     toPrettyBlobURL,
@@ -228,6 +228,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
 
     const navigate = useNavigate()
     const location = useLocation()
+    const isLightTheme = useIsLightTheme()
 
     const [enableBlobPageSwitchAreasShortcuts] = useFeatureFlag('blob-page-switch-areas-shortcuts')
     const focusCodeEditorShortcut = useKeyboardShortcut('focusCodeEditor')
@@ -351,7 +352,10 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
         Boolean(ocgVisibility)
     )
 
-    const { theme } = useTheme()
+    const themeExtension = useCompartment(
+        editorRef,
+        useMemo(() => EditorView.darkTheme.of(!isLightTheme), [isLightTheme])
+    )
 
     const extensions = useMemo(
         () => [
@@ -400,7 +404,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
                 initialState: searchPanelConfig,
                 navigate,
             }),
-            EditorView.theme({}, { dark: theme === Theme.Dark }),
+            themeExtension,
         ],
         // A couple of values are not dependencies (hasPin and position) because those are updated in effects
         // further below. However, they are still needed here because we need to
@@ -420,6 +424,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             wrapCodeSettings,
             blobProps,
             pinnedTooltip,
+            themeExtension,
         ]
     )
 


### PR DESCRIPTION
Closes #60118

It appears that the recent update included changes to CodeMirror's base theme which depend on light/dark mode settings. This makes it important to communicate the current mode to CodeMirror.

In our case we don't use a specific "dark mode theme". All light/dark mode differences are handled via CSS variables. We tell CodeMirror to apply dark mode rules by setting `EditorView.darkTheme.of(true)`.



## Test plan

Visual testing.