### PR TITLE
Search results: add a message for when the display limit is hit

### DIFF
--- a/client/branded/src/search-ui/results/StreamingSearchResultsFooter.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsFooter.tsx
@@ -14,42 +14,53 @@ export const StreamingSearchResultFooter: React.FunctionComponent<
         results?: AggregateStreamingSearchResults
         children?: React.ReactChild | React.ReactChild[]
     }>
-> = ({ results, children }) => (
-    <div className={classNames(styles.contentCentered, 'd-flex flex-column align-items-center')}>
-        {(!results || results?.state === 'loading') && (
-            <div className="text-center my-4" data-testid="loading-container">
-                <LoadingSpinner />
-            </div>
-        )}
+> = ({ results, children }) => {
+    const skippedDisplay =
+        results?.state === 'complete' && results.progress.skipped.find(skipped => skipped.reason.includes('display'))
+    const resultLimitHit =
+        results?.state === 'complete' && results.progress.skipped.some(skipped => skipped.reason.includes('-limit'))
 
-        {results?.state === 'complete' && results?.results.length > 0 && (
-            <StreamingProgressCount progress={results.progress} state={results.state} className="mt-4 mb-2" />
-        )}
-
-        {results?.state === 'error' && (
-            <ErrorAlert className="m-3" data-testid="search-results-list-error" error={results.error} />
-        )}
-
-        {results?.state === 'complete' && !results.alert && results?.results.length === 0 && (
-            <div className="pr-3 mt-3 align-self-stretch">
-                <Alert variant="info">
-                    <H3 as={H2} className="m-0 py-1">
-                        No results matched your search.
-                    </H3>
-                </Alert>
-            </div>
-        )}
-
-        {results?.state === 'complete' &&
-            results.progress.skipped.some(skipped => skipped.reason.includes('-limit')) && (
-                <Alert className="d-flex m-3" variant="info">
-                    <Text className="m-0">
-                        <strong>Result limit hit.</strong> Modify your search with <Code>count:</Code> to return
-                        additional items.
-                    </Text>
-                </Alert>
+    return (
+        <div className={classNames(styles.contentCentered, 'd-flex flex-column align-items-center')}>
+            {(!results || results?.state === 'loading') && (
+                <div className="text-center my-4" data-testid="loading-container">
+                    <LoadingSpinner />
+                </div>
             )}
 
-        {children}
-    </div>
-)
+            {results?.state === 'complete' && results?.results.length > 0 && (
+                <StreamingProgressCount progress={results.progress} state={results.state} className="mt-4 mb-2" />
+            )}
+
+            {results?.state === 'error' && (
+                <ErrorAlert className="m-3" data-testid="search-results-list-error" error={results.error} />
+            )}
+
+            {results?.state === 'complete' && !results.alert && results?.results.length === 0 && (
+                <div className="pr-3 mt-3 align-self-stretch">
+                    <Alert variant="info">
+                        <H3 as={H2} className="m-0 py-1">
+                            No results matched your search.
+                        </H3>
+                    </Alert>
+                </div>
+            )}
+
+            {(skippedDisplay || resultLimitHit) && (
+                <Alert className="d-flex m-3" variant="info">
+                    {skippedDisplay && (
+                        <Text className="m-0">
+                            <strong>Display limit hit.</strong> {skippedDisplay.message}
+                        </Text>
+                    )}
+                    {resultLimitHit && (
+                        <Text className="m-0">
+                            <strong>Result limit hit.</strong> Modify your search with <Code>count:</Code> to return
+                            additional items.
+                        </Text>
+                    )}
+                </Alert>
+            )}
+        </div>
+    )
+}

--- a/client/branded/src/search-ui/results/StreamingSearchResultsFooter.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsFooter.tsx
@@ -47,7 +47,7 @@ export const StreamingSearchResultFooter: React.FunctionComponent<
             )}
 
             {(skippedDisplay || resultLimitHit) && (
-                <Alert className="d-flex m-3" variant="info">
+                <Alert className="d-flex flex-column m-3" variant="info">
                     {skippedDisplay && (
                         <Text className="m-0">
                             <strong>Display limit hit.</strong> {skippedDisplay.message}
@@ -55,8 +55,8 @@ export const StreamingSearchResultFooter: React.FunctionComponent<
                     )}
                     {resultLimitHit && (
                         <Text className="m-0">
-                            <strong>Result limit hit.</strong> Modify your search with <Code>count:</Code> to return
-                            additional items.
+                            <strong>Result limit hit.</strong> Modify your query with <Code>count:</Code> to search for
+                            more items.
                         </Text>
                     )}
                 </Alert>

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -178,7 +178,7 @@ func TestDisplayLimit(t *testing.T) {
 			displayLimit:        1,
 			wantDisplayLimitHit: true,
 			wantMatchCount:      2,
-			wantMessage:         "We only display 1 result even if your search returned more results. To see all results and configure the display limit, use our CLI.",
+			wantMessage:         "We only display 1 result even if your search returned more results. To see all results, use our CLI.",
 		},
 		{
 			queryString:         "foo count:2",

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -130,7 +130,7 @@ func displayLimitHandler(resultsResolver ProgressStats) (Skipped, bool) {
 	return Skipped{
 		Reason:   DisplayLimit,
 		Title:    "display limit hit",
-		Message:  fmt.Sprintf("We only display %d %s even if your search returned more results. To see all results and configure the display limit, use our CLI.", resultsResolver.DisplayLimit, result),
+		Message:  fmt.Sprintf("We only display %d %s even if your search returned more results. To see all results, use our CLI.", resultsResolver.DisplayLimit, result),
 		Severity: SeverityInfo,
 	}, true
 }


### PR DESCRIPTION
The display limit is a separate limit from the result limit. In cases where we don't hit a result limit (which will be more frequent now that `count:` has been increased by default), we might still hit a display limit. This adds a message to the bottom of the search results that indicates that the results being shown are not exhaustive.

Fixes https://github.com/sourcegraph/sourcegraph/issues/60181

When the display limit has been hit:
![CleanShot 2024-02-06 at 10 32 58@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/08b0b409-1c7a-47b0-871a-475fb7ec40f6)

When the display limit has been hit and the result limit has been hit:
![CleanShot 2024-02-06 at 10 32 38@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/4fbc862b-fab0-435b-88ca-1b336e8031bc)

## Test plan

Manual visual testing