### PR TITLE
Code Navigation: adjust global styling for kbd element

### DIFF
--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -93,13 +93,6 @@
     }
 }
 
-// @TODO: Jason Harris: <kbd> element is unuseable unless the following CSS selectors are present.
-// We should use these as a base for adjusting the default styling of <kbd> elements.
 .keybind {
-    font-family: var(--font-family-base);
-    color: var(--text-muted);
-    background: var(--color-bg-1);
-    border: 1px solid var(--border-color-2);
     margin-left: 0.5rem;
-    padding: 0 0.25rem;
 }

--- a/client/wildcard/src/global-styles/code.scss
+++ b/client/wildcard/src/global-styles/code.scss
@@ -34,13 +34,13 @@ code,
 }
 
 kbd {
-    background-color: var(--color-bg-2);
-    border-radius: 3px;
+    background-color: var(--color-bg-1);
+    border-radius: 4px;
     border: 1px solid var(--border-color-2);
-    box-shadow: inset 0 -2px 0 var(--color-bg-3);
+    box-shadow: inset 0 -2px 0 var(--color-bg-2);
     color: var(--text-muted);
     display: inline-block;
-    font-family: var(--font-family-base);
+    font-family: var(--monospace-font-family);
     font-size: var(--code-font-size);
     height: 1.125rem;
     line-height: (16/12);

--- a/client/wildcard/src/global-styles/code.scss
+++ b/client/wildcard/src/global-styles/code.scss
@@ -34,18 +34,19 @@ code,
 }
 
 kbd {
-    font-family: var(--code-font-family);
-    font-size: var(--code-font-size);
-    display: inline-block;
-    line-height: (16/12);
-    height: 1.125rem;
-    padding: 0 0.25rem;
-    margin: 0 0.125rem;
-    vertical-align: middle;
-    border-radius: 3px;
-    color: var(--body-color);
     background-color: var(--color-bg-2);
+    border-radius: 3px;
+    border: 1px solid var(--border-color-2);
     box-shadow: inset 0 -2px 0 var(--color-bg-3);
+    color: var(--text-muted);
+    display: inline-block;
+    font-family: var(--font-family-base);
+    font-size: var(--code-font-size);
+    height: 1.125rem;
+    line-height: (16/12);
+    margin: 0 0.125rem;
+    padding: 0 0.25rem;
+    vertical-align: middle;
 }
 
 // Search examples that link to the results page should use this class.


### PR DESCRIPTION
Adjusts default styling for the `<kbd>` element.

Before: 
<img width="128" alt="Screenshot 2024-02-08 at 9 36 41 AM" src="https://github.com/sourcegraph/sourcegraph/assets/62355966/c7c65971-930f-469e-99bf-d6d02395ae46">

After:
<img width="133" alt="Screenshot 2024-02-08 at 9 36 54 AM" src="https://github.com/sourcegraph/sourcegraph/assets/62355966/0305c559-6d27-488c-af68-b9a7ac52e5d9">

## Test plan
Test manually. CI/CD passing.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
