### PR TITLE
svelte: Escape repository name in repo search input

### DIFF
--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -71,6 +71,7 @@ export { shortcutDisplayName } from '@sourcegraph/shared/src/keyboardShortcuts'
 export { createCodeIntelAPI, type CodeIntelAPI } from '@sourcegraph/shared/src/codeintel/api'
 export { getModeFromPath } from '@sourcegraph/shared/src/languages'
 export type { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
+export { repositoryInsertText } from '@sourcegraph/shared/src/search/query/completion-utils'
 
 // Copies of non-reusable code
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/RepoSearchInput.svelte
@@ -6,6 +6,7 @@
     import { settings } from '$lib/stores'
     import { mdiMagnify } from '@mdi/js'
     import { tick } from 'svelte'
+    import { repositoryInsertText } from '$lib/shared'
 
     export let repoName: string
 
@@ -15,7 +16,7 @@
     } = createDialog()
 
     let searchInput: SearchInput | undefined
-    let queryState = queryStateStore({ query: `repo:${repoName} ` }, $settings)
+    let queryState = queryStateStore({ query: `repo:${repositoryInsertText({ repository: repoName })} ` }, $settings)
 
     $: if ($open) {
         // @melt-ui automatically focuses the search input but that positions the cursor at the

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/layout.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/layout.spec.ts
@@ -34,7 +34,7 @@ test.describe('cloned repository', () => {
 
     test('has search button', async ({ page }) => {
         await page.getByRole('button', { name: 'Search' }).click()
-        await expect(page.getByRole('textbox')).toHaveText('repo:github.com/sourcegraph/sourcegraph ')
+        await expect(page.getByRole('textbox')).toHaveText(String.raw`repo:^github\.com/sourcegraph/sourcegraph$ `)
     })
 })
 


### PR DESCRIPTION
This properly escapes the repository name when opening the search input on a repository name, so that it can be used as a `repo:` filter value.

![2024-02-05_15-41](https://github.com/sourcegraph/sourcegraph/assets/179026/49351b70-6644-46eb-9253-7468832a9a6e)


## Test plan

Manual testing, updated integration test