### PR TITLE
code-search: handle mobile responsiveness for cody banner on search page

### DIFF
--- a/client/web/src/search/home/SearchPage.tsx
+++ b/client/web/src/search/home/SearchPage.tsx
@@ -9,11 +9,17 @@ import { SearchPageContent, getShouldShowAddCodeHostWidget } from '../../storm/p
 
 export interface SearchPageProps {
     authenticatedUser: AuthenticatedUser | null
+    isSourcegraphDotCom: boolean
 }
 
-export const SearchPage: FC<SearchPageProps> = props => {
-    const shouldShowAddCodeHostWidget = useShouldShowAddCodeHostWidget(props.authenticatedUser)
-    return <SearchPageContent shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget} />
+export const SearchPage: FC<SearchPageProps> = ({ authenticatedUser, isSourcegraphDotCom }) => {
+    const shouldShowAddCodeHostWidget = useShouldShowAddCodeHostWidget(authenticatedUser)
+    return (
+        <SearchPageContent
+            shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget}
+            isSourcegraphDotCom={isSourcegraphDotCom}
+        />
+    )
 }
 
 const EXTERNAL_SERVICES_TOTAL_COUNT = gql`

--- a/client/web/src/storm/pages/SearchPage/CodyUpsell.module.scss
+++ b/client/web/src/storm/pages/SearchPage/CodyUpsell.module.scss
@@ -1,3 +1,5 @@
+@import 'wildcard/src/global-styles/breakpoints';
+
 .upsell {
     padding: 1.75rem 2.5rem;
     padding-right: 1rem;
@@ -8,6 +10,10 @@
     grid-template-columns: 1fr 1.5fr;
     gap: 1rem;
 
+    @media (--sm-breakpoint-down) {
+        grid-template-columns: 1fr;
+    }
+
     &-logo {
         width: 2.5rem;
         height: 2.5rem;
@@ -16,6 +22,7 @@
 
     &-image {
         filter: drop-shadow(-7px -16px 32px #a112ff24);
+        width: 100%;
     }
 
     &-meta {

--- a/client/web/src/storm/pages/SearchPage/CodyUpsell.tsx
+++ b/client/web/src/storm/pages/SearchPage/CodyUpsell.tsx
@@ -9,8 +9,14 @@ import { MultiLineCompletion } from './MultilineCompletion'
 
 import styles from './CodyUpsell.module.scss'
 
-export const CodyUpsell: FC = () => {
+interface CodyUpsellProps {
+    isSourcegraphDotCom: boolean
+}
+
+export const CodyUpsell: FC<CodyUpsellProps> = ({ isSourcegraphDotCom }) => {
     const isLightTheme = useIsLightTheme()
+    // On DotCom, we want to redirect to the PLG page. On Enterprise instances, we redirect to their Cody dashboard page.
+    const exploreCodyLink = isSourcegraphDotCom ? 'https://sourcegraph.com/cody?utm_source=server' : '/cody'
     return (
         <section className={styles.upsell}>
             <section className={styles.upsellMeta}>
@@ -20,7 +26,7 @@ export const CodyUpsell: FC = () => {
                     Cody autocompletes single lines, or entire code blocks, in any programming language, keeping all of
                     your company’s codebase in mind.
                 </Text>
-                <Link to="https://sourcegraph.com/cody?utm_source=server">Explore Cody</Link>
+                <Link to={exploreCodyLink}>Explore Cody</Link>
             </section>
             <MultiLineCompletion isLightTheme={isLightTheme} className={styles.upsellImage} />
         </section>

--- a/client/web/src/storm/pages/SearchPage/CodyUpsell.tsx
+++ b/client/web/src/storm/pages/SearchPage/CodyUpsell.tsx
@@ -20,7 +20,7 @@ export const CodyUpsell: FC = () => {
                     Cody autocompletes single lines, or entire code blocks, in any programming language, keeping all of
                     your company’s codebase in mind.
                 </Text>
-                <Link to="/cody">Explore Cody</Link>
+                <Link to="https://sourcegraph.com/cody?utm_source=server">Explore Cody</Link>
             </section>
             <MultiLineCompletion isLightTheme={isLightTheme} className={styles.upsellImage} />
         </section>

--- a/client/web/src/storm/pages/SearchPage/SearchPage.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPage.tsx
@@ -7,7 +7,7 @@ import { SearchPageContent, getShouldShowAddCodeHostWidget } from './SearchPageC
 
 export const SearchPage: FC = () => {
     const { data } = usePreloadedQueryData()
-    const { authenticatedUser } = useLegacyContext_onlyInStormRoutes()
+    const { authenticatedUser, isSourcegraphDotCom } = useLegacyContext_onlyInStormRoutes()
 
     const shouldShowAddCodeHostWidget = getShouldShowAddCodeHostWidget({
         isAddCodeHostWidgetEnabled: !!data?.codehostWidgetFlag,
@@ -15,5 +15,10 @@ export const SearchPage: FC = () => {
         externalServicesCount: data?.externalServices.totalCount,
     })
 
-    return <SearchPageContent shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget} />
+    return (
+        <SearchPageContent
+            shouldShowAddCodeHostWidget={shouldShowAddCodeHostWidget}
+            isSourcegraphDotCom={isSourcegraphDotCom}
+        />
+    )
 }

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.story.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.story.tsx
@@ -25,14 +25,14 @@ export const CloudAuthedHome: StoryFn = () => (
     <WebStory
         legacyLayoutContext={{ isSourcegraphDotCom: true, authenticatedUser: { id: 'userID' } as AuthenticatedUser }}
     >
-        {() => <SearchPageContent shouldShowAddCodeHostWidget={false} />}
+        {() => <SearchPageContent shouldShowAddCodeHostWidget={false} isSourcegraphDotCom={true} />}
     </WebStory>
 )
 
 CloudAuthedHome.storyName = 'Cloud authenticated home'
 
 export const ServerHome: StoryFn = () => (
-    <WebStory>{() => <SearchPageContent shouldShowAddCodeHostWidget={false} />}</WebStory>
+    <WebStory>{() => <SearchPageContent shouldShowAddCodeHostWidget={false} isSourcegraphDotCom={false} />}</WebStory>
 )
 
 ServerHome.storyName = 'Server home'

--- a/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
+++ b/client/web/src/storm/pages/SearchPage/SearchPageContent.tsx
@@ -28,6 +28,7 @@ import styles from './SearchPageContent.module.scss'
 
 interface SearchPageContentProps {
     shouldShowAddCodeHostWidget?: boolean
+    isSourcegraphDotCom: boolean
 }
 
 export const SearchPageContent: FC<SearchPageContentProps> = props => {
@@ -148,7 +149,7 @@ export const SearchPageContent: FC<SearchPageContentProps> = props => {
                     )}
                 </div>
             )}
-            <CodyUpsell />
+            <CodyUpsell isSourcegraphDotCom={isSourcegraphDotCom} />
             <SearchPageFooter />
         </div>
     )


### PR DESCRIPTION
After doing some testing on DotCom, I noticed the new cody banner was unresponsive on mobile. This PR fixes that.

I also noticed the `Explore Cody` link wasn't linking to the marketing page on Dotcom. @taiyab I'm not sure if this is better or we should link to the PLG dashboard instead, however, we'll still need to handle when a user isn't authenticated on DotCom - linking to the marketing page `sourcegraph.com/cody` was the easiest of all options, however, I'm happy to change to something else.

# Before

https://github.com/sourcegraph/sourcegraph/assets/25608335/9c050e69-de16-4a85-a4ba-0ec4a5cc96af

# After

https://github.com/sourcegraph/sourcegraph/assets/25608335/248aecea-7699-4a24-aee8-03e50b2962d6

## Test plan

* Manual testing based on the description above.