### PR TITLE
gitserver: perforce: refactor functions to use argument structs

### DIFF
--- a/cmd/gitserver/internal/p4exec.go
+++ b/cmd/gitserver/internal/p4exec.go
@@ -66,7 +66,7 @@ func (gs *grpcServer) P4Exec(req *proto.P4ExecRequest, ss proto.GitserverService
 	)
 
 	// Make sure credentials are valid before heavier operation
-	err = perforce.P4TestWithTrust(ss.Context(), gs.reposDir, p4home, req.GetP4Port(), req.GetP4User(), req.GetP4Passwd()) //nolint:staticcheck
+	err = perforce.P4TestWithTrust(ss.Context(), perforce.P4TestWithTrustArguments{ReposDir: gs.reposDir, P4Home: p4home, P4Port: req.GetP4Port(), P4User: req.GetP4User(), P4Passwd: req.GetP4Passwd()}) //nolint:staticcheck
 	if err != nil {
 		if ctxErr := ss.Context().Err(); ctxErr != nil {
 			return status.FromContextError(ctxErr).Err()

--- a/cmd/gitserver/internal/patch.go
+++ b/cmd/gitserver/internal/patch.go
@@ -449,7 +449,17 @@ func (s *Server) shelveChangelist(ctx context.Context, req protocol.CreateCommit
 	}
 
 	// check to see if there's a changelist for this target branch already
-	cl, err := perforce.GetChangelistByClient(ctx, p4home, p4port, p4user, p4passwd, tmpClientDir, p4client)
+	args := perforce.GetChangeListByClientArguments{
+		P4Home:   p4home,
+		P4Port:   p4port,
+		P4User:   p4user,
+		P4Passwd: p4passwd,
+
+		WorkDir: tmpClientDir,
+		Client:  p4client,
+	}
+
+	cl, err := perforce.GetChangelistByClient(ctx, args)
 	if err == nil && cl.ID != "" {
 		return cl.ID, nil
 	}

--- a/cmd/gitserver/internal/perforce/cloneable.go
+++ b/cmd/gitserver/internal/perforce/cloneable.go
@@ -7,9 +7,35 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-func IsDepotPathCloneable(ctx context.Context, reposDir, p4home, p4port, p4user, p4passwd, depotPath string) error {
+// IsDepotPathCloneableArguments are the arguments for IsDepotPathCloneable.
+type IsDepotPathCloneableArguments struct {
+	// ReposDir is the directory where the repositories are stored.
+	ReposDir string
+	// P4Home is the path to the directory that 'p4' will use as $HOME
+	// and where it will store cache data.
+	P4Home string
+
+	// P4PORT is the address of the Perforce server.
+	P4Port string
+	// P4User is the Perforce username to authenticate with.
+	P4User string
+	// P4Passwd is the Perforce password to authenticate with.
+	P4Passwd string
+
+	// DepotPath is the path to the depot to check.
+	DepotPath string
+}
+
+func IsDepotPathCloneable(ctx context.Context, args IsDepotPathCloneableArguments) error {
 	// start with a test and set up trust if necessary
-	if err := P4TestWithTrust(ctx, reposDir, p4home, p4port, p4user, p4passwd); err != nil {
+	if err := P4TestWithTrust(ctx, P4TestWithTrustArguments{
+		ReposDir: args.ReposDir,
+		P4Home:   args.P4Home,
+
+		P4Port:   args.P4Port,
+		P4User:   args.P4User,
+		P4Passwd: args.P4Passwd,
+	}); err != nil {
 		return errors.Wrap(err, "checking perforce credentials")
 	}
 
@@ -19,10 +45,20 @@ func IsDepotPathCloneable(ctx context.Context, reposDir, p4home, p4port, p4user,
 	// the first path part will be the depot - subsequent parts define a directory path into a depot
 	// ignore the directory parts for now, and only test for access to the depot
 	// TODO: revisit if we want to also test for access to the directories, if any are included
-	depot := strings.Split(strings.TrimLeft(depotPath, "/"), "/")[0]
+	depot := strings.Split(strings.TrimLeft(args.DepotPath, "/"), "/")[0]
 
 	// get a list of depots that match the supplied depot (if it's defined)
-	depots, err := P4Depots(ctx, reposDir, p4home, p4port, p4user, p4passwd, depot)
+	depots, err := P4Depots(ctx, P4DepotsArguments{
+		ReposDir: args.ReposDir,
+
+		P4Home: args.P4Home,
+		P4Port: args.P4Port,
+
+		P4User:   args.P4User,
+		P4Passwd: args.P4Passwd,
+
+		NameFilter: depot,
+	})
 	if err != nil {
 		return err
 	}
@@ -30,9 +66,9 @@ func IsDepotPathCloneable(ctx context.Context, reposDir, p4home, p4port, p4user,
 		// this user doesn't have access to any depots,
 		// or to the given depot
 		if depot != "" {
-			return errors.Newf("the user %s does not have access to the depot %s on the server %s", p4user, depot, p4port)
+			return errors.Newf("the user %s does not have access to the depot %s on the server %s", args.P4User, depot, args.P4Port)
 		} else {
-			return errors.Newf("the user %s does not have access to any depots on the server %s", p4user, p4port)
+			return errors.Newf("the user %s does not have access to any depots on the server %s", args.P4User, args.P4Port)
 		}
 	}
 

--- a/cmd/gitserver/internal/perforce/protects.go
+++ b/cmd/gitserver/internal/perforce/protects.go
@@ -4,32 +4,52 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/executil"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/gitserverfs"
 	"github.com/sourcegraph/sourcegraph/internal/byteutils"
 	p4types "github.com/sourcegraph/sourcegraph/internal/perforce"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
-	"os"
 )
 
+// P4ProtectsForUserArguments are the arguments for P4ProtectsForUser.
+type P4ProtectsForUserArguments struct {
+	// ReposDir is the directory where the repositories are stored.
+	ReposDir string
+	// P4Home is the path to the directory that 'p4' will use as $HOME
+	// and where it will store cache data.
+	P4Home string
+
+	// P4PORT is the address of the Perforce server.
+	P4Port string
+	// P4User is the Perforce username to authenticate with.
+	P4User string
+	// P4Passwd is the Perforce password to authenticate with.
+	P4Passwd string
+
+	// Username is the username for which to get the protect definition for
+	Username string
+}
+
 // P4ProtectsForUser returns all protect definitions that apply to the given username.
-func P4ProtectsForUser(ctx context.Context, reposDir, p4home, p4port, p4user, p4passwd, username string) ([]*p4types.Protect, error) {
+func P4ProtectsForUser(ctx context.Context, args P4ProtectsForUserArguments) ([]*p4types.Protect, error) {
 	options := []P4OptionFunc{
-		WithAuthentication(p4user, p4passwd),
-		WithHost(p4port),
+		WithAuthentication(args.P4User, args.P4Passwd),
+		WithHost(args.P4Port),
 	}
 
 	// -u User : Displays protection lines that apply to the named user. This option
 	// requires super access.
-	options = append(options, WithArguments("-Mj", "-ztag", "protects", "-u", username))
+	options = append(options, WithArguments("-Mj", "-ztag", "protects", "-u", args.Username))
 
-	scratchDir, err := gitserverfs.TempDir(reposDir, "p4-protects-")
+	scratchDir, err := gitserverfs.TempDir(args.ReposDir, "p4-protects-")
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create temp dir to invoke 'p4 protects'")
 	}
 	defer os.Remove(scratchDir)
 
-	cmd := NewBaseCommand(ctx, p4home, scratchDir, options...)
+	cmd := NewBaseCommand(ctx, args.P4Home, scratchDir, options...)
 	out, err := executil.RunCommandCombinedOutput(ctx, cmd)
 	if err != nil {
 		if ctxerr := ctx.Err(); ctxerr != nil {
@@ -51,24 +71,42 @@ func P4ProtectsForUser(ctx context.Context, reposDir, p4home, p4port, p4user, p4
 	return parseP4Protects(out)
 }
 
+type P4ProtectsForDepotArguments struct {
+	// ReposDir is the directory where the repositories are stored.
+	ReposDir string
+	// P4Home is the path to the directory that 'p4' will use as $HOME
+	// and where it will store cache data.
+	P4Home string
+
+	// P4PORT is the address of the Perforce server.
+	P4Port string
+	// P4User is the Perforce username to authenticate with.
+	P4User string
+	// P4Passwd is the Perforce password to authenticate with.
+	P4Passwd string
+
+	// Depot is the depot to get the protect definition for.
+	Depot string
+}
+
 // P4ProtectsForUser returns all protect definitions that apply to the given depot.
-func P4ProtectsForDepot(ctx context.Context, reposDir, p4home, p4port, p4user, p4passwd, depot string) ([]*p4types.Protect, error) {
+func P4ProtectsForDepot(ctx context.Context, args P4ProtectsForDepotArguments) ([]*p4types.Protect, error) {
 	options := []P4OptionFunc{
-		WithAuthentication(p4user, p4passwd),
-		WithHost(p4port),
+		WithAuthentication(args.P4User, args.P4Passwd),
+		WithHost(args.P4Port),
 	}
 
 	// -a : Displays protection lines for all users. This option requires super
 	// access.
-	options = append(options, WithArguments("-Mj", "-ztag", "protects", "-a", depot))
+	options = append(options, WithArguments("-Mj", "-ztag", "protects", "-a", args.Depot))
 
-	scratchDir, err := gitserverfs.TempDir(reposDir, "p4-protects-")
+	scratchDir, err := gitserverfs.TempDir(args.ReposDir, "p4-protects-")
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create temp dir to invoke 'p4 protects'")
 	}
 	defer os.Remove(scratchDir)
 
-	cmd := NewBaseCommand(ctx, p4home, scratchDir, options...)
+	cmd := NewBaseCommand(ctx, args.P4Home, scratchDir, options...)
 
 	out, err := executil.RunCommandCombinedOutput(ctx, cmd)
 	if err != nil {

--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -437,7 +437,16 @@ func (gs *grpcServer) IsPerforcePathCloneable(ctx context.Context, req *proto.Is
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.IsDepotPathCloneable(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.DepotPath)
+	err = perforce.IsDepotPathCloneable(ctx, perforce.IsDepotPathCloneableArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+
+		DepotPath: req.GetDepotPath(),
+	})
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
@@ -452,7 +461,14 @@ func (gs *grpcServer) CheckPerforceCredentials(ctx context.Context, req *proto.C
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, perforce.P4TestWithTrustArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -471,7 +487,14 @@ func (gs *grpcServer) PerforceUsers(ctx context.Context, req *proto.PerforceUser
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, perforce.P4TestWithTrustArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -487,7 +510,14 @@ func (gs *grpcServer) PerforceUsers(ctx context.Context, req *proto.PerforceUser
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	users, err := perforce.P4Users(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	users, err := perforce.P4Users(ctx, perforce.P4UsersArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+	})
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -510,7 +540,14 @@ func (gs *grpcServer) PerforceProtectsForUser(ctx context.Context, req *proto.Pe
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, perforce.P4TestWithTrustArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -526,7 +563,17 @@ func (gs *grpcServer) PerforceProtectsForUser(ctx context.Context, req *proto.Pe
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	protects, err := perforce.P4ProtectsForUser(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetUsername())
+	args := perforce.P4ProtectsForUserArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+
+		Username: req.GetUsername(),
+	}
+	protects, err := perforce.P4ProtectsForUser(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +595,14 @@ func (gs *grpcServer) PerforceProtectsForDepot(ctx context.Context, req *proto.P
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, perforce.P4TestWithTrustArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -564,7 +618,14 @@ func (gs *grpcServer) PerforceProtectsForDepot(ctx context.Context, req *proto.P
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	protects, err := perforce.P4ProtectsForDepot(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetDepot())
+	protects, err := perforce.P4ProtectsForDepot(ctx, perforce.P4ProtectsForDepotArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+		Depot:    req.GetDepot(),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +647,14 @@ func (gs *grpcServer) PerforceGroupMembers(ctx context.Context, req *proto.Perfo
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, perforce.P4TestWithTrustArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -602,7 +670,18 @@ func (gs *grpcServer) PerforceGroupMembers(ctx context.Context, req *proto.Perfo
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	members, err := perforce.P4GroupMembers(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetGroup())
+	args := perforce.P4GroupMembersArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+
+		Group: req.GetGroup(),
+	}
+
+	members, err := perforce.P4GroupMembers(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -619,7 +698,14 @@ func (gs *grpcServer) IsPerforceSuperUser(ctx context.Context, req *proto.IsPerf
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, perforce.P4TestWithTrustArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -628,7 +714,13 @@ func (gs *grpcServer) IsPerforceSuperUser(ctx context.Context, req *proto.IsPerf
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	err = perforce.P4UserIsSuperUser(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4UserIsSuperUser(ctx, perforce.P4UserIsSuperUserArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -651,7 +743,14 @@ func (gs *grpcServer) PerforceGetChangelist(ctx context.Context, req *proto.Perf
 	}
 
 	conn := req.GetConnectionDetails()
-	err = perforce.P4TestWithTrust(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd())
+	err = perforce.P4TestWithTrust(ctx, perforce.P4TestWithTrustArguments{
+		ReposDir: gs.reposDir,
+		P4Home:   p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+	})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, status.FromContextError(ctxErr).Err()
@@ -667,7 +766,17 @@ func (gs *grpcServer) PerforceGetChangelist(ctx context.Context, req *proto.Perf
 		log.String("p4port", conn.GetP4Port()),
 	)
 
-	changelist, err := perforce.GetChangelistByID(ctx, gs.reposDir, p4home, conn.GetP4Port(), conn.GetP4User(), conn.GetP4Passwd(), req.GetChangelistId())
+	changelist, err := perforce.GetChangelistByID(ctx, perforce.GetChangeListByIDArguments{
+		ReposDir: gs.reposDir,
+
+		P4Home: p4home,
+
+		P4Port:   conn.GetP4Port(),
+		P4User:   conn.GetP4User(),
+		P4Passwd: conn.GetP4Passwd(),
+
+		ChangelistID: req.GetChangelistId(),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gitserver/internal/vcssyncer/perforce.go
+++ b/cmd/gitserver/internal/vcssyncer/perforce.go
@@ -68,7 +68,16 @@ func (s *perforceDepotSyncer) IsCloneable(ctx context.Context, _ api.RepoName, r
 		return errors.Wrap(err, "invalid perforce remote URL")
 	}
 
-	return perforce.IsDepotPathCloneable(ctx, s.reposDir, s.P4Home, host, username, password, path)
+	return perforce.IsDepotPathCloneable(ctx, perforce.IsDepotPathCloneableArguments{
+		ReposDir: s.reposDir,
+		P4Home:   s.P4Home,
+
+		P4Port:   host,
+		P4User:   username,
+		P4Passwd: password,
+
+		DepotPath: path,
+	})
 }
 
 // Clone writes a Perforce depot into tmpPath, using a Perforce-to-git-conversion.
@@ -86,7 +95,14 @@ func (s *perforceDepotSyncer) Clone(ctx context.Context, repo api.RepoName, remo
 
 	// First, do a quick check if we can reach the Perforce server.
 	tryWrite(s.logger, progressWriter, "Checking Perforce server connection\n")
-	err = perforce.P4TestWithTrust(ctx, s.reposDir, s.P4Home, p4port, p4user, p4passwd)
+	err = perforce.P4TestWithTrust(ctx, perforce.P4TestWithTrustArguments{
+		ReposDir: s.reposDir,
+		P4Home:   s.P4Home,
+
+		P4Port:   p4port,
+		P4User:   p4user,
+		P4Passwd: p4passwd,
+	})
 	if err != nil {
 		return errors.Wrap(err, "verifying connection to perforce server")
 	}
@@ -184,7 +200,14 @@ func (s *perforceDepotSyncer) Fetch(ctx context.Context, remoteURL *vcs.URL, _ a
 	}
 
 	// First, do a quick check if we can reach the Perforce server.
-	err = perforce.P4TestWithTrust(ctx, s.reposDir, s.P4Home, p4port, p4user, p4passwd)
+	err = perforce.P4TestWithTrust(ctx, perforce.P4TestWithTrustArguments{
+		ReposDir: s.reposDir,
+		P4Home:   s.P4Home,
+
+		P4Port:   p4port,
+		P4User:   p4user,
+		P4Passwd: p4passwd,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "verifying connection to perforce server")
 	}


### PR DESCRIPTION
While reviewing my refactor of https://github.com/sourcegraph/sourcegraph/pull/59998 given https://github.com/sourcegraph/sourcegraph/pull/59998/files#diff-9c050a0ff56a8416d8dcf8c4fceb82883eb7cc5f2b1a30b288b93722f985f1ec, I found it quite difficult to review since each function had so many back to back `string` arguments with the addition of `reposDir`. It was hard to convince myself that I never made a typo.

Example: 

```go
func IsDepotPathCloneable(ctx context.Context, reposDir, p4home, p4port, p4user, p4passwd, depotPath string) error
```

This PR is a shot at trying to fix this by extracting all these string arguments into a separate arguments struct. Now, I can see at each call-site the names of each argument that I'm using. 

Example:

```go
// IsDepotPathCloneableArguments are the arguments for IsDepotPathCloneable.
type IsDepotPathCloneableArguments struct {
	// ReposDir is the directory where the repositories are stored.
	ReposDir string
	// P4Home is the path to the directory that 'p4' will use as $HOME
	// and where it will store cache data.
	P4Home string

	// P4PORT is the address of the Perforce server.
	P4Port string
	// P4User is the Perforce username to authenticate with.
	P4User string
	// P4Passwd is the Perforce password to authenticate with.
	P4Passwd string

	// DepotPath is the path to the depot to check.
	DepotPath string
}

// ...
func IsDepotPathCloneable(ctx context.Context, args IsDepotPathCloneableArguments) error { }

// ... (usage)

err = perforce.IsDepotPathCloneable(ctx, perforce.IsDepotPathCloneableArguments{
		ReposDir: gs.reposDir,
		P4Home:   p4home,

		P4Port:   conn.GetP4Port(),
		P4User:   conn.GetP4User(),
		P4Passwd: conn.GetP4Passwd(),

		DepotPath: req.GetDepotPath(),
	})



```

PTAL and LMK if you like this refactor?

## Test plan

CI