### PR TITLE
completions: fix HTTP double error-write bug

### DIFF
--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -77,6 +77,7 @@ func newCompletionsHandler(
 		completionsConfig := conf.GetCompletionsConfig(conf.Get().SiteConfig())
 		if completionsConfig == nil {
 			http.Error(w, "completions are not configured or disabled", http.StatusInternalServerError)
+			return
 		}
 
 		var requestParams types.CodyCompletionRequestParameters


### PR DESCRIPTION
I noticed a missing return here, which led to a double `http.Error` write which is obviously illegal (and reported by `net/http` when we hit this case.)

## Test plan

CI