### PR TITLE
svelte: Use parallel data loading

### DIFF
--- a/client/shared/src/search/query/completion-utils.ts
+++ b/client/shared/src/search/query/completion-utils.ts
@@ -4,8 +4,6 @@
 
 import { escapeRegExp } from 'lodash'
 
-import type { RepositoryMatch } from '../stream'
-
 import { escapeSpaces, FILTERS, type FilterType, isNegatableFilter } from './filters'
 
 export const PREDICATE_REGEX = /^([.A-Za-z]+)\((.*?)\)?$/
@@ -23,7 +21,7 @@ export const regexInsertText = (value: string): string => {
  * repositoryInsertText escapes the provides value so that it can be used as a
  * value for the `repo:` filter.
  */
-export const repositoryInsertText = ({ repository }: RepositoryMatch): string => regexInsertText(repository)
+export const repositoryInsertText = ({ repository }: { repository: string }): string => regexInsertText(repository)
 
 /**
  * Given a list of filter types, this function returns a list of objects which

--- a/client/web-sveltekit/src/lib/repo/utils.ts
+++ b/client/web-sveltekit/src/lib/repo/utils.ts
@@ -43,3 +43,24 @@ export function getFileURL(repoURL: string, file: { canonicalURL: string }): str
     // TODO: Find out whether there is a safer way to do this
     return repoURL + file.canonicalURL.slice(file.canonicalURL.indexOf('/-/'))
 }
+
+/**
+ * This function is supposed to be used in repository data loaders.
+ *
+ * In order to ensure data consistency when navigating between repository pages, we have
+ * to ensure that the pages fetch data for the same revision. If a revision specifier is
+ * present in the URL and is a commit ID, we can use it directly. If it's a branch name,
+ * tag name or is missing, we have to wait for the parent loader to resolve the revision
+ * to a commit ID.
+ */
+export async function resolveRevision(
+    parent: () => Promise<{ resolvedRevision: ResolvedRevision }>,
+    revisionFromURL: string | undefined
+): Promise<string> {
+    // There is a chance that a commit ID is used as a branch or tag name,
+    // but it's unlikely. Avoiding waterfall requests is worth the risk.
+    if (revisionFromURL && /[0-9a-f]{40}/.test(revisionFromURL)) {
+        return revisionFromURL
+    }
+    return (await parent()).resolvedRevision.commitID
+}

--- a/client/web-sveltekit/src/lib/search/utils.ts
+++ b/client/web-sveltekit/src/lib/search/utils.ts
@@ -20,6 +20,7 @@ type FilterGroups = Record<Filter['kind'], Filter[]>
 
 export function groupFilters(filters: Filter[] | null | undefined): FilterGroups {
     const groupedFilters: FilterGroups = {
+        type: [],
         file: [],
         repo: [],
         lang: [],

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+layout.svelte
@@ -13,7 +13,6 @@
 
     import type { LayoutData, Snapshot } from './$types'
     import FileTree from './FileTree.svelte'
-    import type { Scalars } from '$lib/graphql-operations'
     import type { GitHistory_HistoryConnection } from './layout.gql'
     import Tabs from '$lib/Tabs.svelte'
     import TabPanel from '$lib/TabPanel.svelte'
@@ -48,7 +47,7 @@
                 })
         )
 
