### PR TITLE
code nav: Respect history.preferAbsoluteTimestamps user setting

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -25,10 +25,9 @@ import styles from './RepoRevisionSidebarCommits.module.scss'
 
 interface CommitNodeProps {
     node: GitCommitFields
-    preferAbsoluteTimestamps: boolean
 }
 
-const CommitNode: FC<CommitNodeProps> = ({ node, preferAbsoluteTimestamps }) => {
+const CommitNode: FC<CommitNodeProps> = ({ node }) => {
     const location = useLocation()
 
     return (
@@ -38,7 +37,6 @@ const CommitNode: FC<CommitNodeProps> = ({ node, preferAbsoluteTimestamps }) => 
                 compact={true}
                 node={node}
                 hideExpandCommitMessageBody={true}
-                preferAbsoluteTimestamps={preferAbsoluteTimestamps}
                 afterElement={
                     <Link
                         to={replaceRevisionInURL(location.pathname + location.search + location.hash, node.oid)}
@@ -55,7 +53,6 @@ const CommitNode: FC<CommitNodeProps> = ({ node, preferAbsoluteTimestamps }) => 
 
 interface Props extends Partial<RevisionSpec>, FileSpec {
     repoID: Scalars['ID']
-    preferAbsoluteTimestamps: boolean
     defaultPageSize?: number
 }
 
@@ -103,7 +100,7 @@ export const RepoRevisionSidebarCommits: FC<Props> = props => {
         <ConnectionContainer>
             {error && <ErrorAlert error={error} />}
             {connection?.nodes.map(node => (
-                <CommitNode key={node.id} node={node} preferAbsoluteTimestamps={props.preferAbsoluteTimestamps} />
+                <CommitNode key={node.id} node={node} />
             ))}
             {loading && <ConnectionLoading />}
             {!loading && connection && (

--- a/client/web/src/repo/blob/panel/BlobPanel.tsx
+++ b/client/web/src/repo/blob/panel/BlobPanel.tsx
@@ -59,7 +59,6 @@ function useBlobPanelViews({
 }: Props): void {
     const subscriptions = useMemo(() => new Subscription(), [])
 
-    const preferAbsoluteTimestamps = preferAbsoluteTimestampsFromSettings(settingsCascade)
     const defaultPageSize = defaultPageSizeFromSettings(settingsCascade)
 
     const location = useLocation()
@@ -119,7 +118,6 @@ function useBlobPanelViews({
                                       repoID={repoID}
                                       revision={revision}
                                       filePath={filePath}
-                                      preferAbsoluteTimestamps={preferAbsoluteTimestamps}
                                       defaultPageSize={defaultPageSize}
                                   />
                               </PanelContent>
@@ -158,7 +156,6 @@ function useBlobPanelViews({
             repoID,
             revision,
             filePath,
-            preferAbsoluteTimestamps,
             defaultPageSize,
             ownEnabled,
             enableOwnershipPanels,
@@ -166,13 +163,6 @@ function useBlobPanelViews({
     )
 
     useEffect(() => () => subscriptions.unsubscribe(), [subscriptions])
-}
-
-function preferAbsoluteTimestampsFromSettings(settingsCascade: SettingsCascadeOrError<Settings>): boolean {
-    if (settingsCascade.final && !isErrorLike(settingsCascade.final)) {
-        return settingsCascade.final['history.preferAbsoluteTimestamps'] as boolean
-    }
-    return false
 }
 
 function defaultPageSizeFromSettings(settingsCascade: SettingsCascadeOrError<Settings>): number | undefined {

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -7,6 +7,7 @@ import { capitalize } from 'lodash'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'
+import { useSettings } from '@sourcegraph/shared/src/settings/settings'
 import { Button, ButtonGroup, ErrorAlert, Link, Icon, Code, screenReaderAnnounce, Tooltip } from '@sourcegraph/wildcard'
 
 import { type GitCommitFields, RepositoryType } from '../../graphql-operations'
@@ -42,7 +43,11 @@ export interface GitCommitNodeProps {
     /** Show the full 40-character SHA and parents on their own row. */
     showSHAAndParentsRow?: boolean
 
-    /** Show the absolute timestamp and move relative time to tooltip. */
+    /**
+     * Show the absolute timestamp and move relative time to tooltip.
+     * If not explicitly set, the user's preference from settings
+     * (history.preferAbsoluteTimestamps) is used.
+     */
     preferAbsoluteTimestamps?: boolean
 
     /** Fragment to show at the end to the right of the SHA. */
@@ -82,6 +87,8 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     onHandleDiffMode,
     wrapperElement: WrapperElement = 'div',
 }) => {
+    const settings = useSettings()
+
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
 
@@ -90,6 +97,8 @@ export const GitCommitNode: React.FunctionComponent<React.PropsWithChildren<GitC
     const abbreviatedRefID = node.perforceChangelist?.cid ?? node.abbreviatedOID
     const refID = node.perforceChangelist?.cid ?? node.oid
     const canonicalURL = getCanonicalURL(sourceType, node)
+    // Fall back to user preference if not explicitly set
+    preferAbsoluteTimestamps = preferAbsoluteTimestamps ?? Boolean(settings?.['history.preferAbsoluteTimestamps'])
 
     const toggleShowCommitMessageBody = useCallback((): void => {
         eventLogger.log('CommitBodyToggled')

--- a/client/web/src/repo/tree/TreePagePanels.module.scss
+++ b/client/web/src/repo/tree/TreePagePanels.module.scss
@@ -73,14 +73,14 @@ table.files {
     }
 
     .commit-date-column {
-        /* stylelint-disable-next-line declaration-property-unit-allowed-list */
-        width: 120px;
+        // Width of the column that fits the text "Last commit date" without overflow
+        width: 7rem;
 
         // When showing absolute dates by default we have to give the column
-        // more space to show the full date + time.
+        // more space to show the full date + time. This width fits absolute
+        // timestamps without overflow.
         &.absolute {
-            /* stylelint-disable-next-line declaration-property-unit-allowed-list */
-            width: 160px;
+            width: 10rem;
         }
     }
 

--- a/client/web/src/repo/tree/TreePagePanels.module.scss
+++ b/client/web/src/repo/tree/TreePagePanels.module.scss
@@ -75,6 +75,13 @@ table.files {
     .commit-date-column {
         /* stylelint-disable-next-line declaration-property-unit-allowed-list */
         width: 120px;
+
+        // When showing absolute dates by default we have to give the column
+        // more space to show the full date + time.
+        &.absolute {
+            /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+            width: 160px;
+        }
     }
 
     th,

--- a/client/web/src/repo/tree/TreePagePanels.tsx
+++ b/client/web/src/repo/tree/TreePagePanels.tsx
@@ -8,6 +8,7 @@ import { NoopEditor } from '@sourcegraph/cody-shared/dist/editor'
 import { basename } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
 import type { TreeFields } from '@sourcegraph/shared/src/graphql-operations'
+import { useSettings } from '@sourcegraph/shared/src/settings/settings'
 import {
     Card,
     CardHeader,
@@ -154,6 +155,8 @@ export interface FilePanelProps {
 }
 
 export const FilesCard: FC<FilePanelProps> = ({ entries, historyEntries, className }) => {
+    const settings = useSettings()
+    const preferAbsoluteTimestamps = Boolean(settings?.['history.preferAbsoluteTimestamps'])
     const hasHistoryEntries = historyEntries && historyEntries.length > 0
     const fileHistoryByPath = useMemo(() => {
         const fileHistoryByPath: Record<string, TreeHistoryFields['history']['nodes'][number]['commit']> = {}
@@ -173,7 +176,14 @@ export const FilesCard: FC<FilePanelProps> = ({ entries, historyEntries, classNa
                     {hasHistoryEntries && (
                         <>
                             <th>Last commit message</th>
-                            <th className={styles.commitDateColumn}>Last commit date</th>
+                            <th
+                                className={classNames(
+                                    styles.commitDateColumn,
+                                    preferAbsoluteTimestamps && styles.absolute
+                                )}
+                            >
+                                Last commit date
+                            </th>
                         </>
                     )}
                 </CardHeader>
@@ -225,7 +235,11 @@ export const FilesCard: FC<FilePanelProps> = ({ entries, historyEntries, classNa
                                     </span>
                                 </td>
                                 <td className={classNames(styles.commitDate, 'text-muted')}>
-                                    <Timestamp noAbout={true} date={getCommitDate(fileHistoryByPath[entry.path])} />
+                                    <Timestamp
+                                        noAbout={true}
+                                        preferAbsolute={preferAbsoluteTimestamps}
+                                        date={getCommitDate(fileHistoryByPath[entry.path])}
+                                    />
                                 </td>
                             </>
                         )}


### PR DESCRIPTION
Closes #51209

This commit changes the logic in the file list panel to respect the `history.preferAbsoluteTimestamps` setting. The issue originally referenced the commits panel but that was removed in favor of the combined file/commit panel.

I also noted that `GitCommitNode` is used in most places but the callsites do not provide the value from the setting. Rather than make every callsite read the user settings the component itself uses settings as a fallback when the prop is not explicitly set.

![2024-02-06_15-02](https://github.com/sourcegraph/sourcegraph/assets/179026/8ca6b9f0-f17b-4c9c-b235-861de813679b)
![2024-02-06_13-53](https://github.com/sourcegraph/sourcegraph/assets/179026/f24229b3-c6d9-49a6-97a2-b9ada2e17c64)
![2024-02-06_13-51](https://github.com/sourcegraph/sourcegraph/assets/179026/75eedc0f-72f8-46fa-adb0-5f2af28a793a)


## Test plan

Manual testing.