### PR TITLE
cody: Improve error messages for isCodyEnabled

### DIFF
--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -596,7 +596,10 @@ func (r *siteResolver) RequiresVerifiedEmailForCody(ctx context.Context) bool {
 	return !isAdmin
 }
 
-func (r *siteResolver) IsCodyEnabled(ctx context.Context) bool { return cody.IsCodyEnabled(ctx, r.db) }
+func (r *siteResolver) IsCodyEnabled(ctx context.Context) bool {
+	enabled, _ := cody.IsCodyEnabled(ctx, r.db)
+	return enabled
+}
 
 func (r *siteResolver) CodyLLMConfiguration(ctx context.Context) *codyLLMConfigurationResolver {
 	c := conf.GetCompletionsConfig(conf.Get().SiteConfig())

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -342,6 +342,8 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 
 	accessTokenDefaultExpirationDays, accessTokenExpirationDaysOptions := conf.AccessTokensExpirationOptions()
 
+	codyEnabled, _ := cody.IsCodyEnabled(ctx, db)
+
 	// 🚨 SECURITY: This struct is sent to all users regardless of whether or
 	// not they are logged in, for example on an auth.public=false private
 	// server. Including secret fields here is OK if it is based on the user's
@@ -401,7 +403,7 @@ func NewJSContextFromRequest(req *http.Request, db database.DB) JSContext {
 		BatchChangesWebhookLogsEnabled:     webhooks.LoggingEnabled(conf.Get()),
 
 		CodyEnabled:               conf.CodyEnabled(),
-		CodyEnabledForCurrentUser: cody.IsCodyEnabled(ctx, db),
+		CodyEnabledForCurrentUser: codyEnabled,
 		CodyRequiresVerifiedEmail: siteResolver.RequiresVerifiedEmailForCody(ctx),
 
 		ExecutorsEnabled:                               conf.ExecutorsEnabled(),

--- a/cmd/frontend/internal/completions/resolvers/resolver.go
+++ b/cmd/frontend/internal/completions/resolvers/resolver.go
@@ -33,8 +33,8 @@ func NewCompletionsResolver(db database.DB, logger log.Logger) graphqlbackend.Co
 }
 
 func (c *completionsResolver) Completions(ctx context.Context, args graphqlbackend.CompletionsArgs) (_ string, err error) {
-	if isEnabled := cody.IsCodyEnabled(ctx, c.db); !isEnabled {
-		return "", errors.New("cody is not enabled for current user")
+	if isEnabled, reason := cody.IsCodyEnabled(ctx, c.db); !isEnabled {
+		return "", errors.Newf("cody is not enabled: %s", reason)
 	}
 
 	if err := cody.CheckVerifiedEmailRequirement(ctx, c.db, c.logger); err != nil {

--- a/cmd/frontend/internal/embeddings/resolvers/resolvers.go
+++ b/cmd/frontend/internal/embeddings/resolvers/resolvers.go
@@ -64,8 +64,8 @@ func (r *Resolver) EmbeddingsMultiSearch(ctx context.Context, args graphqlbacken
 		return nil, errors.New("embeddings are not configured or disabled")
 	}
 
-	if isEnabled := cody.IsCodyEnabled(ctx, r.db); !isEnabled {
-		return nil, errors.New("cody experimental feature flag is not enabled for current user")
+	if isEnabled, reason := cody.IsCodyEnabled(ctx, r.db); !isEnabled {
+		return nil, errors.Newf("cody is not enabled: %s", reason)
 	}
 
 	if err := cody.CheckVerifiedEmailRequirement(ctx, r.db, r.logger); err != nil {
@@ -110,8 +110,8 @@ func (r *Resolver) EmbeddingsMultiSearch(ctx context.Context, args graphqlbacken
 }
 
 func (r *Resolver) IsContextRequiredForChatQuery(ctx context.Context, args graphqlbackend.IsContextRequiredForChatQueryInputArgs) (bool, error) {
-	if isEnabled := cody.IsCodyEnabled(ctx, r.db); !isEnabled {
-		return false, errors.New("cody experimental feature flag is not enabled for current user")
+	if isEnabled, reason := cody.IsCodyEnabled(ctx, r.db); !isEnabled {
+		return false, errors.Newf("cody is not enabled: %s", reason)
 	}
 
 	if err := cody.CheckVerifiedEmailRequirement(ctx, r.db, r.logger); err != nil {

--- a/internal/cody/BUILD.bazel
+++ b/internal/cody/BUILD.bazel
@@ -50,5 +50,6 @@ go_test(
         "//internal/types",
         "//schema",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/codycontext/context.go
+++ b/internal/codycontext/context.go
@@ -114,8 +114,8 @@ func (c *CodyContextClient) GetCodyContext(ctx context.Context, args GetContextA
 	ctx, _, endObservation := c.getCodyContextOp.With(ctx, &err, observation.Args{Attrs: args.Attrs()})
 	defer endObservation(1, observation.Args{})
 
-	if isEnabled := cody.IsCodyEnabled(ctx, c.db); !isEnabled {
-		return nil, errors.New("cody is not enabled for current user")
+	if isEnabled, reason := cody.IsCodyEnabled(ctx, c.db); !isEnabled {
+		return nil, errors.Newf("cody is not enabled: %s", reason)
 	}
 
 	if err := cody.CheckVerifiedEmailRequirement(ctx, c.db, c.obsCtx.Logger); err != nil {

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -69,8 +69,8 @@ func newCompletionsHandler(
 		ctx, cancel := context.WithTimeout(r.Context(), maxRequestDuration)
 		defer cancel()
 
-		if isEnabled := cody.IsCodyEnabled(ctx, db); !isEnabled {
-			http.Error(w, "cody experimental feature flag is not enabled for current user", http.StatusUnauthorized)
+		if isEnabled, reason := cody.IsCodyEnabled(ctx, db); !isEnabled {
+			http.Error(w, fmt.Sprintf("cody is not enabled: %s", reason), http.StatusUnauthorized)
 			return
 		}
 


### PR DESCRIPTION
These messages still referred to an "experimental" feature state, which is no longer true!

So this PR does just a minimal change, it adds some more flavor to the error message and gets rid of the "experimental" wording.

## Test plan

Adjusted existing and wrote new tests.
