### PR TITLE
Search Result: Fix search result scroll jumps

### DIFF
--- a/client/branded/src/search-ui/results/useSearchResultsKeyboardNavigation.ts
+++ b/client/branded/src/search-ui/results/useSearchResultsKeyboardNavigation.ts
@@ -145,7 +145,7 @@ export function useSearchResultsKeyboardNavigation(
     const onVisibilityChange = useCallback(
         (isVisible: boolean, index: number) => {
             if (index === 0 && isVisible && root && enableKeyboardNavigation) {
-                selectFirstResult(root)
+                selectFirstResult(root, true)
             }
         },
         [root, enableKeyboardNavigation]
@@ -154,8 +154,8 @@ export function useSearchResultsKeyboardNavigation(
     return [showFocusInputMessage, onVisibilityChange]
 }
 
-function selectFirstResult(root: HTMLElement): void {
-    selectElement(root.querySelector<HTMLElement>('[data-selectable-search-result="true"]'))
+function selectFirstResult(root: HTMLElement, preventScroll?: boolean): void {
+    selectElement(root.querySelector<HTMLElement>('[data-selectable-search-result="true"]'), preventScroll)
 }
 
 function selectNextResult(
@@ -174,12 +174,17 @@ function selectNextResult(
     return selectElement(nextSelected)
 }
 
-function selectElement(resultElement: HTMLElement | undefined | null): boolean {
+function selectElement(resultElement: HTMLElement | undefined | null, preventScroll?: boolean): boolean {
     if (!resultElement) {
         return false
     }
-    resultElement?.focus()
-    resultElement?.scrollIntoView({ behavior: 'auto', block: 'nearest' })
+
+    resultElement?.focus({ preventScroll })
+
+    if (!preventScroll) {
+        resultElement?.scrollIntoView({ behavior: 'auto', block: 'nearest' })
+    }
+
     return true
 }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/59946

So the problem was that it was our intention logic about preserving focus as we render/hide elements in the virtual list. The problem is that as you focus on element browsers by default try to scroll to the focusable element on the page, this overlaps with our user scroll and as a result, we had jumps. 

This PR still preserves logic we had about saving focus on the first element but doesn't scroll to it when it shows up. 

## Test plan
- Open the search result page with enough results to have a scrollbar on the page
- Scroll to the bottom 
- Scroll to the top slowly 
- Check that there are no scroll jumps when your first search result element shows up in the visible scrollable area

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
