### PR TITLE
auth: append random suffix when derive username from email

### DIFF
--- a/cmd/frontend/auth/BUILD.bazel
+++ b/cmd/frontend/auth/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//cmd/frontend/internal/app/ui",
         "//internal/actor",
         "//internal/auth",
+        "//internal/auth/userpasswd",
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbmocks",

--- a/cmd/frontend/auth/auth.go
+++ b/cmd/frontend/auth/auth.go
@@ -2,7 +2,6 @@
 package auth
 
 import (
-	"math/rand"
 	"net/http"
 
 	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
@@ -60,30 +59,6 @@ func composeMiddleware(middlewares ...*Middleware) *Middleware {
 // username formatting rules.
 func NormalizeUsername(name string) (string, error) {
 	return userpasswd.NormalizeUsername(name)
-}
-
-var mockAddRandomSuffix func(string) (string, error)
-
-// AddRandomSuffix appends a random 5-character lowercase alphabetical suffix (like "-lbwwt")
-// to the username to avoid collisions. If the username already ends with a dash, it is not
-// added again.
-func AddRandomSuffix(username string) (string, error) {
-	if mockAddRandomSuffix != nil {
-		return mockAddRandomSuffix(username)
-	}
-
-	b := make([]byte, 5)
-	_, err := rand.Read(b)
-	if err != nil {
-		return "", err
-	}
-	for i, c := range b {
-		b[i] = "abcdefghijklmnopqrstuvwxyz"[c%26]
-	}
-	if len(username) == 0 || username[len(username)-1] == '-' {
-		return username + string(b), nil
-	}
-	return username + "-" + string(b), nil
 }
 
 // Equivalent to `^\w(?:\w|[-.](?=\w))*-?$` which we have in the DB constraint, but without a lookahead

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/sourcegraph/sourcegraph/internal/security"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/teestore"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetryrecorder"
@@ -14,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/authz/permssync"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -21,7 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
-	"github.com/sourcegraph/sourcegraph/internal/security"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -196,7 +197,7 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (n
 		user, err := users.CreateWithExternalAccount(ctx, op.UserProps, acct)
 		// We re-try creation with a different username with random suffix if the first one is taken.
 		if database.IsUsernameExists(err) {
-			op.UserProps.Username, err = AddRandomSuffix(op.UserProps.Username)
+			op.UserProps.Username, err = userpasswd.AddRandomSuffix(op.UserProps.Username)
 			if err != nil {
 				return 0, false, false, "Unable to create a new user account due to a unexpected error. Ask a site admin for help.", errors.Wrapf(err, "username: %q, email: %q", op.UserProps.Username, op.UserProps.Email)
 			}

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -70,11 +71,11 @@ func TestGetAndSaveUser(t *testing.T) {
 		CreateIfNotExist: true,
 	}
 
-	mockAddRandomSuffix = func(s string) (string, error) {
+	userpasswd.MockAddRandomSuffix = func(s string) (string, error) {
 		return fmt.Sprintf("%s-ubioa", s), nil
 	}
 	t.Cleanup(func() {
-		mockAddRandomSuffix = nil
+		userpasswd.MockAddRandomSuffix = nil
 	})
 
 	mainCase := outerCase{

--- a/cmd/frontend/internal/auth/httpheader/BUILD.bazel
+++ b/cmd/frontend/internal/auth/httpheader/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
         "//cmd/frontend/auth",
         "//internal/actor",
         "//internal/auth/providers",
+        "//internal/auth/userpasswd",
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbtest",

--- a/cmd/frontend/internal/auth/httpheader/middleware_test.go
+++ b/cmd/frontend/internal/auth/httpheader/middleware_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	sgactor "github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth/providers"
+	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/licensing"
@@ -22,6 +23,12 @@ import (
 // SEE ALSO FOR MANUAL TESTING: See the Middleware docstring for information about the testproxy
 // helper program, which helps with manual testing of the HTTP auth proxy behavior.
 func TestMiddleware(t *testing.T) {
+	userpasswd.MockAddRandomSuffix = func(s string) (string, error) {
+		return fmt.Sprintf("%s-ubioa", s), nil
+	}
+	t.Cleanup(func() {
+		userpasswd.MockAddRandomSuffix = nil
+	})
 	defer licensing.TestingSkipFeatureChecks()()
 
 	logger := logtest.Scoped(t)
@@ -134,7 +141,7 @@ func TestMiddleware(t *testing.T) {
 		var calledMock bool
 		auth.MockGetAndSaveUser = func(ctx context.Context, op auth.GetAndSaveUserOp) (newUserCreated bool, userID int32, safeErrMsg string, err error) {
 			calledMock = true
-			if got, want := op.UserProps.Username, "alice"; got != want {
+			if got, want := op.UserProps.Username, "alice-ubioa"; got != want {
 				t.Errorf("expected %v got %v", want, got)
 			}
 			if got, want := op.UserProps.Email, "alice@example.com"; got != want {

--- a/internal/scim/BUILD.bazel
+++ b/internal/scim/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     deps = [
         "//cmd/frontend/auth",
         "//cmd/frontend/globals",
+        "//internal/auth/userpasswd",
         "//internal/authz",
         "//internal/conf",
         "//internal/database",

--- a/internal/scim/BUILD.bazel
+++ b/internal/scim/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
     ],
     embed = [":scim"],
     deps = [
+        "//internal/auth/userpasswd",
         "//internal/conf",
         "//internal/database",
         "//internal/database/dbmocks",

--- a/internal/scim/user.go
+++ b/internal/scim/user.go
@@ -11,6 +11,7 @@ import (
 	scimerrors "github.com/elimity-com/scim/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
+	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -232,14 +233,14 @@ func getUniqueUsername(ctx context.Context, tx database.UserStore, requestedUser
 	normalizedUsername, err := auth.NormalizeUsername(requestedUsername)
 	if err != nil {
 		// Empty username after normalization. Generate a random one, it's the best we can do.
-		normalizedUsername, err = auth.AddRandomSuffix("")
+		normalizedUsername, err = userpasswd.AddRandomSuffix("")
 		if err != nil {
 			return "", scimerrors.ScimErrorBadParams([]string{"invalid username"})
 		}
 	}
 	_, err = tx.GetByUsername(ctx, normalizedUsername)
 	if err == nil { // Username exists, try to add random suffix
-		normalizedUsername, err = auth.AddRandomSuffix(normalizedUsername)
+		normalizedUsername, err = userpasswd.AddRandomSuffix(normalizedUsername)
 		if err != nil {
 			return "", scimerrors.ScimError{Status: http.StatusInternalServerError, Detail: errors.Wrap(err, "could not normalize username").Error()}
 		}

--- a/internal/scim/user_create_test.go
+++ b/internal/scim/user_create_test.go
@@ -2,12 +2,14 @@ package scim
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"testing"
 
 	"github.com/elimity-com/scim"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/sourcegraph/sourcegraph/internal/auth/userpasswd"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -16,6 +18,13 @@ import (
 )
 
 func TestUserResourceHandler_Create(t *testing.T) {
+	userpasswd.MockAddRandomSuffix = func(s string) (string, error) {
+		return fmt.Sprintf("%s-ubioa", s), nil
+	}
+	t.Cleanup(func() {
+		userpasswd.MockAddRandomSuffix = nil
+	})
+
 	txemail.DisableSilently()
 	db := getMockDB([]*types.UserForSCIM{
 		{User: types.User{ID: 1, Username: "user1", DisplayName: "Yay Scim", SCIMControlled: true}, Emails: []string{"a@example.com"}, SCIMExternalID: "id1"},
@@ -63,7 +72,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 			username: "test@company.com",
 			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "test", usernameInDB)
+				assert.Equal(t, "test-ubioa", usernameInDB)
 				assert.Equal(t, "test@company.com", usernameInResource)
 			},
 		},
@@ -81,7 +90,7 @@ func TestUserResourceHandler_Create(t *testing.T) {
 			username: "",
 			testFunc: func(t *testing.T, usernameInDB string, usernameInResource string, err error) {
 				assert.NoError(t, err)
-				assert.Len(t, usernameInDB, 5) // abcde
+				assert.Len(t, usernameInDB, 6) // -abcde
 				assert.Equal(t, "", usernameInResource)
 			},
 		},


### PR DESCRIPTION
We are seeing many email-derived usernames to be rejected as suspicious, or high chance of collisions. This would be a common theme when using custom domain emails to sign in to Sourcegraph.com. Thus this PR updates the logic to append random 5-char suffix when the username is derived from email.

![image](https://github.com/sourcegraph/sourcegraph/assets/2946214/c9f6edc5-5b36-4e2b-b5c1-d34754eb5192)

Not sure if this is something we want to do only in dotcom mode (i.e. hurts Enterprise users, tho SCIM is doing the same thing when turned on), up to the Source team.


## Test plan

CI and tested locally e2e