-    async function updateFileTreeProvider(repoID: Scalars['ID']['input'], commitID: string, parentPath: string) {
+    async function updateFileTreeProvider(repoName: string, revision: string, parentPath: string) {
         const result = await data.fileTree
         if (!result) {
             treeProvider = null
@@ -57,18 +56,14 @@
         const { root, values } = result
 
         // Do nothing if update was called with new arguments in the meantime
-        if (
-            repoID !== data.resolvedRevision.repo.id ||
-            commitID !== data.resolvedRevision.commitID ||
-            parentPath !== data.parentPath
-        ) {
+        if (repoName !== data.repoName || revision !== (data.revision ?? '') || parentPath !== data.parentPath) {
             return
         }
         treeProvider = new FileTreeProvider({
             root,
             values,
-            repoID,
-            commitID,
+            repoName,
+            revision,
             loader: fileTreeLoader,
         })
     }
@@ -97,12 +92,10 @@
     let selectedTab: number | null = null
     let historyPanel: HistoryPanel
 
-    $: ({ revision, parentPath, resolvedRevision } = data)
-    $: commitID = resolvedRevision.commitID
-    $: repoID = resolvedRevision.repo.id
+    $: ({ revision = '', parentPath, repoName } = data)
     // Only update the file tree provider (which causes the tree to rerender) when repo, revision/commit or file path
     // update
-    $: updateFileTreeProvider(repoID, commitID, parentPath)
+    $: updateFileTreeProvider(repoName, revision, parentPath)
     $: commitHistoryQuery = data.commitHistory
     let commitHistory: GitHistory_HistoryConnection | null
     $: if (commitHistoryQuery) {
@@ -111,10 +104,7 @@
         // file/folder until the new commit history is loaded.
         commitHistory = null
     }
-    $: commitHistory =
-        $commitHistoryQuery?.data.node?.__typename === 'Repository'
-            ? $commitHistoryQuery.data.node.commit?.ancestors ?? null
-            : null
+    $: commitHistory = $commitHistoryQuery?.data?.repository?.commit?.ancestors ?? null
 
     const sidebarSize = getSeparatorPosition('repo-sidebar', 0.2)
     $: sidebarWidth = `max(200px, ${$sidebarSize * 100}%)`

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/+page.ts
@@ -23,6 +23,10 @@ export const load: PageLoad = async ({ parent }) => {
                 })
                 .then(result => {
                     if (result.data.node?.__typename !== 'Repository') {
+                        // This page will never render when the repository is not found.
+                        // The (validrev) data loader will render an error page instead.
+                        // Still, this error will show up as an unhandled promise rejection
+                        // in the console. We should find a better way to handle this.
                         throw new Error('Expected Repository')
                     }
                     return result.data.node.commit?.blob ?? null

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -1,13 +1,15 @@
 import { getGraphQLClient } from '$lib/graphql'
+import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
 
 import type { PageLoad } from './$types'
 import { BlobDiffQuery, BlobPageQuery, BlobSyntaxHighlightQuery } from './page.gql'
 
-export const load: PageLoad = async ({ params, url }) => {
+export const load: PageLoad = async ({ parent, params, url }) => {
     const revisionToCompare = url.searchParams.get('rev')
     const graphqlClient = await getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
+    const resolvedRevision = await resolveRevision(parent, revision)
 
     return {
         filePath: params.path,
@@ -16,7 +18,7 @@ export const load: PageLoad = async ({ params, url }) => {
                 query: BlobPageQuery,
                 variables: {
                     repoName,
-                    revspec: revision,
+                    revspec: resolvedRevision,
                     path: params.path,
                 },
             })
@@ -31,7 +33,7 @@ export const load: PageLoad = async ({ params, url }) => {
                 query: BlobSyntaxHighlightQuery,
                 variables: {
                     repoName,
-                    revspec: revision,
+                    revspec: resolvedRevision,
                     path: params.path,
                     disableTimeout: false,
                 },

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.ts
@@ -1,9 +1,13 @@
+import { getGraphQLClient } from '$lib/graphql'
+import { parseRepoRevision } from '$lib/shared'
+
 import type { PageLoad } from './$types'
 import { BlobDiffQuery, BlobPageQuery, BlobSyntaxHighlightQuery } from './page.gql'
 
-export const load: PageLoad = async ({ parent, params, url }) => {
+export const load: PageLoad = async ({ params, url }) => {
     const revisionToCompare = url.searchParams.get('rev')
-    const { resolvedRevision, graphqlClient } = await parent()
+    const graphqlClient = await getGraphQLClient()
+    const { repoName, revision = '' } = parseRepoRevision(params.repo)
 
     return {
         filePath: params.path,
@@ -11,32 +15,29 @@ export const load: PageLoad = async ({ parent, params, url }) => {
             .query({
                 query: BlobPageQuery,
                 variables: {
-                    repoID: resolvedRevision.repo.id,
-                    revspec: resolvedRevision.commitID,
+                    repoName,
+                    revspec: revision,
                     path: params.path,
                 },
             })
             .then(result => {
-                if (result.data.node?.__typename !== 'Repository' || !result.data.node.commit?.blob) {
-                    throw new Error('Commit or file not found')
+                if (!result.data.repository?.commit) {
+                    throw new Error('Repository not found')
                 }
-                return result.data.node.commit.blob
+                return result.data.repository.commit.blob
             }),
         highlights: graphqlClient
             .query({
                 query: BlobSyntaxHighlightQuery,
                 variables: {
-                    repoID: resolvedRevision.repo.id,
-                    revspec: resolvedRevision.commitID,
+                    repoName,
+                    revspec: revision,
                     path: params.path,
                     disableTimeout: false,
                 },
             })
             .then(result => {
-                if (result.data.node?.__typename !== 'Repository') {
-                    throw new Error('Expected Repository')
-                }
-                return result.data.node.commit?.blob?.highlight.lsif
+                return result.data.repository?.commit?.blob?.highlight.lsif
             }),
         compare: revisionToCompare
             ? {
@@ -45,16 +46,13 @@ export const load: PageLoad = async ({ parent, params, url }) => {
                       .query({
                           query: BlobDiffQuery,
                           variables: {
-                              repoID: resolvedRevision.repo.id,
+                              repoName,
                               revspec: revisionToCompare,
                               paths: [params.path],
                           },
                       })
                       .then(result => {
-                          if (result.data.node?.__typename !== 'Repository') {
-                              throw new Error('Expected Repository')
-                          }
-                          return result.data.node.commit?.diff.fileDiffs.nodes[0]
+                          return result.data.repository?.commit?.diff.fileDiffs.nodes[0]
                       }),
               }
             : null,

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
@@ -1,14 +1,12 @@
-query BlobDiffQuery($repoID: ID!, $revspec: String!, $paths: [String!]) {
-    node(id: $repoID) {
-        ... on Repository {
+query BlobDiffQuery($repoName: String!, $revspec: String!, $paths: [String!]) {
+    repository(name: $repoName) {
+        id
+        commit(rev: $revspec) {
             id
-            commit(rev: $revspec) {
-                id
-                diff {
-                    fileDiffs(paths: $paths) {
-                        nodes {
-                            ...FileDiff_Diff
-                        }
+            diff {
+                fileDiffs(paths: $paths) {
+                    nodes {
+                        ...FileDiff_Diff
                     }
                 }
             }
@@ -16,16 +14,14 @@ query BlobDiffQuery($repoID: ID!, $revspec: String!, $paths: [String!]) {
     }
 }
 
-query BlobPageQuery($repoID: ID!, $revspec: String!, $path: String!) {
-    node(id: $repoID) {
-        ... on Repository {
+query BlobPageQuery($repoName: String!, $revspec: String!, $path: String!) {
+    repository(name: $repoName) {
+        id
+        commit(rev: $revspec) {
             id
-            commit(rev: $revspec) {
-                id
-                oid
-                blob(path: $path) {
-                    ...BlobPage_Blob
-                }
+            oid
+            blob(path: $path) {
+                ...BlobPage_Blob
             }
         }
     }
@@ -38,18 +34,16 @@ fragment BlobPage_Blob on GitBlob {
     languages
 }
 
-query BlobSyntaxHighlightQuery($repoID: ID!, $revspec: String!, $path: String!, $disableTimeout: Boolean!) {
-    node(id: $repoID) {
-        ... on Repository {
+query BlobSyntaxHighlightQuery($repoName: String!, $revspec: String!, $path: String!, $disableTimeout: Boolean!) {
+    repository(name: $repoName) {
+        id
+        commit(rev: $revspec) {
             id
-            commit(rev: $revspec) {
-                id
-                blob(path: $path) {
-                    canonicalURL
-                    highlight(disableTimeout: $disableTimeout) {
-                        aborted
-                        lsif
-                    }
+            blob(path: $path) {
+                canonicalURL
+                highlight(disableTimeout: $disableTimeout) {
+                    aborted
+                    lsif
                 }
             }
         }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/+page.ts
@@ -1,18 +1,20 @@
 import { getGraphQLClient } from '$lib/graphql'
 import { fetchTreeEntries } from '$lib/repo/api/tree'
 import { findReadme } from '$lib/repo/tree'
+import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
 
 import type { PageLoad } from './$types'
 import { TreePageCommitInfoQuery, TreePageReadmeQuery } from './page.gql'
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ parent, params }) => {
     const client = await getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
+    const resolvedRevision = await resolveRevision(parent, revision)
 
     const treeEntries = fetchTreeEntries({
         repoName,
-        revision,
+        revision: resolvedRevision,
         filePath: params.path,
         first: null,
     }).then(
@@ -28,7 +30,7 @@ export const load: PageLoad = async ({ params }) => {
                 query: TreePageCommitInfoQuery,
                 variables: {
                     repoName,
-                    revision,
+                    revision: resolvedRevision,
                     filePath: params.path,
                     first: null,
                 },
@@ -49,7 +51,7 @@ export const load: PageLoad = async ({ params }) => {
                     query: TreePageReadmeQuery,
                     variables: {
                         repoName,
-                        revision,
+                        revision: resolvedRevision,
                         path: readme.path,
                     },
                 })

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/tree/[...path]/page.gql
@@ -5,31 +5,26 @@ fragment TreePage_TreeWithCommitInfo on GitTree {
     }
 }
 
-query TreePageCommitInfoQuery($repoID: ID!, $commitID: String!, $filePath: String!, $first: Int) {
-    node(id: $repoID) {
-        __typename
+query TreePageCommitInfoQuery($repoName: String!, $revision: String!, $filePath: String!, $first: Int) {
+    repository(name: $repoName) {
         id
-        ... on Repository {
-            commit(rev: $commitID) {
-                id
-                tree(path: $filePath) {
-                    ...TreePage_TreeWithCommitInfo
-                }
+        commit(rev: $revision) {
+            id
+            tree(path: $filePath) {
+                ...TreePage_TreeWithCommitInfo
             }
         }
     }
 }
 
-query TreePageReadmeQuery($repoID: ID!, $revspec: String!, $path: String!) {
-    node(id: $repoID) {
-        ... on Repository {
+query TreePageReadmeQuery($repoName: String!, $revision: String!, $path: String!) {
+    repository(name: $repoName) {
+        id
+        commit(rev: $revision) {
             id
-            commit(rev: $revspec) {
-                id
-                blob(path: $path) {
-                    canonicalURL # key field
-                    ...RepoPage_Readme
-                }
+            blob(path: $path) {
+                canonicalURL # key field
+                ...RepoPage_Readme
             }
         }
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -81,18 +81,18 @@
     }
 
     let treeView: TreeView<FileTreeNodeValue>
-    let repoID = treeProvider.getRepoID()
+    let repoName = treeProvider.getRepoName()
     // Since context is only set once when the component is created
     // we need to dynamically sync any changes to the corresponding
     // file tree state store
-    const treeState = createForwardStore(getSidebarFileTreeStateForRepo(treeProvider.getRepoID()))
+    const treeState = createForwardStore(getSidebarFileTreeStateForRepo(treeProvider.getRepoName()))
     // Propagating the tree state via context yielded better performance than passing
     // it via props.
     setTreeContext(treeState)
 
     $: treeRoot = treeProvider.getRoot()
-    $: repoID = treeProvider.getRepoID()
-    $: treeState.updateStore(getSidebarFileTreeStateForRepo(repoID))
+    $: repoName = treeProvider.getRepoName()
+    $: treeState.updateStore(getSidebarFileTreeStateForRepo(repoName))
     // Update open and selected nodes when the path changes.
     $: markSelected(selectedPath)
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/layout.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/layout.gql
@@ -1,18 +1,16 @@
-query GitHistoryQuery($repo: ID!, $revspec: String!, $first: Int, $afterCursor: String, $filePath: String) {
-    node(id: $repo) {
-        ... on Repository {
+query GitHistoryQuery($repoName: String!, $revspec: String!, $first: Int, $afterCursor: String, $filePath: String) {
+    repository(name: $repoName) {
+        id
+        commit(rev: $revspec) {
             id
-            commit(rev: $revspec) {
-                id
-                ancestors(first: $first, path: $filePath, afterCursor: $afterCursor) {
-                    # This is a bit hacky, but by fetching all the data needed by both
-                    # the history panel and the commits page we ensure that our custom
-                    # Apollo infinitiy scroll cache handling for this field works
-                    # correctly. Eventually we should revsisit the use of infinity scroll
-                    # on the commits page.
-                    ...CommitsPage_GitCommitConnection
-                    ...GitHistory_HistoryConnection
-                }
+            ancestors(first: $first, path: $filePath, afterCursor: $afterCursor) {
+                # This is a bit hacky, but by fetching all the data needed by both
+                # the history panel and the commits page we ensure that our custom
+                # Apollo infinitiy scroll cache handling for this field works
+                # correctly. Eventually we should revsisit the use of infinity scroll
+                # on the commits page.
+                ...CommitsPage_GitCommitConnection
+                ...GitHistory_HistoryConnection
             }
         }
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/page.spec.ts
@@ -7,6 +7,7 @@ test.beforeEach(({ sg }) => {
         {
             __typename: 'Repository',
             id: '1',
+            name: repoName,
             description: 'Example description',
             mirrorInfo: {
                 cloned: true,
@@ -54,15 +55,14 @@ test.beforeEach(({ sg }) => {
     ])
 
     sg.mockOperations({
-        ResolveRepoRevison: ({ repoName }) => ({
+        ResolveRepoRevison: () => ({
             repositoryRedirect: {
                 id: '1',
-                name: repoName,
             },
         }),
-        TreeEntries: ({ repoID }) => ({
-            node: {
-                id: repoID,
+        TreeEntries: () => ({
+            repository: {
+                id: '1',
             },
         }),
         RepoPageReadmeQuery: ({ repoID, path }) => ({
@@ -115,8 +115,7 @@ test('repo description', async ({ page, sg }) => {
     // Shows the repo description if there is no readme file in the repo root
     sg.mockOperations({
         TreeEntries: () => ({
-            node: {
-                __typename: 'Repository',
+            repository: {
                 commit: {
                     tree: {
                         isRoot: true,
@@ -135,8 +134,7 @@ test('repo description', async ({ page, sg }) => {
 test('history panel', async ({ page, sg }) => {
     sg.mockOperations({
         GitHistoryQuery: () => ({
-            node: {
-                __typename: 'Repository',
+            repository: {
                 id: '1',
                 commit: {
                     ancestors: {

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/+page.ts
@@ -1,23 +1,32 @@
-import type { PageLoad } from './$types'
-import { GitBranchesOverviewQuery } from './page.gql'
+import { getGraphQLClient } from '$lib/graphql'
+import { parseRepoRevision } from '$lib/shared'
 
-export const load: PageLoad = async ({ parent }) => {
-    const { resolvedRevision, graphqlClient } = await parent()
+import type { PageLoad } from './$types'
+import { BranchesPage_OverviewQuery } from './page.gql'
+
+export const load: PageLoad = async ({ params }) => {
+    const client = await getGraphQLClient()
+    const { repoName } = parseRepoRevision(params.repo)
+
     return {
-        overview: graphqlClient
+        overview: client
             .query({
-                query: GitBranchesOverviewQuery,
+                query: BranchesPage_OverviewQuery,
                 variables: {
                     first: 20,
-                    repo: resolvedRevision.repo.id,
+                    repoName,
                     withBehindAhead: true,
                 },
             })
             .then(result => {
-                if (result.data.node?.__typename !== 'Repository') {
+                if (!result.data.repository) {
+                    // This page will never render when the repository is not found.
+                    // The (validrev) data loader will render an error page instead.
+                    // Still, this error will show up as an unhandled promise rejection
+                    // in the console. We should find a better way to handle this.
                     throw new Error('Expected Repository')
                 }
-                return result.data.node
+                return result.data.repository
             }),
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/all/page.gql
@@ -1,10 +1,13 @@
-query GitBranchesQuery($repo: ID!, $first: Int!, $withBehindAhead: Boolean!, $revspec: String = "") {
-    node(id: $repo) {
+query AllBranchesPage_BranchesQuery(
+    $repoName: String!
+    $first: Int!
+    $withBehindAhead: Boolean!
+    $revspec: String = ""
+) {
+    repository(name: $repoName) {
         id
-        ... on Repository {
-            branches(first: $first, orderBy: AUTHORED_OR_COMMITTED_AT) {
-                ...GitBranchesConnection
-            }
+        branches(first: $first, orderBy: AUTHORED_OR_COMMITTED_AT) {
+            ...GitBranchesConnection
         }
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/branches/page.gql
@@ -1,5 +1,5 @@
-query GitBranchesOverviewQuery($repo: ID!, $first: Int!, $withBehindAhead: Boolean!, $revspec: String = "") {
-    node(id: $repo) {
+query BranchesPage_OverviewQuery($repoName: String!, $first: Int!, $withBehindAhead: Boolean!, $revspec: String = "") {
+    repository(name: $repoName) {
         id
         ...GitBranchesOverview
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/+page.svelte
@@ -24,8 +24,8 @@
     let loading = true
     let expandedDiffs = new Map<number, boolean>()
 
-    $: fileDiffConnection = $diff?.data.node?.__typename === 'Repository' ? $diff.data.node.comparison.fileDiffs : null
-    $: if ($diff?.data.node) {
+    $: fileDiffConnection = $diff?.data.repository?.comparison.fileDiffs ?? null
+    $: if ($diff?.data.repository) {
         loading = false
     }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/+page.ts
@@ -1,29 +1,27 @@
+import { getGraphQLClient } from '$lib/graphql'
+import { parseRepoRevision } from '$lib/shared'
+
 import type { PageLoad } from './$types'
 import { CommitPage_CommitQuery, CommitPage_DiffQuery } from './page.gql'
 
 const PAGE_SIZE = 20
 
-export const load: PageLoad = async ({ parent, params }) => {
-    const {
-        resolvedRevision: { repo },
-        graphqlClient,
-    } = await parent()
+export const load: PageLoad = async ({ params }) => {
+    const client = await getGraphQLClient()
+    const { repoName } = parseRepoRevision(params.repo)
 
-    const commit = await graphqlClient
-        .query({ query: CommitPage_CommitQuery, variables: { repo: repo.id, revspec: params.revspec } })
+    const commit = await client
+        .query({ query: CommitPage_CommitQuery, variables: { repoName, revspec: params.revspec } })
         .then(result => {
-            if (result.data.node?.__typename === 'Repository') {
-                return result.data.node.commit
-            }
-            return null
+            return result.data.repository?.commit ?? null
         })
 
     const diff =
         commit?.oid && commit?.parents[0]?.oid
-            ? graphqlClient.watchQuery({
+            ? client.watchQuery({
                   query: CommitPage_DiffQuery,
                   variables: {
-                      repo: repo.id,
+                      repoName,
                       base: commit.parents[0].oid,
                       head: commit.oid,
                       first: PAGE_SIZE,
@@ -32,7 +30,7 @@ export const load: PageLoad = async ({ parent, params }) => {
               })
             : null
 
-    if (diff && !graphqlClient.readQuery({ query: CommitPage_DiffQuery, variables: diff.variables })) {
+    if (diff && !client.readQuery({ query: CommitPage_DiffQuery, variables: diff.variables })) {
         // Eagerly fetch data if it isn't in the cache already. This ensures that the data is fetched
         // as soon as possible, not only after the layout subscribes to the query.
         diff.refetch()

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commit/[...revspec]/page.gql
@@ -1,36 +1,32 @@
-query CommitPage_CommitQuery($repo: ID!, $revspec: String!) {
-    node(id: $repo) {
-        ... on Repository {
+query CommitPage_CommitQuery($repoName: String!, $revspec: String!) {
+    repository(name: $repoName) {
+        id
+        commit(rev: $revspec) {
             id
-            commit(rev: $revspec) {
+            oid
+            parents {
                 id
                 oid
-                parents {
-                    id
-                    oid
-                    abbreviatedOID
-                    canonicalURL
-                }
-
-                ...Commit
+                abbreviatedOID
+                canonicalURL
             }
+
+            ...Commit
         }
     }
 }
 
-query CommitPage_DiffQuery($repo: ID!, $base: String, $head: String, $first: Int, $after: String) {
-    node(id: $repo) {
-        ... on Repository {
-            id
-            comparison(base: $base, head: $head) {
-                fileDiffs(first: $first, after: $after) {
-                    nodes {
-                        ...FileDiff_Diff
-                    }
-                    pageInfo {
-                        endCursor
-                        hasNextPage
-                    }
+query CommitPage_DiffQuery($repoName: String!, $base: String, $head: String, $first: Int, $after: String) {
+    repository(name: $repoName) {
+        id
+        comparison(base: $base, head: $head) {
+            fileDiffs(first: $first, after: $after) {
+                nodes {
+                    ...FileDiff_Diff
+                }
+                pageInfo {
+                    endCursor
+                    hasNextPage
                 }
             }
         }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/+page.svelte
@@ -86,8 +86,7 @@
     let restored = false
 
     $: commitsQuery = data.commitsQuery
-    $: commits =
-        $commitsQuery?.data.node?.__typename === 'Repository' ? $commitsQuery.data.node.commit?.ancestors : undefined
+    $: commits = $commitsQuery?.data.repository?.commit?.ancestors
     $: if (!restored) {
         restoreCommits(commits, restoredCommitCount, restoredScroller)
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/+page.ts
@@ -1,23 +1,27 @@
+import { getGraphQLClient } from '$lib/graphql'
+import { parseRepoRevision } from '$lib/shared'
+
 import type { PageLoad } from './$types'
 import { CommitsPage_CommitsQuery } from './page.gql'
 
 const PAGE_SIZE = 20
 
-export const load: PageLoad = async ({ parent }) => {
-    const { resolvedRevision, graphqlClient } = await parent()
+export const load: PageLoad = async ({ params }) => {
+    const client = await getGraphQLClient()
+    const { repoName, revision = '' } = parseRepoRevision(params.repo)
 
-    const commitsQuery = graphqlClient.watchQuery({
+    const commitsQuery = client.watchQuery({
         query: CommitsPage_CommitsQuery,
         variables: {
-            repo: resolvedRevision.repo.id,
-            revspec: resolvedRevision.commitID,
+            repoName,
+            revision,
             first: PAGE_SIZE,
             afterCursor: null,
         },
         notifyOnNetworkStatusChange: true,
     })
 
-    if (!graphqlClient.readQuery({ query: CommitsPage_CommitsQuery, variables: commitsQuery.variables })) {
+    if (!client.readQuery({ query: CommitsPage_CommitsQuery, variables: commitsQuery.variables })) {
         // Eagerly fetch data if it isn't in the cache already. This ensures that the data is fetched
         // as soon as possible, not only after the layout subscribes to the query.
         commitsQuery.refetch()

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/+page.ts
@@ -1,4 +1,5 @@
 import { getGraphQLClient } from '$lib/graphql'
+import { resolveRevision } from '$lib/repo/utils'
 import { parseRepoRevision } from '$lib/shared'
 
 import type { PageLoad } from './$types'
@@ -6,15 +7,16 @@ import { CommitsPage_CommitsQuery } from './page.gql'
 
 const PAGE_SIZE = 20
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ parent, params }) => {
     const client = await getGraphQLClient()
     const { repoName, revision = '' } = parseRepoRevision(params.repo)
+    const resolvedRevision = await resolveRevision(parent, revision)
 
     const commitsQuery = client.watchQuery({
         query: CommitsPage_CommitsQuery,
         variables: {
             repoName,
-            revision,
+            revision: resolvedRevision,
             first: PAGE_SIZE,
             afterCursor: null,
         },

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/page.gql
@@ -8,22 +8,19 @@ fragment CommitsPage_GitCommitConnection on GitCommitConnection {
     }
 }
 
-query CommitsPage_CommitsQuery($repo: ID!, $revspec: String!, $first: Int, $afterCursor: String) {
-    node(id: $repo) {
-        __typename
-        ... on Repository {
+query CommitsPage_CommitsQuery($repoName: String!, $revision: String!, $first: Int, $afterCursor: String) {
+    repository(name: $repoName) {
+        id
+        commit(rev: $revision) {
             id
-            commit(rev: $revspec) {
-                id
-                ancestors(first: $first, afterCursor: $afterCursor) {
-                    # This is a bit hacky, but by fetching all the data needed by both
-                    # the history panel and the commits page we ensure that our custom
-                    # Apollo infinitiy scroll cache handling for this field works
-                    # correctly. Eventually we should revisit the use of infinity scroll
-                    # on the commits page.
-                    ...HistoryPanel_HistoryConnection
-                    ...CommitsPage_GitCommitConnection
-                }
+            ancestors(first: $first, afterCursor: $afterCursor) {
+                # This is a bit hacky, but by fetching all the data needed by both
+                # the history panel and the commits page we ensure that our custom
+                # Apollo infinitiy scroll cache handling for this field works
+                # correctly. Eventually we should revisit the use of infinity scroll
+                # on the commits page.
+                ...HistoryPanel_HistoryConnection
+                ...CommitsPage_GitCommitConnection
             }
         }
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/page.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/commits/page.spec.ts
@@ -19,8 +19,7 @@ test.beforeEach(async ({ sg }) => {
             const from = afterCursor ? +afterCursor : 0
             const to = from ? (first ?? 20) - 5 : first ?? 20
             return {
-                node: {
-                    __typename: 'Repository',
+                repository: {
                     id: '1',
                     commit: {
                         id: '1',

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/stats/contributors/page.gql
@@ -25,8 +25,8 @@ fragment ContributorConnection on RepositoryContributorConnection {
     totalCount
 }
 
-query PagedRepositoryContributors(
-    $repo: ID!
+query ContributorsPage_ContributorsQuery(
+    $repoName: String!
     $first: Int
     $last: Int
     $after: String
@@ -35,21 +35,18 @@ query PagedRepositoryContributors(
     $afterDate: String
     $path: String
 ) {
-    node(id: $repo) {
-        __typename
-        ... on Repository {
-            id
-            contributors(
-                first: $first
-                last: $last
-                before: $before
-                after: $after
-                revisionRange: $revisionRange
-                afterDate: $afterDate
-                path: $path
-            ) {
-                ...ContributorConnection
-            }
+    repository(name: $repoName) {
+        id
+        contributors(
+            first: $first
+            last: $last
+            before: $before
+            after: $after
+            revisionRange: $revisionRange
+            afterDate: $afterDate
+            path: $path
+        ) {
+            ...ContributorConnection
         }
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/+page.ts
@@ -1,24 +1,28 @@
-import type { PageLoad } from './$types'
-import { GitTagsQuery } from './page.gql'
+import { getGraphQLClient } from '$lib/graphql'
+import { parseRepoRevision } from '$lib/shared'
 
-export const load: PageLoad = async ({ parent }) => {
-    const { resolvedRevision, graphqlClient } = await parent()
+import type { PageLoad } from './$types'
+import { TagsPage_TagsQuery } from './page.gql'
+
+export const load: PageLoad = async ({ params }) => {
+    const client = await getGraphQLClient()
+    const { repoName } = parseRepoRevision(params.repo)
 
     return {
-        tags: graphqlClient
+        tags: client
             .query({
-                query: GitTagsQuery,
+                query: TagsPage_TagsQuery,
                 variables: {
-                    repo: resolvedRevision.repo.id,
+                    repoName,
                     first: 20,
                     withBehindAhead: false,
                 },
             })
             .then(result => {
-                if (result.data.node?.__typename !== 'Repository') {
+                if (!result.data.repository) {
                     throw new Error('Expected Repository')
                 }
-                return result.data.node.gitRefs
+                return result.data.repository.gitRefs
             }),
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/-/tags/page.gql
@@ -1,10 +1,8 @@
-query GitTagsQuery($repo: ID!, $first: Int!, $withBehindAhead: Boolean!, $revspec: String = "") {
-    node(id: $repo) {
+query TagsPage_TagsQuery($repoName: String!, $first: Int!, $withBehindAhead: Boolean!, $revspec: String = "") {
+    repository(name: $repoName) {
         id
-        ... on Repository {
-            gitRefs(first: $first, type: GIT_TAG, orderBy: AUTHORED_OR_COMMITTED_AT) {
-                ...GitTagsConnection
-            }
+        gitRefs(first: $first, type: GIT_TAG, orderBy: AUTHORED_OR_COMMITTED_AT) {
+            ...GitTagsConnection
         }
     }
 }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/layout.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/layout.gql
@@ -1,4 +1,4 @@
-query ResolveRepoRevison($repoName: String!, $revision: String!) {
+query ResolveRepoRevision($repoName: String!, $revision: String!) {
     repositoryRedirect(name: $repoName) {
         __typename
         ... on Repository {


### PR DESCRIPTION
The way how data loaders are currently depending on each other results in unnecessary waterfall data loading. I originally thought that it would make the data flow clearer, but I think the benefit of parallel data loading outweighs this.

Before:
- all data loaders depend on the top level data loader to provide the GraphQL client, but the top level data loader also fetches initial data for the app which can take time
- any repo data loaders depend on the repo root data loader to validate/resolve the repo and commit

![2024-02-08_10-20](https://github.com/sourcegraph/sourcegraph/assets/179026/6f7a8770-39dc-4457-8629-8437016b1fb6)


Now:
- data loaders fetch a reference to the global graphql client
- almost all repo loaders use the repo name and revision from the URL
  - this required to change GraphQL queries from `node(id)` to `repository(name)`
  - before the loader could assume that the repo and revision are valid. That's not the case anymore, so each of these queries could "fail". However the `(validrev)` data loader will still validate the revision and render an appropriate error page. So even though the data loaders run and try to fetch the data for an invalid repo/revision, the corresponding page won't be rendered.

![2024-02-08_10-21](https://github.com/sourcegraph/sourcegraph/assets/179026/3311f9d4-115b-49cb-9148-5a0df71db9a4)


If a loader needs access to user data they will of course need to wait for the parent loader to resolve. But so far that hasn't been the case.


## Test plan

Manual testing, `pnpm test`
