### PR TITLE
licensing: Don't offer disabled deprecated plans

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -347,7 +347,7 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                                 <option value="" disabled={true}>
                                     Select a plan
                                 </option>
-                                {ALL_PLANS.filter(plan => !plan.deprecated).map(plan => (
+                                {ALL_PLANS.filter(plan => !plan.deprecated && !plan.stopIssuance).map(plan => (
                                     <option key={plan.label} value={plan.label}>
                                         {plan.name}
                                     </option>
@@ -355,8 +355,8 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                                 <option value="" disabled={true}>
                                     Deprecated plans
                                 </option>
-                                {ALL_PLANS.filter(plan => plan.deprecated).map(plan => (
-                                    <option key={plan.label} value={plan.label} disabled={plan.stopIssuance}>
+                                {ALL_PLANS.filter(plan => plan.deprecated && !plan.stopIssuance).map(plan => (
+                                    <option key={plan.label} value={plan.label}>
                                         {plan.name}
                                     </option>
                                 ))}


### PR DESCRIPTION
As pointed out by Aimee, this is just confusing and not adding any value. So we're hiding them, but keep them around for tag validity checks otherwise.

![Screenshot 2024-02-05 at 17 09 34@2x](https://github.com/sourcegraph/sourcegraph/assets/19534377/0ef247f7-3079-42ed-82e6-01472f8f2d7a)


## Test plan

Verified manually, see screenshot.