### PR TITLE
Docs: update `/help` redirect to point to new docs site

### DIFF
--- a/cmd/frontend/internal/app/ui/help.go
+++ b/cmd/frontend/internal/app/ui/help.go
@@ -44,16 +44,19 @@ func serveHelp(w http.ResponseWriter, r *http.Request) {
 	// Note that the URI fragment (e.g., #some-section-in-doc) *should* be preserved by most user
 	// agents even though the Location HTTP response header omits it. See
 	// https://stackoverflow.com/a/2305927.
-	dest := &url.URL{
-		// TODO: test if docRevPrefix is empty
-		Path: path.Join("/", "docs", docRevPrefix, page),
-	}
+	var dest *url.URL
 	if version.IsDev(versionStr) && !envvar.SourcegraphDotComMode() {
-		dest.Scheme = "http"
-		dest.Host = "localhost:5080" // local documentation server (defined in Procfile) -- CI:LOCALHOST_OK
+		dest = &url.URL{
+			Scheme: "http",
+			Host:   "localhost:5080", // local documentation server (defined in Procfile) -- CI:LOCALHOST_OK
+			Path:   path.Join("/", docRevPrefix, page),
+		}
 	} else {
-		dest.Scheme = "https"
-		dest.Host = "sourcegraph.com"
+		dest = &url.URL{
+			Scheme: "https",
+			Host:   "sourcegraph.com",
+			Path:   path.Join("/", "docs", docRevPrefix, page),
+		}
 	}
 
 	// Use temporary, not permanent, redirect, because the destination URL changes (depending on the

--- a/cmd/frontend/internal/app/ui/help.go
+++ b/cmd/frontend/internal/app/ui/help.go
@@ -15,10 +15,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/version"
 )
 
-// serveHelp redirects to documentation pages on https://docs.sourcegraph.com for the current
-// product version, i.e., /help/PATH -> https://docs.sourcegraph.com/@VERSION/PATH. In unreleased
-// development builds (whose docs aren't necessarily available on https://docs.sourcegraph.com, it
-// shows a message with instructions on how to see the docs.)
+// serveHelp redirects to documentation pages on https://sourcegraph.com/docs for the current
+// product version, i.e., /help/PATH -> https://sourcegraph.com/docs/v/VERSION/PATH. In unreleased
+// development builds (whose docs aren't necessarily available on https://sourcegraph.com/docs), it
+// shows a message with instructions on how to see the docs.
 func serveHelp(w http.ResponseWriter, r *http.Request) {
 	page := strings.TrimPrefix(r.URL.Path, "/help")
 	versionStr := version.Version()
@@ -35,27 +35,25 @@ func serveHelp(w http.ResponseWriter, r *http.Request) {
 	var docRevPrefix string
 	if !version.IsDev(versionStr) && !envvar.SourcegraphDotComMode() {
 		v, err := semver.NewVersion(versionStr)
-		if err != nil {
-			// If not a semver, just use the version string and hope for the best
-			docRevPrefix = "@" + versionStr
-		} else {
-			// Otherwise, send viewer to the major.minor branch of this version
-			docRevPrefix = fmt.Sprintf("@%d.%d", v.Major, v.Minor)
+		if err == nil {
+			docRevPrefix = fmt.Sprintf("v/%d.%d", v.Major, v.Minor)
 		}
+		// In the case of an error, just redirect to the latest version of the docs
 	}
 
 	// Note that the URI fragment (e.g., #some-section-in-doc) *should* be preserved by most user
 	// agents even though the Location HTTP response header omits it. See
 	// https://stackoverflow.com/a/2305927.
 	dest := &url.URL{
-		Path: path.Join("/", docRevPrefix, page),
+		// TODO: test if docRevPrefix is empty
+		Path: path.Join("/", "docs", docRevPrefix, page),
 	}
 	if version.IsDev(versionStr) && !envvar.SourcegraphDotComMode() {
 		dest.Scheme = "http"
 		dest.Host = "localhost:5080" // local documentation server (defined in Procfile) -- CI:LOCALHOST_OK
 	} else {
 		dest.Scheme = "https"
-		dest.Host = "docs.sourcegraph.com"
+		dest.Host = "sourcegraph.com"
 	}
 
 	// Use temporary, not permanent, redirect, because the destination URL changes (depending on the

--- a/cmd/frontend/internal/app/ui/help_test.go
+++ b/cmd/frontend/internal/app/ui/help_test.go
@@ -55,7 +55,7 @@ func TestServeHelp(t *testing.T) {
 		if want := http.StatusTemporaryRedirect; rw.Code != want {
 			t.Errorf("got %d, want %d", rw.Code, want)
 		}
-		if got, want := rw.Header().Get("Location"), "https://docs.sourcegraph.com/@3.39/dev"; got != want {
+		if got, want := rw.Header().Get("Location"), "https://sourcegraph.com/docs/v/3.39/dev"; got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
 	})
@@ -72,7 +72,7 @@ func TestServeHelp(t *testing.T) {
 		if want := http.StatusTemporaryRedirect; rw.Code != want {
 			t.Errorf("got %d, want %d", rw.Code, want)
 		}
-		if got, want := rw.Header().Get("Location"), "https://docs.sourcegraph.com/foo/bar"; got != want {
+		if got, want := rw.Header().Get("Location"), "https://sourcegraph.com/docs/foo/bar"; got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
 	})


### PR DESCRIPTION
This updates the `/help` redirect to point to the new docs site. This is used within the product to link to the docs for the version being run. When 5.3 is released, the docs for it will be found at `sourcegraph.com/docs/v/5.3` instead of the current `docs.sourcegraph.com/@5.3`.

Fixes #59597

## Test plan

Updated automated tests and manually tested that previously-broken links now work as intended. We wrote a script to check that all the `/help/.*` paths in the `sourcegraph/sourcegraph` repository can be redirected to `sourcegraph.com/docs` without a 404