### PR TITLE
search: Don't show drop shadow for when autofocused

### DIFF
--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -98,13 +98,16 @@
     left: 0;
     right: 0;
     border-radius: 8px;
-    background-color: var(--color-bg-1);
 
     // Set a default paddings to the suggestion panel (see Suggestions.module.scss)
     --suggestions-padding: 0.75rem;
 
+    // Only apply the "container" style if the suggestions are open, as indicated
+    // by the "open" class. When autofocus is enabled we do not want the suggestions
+    // container to be visible.
     &.open {
         box-shadow: 0 10px 50px rgba(0, 0, 0, 0.15);
+        background-color: var(--color-bg-1);
 
         :global(.theme-dark) & {
             box-shadow: 0 10px 60px rgba(0, 0, 0, 0.8);

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.module.scss
@@ -99,13 +99,16 @@
     right: 0;
     border-radius: 8px;
     background-color: var(--color-bg-1);
-    box-shadow: 0 10px 50px rgba(0, 0, 0, 0.15);
 
     // Set a default paddings to the suggestion panel (see Suggestions.module.scss)
     --suggestions-padding: 0.75rem;
 
-    :global(.theme-dark) & {
-        box-shadow: 0 10px 60px rgba(0, 0, 0, 0.8);
+    &.open {
+        box-shadow: 0 10px 50px rgba(0, 0, 0, 0.15);
+
+        :global(.theme-dark) & {
+            box-shadow: 0 10px 60px rgba(0, 0, 0, 0.8);
+        }
     }
 }
 

--- a/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
+++ b/client/branded/src/search-ui/input/experimental/CodeMirrorQueryInputWrapper.tsx
@@ -327,7 +327,7 @@ export const CodeMirrorQueryInputWrapper = forwardRef<Editor, PropsWithChildren<
                     {!mode && children}
                 </div>
                 <div
-                    className={styles.suggestions}
+                    className={classNames(styles.suggestions, showSuggestions && styles.open)}
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{ paddingTop: height }}
                 >


### PR DESCRIPTION
@rrhyne mentioned to remove the dropshadow when the input is autofocused. Personally it feels weird to me that the shadow suddenly appears after user interaction.

![2024-02-05_15-53](https://github.com/sourcegraph/sourcegraph/assets/179026/30fd527c-aa0d-41c6-b032-41068c33a390)


https://github.com/sourcegraph/sourcegraph/assets/179026/b06a1026-8c45-46be-95b6-8808b754cd1c

## Update: Without background color change

![2024-02-05_16-10](https://github.com/sourcegraph/sourcegraph/assets/179026/8399eca1-7d7d-4c0b-90cd-5f612e025c4b)

https://github.com/sourcegraph/sourcegraph/assets/179026/cf1aa98d-5829-4d05-89b6-ec05c1e065a8




## Test plan

Manual testing