### PR TITLE
sg: ensure sg expected output is sorted before compare

### DIFF
--- a/dev/sg/sg_start_test.go
+++ b/dev/sg/sg_start_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"testing"
 
@@ -105,6 +106,9 @@ func expectOutput(t *testing.T, buf *outputtest.Buffer, want []string) {
 	t.Helper()
 
 	have := buf.Lines()
+
+	sort.Strings(want)
+	sort.Strings(have)
 	if !cmp.Equal(want, have) {
 		t.Fatalf("wrong output:\n%s", cmp.Diff(want, have))
 	}


### PR DESCRIPTION
Make the slices order stable.

Without fix ❌ 
```
//dev/sg:sg_test                                                         FAILED in 19 out of 50 in 11.4s
```

With fix ✅ 
```
//dev/sg:sg_test                                                         FAILED in 3 out of 50 in 5.2s
```
The three failures were (which is unrelated)
```
WARNING: DATA RACE
Write at 0x00c0020433b0 by goroutine 229:
  github.com/sourcegraph/sourcegraph/lib/output/outputtest.(*Buffer).writeToCurrentLine()
      lib/output/outputtest/buffer.go:111 +0x57c
  github.com/sourcegraph/sourcegraph/lib/output/outputtest.(*Buffer).Write()
      lib/output/outputtest/buffer.go:100 +0x490
  fmt.Fprintf()
      GOROOT/src/fmt/print.go:225 +0x94
--- FAIL: TestStartCommandSet (0.03s)
    sg_start_test.go:39: wrong output:
          []string{
                ... // 8 identical elements
                "Starting 1 cmds",
                "Running test-cmd-1...",
        -       "[     test-cmd-1] horsegraph booted up. mount your horse.",
                "[     test-cmd-1] quitting. not horsing around anymore.",
                "test-cmd-1 exited without error",
          }
    testing.go:1465: race detected during execution of test
  github.com/sourcegraph/sourcegraph/lib/output.(*Output).Writef()
      lib/output/output.go:184 +0x26c
  github.com/sourcegraph/sourcegraph/dev/sg/internal/run.newBufferedCmdLogger.func1.1()
      dev/sg/internal/run/logger.go:43 +0x204
```

Closes https://github.com/sourcegraph/devx-support/issues/608
## Test plan
Tested locally
