### PR TITLE
Update PLG launch dates hard coded in frontend

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -144,13 +144,13 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
     // Correct the situation where the user is on a Cody Pro free trial, but hasn't entered
     // any subscription information into the SSC frontend. This would mean that their free
-    // trial is coming to an end on ~2/15. We need the UI to reflect this, however, because
+    // trial is coming to an end on ~2/21. We need the UI to reflect this, however, because
     // we are overloading `currentPeriodEnd` for usageRefreshTime, we do not return the
     // correct value from the backend. So we separate it out into a separate variable and
     // change its value accordingly.
-    const freeTrialEndString = 'Until Feb 14, 2024'
+    const freeTrialEndString = 'Until Feb 21, 2024'
     if (!hasTrialEnded && userIsOnProTier) {
-        codyProSubscriptionEndTime = new Date(2024, 2, 14, 12, 0, 0).toISOString()
+        codyProSubscriptionEndTime = new Date(2024, 2, 21, 12, 0, 0).toISOString()
     }
 
     return (

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -224,7 +224,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         )}
                                         {/* The free trial has not ended, but we ARE accepting payments. */}
                                         {arePaymentsEnabled && !hasTrialEnded && (
-                                            <strong>Free until February 15, 2024.</strong>
+                                            <strong>Free until February 21, 2024.</strong>
                                         )}
                                         {arePaymentsEnabled && hasTrialEnded && (
                                             <strong>Billed monthly. Cancel anytime.</strong>


### PR DESCRIPTION
We pushed the PLG launch date back from 2/15 to 2/21. This means that Cody Pro free trials will continue to run a little bit longer.

This PR updates the places in the frontend where we mention the specific date. However, in reality the "free trial end" will be managed via flag flip. On that day we will need to roll set the `cody-pro-trial-ended` to `true` globally. (As that is what will change the frontend's behavior.)

Part of https://github.com/sourcegraph/accounts.sourcegraph.com/issues/475.

## Test plan

NA. String changes only.