### PR TITLE
Add Llama Code 13b to all PLG users and remove unused model conversation

### DIFF
--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -374,6 +374,7 @@ func allowedModels(scope types.CompletionsFeature, isProUser bool) []string {
 			"anthropic/claude-instant-1.2-cyan",
 			"anthropic/claude-instant-1.2",
 			"fireworks/starcoder",
+			"fireworks/" + fireworks.Llama213bCode,
 			// TODO: Remove the specific model identifiers below when Cody Gateway for PLG was updated.
 			"fireworks/" + fireworks.Starcoder16b,
 			"fireworks/" + fireworks.Starcoder7b,

--- a/internal/completions/httpapi/codecompletion.go
+++ b/internal/completions/httpapi/codecompletion.go
@@ -45,13 +45,9 @@ func NewCodeCompletionsHandler(logger log.Logger, db database.DB, test guardrail
 
 func allowedCustomModel(model string) string {
 	switch model {
-	// These virtual model strings allow the server to choose the model.
-	// TODO: Remove the specific model identifiers below when Cody Gateway for PLG was updated.
-	case "fireworks/starcoder-16b":
-		return "fireworks/" + fireworks.Starcoder16b
-	case "fireworks/starcoder-7b":
-		return "fireworks/" + fireworks.Starcoder7b
 	case "fireworks/starcoder",
+		"fireworks/starcoder-16b",
+		"fireworks/starcoder-7b",
 		"fireworks/" + fireworks.Starcoder16b,
 		"fireworks/" + fireworks.Starcoder7b,
 		"fireworks/" + fireworks.Llama27bCode,


### PR DESCRIPTION
Two things going on here:

1. We add Llama Code 13b to all PLG users. c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1707411649398769?thread_ts=1706882079.259169&cid=C05AGQYD528
2. Removed some no longer needed model translation. CG can handle the virtual `fireworks/starcoder-16b` model names for a while now.

## Test plan

- Trivial change, CI will test it