### PR TITLE
sg/msp: enable security audit logging for production projects

### DIFF
--- a/dev/managedservicesplatform/stacks/project/project.go
+++ b/dev/managedservicesplatform/stacks/project/project.go
@@ -127,6 +127,12 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 				for k, v := range input {
 					labels[sanitizeName(k)] = pointers.Ptr(v)
 				}
+
+				// For security purposes enable audit logging for production projects (external and internal)
+				if vars.Category == spec.EnvironmentCategoryExternal || vars.Category == spec.EnvironmentCategoryInternal {
+					labels["collect-security-audit-logs"] = pointers.Ptr("true")
+				}
+
 				return &labels
 			}(vars.Labels),
 


### PR DESCRIPTION
Adds the `collect-security-audit-logs` label to production projects 
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
- CI
- Locally checked label gets added to correct projects when running `sg msp gen`