### PR TITLE
gitserver: Default to unimplemented handler of P4Exec

### DIFF
--- a/cmd/gitserver/internal/mocks_test.go
+++ b/cmd/gitserver/internal/mocks_test.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"sync"
 
-	log "github.com/sourcegraph/log"
 	api "github.com/sourcegraph/sourcegraph/internal/api"
 	protocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	v1 "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
@@ -44,9 +43,6 @@ type MockService struct {
 	// MaybeStartCloneFunc is an instance of a mock function object
 	// controlling the behavior of the method MaybeStartClone.
 	MaybeStartCloneFunc *ServiceMaybeStartCloneFunc
-	// P4ExecFunc is an instance of a mock function object controlling the
-	// behavior of the method P4Exec.
-	P4ExecFunc *ServiceP4ExecFunc
 	// RepoUpdateFunc is an instance of a mock function object controlling
 	// the behavior of the method RepoUpdate.
 	RepoUpdateFunc *ServiceRepoUpdateFunc
@@ -91,11 +87,6 @@ func NewMockService() *MockService {
 		},
 		MaybeStartCloneFunc: &ServiceMaybeStartCloneFunc{
 			defaultHook: func(context.Context, api.RepoName) (r0 *protocol.NotFoundPayload, r1 bool) {
-				return
-			},
-		},
-		P4ExecFunc: &ServiceP4ExecFunc{
-			defaultHook: func(context.Context, log.Logger, *p4ExecRequest, io.Writer) (r0 execStatus) {
 				return
 			},
 		},
@@ -151,11 +142,6 @@ func NewStrictMockService() *MockService {
 				panic("unexpected invocation of MockService.MaybeStartClone")
 			},
 		},
