### PR TITLE
search: mention "..." in alert for unbalanced parens

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -962,7 +962,10 @@ loop:
 			nodes = append(nodes, result...)
 		case p.expect(RPAREN) && !isSet(p.heuristics, allowDanglingParens):
 			if p.balanced <= 0 {
-				return nil, errors.New("unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses")
+				if label.IsSet(QuotesAsLiterals) {
+					return nil, errors.New("unsupported expression. The combination of parentheses in the query has an unclear meaning. Use \"...\" to quote patterns that contain parentheses")
+				}
+				return nil, errors.New("unsupported expression. The combination of parentheses in the query has an unclear meaning. Try using the content: filter to quote patterns that contain parentheses")
 			}
 			p.balanced--
 			p.heuristics |= disambiguated


### PR DESCRIPTION
For keyword search we support quoting literals. This makes the content filter unnecessary. Here we change the copy of the alert to recommend using quotes instead of the content: filter.

**standard search**
<img width="1537" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/6990f756-7e4a-4cf4-aece-899d29dfe439">

**keyword search**
<img width="1545" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/26413131/acb1980f-8212-460e-b183-7e9d71a3d173">


Test plan:
manual testing
