### PR TITLE
licensing: hide ask cody button when cody feature isn't enabled

### DIFF
--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -57,6 +57,7 @@ import { useV2QueryInput } from '../search/useV2QueryInput'
 import { useNavbarQueryState } from '../stores'
 import { EventName } from '../util/constants'
 import type { RouteV6Descriptor } from '../util/contributions'
+import { getLicenseFeatures } from '../util/license'
 import { parseBrowserRepoURL } from '../util/url'
 
 import { GoToCodeHostAction } from './actions/GoToCodeHostAction'
@@ -470,7 +471,8 @@ const RepoUserContainer: FC<RepoUserContainerProps> = ({
 
     // must exactly match how the revision was encoded in the URL
     const repoNameAndRevision = `${repoName}${typeof rawRevision === 'string' ? `@${rawRevision}` : ''}`
-    const showAskCodyBtn = !isCodySidebarOpen && Boolean(window.context.licenseInfo?.features.cody)
+    const licenseFeatures = getLicenseFeatures()
+    const showAskCodyBtn = licenseFeatures.isCodyEnabled && !isCodySidebarOpen
 
     return (
         <>

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -470,6 +470,7 @@ const RepoUserContainer: FC<RepoUserContainerProps> = ({
 
     // must exactly match how the revision was encoded in the URL
     const repoNameAndRevision = `${repoName}${typeof rawRevision === 'string' ? `@${rawRevision}` : ''}`
+    const showAskCodyBtn = !isCodySidebarOpen && Boolean(window.context.licenseInfo?.features.cody)
 
     return (
         <>
@@ -483,7 +484,7 @@ const RepoUserContainer: FC<RepoUserContainerProps> = ({
                 />
             ))}
 
-            {!isCodySidebarOpen && (
+            {showAskCodyBtn && (
                 <RepoHeaderContributionPortal
                     position="right"
                     priority={1}


### PR DESCRIPTION

## Test plan

When an instance doesn't have the Cody feature enabled on it's license, we want to hide the `AskCody` button shown on the blob view.
