### PR TITLE
ci: do not push to prod on main-dry-run builds

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -67,7 +67,14 @@ push_prod=false
 # ok: main-dry-run
 # ok: main-dry-run-123
 # no: main-foo
-if [[ "$BUILDKITE_BRANCH" =~ ^main(-dry-run/)?.* ]] || [[ "$BUILDKITE_BRANCH" =~ ^docker-images-candidates-notest/.* ]]; then
+if [[ "$BUILDKITE_BRANCH" =~ ^main(-dry-run/)?.* ]]; then
+  dev_tags+=("insiders")
+  prod_tags+=("insiders")
+  # We only push on internal registries on a main-dry-run.
+  push_prod=false
+fi
+
+if [[ "$BUILDKITE_BRANCH" =~ ^docker-images-candidates-notest/.* ]]; then
   dev_tags+=("insiders")
   prod_tags+=("insiders")
   push_prod=true

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -67,17 +67,17 @@ push_prod=false
 # ok: main-dry-run
 # ok: main-dry-run-123
 # no: main-foo
-if [[ "$BUILDKITE_BRANCH" =~ ^main(-dry-run/)?.* ]]; then
-  dev_tags+=("insiders")
-  prod_tags+=("insiders")
-  # We only push on internal registries on a main-dry-run.
-  push_prod=false
-fi
-
-if [[ "$BUILDKITE_BRANCH" =~ ^docker-images-candidates-notest/.* ]]; then
+if [[ "$BUILDKITE_BRANCH" =~ ^main$ ]] || [[ "$BUILDKITE_BRANCH" =~ ^docker-images-candidates-notest/.* ]]; then
   dev_tags+=("insiders")
   prod_tags+=("insiders")
   push_prod=true
+fi
+
+# We only push on internal registries on a main-dry-run.
+if [[ "$BUILDKITE_BRANCH" =~ ^main-dry-run/.*  ]]; then
+  dev_tags+=("insiders")
+  prod_tags+=("insiders")
+  push_prod=false
 fi
 
 # All release branch builds must be published to prod tags to support


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/597

## Test plan

Will fire a `main-dry-run` build in a minute and report back
report: 

```
	bazel     --bazelrc=.bazelrc --bazelrc=.aspect/bazelrc/ci.bazelrc --bazelrc=.aspect/bazelrc/ci.sourcegraph.bazelrc     run     //cmd/searcher:candidate_push     --stamp     --workspace_status_command=./dev/bazel_stamp_vars.sh --  --tag 78208ef98d5b --tag 78208ef98d5b_2024-02-06 --tag 78208ef98d5b_260954 --tag insiders  --repository us.gcr.io/sourcegraph-dev/searcher
```

we're good 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
