### PR TITLE
gitserver: Fix goroutine leak when reader is not drained

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/odb.go
+++ b/cmd/gitserver/internal/git/gitcli/odb.go
@@ -38,7 +38,7 @@ func (g *gitCLIBackend) ReadFile(ctx context.Context, commit api.CommitID, path 
 
 	return &closingFileReader{
 		ReadCloser: r,
-		onClose:    func() { cancel() },
+		onClose:    cancel,
 	}, nil
 }
 


### PR DESCRIPTION
When not all messages are read from a reader (for example, if an archive operation times out, or if a ReadFile request is canceled, or the reader is only interested in the first X lines), we didn't properly Wait() on the command.

The added test case proves that before the code changes to the reader, there is 1 goroutine too much still active in the runtime. After this change, it's equal, across a few hundred runs.

## Test plan

Added test case.