### PR TITLE
gitserver: Reduce frequency of janitor runs and slow start

### DIFF
--- a/cmd/gitserver/internal/cleanup.go
+++ b/cmd/gitserver/internal/cleanup.go
@@ -50,6 +50,10 @@ type JanitorConfig struct {
 	DisableDeleteReposOnWrongShard bool
 }
 
+// Let gitserver come up healthy first, and only start the janitor after a minute
+// to let things stabilize a little bit.
+const initialJanitorWait = 1 * time.Minute
+
 func NewJanitor(ctx context.Context, cfg JanitorConfig, db database.DB, rcf *wrexec.RecordingCommandFactory, cloneRepo cloneRepoFunc, logger log.Logger) goroutine.BackgroundRoutine {
 	return goroutine.NewPeriodicGoroutine(
 		actor.WithInternalActor(ctx),
@@ -87,6 +91,7 @@ func NewJanitor(ctx context.Context, cfg JanitorConfig, db database.DB, rcf *wre
 		goroutine.WithName("gitserver.janitor"),
 		goroutine.WithDescription("cleans up and maintains repositories regularly"),
 		goroutine.WithInterval(cfg.JanitorInterval),
+		goroutine.WithInitialDelay(initialJanitorWait),
 	)
 }
 

--- a/cmd/gitserver/shared/config.go
+++ b/cmd/gitserver/shared/config.go
@@ -82,6 +82,6 @@ func (c *Config) Load() {
 		c.AddError(errors.Errorf("excessively high value given for SRC_REPOS_DESIRED_PERCENT_FREE: %d", c.JanitorReposDesiredPercentFree))
 	}
 
-	c.JanitorInterval = c.GetInterval("SRC_REPOS_JANITOR_INTERVAL", "1m", "Interval between cleanup runs")
+	c.JanitorInterval = c.GetInterval("SRC_REPOS_JANITOR_INTERVAL", "24h", "Interval between cleanup runs")
 	c.JanitorDisableDeleteReposOnWrongShard = c.GetBool("SRC_REPOS_JANITOR_DISABLE_DELETE_REPOS_ON_WRONG_SHARD", "false", "Disable deleting repos on wrong shard")
 }

--- a/cmd/gitserver/shared/config_test.go
+++ b/cmd/gitserver/shared/config_test.go
@@ -34,7 +34,7 @@ func TestConfigDefaults(t *testing.T) {
 	if have, want := config.JanitorReposDesiredPercentFree, 10; have != want {
 		t.Errorf("invalid value for JanitorReposDesiredPercentFree: have=%d want=%d", have, want)
 	}
-	if have, want := config.JanitorInterval, time.Minute; have != want {
+	if have, want := config.JanitorInterval, 24*time.Hour; have != want {
 		t.Errorf("invalid value for JanitorInterval: have=%s want=%s", have, want)
 	}
 	if have, want := config.JanitorDisableDeleteReposOnWrongShard, false; have != want {


### PR DESCRIPTION
The frequency of this janitor was WAY too frequent. It's been like that for 5 years, but there's no good reason to run those git maintenance tasks more often than every day. They're meant to optimize the repository, and spending basically every minute a ton of compute on optimizing is probably not actually making things better.

## Test plan

On sourcegraph.com, this will not make a difference, as the janitor doesn't get through all the repos before the usual 24h restart cycle anyways. It only finishes on weekends, indicating that even a week would probably not be problematic here. We'll see on S2 that this change will not negatively impact availability.

