### PR TITLE
search: introduce max-line-len streaming parameter

### DIFF
--- a/client/branded/src/search-ui/components/FileContentSearchResult.tsx
+++ b/client/branded/src/search-ui/components/FileContentSearchResult.tsx
@@ -124,6 +124,13 @@ export const FileContentSearchResult: React.FunctionComponent<React.PropsWithChi
             return
         }
         setHasBeenVisible(true)
+
+        // This file contains some large lines, avoid stressing
+        // syntax-highlighter and the browser.
+        if (result.chunkMatches?.some(chunk => chunk.contentTruncated)) {
+            return
+        }
+
         const subscription = fetchHighlightedFileLineRanges(
             {
                 repoName: result.repository,

--- a/client/web/src/search/results/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.test.tsx
@@ -110,6 +110,7 @@ describe('StreamingSearchResults', () => {
             searchMode: SearchMode.SmartSearch,
             trace: undefined,
             chunkMatches: true,
+            maxLineLen: 5 * 1024,
             featureOverrides: [],
             zoektSearchOptions: '',
         })

--- a/client/web/src/search/results/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/StreamingSearchResults.tsx
@@ -93,6 +93,9 @@ export const StreamingSearchResults: FC<StreamingSearchResultsProps> = props => 
             featureOverrides: formatUrlOverrideFeatureFlags(featureOverrides),
             searchMode,
             chunkMatches: true,
+            // 5kb is a conservative upperbound on a reasonable line to show
+            // to a user. In practice we can likely go much lower.
+            maxLineLen: 5 * 1024,
             zoektSearchOptions: searchOptions,
         }),
         [patternType, caseSensitive, trace, featureOverrides, searchMode, searchOptions]

