### PR TITLE
gitserver: Make patch reader for CreateCommitFromPatch streaming

### DIFF
--- a/cmd/gitserver/internal/mocks_test.go
+++ b/cmd/gitserver/internal/mocks_test.go
@@ -70,7 +70,7 @@ func NewMockService() *MockService {
 			},
 		},
 		CreateCommitFromPatchFunc: &ServiceCreateCommitFromPatchFunc{
-			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest) (r0 int, r1 protocol.CreateCommitFromPatchResponse) {
+			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) (r0 protocol.CreateCommitFromPatchResponse) {
 				return
 			},
 		},
@@ -127,7 +127,7 @@ func NewStrictMockService() *MockService {
 			},
 		},
 		CreateCommitFromPatchFunc: &ServiceCreateCommitFromPatchFunc{
-			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
+			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse {
 				panic("unexpected invocation of MockService.CreateCommitFromPatch")
 			},
 		},
@@ -175,7 +175,7 @@ func NewStrictMockService() *MockService {
 type surrogateMockService interface {
 	BatchGitLogInstrumentedHandler(context.Context, *v1.BatchLogRequest) (*v1.BatchLogResponse, error)
 	CloneRepo(context.Context, api.RepoName, CloneOptions) (string, error)
-	CreateCommitFromPatch(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)
+	CreateCommitFromPatch(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse
 	Exec(context.Context, *protocol.ExecRequest, io.Writer) (execStatus, error)
 	IsRepoCloneable(context.Context, api.RepoName) (protocol.IsRepoCloneableResponse, error)
 	LogIfCorrupt(context.Context, api.RepoName, error)
@@ -448,24 +448,24 @@ func (c ServiceCloneRepoFuncCall) Results() []interface{} {
 // CreateCommitFromPatch method of the parent MockService instance is
 // invoked.
 type ServiceCreateCommitFromPatchFunc struct {
-	defaultHook func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)
-	hooks       []func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)
+	defaultHook func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse
+	hooks       []func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse
 	history     []ServiceCreateCommitFromPatchFuncCall
 	mutex       sync.Mutex
 }
 
 // CreateCommitFromPatch delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockService) CreateCommitFromPatch(v0 context.Context, v1 protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
-	r0, r1 := m.CreateCommitFromPatchFunc.nextHook()(v0, v1)
-	m.CreateCommitFromPatchFunc.appendCall(ServiceCreateCommitFromPatchFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockService) CreateCommitFromPatch(v0 context.Context, v1 protocol.CreateCommitFromPatchRequest, v2 io.Reader) protocol.CreateCommitFromPatchResponse {
+	r0 := m.CreateCommitFromPatchFunc.nextHook()(v0, v1, v2)
+	m.CreateCommitFromPatchFunc.appendCall(ServiceCreateCommitFromPatchFuncCall{v0, v1, v2, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // CreateCommitFromPatch method of the parent MockService instance is
 // invoked and the hook queue is empty.
-func (f *ServiceCreateCommitFromPatchFunc) SetDefaultHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)) {
+func (f *ServiceCreateCommitFromPatchFunc) SetDefaultHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse) {
 	f.defaultHook = hook
 }
 
@@ -473,7 +473,7 @@ func (f *ServiceCreateCommitFromPatchFunc) SetDefaultHook(hook func(context.Cont
 // CreateCommitFromPatch method of the parent MockService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *ServiceCreateCommitFromPatchFunc) PushHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)) {
+func (f *ServiceCreateCommitFromPatchFunc) PushHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -481,20 +481,20 @@ func (f *ServiceCreateCommitFromPatchFunc) PushHook(hook func(context.Context, p
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ServiceCreateCommitFromPatchFunc) SetDefaultReturn(r0 int, r1 protocol.CreateCommitFromPatchResponse) {
-	f.SetDefaultHook(func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
-		return r0, r1
+func (f *ServiceCreateCommitFromPatchFunc) SetDefaultReturn(r0 protocol.CreateCommitFromPatchResponse) {
+	f.SetDefaultHook(func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ServiceCreateCommitFromPatchFunc) PushReturn(r0 int, r1 protocol.CreateCommitFromPatchResponse) {
-	f.PushHook(func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
-		return r0, r1
+func (f *ServiceCreateCommitFromPatchFunc) PushReturn(r0 protocol.CreateCommitFromPatchResponse) {
+	f.PushHook(func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse {
+		return r0
 	})
 }
 
-func (f *ServiceCreateCommitFromPatchFunc) nextHook() func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
+func (f *ServiceCreateCommitFromPatchFunc) nextHook() func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -533,24 +533,24 @@ type ServiceCreateCommitFromPatchFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 protocol.CreateCommitFromPatchRequest
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 io.Reader
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 int
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 protocol.CreateCommitFromPatchResponse
+	Result0 protocol.CreateCommitFromPatchResponse
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ServiceCreateCommitFromPatchFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ServiceCreateCommitFromPatchFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // ServiceExecFunc describes the behavior when the Exec method of the parent

--- a/cmd/gitserver/internal/server_grpc_test.go
+++ b/cmd/gitserver/internal/server_grpc_test.go
@@ -62,7 +62,7 @@ func TestGRPCServer_Blame(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("checks for subrepo perms access to given path", func(t *testing.T) {
@@ -201,7 +201,7 @@ func TestGRPCServer_DefaultBranch(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("e2e", func(t *testing.T) {
@@ -263,7 +263,7 @@ func TestGRPCServer_MergeBase(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("e2e", func(t *testing.T) {
@@ -319,7 +319,7 @@ func TestGRPCServer_ReadFile(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("checks for subrepo perms access to given path", func(t *testing.T) {
@@ -449,7 +449,7 @@ func TestGRPCServer_GetCommit(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("checks for subrepo perms access to commit", func(t *testing.T) {

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -120,7 +120,6 @@ func TestClient_CreateCommitFromPatchRequest_ProtoRoundTrip(t *testing.T) {
 		fn := func(
 			repo string,
 			baseCommit string,
-			patch []byte,
 			targetRef string,
 			uniqueRef bool,
 			pushRef *string,
@@ -138,7 +137,6 @@ func TestClient_CreateCommitFromPatchRequest_ProtoRoundTrip(t *testing.T) {
 			original := protocol.CreateCommitFromPatchRequest{
 				Repo:       api.RepoName(repo),
 				BaseCommit: api.CommitID(baseCommit),
-				Patch:      patch,
 				TargetRef:  targetRef,
 				UniqueRef:  uniqueRef,
 				CommitInfo: protocol.PatchCommitInfo{
@@ -152,7 +150,7 @@ func TestClient_CreateCommitFromPatchRequest_ProtoRoundTrip(t *testing.T) {
 				GitApplyArgs: gitApplyArgs,
 			}
 			var converted protocol.CreateCommitFromPatchRequest
-			converted.FromProto(original.ToMetadataProto(), original.Patch)
+			converted.FromProto(original.ToMetadataProto())
 
 			if diff = cmp.Diff(original, converted); diff != "" {
 				return false

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -489,7 +489,7 @@ func (c *CreateCommitFromPatchRequest) ToMetadataProto() *proto.CreateCommitFrom
 	return cc
 }
 
-func (c *CreateCommitFromPatchRequest) FromProto(p *proto.CreateCommitFromPatchBinaryRequest_Metadata, patch []byte) {
+func (c *CreateCommitFromPatchRequest) FromProto(p *proto.CreateCommitFromPatchBinaryRequest_Metadata) {
 	gp := p.GetPush()
 	var pushConfig *PushConfig
 	if gp != nil {
@@ -502,7 +502,6 @@ func (c *CreateCommitFromPatchRequest) FromProto(p *proto.CreateCommitFromPatchB
 		BaseCommit:   api.CommitID(p.GetBaseCommit()),
 		TargetRef:    p.GetTargetRef(),
 		UniqueRef:    p.GetUniqueRef(),
-		Patch:        patch,
 		CommitInfo:   PatchCommitInfoFromProto(p.GetCommitInfo()),
 		Push:         pushConfig,
 		GitApplyArgs: p.GetGitApplyArgs(),


### PR DESCRIPTION
This makes it so that we don't have to buffer the entire patch in memory, which has been seen to be 100MB+ in the past.

## Test plan

Existing test suites cover that this didn't break anything.
