### PR TITLE
svelte: Improve scroll behavior on repo pages

### DIFF
--- a/client/web-sveltekit/src/app.html
+++ b/client/web-sveltekit/src/app.html
@@ -13,6 +13,6 @@
         %sveltekit.head%
     </head>
     <body data-sveltekit-preload-data data-sveltekit-preload-code="hover">
-        <div>%sveltekit.body%</div>
+        %sveltekit.body%
     </body>
 </html>

--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -168,3 +168,25 @@ export const computeFit: Action<HTMLElement, void, ComputeFitAttributes> = node 
         },
     }
 }
+
+/**
+ * Helper action to manage CSS classes on an element. This is used on svelte:body because
+ * it doesn't support the class directive.
+ * See https://github.com/sveltejs/svelte/issues/3105
+ */
+export const classNames: Action<HTMLElement, string | string[]> = (node, classes) => {
+    classes = (Array.isArray(classes) ? classes : [classes]).filter(Boolean)
+    node.classList.add(...classes)
+
+    return {
+        update(newClasses) {
+            newClasses = (Array.isArray(newClasses) ? newClasses : [newClasses]).filter(Boolean)
+            node.classList.remove(...classes)
+            node.classList.add(...newClasses)
+            classes = newClasses
+        },
+        destroy() {
+            node.classList.remove(...classes)
+        },
+    }
+}

--- a/client/web-sveltekit/src/lib/dom.ts
+++ b/client/web-sveltekit/src/lib/dom.ts
@@ -175,15 +175,20 @@ export const computeFit: Action<HTMLElement, void, ComputeFitAttributes> = node 
  * See https://github.com/sveltejs/svelte/issues/3105
  */
 export const classNames: Action<HTMLElement, string | string[]> = (node, classes) => {
-    classes = (Array.isArray(classes) ? classes : [classes]).filter(Boolean)
+    // Converts the input to an array of non-empty strings.
+    // Empty strings are not valid inputs for classList and would throw an error.
+    function clean(classes: string | string[]): string[] {
+        return (Array.isArray(classes) ? classes : [classes]).filter(cls => cls.trim().length > 0)
+    }
+
+    classes = clean(classes)
     node.classList.add(...classes)
 
     return {
         update(newClasses) {
-            newClasses = (Array.isArray(newClasses) ? newClasses : [newClasses]).filter(Boolean)
             node.classList.remove(...classes)
-            node.classList.add(...newClasses)
-            classes = newClasses
+            classes = clean(newClasses)
+            node.classList.add(...classes)
         },
         destroy() {
             node.classList.remove(...classes)

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
     import { isLightTheme, KEY, scrollAll, type SourcegraphContext } from '$lib/stores'
     import { createTemporarySettingsStorage, temporarySetting } from '$lib/temporarySettings'
     import { setThemeFromString } from '$lib/theme'
+    import { classNames } from '$lib/dom'
 
     import Header from './Header.svelte'
 
@@ -89,28 +90,24 @@
     <meta name="description" content="Code search" />
 </svelte:head>
 
-<div class="app" class:overflowHidden={!$scrollAll}>
-    <InfoBanner />
-    <Header authenticatedUser={$user} />
+<svelte:body use:classNames={$scrollAll ? '' : 'overflowHidden'} />
 
-    <main bind:this={main}>
-        <slot />
-    </main>
-</div>
+<InfoBanner />
+<Header authenticatedUser={$user} />
+
+<main bind:this={main}>
+    <slot />
+</main>
 
 <style lang="scss">
-    .app {
+    :global(body.overflowHidden) {
         display: flex;
         flex-direction: column;
         height: 100vh;
-        overflow-y: auto;
+        overflow: hidden;
 
-        &.overflowHidden {
-            overflow: hidden;
-
-            main {
-                overflow-y: auto;
-            }
+        main {
+            overflow-y: auto;
         }
     }
 

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/FileTree.svelte
@@ -143,6 +143,8 @@
 <style lang="scss">
     div {
         overflow: auto;
+        // Don't scroll file/folder page when scrolling to the top or bottom of the file tree
+        overscroll-behavior-y: contain;
 
         :global(.treeitem.selectable) > :global(.label) {
             cursor: pointer;


### PR DESCRIPTION
This fixes an issue that had been bugging for quite a while: When you scrolled within a file and navigated to a new file, we would open the new file at the same scroll position instead of at the top of the file.

SvelteKit has native support for restoring and resetting the scroll position, but that only works when the whole page is scrollable. In our case we made an "app" wrapper `<div>` scrollable, so that wouldn't work with SvelteKit.
I made the necessary HTML changes so that we can leverage SvelteKit's default behavior but that was problematic too: After clicking on an entry in the file tree the whole file tree would be moved down because now the whole page would be scrolled to the top, revealing the page navigation bar and repo header again.

So what we really want is to scroll to the top of what I consider the *content* of the repo page, excluding page navigation and repo header. That's exactly what the changes in the repo layout file do: After navigation we check the scroll position of the page (easy to do now that truly the whole page is scrollable), and scroll to the beginning of the page content. We need to take some additional steps to restore the correct scroll position when navigating back and forth via the built-in snapshot feature.


https://github.com/sourcegraph/sourcegraph/assets/179026/bd882831-2ee4-449f-89ef-8dc3e1a7cc84



## Test plan

Manual testing