### PR TITLE
code nav: Better truncation of revision names in revision selector

### DIFF
--- a/client/web/src/repo/RepoRevisionContainer.module.scss
+++ b/client/web/src/repo/RepoRevisionContainer.module.scss
@@ -2,3 +2,9 @@
     margin-left: 0.375rem;
     margin-right: 0.375rem;
 }
+
+.revision-label {
+    max-width: 15ch;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback, useMemo, useState } from 'react'
+import { type FC, useCallback, useMemo, useState, useEffect } from 'react'
 
 import { Route, Routes } from 'react-router-dom'
 
@@ -121,6 +121,7 @@ export const RepoRevisionContainerBreadcrumb: FC<RepoRevisionBreadcrumbProps> = 
     const { revision, resolvedRevision, repoName, repo } = props
 
     const [revisionLabelElement, setRevisionLabelElement] = useState<HTMLElement | null>(null)
+    const [showRevisionTooltip, setShowRevisionTooltip] = useState(false)
     const [popoverOpen, setPopoverOpen] = useState(false)
     const togglePopover = useCallback(() => setPopoverOpen(previous => !previous), [])
 
@@ -133,8 +134,11 @@ export const RepoRevisionContainerBreadcrumb: FC<RepoRevisionBreadcrumbProps> = 
 
     // The revision label has a max-width, an ellipsis is shown when the revision is too long.
     // In this case, we show the full revision in a tooltip.
-    const showRevisionTooltip =
-        revisionLabelElement && revisionLabelElement.scrollWidth > revisionLabelElement.offsetWidth
+    useEffect(() => {
+        if (revisionLabel && revisionLabelElement) {
+            setShowRevisionTooltip(revisionLabelElement.scrollWidth > revisionLabelElement.offsetWidth)
+        }
+    }, [revisionLabelElement, revisionLabel])
     const isPopoverContentReady = repo && resolvedRevision
 
     return (
@@ -150,7 +154,7 @@ export const RepoRevisionContainerBreadcrumb: FC<RepoRevisionBreadcrumbProps> = 
                 size="sm"
                 disabled={!isPopoverContentReady}
             >
-                <Tooltip content={showRevisionTooltip ? revision : ''}>
+            <Tooltip content={showRevisionTooltip ? revision : ''}>
                     <span ref={setRevisionLabelElement} className={styles.revisionLabel}>
                         {revisionLabel}
                     </span>

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -125,12 +125,11 @@ export const RepoRevisionContainerBreadcrumb: FC<RepoRevisionBreadcrumbProps> = 
     const [popoverOpen, setPopoverOpen] = useState(false)
     const togglePopover = useCallback(() => setPopoverOpen(previous => !previous), [])
 
-    let revisionLabel = resolvedRevision?.defaultBranch || <LoadingSpinner />
-    if (revision && revision === resolvedRevision?.commitID) {
-        revisionLabel = resolvedRevision?.commitID.slice(0, 7)
-    } else {
-        revisionLabel = revision
-    }
+    const revisionLabel = revision
+        ? revision === resolvedRevision?.commitID
+            ? resolvedRevision?.commitID.slice(0, 7)
+            : revision
+        : resolvedRevision?.defaultBranch || <LoadingSpinner />
 
     // The revision label has a max-width, an ellipsis is shown when the revision is too long.
     // In this case, we show the full revision in a tooltip.
@@ -154,7 +153,7 @@ export const RepoRevisionContainerBreadcrumb: FC<RepoRevisionBreadcrumbProps> = 
                 size="sm"
                 disabled={!isPopoverContentReady}
             >
-            <Tooltip content={showRevisionTooltip ? revision : ''}>
+                <Tooltip content={showRevisionTooltip ? revision : ''}>
                     <span ref={setRevisionLabelElement} className={styles.revisionLabel}>
                         {revisionLabel}
                     </span>

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -125,11 +125,15 @@ export const RepoRevisionContainerBreadcrumb: FC<RepoRevisionBreadcrumbProps> = 
     const [popoverOpen, setPopoverOpen] = useState(false)
     const togglePopover = useCallback(() => setPopoverOpen(previous => !previous), [])
 
-    const revisionLabel = revision
-        ? revision === resolvedRevision?.commitID
-            ? resolvedRevision?.commitID.slice(0, 7)
-            : revision
-        : resolvedRevision?.defaultBranch || <LoadingSpinner />
+    const revisionLabel = useMemo(
+        () =>
+            revision
+                ? revision === resolvedRevision?.commitID
+                    ? resolvedRevision?.commitID.slice(0, 7)
+                    : revision
+                : resolvedRevision?.defaultBranch || <LoadingSpinner />,
+        [revision, resolvedRevision]
+    )
 
     // The revision label has a max-width, an ellipsis is shown when the revision is too long.
     // In this case, we show the full revision in a tooltip.


### PR DESCRIPTION
Closes #47884

Instead of just truncating it we let CSS handle the overflow rendering and show a tooltip when it overflows.


https://github.com/sourcegraph/sourcegraph/assets/179026/9c76e23c-bf89-40a9-86bf-2184d836c7f1



## Test plan

Manual testing