-		P4ExecFunc: &ServiceP4ExecFunc{
-			defaultHook: func(context.Context, log.Logger, *p4ExecRequest, io.Writer) execStatus {
-				panic("unexpected invocation of MockService.P4Exec")
-			},
-		},
 		RepoUpdateFunc: &ServiceRepoUpdateFunc{
 			defaultHook: func(*protocol.RepoUpdateRequest) protocol.RepoUpdateResponse {
 				panic("unexpected invocation of MockService.RepoUpdate")
@@ -180,7 +166,6 @@ type surrogateMockService interface {
 	IsRepoCloneable(context.Context, api.RepoName) (protocol.IsRepoCloneableResponse, error)
 	LogIfCorrupt(context.Context, api.RepoName, error)
 	MaybeStartClone(context.Context, api.RepoName) (*protocol.NotFoundPayload, bool)
-	P4Exec(context.Context, log.Logger, *p4ExecRequest, io.Writer) execStatus
 	RepoUpdate(*protocol.RepoUpdateRequest) protocol.RepoUpdateResponse
 	SearchWithObservability(context.Context, trace.Trace, *protocol.SearchRequest, func(*protocol.CommitMatch) error) (bool, error)
 }
@@ -209,9 +194,6 @@ func NewMockServiceFrom(i surrogateMockService) *MockService {
 		},
 		MaybeStartCloneFunc: &ServiceMaybeStartCloneFunc{
 			defaultHook: i.MaybeStartClone,
-		},
-		P4ExecFunc: &ServiceP4ExecFunc{
-			defaultHook: i.P4Exec,
 		},
 		RepoUpdateFunc: &ServiceRepoUpdateFunc{
 			defaultHook: i.RepoUpdate,
@@ -982,116 +964,6 @@ func (c ServiceMaybeStartCloneFuncCall) Args() []interface{} {
 // invocation.
 func (c ServiceMaybeStartCloneFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
-}
-
-// ServiceP4ExecFunc describes the behavior when the P4Exec method of the
-// parent MockService instance is invoked.
-type ServiceP4ExecFunc struct {
-	defaultHook func(context.Context, log.Logger, *p4ExecRequest, io.Writer) execStatus
-	hooks       []func(context.Context, log.Logger, *p4ExecRequest, io.Writer) execStatus
-	history     []ServiceP4ExecFuncCall
-	mutex       sync.Mutex
-}
-
-// P4Exec delegates to the next hook function in the queue and stores the
-// parameter and result values of this invocation.
-func (m *MockService) P4Exec(v0 context.Context, v1 log.Logger, v2 *p4ExecRequest, v3 io.Writer) execStatus {
-	r0 := m.P4ExecFunc.nextHook()(v0, v1, v2, v3)
-	m.P4ExecFunc.appendCall(ServiceP4ExecFuncCall{v0, v1, v2, v3, r0})
-	return r0
-}
-
-// SetDefaultHook sets function that is called when the P4Exec method of the
-// parent MockService instance is invoked and the hook queue is empty.
-func (f *ServiceP4ExecFunc) SetDefaultHook(hook func(context.Context, log.Logger, *p4ExecRequest, io.Writer) execStatus) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// P4Exec method of the parent MockService instance invokes the hook at the
-// front of the queue and discards it. After the queue is empty, the default
-// hook function is invoked for any future action.
-func (f *ServiceP4ExecFunc) PushHook(hook func(context.Context, log.Logger, *p4ExecRequest, io.Writer) execStatus) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ServiceP4ExecFunc) SetDefaultReturn(r0 execStatus) {
-	f.SetDefaultHook(func(context.Context, log.Logger, *p4ExecRequest, io.Writer) execStatus {
-		return r0
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ServiceP4ExecFunc) PushReturn(r0 execStatus) {
-	f.PushHook(func(context.Context, log.Logger, *p4ExecRequest, io.Writer) execStatus {
-		return r0
-	})
-}
-
-func (f *ServiceP4ExecFunc) nextHook() func(context.Context, log.Logger, *p4ExecRequest, io.Writer) execStatus {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ServiceP4ExecFunc) appendCall(r0 ServiceP4ExecFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ServiceP4ExecFuncCall objects describing
-// the invocations of this function.
-func (f *ServiceP4ExecFunc) History() []ServiceP4ExecFuncCall {
-	f.mutex.Lock()
-	history := make([]ServiceP4ExecFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ServiceP4ExecFuncCall is an object that describes an invocation of method
-// P4Exec on an instance of MockService.
-type ServiceP4ExecFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 log.Logger
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 *p4ExecRequest
-	// Arg3 is the value of the 4th argument passed to this method
-	// invocation.
-	Arg3 io.Writer
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 execStatus
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ServiceP4ExecFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ServiceP4ExecFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
 }
 
 // ServiceRepoUpdateFunc describes the behavior when the RepoUpdate method

--- a/cmd/gitserver/internal/mocks_test.go
+++ b/cmd/gitserver/internal/mocks_test.go
@@ -70,7 +70,7 @@ func NewMockService() *MockService {
 			},
 		},
 		CreateCommitFromPatchFunc: &ServiceCreateCommitFromPatchFunc{
-			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest) (r0 int, r1 protocol.CreateCommitFromPatchResponse) {
+			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) (r0 protocol.CreateCommitFromPatchResponse) {
 				return
 			},
 		},
@@ -127,7 +127,7 @@ func NewStrictMockService() *MockService {
 			},
 		},
 		CreateCommitFromPatchFunc: &ServiceCreateCommitFromPatchFunc{
-			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
+			defaultHook: func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse {
 				panic("unexpected invocation of MockService.CreateCommitFromPatch")
 			},
 		},
@@ -175,7 +175,7 @@ func NewStrictMockService() *MockService {
 type surrogateMockService interface {
 	BatchGitLogInstrumentedHandler(context.Context, *v1.BatchLogRequest) (*v1.BatchLogResponse, error)
 	CloneRepo(context.Context, api.RepoName, CloneOptions) (string, error)
-	CreateCommitFromPatch(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)
+	CreateCommitFromPatch(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse
 	Exec(context.Context, *protocol.ExecRequest, io.Writer) (execStatus, error)
 	IsRepoCloneable(context.Context, api.RepoName) (protocol.IsRepoCloneableResponse, error)
 	LogIfCorrupt(context.Context, api.RepoName, error)
@@ -448,24 +448,24 @@ func (c ServiceCloneRepoFuncCall) Results() []interface{} {
 // CreateCommitFromPatch method of the parent MockService instance is
 // invoked.
 type ServiceCreateCommitFromPatchFunc struct {
-	defaultHook func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)
-	hooks       []func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)
+	defaultHook func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse
+	hooks       []func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse
 	history     []ServiceCreateCommitFromPatchFuncCall
 	mutex       sync.Mutex
 }
 
 // CreateCommitFromPatch delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockService) CreateCommitFromPatch(v0 context.Context, v1 protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
-	r0, r1 := m.CreateCommitFromPatchFunc.nextHook()(v0, v1)
-	m.CreateCommitFromPatchFunc.appendCall(ServiceCreateCommitFromPatchFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockService) CreateCommitFromPatch(v0 context.Context, v1 protocol.CreateCommitFromPatchRequest, v2 io.Reader) protocol.CreateCommitFromPatchResponse {
+	r0 := m.CreateCommitFromPatchFunc.nextHook()(v0, v1, v2)
+	m.CreateCommitFromPatchFunc.appendCall(ServiceCreateCommitFromPatchFuncCall{v0, v1, v2, r0})
+	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // CreateCommitFromPatch method of the parent MockService instance is
 // invoked and the hook queue is empty.
-func (f *ServiceCreateCommitFromPatchFunc) SetDefaultHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)) {
+func (f *ServiceCreateCommitFromPatchFunc) SetDefaultHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse) {
 	f.defaultHook = hook
 }
 
@@ -473,7 +473,7 @@ func (f *ServiceCreateCommitFromPatchFunc) SetDefaultHook(hook func(context.Cont
 // CreateCommitFromPatch method of the parent MockService instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *ServiceCreateCommitFromPatchFunc) PushHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse)) {
+func (f *ServiceCreateCommitFromPatchFunc) PushHook(hook func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -481,20 +481,20 @@ func (f *ServiceCreateCommitFromPatchFunc) PushHook(hook func(context.Context, p
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *ServiceCreateCommitFromPatchFunc) SetDefaultReturn(r0 int, r1 protocol.CreateCommitFromPatchResponse) {
-	f.SetDefaultHook(func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
-		return r0, r1
+func (f *ServiceCreateCommitFromPatchFunc) SetDefaultReturn(r0 protocol.CreateCommitFromPatchResponse) {
+	f.SetDefaultHook(func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse {
+		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *ServiceCreateCommitFromPatchFunc) PushReturn(r0 int, r1 protocol.CreateCommitFromPatchResponse) {
-	f.PushHook(func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
-		return r0, r1
+func (f *ServiceCreateCommitFromPatchFunc) PushReturn(r0 protocol.CreateCommitFromPatchResponse) {
+	f.PushHook(func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse {
+		return r0
 	})
 }
 
-func (f *ServiceCreateCommitFromPatchFunc) nextHook() func(context.Context, protocol.CreateCommitFromPatchRequest) (int, protocol.CreateCommitFromPatchResponse) {
+func (f *ServiceCreateCommitFromPatchFunc) nextHook() func(context.Context, protocol.CreateCommitFromPatchRequest, io.Reader) protocol.CreateCommitFromPatchResponse {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -533,24 +533,24 @@ type ServiceCreateCommitFromPatchFuncCall struct {
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
 	Arg1 protocol.CreateCommitFromPatchRequest
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 io.Reader
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 int
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 protocol.CreateCommitFromPatchResponse
+	Result0 protocol.CreateCommitFromPatchResponse
 }
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c ServiceCreateCommitFromPatchFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ServiceCreateCommitFromPatchFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0}
 }
 
 // ServiceExecFunc describes the behavior when the Exec method of the parent

--- a/cmd/gitserver/internal/server.go
+++ b/cmd/gitserver/internal/server.go
@@ -815,15 +815,6 @@ func (s *Server) CloneRepo(ctx context.Context, repo api.RepoName, opts CloneOpt
 	return "", nil
 }
 
-func (s *Server) P4Exec(_ context.Context, logger log.Logger, _ *p4ExecRequest, _ io.Writer) execStatus {
-	logger.Error("p4exec has been deprecated and removed on gitserver")
-
-	return execStatus{
-		ExitStatus: 1,
-		Err:        errors.New("p4exec has been deprecated and removed on gitserver"),
-	}
-}
-
 func (s *Server) doClone(
 	ctx context.Context,
 	repo api.RepoName,

--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -42,7 +42,6 @@ type service interface {
 	SearchWithObservability(ctx context.Context, tr trace.Trace, args *protocol.SearchRequest, onMatch func(*protocol.CommitMatch) error) (limitHit bool, err error)
 
 	BatchGitLogInstrumentedHandler(ctx context.Context, req *proto.BatchLogRequest) (resp *proto.BatchLogResponse, err error)
-	P4Exec(ctx context.Context, logger log.Logger, req *p4ExecRequest, w io.Writer) execStatus
 }
 
 func NewGRPCServer(server *Server) proto.GitserverServiceServer {
@@ -1188,20 +1187,4 @@ func hasAccessToCommit(ctx context.Context, repoName api.RepoName, files []strin
 		}
 	}
 	return false, nil
-}
-
-func (gs *grpcServer) P4Exec(_ *proto.P4ExecRequest, _ proto.GitserverService_P4ExecServer) error {
-	return status.Error(codes.Unimplemented, "P4Exec has been deprecated and removed")
-}
-
-// p4ExecRequest is a request to execute a p4 command with given arguments.
-//
-// Note that this request is deserialized by both gitserver and the frontend's
-// internal proxy route and any major change to this structure will need to be
-// reconciled in both places.
-type p4ExecRequest struct {
-	P4Port   string   `json:"p4port"`
-	P4User   string   `json:"p4user"`
-	P4Passwd string   `json:"p4passwd"`
-	Args     []string `json:"args"`
 }

--- a/cmd/gitserver/internal/server_grpc_test.go
+++ b/cmd/gitserver/internal/server_grpc_test.go
@@ -62,7 +62,7 @@ func TestGRPCServer_Blame(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("checks for subrepo perms access to given path", func(t *testing.T) {
@@ -201,7 +201,7 @@ func TestGRPCServer_DefaultBranch(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("e2e", func(t *testing.T) {
@@ -263,7 +263,7 @@ func TestGRPCServer_MergeBase(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("e2e", func(t *testing.T) {
@@ -319,7 +319,7 @@ func TestGRPCServer_ReadFile(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("checks for subrepo perms access to given path", func(t *testing.T) {
@@ -449,7 +449,7 @@ func TestGRPCServer_GetCommit(t *testing.T) {
 		require.Error(t, err)
 		assertGRPCStatusCode(t, err, codes.NotFound)
 		assertHasGRPCErrorDetailOfType(t, err, &proto.RepoNotFoundPayload{})
-		require.Contains(t, err.Error(), "repo not cloned")
+		require.Contains(t, err.Error(), "repo not found")
 		mockassert.Called(t, svc.MaybeStartCloneFunc)
 	})
 	t.Run("checks for subrepo perms access to commit", func(t *testing.T) {

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -120,7 +120,6 @@ func TestClient_CreateCommitFromPatchRequest_ProtoRoundTrip(t *testing.T) {
 		fn := func(
 			repo string,
 			baseCommit string,
-			patch []byte,
 			targetRef string,
 			uniqueRef bool,
 			pushRef *string,
@@ -138,7 +137,6 @@ func TestClient_CreateCommitFromPatchRequest_ProtoRoundTrip(t *testing.T) {
 			original := protocol.CreateCommitFromPatchRequest{
 				Repo:       api.RepoName(repo),
 				BaseCommit: api.CommitID(baseCommit),
-				Patch:      patch,
 				TargetRef:  targetRef,
 				UniqueRef:  uniqueRef,
 				CommitInfo: protocol.PatchCommitInfo{
@@ -152,7 +150,7 @@ func TestClient_CreateCommitFromPatchRequest_ProtoRoundTrip(t *testing.T) {
 				GitApplyArgs: gitApplyArgs,
 			}
 			var converted protocol.CreateCommitFromPatchRequest
-			converted.FromProto(original.ToMetadataProto(), original.Patch)
+			converted.FromProto(original.ToMetadataProto())
 
 			if diff = cmp.Diff(original, converted); diff != "" {
 				return false

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -489,7 +489,7 @@ func (c *CreateCommitFromPatchRequest) ToMetadataProto() *proto.CreateCommitFrom
 	return cc
 }
 
-func (c *CreateCommitFromPatchRequest) FromProto(p *proto.CreateCommitFromPatchBinaryRequest_Metadata, patch []byte) {
+func (c *CreateCommitFromPatchRequest) FromProto(p *proto.CreateCommitFromPatchBinaryRequest_Metadata) {
 	gp := p.GetPush()
 	var pushConfig *PushConfig
 	if gp != nil {
@@ -502,7 +502,6 @@ func (c *CreateCommitFromPatchRequest) FromProto(p *proto.CreateCommitFromPatchB
 		BaseCommit:   api.CommitID(p.GetBaseCommit()),
 		TargetRef:    p.GetTargetRef(),
 		UniqueRef:    p.GetUniqueRef(),
-		Patch:        patch,
 		CommitInfo:   PatchCommitInfoFromProto(p.GetCommitInfo()),
 		Push:         pushConfig,
 		GitApplyArgs: p.GetGitApplyArgs(),


### PR DESCRIPTION
Just a simple change, we don't need to explicitly reimplement this.

## Test plan

This endpoint is unused, so as long as Go is happy, it will be fine.
