### PR TITLE
Add default value for ssc.apiBaseURL

### DIFF
--- a/internal/ssc/ssc.go
+++ b/internal/ssc/ssc.go
@@ -152,12 +152,17 @@ func NewClient() (Client, error) {
 		return &client{}, errors.New("no SAMS authorization provider configured")
 	}
 
+	baseURL := sgconf.SscApiBaseUrl
+	if baseURL == "" {
+		baseURL = "https://accounts.sourcegraph.com/cody/api"
+	}
+
 	// We want this tokenSource to be long lived, so we benefit from reusing existing
 	// SAMS tokens if repeated requests are made within the token's lifetime. (Under
 	// the hood it returns an oauth2.ReuseTokenSource.)
 	tokenSource := samsConfig.TokenSource(context.Background())
 	return &client{
-		baseURL:         sgconf.SscApiBaseUrl,
+		baseURL:         baseURL,
 		samsTokenSource: tokenSource,
 	}, nil
 }


### PR DESCRIPTION
Add default value for ssc.apiBaseURL site config param. The default value was mentioned in the JSON schema but not applied. 

fixing this under https://github.com/sourcegraph/sourcegraph/issues/60218

## Test plan

verified locally. 