### PR TITLE
packages: Temporarily disable failing for invalid versions on dotcom

### DIFF
--- a/cmd/gitserver/internal/vcssyncer/BUILD.bazel
+++ b/cmd/gitserver/internal/vcssyncer/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/vcssyncer",
     visibility = ["//cmd/gitserver:__subpackages__"],
     deps = [
+        "//cmd/frontend/envvar",
         "//cmd/gitserver/internal/common",
         "//cmd/gitserver/internal/executil",
         "//cmd/gitserver/internal/git",

--- a/cmd/gitserver/internal/vcssyncer/packages_syncer.go
+++ b/cmd/gitserver/internal/vcssyncer/packages_syncer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sourcegraph/log"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/executil"
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/git"
@@ -253,6 +254,15 @@ func (s *vcsPackagesSyncer) fetchVersions(ctx context.Context, name reposource.P
 
 	// Return error if at least one version failed to download.
 	if errs != nil {
+		// TEMP: For dotcom, we don't want to hard fail for missing versions.
+		// Currently, our DB does not contain valid versions only, and attempting
+		// to download versions over and over again clogs out large clone queue.
+		// TODO(eseliger): Remove this branch! Also make sure to remove all the
+		// existing packages from gitserver disks.
+		if envvar.SourcegraphDotComMode() {
+			s.logger.Error("failed to fetch some dependency versions", log.Error(errs))
+			return nil
+		}
 		return errs
 	}
 


### PR DESCRIPTION
Since we don't validate versions, we have about 170k packages on dotcom that constantly fail cloning. This is putting unnecessary load at it, so until we fix this, let's accept that some packages will have a few missing versions, in favor of having the package cloned at all, and a calmer system.

## Test plan

Will monitor dotcom.