--- a/client/web/src/search/results/export/searchResultsExport.ts
+++ b/client/web/src/search/results/export/searchResultsExport.ts
@@ -242,7 +242,11 @@ export const downloadSearchResults = (
     shouldRerunSearch: boolean
 ): Promise<void> => {
     const resultsObservable = shouldRerunSearch
-        ? aggregateStreamingSearch(of(query), { ...options, displayLimit: EXPORT_RESULT_DISPLAY_LIMIT })
+        ? aggregateStreamingSearch(of(query), {
+              ...options,
+              displayLimit: EXPORT_RESULT_DISPLAY_LIMIT,
+              maxLineLen: -1, // disable content truncation
+          })
         : of(results)
 
     // Once we update to RxJS 7, we need to change `toPromise` to `lastValueFrom`.

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -189,6 +189,7 @@ func (h *streamHandler) serveHTTP(r *http.Request, tr trace.Trace, eventWriter *
 			h.flushTickerInterval,
 			h.pingTickerInterval,
 			displayFilter,
+			args.MaxLineLen,
 			args.EnableChunkMatches,
 			logLatency,
 		)
@@ -259,6 +260,7 @@ type args struct {
 	Version                    string
 	PatternType                string
 	Display                    int
+	MaxLineLen                 int
 	EnableChunkMatches         bool
 	SearchMode                 int
 	ContextLines               *int32
@@ -289,6 +291,11 @@ func parseURLQuery(q url.Values) (*args, error) {
 	var err error
 	if a.Display, err = strconv.Atoi(display); err != nil {
 		return nil, errors.Errorf("display must be an integer, got %q: %w", display, err)
+	}
+
+	maxLineLen := get("max-line-len", "-1")
+	if a.MaxLineLen, err = strconv.Atoi(maxLineLen); err != nil {
+		return nil, errors.Errorf("max-line-len must be an integer, got %q: %w", display, err)
 	}
 
 	chunkMatches := get("cm", "f")
@@ -383,6 +390,7 @@ func newEventHandler(
 	flushInterval time.Duration,
 	progressInterval time.Duration,
 	displayFilter *displayFilter,
+	maxLineLen int,
 	enableChunkMatches bool,
 	logLatency func(),
 ) *eventHandler {
@@ -404,6 +412,7 @@ func newEventHandler(
 		progress:           progress,
 		progressInterval:   progressInterval,
 		displayFilter:      displayFilter,
+		maxLineLen:         maxLineLen,
 		enableChunkMatches: enableChunkMatches,
 		first:              true,
 		logLatency:         logLatency,
@@ -427,6 +436,7 @@ type eventHandler struct {
 
 	// Config params
 	enableChunkMatches bool
+	maxLineLen         int
 	flushInterval      time.Duration
 	progressInterval   time.Duration
 
@@ -478,7 +488,10 @@ func (h *eventHandler) Send(event streaming.SearchEvent) {
 			continue
 		}
 
-		eventMatch := search.FromMatch(match, repoMetadata, h.enableChunkMatches)
+		eventMatch := search.FromMatch(match, repoMetadata, search.FromMatchOptions{
+			ChunkMatches:         h.enableChunkMatches,
+			MaxContentLineLength: h.maxLineLen,
+		})
 		h.matchesBuf.Append(eventMatch)
 	}
 

--- a/internal/search/BUILD.bazel
+++ b/internal/search/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "env.go",
         "repo_revs.go",
         "repo_status.go",
+        "truncate.go",
         "type_converters.go",
         "types.go",
     ],
@@ -48,6 +49,7 @@ go_test(
     srcs = [
         "alert_test.go",
         "repo_status_test.go",
+        "truncate_test.go",
         "types_test.go",
     ],
     embed = [":search"],

--- a/internal/search/exhaustive/service/matchjson.go
+++ b/internal/search/exhaustive/service/matchjson.go
@@ -37,7 +37,10 @@ func (m MatchJSONWriter) Flush() error {
 }
 
 func (m MatchJSONWriter) Write(match result.Match) error {
-	eventMatch := search.FromMatch(match, nil, true) // chunk matches enabled
+	eventMatch := search.FromMatch(match, nil, search.FromMatchOptions{
+		ChunkMatches:         true,
+		MaxContentLineLength: -1, // do not truncate content
+	})
 
 	return m.w.Append(eventMatch)
 }

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -82,9 +82,10 @@ type DecoratedContent struct {
 }
 
 type ChunkMatch struct {
-	Content      string   `json:"content"`
-	ContentStart Location `json:"contentStart"`
-	Ranges       []Range  `json:"ranges"`
+	Content          string   `json:"content"`
+	ContentStart     Location `json:"contentStart"`
+	Ranges           []Range  `json:"ranges"`
+	ContentTruncated bool     `json:"contentTruncated,omitempty"`
 }
 
 // EventLineMatch is a subset of zoekt.LineMatch for our Event API.

--- a/internal/search/truncate.go
+++ b/internal/search/truncate.go
@@ -1,0 +1,46 @@
+package search
+
+import "strings"
+
+// truncateLines truncates the lines in content to be at most maxLineLen and
+// includes a truncation suffix.
+func truncateLines(content string, maxLineLen int) (_ string, truncated bool) {
+	// Skip if disabled or impossible to have a line longer than maxLineLen.
+	if maxLineLen <= 0 || len(content) < maxLineLen {
+		return content, false
+	}
+
+	// Before doing allocations, check if every line is short enough.
+	if allLineLenLessThanEqual(content, maxLineLen) {
+		return content, false
+	}
+
+	truncateSuffix := "...truncated"
+	if len(truncateSuffix) > maxLineLen {
+		truncateSuffix = ""
+	}
+
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if len(line) <= maxLineLen {
+			continue
+		}
+
+		lines[i] = line[:maxLineLen-len(truncateSuffix)] + truncateSuffix
+	}
+
+	return strings.Join(lines, "\n"), true
+}
+
+func allLineLenLessThanEqual(s string, l int) bool {
+	for len(s) > 0 {
+		idx := strings.IndexByte(s, '\n')
+		if idx < 0 {
+			return len(s) <= l
+		} else if idx > l {
+			return false
+		}
+		s = s[idx+1:]
+	}
+	return true
+}

--- a/internal/search/truncate_test.go
+++ b/internal/search/truncate_test.go
@@ -1,0 +1,99 @@
+package search
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+func TestTruncateLines(t *testing.T) {
+	type testCase struct {
+		name       string
+		content    string
+		maxLineLen int
+		want       string
+	}
+
+	testCases := []testCase{{
+		name:       "empty",
+		content:    "",
+		maxLineLen: 10,
+	}, {
+		name:       "no truncation",
+		content:    "line 1\nline 2",
+		maxLineLen: 10,
+	}, {
+		name:       "no suffix",
+		content:    "line 1\nline 2",
+		maxLineLen: 4,
+		want:       "line\nline",
+	}, {
+		name:       "trunc 1st",
+		content:    "line 1 is too long to show\nline 2\nline 3",
+		maxLineLen: 15,
+		want:       "lin...truncated\nline 2\nline 3",
+	}, {
+		name:       "trunc 2st",
+		content:    "line 1\nline 2 is too long to show\nline 3",
+		maxLineLen: 15,
+		want:       "line 1\nlin...truncated\nline 3",
+	}, {
+		name:       "trunc 3rd",
+		content:    "line 1\nline 2\nline 3 is too long to show",
+		maxLineLen: 15,
+		want:       "line 1\nline 2\nlin...truncated",
+	}, {
+		name:       "trunc 1st and third",
+		content:    "line 1 is too long to show\nline 2\nline 3 is too long to show",
+		maxLineLen: 15,
+		want:       "lin...truncated\nline 2\nlin...truncated",
+	}}
+
+	// For each test case we ensure that if we have a trailing nl it is still
+	// treated well.
+	for _, tc := range testCases {
+		tcnl := testCase{
+			name:       tc.name + " nl",
+			content:    tc.content + "\n",
+			maxLineLen: tc.maxLineLen,
+		}
+		if tc.want != "" {
+			tcnl.want = tc.want + "\n"
+		}
+		testCases = append(testCases, tcnl)
+	}
+
+	for _, tc := range testCases {
+		want := tc.want
+		wantTruncated := true
+		if want == "" {
+			want = tc.content
+			wantTruncated = false
+		}
+
+		got, truncated := truncateLines(tc.content, tc.maxLineLen)
+		if got != want || truncated != wantTruncated {
+			t.Errorf("%s: got %q %v, want %q %v", tc.name, got, truncated, want, wantTruncated)
+		}
+	}
+}
+
+func TestTruncateLines_disabled(t *testing.T) {
+	fn := func(content string) bool {
+		for _, maxLineLen := range []int{0, -1, -10} {
+			got, gotTrunc := truncateLines(content, maxLineLen)
+			if got != content {
+				t.Logf("got content %q want %q", got, content)
+				return false
+			}
+			if gotTrunc {
+				t.Logf("truncated for %q", content)
+				return false
+			}
+		}
+		return true
+	}
+
+	if err := quick.Check(fn, nil); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
max-line-len is a new parameter which when set will truncate the Content field of ChunkMatch such that no line is longer than max-line-len. Currently we only set it for interactive queries in the webapp with the conservative number 5kb.

A new field is introduced to ChunkMatch when its content has been truncated. The webapp detects this and will skip syntax highlighting files which contain truncated ChunkMatches. The webapp will still highlight the non-truncated ranges.

We have noticed that some documents are close to our max index size (about 1mb), and are all 1 line. This can lead to response sizes in the 100s of megabytes. This both is slow for the browser to receive and parse, as well as causing locking up/freezing of the browser.

The name max-line-len was chosen as a trade-off between brevity and exactness. I like short key names for URL params that are nearly always set.

Two alternative approaches were considered. The first is something along the lines of display limit which omits large events. This had the downside of potentially displaying nothing or having hard to understand semantics to avoid that. The second approach was naive truncation. The downside here is you miss a lot of potential ranges you could highlight and not having per line information lead to results looking broken.

Test Plan: In my dev environment I:
- lowered the max-line-len to 8
- introduced console logs for skipping syntax highlighting
- introduced an artifical delay to syntax highlighting

The delay was not as important with the final approach I ended up with, but was kept in testing due to its usefulness to notice how the app behaves when that is slow.

I then observed that highlighting on the non-truncated parts still worked. There is one minor artifact of highlighting the text "...truncated", but that seems acceptable.

<img width="850" alt="Screenshot 2024-02-06 at 15 14 26" src="https://github.com/sourcegraph/sourcegraph/assets/187831/6f05a044-5d5d-4845-bf37-c5e3d005d2ad">

https://github.com/sourcegraph/sourcegraph/assets/187831/a35b569a-5867-40d3-898e-4c4af5686e6b

Part of https://github.com/sourcegraph/sourcegraph/issues/58815