### PR TITLE
Search filters: update empty state for dynamic filter searches

### DIFF
--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -162,7 +162,7 @@ interface QueryExampleChipProps extends QueryExample {
     onClick: (query: string) => void | undefined
 }
 
-const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
+export const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
     query,
     helperText,
     className,

--- a/client/branded/src/search-ui/components/QueryExamples.tsx
+++ b/client/branded/src/search-ui/components/QueryExamples.tsx
@@ -162,7 +162,7 @@ interface QueryExampleChipProps extends QueryExample {
     onClick: (query: string) => void | undefined
 }
 
-export const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
+const QueryExampleChip: React.FunctionComponent<QueryExampleChipProps> = ({
     query,
     helperText,
     className,

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -118,6 +118,10 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
         telemetryService.log('SearchFiltersApplyFiltersClick')
     }
 
+    const onAddFilterToQuery = (filter: string): void => {
+        onQueryChange(`${query} ${filter}`)
+    }
+
     const handleKeyDown = useCallback(
         (e: KeyboardEvent) => {
             if (e.altKey && e.key === 'Backspace') {
@@ -173,6 +177,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     selectedFilters={selectedFilters}
                     renderItem={repoFilter}
                     onSelectedFilterChange={handleFilterChange}
+                    onAddFilterToQuery={onAddFilterToQuery}
                 />
 
                 <SearchDynamicFilter
@@ -182,6 +187,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     selectedFilters={selectedFilters}
                     renderItem={languageFilter}
                     onSelectedFilterChange={handleFilterChange}
+                    onAddFilterToQuery={onAddFilterToQuery}
                 />
 
                 <SearchDynamicFilter
@@ -191,6 +197,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     selectedFilters={selectedFilters}
                     renderItem={symbolFilter}
                     onSelectedFilterChange={handleFilterChange}
+                    onAddFilterToQuery={onAddFilterToQuery}
                 />
 
                 <SearchDynamicFilter
@@ -200,6 +207,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     selectedFilters={selectedFilters}
                     renderItem={authorFilter}
                     onSelectedFilterChange={handleFilterChange}
+                    onAddFilterToQuery={onAddFilterToQuery}
                 />
 
                 <SearchDynamicFilter
@@ -209,6 +217,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     selectedFilters={selectedFilters}
                     renderItem={commitDateFilter}
                     onSelectedFilterChange={handleFilterChange}
+                    onAddFilterToQuery={onAddFilterToQuery}
                 />
 
                 <SearchDynamicFilter
@@ -217,6 +226,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     filters={filters}
                     selectedFilters={selectedFilters}
                     onSelectedFilterChange={handleFilterChange}
+                    onAddFilterToQuery={onAddFilterToQuery}
                 />
 
                 <SearchDynamicFilter
@@ -226,6 +236,7 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     selectedFilters={selectedFilters}
                     renderItem={utilityFilter}
                     onSelectedFilterChange={handleFilterChange}
+                    onAddFilterToQuery={onAddFilterToQuery}
                 />
 
                 <SyntheticCountFilter

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -350,6 +350,7 @@ const SyntheticCountFilter: FC<SyntheticCountFilterProps> = props => {
             selectedFilters={selectedCountFilter}
             renderItem={commitDateFilter}
             onSelectedFilterChange={handleCountAllFilter}
+            onAddFilterToQuery={() => {}}
         />
     )
 }

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
@@ -67,18 +67,37 @@
 }
 
 .description {
+    &-header {
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+    }
+
     // margin: 0 0.65rem -0.25rem 0.65rem;
-    background-color: var(--secondary);
+    background-color: var(--secondary-2);
     color: var(--text-muted);
     padding: 0.75rem 1rem;
     border-radius: 0.5rem;
+}
+
+.zero-state-query-button {
+    display: inline;
+    padding: 0 2px;
+    border-radius: 3px;
+    background-color: var(--primary-4);
+    font-size: inherit;
+    text-align: unset;
+    color: var(--text-muted);
+    font-weight: normal;
+    margin: 0;
+    border: none;
+    vertical-align: unset;
 }
 
 .zero-state-search-button {
     text-decoration: underline;
     display: inline;
     padding: 0;
-    font-size: 0.75rem;
+    font-size: inherit;
     text-align: unset;
     color: var(--text-muted);
     font-weight: normal;

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
@@ -81,7 +81,7 @@
 
 .zero-state-query-button {
     display: inline;
-    padding: 0 2px;
+    padding: 0 0.125rem;
     border-radius: 3px;
     background-color: var(--primary-4);
     font-size: inherit;

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -222,12 +222,15 @@ const DynamicFilterItem: FC<DynamicFilterItemProps> = props => {
 
 function filterForSearchTerm(input: string, filterKind: Filter['kind']): string | null {
     switch (filterKind) {
-        case 'repo':
+        case 'repo': {
             return `repo:${maybeQuoteString(input)}`
-        case 'author':
+        }
+        case 'author': {
             return `author:${maybeQuoteString(input)}`
-        default:
+        }
+        default: {
             return null
+        }
     }
 }
 

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -11,6 +11,7 @@ import { SymbolKind } from '@sourcegraph/shared/src/symbols/SymbolKind'
 import { Button, Icon, H2, H4, Input, LanguageIcon, Code, Tooltip } from '@sourcegraph/wildcard'
 
 import { codeHostIcon } from '../../../../components'
+import { SyntaxHighlightedSearchQuery } from '../../../../components/SyntaxHighlightedSearchQuery'
 import { URLQueryFilter } from '../../hooks'
 import { DynamicFilterBadge } from '../DynamicFilterBadge'
 
@@ -48,6 +49,8 @@ interface SearchDynamicFilterProps {
      * @param nextQuery
      */
     onSelectedFilterChange: (filterKind: Filter['kind'], filters: URLQueryFilter[]) => void
+
+    onAddFilterToQuery: (newFilter: string) => void
 }
 
 /**
@@ -61,6 +64,7 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
     selectedFilters,
     renderItem,
     onSelectedFilterChange,
+    onAddFilterToQuery,
 }) => {
     const inputRef = useRef<HTMLInputElement>(null)
 
@@ -109,6 +113,12 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
         ? filteredFilters.slice(0, MAX_FILTERS_NUMBER)
         : filteredFilters.slice(0, DEFAULT_FILTERS_NUMBER)
 
+    // HACK(camdencheek): we limit the number of filters of each type to 1000, so if we get
+    // exactly 1000 filters, assume that we hit that limit. Ideally, we wouldn't hard-code this
+    // and the backend would tell us whether we hit that limit.
+    const limitHit = filters?.some(filter => !filter.exhaustive) || filters?.length === 1000
+    const suggestedQueryFilter = filterForSearchTerm(searchTerm, filterKind)
+
     return (
         <div className={styles.root}>
             {title && (
@@ -139,12 +149,31 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
 
                 {filtersToShow.length === 0 && (
                     <small className={styles.description}>
-                        <b>We couldn’t return a {filterKind} that matched your filter input.</b> Try a more expansive
-                        search{' '}
-                        <Button onClick={handleZeroStateButtonClick} className={styles.zeroStateSearchButton}>
-                            using the search bar
-                        </Button>{' '}
-                        above.
+                        <div className={styles.descriptionHeader}>No matches in search results.</div>
+                        {limitHit && suggestedQueryFilter ? (
+                            <>
+                                Try searching in your repo explicitly by adding{' '}
+                                <Button
+                                    onClick={() => onAddFilterToQuery(suggestedQueryFilter)}
+                                    className={styles.zeroStateQueryButton}
+                                >
+                                    <SyntaxHighlightedSearchQuery query={suggestedQueryFilter} />
+                                </Button>{' '}
+                                to your original search query.
+                            </>
+                        ) : (
+                            <>
+                                Try expanding your search using the{' '}
+                                <Button
+                                    variant="link"
+                                    onClick={handleZeroStateButtonClick}
+                                    className={styles.zeroStateSearchButton}
+                                >
+                                    search bar
+                                </Button>{' '}
+                                above.
+                            </>
+                        )}
                     </small>
                 )}
             </ul>
@@ -189,6 +218,24 @@ const DynamicFilterItem: FC<DynamicFilterItemProps> = props => {
             </Button>
         </li>
     )
+}
+
+function filterForSearchTerm(input: string, filterKind: Filter['kind']): string | null {
+    switch (filterKind) {
+        case 'repo':
+            return `repo:${maybeQuoteString(input)}`
+        case 'author':
+            return `author:${maybeQuoteString(input)}`
+        default:
+            return null
+    }
+}
+
+function maybeQuoteString(input: string): string {
+    if (input.match(/\s/)) {
+        return `"${input.replaceAll('"', '\\"')}"`
+    }
+    return input
 }
 
 function filtersEqual(a: URLQueryFilter, b: URLQueryFilter): boolean {

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -152,14 +152,14 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
                         <div className={styles.descriptionHeader}>No matches in search results.</div>
                         {limitHit && suggestedQueryFilter ? (
                             <>
-                                Try searching in your repo explicitly by adding{' '}
+                                Try adding{' '}
                                 <Button
                                     onClick={() => onAddFilterToQuery(suggestedQueryFilter)}
                                     className={styles.zeroStateQueryButton}
                                 >
                                     <SyntaxHighlightedSearchQuery query={suggestedQueryFilter} />
                                 </Button>{' '}
-                                to your original search query.
+                                to your original search query narrow results to that repo.
                             </>
                         ) : (
                             <>

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.tsx
@@ -159,7 +159,7 @@ export const SearchDynamicFilter: FC<SearchDynamicFilterProps> = ({
                                 >
                                     <SyntaxHighlightedSearchQuery query={suggestedQueryFilter} />
                                 </Button>{' '}
-                                to your original search query narrow results to that repo.
+                                to your original search query to narrow results to that repo.
                             </>
                         ) : (
                             <>


### PR DESCRIPTION
This implements the changes in https://github.com/sourcegraph/sourcegraph/issues/60195, with a couple of small tweaks described below.

First, I modified the copy because "all repositories" is not accurate since we will be limiting to only the repository they entered.

Before: "Try searching all repositories explicitly by adding `repo:hand` to your original search query" 
After: "Try adding `repo:hand` to your original search query narrow results to that repo."

Second, I modified the text in the button to only link `search bar` because text cannot wrap within a button, so it was making the alignment weird if the linked text was larger.

[Loom walkthrough](https://www.loom.com/share/fce0b1d138774f2b8b305f3419bbba75?sid=e6a4865c-e394-4bb6-845a-118abadc45f5)

Fixes #60195 
Fixes https://github.com/sourcegraph/sourcegraph/issues/60172

## Test plan

Manual testing.


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
