### PR TITLE
v2 telemetry: add v2 telemetry to src/auth

### DIFF
--- a/client/web/src/auth/CloudSignUpPage.story.tsx
+++ b/client/web/src/auth/CloudSignUpPage.story.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 import sinon from 'sinon'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../components/WebStory'
@@ -58,6 +59,7 @@ export const Default: StoryFn = () => (
                 context={context}
                 showEmailForm={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 isSourcegraphDotCom={true}
             />
         )}
@@ -74,6 +76,7 @@ export const EmailForm: StoryFn = () => (
                 context={context}
                 showEmailForm={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 isSourcegraphDotCom={true}
             />
         )}
@@ -90,6 +93,7 @@ export const InvalidSource: StoryFn = () => (
                 context={context}
                 showEmailForm={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 isSourcegraphDotCom={true}
             />
         )}
@@ -106,6 +110,7 @@ export const OptimizationSignup: StoryFn = () => (
                 context={context}
                 showEmailForm={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 isSourcegraphDotCom={true}
             />
         )}

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -6,6 +6,7 @@ import { useLocation } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { UserAvatar } from '@sourcegraph/shared/src/components/UserAvatar'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, Icon, H2 } from '@sourcegraph/wildcard'
 
@@ -13,7 +14,7 @@ import { BrandLogo } from '../components/branding/BrandLogo'
 import type { UserAreaUserProfileResult, UserAreaUserProfileVariables } from '../graphql-operations'
 import type { AuthProvider, SourcegraphContext } from '../jscontext'
 import { USER_AREA_USER_PROFILE } from '../user/area/UserArea'
-import { EventName } from '../util/constants'
+import { EventName, V2AuthProviderTypes } from '../util/constants'
 
 import { ExternalsAuth } from './components/ExternalsAuth'
 import { FeatureList } from './components/FeatureList'
@@ -21,7 +22,7 @@ import { type SignUpArguments, SignUpForm } from './SignUpForm'
 
 import styles from './CloudSignUpPage.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     source: string | null
     showEmailForm: boolean
     /** Called to perform the signup on the server. */
@@ -56,6 +57,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     onSignUp,
     context,
     telemetryService,
+    telemetryRecorder,
     isSourcegraphDotCom,
 }) => {
     const location = useLocation()
@@ -82,6 +84,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     const logEventAndSetFlags = (type: AuthProvider['serviceType']): void => {
         const eventType = type === 'builtin' ? 'form' : type
         telemetryService.log(EventName.AUTH_INITIATED, { type: eventType }, { type: eventType })
+        telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes[type] })
     }
 
     const signUpForm = (
@@ -98,6 +101,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
             buttonLabel="Sign up"
             experimental={true}
             className="my-3"
+            telemetryRecorder={telemetryRecorder}
         />
     )
 

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -12,9 +12,8 @@ import { Link, Icon, H2 } from '@sourcegraph/wildcard'
 
 import { BrandLogo } from '../components/branding/BrandLogo'
 import type { UserAreaUserProfileResult, UserAreaUserProfileVariables } from '../graphql-operations'
-import type { AuthProvider, SourcegraphContext } from '../jscontext'
+import type { SourcegraphContext } from '../jscontext'
 import { USER_AREA_USER_PROFILE } from '../user/area/UserArea'
-import { EventName, V2AuthProviderTypes } from '../util/constants'
 
 import { ExternalsAuth } from './components/ExternalsAuth'
 import { FeatureList } from './components/FeatureList'

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -81,18 +81,9 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     })
     const invitedByUser = data?.user
 
