### PR TITLE
Keyword search: add 'beta' labels and fix URL parsing

### DIFF
--- a/client/web/src/search/index.ts
+++ b/client/web/src/search/index.ts
@@ -115,7 +115,7 @@ export function parseSearchURL(
     let query = queryInput
     const { queryInput: newQuery, patternTypeInput: patternType } = literalSearchCompatibility({
         queryInput,
-        patternTypeInput: patternTypeInput || SearchPatternType.standard,
+        patternTypeInput,
     })
     query = newQuery
 
@@ -168,11 +168,11 @@ export function quoteIfNeeded(string: string): string {
 
 interface QueryCompatibility {
     queryInput: string
-    patternTypeInput: SearchPatternType
+    patternTypeInput?: SearchPatternType
 }
 
 export function literalSearchCompatibility({ queryInput, patternTypeInput }: QueryCompatibility): QueryCompatibility {
-    if (patternTypeInput !== SearchPatternType.literal) {
+    if (patternTypeInput === undefined || patternTypeInput !== SearchPatternType.literal) {
         return { queryInput, patternTypeInput }
     }
     const tokens = scanSearchQuery(queryInput, false, SearchPatternType.standard)

--- a/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/components/search-results-info-bar/SearchResultsInfoBar.tsx
@@ -23,6 +23,7 @@ import {
     PopoverContent,
     PopoverTrigger,
     Position,
+    ProductStatusBadge,
     Text,
     useSessionStorage,
 } from '@sourcegraph/wildcard'
@@ -312,7 +313,10 @@ export const SearchResultsInfoBar: FC<SearchResultsInfoBarProps> = props => {
                                 targetPadding={KEYWORD_SEARCH_POPOVER_PADDING}
                             >
                                 <div>
-                                    <H3>About keyword search</H3>
+                                    <H3>
+                                        About keyword search
+                                        <ProductStatusBadge status="beta" className="ml-2" />
+                                    </H3>
                                     <Text>
                                         The new search behavior ANDs terms together instead of searching literally by
                                         default. To search literally, wrap the query in quotes.

--- a/client/web/src/stores/navbarSearchQueryState.test.ts
+++ b/client/web/src/stores/navbarSearchQueryState.test.ts
@@ -88,6 +88,13 @@ describe('navbar query state', () => {
 
             expect(useNavbarQueryState.getState().searchCaseSensitivity).toBe(false)
         })
+
+        it('should not default to "standard" if patterntype is missing', () => {
+            useNavbarQueryState.setState({ searchPatternType: SearchPatternType.keyword })
+            setQueryStateFromURL(parseSearchURL('q=hello'))
+
+            expect(useNavbarQueryState.getState().searchPatternType).toBe(SearchPatternType.keyword)
+        })
     })
 
     describe('state initialization precedence', () => {

--- a/client/web/src/storm/pages/SearchPage/KeywordSearchCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/KeywordSearchCtaSection.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
-import { Code, H2, Icon, Link, Text } from '@sourcegraph/wildcard'
+import { Code, H2, Icon, Link, ProductStatusBadge, Text } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../../../components/MarketingBlock'
 
@@ -19,7 +19,7 @@ interface KeywordSearchCtaSection {
 
 export const KeywordSearchCtaSection: React.FC<KeywordSearchCtaSection> = ({ className }) => {
     const keywordSearchEnabled = useExperimentalFeatures(features => features.keywordSearch)
-    const [isDismissed = true, setIsDismissed] = useTemporarySetting('search.homepage.keywordCta.dismissed', false)
+    const [isDismissed = true, setIsDismissed] = useTemporarySetting('search.homepage.keywordCta.dismissed', true)
     if (!keywordSearchEnabled || isDismissed) {
         return null
     }
@@ -30,7 +30,10 @@ export const KeywordSearchCtaSection: React.FC<KeywordSearchCtaSection> = ({ cla
             contentClassName={classNames('flex-grow-1 d-flex justify-content-between p-4', styles.card)}
         >
             <div>
-                <H2>New keyword search</H2>
+                <H2>
+                    New keyword search
+                    <ProductStatusBadge status="beta" className="ml-2" />
+                </H2>
                 <div className="d-flex d-flex-column">
                     <div>
                         <KeywordSearchStarsIcon aria-hidden={true} />

--- a/client/web/src/storm/pages/SearchPage/KeywordSearchCtaSection.tsx
+++ b/client/web/src/storm/pages/SearchPage/KeywordSearchCtaSection.tsx
@@ -19,7 +19,7 @@ interface KeywordSearchCtaSection {
 
 export const KeywordSearchCtaSection: React.FC<KeywordSearchCtaSection> = ({ className }) => {
     const keywordSearchEnabled = useExperimentalFeatures(features => features.keywordSearch)
-    const [isDismissed = true, setIsDismissed] = useTemporarySetting('search.homepage.keywordCta.dismissed', true)
+    const [isDismissed = true, setIsDismissed] = useTemporarySetting('search.homepage.keywordCta.dismissed', false)
     if (!keywordSearchEnabled || isDismissed) {
         return null
     }


### PR DESCRIPTION
This PR adds 'Beta' labels to the keyword search banner and popover, as we've
decided to ship the feature as 'beta'.

It also sneaks in a bug fix: before, if the URL did not contain a `patterntype`
parameter, we always defaulted to `standard`. Now, we use the correct default
based on the settings. This is important because users often configure a custom
search engine to search Sourcegraph (so for example they can type
`sg "some query"` in the chrome search bar). Now, these searches use `keyword`
search when the feature is enabled, whereas before they always used `standard`.

## Test plan

Added new unit test for bug fix
