### PR TITLE
keyword search: implicit operators and parens as groups

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -142,7 +142,7 @@ type heuristics uint8
 const (
 	// If set, balanced parentheses, which would normally be treated as
 	// delimiting expression groups, may in select cases be parsed as
-	// literal search patterns instead.
+	// literal search patterns instead. Example: (a b) -> "a b"
 	parensAsPatterns heuristics = 1 << iota
 	// If set, all parentheses, whether balanced or unbalanced, are parsed
 	// as literal search patterns (i.e., interpreting parentheses as
@@ -151,6 +151,12 @@ const (
 	// If set, implies that at least one expression was disambiguated by
 	// explicit parentheses.
 	disambiguated
+	// If set, the parser will parse patterns containing balanced parentheses as
+	// literal patterns. Example: func(a int, b int) -> "func(a int, b int)"
+	balancedPattern
+	// If set, the parser will parse () as a literal pattern instead of as pattern
+	// group.
+	emptyParens
 )
 
 func isSet(h, heuristic heuristics) bool { return h&heuristic != 0 }
@@ -840,7 +846,7 @@ func (p *parser) ParsePattern(label labels) Pattern {
 		}
 	}
 
-	if isSet(p.heuristics, parensAsPatterns) {
+	if isSet(p.heuristics, balancedPattern) {
 		if pattern, ok := p.TryScanBalancedPattern(label); ok {
 			return pattern
 		}
@@ -962,7 +968,7 @@ loop:
 			p.heuristics |= disambiguated
 			if len(nodes) == 0 {
 				// We parsed "()".
-				if isSet(p.heuristics, parensAsPatterns) {
+				if isSet(p.heuristics, parensAsPatterns|emptyParens) {
 					// Interpret literally.
 					nodes = []Node{newPattern("()", Literal|HeuristicParensAsPatterns, newRange(start, p.pos))}
 				} else {
@@ -1161,8 +1167,12 @@ func Parse(in string, searchType SearchType) ([]Node, error) {
 
 	parser := &parser{
 		buf:        []byte(in),
-		heuristics: parensAsPatterns,
+		heuristics: balancedPattern | parensAsPatterns,
 		leafParser: searchType,
+	}
+
+	if searchType == SearchTypeKeyword {
+		parser.heuristics = balancedPattern | emptyParens
 	}
 
 	nodes, err := parser.parseOr()
@@ -1192,7 +1202,10 @@ func Parse(in string, searchType SearchType) ([]Node, error) {
 			nodes = hoistedNodes
 		}
 	}
-	if searchType == SearchTypeLiteral || searchType == SearchTypeStandard || searchType == SearchTypeKeyword {
+
+	// Note that we don't include keyword search in this check because we want to
+	// support mixing of implicit and explicit operators
+	if searchType == SearchTypeLiteral || searchType == SearchTypeStandard {
 		err = validatePureLiteralPattern(nodes, parser.balanced == 0)
 		if err != nil {
 			return nil, err

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1175,7 +1175,6 @@ func Parse(in string, searchType SearchType) ([]Node, error) {
 		parser.heuristics = balancedPattern | emptyParens
 	default:
 		parser.heuristics = balancedPattern | emptyParens | parensAsPatterns
-
 	}
 
 	nodes, err := parser.parseOr()

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -40,7 +40,7 @@ func TestParseParameterList(t *testing.T) {
 	}
 
 	test := func(input string) value {
-		parser := &parser{buf: []byte(input), heuristics: parensAsPatterns | allowDanglingParens}
+		parser := &parser{buf: []byte(input), heuristics: parensAsPatterns | balancedPattern | allowDanglingParens}
 		result, err := parser.parseLeaves(Regexp)
 		if err != nil {
 			t.Fatal(fmt.Sprintf("Unexpected error: %s", err))
@@ -68,15 +68,15 @@ func TestParseParameterList(t *testing.T) {
 		}
 	}
 
-	autogold.Expect(value{
-		Result:      `{"field":"file","value":"README.md","negated":false}`,
-		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
-	}).Equal(t, test(`file:README.md`))
-
-	autogold.Expect(value{
-		Result:      `{"field":"file","value":"README.md","negated":false}`,
-		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
-	}).Equal(t, test(`file:README.md    `))
+	// autogold.Expect(value{
+	// 	Result:      `{"field":"file","value":"README.md","negated":false}`,
+	// 	ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
+	// }).Equal(t, test(`file:README.md`))
+	//
+	// autogold.Expect(value{
+	// 	Result:      `{"field":"file","value":"README.md","negated":false}`,
+	// 	ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
+	// }).Equal(t, test(`file:README.md    `))
 
 	autogold.Expect(value{
 		Result: `{"value":":foo","negated":false}`, ResultLabels: "Regexp",
@@ -625,7 +625,7 @@ func TestDelimited(t *testing.T) {
 
 func TestMergePatterns(t *testing.T) {
 	test := func(input string) string {
-		p := &parser{buf: []byte(input), heuristics: parensAsPatterns}
+		p := &parser{buf: []byte(input), heuristics: parensAsPatterns | balancedPattern}
 		nodes, err := p.parseLeaves(Regexp)
 		got := nodes[0].(Pattern).Annotation.Range.String()
 		if err != nil {
@@ -650,6 +650,61 @@ func TestMatchUnaryKeyword(t *testing.T) {
 	autogold.Expect("false").Equal(t, test("fooNOT bar", 3))
 	autogold.Expect("false").Equal(t, test("NOTbar", 0))
 	autogold.Expect("true").Equal(t, test("(not bar)", 1))
+}
+
+func TestParseParensKeyword(t *testing.T) {
+	test := func(input string) string {
+		plan, err := Pipeline(
+			Init(input, SearchTypeKeyword),
+		)
+		require.NoError(t, err)
+
+		return plan.ToQ().String()
+	}
+
+	// parens as grouping
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("foo and bar and bas"))
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("(foo and bar) and bas"))
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("foo bar bas"))
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("(foo bar) bas"))
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("foo (bar bas)"))
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("(foo bar bas)"))
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("(foo) bar bas"))
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("foo (bar) bas"))
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("foo bar (bas)"))
+
+	// not
+	autogold.Expect(`(and "foo" (not "bar"))`).Equal(t, test("foo and not bar"))
+	autogold.Expect(`(and "foo" (not "bar"))`).Equal(t, test("foo (not bar)"))
+	autogold.Expect(`(and "foo" (not "bar"))`).Equal(t, test("foo not bar"))
+
+	// literal
+	autogold.Expect(`(and "(foo bar)" "bas")`).Equal(t, test(`"(foo bar)" bas`))
+
+	// mix implicit AND and explicit OR
+	autogold.Expect(`(and "foo" "bar" "bas")`).Equal(t, test("(foo bar) and bas"))
+	autogold.Expect(`(or (and "foo" "bar") "bas")`).Equal(t, test("(foo bar) or bas"))
+	autogold.Expect(`(and (or "foo" "bar") "bas")`).Equal(t, test(`(foo or bar) bas`))
+	autogold.Expect(`(and (or "foo" "bar") "bas" "qux")`).Equal(t, test(`(foo or bar) bas qux`))
+
+	// nested
+	autogold.Expect(`(and "foo" "bar" (or "bas" "qux"))`).Equal(t, test("foo (bar (bas or qux))"))
+	autogold.Expect(`(and (or "foo" "bas") (or "bar" "qux") "hoge")`).Equal(t, test("(foo or bas) (bar or qux) hoge"))
+	autogold.Expect(`(or "foo" (and "bas" "qux" (or "hoge" "fuga")))`).Equal(t, test("(foo or (bas and qux and (hoge or fuga)))"))
+	autogold.Expect(`(or (and "foo" "bas") (and "hoge" "fuga"))`).Equal(t, test("(foo and bas) or (hoge and fuga)"))
+
+	// regex
+	autogold.Expect(`(and "foo" "ba.*" "bas")`).Equal(t, test("(foo /ba.*/) bas"))
+	autogold.Expect(`(and (or "foo" "bar") "bas")`).Equal(t, test("(foo or /bar/) and bas"))
+
+	// function signatures
+	autogold.Expect(`(and "func()" "error")`).Equal(t, test("func() error"))
+	autogold.Expect(`(and "func(a int, b bool)" "error")`).Equal(t, test("func(a int, b bool) error"))
+
+	// parentheses
+	autogold.Expect(`"()"`).Equal(t, test("()"))
+	autogold.Expect(`(and "()" "=>" "{}")`).Equal(t, test("() => {}"))
+	autogold.Expect(`(and "err" "error," "ok" "bool")`).Equal(t, test("(err error, ok bool)"))
 }
 
 func TestParseAndOrLiteral(t *testing.T) {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -68,15 +68,15 @@ func TestParseParameterList(t *testing.T) {
 		}
 	}
 
-	// autogold.Expect(value{
-	// 	Result:      `{"field":"file","value":"README.md","negated":false}`,
-	// 	ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
-	// }).Equal(t, test(`file:README.md`))
-	//
-	// autogold.Expect(value{
-	// 	Result:      `{"field":"file","value":"README.md","negated":false}`,
-	// 	ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
-	// }).Equal(t, test(`file:README.md    `))
+	autogold.Expect(value{
+		Result:      `{"field":"file","value":"README.md","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
+	}).Equal(t, test(`file:README.md`))
+
+	autogold.Expect(value{
+		Result:      `{"field":"file","value":"README.md","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
+	}).Equal(t, test(`file:README.md    `))
 
 	autogold.Expect(value{
 		Result: `{"value":":foo","negated":false}`, ResultLabels: "Regexp",

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -102,7 +102,7 @@ func For(searchType SearchType) step {
 	case SearchTypeStructural:
 		processType = succeeds(labelStructural, ellipsesForHoles, substituteConcat(space))
 	case SearchTypeKeyword:
-		processType = succeeds(substituteConcat(and))
+		processType = succeeds(substituteConcatForKeyword(and))
 	}
 	normalize := succeeds(LowercaseFieldNames, SubstituteAliases(searchType), SubstituteCountAll)
 	return Sequence(normalize, processType)

--- a/internal/search/query/testdata/TestConcat/#12.golden
+++ b/internal/search/query/testdata/TestConcat/#12.golden
@@ -1,78 +1,82 @@
 [
   {
-    "value": "a",
-    "negated": false,
-    "labels": [
-      "Literal",
-      "QuotesAsLiterals",
-      "Standard"
-    ],
-    "range": {
-      "start": {
-        "line": 0,
-        "column": 1
+    "and": [
+      {
+        "value": "a",
+        "negated": false,
+        "labels": [
+          "Literal",
+          "QuotesAsLiterals",
+          "Standard"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 1
+          },
+          "end": {
+            "line": 0,
+            "column": 2
+          }
+        }
       },
-      "end": {
-        "line": 0,
-        "column": 2
-      }
-    }
-  },
-  {
-    "value": "b",
-    "negated": true,
-    "labels": [
-      "Literal",
-      "QuotesAsLiterals",
-      "Standard"
-    ],
-    "range": {
-      "start": {
-        "line": 0,
-        "column": 3
+      {
+        "value": "b",
+        "negated": true,
+        "labels": [
+          "Literal",
+          "QuotesAsLiterals",
+          "Standard"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 3
+          },
+          "end": {
+            "line": 0,
+            "column": 8
+          }
+        }
       },
-      "end": {
-        "line": 0,
-        "column": 8
-      }
-    }
-  },
-  {
-    "value": "c",
-    "negated": true,
-    "labels": [
-      "Literal",
-      "QuotesAsLiterals",
-      "Standard"
-    ],
-    "range": {
-      "start": {
-        "line": 0,
-        "column": 9
+      {
+        "value": "c",
+        "negated": true,
+        "labels": [
+          "Literal",
+          "QuotesAsLiterals",
+          "Standard"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 9
+          },
+          "end": {
+            "line": 0,
+            "column": 14
+          }
+        }
       },
-      "end": {
-        "line": 0,
-        "column": 14
+      {
+        "value": "d",
+        "negated": false,
+        "labels": [
+          "Literal",
+          "QuotesAsLiterals",
+          "Standard"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 15
+          },
+          "end": {
+            "line": 0,
+            "column": 16
+          }
+        }
       }
-    }
-  },
-  {
-    "value": "d",
-    "negated": false,
-    "labels": [
-      "Literal",
-      "QuotesAsLiterals",
-      "Standard"
-    ],
-    "range": {
-      "start": {
-        "line": 0,
-        "column": 15
-      },
-      "end": {
-        "line": 0,
-        "column": 16
-      }
-    }
+    ]
   }
 ]

--- a/internal/search/query/testdata/TestConcat/#13.golden
+++ b/internal/search/query/testdata/TestConcat/#13.golden
@@ -2,10 +2,9 @@
   {
     "and": [
       {
-        "value": "(((a b c)))",
+        "value": "a",
         "negated": false,
         "labels": [
-          "HeuristicParensAsPatterns",
           "Literal",
           "QuotesAsLiterals",
           "Standard"
@@ -13,11 +12,49 @@
         "range": {
           "start": {
             "line": 0,
-            "column": 0
+            "column": 3
           },
           "end": {
             "line": 0,
-            "column": 11
+            "column": 4
+          }
+        }
+      },
+      {
+        "value": "b",
+        "negated": false,
+        "labels": [
+          "Literal",
+          "QuotesAsLiterals",
+          "Standard"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 5
+          },
+          "end": {
+            "line": 0,
+            "column": 6
+          }
+        }
+      },
+      {
+        "value": "c",
+        "negated": false,
+        "labels": [
+          "Literal",
+          "QuotesAsLiterals",
+          "Standard"
+        ],
+        "range": {
+          "start": {
+            "line": 0,
+            "column": 7
+          },
+          "end": {
+            "line": 0,
+            "column": 8
           }
         }
       },

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -378,7 +378,7 @@ func space(patterns []Pattern) []Node {
 }
 
 // and concatenates patterns with AND.
-func and(patterns []Pattern) []Node {
+func and(patterns []Node) []Node {
 	p := make([]Node, 0, len(patterns))
 	for _, pattern := range patterns {
 		p = append(p, pattern)
@@ -428,6 +428,50 @@ func substituteConcat(callback func([]Pattern) []Node) func([]Node) []Node {
 							ps = []Pattern{}
 						}
 						newNode = append(newNode, substituteNodes([]Node{node})...)
+					}
+					if len(ps) > 0 {
+						newNode = append(newNode, callback(ps)...)
+					}
+				} else {
+					newNode = append(newNode, NewOperator(substituteNodes(v.Operands), v.Kind)...)
+				}
+			}
+		}
+		return newNode
+	}
+	return substituteNodes
+}
+
+// substituteConcatForKeyword returns a function that replaces concat with the
+// result of callback. Unlike substituteConcat, this function allows "OR" and
+// "AND" operators to be nested inside "CONCAT".
+func substituteConcatForKeyword(callback func([]Node) []Node) func([]Node) []Node {
+	isPattern := func(node Node) bool {
+		if pattern, ok := node.(Pattern); ok && !pattern.Negated {
+			return true
+		}
+		return false
+	}
+
+	// define a recursive function to close over callback and isPattern.
+	var substituteNodes func(nodes []Node) []Node
+	substituteNodes = func(nodes []Node) []Node {
+		var newNode []Node
+		for _, node := range nodes {
+			switch v := node.(type) {
+			case Parameter, Pattern:
+				newNode = append(newNode, node)
+			case Operator:
+				if v.Kind == Concat {
+					// Merge consecutive patterns.
+					var ps []Node
+					for _, node := range v.Operands {
+						if isPattern(node) {
+							ps = append(ps, node)
+							continue
+						} else {
+							ps = append(ps, substituteNodes([]Node{node})...)
+						}
 					}
 					if len(ps) > 0 {
 						newNode = append(newNode, callback(ps)...)

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -379,11 +379,7 @@ func space(patterns []Pattern) []Node {
 
 // and concatenates patterns with AND.
 func and(patterns []Node) []Node {
-	p := make([]Node, 0, len(patterns))
-	for _, pattern := range patterns {
-		p = append(p, pattern)
-	}
-	return NewOperator(p, And)
+	return NewOperator(patterns, And)
 }
 
 // substituteConcat returns a function that concatenates all contiguous patterns


### PR DESCRIPTION
We change the behavior of the parser for **keyword search** to support the
following:
- parse parenthesis as groups instead of as literals
- allow mixing of implicit and explicit boolean operators


|query | parser (before) | parser (now) |
|:-----|:-------|:-------|
(a b)| "(a b)" | (and a b) | 
(a or b) c | ERROR | (and (or a b) c)
func(a int)*| "func(a int)" | "func(a int)"

*To support searching for function signatures without escaping the query,
we heuristically parse parenthesis inside patterns as literals. 
We already supported this behavior with "standard" search.
However this heuristic causes **inconsistencies** which may or may not be acceptable, 
depending on how much we want to support queries such as "func(a int)" without quotation.

(foo bar)bas -> (and "foo" "bar" "bas")
foo(bar bas) -> "foo(bar bas)"

Note the lack of space before and after the parenthesis.

Test plan:
- Apart from a minor change to the parsing flags, the changes are a NOP for
the other pattern types
- I added a lot of unit tests for keyword search. The tests should give a
good overview of the new behavior.
