### PR TITLE
ratelimiter: Add configuration options for ADO

### DIFF
--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -668,6 +668,12 @@ func GetLimitFromConfig(config any, kind string) (limit rate.Limit, isDefault bo
 			isDefault = false
 			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
 		}
+	case *schema.AzureDevOpsConnection:
+		limit = GetDefaultRateLimit(KindAzureDevOps)
+		if c != nil && c.RateLimit != nil {
+			isDefault = false
+			limit = limitOrInf(c.RateLimit.Enabled, c.RateLimit.RequestsPerHour)
+		}
 	default:
 		return limit, isDefault, ErrRateLimitUnsupported{codehostKind: kind}
 	}
@@ -712,6 +718,8 @@ func GetDefaultRateLimit(kind string) rate.Limit {
 	case KindRubyPackages:
 		// The rubygems.org API allows 10 rps https://guides.rubygems.org/rubygems-org-rate-limits/
 		return rate.Limit(10)
+	case KindAzureDevOps:
+		return rate.Inf
 	default:
 		return rate.Inf
 	}

--- a/schema/azuredevops.schema.json
+++ b/schema/azuredevops.schema.json
@@ -19,6 +19,28 @@
       "format": "uri",
       "examples": ["https://dev.azure.com"]
     },
+    "rateLimit": {
+      "description": "Rate limit applied when making background API requests.",
+      "title": "AzureDevOpsRateLimit",
+      "type": "object",
+      "required": ["enabled", "requestsPerHour"],
+      "properties": {
+        "enabled": {
+          "description": "true if rate limiting is enabled.",
+          "type": "boolean",
+          "default": false
+        },
+        "requestsPerHour": {
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "default": {
+        "enabled": false,
+        "requestsPerHour": 0
+      }
+    },
     "gitURLType": {
       "description": "The type of Git URLs to use for cloning and fetching Git repositories.\n\nIf \"http\", Sourcegraph will access repositories using Git URLs of the form http(s)://dev.azure.com/myrepo.git.\n\nIf \"ssh\", Sourcegraph will access repositories using Git URLs of the form git@ssh.dev.azure.com:v3/myrepo. See the documentation for how to provide SSH private keys and known_hosts: https://docs.sourcegraph.com/admin/repo/auth#repositories-that-need-http-s-or-ssh-authentication.",
       "type": "string",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -262,12 +262,22 @@ type AzureDevOpsConnection struct {
 	Orgs []string `json:"orgs,omitempty"`
 	// Projects description: An array of projects "org/project" strings specifying which Azure DevOps projects' repositories should be mirrored on Sourcegraph.
 	Projects []string `json:"projects,omitempty"`
+	// RateLimit description: Rate limit applied when making background API requests.
+	RateLimit *AzureDevOpsRateLimit `json:"rateLimit,omitempty"`
 	// Token description: The Personal Access Token associated with the Azure DevOps username used for authentication.
 	Token string `json:"token"`
 	// Url description: URL for Azure DevOps Services, set to https://dev.azure.com.
 	Url string `json:"url"`
 	// Username description: A username for authentication with the Azure DevOps code host.
 	Username string `json:"username"`
+}
+
+// AzureDevOpsRateLimit description: Rate limit applied when making background API requests.
+type AzureDevOpsRateLimit struct {
+	// Enabled description: true if rate limiting is enabled.
+	Enabled bool `json:"enabled"`
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
+	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type BatchChangeRolloutWindow struct {
 	// Days description: Day(s) the window applies to. If omitted, this rule applies to all days of the week.


### PR DESCRIPTION
We already had a rate limiter in the code, it was just not configurable, so we used Inf always. This was a quick win.

Closes https://github.com/sourcegraph/sourcegraph/issues/46956

## Test plan

Manually set a very low limit locally, ran again, saw requests getting queued. Also the rate limiter state in the UI correctly reflects the configuration.
