### PR TITLE
Add inline styling in old docs banner

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -235,7 +235,7 @@ body > div#page {
 }
 
 /* Top Notice */
-.notice {
+/* .notice {
     display: flex;
     flex-direction: row;
     width: 100%;
@@ -246,22 +246,22 @@ body > div#page {
     text-align: center;
     margin: 0 auto .5rem;
     color: black;
-}
+} */
 
-.notice p {
+/* .notice p {
     text-align: center;
     display: flex;
     margin: 0 auto;
     align-items: center;
-}
+} */
 
-.notice a{
+/* .notice a{
     background: black;
     padding: 0.2rem 0.6rem;
     border-radius: 5px;
     margin-left: 0.5rem;
     color: white;
-}
+} */
 /* SIDEBAR */
 body > #sidebar {
     background-color: var(--body-bg);

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -53,8 +53,8 @@
 
         <!-- Default to light theme if no JavaScript -->
 		<body class="theme-light">
-             <nav class="notice">
-                    <p>⚠️ You're viewing our old docs, which we no longer maintain. For all the new updates, read our <a href="https://sourcegraph.com/docs/">Latest Docs »</a></p>
+             <nav class="notice" style="display: flex; flex-direction: row; width: 100%; position: absolute; z-index: 9999; background: #ec624d; padding: 0.5rem; text-align: center; margin: 0 auto .5rem; color: black;">
+                    <p style="text-align: center; display: flex; margin: 0 auto; align-items: center;">⚠️ You're viewing our old docs, which we no longer maintain. For all the new updates, read our <a style="background: black; padding: 0.2rem 0.6rem; border-radius: 5px; margin-left: 0.5rem; color: white;" href="https://sourcegraph.com/docs/">Latest Docs »</a></p>
             </nav>
             <script>
                 // If dark theme is requested, set it immediately to avoid flashing.


### PR DESCRIPTION
The PR adds inline CSS styling in markdown since the CSS is not getting fetched by docsite.css file.

## Test plan

Docs CSS added.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@fix-banner-css)