### PR TITLE
Autocomplete attribution requires site config setting but can be individually disabled with feature flag

### DIFF
--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -256,7 +256,7 @@ func newStreamingResponseHandler(logger log.Logger, db database.DB, feature type
 		}
 		f := guardrails.NoopCompletionsFilter(eventSink)
 		if conf.GetConfigFeatures(conf.SiteConfig()).Attribution &&
-			featureflag.FromContext(ctx).GetBoolOr("autocomplete-attribution", false) {
+			featureflag.FromContext(ctx).GetBoolOr("autocomplete-attribution", true) {
 			ff, err := guardrails.NewCompletionsFilter(guardrails.CompletionsFilterConfig{
 				Sink:             eventSink,
 				Test:             test,

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -255,7 +255,7 @@ func newStreamingResponseHandler(logger log.Logger, db database.DB, feature type
 			l.Error("attribution error", log.Error(err))
 		}
 		f := guardrails.NoopCompletionsFilter(eventSink)
-		if conf.GetConfigFeatures(conf.SiteConfig()).Attribution &&
+		if cf := conf.GetConfigFeatures(conf.SiteConfig()); cf != nil && cf.Attribution &&
 			featureflag.FromContext(ctx).GetBoolOr("autocomplete-attribution", true) {
 			ff, err := guardrails.NewCompletionsFilter(guardrails.CompletionsFilterConfig{
 				Sink:             eventSink,

--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -255,7 +255,8 @@ func newStreamingResponseHandler(logger log.Logger, db database.DB, feature type
 			l.Error("attribution error", log.Error(err))
 		}
 		f := guardrails.NoopCompletionsFilter(eventSink)
-		if featureflag.FromContext(ctx).GetBoolOr("autocomplete-attribution", false) {
+		if conf.GetConfigFeatures(conf.SiteConfig()).Attribution &&
+			featureflag.FromContext(ctx).GetBoolOr("autocomplete-attribution", false) {
 			ff, err := guardrails.NewCompletionsFilter(guardrails.CompletionsFilterConfig{
 				Sink:             eventSink,
 				Test:             test,


### PR DESCRIPTION
Closes #59824

Attribution for autocomplete is implemented in the back-end and can currently be enabled by using `attribution.enabled: true` site config. However for safety we allow disabling attribution just for autocomoplete by setting `autocomplete-attribution` feature flag to `false`.

## Test plan

- [ ] Unit tests
- [x] Manual check