-    const logEventAndSetFlags = (type: AuthProvider['serviceType']): void => {
-        const eventType = type === 'builtin' ? 'form' : type
-        telemetryService.log(EventName.AUTH_INITIATED, { type: eventType }, { type: eventType })
-        telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes[type] } })
-    }
-
     const signUpForm = (
         <SignUpForm
-            onSignUp={args => {
-                logEventAndSetFlags('builtin')
-                return onSignUp(args)
-            }}
+            onSignUp={args => onSignUp(args)}
             context={{
                 authProviders: [],
                 authMinPasswordLength: context.authMinPasswordLength,
@@ -108,11 +99,14 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     const renderCodeHostAuth = (): JSX.Element => (
         <>
             <ExternalsAuth
+                page="cloud-signup-page"
                 context={context}
                 githubLabel="Continue with GitHub"
                 gitlabLabel="Continue with GitLab"
                 googleLabel="Continue with Google"
-                onClick={logEventAndSetFlags}
+                onClick={() => {}}
+                telemetryRecorder={telemetryRecorder}
+                telemetryService={telemetryService}
             />
         </>
     )

--- a/client/web/src/auth/CloudSignUpPage.tsx
+++ b/client/web/src/auth/CloudSignUpPage.tsx
@@ -84,7 +84,7 @@ export const CloudSignUpPage: React.FunctionComponent<React.PropsWithChildren<Pr
     const logEventAndSetFlags = (type: AuthProvider['serviceType']): void => {
         const eventType = type === 'builtin' ? 'form' : type
         telemetryService.log(EventName.AUTH_INITIATED, { type: eventType }, { type: eventType })
-        telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes[type] })
+        telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes[type] } })
     }
 
     const signUpForm = (

--- a/client/web/src/auth/RequestAccessPage.story.tsx
+++ b/client/web/src/auth/RequestAccessPage.story.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import { WebStory } from '../components/WebStory'
 
 import { RequestAccessPage } from './RequestAccessPage'
@@ -13,8 +15,12 @@ const config: Meta = {
 
 export default config
 
-export const Default: StoryFn = () => <WebStory>{() => <RequestAccessPage />}</WebStory>
+export const Default: StoryFn = () => (
+    <WebStory>{() => <RequestAccessPage telemetryRecorder={noOpTelemetryRecorder} />}</WebStory>
+)
 
 export const Done: StoryFn = () => (
-    <WebStory initialEntries={[{ pathname: '/done' }]}>{() => <RequestAccessPage />}</WebStory>
+    <WebStory initialEntries={[{ pathname: '/done' }]}>
+        {() => <RequestAccessPage telemetryRecorder={noOpTelemetryRecorder} />}
+    </WebStory>
 )

--- a/client/web/src/auth/RequestAccessPage.test.tsx
+++ b/client/web/src/auth/RequestAccessPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent } from '@testing-library/react'
 import { Route, Routes } from 'react-router-dom'
 import { afterEach, describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import type { SourcegraphContext } from '../jscontext'
@@ -32,7 +33,7 @@ function renderPage({
     } as any
     return renderWithBrandedContext(
         <Routes>
-            <Route path="/request-access/*" element={<RequestAccessPage />} />
+            <Route path="/request-access/*" element={<RequestAccessPage telemetryRecorder={noOpTelemetryRecorder} />} />
             <Route path="/sign-in" element={<div>Sign in</div>} />
         </Routes>,
         { route }

--- a/client/web/src/auth/RequestAccessPage.tsx
+++ b/client/web/src/auth/RequestAccessPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Text, Link, ErrorAlert, Form, Input, TextArea, Container, Alert } from '@sourcegraph/wildcard'
 
 import { LoaderButton } from '../components/LoaderButton'
@@ -116,11 +117,16 @@ const RequestAccessForm: React.FunctionComponent<RequestAccessFormProps> = ({ on
     )
 }
 
+export interface RequestAccessPageProps extends TelemetryV2Props {}
+
 /**
  * The request access page component.
  */
-export const RequestAccessPage: React.FunctionComponent = () => {
-    useEffect(() => eventLogger.logPageView('RequestAccessPage'), [])
+export const RequestAccessPage: React.FunctionComponent<RequestAccessPageProps> = ({ telemetryRecorder }) => {
+    useEffect(() => {
+        eventLogger.logPageView('RequestAccessPage')
+        telemetryRecorder.recordEvent('auth.request-access-page', 'view')
+    }, [telemetryRecorder])
     const location = useLocation()
     const navigate = useNavigate()
     const [error, setError] = useState<Error | null>(null)

--- a/client/web/src/auth/RequestAccessPage.tsx
+++ b/client/web/src/auth/RequestAccessPage.tsx
@@ -125,7 +125,7 @@ export interface RequestAccessPageProps extends TelemetryV2Props {}
 export const RequestAccessPage: React.FunctionComponent<RequestAccessPageProps> = ({ telemetryRecorder }) => {
     useEffect(() => {
         eventLogger.logPageView('RequestAccessPage')
-        telemetryRecorder.recordEvent('auth.request-access-page', 'view')
+        telemetryRecorder.recordEvent('auth.requestAccess', 'view')
     }, [telemetryRecorder])
     const location = useLocation()
     const navigate = useNavigate()

--- a/client/web/src/auth/ResetPasswordPage.story.tsx
+++ b/client/web/src/auth/ResetPasswordPage.story.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import type { AuthenticatedUser } from '../auth'
 import { WebStory } from '../components/WebStory'
 
@@ -20,6 +22,7 @@ export const Default: StoryFn = () => (
             <ResetPasswordPage
                 context={{ xhrHeaders: {}, resetPasswordEnabled: true, sourcegraphDotComMode: false }}
                 authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -31,6 +34,7 @@ export const WithCode: StoryFn = () => (
             <ResetPasswordPage
                 context={{ xhrHeaders: {}, resetPasswordEnabled: true, sourcegraphDotComMode: false }}
                 authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -42,6 +46,7 @@ export const LoggedInUser: StoryFn = () => (
             <ResetPasswordPage
                 context={{ xhrHeaders: {}, resetPasswordEnabled: true, sourcegraphDotComMode: false }}
                 authenticatedUser={{ id: 'user' } as AuthenticatedUser}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -53,6 +58,7 @@ export const Disabled: StoryFn = () => (
             <ResetPasswordPage
                 context={{ xhrHeaders: {}, resetPasswordEnabled: false, sourcegraphDotComMode: false }}
                 authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -64,6 +70,7 @@ export const Dotcom: StoryFn = () => (
             <ResetPasswordPage
                 context={{ xhrHeaders: {}, resetPasswordEnabled: true, sourcegraphDotComMode: true }}
                 authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>

--- a/client/web/src/auth/ResetPasswordPage.tsx
+++ b/client/web/src/auth/ResetPasswordPage.tsx
@@ -32,7 +32,7 @@ interface ResetPasswordInitFormState {
  * A form where the user can initiate the reset-password flow. This is the 1st step in the
  * reset-password flow; ResetPasswordCodePage is the 2nd step.
  */
-class ResetPasswordInitForm extends React.PureComponent<{}, ResetPasswordInitFormState> {
+class ResetPasswordInitForm extends React.PureComponent<TelemetryV2Props, ResetPasswordInitFormState> {
     public state: ResetPasswordInitFormState = {
         email: '',
         submitOrError: undefined,
@@ -96,6 +96,7 @@ class ResetPasswordInitForm extends React.PureComponent<{}, ResetPasswordInitFor
     private handleSubmitResetPasswordInit = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
         this.setState({ submitOrError: 'loading' })
+        this.props.telemetryRecorder.recordEvent('auth.reset-password.init', 'submit')
         fetch('/-/reset-password-init', {
             credentials: 'same-origin',
             method: 'POST',
@@ -195,7 +196,7 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
 
     private handleSubmitResetPassword = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
-        this.props.telemetryRecorder.recordEvent('auth.reset-password', 'submitted')
+        this.props.telemetryRecorder.recordEvent('auth.reset-password', 'submit')
         this.setState({ submitOrError: 'loading' })
         fetch('/-/reset-password-code', {
             credentials: 'same-origin',
@@ -266,7 +267,7 @@ export const ResetPasswordPage: React.FunctionComponent<ResetPasswordPageProps> 
                 body = <Alert variant="danger">The password reset link you followed is invalid.</Alert>
             }
         } else {
-            body = <ResetPasswordInitForm />
+            body = <ResetPasswordInitForm telemetryRecorder={props.telemetryRecorder} />
         }
     } else {
         body = (

--- a/client/web/src/auth/ResetPasswordPage.tsx
+++ b/client/web/src/auth/ResetPasswordPage.tsx
@@ -259,6 +259,7 @@ export const ResetPasswordPage: React.FunctionComponent<ResetPasswordPageProps> 
                         userID={userID}
                         email={email}
                         emailVerifyCode={emailVerifyCode}
+                        telemetryRecorder={props.telemetryRecorder}
                     />
                 )
             } else {

--- a/client/web/src/auth/ResetPasswordPage.tsx
+++ b/client/web/src/auth/ResetPasswordPage.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { asError, type ErrorLike, isErrorLike, logger } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, Link, LoadingSpinner, Alert, Text, Input, ErrorAlert, Form, Container } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../auth'
@@ -125,7 +126,7 @@ class ResetPasswordInitForm extends React.PureComponent<{}, ResetPasswordInitFor
     }
 }
 
-interface ResetPasswordCodeFormProps {
+interface ResetPasswordCodeFormProps extends TelemetryV2Props {
     userID: number
     code: string
     email: string | null
@@ -194,6 +195,7 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
 
     private handleSubmitResetPassword = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
+        this.props.telemetryRecorder.recordEvent('auth.reset-password', 'submitted')
         this.setState({ submitOrError: 'loading' })
         fetch('/-/reset-password-code', {
             credentials: 'same-origin',
@@ -223,7 +225,7 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
     }
 }
 
-interface ResetPasswordPageProps {
+interface ResetPasswordPageProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     context: Pick<SourcegraphContext, 'xhrHeaders' | 'sourcegraphDotComMode' | 'resetPasswordEnabled'>
 }
@@ -237,7 +239,8 @@ export const ResetPasswordPage: React.FunctionComponent<ResetPasswordPageProps> 
 
     React.useEffect(() => {
         eventLogger.logViewEvent('ResetPassword', false)
-    }, [])
+        props.telemetryRecorder.recordEvent('auth.reset-password', 'view')
+    }, [props.telemetryRecorder])
 
     let body: JSX.Element
     if (props.authenticatedUser) {

--- a/client/web/src/auth/ResetPasswordPage.tsx
+++ b/client/web/src/auth/ResetPasswordPage.tsx
@@ -96,7 +96,7 @@ class ResetPasswordInitForm extends React.PureComponent<TelemetryV2Props, ResetP
     private handleSubmitResetPasswordInit = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
         this.setState({ submitOrError: 'loading' })
-        this.props.telemetryRecorder.recordEvent('auth.reset-password.init', 'submit')
+        this.props.telemetryRecorder.recordEvent('auth.resetPassword.init', 'submit')
         fetch('/-/reset-password-init', {
             credentials: 'same-origin',
             method: 'POST',
@@ -196,7 +196,7 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
 
     private handleSubmitResetPassword = (event: React.FormEvent<HTMLFormElement>): void => {
         event.preventDefault()
-        this.props.telemetryRecorder.recordEvent('auth.reset-password', 'submit')
+        this.props.telemetryRecorder.recordEvent('auth.resetPassword', 'submit')
         this.setState({ submitOrError: 'loading' })
         fetch('/-/reset-password-code', {
             credentials: 'same-origin',
@@ -240,7 +240,7 @@ export const ResetPasswordPage: React.FunctionComponent<ResetPasswordPageProps> 
 
     React.useEffect(() => {
         eventLogger.logViewEvent('ResetPassword', false)
-        props.telemetryRecorder.recordEvent('auth.reset-password', 'view')
+        props.telemetryRecorder.recordEvent('auth.resetPassword', 'view')
     }, [props.telemetryRecorder])
 
     let body: JSX.Element

--- a/client/web/src/auth/SignInPage.story.tsx
+++ b/client/web/src/auth/SignInPage.story.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import { WebStory } from '../components/WebStory'
 import type { SourcegraphContext } from '../jscontext'
 
@@ -55,39 +57,81 @@ const context: SignInPageProps['context'] = {
 }
 
 export const Default: StoryFn = () => (
-    <WebStory>{() => <SignInPage context={context} authenticatedUser={null} />}</WebStory>
+    <WebStory>
+        {() => <SignInPage context={context} authenticatedUser={null} telemetryRecorder={noOpTelemetryRecorder} />}
+    </WebStory>
 )
 
 export const ShowMore: StoryFn = () => (
     <WebStory initialEntries={[{ pathname: '/sign-in', search: '?showMore' }]}>
-        {() => <SignInPage context={{ ...context, primaryLoginProvidersCount: 1 }} authenticatedUser={null} />}
+        {() => (
+            <SignInPage
+                context={{ ...context, primaryLoginProvidersCount: 1 }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
 export const Dotcom: StoryFn = () => (
     <WebStory>
-        {() => <SignInPage context={{ ...context, sourcegraphDotComMode: true }} authenticatedUser={null} />}
+        {() => (
+            <SignInPage
+                context={{ ...context, sourcegraphDotComMode: true }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
 export const NoProviders: StoryFn = () => (
-    <WebStory>{() => <SignInPage context={{ ...context, authProviders: [] }} authenticatedUser={null} />}</WebStory>
+    <WebStory>
+        {() => (
+            <SignInPage
+                context={{ ...context, authProviders: [] }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
+    </WebStory>
 )
 
 export const NoBuiltIn: StoryFn = () => (
     <WebStory>
-        {() => <SignInPage context={{ ...context, authProviders: noBuiltInAuthProviders }} authenticatedUser={null} />}
+        {() => (
+            <SignInPage
+                context={{ ...context, authProviders: noBuiltInAuthProviders }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
 export const NoResetPassword: StoryFn = () => (
     <WebStory>
-        {() => <SignInPage context={{ ...context, resetPasswordEnabled: false }} authenticatedUser={null} />}
+        {() => (
+            <SignInPage
+                context={{ ...context, resetPasswordEnabled: false }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
 export const NoSignUp: StoryFn = () => (
-    <WebStory>{() => <SignInPage context={{ ...context, allowSignup: false }} authenticatedUser={null} />}</WebStory>
+    <WebStory>
+        {() => (
+            <SignInPage
+                context={{ ...context, allowSignup: false }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
+    </WebStory>
 )
 
 export const NoAccessRequest: StoryFn = () => (
@@ -96,6 +140,7 @@ export const NoAccessRequest: StoryFn = () => (
             <SignInPage
                 context={{ ...context, allowSignup: false, authAccessRequest: { enabled: false } }}
                 authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -103,13 +148,25 @@ export const NoAccessRequest: StoryFn = () => (
 
 export const DotComSignUp: StoryFn = () => (
     <WebStory>
-        {() => <SignInPage context={{ ...context, sourcegraphDotComMode: true }} authenticatedUser={null} />}
+        {() => (
+            <SignInPage
+                context={{ ...context, sourcegraphDotComMode: true }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
 export const OnlyOnePrimaryProvider: StoryFn = () => (
     <WebStory>
-        {() => <SignInPage context={{ ...context, primaryLoginProvidersCount: 1 }} authenticatedUser={null} />}
+        {() => (
+            <SignInPage
+                context={{ ...context, primaryLoginProvidersCount: 1 }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
@@ -119,6 +176,7 @@ export const OnlyOnePrimaryProviderWithoutBuiltIn: StoryFn = () => (
             <SignInPage
                 context={{ ...context, primaryLoginProvidersCount: 1, authProviders: noBuiltInAuthProviders }}
                 authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -126,7 +184,13 @@ export const OnlyOnePrimaryProviderWithoutBuiltIn: StoryFn = () => (
 
 export const ShowMoreProviders: StoryFn = () => (
     <WebStory initialEntries={['/sign-in?showMore']}>
-        {() => <SignInPage context={{ ...context, primaryLoginProvidersCount: 1 }} authenticatedUser={null} />}
+        {() => (
+            <SignInPage
+                context={{ ...context, primaryLoginProvidersCount: 1 }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
@@ -136,6 +200,7 @@ export const ShowMoreProvidersWithoutBuiltIn: StoryFn = () => (
             <SignInPage
                 context={{ ...context, authProviders: noBuiltInAuthProviders, primaryLoginProvidersCount: 1 }}
                 authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -143,7 +208,13 @@ export const ShowMoreProvidersWithoutBuiltIn: StoryFn = () => (
 
 export const OnlyBuiltInAuthProvider: StoryFn = () => (
     <WebStory>
-        {() => <SignInPage context={{ ...context, authProviders: onlyBuiltInAuthProvider }} authenticatedUser={null} />}
+        {() => (
+            <SignInPage
+                context={{ ...context, authProviders: onlyBuiltInAuthProvider }}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
@@ -152,7 +223,13 @@ export const PrefixCanBeChanged: StoryFn = () => {
 
     return (
         <WebStory>
-            {() => <SignInPage context={{ ...context, authProviders: providers }} authenticatedUser={null} />}
+            {() => (
+                <SignInPage
+                    context={{ ...context, authProviders: providers }}
+                    authenticatedUser={null}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
+            )}
         </WebStory>
     )
 }

--- a/client/web/src/auth/SignInPage.test.tsx
+++ b/client/web/src/auth/SignInPage.test.tsx
@@ -2,6 +2,7 @@ import { within } from '@testing-library/dom'
 import { Route, Routes } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import type { AuthenticatedUser } from '../auth'
@@ -62,6 +63,7 @@ describe('SignInPage', () => {
                                 xhrHeaders: {},
                                 primaryLoginProvidersCount: props.primaryLoginProvidersCount ?? 5,
                             }}
+                            telemetryRecorder={noOpTelemetryRecorder}
                         />
                     }
                 />

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { partition } from 'lodash'
 import { Navigate, useLocation, useSearchParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Alert, Icon, Text, Link, Button, ErrorAlert, AnchorLink, Container } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../auth'
@@ -20,7 +21,7 @@ import { UsernamePasswordSignInForm } from './UsernamePasswordSignInForm'
 
 import styles from './SignInPage.module.scss'
 
-export interface SignInPageProps {
+export interface SignInPageProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     context: Pick<
         SourcegraphContext,
@@ -38,7 +39,10 @@ export interface SignInPageProps {
 
 export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInPageProps>> = props => {
     const { context, authenticatedUser } = props
-    useEffect(() => eventLogger.logViewEvent('SignIn', null, false))
+    useEffect(() => {
+        eventLogger.logViewEvent('SignIn', null, false)
+        props.telemetryRecorder.recordEvent('auth.sign-in', 'view')
+    }, [props.telemetryRecorder])
 
     const location = useLocation()
     const [error, setError] = useState<Error | null>(null)
@@ -189,6 +193,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
                 allowSignup={context.allowSignup}
                 isRequestAccessAllowed={isRequestAccessAllowed}
                 sourcegraphDotComMode={context.sourcegraphDotComMode}
+                telemetryRecorder={props.telemetryRecorder}
             />
         </>
     )
@@ -227,16 +232,26 @@ const ProviderIcon: React.FunctionComponent<{ serviceType: AuthProvider['service
     }
 }
 
-const SignUpNotice: React.FunctionComponent<{
+interface SignUpNoticeProps extends TelemetryV2Props {
     allowSignup: boolean
     sourcegraphDotComMode: boolean
     isRequestAccessAllowed: boolean
-}> = ({ allowSignup, sourcegraphDotComMode, isRequestAccessAllowed }) => {
+}
+
+const SignUpNotice: React.FunctionComponent<SignUpNoticeProps> = ({
+    allowSignup,
+    sourcegraphDotComMode,
+    isRequestAccessAllowed,
+    telemetryRecorder,
+}) => {
     const dotcomCTAs = (
         <>
             <Link
                 to="https://sourcegraph.com/get-started?t=enterprise"
-                onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })}
+                onClick={() => {
+                    eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })
+                    telemetryRecorder.recordEvent('auth.enterprise-cta', 'click', { location: 'SignInPage' })
+                }}
             >
                 consider Sourcegraph Enterprise
             </Link>

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -250,7 +250,7 @@ const SignUpNotice: React.FunctionComponent<SignUpNoticeProps> = ({
                 to="https://sourcegraph.com/get-started?t=enterprise"
                 onClick={() => {
                     eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })
-                    telemetryRecorder.recordEvent('auth.enterprise-cta', 'click', { location: 'SignInPage' })
+                    telemetryRecorder.recordEvent('auth.enterprise-cta', 'click')
                 }}
             >
                 consider Sourcegraph Enterprise

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -41,7 +41,7 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
     const { context, authenticatedUser } = props
     useEffect(() => {
         eventLogger.logViewEvent('SignIn', null, false)
-        props.telemetryRecorder.recordEvent('auth.sign-in', 'view')
+        props.telemetryRecorder.recordEvent('auth.signIn', 'view')
     }, [props.telemetryRecorder])
 
     const location = useLocation()
@@ -250,7 +250,7 @@ const SignUpNotice: React.FunctionComponent<SignUpNoticeProps> = ({
                 to="https://sourcegraph.com/get-started?t=enterprise"
                 onClick={() => {
                     eventLogger.log('ClickedOnEnterpriseCTA', { location: 'SignInPage' })
-                    telemetryRecorder.recordEvent('auth.enterprise-cta', 'click')
+                    telemetryRecorder.recordEvent('auth.enterpriseCTA', 'click')
                 }}
             >
                 consider Sourcegraph Enterprise

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -118,9 +118,9 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
                 setLoading(false)
             })
             eventLogger.log('InitiateSignUp')
-            telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes['builtin'] } })
+            telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes.builtin } })
         },
-        [onSignUp, disabled, emailState, usernameState, passwordState]
+        [onSignUp, disabled, emailState, usernameState, passwordState, telemetryRecorder]
     )
 
     const externalAuthProviders = context.authProviders.filter(provider => !provider.isBuiltin)
@@ -132,7 +132,7 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
             eventLogger.log(EventName.AUTH_INITIATED, { type }, { type })
             telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes[type] } })
         },
-        []
+        [telemetryRecorder]
     )
 
     return (

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -7,6 +7,7 @@ import { fromFetch } from 'rxjs/fetch'
 import { catchError, switchMap } from 'rxjs/operators'
 
 import { asError } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     useInputValidation,
     type ValidationOptions,
@@ -17,7 +18,7 @@ import { Link, Icon, Label, Text, Button, AnchorLink, LoaderInput, ErrorAlert } 
 import { LoaderButton } from '../components/LoaderButton'
 import type { AuthProvider, SourcegraphContext } from '../jscontext'
 import { eventLogger } from '../tracking/eventLogger'
-import { EventName } from '../util/constants'
+import { EventName, V2AuthProviderTypes } from '../util/constants'
 import { validatePassword, getPasswordRequirements } from '../util/security'
 
 import { OrDivider } from './OrDivider'
@@ -33,7 +34,7 @@ export interface SignUpArguments {
     lastSourceUrl?: string
 }
 
-interface SignUpFormProps {
+interface SignUpFormProps extends TelemetryV2Props {
     className?: string
 
     /** Called to perform the signup on the server. */
@@ -60,6 +61,7 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
     className,
     context,
     experimental = false,
+    telemetryRecorder,
 }) => {
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<Error | null>(null)
@@ -116,6 +118,7 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
                 setLoading(false)
             })
             eventLogger.log('InitiateSignUp')
+            telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes['builtin'] })
         },
         [onSignUp, disabled, emailState, usernameState, passwordState]
     )
@@ -127,6 +130,7 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
             // TODO: Log events with keepalive=true to ensure they always outlive the webpage
             // https://github.com/sourcegraph/sourcegraph/issues/19174
             eventLogger.log(EventName.AUTH_INITIATED, { type }, { type })
+            telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes[type] })
         },
         []
     )

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -118,7 +118,7 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
                 setLoading(false)
             })
             eventLogger.log('InitiateSignUp')
-            telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes['builtin'] })
+            telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes['builtin'] } })
         },
         [onSignUp, disabled, emailState, usernameState, passwordState]
     )
@@ -130,7 +130,7 @@ export const SignUpForm: React.FunctionComponent<React.PropsWithChildren<SignUpF
             // TODO: Log events with keepalive=true to ensure they always outlive the webpage
             // https://github.com/sourcegraph/sourcegraph/issues/19174
             eventLogger.log(EventName.AUTH_INITIATED, { type }, { type })
-            telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes[type] })
+            telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes[type] } })
         },
         []
     )

--- a/client/web/src/auth/SignUpPage.story.tsx
+++ b/client/web/src/auth/SignUpPage.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../components/WebStory'
@@ -57,6 +58,7 @@ export const Default: StoryFn = () => (
                     sourcegraphDotComMode: false,
                 }}
                 authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>

--- a/client/web/src/auth/SignUpPage.test.tsx
+++ b/client/web/src/auth/SignUpPage.test.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
@@ -52,6 +53,7 @@ describe('SignUpPage', () => {
                                         xhrHeaders: {},
                                     }}
                                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                                    telemetryRecorder={noOpTelemetryRecorder}
                                 />
                             }
                         />
@@ -81,6 +83,7 @@ describe('SignUpPage', () => {
                                         xhrHeaders: {},
                                     }}
                                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                                    telemetryRecorder={noOpTelemetryRecorder}
                                 />
                             }
                         />
@@ -118,6 +121,7 @@ describe('SignUpPage', () => {
                                         xhrHeaders: {},
                                     }}
                                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                                    telemetryRecorder={noOpTelemetryRecorder}
                                 />
                             }
                         />

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -50,7 +50,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
 
     useEffect(() => {
         eventLogger.logViewEvent('SignUp', null, false)
-        telemetryRecorder.recordEvent('auth.sign-up', 'view', {
+        telemetryRecorder.recordEvent('auth.signUp', 'view', {
             metadata: { 'invited-by-user': invitedBy !== null ? 1 : 0 },
         })
 
@@ -89,7 +89,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
             const source = query.get('editor') === 'vscode' ? 'ide_extension' : 'web'
             telemetryService.log(EventName.SIGNUP_COMPLETED, { source }, { source })
             const v2Source = query.get('editor') === 'vscode' ? 0 : 1
-            telemetryRecorder.recordEvent('auth.signup', 'complete', { metadata: { source: v2Source } })
+            telemetryRecorder.recordEvent('auth.signUp', 'complete', { metadata: { source: v2Source } })
 
             // Redirects to the /post-sign-up after successful signup on sourcegraphDotCom.
             window.location.replace(context.sourcegraphDotComMode ? PageRoutes.PostSignUp : returnTo)

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -50,7 +50,9 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
 
     useEffect(() => {
         eventLogger.logViewEvent('SignUp', null, false)
-        telemetryRecorder.recordEvent('auth.sign-up', 'view', { 'invited-by-user': invitedBy !== null })
+        telemetryRecorder.recordEvent('auth.sign-up', 'view', {
+            metadata: { 'invited-by-user': invitedBy !== null ? 1 : 0 },
+        })
 
         if (invitedBy !== null) {
             const parameters = {
@@ -87,7 +89,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
             const source = query.get('editor') === 'vscode' ? 'ide_extension' : 'web'
             telemetryService.log(EventName.SIGNUP_COMPLETED, { source }, { source })
             const v2Source = query.get('editor') === 'vscode' ? 0 : 1
-            telemetryRecorder.recordEvent('auth.signup', 'complete', { source: v2Source })
+            telemetryRecorder.recordEvent('auth.signup', 'complete', { metadata: { source: v2Source } })
 
             // Redirects to the /post-sign-up after successful signup on sourcegraphDotCom.
             window.location.replace(context.sourcegraphDotComMode ? PageRoutes.PostSignUp : returnTo)

--- a/client/web/src/auth/SignUpPage.tsx
+++ b/client/web/src/auth/SignUpPage.tsx
@@ -136,7 +136,7 @@ export const SignUpPage: React.FunctionComponent<React.PropsWithChildren<SignUpP
             >
                 {context.sourcegraphDotComMode && <Text className="pt-1 pb-2">Start searching public code now</Text>}
                 <Container>
-                    <SignUpForm context={context} onSignUp={handleSignUp} />
+                    <SignUpForm context={context} onSignUp={handleSignUp} telemetryRecorder={telemetryRecorder} />
                 </Container>
                 <Text className="text-center mt-3">
                     Already have an account? <Link to={`/sign-in${location.search}`}>Sign in</Link>

--- a/client/web/src/auth/UnlockAccount.story.tsx
+++ b/client/web/src/auth/UnlockAccount.story.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import { WebStory } from '../components/WebStory'
 import type { SourcegraphContext } from '../jscontext'
 
@@ -54,6 +56,7 @@ export const Default: StoryFn = () => (
                 }}
                 mockSuccess={true}
                 authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>

--- a/client/web/src/auth/UnlockAccount.tsx
+++ b/client/web/src/auth/UnlockAccount.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 
 import { Navigate, useLocation, useParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Alert, Link, LoadingSpinner, ErrorAlert, Container } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../auth'
@@ -14,7 +15,7 @@ import { getReturnTo } from './SignInSignUpCommon'
 
 import styles from './UnlockAccount.module.scss'
 
-interface UnlockAccountPageProps {
+interface UnlockAccountPageProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     context: Pick<
         SourcegraphContext,
@@ -51,24 +52,28 @@ export const UnlockAccountPage: React.FunctionComponent<React.PropsWithChildren<
                 throw new Error('The url you provided is either expired or invalid.')
             }
 
-            eventLogger.log('OkUnlockAccount', { token })
+            eventLogger.log('OkUnlockAccount')
+            props.telemetryRecorder.recordEvent('auth.unlock-account', 'success')
         } catch (error) {
             setError(error)
-            eventLogger.log('KoUnlockAccount', { token })
+            eventLogger.log('KoUnlockAccount')
+            props.telemetryRecorder.recordEvent('auth.unlock-account', 'fail')
         } finally {
             setLoading(false)
         }
-    }, [token, props.context.xhrHeaders])
+    }, [token, props.context.xhrHeaders, props.telemetryRecorder])
 
     useEffect(() => {
         if (props.authenticatedUser) {
             return
         }
         eventLogger.logPageView('UnlockUserAccountRequest', null, false)
+        props.telemetryRecorder.recordEvent('auth.unlock-account', 'view')
+
         unlockAccount().catch(error => {
             setError(error)
         })
-    }, [unlockAccount, props.authenticatedUser])
+    }, [unlockAccount, props.authenticatedUser, props.telemetryRecorder])
 
     if (props.authenticatedUser) {
         const returnTo = getReturnTo(location)

--- a/client/web/src/auth/UnlockAccount.tsx
+++ b/client/web/src/auth/UnlockAccount.tsx
@@ -53,11 +53,11 @@ export const UnlockAccountPage: React.FunctionComponent<React.PropsWithChildren<
             }
 
             eventLogger.log('OkUnlockAccount')
-            props.telemetryRecorder.recordEvent('auth.unlock-account', 'success')
+            props.telemetryRecorder.recordEvent('auth.unlockAccount', 'success')
         } catch (error) {
             setError(error)
             eventLogger.log('KoUnlockAccount')
-            props.telemetryRecorder.recordEvent('auth.unlock-account', 'fail')
+            props.telemetryRecorder.recordEvent('auth.unlockAccount', 'fail')
         } finally {
             setLoading(false)
         }
@@ -68,7 +68,7 @@ export const UnlockAccountPage: React.FunctionComponent<React.PropsWithChildren<
             return
         }
         eventLogger.logPageView('UnlockUserAccountRequest', null, false)
-        props.telemetryRecorder.recordEvent('auth.unlock-account', 'view')
+        props.telemetryRecorder.recordEvent('auth.unlockAccount', 'view')
 
         unlockAccount().catch(error => {
             setError(error)

--- a/client/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/client/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -4,14 +4,16 @@ import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
 import { asError, logger } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Label, Button, LoadingSpinner, Link, Text, Input, Form } from '@sourcegraph/wildcard'
 
 import type { SourcegraphContext } from '../jscontext'
 import { eventLogger } from '../tracking/eventLogger'
+import { V2AuthProviderTypes } from '../util/constants'
 
 import { getReturnTo, PasswordInput } from './SignInSignUpCommon'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     onAuthError: (error: Error | null) => void
     context: Pick<
         SourcegraphContext,
@@ -27,6 +29,7 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
     onAuthError,
     className,
     context,
+    telemetryRecorder,
 }) => {
     const location = useLocation()
     const [usernameOrEmail, setUsernameOrEmail] = useState('')
@@ -50,6 +53,7 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
 
             setLoading(true)
             eventLogger.log('InitiateSignIn')
+            telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes['builtin'] })
             try {
                 const response = await fetch('/-/sign-in', {
                     credentials: 'same-origin',
@@ -85,7 +89,7 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
                 onAuthError(asError(error))
             }
         },
-        [usernameOrEmail, loading, location, password, onAuthError, context]
+        [usernameOrEmail, loading, location, password, onAuthError, context, telemetryRecorder]
     )
 
     return (

--- a/client/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/client/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -53,7 +53,7 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
 
             setLoading(true)
             eventLogger.log('InitiateSignIn')
-            telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes.builtin] } })
+            telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes.builtin } })
             try {
                 const response = await fetch('/-/sign-in', {
                     credentials: 'same-origin',

--- a/client/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/client/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -53,7 +53,7 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
 
             setLoading(true)
             eventLogger.log('InitiateSignIn')
-            telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes['builtin'] })
+            telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes['builtin'] } })
             try {
                 const response = await fetch('/-/sign-in', {
                     credentials: 'same-origin',

--- a/client/web/src/auth/UsernamePasswordSignInForm.tsx
+++ b/client/web/src/auth/UsernamePasswordSignInForm.tsx
@@ -53,7 +53,7 @@ export const UsernamePasswordSignInForm: React.FunctionComponent<React.PropsWith
 
             setLoading(true)
             eventLogger.log('InitiateSignIn')
-            telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes['builtin'] } })
+            telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes.builtin] } })
             try {
                 const response = await fetch('/-/sign-in', {
                     credentials: 'same-origin',

--- a/client/web/src/auth/VsCodeSignUpPage.story.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../components/WebStory'
@@ -56,6 +57,7 @@ export const WithoutEmailForm: StoryFn = () => (
                 showEmailForm={false}
                 source="test"
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 context={context}
             />
         )}
@@ -70,6 +72,7 @@ export const WithEmailForm: StoryFn = () => (
                 showEmailForm={true}
                 source="test"
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 context={context}
             />
         )}

--- a/client/web/src/auth/VsCodeSignUpPage.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.tsx
@@ -4,13 +4,14 @@ import { mdiChevronLeft } from '@mdi/js'
 import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Link, Icon, H2 } from '@sourcegraph/wildcard'
 
 import { BrandLogo } from '../components/branding/BrandLogo'
 import type { AuthProvider, SourcegraphContext } from '../jscontext'
-import { EventName } from '../util/constants'
+import { EventName, V2AuthProviderTypes } from '../util/constants'
 
 import { ExternalsAuth } from './components/ExternalsAuth'
 import { type SignUpArguments, SignUpForm } from './SignUpForm'
@@ -19,7 +20,7 @@ import styles from './VsCodeSignUpPage.module.scss'
 
 export const ShowEmailFormQueryParameter = 'showEmail'
 
-export interface VsCodeSignUpPageProps extends TelemetryProps {
+export interface VsCodeSignUpPageProps extends TelemetryProps, TelemetryV2Props {
     source: string | null
     showEmailForm: boolean
     /** Called to perform the signup on the server. */
@@ -44,6 +45,7 @@ export const VsCodeSignUpPage: React.FunctionComponent<React.PropsWithChildren<V
     onSignUp,
     context,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const isLightTheme = useIsLightTheme()
     const location = useLocation()
@@ -64,6 +66,7 @@ export const VsCodeSignUpPage: React.FunctionComponent<React.PropsWithChildren<V
             { type: eventType, source: 'vs-code' },
             { type: eventType, source: 'vs-code' }
         )
+        telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes[type] })
     }
 
     const signUpForm = (
@@ -80,6 +83,7 @@ export const VsCodeSignUpPage: React.FunctionComponent<React.PropsWithChildren<V
             buttonLabel="Sign up"
             experimental={true}
             className="my-3"
+            telemetryRecorder={telemetryRecorder}
         />
     )
 

--- a/client/web/src/auth/VsCodeSignUpPage.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.tsx
@@ -59,22 +59,9 @@ export const VsCodeSignUpPage: React.FunctionComponent<React.PropsWithChildren<V
 
     const assetsRoot = window.context?.assetsRoot || ''
 
-    const logEvent = (type: AuthProvider['serviceType']): void => {
-        const eventType = type === 'builtin' ? 'form' : type
-        telemetryService.log(
-            EventName.AUTH_INITIATED,
-            { type: eventType, source: 'vs-code' },
-            { type: eventType, source: 'vs-code' }
-        )
-        telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes[type] } })
-    }
-
     const signUpForm = (
         <SignUpForm
-            onSignUp={args => {
-                logEvent('builtin')
-                return onSignUp(args)
-            }}
+            onSignUp={args => onSignUp(args)}
             context={{
                 authProviders: [],
                 sourcegraphDotComMode: true,
@@ -90,11 +77,14 @@ export const VsCodeSignUpPage: React.FunctionComponent<React.PropsWithChildren<V
     const renderCodeHostAuth = (): JSX.Element => (
         <>
             <ExternalsAuth
+                page="vscode-signup-page"
                 context={context}
                 githubLabel="Continue with GitHub"
                 gitlabLabel="Continue with GitLab"
                 googleLabel="Continue with Google"
-                onClick={logEvent}
+                onClick={() => {}}
+                telemetryRecorder={telemetryRecorder}
+                telemetryService={telemetryService}
             />
         </>
     )

--- a/client/web/src/auth/VsCodeSignUpPage.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.tsx
@@ -10,8 +10,7 @@ import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Link, Icon, H2 } from '@sourcegraph/wildcard'
 
 import { BrandLogo } from '../components/branding/BrandLogo'
-import type { AuthProvider, SourcegraphContext } from '../jscontext'
-import { EventName, V2AuthProviderTypes } from '../util/constants'
+import type { SourcegraphContext } from '../jscontext'
 
 import { ExternalsAuth } from './components/ExternalsAuth'
 import { type SignUpArguments, SignUpForm } from './SignUpForm'

--- a/client/web/src/auth/VsCodeSignUpPage.tsx
+++ b/client/web/src/auth/VsCodeSignUpPage.tsx
@@ -66,7 +66,7 @@ export const VsCodeSignUpPage: React.FunctionComponent<React.PropsWithChildren<V
             { type: eventType, source: 'vs-code' },
             { type: eventType, source: 'vs-code' }
         )
-        telemetryRecorder.recordEvent('auth', 'initiate', { type: V2AuthProviderTypes[type] })
+        telemetryRecorder.recordEvent('auth', 'initiate', { metadata: { type: V2AuthProviderTypes[type] } })
     }
 
     const signUpForm = (

--- a/client/web/src/auth/components/ExternalsAuth.tsx
+++ b/client/web/src/auth/components/ExternalsAuth.tsx
@@ -2,13 +2,34 @@ import React from 'react'
 
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link } from '@sourcegraph/wildcard'
 
 import type { AuthProvider, SourcegraphContext } from '../../jscontext'
+import { EventName, V2AuthProviderTypes } from '../../util/constants'
 
 import styles from './ExternalsAuth.module.scss'
 
-interface ExternalsAuthProps {
+export type AuthPages =
+    | 'vscode-signup-page'
+    | 'cloud-signup-page'
+    | 'cody-marketing-page'
+    | 'get-cody-page'
+    | 'try-cody-widget-blob'
+    | 'try-cody-widget-repo'
+const v2Pages: { [p in AuthPages]: number } = {
+    'vscode-signup-page': 0,
+    'cloud-signup-page': 1,
+    'cody-marketing-page': 2,
+    'get-cody-page': 3,
+    'try-cody-widget-blob': 4,
+    'try-cody-widget-repo': 5,
+}
+
+interface ExternalsAuthProps extends TelemetryProps, TelemetryV2Props {
+    // page is the page on which external auth was initiated; used as metadata for telemetry.
+    page: AuthPages
     context: Pick<SourcegraphContext, 'authProviders'>
     githubLabel: string
     gitlabLabel: string
@@ -123,6 +144,7 @@ const GoogleIcon: React.FunctionComponent<React.PropsWithChildren<{ className?: 
 )
 
 export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<ExternalsAuthProps>> = ({
+    page,
     context,
     githubLabel,
     gitlabLabel,
@@ -132,6 +154,8 @@ export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<Exte
     ctaClassName,
     iconClassName,
     redirect,
+    telemetryService,
+    telemetryRecorder,
 }) => {
     // Since this component is only intended for use on Sourcegraph.com, it's OK to hardcode
     // GitHub and GitLab auth providers here as they are the only ones used on Sourcegraph.com.
@@ -147,6 +171,17 @@ export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<Exte
     const googleProvider = context.authProviders.find(provider =>
         provider.authenticationURL.startsWith('/.auth/openidconnect/login?pc=google')
     )
+
+    const logAuthAndCallback = (
+        type: AuthProvider['serviceType'],
+        callback: (type: AuthProvider['serviceType']) => void
+    ) => {
+        telemetryService.log(EventName.AUTH_INITIATED, { type, page }, { type, page })
+        telemetryRecorder.recordEvent('auth', 'initiate', {
+            metadata: { type: V2AuthProviderTypes[type], page: v2Pages[page] },
+        })
+        callback(type)
+    }
 
     return (
         <>
@@ -165,7 +200,7 @@ export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<Exte
                         styles.githubButton,
                         ctaClassName
                     )}
-                    onClick={() => onClick('github')}
+                    onClick={() => logAuthAndCallback('github', onClick)}
                 >
                     <GithubIcon className={classNames('mr-2', iconClassName)} />
                     {githubLabel}
@@ -187,7 +222,7 @@ export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<Exte
                         styles.gitlabButton,
                         ctaClassName
                     )}
-                    onClick={() => onClick('gitlab')}
+                    onClick={() => logAuthAndCallback('gitlab', onClick)}
                 >
                     <GitlabColorIcon className={classNames('mr-2', iconClassName)} /> {gitlabLabel}
                 </Link>
@@ -208,7 +243,7 @@ export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<Exte
                         styles.googleButton,
                         ctaClassName
                     )}
