### PR TITLE
Set wolfi auto-update backport target branch to 5.3

### DIFF
--- a/dev/ci/scripts/wolfi/update-base-image-hashes.sh
+++ b/dev/ci/scripts/wolfi/update-base-image-hashes.sh
@@ -18,7 +18,7 @@ BRANCH_NAME="wolfi-auto-update/main"
 TIMESTAMP=$(TZ=UTC date "+%Y-%m-%d %H:%M:%S UTC")
 PR_TITLE="Auto-update Wolfi base images to latest"
 # PR_REVIEWER="sourcegraph/security"
-PR_LABELS="SSDLC,wolfi-auto-update,backport 5.2"
+PR_LABELS="SSDLC,wolfi-auto-update,backport 5.3"
 PR_BODY="Automatically generated PR to update Wolfi base images to the latest hashes.
 
 Built from Buildkite run [#${BUILDKITE_BUILD_NUMBER}](https://buildkite.com/sourcegraph/sourcegraph/builds/${BUILDKITE_BUILD_NUMBER}).


### PR DESCRIPTION
The wolfi automatic update PRs include a `backport-<branch>` label so that they will be backported to the latest release.

Update this from 5.2 -> 5.3

e.g. of auto PR: https://github.com/sourcegraph/sourcegraph/pull/60143

## Test plan

- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
