### PR TITLE
sg ops: sanitize raw image values more

### DIFF
--- a/dev/sg/internal/images/images_test.go
+++ b/dev/sg/internal/images/images_test.go
@@ -130,11 +130,26 @@ func TestParseRawImgString(t *testing.T) {
 				digest:   "sha256:775a22b491a9956b725c12d72841adbcd9852964f171a942118f9aa8839e47d7",
 			},
 		},
+		{
+			"base",
+			// sometimes yaml image values are quoted
+			`"us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal/cadvisor:5.3.666@sha256:775a22b491a9956b725c12d72841adbcd9852964f171a942118f9aa8839e47d7"`,
+			&Repository{
+				registry: "us-central1-docker.pkg.dev",
+				org:      "sourcegraph-ci/rfc795-internal",
+				name:     "cadvisor",
+				tag:      "5.3.666",
+				digest:   "sha256:775a22b491a9956b725c12d72841adbcd9852964f171a942118f9aa8839e47d7",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := ParseRepository(tt.rawImg); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseImgString() got = %v, want %v", got, tt.want)
+			got, err := ParseRepository(tt.rawImg)
+			if err != nil {
+				t.Errorf("ParseRepository() error = %v", err)
+			} else if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseRepository() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/dev/sg/internal/images/registry.go
+++ b/dev/sg/internal/images/registry.go
@@ -56,7 +56,7 @@ func ParseRepository(rawImg string) (*Repository, error) {
 	sanitizedImg := strings.TrimSpace(rawImg)
 	// Sometimes the rawImg from yaml can contain quotes, so we remove those as well
 	sanitizedImg = strings.Trim(sanitizedImg, `"`)
-	ref, err := reference.ParseNormalizedNamed(strings.TrimSpace(sanitizedImg))
+	ref, err := reference.ParseNormalizedNamed(sanitizedImg)
 	if err != nil {
 		return nil, err
 	}

--- a/dev/sg/internal/images/registry.go
+++ b/dev/sg/internal/images/registry.go
@@ -52,7 +52,11 @@ func (r *Repository) Tag() string {
 }
 
 func ParseRepository(rawImg string) (*Repository, error) {
-	ref, err := reference.ParseNormalizedNamed(strings.TrimSpace(rawImg))
+	// First remove all trailing and leading spaces
+	sanitizedImg := strings.TrimSpace(rawImg)
+	// Sometimes the rawImg from yaml can contain quotes, so we remove those as well
+	sanitizedImg = strings.Trim(sanitizedImg, `"`)
+	ref, err := reference.ParseNormalizedNamed(strings.TrimSpace(sanitizedImg))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When getting the rawImg value from the yaml, the `"` quotes do not get removed leading to the parsing of the image value faliing.
## Test plan
Unit tests