### PR TITLE
[SSC] do no unmarshal if response status not ok

### DIFF
--- a/internal/ssc/ssc.go
+++ b/internal/ssc/ssc.go
@@ -65,7 +65,7 @@ func (c *client) sendRequest(ctx context.Context, method string, url string, out
 	}
 	defer resp.Body.Close()
 
-	if outBody != nil {
+	if outBody != nil && resp.StatusCode == http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return &resp.StatusCode, errors.Wrap(err, "reading response")


### PR DESCRIPTION
Do not unmarshal if the response status is not okay. It throws json.Unmarshal error when the body is nil. 

## Test plan

Tested locally for the case when there is no cody subscription on SSC.