### PR TITLE
Search Result: Fix search result padding problem

### DIFF
--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -12,7 +12,9 @@
     flex-wrap: wrap;
 
     position: sticky;
-    top: 0;
+    // Compensate content parent block paddings in order
+    // to have paddings anywhere but content list with search matches
+    top: -1rem;
 
     z-index: 1; // Show on top of search result contents
 

--- a/client/branded/src/search-ui/components/ResultContainer.module.scss
+++ b/client/branded/src/search-ui/components/ResultContainer.module.scss
@@ -12,9 +12,7 @@
     flex-wrap: wrap;
 
     position: sticky;
-    // Compensate content parent block paddings in order
-    // to have paddings anywhere but content list with search matches
-    top: -1rem;
+    top: 0;
 
     z-index: 1; // Show on top of search result contents
 

--- a/client/branded/src/search-ui/components/ResultContainer.tsx
+++ b/client/branded/src/search-ui/components/ResultContainer.tsx
@@ -75,7 +75,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
             ref={reference}
         >
             <article aria-labelledby={`result-container-${index}`}>
-                <div className={styles.header} id={`result-container-${index}`}>
+                <header className={styles.header} id={`result-container-${index}`} data-result-header={true}>
                     {/* Add a result type to be read out to screen readers only, so that screen reader users can
                     easily scan the search results list (for example, by navigating by landmarks). */}
                     <span className="sr-only">{resultType ? accessibleResultType[resultType] : 'search'} result,</span>
@@ -95,7 +95,7 @@ export const ResultContainer: ForwardReferenceExoticComponent<
                         </span>
                     )}
                     {repoLastFetched && <LastSyncedIcon lastSyncedTime={repoLastFetched} className="ml-2" />}
-                </div>
+                </header>
                 {rankingDebug && <div>{rankingDebug}</div>}
                 {children && <div className={classNames(styles.result, resultClassName)}>{children}</div>}
             </article>

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -260,7 +260,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     )
 
     return (
-        <div>
+        <>
             <VirtualList<SearchMatch>
                 as="ol"
                 aria-label="Search results"
@@ -297,7 +297,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                     </>
                 </StreamingSearchResultFooter>
             )}
-        </div>
+        </>
     )
 }
 

--- a/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
+++ b/client/branded/src/search-ui/results/StreamingSearchResultsList.tsx
@@ -88,6 +88,7 @@ export interface StreamingSearchResultsListProps
     logSearchResultClicked?: (index: number, type: string, resultsLength: number) => void
 
     enableRepositoryMetadata?: boolean
+    className?: string
 }
 
 export const StreamingSearchResultsList: React.FunctionComponent<
@@ -113,6 +114,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     logSearchResultClicked,
     enableRepositoryMetadata,
     queryExamplesPatternType = SearchPatternType.standard,
+    className,
 }) => {
     const resultsNumber = results?.results.length || 0
     const { itemsToShow, handleBottomHit } = useItemsToShow(executedQuery, resultsNumber)
@@ -258,11 +260,11 @@ export const StreamingSearchResultsList: React.FunctionComponent<
     )
 
     return (
-        <>
+        <div>
             <VirtualList<SearchMatch>
                 as="ol"
                 aria-label="Search results"
-                className={classNames(styles.list)}
+                className={classNames(styles.list, className)}
                 itemsToShow={itemsToShow}
                 onShowMoreItems={handleBottomHit}
                 items={results?.results || []}
@@ -295,7 +297,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<
                     </>
                 </StreamingSearchResultFooter>
             )}
-        </>
+        </div>
     )
 }
 

--- a/client/web/src/search/results/components/aggregation/SearchAggregationResult.module.scss
+++ b/client/web/src/search/results/components/aggregation/SearchAggregationResult.module.scss
@@ -13,7 +13,7 @@
 
 .card {
     max-width: 60rem;
-    margin: 1rem auto 0;
+    margin: 0 auto;
     border: 1px solid var(--border-color);
 }
 

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.module.scss
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.module.scss
@@ -126,6 +126,7 @@
 .content {
     grid-area: contents;
     overflow: auto;
+    padding: 1rem;
 
     &::-webkit-scrollbar {
         width: 0.5rem;
@@ -158,6 +159,12 @@
             scrollbar-width: thin;
             scrollbar-color: var(--oc-gray-6);
         }
+    }
+
+    &--list {
+        // Compensate content parent block paddings in order
+        // to have paddings anywhere but content list with search matches
+        margin: -1rem;
     }
 }
 

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.module.scss
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.module.scss
@@ -165,6 +165,13 @@
         // Compensate content parent block paddings in order
         // to have paddings anywhere but content list with search matches
         margin: -1rem;
+
+        // This is needed because search list may have search result matches
+        // block which have sticky header elements, sticky top position doesn't
+        // take into account negative margins so we
+        [data-result-header] {
+            top: -1rem;
+        }
     }
 }
 

--- a/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
+++ b/client/web/src/search/results/components/new-search-content/NewSearchContent.tsx
@@ -257,7 +257,6 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                         patternType={patternType}
                         caseSensitive={caseSensitive}
                         aria-label="Aggregation results panel"
-                        className="mt-3"
                         onQuerySubmit={onQuerySubmit}
                         telemetryService={telemetryService}
                     />
@@ -323,6 +322,7 @@ export const NewSearchContent: FC<NewSearchContentProps> = props => {
                             selectedSearchContextSpec={selectedSearchContextSpec}
                             logSearchResultClicked={onLogSearchResultClick}
                             queryExamplesPatternType={patternType}
+                            className={styles.contentList}
                         />
                     </>
                 )}


### PR DESCRIPTION

## Test plan
- Check the search result matches UI got no regressions in the layout 
- Check that the search aggregation UI has proper paddings 
- Check that zero state UI has proper paddings

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
