### PR TITLE
Update SSC release feature flag name

### DIFF
--- a/client/web/src/cody/featureFlags.ts
+++ b/client/web/src/cody/featureFlags.ts
@@ -1,7 +1,7 @@
 import { useFeatureFlag } from '../featureFlags/useFeatureFlag'
 
 export const useArePaymentsEnabled = (): boolean => {
-    const [enabled] = useFeatureFlag('use-ssc-for-cody-subscription', false)
+    const [enabled] = useFeatureFlag('use-ssc-for-cody-subscription-on-web', false)
 
     return enabled
 }

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -42,7 +42,7 @@ export const FEATURE_FLAGS = [
     'search.newFilters',
     'signup-survey-enabled',
     'sourcegraph-operator-site-admin-hide-maintenance',
-    'use-ssc-for-cody-subscription',
+    'use-ssc-for-cody-subscription-on-web',
     'cody-pro-trial-ended',
     'cody-payments-testing-mode',
 ] as const

--- a/internal/cody/subscription.go
+++ b/internal/cody/subscription.go
@@ -14,7 +14,7 @@ import (
 )
 
 // featureFlagUseSCCForSubscription determines if we should attempt to lookup subscription data from SSC.
-const featureFlagUseSCCForSubscription = "use-ssc-for-cody-subscription"
+const featureFlagUseSCCForSubscription = "use-ssc-for-cody-subscription-on-web"
 
 // featureFlagCodyProTrialEnded indicates if the Cody Pro "Free Trial"  has ended.
 // (Enabling users to use Cody Pro for free for 3-months starting in late Q4'2023.)


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/60270

Change feature flag name `use-ssc-for-cody-subscription` to `use-ssc-for-cody-subscription-on-web`, so it is different from the one used on clients and we can control the two releases separately.

## Test plan
 unit tests covers it.
