### PR TITLE
Hide free trial tile if cc added

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -120,6 +120,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
     const userIsOnProTier =
         subscription.plan === CodySubscriptionPlan.PRO &&
         !(subscription.status === CodySubscriptionStatus.TRIALING && subscription.cancelAtPeriodEnd)
+    const hasNotAddedCreditCard = subscription.status === CodySubscriptionStatus.PENDING
 
     // Flag usage limits as resetting based on the current subscription's billing cycle.
     //
@@ -305,7 +306,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                     </Text>
                                 ))}
                         </div>
-                        {!hasTrialEnded && userIsOnProTier && (
+                        {!hasTrialEnded && userIsOnProTier && hasNotAddedCreditCard && (
                             <div className="d-flex flex-column align-items-center flex-grow-1 p-3 border-left">
                                 <TrialPeriodIcon />
                                 <div className="mb-2 mt-4">

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -90,7 +90,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
     }
 
     const isProUser = data.currentUser.codySubscription?.plan === CodySubscriptionPlan.PRO
-    const hasAddedCreditCard = data.currentUser.codySubscription?.status !== CodySubscriptionStatus.PENDING
+    const hasNotAddedCreditCard = data.currentUser.codySubscription?.status === CodySubscriptionStatus.PENDING
 
     return (
         <>
@@ -232,7 +232,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                     </Text>
                                 )}
                                 {isProUser ? (
-                                    arePaymentsEnabled && !hasAddedCreditCard ? (
+                                    arePaymentsEnabled && hasNotAddedCreditCard ? (
                                         <Button
                                             className="flex-1 mt-1"
                                             variant="primary"


### PR DESCRIPTION
closes: https://github.com/sourcegraph/accounts.sourcegraph.com/issues/444
![image](https://github.com/sourcegraph/sourcegraph/assets/22571395/9b500ea0-cd93-4363-a72b-3dd9a691d8a9)


Right now, the tile should go away once the trial period ends. 

But this PR also hides it for the users who put in their CC even before the trial ends.

## Test plan
- sign up for pro trial
- add credit card
- the free trial tile should not be visible