### PR TITLE
Search filters: final design tweaks

### DIFF
--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -11,32 +11,8 @@
         height: 0.5rem;
     }
 
-    &::-webkit-scrollbar-thumb {
-        background-color: var(--oc-gray-4);
-    }
-
-    &::-webkit-scrollbar-track {
-        background-color: var(--oc-gray-1);
-    }
-
     @-moz-document url-prefix('') {
         scrollbar-width: thin;
-        scrollbar-color: var(--oc-gray-1);
-    }
-
-    :global(.theme-dark) & {
-        &::-webkit-scrollbar-thumb {
-            background-color: var(--oc-gray-8);
-        }
-
-        &::-webkit-scrollbar-track {
-            background-color: var(--oc-gray-7);
-        }
-
-        @-moz-document url-prefix('') {
-            scrollbar-width: thin;
-            scrollbar-color: var(--oc-gray-6);
-        }
     }
 }
 

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -19,14 +19,12 @@
 .filters {
     display: flex;
     flex-direction: column;
-    margin-bottom: 1rem;
     gap: 0.5rem;
 }
 
 .actions {
     position: sticky;
     bottom: 0;
-    margin-top: -0.5rem;
     padding: 1rem 0.75rem;
     border-top: 1px solid var(--border-color);
     background-color: var(--code-bg);

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -20,6 +20,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    margin-bottom: auto;
 }
 
 .actions {

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -4,7 +4,6 @@
     overflow: auto;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
     background-color: var(--code-bg);
 
     &::-webkit-scrollbar {
@@ -42,7 +41,10 @@
 }
 
 .filters {
-    margin-bottom: auto;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1rem;
+    gap: 0.5rem;
 }
 
 .actions {

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -11,8 +11,32 @@
         height: 0.5rem;
     }
 
+    &::-webkit-scrollbar-thumb {
+        background-color: var(--oc-gray-4);
+    }
+
+    &::-webkit-scrollbar-track {
+        background-color: var(--oc-gray-1);
+    }
+
     @-moz-document url-prefix('') {
         scrollbar-width: thin;
+        scrollbar-color: var(--oc-gray-4) var(--oc-gray-1);
+    }
+
+    :global(.theme-dark) & {
+        &::-webkit-scrollbar-thumb {
+            background-color: var(--oc-gray-8);
+        }
+
+        &::-webkit-scrollbar-track {
+            background-color: var(--oc-gray-7);
+        }
+
+        @-moz-document url-prefix('') {
+            scrollbar-width: thin;
+            scrollbar-color: var(--oc-gray-8) var(--oc-gray-7);
+        }
     }
 }
 

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -246,9 +246,9 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     onQueryChange={onQueryChange}
                     telemetryService={telemetryService}
                 />
-
-                <FiltersDocFooter />
             </div>
+
+            <FiltersDocFooter />
 
             <footer className={styles.actions}>
                 {selectedFilters.length > 0 && (

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -155,15 +155,14 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     </div>
                 )}
             </div>
-            {!queryHasTypeFilter(query) && (
-                <FilterTypeList
-                    backendFilters={filters ?? []}
-                    disabled={queryHasTypeFilter(query)}
-                    selectedFilters={selectedFilters}
-                    onClick={handleFilterTypeClick}
-                />
-            )}
             <div className={styles.filters}>
