### PR TITLE
search: fix hoisting heuristic for nested queries

### DIFF
--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -781,6 +781,11 @@ func TestNewPlanJob(t *testing.T) {
             (patternInfo.isStructural . true)
             (patternInfo.fileMatchLimit . 10000)))))))`),
 		},
+		// The next query shows an unexpected way that a query is
+		// translated into a global zoekt query, all depending on if context:
+		// is specified (which it normally is). We expect to just have one
+		// global zoekt query, but with context we do not. Recording this test
+		// to capture the current inefficiency.
 		{
 			query:      `context:global (foo AND bar AND baz) OR "foo bar baz"`,
 			protocol:   search.Streaming,
@@ -791,18 +796,18 @@ func TestNewPlanJob(t *testing.T) {
     (query . )
     (originalQuery . )
     (patternType . keyword)
-    (TIMEOUT
-      (timeout . 20s)
-      (LIMIT
-        (limit . 10000)
-        (PARALLEL
-          (ZOEKTGLOBALTEXTSEARCH
-            (query . (or (and substr:"foo" substr:"bar" substr:"baz") substr:"foo bar baz"))
-            (type . text)
-            (repoOpts.searchContextSpec . global))
-          (REPOSCOMPUTEEXCLUDED
-            (repoOpts.searchContextSpec . global))
-          (OR
+    (OR
+      (TIMEOUT
+        (timeout . 20s)
+        (LIMIT
+          (limit . 10000)
+          (PARALLEL
+            (ZOEKTGLOBALTEXTSEARCH
+              (query . (and substr:"foo" substr:"bar" substr:"baz"))
+              (type . text)
+              (repoOpts.searchContextSpec . global))
+            (REPOSCOMPUTEEXCLUDED
+              (repoOpts.searchContextSpec . global))
             (AND
               (LIMIT
                 (limit . 40000)
@@ -821,11 +826,22 @@ func TestNewPlanJob(t *testing.T) {
                 (REPOSEARCH
                   (repoOpts.repoFilters . [baz])
                   (repoOpts.searchContextSpec . global)
-                  (repoNamePatterns . [(?i)baz]))))
-            (REPOSEARCH
-              (repoOpts.repoFilters . [foo bar baz])
-              (repoOpts.searchContextSpec . global)
-              (repoNamePatterns . [(?i)foo bar baz]))))))))`),
+                  (repoNamePatterns . [(?i)baz])))))))
+      (TIMEOUT
+        (timeout . 20s)
+        (LIMIT
+          (limit . 10000)
+          (PARALLEL
+            (SEQUENTIAL
+              (ensureUnique . false)
+              (ZOEKTGLOBALTEXTSEARCH
+                (query . substr:"foo bar baz")
+                (type . text))
+              (REPOSEARCH
+                (repoOpts.repoFilters . [foo bar baz])
+                (repoNamePatterns . [(?i)foo bar baz])))
+            REPOSCOMPUTEEXCLUDED
+            NOOP))))))`),
 		},
 	}
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -965,7 +965,6 @@ loop:
 				return nil, errors.New("unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses")
 			}
 			p.balanced--
-			p.heuristics |= disambiguated
 			if len(nodes) == 0 {
 				// We parsed "()".
 				if isSet(p.heuristics, emptyParens) {
@@ -979,6 +978,9 @@ loop:
 			break loop
 		case p.matchKeyword(AND), p.matchKeyword(OR):
 			// Caller advances.
+			if p.balanced > 0 {
+				p.heuristics = p.heuristics &^ disambiguated
+			}
 			break loop
 		case p.matchUnaryKeyword(NOT):
 			start := p.pos

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -167,6 +167,9 @@ type parser struct {
 	pos        int
 	balanced   int
 	leafParser SearchType
+
+	seenRightParen bool
+	seenOr         bool
 }
 
 func (p *parser) done() bool {
@@ -954,7 +957,9 @@ loop:
 			// group as part of an and/or expression.
 			_ = p.expect(LPAREN) // Guaranteed to succeed.
 			p.balanced++
-			p.heuristics |= disambiguated
+			if p.seenOr {
+				p.heuristics |= disambiguated
+			}
 			result, err := p.parseOr()
 			if err != nil {
 				return nil, err
@@ -965,6 +970,7 @@ loop:
 				return nil, errors.New("unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses")
 			}
 			p.balanced--
+			p.seenRightParen = true
 			if len(nodes) == 0 {
 				// We parsed "()".
 				if isSet(p.heuristics, emptyParens) {
@@ -976,10 +982,14 @@ loop:
 				}
 			}
 			break loop
-		case p.matchKeyword(AND), p.matchKeyword(OR):
+		case p.matchKeyword(AND):
 			// Caller advances.
-			if p.balanced > 0 {
-				p.heuristics = p.heuristics &^ disambiguated
+			break loop
+		case p.matchKeyword(OR):
+			// Caller advances.
+			p.seenOr = true
+			if p.seenRightParen {
+				p.heuristics |= disambiguated
 			}
 			break loop
 		case p.matchUnaryKeyword(NOT):

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -343,15 +343,45 @@ func TestParse(t *testing.T) {
 		}
 	}
 
-	// Queries with repo
+	// Queries with top-level parentheses, to mirror what we receive from client
+	autogold.Expect(value{
+		Grammar:   `(or (and "repo:foo" "count:2000" "internal") "src")`,
+		Heuristic: `(and "repo:foo" "count:2000" (or "internal" "src"))`,
+	}).Equal(t, test("(repo:foo count:2000 internal or src)"))
+	autogold.Expect(value{
+		Grammar:   `(and "lang:C++" "type:path" (or (and "repo:foo" "count:2000" "internal") "src"))`,
+		Heuristic: `(and "lang:C++" "type:path" "repo:foo" "count:2000" (or "internal" "src"))`,
+	}).Equal(t, test("(repo:foo count:2000 internal or src) lang:C++ type:path"))
+	autogold.Expect(value{
+		Grammar:   `(or (and "repo:foo" "count:2000" "internal" "limit") "src")`,
+		Heuristic: "Same",
+	}).Equal(t, test("((repo:foo count:2000 internal and limit) or src)"))
+	autogold.Expect(value{
+		Grammar:   `(and "lang:C++" "type:path" (or (and "repo:foo" "count:2000" "internal" "limit") "src"))`,
+		Heuristic: "Same",
+	}).Equal(t, test("((repo:foo count:2000 internal and limit) or src) lang:C++ type:path"))
+
+	// More queries with repo
+	autogold.Expect(value{
+		Grammar:   `(or (and "repo:foo" "count:2000" "internal") "src")`,
+		Heuristic: `(and "repo:foo" "count:2000" (or "internal" "src"))`,
+	}).Equal(t, test("repo:foo count:2000 internal or src"))
 	autogold.Expect(value{
 		Grammar:   `(or (and "repo:foo" "count:2000" "internal") "src")`,
 		Heuristic: "Same",
 	}).Equal(t, test("(repo:foo count:2000 internal) or src"))
 	autogold.Expect(value{
-		Grammar:   `(or (and "repo:foo" "count:2000" "internal") "src")`,
-		Heuristic: `(and "repo:foo" "count:2000" (or "internal" "src"))`,
-	}).Equal(t, test("repo:foo count:2000 internal or src"))
+		Grammar:   `(or (and "repo:foo" "count:2000" (concat "internal" "limit")) "src")`,
+		Heuristic: "Same",
+	}).Equal(t, test("(repo:foo count:2000 internal limit) or src"))
+	autogold.Expect(value{
+		Grammar:   `(or (and "repo:foo" "count:2000" "internal" "limit") "src")`,
+		Heuristic: "Same",
+	}).Equal(t, test("(repo:foo count:2000 internal and limit) or src"))
+	autogold.Expect(value{
+		Grammar:   `(or (and "repo:foo" "count:2000" "internal" "limit") "src")`,
+		Heuristic: `(and "repo:foo" "count:2000" (or (and "internal" "limit") "src"))`,
+	}).Equal(t, test("repo:foo count:2000 internal and limit or src"))
 
 	// Queries with context
 	autogold.Expect(value{

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -343,6 +343,28 @@ func TestParse(t *testing.T) {
 		}
 	}
 
+	// Queries with context
+	autogold.Expect(value{
+		Grammar:   `(and "context:foo" "context:bar" (or (and "type:file" "a") "b"))`,
+		Heuristic: `(and "context:foo" "context:bar" "type:file" (or "a" "b"))`,
+	}).Equal(t, test("context:foo context:bar (type:file a or b)"))
+	autogold.Expect(value{
+		Grammar:   `(and "context:foo" "lang:go" (or (and "type:file" "a") "b"))`,
+		Heuristic: `(and "context:foo" "lang:go" "type:file" (or "a" "b"))`,
+	}).Equal(t, test("context:foo lang:go (type:file a or b) "))
+	autogold.Expect(value{
+		Grammar:   `(and "context:global" (or (and "type:file" "a") "b"))`,
+		Heuristic: `(and "context:global" "type:file" (or "a" "b"))`,
+	}).Equal(t, test("context:global (type:file a or b)"))
+	autogold.Expect(value{
+		Grammar:   `(or (and "context:foo" "type:file" "a") "b")`,
+		Heuristic: `(and "context:foo" "type:file" (or "a" "b"))`,
+	}).Equal(t, test("context:foo type:file a or b"))
+
+	// Groups containing operators.
+	autogold.Expect(value{Grammar: `(or (and "type:file" "a") "b")`, Heuristic: `(and "type:file" (or "a" "b"))`}).Equal(t, test("(type:file a or b)"))
+	autogold.Expect(value{Grammar: `(or (and "type:file" "a") "b")`, Heuristic: "Same"}).Equal(t, test("(type:file a) or b"))
+
 	autogold.Expect(value{Grammar: "", Heuristic: "Same"}).Equal(t, test(""))
 	autogold.Expect(value{Grammar: "", Heuristic: "Same"}).Equal(t, test("             "))
 	autogold.Expect(value{Grammar: `"a"`, Heuristic: "Same"}).Equal(t, test("a"))
@@ -750,16 +772,16 @@ func TestParseAndOrLiteral(t *testing.T) {
 	autogold.Expect(`(and "repo:foo" (or "foo(" "bar(")) (HeuristicHoisted,Literal)`).Equal(t, test("repo:foo foo( or bar("))
 	autogold.Expect(`(concat "x" "or") (Literal)`).Equal(t, test("x or"))
 	autogold.Expect(`(and "repo:foo" "(x") (HeuristicDanglingParens,Literal)`).Equal(t, test("repo:foo (x"))
-	autogold.Expect(`(or "x" "bar()") (Literal)`).Equal(t, test("(x or bar() )"))
+	autogold.Expect(`(or "x" "bar()") (HeuristicHoisted,Literal)`).Equal(t, test("(x or bar() )"))
 	autogold.Expect(`"(x" (HeuristicDanglingParens,Literal)`).Equal(t, test("(x"))
 	autogold.Expect(`(or "x" "(x") (HeuristicDanglingParens,Literal)`).Equal(t, test("x or (x"))
 	autogold.Expect(`(or "(y" "(z") (HeuristicDanglingParens,Literal)`).Equal(t, test("(y or (z"))
 	autogold.Expect(`(and "repo:foo" "(lisp)") (HeuristicParensAsPatterns,Literal)`).Equal(t, test("repo:foo (lisp)"))
 	autogold.Expect(`(and "repo:foo" "(lisp lisp())") (HeuristicParensAsPatterns,Literal)`).Equal(t, test("repo:foo (lisp lisp())"))
-	autogold.Expect(`(and "repo:foo" (or "lisp" "lisp")) (Literal)`).Equal(t, test("repo:foo (lisp or lisp)"))
-	autogold.Expect(`(and "repo:foo" (or "lisp" "lisp()")) (Literal)`).Equal(t, test("repo:foo (lisp or lisp())"))
+	autogold.Expect(`(and "repo:foo" (or "lisp" "lisp")) (HeuristicHoisted,Literal)`).Equal(t, test("repo:foo (lisp or lisp)"))
+	autogold.Expect(`(and "repo:foo" (or "lisp" "lisp()")) (HeuristicHoisted,Literal)`).Equal(t, test("repo:foo (lisp or lisp())"))
 	autogold.Expect(`(and "repo:foo" (or "(lisp" "lisp()")) (HeuristicDanglingParens,HeuristicHoisted,Literal)`).Equal(t, test("repo:foo (lisp or lisp()"))
-	autogold.Expect(`(or "y" "bar()") (Literal)`).Equal(t, test("(y or bar())"))
+	autogold.Expect(`(or "y" "bar()") (HeuristicHoisted,Literal)`).Equal(t, test("(y or bar())"))
 	autogold.Expect(`(or "((x" "bar(") (HeuristicDanglingParens,Literal)`).Equal(t, test("((x or bar("))
 	autogold.Expect(" (None)").Equal(t, test(""))
 	autogold.Expect(" (None)").Equal(t, test(" "))
@@ -811,7 +833,7 @@ func TestParseAndOrLiteral(t *testing.T) {
 	autogold.Expect("ERROR: unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses").Equal(t, test(`repo:foo bar)) and baz`))
 	autogold.Expect("ERROR: unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses").Equal(t, test(`repo:foo (bar and baz))`))
 	autogold.Expect("ERROR: unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses").Equal(t, test(`repo:foo (bar and (baz)))`))
-	autogold.Expect(`(and "repo:foo" "bar(" "baz()") (Literal)`).Equal(t, test(`repo:foo (bar( and baz())`))
+	autogold.Expect(`(and "repo:foo" "bar(" "baz()") (HeuristicHoisted,Literal)`).Equal(t, test(`repo:foo (bar( and baz())`))
 	autogold.Expect(`"\"quoted\"" (Literal)`).Equal(t, test(`"quoted"`))
 	autogold.Expect("ERROR: it looks like you tried to use an expression after NOT. The NOT operator can only be used with simple search patterns or filters, and is not supported for expressions or subqueries").Equal(t, test(`not (stocks or stonks)`))
 

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -343,6 +343,16 @@ func TestParse(t *testing.T) {
 		}
 	}
 
+	// Queries with repo
+	autogold.Expect(value{
+		Grammar:   `(or (and "repo:foo" "count:2000" "internal") "src")`,
+		Heuristic: "Same",
+	}).Equal(t, test("(repo:foo count:2000 internal) or src"))
+	autogold.Expect(value{
+		Grammar:   `(or (and "repo:foo" "count:2000" "internal") "src")`,
+		Heuristic: `(and "repo:foo" "count:2000" (or "internal" "src"))`,
+	}).Equal(t, test("repo:foo count:2000 internal or src"))
+
 	// Queries with context
 	autogold.Expect(value{
 		Grammar:   `(and "context:foo" "context:bar" (or (and "type:file" "a") "b"))`,

--- a/internal/search/query/testdata/TestConcat/#13.golden
+++ b/internal/search/query/testdata/TestConcat/#13.golden
@@ -5,6 +5,7 @@
         "value": "a",
         "negated": false,
         "labels": [
+          "HeuristicHoisted",
           "Literal",
           "QuotesAsLiterals",
           "Standard"
@@ -24,6 +25,7 @@
         "value": "b",
         "negated": false,
         "labels": [
+          "HeuristicHoisted",
           "Literal",
           "QuotesAsLiterals",
           "Standard"
@@ -43,6 +45,7 @@
         "value": "c",
         "negated": false,
         "labels": [
+          "HeuristicHoisted",
           "Literal",
           "QuotesAsLiterals",
           "Standard"
@@ -62,6 +65,7 @@
         "value": "d",
         "negated": false,
         "labels": [
+          "HeuristicHoisted",
           "Literal",
           "QuotesAsLiterals",
           "Standard"

--- a/internal/search/query/testdata/TestParseKeywordPattern/parens_around_slash...slash.golden
+++ b/internal/search/query/testdata/TestParseKeywordPattern/parens_around_slash...slash.golden
@@ -5,6 +5,7 @@
         "value": "sancerre",
         "negated": false,
         "labels": [
+          "HeuristicHoisted",
           "Literal",
           "QuotesAsLiterals",
           "Standard"
@@ -24,6 +25,7 @@
         "value": "pouilly-fume",
         "negated": false,
         "labels": [
+          "HeuristicHoisted",
           "Regexp"
         ],
         "range": {

--- a/internal/search/query/testdata/TestParseStandard/parens_around_slash...slash.golden
+++ b/internal/search/query/testdata/TestParseStandard/parens_around_slash...slash.golden
@@ -5,6 +5,7 @@
         "value": "sancerre",
         "negated": false,
         "labels": [
+          "HeuristicHoisted",
           "Literal",
           "Standard"
         ],
@@ -23,6 +24,7 @@
         "value": "pouilly-fume",
         "negated": false,
         "labels": [
+          "HeuristicHoisted",
           "Regexp"
         ],
         "range": {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -159,6 +159,15 @@ func Hoist(nodes []Node) ([]Node, error) {
 	var scopeParameters []Parameter
 	for i, node := range expression.Operands {
 		if i == 0 {
+			// Handles the case "(and parameter expression)"
+			if parameter, ok := node.(Parameter); ok && expression.Kind == And {
+				hoisted, err := Hoist(NewOperator(expression.Operands[1:], expression.Kind))
+				if err != nil {
+					return nil, err
+				}
+				return append([]Node{parameter}, hoisted...), nil
+			}
+
 			scopePart, patternPart, err := PartitionSearchPattern([]Node{node})
 			if err != nil || patternPart == nil {
 				return nil, errors.New("could not partition first expression")


### PR DESCRIPTION
With the recent changes in the client, the client now sends us queries wrapped in parentheses which our hoisting heuristics don't handle well.

There are 2 issues.

1. The leaf parser incorrectly marks some queries as "disambiguated"
2. `Hoist` doesn't deal well with common nested queries such as `(and parameter (or (and parameter pattern ) pattern))`

This PR addresses both issues like follows:

1. We don't mark queries as disambiguated if we encounter a boolean operator inside parenthesis
2. We add a recursion to `Hoist` that deals with the simplest case of `(and parameter expression)`

Note:
This is also fixes a bug we recently documented with a test case, see `job_test.go`

The question is, are we hoisting anything now that we shouldn't but we haven't documented it in tests?

Test plan:
- added new tests to cover the changes

