### PR TITLE
Made all file watches in `sg start` recursive

### DIFF
--- a/dev/sg/internal/run/sgconfig_command.go
+++ b/dev/sg/internal/run/sgconfig_command.go
@@ -41,7 +41,7 @@ func WatchPaths(ctx context.Context, paths []string, skipEvents ...notify.Event)
 	}
 
 	for _, path := range paths {
-		if err := notify.Watch(path, events, notify.All); err != nil {
+		if err := notify.Watch(path+"/...", events, notify.All); err != nil {
 			return nil, err
 		}
 	}

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1134,16 +1134,6 @@ commandsets:
       - zoekt-web-1
       - caddy
 
-  simple:
-    requiresDevPrivate: true
-    bazelCommands:
-      - docsite
-      - worker
-      - syntax-highlighter
-    commands:
-      - web
-      - slow
-
   # If you modify this command set, please consider also updating the dotcom runset.
   enterprise: &enterprise_set
     requiresDevPrivate: true


### PR DESCRIPTION
The [file watching notification library](https://github.com/rjeczalik/notify) we use defaults to making all watches shallow, but our convention was always that they should be recursive. A simple fix.
## Test plan
Manually tested locally with changes to deep files

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