+                {!queryHasTypeFilter(query) && (
+                    <FilterTypeList
+                        backendFilters={filters ?? []}
+                        selectedFilters={selectedFilters}
+                        onClick={handleFilterTypeClick}
+                    />
+                )}
                 {hasNoFilters && !isFilterLoadingComplete && (
                     <>
                         <SearchFilterSkeleton />
@@ -247,9 +246,9 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     onQueryChange={onQueryChange}
                     telemetryService={telemetryService}
                 />
-            </div>
 
-            <FiltersDocFooter />
+                <FiltersDocFooter />
+            </div>
 
             <footer className={styles.actions}>
                 {selectedFilters.length > 0 && (

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -351,7 +351,7 @@ const SyntheticCountFilter: FC<SyntheticCountFilterProps> = props => {
             selectedFilters={selectedCountFilter}
             renderItem={commitDateFilter}
             onSelectedFilterChange={handleCountAllFilter}
-            onAddFilterToQuery={() => { }}
+            onAddFilterToQuery={() => {}}
         />
     )
 }

--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.tsx
@@ -155,12 +155,14 @@ export const NewSearchFilters: FC<NewSearchFiltersProps> = ({
                     </div>
                 )}
             </div>
-            <FilterTypeList
-                backendFilters={filters ?? []}
-                disabled={queryHasTypeFilter(query)}
-                selectedFilters={selectedFilters}
-                onClick={handleFilterTypeClick}
-            />
+            {!queryHasTypeFilter(query) && (
+                <FilterTypeList
+                    backendFilters={filters ?? []}
+                    disabled={queryHasTypeFilter(query)}
+                    selectedFilters={selectedFilters}
+                    onClick={handleFilterTypeClick}
+                />
+            )}
             <div className={styles.filters}>
                 {hasNoFilters && !isFilterLoadingComplete && (
                     <>
@@ -350,7 +352,7 @@ const SyntheticCountFilter: FC<SyntheticCountFilterProps> = props => {
             selectedFilters={selectedCountFilter}
             renderItem={commitDateFilter}
             onSelectedFilterChange={handleCountAllFilter}
-            onAddFilterToQuery={() => {}}
+            onAddFilterToQuery={() => { }}
         />
     )
 }

--- a/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/dynamic-filter/SearchDynamicFilter.module.scss
@@ -1,5 +1,5 @@
 .root {
-    padding: 0.5rem 0.5rem 0.5rem 0.75rem;
+    padding: 0.75rem 1rem;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;

--- a/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.module.scss
@@ -1,10 +1,14 @@
+.type-list-container {
+    padding: 0.75rem 1rem;
+}
+
 .type-list {
     display: flex;
     flex-direction: column;
     list-style: none;
     gap: 0.15rem;
     margin: 0;
-    padding: 0.25rem 0.5rem;
+    padding: 0;
 
     &-item {
         width: 100%;
@@ -14,6 +18,7 @@
         border: none;
         border-radius: 4px;
         font-weight: normal;
+        padding: 0.375rem 0.25rem 0.375rem 0.5rem;
 
         &-text {
             margin-right: auto;
@@ -30,5 +35,5 @@
 }
 
 .heading {
-    margin: 0 1rem;
+    margin-bottom: 0.75rem;
 }

--- a/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
+++ b/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
@@ -124,7 +124,6 @@ const FilterTypeButton: FC<FilterTypeButtonProps> = props => {
                 [styles.typeListItemSelected]: selected,
             })}
             onClick={() => onClick(filter, selected)}
-            ref={null}
         >
             <Icon svgPath={FILTER_TYPE_ICONS[filter.label]} aria-hidden={true} />
             <span className={styles.typeListItemText}>{filter.label}</span>

--- a/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
+++ b/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
@@ -53,7 +53,7 @@ export const FilterTypeList: FC<SearchFilterTypesProps> = props => {
     })
 
     return (
-        <>
+        <div className={styles.typeListContainer}>
             <H4 as={H2} className={styles.heading}>
                 By type
             </H4>
@@ -69,7 +69,7 @@ export const FilterTypeList: FC<SearchFilterTypesProps> = props => {
                     </li>
                 ))}
             </ul>
-        </>
+        </div>
     )
 }
 

--- a/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
+++ b/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
@@ -24,11 +24,12 @@ interface SearchFilterTypesProps {
     backendFilters: Filter[]
     selectedFilters: URLQueryFilter[]
     onClick: (filter: URLQueryFilter, remove: boolean) => void
-    disabled: boolean
 }
 
 export const FilterTypeList: FC<SearchFilterTypesProps> = props => {
-    const { backendFilters, selectedFilters, disabled, onClick } = props
+    const { backendFilters, selectedFilters, onClick } = props
+
+    const defaultExhaustive = backendFilters.every(filter => filter.exhaustive)
 
     const mergedFilters = STATIC_TYPE_FILTERS.map(staticFilter => {
         const backendFilter = backendFilters.find(
@@ -41,13 +42,13 @@ export const FilterTypeList: FC<SearchFilterTypesProps> = props => {
             value: staticFilter.value,
             label: staticFilter.label,
             count: backendFilter?.count ?? 0,
-            exhaustive: backendFilter ? backendFilter.exhaustive : true,
+            exhaustive: backendFilter ? backendFilter.exhaustive : defaultExhaustive,
             kind: staticFilter.kind,
         }
         return {
             filter,
-            forceCount: !disabled && selectedFilters.length === 0 && DEFAULT_SEARCH_TYPES.has(staticFilter.label),
-            selected: selectedFilter !== undefined && !disabled,
+            forceCount: selectedFilters.length === 0 && DEFAULT_SEARCH_TYPES.has(staticFilter.label),
+            selected: selectedFilter !== undefined,
         }
     })
 
@@ -61,9 +62,8 @@ export const FilterTypeList: FC<SearchFilterTypesProps> = props => {
                     <li key={filter.value}>
                         <FilterTypeButton
                             filter={filter}
-                            disabled={disabled}
                             selected={selected}
-                            onClick={disabled ? undefined : onClick}
+                            onClick={onClick}
                             forceCount={forceCount}
                         />
                     </li>
@@ -110,32 +110,28 @@ interface FilterTypeButtonProps {
     filter: Filter
     selected: boolean
     forceCount: boolean
-    disabled: boolean
-    onClick?: (filter: URLQueryFilter, remove: boolean) => void
+    onClick: (filter: URLQueryFilter, remove: boolean) => void
 }
 
 const FilterTypeButton: FC<FilterTypeButtonProps> = props => {
-    const { filter, selected, forceCount, disabled, onClick } = props
+    const { filter, selected, forceCount, onClick } = props
 
     return (
-        <Tooltip placement="right" content={disabled ? 'Cannot override type if specified in search query' : ''}>
-            <Button
-                variant={selected ? 'primary' : 'secondary'}
-                outline={!selected}
-                className={classNames(styles.typeListItem, {
-                    [styles.typeListItemSelected]: selected,
-                    [styles.typeListItemDisabled]: disabled,
-                })}
-                onClick={() => onClick && onClick(filter, selected)}
-                ref={null}
-            >
-                <Icon svgPath={FILTER_TYPE_ICONS[filter.label]} aria-hidden={true} />
-                <span className={styles.typeListItemText}>{filter.label}</span>
-                {(filter.count > 0 || forceCount) && (
-                    <DynamicFilterBadge exhaustive={filter.exhaustive} count={filter.count} />
-                )}
-                {selected && <Icon svgPath={mdiClose} aria-hidden={true} className="ml-1 flex-shrink-0" />}
-            </Button>
-        </Tooltip>
+        <Button
+            variant={selected ? 'primary' : 'secondary'}
+            outline={!selected}
+            className={classNames(styles.typeListItem, {
+                [styles.typeListItemSelected]: selected,
+            })}
+            onClick={() => onClick(filter, selected)}
+            ref={null}
+        >
+            <Icon svgPath={FILTER_TYPE_ICONS[filter.label]} aria-hidden={true} />
+            <span className={styles.typeListItemText}>{filter.label}</span>
+            {(filter.count > 0 || forceCount) && (
+                <DynamicFilterBadge exhaustive={filter.exhaustive} count={filter.count} />
+            )}
+            {selected && <Icon svgPath={mdiClose} aria-hidden={true} className="ml-1 flex-shrink-0" />}
+        </Button>
     )
 }

--- a/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
+++ b/client/branded/src/search-ui/results/filters/components/filter-type-list/FilterTypeList.tsx
@@ -12,7 +12,7 @@ import {
 import classNames from 'classnames'
 
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
-import { Tooltip, Button, Icon, H4, H2 } from '@sourcegraph/wildcard'
+import { Button, Icon, H4, H2 } from '@sourcegraph/wildcard'
 
 import { URLQueryFilter } from '../../hooks'
 import { FilterKind } from '../../types'

--- a/client/branded/src/search-ui/results/filters/components/filters-doc-footer/FiltersDocFooter.module.scss
+++ b/client/branded/src/search-ui/results/filters/components/filters-doc-footer/FiltersDocFooter.module.scss
@@ -1,4 +1,5 @@
 .footer {
+    margin-top: 1rem;
     &::before {
         content: '';
         width: 100%;


### PR DESCRIPTION
This is my last planned set of design fixes for the filters panel. It's somewhat of a monolithic PR since it's the result of pairing with @taiyab and we just fixed things while we were looking at it together.

In summary:
- Fixes the issue where we would show `0` count even though a limit was hit
- Hides the entire "By type" section when a `type:` filter is entered explicitly by the user
- Fixes various spacing issues that became more apparent when the "By type" section is gone
- Fixes various small consistency issues where the "By type" section is rendered differently than the other sections
- Fixes some overlap issues that were caused by negative margins

Depends on and includes https://github.com/sourcegraph/sourcegraph/pull/60216
Stacked on https://github.com/sourcegraph/sourcegraph/pull/60239

Video demo:

https://github.com/sourcegraph/sourcegraph/assets/12631702/35c2357e-263c-4462-8eeb-c7959cafc9ca



## Test plan

Visual testing with Taiyab