### PR TITLE
[Cody Manage] update redirection URLs

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -46,7 +46,7 @@ import {
 import { useArePaymentsEnabled, useHasTrialEnded } from '../featureFlags'
 import { isCodyEnabled } from '../isCodyEnabled'
 import { CodyOnboarding, editorGroups, type IEditor } from '../onboarding/CodyOnboarding'
-import { ProTierIcon, useCodyPaymentsUrl } from '../subscription/CodySubscriptionPage'
+import { ProTierIcon } from '../subscription/CodySubscriptionPage'
 import { CHANGE_CODY_PLAN, USER_CODY_PLAN, USER_CODY_USAGE } from '../subscription/queries'
 
 import styles from './CodyManagementPage.module.scss'
@@ -66,8 +66,6 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
     const arePaymentsEnabled = useArePaymentsEnabled()
     const hasTrialEnded = useHasTrialEnded()
-    const codyPaymentsUrl = useCodyPaymentsUrl()
-    const manageSubscriptionRedirectURL = `${codyPaymentsUrl}/cody/subscription`
 
     useEffect(() => {
         eventLogger.log(EventName.CODY_MANAGEMENT_PAGE_VIEWED, { utm_source })
@@ -159,17 +157,12 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                     </PageHeader.Heading>
                 </PageHeader>
 
-                <UpgradeToProBanner
-                    userIsOnProTier={userIsOnProTier}
-                    arePaymentsEnabled={arePaymentsEnabled}
-                    manageSubscriptionRedirectURL={manageSubscriptionRedirectURL}
-                />
+                <UpgradeToProBanner userIsOnProTier={userIsOnProTier} />
                 <DoNotLoseCodyProBanner
                     userIsOnProTier={userIsOnProTier}
                     arePaymentsEnabled={arePaymentsEnabled}
                     hasTrialEnded={hasTrialEnded}
                     subscriptionStatus={subscription.status}
-                    manageSubscriptionRedirectURL={manageSubscriptionRedirectURL}
                 />
 
                 <div className={classNames('p-4 border bg-1 mt-4', styles.container)}>
@@ -189,16 +182,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                         </div>
                         {userIsOnProTier && (
                             <div>
-                                <ButtonLink
-                                    to={
-                                        arePaymentsEnabled
-                                            ? `${manageSubscriptionRedirectURL}?pro=true`
-                                            : '/cody/subscription'
-                                    }
-                                    variant="secondary"
-                                    outline={true}
-                                    size="sm"
-                                >
+                                <ButtonLink to="/cody/subscription" variant="secondary" outline={true} size="sm">
                                     Manage subscription
                                 </ButtonLink>
                             </div>
@@ -457,9 +441,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
 const UpgradeToProBanner: React.FunctionComponent<{
     userIsOnProTier: boolean
-    arePaymentsEnabled: boolean
-    manageSubscriptionRedirectURL: string
-}> = ({ userIsOnProTier, arePaymentsEnabled, manageSubscriptionRedirectURL }) =>
+}> = ({ userIsOnProTier }) =>
     userIsOnProTier ? null : (
         <div className={classNames('d-flex justify-content-between align-items-center p-4', styles.upgradeToProBanner)}>
             <div>
@@ -473,11 +455,7 @@ const UpgradeToProBanner: React.FunctionComponent<{
                 </ul>
             </div>
             <div>
-                <ButtonLink
-                    to={arePaymentsEnabled ? manageSubscriptionRedirectURL : '/cody/subscription'}
-                    variant="primary"
-                    size="sm"
-                >
+                <ButtonLink to="/cody/subscription" variant="primary" size="sm">
                     Upgrade
                 </ButtonLink>
             </div>
@@ -489,8 +467,7 @@ const DoNotLoseCodyProBanner: React.FunctionComponent<{
     arePaymentsEnabled: boolean
     hasTrialEnded: boolean
     subscriptionStatus: CodySubscriptionStatus
-    manageSubscriptionRedirectURL: string
-}> = ({ userIsOnProTier, arePaymentsEnabled, hasTrialEnded, subscriptionStatus, manageSubscriptionRedirectURL }) =>
+}> = ({ userIsOnProTier, arePaymentsEnabled, hasTrialEnded, subscriptionStatus }) =>
     arePaymentsEnabled && userIsOnProTier && subscriptionStatus === CodySubscriptionStatus.PENDING ? (
         <div
             className={classNames(
@@ -515,7 +492,7 @@ const DoNotLoseCodyProBanner: React.FunctionComponent<{
                 </div>
             </div>
             <div>
-                <ButtonLink to={manageSubscriptionRedirectURL} variant="primary" size="sm">
+                <ButtonLink to="/cody/subscription" variant="primary" size="sm">
                     Add Credit Card
                 </ButtonLink>
             </div>

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -71,9 +71,12 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         eventLogger.log(EventName.CODY_MANAGEMENT_PAGE_VIEWED, { utm_source })
     }, [utm_source])
 
-    const { data } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
+    const { data, error: dataError } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
 
-    const { data: usageData } = useQuery<UserCodyUsageResult, UserCodyUsageVariables>(USER_CODY_USAGE, {})
+    const { data: usageData, error: usageDateError } = useQuery<UserCodyUsageResult, UserCodyUsageVariables>(
+        USER_CODY_USAGE,
+        {}
+    )
 
     const stats = usageData?.currentUser
     const codyCurrentPeriodChatLimit = stats?.codyCurrentPeriodChatLimit || 0
@@ -103,6 +106,10 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
             navigate('/sign-in?returnTo=/cody/manage')
         }
     }, [data, navigate])
+
+    if (dataError || usageDateError) {
+        throw dataError || usageDateError
+    }
 
     if (!isCodyEnabled() || !isSourcegraphDotCom || !subscription) {
         return null

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -22,7 +22,7 @@ import {
 import type { AuthenticatedUser } from '../../auth'
 import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
-import { CodySubscriptionPlan } from '../../graphql-operations'
+import { CodySubscriptionPlan, CodySubscriptionStatus } from '../../graphql-operations'
 import type { UserCodyPlanResult, UserCodyPlanVariables } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
@@ -84,6 +84,9 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
     if (!isCodyEnabled() || !isSourcegraphDotCom || !data?.currentUser || !authenticatedUser) {
         return null
     }
+
+    const isProUser = data.currentUser.codySubscription?.plan === CodySubscriptionPlan.PRO
+    const hasAddedCreditCard = data.currentUser.codySubscription?.status !== CodySubscriptionStatus.PENDING
 
     return (
         <>
@@ -224,32 +227,45 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         )}
                                     </Text>
                                 )}
-                                {data.currentUser?.codySubscription?.plan === CodySubscriptionPlan.PRO ? (
-                                    <div>
-                                        <Text
-                                            className="mb-0 text-muted d-inline cursor-pointer"
-                                            size="small"
+                                {isProUser ? (
+                                    arePaymentsEnabled && !hasAddedCreditCard ? (
+                                        <Button
+                                            className="flex-1 mt-1"
+                                            variant="primary"
                                             onClick={() => {
-                                                eventLogger.log(
-                                                    EventName.CODY_SUBSCRIPTION_PLAN_CLICKED,
-                                                    {
-                                                        tier: 'free',
-                                                    },
-                                                    {
-                                                        tier: 'free',
-                                                    }
-                                                )
-                                                if (arePaymentsEnabled) {
-                                                    window.location.href = manageSubscriptionRedirectURL
-                                                    return
-                                                }
-
-                                                setShowCancelPro(true)
+                                                eventLogger.log(EventName.CODY_SUBSCRIPTION_ADD_CREDIT_CARD_CLICKED)
+                                                window.location.href = manageSubscriptionRedirectURL
                                             }}
                                         >
-                                            {arePaymentsEnabled ? 'Manage' : 'Cancel'} subscription
-                                        </Text>
-                                    </div>
+                                            Add credit card
+                                        </Button>
+                                    ) : (
+                                        <div>
+                                            <Text
+                                                className="mb-0 text-muted d-inline cursor-pointer"
+                                                size="small"
+                                                onClick={() => {
+                                                    eventLogger.log(
+                                                        EventName.CODY_SUBSCRIPTION_PLAN_CLICKED,
+                                                        {
+                                                            tier: 'free',
+                                                        },
+                                                        {
+                                                            tier: 'free',
+                                                        }
+                                                    )
+                                                    if (arePaymentsEnabled) {
+                                                        window.location.href = manageSubscriptionRedirectURL
+                                                        return
+                                                    }
+
+                                                    setShowCancelPro(true)
+                                                }}
+                                            >
+                                                {arePaymentsEnabled ? 'Manage' : 'Cancel'} subscription
+                                            </Text>
+                                        </div>
+                                    )
                                 ) : (
                                     <Button
                                         className="flex-1"

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -68,7 +68,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
         eventLogger.log(EventName.CODY_SUBSCRIPTION_PAGE_VIEWED, { utm_source }, { utm_source })
     }, [utm_source])
 
-    const { data } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
+    const { data, error: dataError } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
 
     const [showUpgradeToPro, setShowUpgradeToPro] = useState<boolean>(false)
     const [showCancelPro, setShowCancelPro] = useState<boolean>(false)
@@ -80,6 +80,10 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
             navigate('/sign-in?returnTo=/cody/subscription')
         }
     }, [data, navigate])
+
+    if (dataError) {
+        throw dataError
+    }
 
     if (!isCodyEnabled() || !isSourcegraphDotCom || !data?.currentUser || !authenticatedUser) {
         return null

--- a/client/web/src/util/constants.ts
+++ b/client/web/src/util/constants.ts
@@ -43,6 +43,7 @@ export const enum EventName {
     CODY_SUBSCRIPTION_PAGE_VIEWED = 'CodyPlanSelectionViewed',
     CODY_SUBSCRIPTION_PLAN_CLICKED = 'CodyPlanSelectionClicked',
     CODY_SUBSCRIPTION_PLAN_CONFIRMED = 'CodyPlanSelectionConfirmed',
+    CODY_SUBSCRIPTION_ADD_CREDIT_CARD_CLICKED = 'CodyAddCreditCard',
     CODY_ONBOARDING_WELCOME_VIEWED = 'CodyWelcomeViewed',
     CODY_ONBOARDING_PURPOSE_VIEWED = 'CodyUseCaseViewed',
     CODY_ONBOARDING_PURPOSE_SELECTED = 'CodyUseCaseSelected',


### PR DESCRIPTION
closes: https://github.com/sourcegraph/accounts.sourcegraph.com/issues/465
closes: https://github.com/sourcegraph/accounts.sourcegraph.com/issues/442

Rather than redirecting users to accounts.sourcegraph.com directly from cody/manage, always send them to /cody/subscription page.

## Test plan

Test all flows by going through this locally: https://docs.google.com/drawings/d/1zFen6ut00ljsaJ8kjHVP7FRTeeWN-vcm5S0GGUVB_Ak/edit