### PR TITLE
[Cody Manage] make ssc url configurable for testing

### DIFF
--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -220,7 +220,7 @@ ts_project(
         "src/cody/components/ScopeSelector/backend.ts",
         "src/cody/components/ScopeSelector/index.tsx",
         "src/cody/components/ScopeSelector/useRepoSuggestions.ts",
-        "src/cody/featurFlags.ts",
+        "src/cody/featureFlags.ts",
         "src/cody/isCodyEnabled.tsx",
         "src/cody/management/CodyManagementPage.tsx",
         "src/cody/onboarding/CodyOnboarding.tsx",

--- a/client/web/src/cody/featureFlags.ts
+++ b/client/web/src/cody/featureFlags.ts
@@ -11,3 +11,10 @@ export const useHasTrialEnded = (): boolean => {
 
     return ended
 }
+
+// TODO(sourcegraph:#60213) remove this flag after testing is complete
+export const useIsCodyPaymentsTestingMode = (): boolean => {
+    const [testingMode] = useFeatureFlag('cody-payments-testing-mode', false)
+
+    return testingMode
+}

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -43,10 +43,10 @@ import {
     TrialPeriodIcon,
     DashboardIcon,
 } from '../components/CodyIcon'
-import { useArePaymentsEnabled, useHasTrialEnded } from '../featurFlags'
+import { useArePaymentsEnabled, useHasTrialEnded } from '../featureFlags'
 import { isCodyEnabled } from '../isCodyEnabled'
 import { CodyOnboarding, editorGroups, type IEditor } from '../onboarding/CodyOnboarding'
-import { ProTierIcon } from '../subscription/CodySubscriptionPage'
+import { ProTierIcon, useCodyPaymentsUrl } from '../subscription/CodySubscriptionPage'
 import { CHANGE_CODY_PLAN, USER_CODY_PLAN, USER_CODY_USAGE } from '../subscription/queries'
 
 import styles from './CodyManagementPage.module.scss'
@@ -66,6 +66,8 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
     const arePaymentsEnabled = useArePaymentsEnabled()
     const hasTrialEnded = useHasTrialEnded()
+    const codyPaymentsUrl = useCodyPaymentsUrl()
+    const manageSubscriptionRedirectURL = `${codyPaymentsUrl}/cody/subscription`
 
     useEffect(() => {
         eventLogger.log(EventName.CODY_MANAGEMENT_PAGE_VIEWED, { utm_source })
@@ -157,18 +159,24 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                     </PageHeader.Heading>
                 </PageHeader>
 
-                <UpgradeToProBanner userIsOnProTier={userIsOnProTier} arePaymentsEnabled={arePaymentsEnabled} />
+                <UpgradeToProBanner
+                    userIsOnProTier={userIsOnProTier}
+                    arePaymentsEnabled={arePaymentsEnabled}
+                    manageSubscriptionRedirectURL={manageSubscriptionRedirectURL}
+                />
                 <DoNotLoseCodyProBanner
                     userIsOnProTier={userIsOnProTier}
                     arePaymentsEnabled={arePaymentsEnabled}
                     hasTrialEnded={hasTrialEnded}
                     subscriptionStatus={subscription.status}
+                    manageSubscriptionRedirectURL={manageSubscriptionRedirectURL}
                 />
                 <RevertBackToTrialBanner
                     userIsOnProTier={userIsOnProTier}
                     arePaymentsEnabled={arePaymentsEnabled}
                     hasTrialEnded={hasTrialEnded}
                     subscriptionStatus={subscription.status}
+                    manageSubscriptionRedirectURL={manageSubscriptionRedirectURL}
                 />
 
                 <div className={classNames('p-4 border bg-1 mt-4', styles.container)}>
@@ -191,7 +199,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                 <ButtonLink
                                     to={
                                         arePaymentsEnabled
-                                            ? 'https://accounts.sourcegraph.com/cody/subscription?pro=true'
+                                            ? `${manageSubscriptionRedirectURL}?pro=true`
                                             : '/cody/subscription'
                                     }
                                     variant="secondary"
@@ -454,10 +462,11 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
     )
 }
 
-const UpgradeToProBanner: React.FunctionComponent<{ userIsOnProTier: boolean; arePaymentsEnabled: boolean }> = ({
-    userIsOnProTier,
-    arePaymentsEnabled,
-}) =>
+const UpgradeToProBanner: React.FunctionComponent<{
+    userIsOnProTier: boolean
+    arePaymentsEnabled: boolean
+    manageSubscriptionRedirectURL: string
+}> = ({ userIsOnProTier, arePaymentsEnabled, manageSubscriptionRedirectURL }) =>
     userIsOnProTier ? null : (
         <div className={classNames('d-flex justify-content-between align-items-center p-4', styles.upgradeToProBanner)}>
             <div>
@@ -472,9 +481,7 @@ const UpgradeToProBanner: React.FunctionComponent<{ userIsOnProTier: boolean; ar
             </div>
             <div>
                 <ButtonLink
-                    to={
-                        arePaymentsEnabled ? 'https://accounts.sourcegraph.com/cody/subscription' : '/cody/subscription'
-                    }
+                    to={arePaymentsEnabled ? manageSubscriptionRedirectURL : '/cody/subscription'}
                     variant="primary"
                     size="sm"
                 >
@@ -489,7 +496,8 @@ const DoNotLoseCodyProBanner: React.FunctionComponent<{
     arePaymentsEnabled: boolean
     hasTrialEnded: boolean
     subscriptionStatus: CodySubscriptionStatus
-}> = ({ userIsOnProTier, arePaymentsEnabled, hasTrialEnded, subscriptionStatus }) =>
+    manageSubscriptionRedirectURL: string
+}> = ({ userIsOnProTier, arePaymentsEnabled, hasTrialEnded, subscriptionStatus, manageSubscriptionRedirectURL }) =>
     arePaymentsEnabled && userIsOnProTier && subscriptionStatus === CodySubscriptionStatus.PENDING ? (
         <div
             className={classNames(
@@ -514,7 +522,7 @@ const DoNotLoseCodyProBanner: React.FunctionComponent<{
                 </div>
             </div>
             <div>
-                <ButtonLink to="https://accounts.sourcegraph.com/cody/subscription" variant="primary" size="sm">
+                <ButtonLink to={manageSubscriptionRedirectURL} variant="primary" size="sm">
                     Add Credit Card
                 </ButtonLink>
             </div>
@@ -526,7 +534,8 @@ const RevertBackToTrialBanner: React.FunctionComponent<{
     arePaymentsEnabled: boolean
     hasTrialEnded: boolean
     subscriptionStatus: CodySubscriptionStatus
-}> = ({ userIsOnProTier, arePaymentsEnabled, hasTrialEnded, subscriptionStatus }) =>
+    manageSubscriptionRedirectURL: string
+}> = ({ userIsOnProTier, arePaymentsEnabled, hasTrialEnded, subscriptionStatus, manageSubscriptionRedirectURL }) =>
     arePaymentsEnabled &&
     !hasTrialEnded &&
     userIsOnProTier &&
@@ -547,7 +556,7 @@ const RevertBackToTrialBanner: React.FunctionComponent<{
                 </div>
             </div>
             <div>
-                <ButtonLink to="https://accounts.sourcegraph.com/cody/subscription" variant="secondary" size="sm">
+                <ButtonLink to={manageSubscriptionRedirectURL} variant="secondary" size="sm">
                     Revert back to trial
                 </ButtonLink>
             </div>

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -27,7 +27,7 @@ import type { UserCodyPlanResult, UserCodyPlanVariables } from '../../graphql-op
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
 import { CodyColorIcon } from '../chat/CodyPageIcon'
-import { useArePaymentsEnabled, useHasTrialEnded } from '../featurFlags'
+import { useArePaymentsEnabled, useHasTrialEnded, useIsCodyPaymentsTestingMode } from '../featureFlags'
 import { isCodyEnabled } from '../isCodyEnabled'
 
 import { CancelProModal } from './CancelProModal'
@@ -40,7 +40,16 @@ interface CodySubscriptionPageProps {
     isSourcegraphDotCom: boolean
     authenticatedUser?: AuthenticatedUser | null
 }
-const MANAGE_SUBSCRIPTION_REDIRECT_URL = 'https://accounts.sourcegraph.com/cody/subscription'
+
+export const useCodyPaymentsUrl = (): string => {
+    const isCodyPaymentsTestingMode = useIsCodyPaymentsTestingMode()
+
+    if (isCodyPaymentsTestingMode) {
+        return 'https://accounts.sgdev.org'
+    }
+
+    return 'https://accounts.sourcegraph.com'
+}
 
 export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageProps> = ({
     isSourcegraphDotCom,
@@ -52,6 +61,8 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
 
     const arePaymentsEnabled = useArePaymentsEnabled()
     const hasTrialEnded = useHasTrialEnded()
+    const codyPaymentsUrl = useCodyPaymentsUrl()
+    const manageSubscriptionRedirectURL = `${codyPaymentsUrl}/cody/subscription`
 
     useEffect(() => {
         eventLogger.log(EventName.CODY_SUBSCRIPTION_PAGE_VIEWED, { utm_source }, { utm_source })
@@ -229,7 +240,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                     }
                                                 )
                                                 if (arePaymentsEnabled) {
-                                                    window.location.href = MANAGE_SUBSCRIPTION_REDIRECT_URL
+                                                    window.location.href = manageSubscriptionRedirectURL
                                                     return
                                                 }
 
@@ -250,7 +261,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 { tier: 'pro' }
                                             )
                                             if (arePaymentsEnabled) {
-                                                window.location.href = MANAGE_SUBSCRIPTION_REDIRECT_URL
+                                                window.location.href = manageSubscriptionRedirectURL
                                                 return
                                             }
 

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -44,6 +44,7 @@ export const FEATURE_FLAGS = [
     'sourcegraph-operator-site-admin-hide-maintenance',
     'use-ssc-for-cody-subscription',
     'cody-pro-trial-ended',
+    'cody-payments-testing-mode',
 ] as const
 
 export type FeatureFlagName = typeof FEATURE_FLAGS[number]


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/60212

We are blocked from testing complete SSC integration on https://cody-services-dev.sgdev.dev/cody/manage due to hard-coded sams URL in the code. 

For a quick fix, this PR makes the URL origin toggle between `accounts.sourcegraph.com` and `accounts.sgdev.org` using feature flag `cody-payments-testing-mode`

Ideally yes, it should be configurable through site config. But that will take a bit longer to implement and unblock testing. 

## Test plan
tested locally. 