-                    onClick={() => onClick('openidconnect')}
+                    onClick={() => logAuthAndCallback('openidconnect', onClick)}
                 >
                     <GoogleIcon className={classNames('mr-2', iconClassName)} /> {googleLabel}
                 </Link>

--- a/client/web/src/auth/components/ExternalsAuth.tsx
+++ b/client/web/src/auth/components/ExternalsAuth.tsx
@@ -175,7 +175,7 @@ export const ExternalsAuth: React.FunctionComponent<React.PropsWithChildren<Exte
     const logAuthAndCallback = (
         type: AuthProvider['serviceType'],
         callback: (type: AuthProvider['serviceType']) => void
-    ) => {
+    ): void => {
         telemetryService.log(EventName.AUTH_INITIATED, { type, page }, { type, page })
         telemetryRecorder.recordEvent('auth', 'initiate', {
             metadata: { type: V2AuthProviderTypes[type], page: v2Pages[page] },

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -1,6 +1,7 @@
 import { mdiChevronRight, mdiCodeBracesBox, mdiGit } from '@mdi/js'
 import classNames from 'classnames'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { Theme, useTheme } from '@sourcegraph/shared/src/theme'
 import { Badge, H1, H2, H3, H4, Icon, Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
@@ -27,8 +28,6 @@ interface CodyPlatformCardProps {
 /* eslint-disable  @sourcegraph/sourcegraph/check-help-links */
 
 const onSpeakToAnEngineer = (): void => eventLogger.log(EventName.SPEAK_TO_AN_ENGINEER_CTA)
-const onClickCTAButton = (type: string): void =>
-    eventLogger.log(EventName.AUTH_INITIATED, { type, source: 'cody-signed-out' }, { type, page: 'cody-signed-out' })
 
 const IDEIcon: React.FunctionComponent<{}> = () => (
     <svg viewBox="-4 -4 31 31" fill="none" xmlns="http://www.w3.org/2000/svg" className={styles.codyPlatformCardIcon}>
@@ -168,14 +167,18 @@ export const CodyMarketingPage: React.FunctionComponent<CodyMarketingPageProps> 
                         </Text>
                         <div className={styles.buttonWrapper}>
                             <ExternalsAuth
+                                page="cody-marketing-page"
                                 context={context}
                                 githubLabel="GitHub"
                                 gitlabLabel="GitLab"
                                 googleLabel="Google"
                                 withCenteredText={true}
-                                onClick={onClickCTAButton}
+                                onClick={() => {}}
                                 ctaClassName={styles.authButton}
                                 iconClassName={styles.buttonIcon}
+                                // TODO (dadlerj): update with a real telemetry recorder
+                                telemetryRecorder={noOpTelemetryRecorder}
+                                telemetryService={eventLogger}
                             />
                         </div>
                         <Text className="mt-3 mb-0">

--- a/client/web/src/get-cody/GetCodyPage.tsx
+++ b/client/web/src/get-cody/GetCodyPage.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { useNavigate, useLocation } from 'react-router-dom'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { Badge, H2, Icon, Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
 import { ExternalsAuth } from '../auth/components/ExternalsAuth'
@@ -36,9 +37,6 @@ const SOURCEGRAPH_MAC_SILICON = 'https://sourcegraph.com/.api/app/latest?arch=aa
 const SOURCEGRAPH_MAC_INTEL = 'https://sourcegraph.com/.api/app/latest?arch=x86_64&target=darwin'
 
 const SOURCEGRAPH_LINUX = 'https://sourcegraph.com/.api/app/latest?arch=x86_64&target=linux'
-
-const onClickCTAButton = (type: string): void =>
-    eventLogger.log(EventName.AUTH_INITIATED, { type, source: 'get-started' })
 
 const logEvent = (eventName: string, type?: string, source?: string): void =>
     eventLogger.log(eventName, { type, source })
@@ -103,13 +101,16 @@ export const GetCodyPage: React.FunctionComponent<GetCodyPageProps> = ({ authent
                             <div className={styles.authButtonsWrap}>
                                 <div className={styles.externalAuthWrapper}>
                                     <ExternalsAuth
+                                        page="get-cody-page"
                                         context={context}
                                         githubLabel="GitHub"
                                         gitlabLabel="Gitlab"
                                         googleLabel="Google"
                                         withCenteredText={true}
-                                        onClick={onClickCTAButton}
+                                        onClick={() => {}}
                                         ctaClassName={styles.authButton}
+                                        telemetryRecorder={noOpTelemetryRecorder}
+                                        telemetryService={eventLogger}
                                     />
                                 </div>
                             </div>

--- a/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
+++ b/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
@@ -12,7 +12,7 @@ import { Button, H2, H4, Icon, Link, Text } from '@sourcegraph/wildcard'
 import type { AuthenticatedUser } from '../../../auth'
 import { ExternalsAuth } from '../../../auth/components/ExternalsAuth'
 import { MarketingBlock } from '../../../components/MarketingBlock'
-import type { AuthProvider, SourcegraphContext } from '../../../jscontext'
+import type { SourcegraphContext } from '../../../jscontext'
 import { EventName } from '../../../util/constants'
 
 import { GlowingCodySVG, MeetCodySVG } from './WidgetIcons'

--- a/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
+++ b/client/web/src/repo/components/TryCodyWidget/TryCodyWidget.tsx
@@ -4,6 +4,7 @@ import { mdiClose } from '@mdi/js'
 import classNames from 'classnames'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Button, H2, H4, Icon, Link, Text } from '@sourcegraph/wildcard'
@@ -58,18 +59,8 @@ function useTryCodyWidget(telemetryService: TelemetryProps['telemetryService']):
 }
 
 const NoAuthWidgetContent: React.FC<NoAuhWidgetContentProps> = ({ type, telemetryService, context }) => {
-    const logEvent = (provider: AuthProvider['serviceType']): void => {
-        const eventType = provider === 'builtin' ? 'form' : provider
-        const eventPage = type === 'blob' ? 'Blobview' : 'RepositoryPage'
-        const eventArguments = {
-            type: eventType,
-            page: eventPage,
-            description: '',
-        }
-        telemetryService.log(EventName.AUTH_INITIATED, eventArguments, eventArguments)
-    }
-
     const title = type === 'blob' ? 'Sign up to get Cody, our AI assistant, free' : 'Meet Cody, your AI assistant'
+    const eventPage = type === 'blob' ? 'try-cody-widget-blob' : 'try-cody-widget-repo'
 
     return (
         <>
@@ -82,13 +73,16 @@ const NoAuthWidgetContent: React.FC<NoAuhWidgetContentProps> = ({ type, telemetr
                 </Text>
                 <div className={styles.authButtonsWrap}>
                     <ExternalsAuth
+                        page={eventPage}
                         context={context}
                         githubLabel="GitHub"
                         gitlabLabel="GitLab"
                         googleLabel="Google"
                         withCenteredText={true}
-                        onClick={logEvent}
+                        onClick={() => {}}
                         ctaClassName={styles.authButton}
+                        telemetryRecorder={noOpTelemetryRecorder}
+                        telemetryService={telemetryService}
                     />
                 </div>
                 <Text className="mb-2 mt-2">

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -104,15 +104,39 @@ export const routes: RouteObject[] = [
     },
     {
         path: PageRoutes.SignIn,
-        element: <LegacyRoute render={props => <SignInPage {...props} context={window.context} />} />,
+        element: (
+            <LegacyRoute
+                render={props => (
+                    <SignInPage
+                        {...props}
+                        context={window.context}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
+                    />
+                )}
+            />
+        ),
     },
     {
         path: PageRoutes.RequestAccess,
-        element: <RequestAccessPage />,
+        element: (
+            <LegacyRoute
+                render={props => <RequestAccessPage telemetryRecorder={props.platformContext.telemetryRecorder} />}
+            />
+        ),
     },
     {
         path: PageRoutes.SignUp,
-        element: <LegacyRoute render={props => <SignUpPage {...props} context={window.context} />} />,
+        element: (
+            <LegacyRoute
+                render={props => (
+                    <SignUpPage
+                        {...props}
+                        context={window.context}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
+                    />
+                )}
+            />
+        ),
     },
     {
         path: PageRoutes.UnlockAccount,
@@ -274,7 +298,17 @@ export const routes: RouteObject[] = [
     },
     {
         path: PageRoutes.PasswordReset,
-        element: <LegacyRoute render={props => <ResetPasswordPage {...props} context={window.context} />} />,
+        element: (
+            <LegacyRoute
+                render={props => (
+                    <ResetPasswordPage
+                        {...props}
+                        context={window.context}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
+                    />
+                )}
+            />
+        ),
     },
     {
         path: PageRoutes.ApiConsole,

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Navigate } from 'react-router-dom'
 
 import { logger } from '@sourcegraph/common'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { Text, Container } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -99,6 +100,8 @@ export const SiteInitPage: React.FunctionComponent<React.PropsWithChildren<Props
                             // This page is never shown on dotcom, to keep the API surface
                             // of this component clean, we don't expose this option.
                             context={{ ...context, sourcegraphDotComMode, authProviders: [] }}
+                            // TODO(dadlerj): update this to use a real telemetry recorder.
+                            telemetryRecorder={noOpTelemetryRecorder}
                         />
                     </Container>
                 )}

--- a/client/web/src/util/constants.ts
+++ b/client/web/src/util/constants.ts
@@ -1,3 +1,5 @@
+import type { AuthProvider } from '../jscontext'
+
 // NOTE(naman): Remember to add events to allow list: https://docs.sourcegraph.com/dev/background-information/data-usage-pipeline#allow-list
 export const enum EventName {
     CODY_CHAT_PAGE_VIEWED = 'web:codyChat:pageViewed',
@@ -56,4 +58,17 @@ export const enum EventName {
 export const enum EventLocation {
     NAV_BAR = 'NavBar',
     CHAT_RESPONSE = 'ChatResponse',
+}
+
+export const V2AuthProviderTypes: { [k in AuthProvider['serviceType']]: number } = {
+    github: 0,
+    gitlab: 1,
+    bitbucketCloud: 2,
+    'http-header': 3,
+    openidconnect: 4,
+    'sourcegraph-operator': 5,
+    saml: 6,
+    builtin: 7,
+    gerrit: 8,
+    azuredevops: 9,
 }


### PR DESCRIPTION
Context:
* https://github.com/sourcegraph/sourcegraph/pull/60127

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally

(This is actually harder with this commit given some of these pages are hard to reach, so more testing would be helpful)