### PR TITLE
Uses Result over panics in scip evaluation

### DIFF
--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/evaluate.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/evaluate.rs
@@ -20,12 +20,10 @@ pub fn evaluate_command(
     candidate: PathBuf,
     ground_truth: PathBuf,
     evaluation_output_options: EvaluationOutputOptions,
-) {
+) -> Result<()> {
     Evaluator::default()
-        .evaluate_files(candidate, ground_truth)
-        .unwrap()
+        .evaluate_files(candidate, ground_truth)?
         .write_summary(&mut std::io::stdout(), evaluation_output_options)
-        .unwrap()
 }
 
 fn validate_index(idx: &Index) -> Result<()> {
@@ -419,8 +417,8 @@ impl Evaluator {
         ground_truth: PathBuf,
     ) -> Result<EvaluationResult<'e>> {
         self.evaluate_indexes(
-            &read_index_from_file(candidate),
-            &read_index_from_file(ground_truth),
+            &read_index_from_file(&candidate)?,
+            &read_index_from_file(&ground_truth)?,
         )
     }
 
@@ -429,8 +427,8 @@ impl Evaluator {
         candidate: &Index,
         ground_truth: &Index,
     ) -> Result<EvaluationResult<'e>> {
-        validate_index(candidate)?;
-        validate_index(ground_truth)?;
+        validate_index(candidate).context("When validating the candidate index")?;
+        validate_index(ground_truth).context("When validating the ground truth index")?;
 
         let bar = create_spinner();
         bar.set_message("Indexing candidate symbols by location");

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/io.rs
@@ -1,15 +1,19 @@
+use anyhow::{Context, Result};
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use protobuf::{CodedInputStream, Message};
 
-pub fn read_index_from_file(file: PathBuf) -> scip::types::Index {
+pub fn read_index_from_file(file: &PathBuf) -> Result<scip::types::Index> {
     let mut candidate_idx = scip::types::Index::new();
-    let candidate_f = File::open(file).unwrap();
+    let candidate_f = File::open(file).context(format!(
+        "when trying to read an index from {}",
+        file.display()
+    ))?;
 
     let mut reader = BufReader::new(candidate_f);
     let mut cis = CodedInputStream::from_buf_read(&mut reader);
 
-    candidate_idx.merge_from(&mut cis).unwrap();
+    candidate_idx.merge_from(&mut cis)?;
 
-    candidate_idx
+    Ok(candidate_idx)
 }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/src/main.rs
@@ -81,7 +81,7 @@ enum Commands {
     },
 }
 
-pub fn main() {
+pub fn main() -> anyhow::Result<()> {
     // Exits with a code zero if the environment variable SANITY_CHECK equals
     // to "true". This enables testing that the current program is in a runnable
     // state against the platform it's being executed on.
@@ -133,7 +133,7 @@ pub fn main() {
                     analysis_mode: mode,
                     fail_fast,
                 },
-            )
+            )?
         }
 
         Commands::ScipEvaluate {
@@ -154,6 +154,7 @@ pub fn main() {
                 print_false_negatives,
                 disable_colors,
             },
-        ),
+        )?,
     }
+    Ok(())
 }

--- a/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
+++ b/docker-images/syntax-highlighter/crates/scip-syntax/tests/integration_test.rs
@@ -68,7 +68,8 @@ fn java_e2e_evaluation() {
             analysis_mode: AnalysisMode::Full,
             fail_fast: true,
         },
-    );
+    )
+    .unwrap();
 
     let mut str = vec![];
 
@@ -100,7 +101,7 @@ fn java_e2e_indexing() {
 
     run_index(&out_dir, &setup, vec!["--language", "java"]);
 
-    let index = read_index_from_file(out_dir.join("index.scip"));
+    let index = read_index_from_file(&out_dir.join("index.scip")).unwrap();
 
     for doc in &index.documents {
         let path = &doc.relative_path;


### PR DESCRIPTION
`anyhow` allows us to use Result instead of panics in most places, and lets us attach more context to errors. This way we can eg. print file paths we failed to read, rather than just "Failed to read"

## Test plan

Code continues to compile