### PR TITLE
v2 telemetry: add v2 telemetry to src/cody

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -15,6 +15,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 
 import { CodyLogo } from '@sourcegraph/cody-ui/dist/icons/CodyLogo'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
 import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
@@ -52,9 +53,10 @@ import { CodyColorIcon } from './CodyPageIcon'
 
 import styles from './CodyChatPage.module.scss'
 
-interface CodyChatPageProps extends TelemetryV2Props {
+interface CodyChatPageProps {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
+    platformContext: Pick<PlatformContext, 'telemetryRecorder'>
     context: Pick<SourcegraphContext, 'authProviders'>
 }
 
@@ -92,9 +94,10 @@ const onTranscriptHistoryLoad = (
 export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
     authenticatedUser,
     context,
+    platformContext,
     isSourcegraphDotCom,
-    telemetryRecorder,
 }) => {
+    const telemetryRecorder = platformContext.telemetryRecorder
     const { pathname } = useLocation()
     const navigate = useNavigate()
 

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -124,7 +124,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
     const onCTADismiss = (): void => setIsCTADismissed(true)
 
     useEffect(() => {
-        logTranscriptEvent(EventName.CODY_CHAT_PAGE_VIEWED, 'cody-chat', 'view')
+        logTranscriptEvent(EventName.CODY_CHAT_PAGE_VIEWED, 'cody.chat', 'view')
     }, [logTranscriptEvent])
 
     const transcriptId = transcript?.id
@@ -297,7 +297,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                     onClick={() =>
                                         logTranscriptEvent(
                                             EventName.CODY_CHAT_GET_EDITOR_EXTENSION,
-                                            'cody-chat.get-editor-extension-cta',
+                                            'cody.chat.getEditorExtensionCta',
                                             'click'
                                         )
                                     }

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -15,8 +15,8 @@ import { useLocation, useNavigate } from 'react-router-dom'
 
 import { CodyLogo } from '@sourcegraph/cody-ui/dist/icons/CodyLogo'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
-import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Badge,
     Button,
@@ -52,10 +52,9 @@ import { CodyColorIcon } from './CodyPageIcon'
 
 import styles from './CodyChatPage.module.scss'
 
-interface CodyChatPageProps {
+interface CodyChatPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
-    platformContext: Pick<PlatformContext, 'telemetryRecorder'>
     context: Pick<SourcegraphContext, 'authProviders'>
 }
 
@@ -93,10 +92,9 @@ const onTranscriptHistoryLoad = (
 export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
     authenticatedUser,
     context,
-    platformContext,
     isSourcegraphDotCom,
+    telemetryRecorder,
 }) => {
-    const telemetryRecorder = platformContext.telemetryRecorder
     const { pathname } = useLocation()
     const navigate = useNavigate()
 

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -16,6 +16,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { CodyLogo } from '@sourcegraph/cody-ui/dist/icons/CodyLogo'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Badge,
     Button,
@@ -51,7 +52,7 @@ import { CodyColorIcon } from './CodyPageIcon'
 
 import styles from './CodyChatPage.module.scss'
 
-interface CodyChatPageProps {
+interface CodyChatPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
     context: Pick<SourcegraphContext, 'authProviders'>
@@ -92,6 +93,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
     authenticatedUser,
     context,
     isSourcegraphDotCom,
+    telemetryRecorder,
 }) => {
     const { pathname } = useLocation()
     const navigate = useNavigate()
@@ -103,6 +105,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
         userID: authenticatedUser?.id,
         onTranscriptHistoryLoad,
         autoLoadTranscriptFromHistory: false,
+        telemetryRecorder,
     })
     const {
         initializeNewChat,
@@ -118,7 +121,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
     const onCTADismiss = (): void => setIsCTADismissed(true)
 
     useEffect(() => {
-        logTranscriptEvent(EventName.CODY_CHAT_PAGE_VIEWED)
+        logTranscriptEvent(EventName.CODY_CHAT_PAGE_VIEWED, 'cody-chat', 'view')
     }, [logTranscriptEvent])
 
     const transcriptId = transcript?.id
@@ -288,7 +291,13 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                         'd-inline-flex align-items-center text-merged',
                                         styles.ctaLink
                                     )}
-                                    onClick={() => logTranscriptEvent(EventName.CODY_CHAT_GET_EDITOR_EXTENSION)}
+                                    onClick={() =>
+                                        logTranscriptEvent(
+                                            EventName.CODY_CHAT_GET_EDITOR_EXTENSION,
+                                            'cody-chat.get-editor-extension-cta',
+                                            'click'
+                                        )
+                                    }
                                 >
                                     Get Cody in your editor
                                     <Icon svgPath={mdiChevronRight} aria-hidden={true} />
@@ -365,6 +374,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                             codyChatStore={codyChatStore}
                             isCodyChatPage={true}
                             authenticatedUser={authenticatedUser}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     )}
                 </div>

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -17,7 +17,6 @@ import { CodyLogo } from '@sourcegraph/cody-ui/dist/icons/CodyLogo'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { PlatformContext } from '@sourcegraph/shared/src/platform/context'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
-import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Badge,
     Button,
@@ -297,7 +296,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                                     onClick={() =>
                                         logTranscriptEvent(
                                             EventName.CODY_CHAT_GET_EDITOR_EXTENSION,
-                                            'cody.chat.getEditorExtensionCta',
+                                            'cody.chat.getEditorExtensionCTA',
                                             'click'
                                         )
                                     }

--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -155,6 +155,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                 isSourcegraphDotCom={isSourcegraphDotCom}
                 authenticatedUser={authenticatedUser}
                 context={context}
+                telemetryRecorder={telemetryRecorder}
             />
         )
     }

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -23,6 +23,7 @@ import {
 } from '@sourcegraph/cody-ui/dist/Chat'
 import type { FileLinkProps } from '@sourcegraph/cody-ui/dist/chat/ContextFiles'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, Icon, TextArea, Link, Tooltip, Alert, Text, H2 } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../../tracking/eventLogger'
@@ -40,15 +41,29 @@ import styles from './ChatUi.module.scss'
 
 export const SCROLL_THRESHOLD = 100
 
-const onFeedbackSubmit = (feedback: string): void => eventLogger.log(`web:cody:feedbackSubmit:${feedback}`)
-
-interface IChatUIProps {
+interface IChatUIProps extends TelemetryV2Props {
     codyChatStore: CodyChatStore
     isCodyChatPage?: boolean
     authenticatedUser: AuthenticatedUser | null
 }
 
-export const ChatUI: React.FC<IChatUIProps> = ({ codyChatStore, isCodyChatPage, authenticatedUser }): JSX.Element => {
+export const ChatUI: React.FC<IChatUIProps> = ({
+    codyChatStore,
+    isCodyChatPage,
+    authenticatedUser,
+    telemetryRecorder,
+}): JSX.Element => {
+    const onFeedbackSubmit = (feedback: string): void => {
+        eventLogger.log(`web:cody:feedbackSubmit:${feedback}`)
+        // TODO (dadlerj): update @sourcegraph/cody-ui/dist/Chat package to enforce a limited set of feedback strings.
+        // Until then, this is a hack to avoid arbitrary event features.
+        if (feedback == 'positive' || feedback == 'negative') {
+            telemetryRecorder.recordEvent(`cody-web.feedback.${feedback}`, 'submit')
+        } else {
+            telemetryRecorder.recordEvent(`cody-web.feedback.other`, 'submit')
+        }
+    }
+
     const {
         submitMessage,
         editMessage,

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -57,10 +57,10 @@ export const ChatUI: React.FC<IChatUIProps> = ({
         eventLogger.log(`web:cody:feedbackSubmit:${feedback}`)
         // TODO (dadlerj): update @sourcegraph/cody-ui/dist/Chat package to enforce a limited set of feedback strings.
         // Until then, this is a hack to avoid arbitrary event features.
-        if (feedback == 'positive' || feedback == 'negative') {
+        if (feedback === 'positive' || feedback === 'negative') {
             telemetryRecorder.recordEvent(`cody.feedback.${feedback}`, 'submit')
         } else {
-            telemetryRecorder.recordEvent(`cody.feedback.other`, 'submit')
+            telemetryRecorder.recordEvent('cody.feedback.other', 'submit')
         }
     }
 

--- a/client/web/src/cody/components/ChatUI/ChatUi.tsx
+++ b/client/web/src/cody/components/ChatUI/ChatUi.tsx
@@ -58,9 +58,9 @@ export const ChatUI: React.FC<IChatUIProps> = ({
         // TODO (dadlerj): update @sourcegraph/cody-ui/dist/Chat package to enforce a limited set of feedback strings.
         // Until then, this is a hack to avoid arbitrary event features.
         if (feedback == 'positive' || feedback == 'negative') {
-            telemetryRecorder.recordEvent(`cody-web.feedback.${feedback}`, 'submit')
+            telemetryRecorder.recordEvent(`cody.feedback.${feedback}`, 'submit')
         } else {
-            telemetryRecorder.recordEvent(`cody-web.feedback.other`, 'submit')
+            telemetryRecorder.recordEvent(`cody.feedback.other`, 'submit')
         }
     }
 

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.story.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.story.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import type { AuthenticatedUser } from '../../../auth'
 import { WebStory } from '../../../components/WebStory'
 import type { SourcegraphContext } from '../../../jscontext'
@@ -35,12 +37,26 @@ const context: Pick<SourcegraphContext, 'authProviders'> = {
 
 export const SourcegraphDotCom: StoryFn = () => (
     <WebStory>
-        {() => <CodyMarketingPage context={context} isSourcegraphDotCom={true} authenticatedUser={null} />}
+        {() => (
+            <CodyMarketingPage
+                context={context}
+                isSourcegraphDotCom={true}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 export const Enterprise: StoryFn = () => (
     <WebStory>
-        {() => <CodyMarketingPage context={context} isSourcegraphDotCom={false} authenticatedUser={null} />}
+        {() => (
+            <CodyMarketingPage
+                context={context}
+                isSourcegraphDotCom={false}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
@@ -51,6 +67,7 @@ export const EnterpriseSiteAdmin: StoryFn = () => (
                 context={context}
                 isSourcegraphDotCom={false}
                 authenticatedUser={{ siteAdmin: true } as AuthenticatedUser}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -1,3 +1,5 @@
+// TODO UPDATE THIS FILE ONCE SRC/AUTH IS MERGED
+
 import { mdiChevronRight, mdiCodeBracesBox, mdiGit } from '@mdi/js'
 import classNames from 'classnames'
 

--- a/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
+++ b/client/web/src/cody/components/CodyMarketingPage/CodyMarketingPage.tsx
@@ -1,9 +1,9 @@
-// TODO UPDATE THIS FILE ONCE SRC/AUTH IS MERGED
+import { useEffect } from 'react'
 
 import { mdiChevronRight, mdiCodeBracesBox, mdiGit } from '@mdi/js'
 import classNames from 'classnames'
 
-import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Theme, useTheme } from '@sourcegraph/shared/src/theme'
 import { Badge, H1, H2, H3, H4, Icon, Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
@@ -107,7 +107,7 @@ const codyPlatformCardItems = (
           ]),
 ]
 
-export interface CodyMarketingPageProps {
+export interface CodyMarketingPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
     context: Pick<SourcegraphContext, 'authProviders'>
     authenticatedUser: AuthenticatedUser | null
@@ -117,9 +117,12 @@ export const CodyMarketingPage: React.FunctionComponent<CodyMarketingPageProps> 
     context,
     isSourcegraphDotCom,
     authenticatedUser,
+    telemetryRecorder,
 }) => {
     const { theme } = useTheme()
     const isDarkTheme = theme === Theme.Dark
+
+    useEffect(() => telemetryRecorder.recordEvent('cody.marketing', 'view'), [telemetryRecorder])
 
     return (
         <Page>
@@ -178,8 +181,7 @@ export const CodyMarketingPage: React.FunctionComponent<CodyMarketingPageProps> 
                                 onClick={() => {}}
                                 ctaClassName={styles.authButton}
                                 iconClassName={styles.buttonIcon}
-                                // TODO (dadlerj): update with a real telemetry recorder
-                                telemetryRecorder={noOpTelemetryRecorder}
+                                telemetryRecorder={telemetryRecorder}
                                 telemetryService={eventLogger}
                             />
                         </div>

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -21,7 +21,12 @@ export interface ScopeSelectorProps {
     setScope: (scope: CodyClientScope) => void
     toggleIncludeInferredRepository: () => void
     toggleIncludeInferredFile: () => void
-    logTranscriptEvent: (eventLabel: string, eventProperties?: { [key: string]: any }) => void
+    logTranscriptEvent: (
+        v1EventLabel: string,
+        feature: string,
+        action: string,
+        eventProperties?: { [key: string]: any }
+    ) => void
     transcriptHistory: TranscriptJSON[]
     className?: string
     renderHint?: (repos: IRepo[]) => React.ReactNode
@@ -104,7 +109,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
     const addRepository = useCallback(
         (repoName: string) => {
             if (!scope.repositories.includes(repoName)) {
-                logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_ADDED)
+                logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_ADDED, 'cody-chat.scope.repo', 'add')
                 setScope({ ...scope, repositories: [...scope.repositories, repoName] })
             }
         },
@@ -113,14 +118,14 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
 
     const removeRepository = useCallback(
         (repoName: string) => {
-            logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_REMOVED)
+            logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_REMOVED, 'cody-chat.scope.repo', 'remove')
             setScope({ ...scope, repositories: scope.repositories.filter(repo => repo !== repoName) })
         },
         [scope, setScope, logTranscriptEvent]
     )
 
     const resetScope = useCallback((): void => {
-        logTranscriptEvent(EventName.CODY_CHAT_SCOPE_RESET)
+        logTranscriptEvent(EventName.CODY_CHAT_SCOPE_RESET, 'cody-chat.scope.repo', 'reset')
         setScope({ ...scope, repositories: [], includeInferredRepository: true, includeInferredFile: true })
     }, [scope, setScope, logTranscriptEvent])
 

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -109,7 +109,7 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
     const addRepository = useCallback(
         (repoName: string) => {
             if (!scope.repositories.includes(repoName)) {
-                logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_ADDED, 'cody-chat.scope.repo', 'add')
+                logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_ADDED, 'cody.chat.scope.repo', 'add')
                 setScope({ ...scope, repositories: [...scope.repositories, repoName] })
             }
         },
@@ -118,14 +118,14 @@ export const ScopeSelector: React.FC<ScopeSelectorProps> = React.memo(function S
 
     const removeRepository = useCallback(
         (repoName: string) => {
-            logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_REMOVED, 'cody-chat.scope.repo', 'remove')
+            logTranscriptEvent(EventName.CODY_CHAT_SCOPE_REPO_REMOVED, 'cody.chat.scope.repo', 'remove')
             setScope({ ...scope, repositories: scope.repositories.filter(repo => repo !== repoName) })
         },
         [scope, setScope, logTranscriptEvent]
     )
 
     const resetScope = useCallback((): void => {
-        logTranscriptEvent(EventName.CODY_CHAT_SCOPE_RESET, 'cody-chat.scope.repo', 'reset')
+        logTranscriptEvent(EventName.CODY_CHAT_SCOPE_RESET, 'cody.chat.scope.repo', 'reset')
         setScope({ ...scope, repositories: [], includeInferredRepository: true, includeInferredFile: true })
     }, [scope, setScope, logTranscriptEvent])
 

--- a/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
+++ b/client/web/src/cody/components/ScopeSelector/ScopeSelector.tsx
@@ -10,6 +10,7 @@ import { Text } from '@sourcegraph/wildcard'
 
 import type { ReposStatusResult, ReposStatusVariables } from '../../../graphql-operations'
 import { EventName } from '../../../util/constants'
+import { CodyTranscriptEventActions, CodyTranscriptEventFeatures } from '../../useCodyChat'
 
 import { ReposStatusQuery } from './backend'
 import { RepositoriesSelectorPopover, getFileName, type IRepo } from './RepositoriesSelectorPopover'
@@ -23,8 +24,8 @@ export interface ScopeSelectorProps {
     toggleIncludeInferredFile: () => void
     logTranscriptEvent: (
         v1EventLabel: string,
-        feature: string,
-        action: string,
+        feature: CodyTranscriptEventFeatures,
+        action: CodyTranscriptEventActions,
         eventProperties?: { [key: string]: any }
     ) => void
     transcriptHistory: TranscriptJSON[]

--- a/client/web/src/cody/dashboard/CodyDashboardPage.tsx
+++ b/client/web/src/cody/dashboard/CodyDashboardPage.tsx
@@ -1,7 +1,8 @@
-import { type FC, useState } from 'react'
+import { type FC, useState, useEffect } from 'react'
 
 import { mdiChevronDown } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
     Text,
@@ -48,9 +49,13 @@ const setupOptions: SetupOption[] = [
     },
 ]
 
-interface CodyDashboardPageProps {}
+interface CodyDashboardPageProps extends TelemetryV2Props {}
 
-export const CodyDashboardPage: FC<CodyDashboardPageProps> = () => {
+export const CodyDashboardPage: FC<CodyDashboardPageProps> = ({ telemetryRecorder }) => {
+    useEffect(() => {
+        telemetryRecorder.recordEvent('cody.dashboard', 'view')
+    }, [telemetryRecorder])
+
     const isLightTheme = useIsLightTheme()
     const codySetupLink = 'https://sourcegraph.com/docs/cody'
     const features = getLicenseFeatures()

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import { mdiHelpCircleOutline, mdiInformationOutline, mdiOpenInNew, mdiCreditCardOutline } from '@mdi/js'
 import classNames from 'classnames'
@@ -113,6 +113,10 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
         }
     }, [data, navigate])
 
+    const onClickUpgradeToProCTA = useCallback(() => {
+        telemetryRecorder.recordEvent('cody.management.upgradeToProCTA', 'click')
+    }, [telemetryRecorder])
+
     if (dataError || usageDateError) {
         throw dataError || usageDateError
     }
@@ -171,7 +175,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                     </PageHeader.Heading>
                 </PageHeader>
 
-                <UpgradeToProBanner userIsOnProTier={userIsOnProTier} />
+                <UpgradeToProBanner userIsOnProTier={userIsOnProTier} onClick={onClickUpgradeToProCTA} />
                 <DoNotLoseCodyProBanner
                     userIsOnProTier={userIsOnProTier}
                     arePaymentsEnabled={arePaymentsEnabled}
@@ -207,6 +211,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                     onClick={event => {
                                         event.preventDefault()
                                         eventLogger.log(EventName.CODY_MANAGE_SUBSCRIPTION_CLICKED)
+                                        telemetryRecorder.recordEvent('cody.manageSubscription', 'click')
                                         window.location.href = manageSubscriptionRedirectURL
                                     }}
                                 >
@@ -470,7 +475,8 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
 const UpgradeToProBanner: React.FunctionComponent<{
     userIsOnProTier: boolean
-}> = ({ userIsOnProTier }) =>
+    onClick: () => void
+}> = ({ userIsOnProTier, onClick }) =>
     userIsOnProTier ? null : (
         <div className={classNames('d-flex justify-content-between align-items-center p-4', styles.upgradeToProBanner)}>
             <div>
@@ -484,7 +490,7 @@ const UpgradeToProBanner: React.FunctionComponent<{
                 </ul>
             </div>
             <div>
-                <ButtonLink to="/cody/subscription" variant="primary" size="sm">
+                <ButtonLink to="/cody/subscription" variant="primary" size="sm" onClick={onClick}>
                     Upgrade
                 </ButtonLink>
             </div>

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     ButtonLink,
     H1,
@@ -51,7 +52,7 @@ import { CHANGE_CODY_PLAN, USER_CODY_PLAN, USER_CODY_USAGE } from '../subscripti
 
 import styles from './CodyManagementPage.module.scss'
 
-interface CodyManagementPageProps {
+interface CodyManagementPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
 }
@@ -59,6 +60,7 @@ interface CodyManagementPageProps {
 export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps> = ({
     isSourcegraphDotCom,
     authenticatedUser,
+    telemetryRecorder,
 }) => {
     const parameters = useSearchParameters()
 
@@ -69,7 +71,8 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
     useEffect(() => {
         eventLogger.log(EventName.CODY_MANAGEMENT_PAGE_VIEWED, { utm_source })
-    }, [utm_source])
+        telemetryRecorder.recordEvent('cody.management', 'view')
+    }, [utm_source, telemetryRecorder])
 
     const { data, error: dataError } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
 
@@ -460,7 +463,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                     ))}
                 </div>
             </Page>
-            <CodyOnboarding authenticatedUser={authenticatedUser} />
+            <CodyOnboarding authenticatedUser={authenticatedUser} telemetryRecorder={telemetryRecorder} />
         </>
     )
 }

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -348,7 +348,7 @@ function EditorStep({
             { tier: pro ? 'pro' : 'free' }
         )
         telemetryRecorder.recordEvent('cody.onboarding.chooseEditor', 'view', { metadata: { tier: pro ? 1 : 0 } })
-    }, [pro])
+    }, [pro, telemetryRecorder])
 
     const [editor, setEditor] = useState<null | IEditor>(null)
 

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -347,7 +347,7 @@ function EditorStep({
             { tier: pro ? 'pro' : 'free' },
             { tier: pro ? 'pro' : 'free' }
         )
-        telemetryRecorder.recordEvent('cody.onboarding.choose-editor', 'view', { metadata: { tier: pro ? 1 : 0 } })
+        telemetryRecorder.recordEvent('cody.onboarding.chooseEditor', 'view', { metadata: { tier: pro ? 1 : 0 } })
     }, [pro])
 
     const [editor, setEditor] = useState<null | IEditor>(null)
@@ -398,7 +398,7 @@ function EditorStep({
                                             editor,
                                         }
                                     )
-                                    telemetryRecorder.recordEvent('cody.onboarding.choose-editor', 'select', {
+                                    telemetryRecorder.recordEvent('cody.onboarding.chooseEditor', 'select', {
                                         metadata: { tier: pro ? 1 : 0, editor: editor.id },
                                     })
                                 }}
@@ -414,7 +414,7 @@ function EditorStep({
                                             editor,
                                         }
                                     )
-                                    telemetryRecorder.recordEvent('cody.onboarding.choose-editor', 'select', {
+                                    telemetryRecorder.recordEvent('cody.onboarding.chooseEditor', 'select', {
                                         metadata: { tier: pro ? 1 : 0, editor: editor.id },
                                     })
                                     setEditor(editor)
@@ -458,7 +458,7 @@ function EditorStep({
                             { tier: pro ? 'pro' : 'free' },
                             { tier: pro ? 'pro' : 'free' }
                         )
-                        telemetryRecorder.recordEvent('cody.onboarding.choose-editor', 'skip', {
+                        telemetryRecorder.recordEvent('cody.onboarding.chooseEditor', 'skip', {
                             metadata: { tier: pro ? 1 : 0 },
                         })
                     }}

--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryRecorder, TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Button, H2, H5, Modal, Text, useSearchParameters } from '@sourcegraph/wildcard'
 
@@ -19,6 +20,7 @@ import { VSCodeInstructions } from './instructions/VsCode'
 import styles from './CodyOnboarding.module.scss'
 
 export interface IEditor {
+    id: number // a unique number identifier for telemetry
     icon: string
     name: string
     publisher: string
@@ -30,6 +32,7 @@ export interface IEditor {
 export const editorGroups: IEditor[][] = [
     [
         {
+            id: 1,
             icon: 'VsCode',
             name: 'VS Code',
             publisher: 'Microsoft',
@@ -38,6 +41,7 @@ export const editorGroups: IEditor[][] = [
             instructions: VSCodeInstructions,
         },
         {
+            id: 2,
             icon: 'IntelliJ',
             name: 'IntelliJ IDEA',
             publisher: 'JetBrains',
@@ -46,6 +50,7 @@ export const editorGroups: IEditor[][] = [
             instructions: JetBrainsInstructions,
         },
         {
+            id: 3,
             icon: 'PhpStorm',
             name: 'PhpStorm ',
             publisher: 'JetBrains',
@@ -54,6 +59,7 @@ export const editorGroups: IEditor[][] = [
             instructions: JetBrainsInstructions,
         },
         {
+            id: 4,
             icon: 'PyCharm',
             name: 'PyCharm',
             publisher: 'JetBrains',
@@ -64,6 +70,7 @@ export const editorGroups: IEditor[][] = [
     ],
     [
         {
+            id: 5,
             icon: 'WebStorm',
             name: 'WebStorm',
             publisher: 'JetBrains',
@@ -72,6 +79,7 @@ export const editorGroups: IEditor[][] = [
             instructions: JetBrainsInstructions,
         },
         {
+            id: 6,
             icon: 'RubyMine',
             name: 'RubyMine',
             publisher: 'JetBrains',
@@ -80,6 +88,7 @@ export const editorGroups: IEditor[][] = [
             instructions: JetBrainsInstructions,
         },
         {
+            id: 7,
             icon: 'GoLand',
             name: 'GoLand',
             publisher: 'JetBrains',
@@ -88,6 +97,7 @@ export const editorGroups: IEditor[][] = [
             instructions: JetBrainsInstructions,
         },
         {
+            id: 8,
             icon: 'AndroidStudio',
             name: 'Android Studio',
             publisher: 'Google',
@@ -98,6 +108,7 @@ export const editorGroups: IEditor[][] = [
     ],
     [
         {
+            id: 9,
             icon: 'NeoVim',
             name: 'Neovim',
             publisher: 'Neovim Team',
@@ -106,6 +117,7 @@ export const editorGroups: IEditor[][] = [
             instructions: NeoVimInstructions,
         },
         {
+            id: 10,
             icon: 'Emacs',
             name: 'Emacs',
             publisher: 'GNU',
@@ -124,11 +136,11 @@ function formatUseCase(action: { work: boolean; personal: boolean }): string {
     return useCases.length === 0 ? 'none' : useCases.join(',')
 }
 
-export function CodyOnboarding({
-    authenticatedUser,
-}: {
+interface CodyOnboardingProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
-}): JSX.Element | null {
+}
+
+export function CodyOnboarding({ authenticatedUser, telemetryRecorder }: CodyOnboardingProps): JSX.Element | null {
     const [showEditorStep, setShowEditorStep] = useState(false)
     const [completed = false, setOnboardingCompleted] = useTemporarySetting('cody.onboarding.completed', false)
     // steps start from 0
@@ -168,7 +180,7 @@ export function CodyOnboarding({
             className={styles.modal}
             containerClassName={styles.root}
         >
-            {step === 0 && <WelcomeStep onNext={onNext} pro={enrollPro} />}
+            {step === 0 && <WelcomeStep onNext={onNext} pro={enrollPro} telemetryRecorder={telemetryRecorder} />}
             {step === 1 && (
                 <PurposeStep
                     authenticatedUser={authenticatedUser}
@@ -178,6 +190,7 @@ export function CodyOnboarding({
                         setShowEditorStep(true)
                     }}
                     pro={enrollPro}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
             {showEditorStep && (
@@ -186,13 +199,22 @@ export function CodyOnboarding({
                         setShowEditorStep(false)
                     }}
                     pro={enrollPro}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
         </Modal>
     )
 }
 
-function WelcomeStep({ onNext, pro }: { onNext: () => void; pro: boolean }): JSX.Element {
+function WelcomeStep({
+    onNext,
+    pro,
+    telemetryRecorder,
+}: {
+    onNext: () => void
+    pro: boolean
+    telemetryRecorder: TelemetryRecorder
+}): JSX.Element {
     const [show, setShow] = useState(false)
     const isLightTheme = useIsLightTheme()
     useEffect(() => {
@@ -201,7 +223,8 @@ function WelcomeStep({ onNext, pro }: { onNext: () => void; pro: boolean }): JSX
             { tier: pro ? 'pro' : 'free' },
             { tier: pro ? 'pro' : 'free' }
         )
-    }, [pro])
+        telemetryRecorder.recordEvent('cody.onboarding.welcome', 'view', { metadata: { tier: pro ? 1 : 0 } })
+    }, [pro, telemetryRecorder])
 
     useEffect(() => {
         // theme is not ready on first render, it defaults to system theme.
@@ -250,10 +273,12 @@ function PurposeStep({
     onNext,
     pro,
     authenticatedUser,
+    telemetryRecorder,
 }: {
     onNext: () => void
     pro: boolean
     authenticatedUser: AuthenticatedUser
+    telemetryRecorder: TelemetryRecorder
 }): JSX.Element {
     useEffect(() => {
         eventLogger.log(
@@ -261,7 +286,8 @@ function PurposeStep({
             { tier: pro ? 'pro' : 'free' },
             { tier: pro ? 'pro' : 'free' }
         )
-    }, [pro])
+        telemetryRecorder.recordEvent('cody.onboarding.purpose', 'view', { metadata: { tier: pro ? 1 : 0 } })
+    }, [pro, telemetryRecorder])
 
     const primaryEmail = authenticatedUser.emails.find(email => email.isPrimary)?.email
 
@@ -274,6 +300,9 @@ function PurposeStep({
             personal: personalInput.checked,
         })
         eventLogger.log(EventName.CODY_ONBOARDING_PURPOSE_SELECTED, { useCase }, { useCase })
+        telemetryRecorder.recordEvent('cody.onboarding.purpose', 'select', {
+            metadata: { workUseCase: workInput.checked ? 1 : 0, personalUseCase: personalInput.checked ? 1 : 0 },
+        })
     }
 
     return (
@@ -303,13 +332,22 @@ function PurposeStep({
     )
 }
 
-function EditorStep({ onCompleted, pro }: { onCompleted: () => void; pro: boolean }): JSX.Element {
+function EditorStep({
+    onCompleted,
+    pro,
+    telemetryRecorder,
+}: {
+    onCompleted: () => void
+    pro: boolean
+    telemetryRecorder: TelemetryRecorder
+}): JSX.Element {
     useEffect(() => {
         eventLogger.log(
             EventName.CODY_ONBOARDING_CHOOSE_EDITOR_VIEWED,
             { tier: pro ? 'pro' : 'free' },
             { tier: pro ? 'pro' : 'free' }
         )
+        telemetryRecorder.recordEvent('cody.onboarding.choose-editor', 'view', { metadata: { tier: pro ? 1 : 0 } })
     }, [pro])
 
     const [editor, setEditor] = useState<null | IEditor>(null)
@@ -360,6 +398,9 @@ function EditorStep({ onCompleted, pro }: { onCompleted: () => void; pro: boolea
                                             editor,
                                         }
                                     )
+                                    telemetryRecorder.recordEvent('cody.onboarding.choose-editor', 'select', {
+                                        metadata: { tier: pro ? 1 : 0, editor: editor.id },
+                                    })
                                 }}
                                 onClick={() => {
                                     eventLogger.log(
@@ -373,6 +414,9 @@ function EditorStep({ onCompleted, pro }: { onCompleted: () => void; pro: boolea
                                             editor,
                                         }
                                     )
+                                    telemetryRecorder.recordEvent('cody.onboarding.choose-editor', 'select', {
+                                        metadata: { tier: pro ? 1 : 0, editor: editor.id },
+                                    })
                                     setEditor(editor)
                                 }}
                             >
@@ -414,6 +458,9 @@ function EditorStep({ onCompleted, pro }: { onCompleted: () => void; pro: boolea
                             { tier: pro ? 'pro' : 'free' },
                             { tier: pro ? 'pro' : 'free' }
                         )
+                        telemetryRecorder.recordEvent('cody.onboarding.choose-editor', 'skip', {
+                            metadata: { tier: pro ? 1 : 0 },
+                        })
                     }}
                 >
                     Skip for now

--- a/client/web/src/cody/search/CodySearchPage.tsx
+++ b/client/web/src/cody/search/CodySearchPage.tsx
@@ -29,6 +29,12 @@ interface CodeSearchPageProps extends TelemetryV2Props {
     telemetryService: TelemetryService
 }
 
+// Mapping for telemetry
+const failureReasons = {
+    untranslateable: 0,
+    unreachable: 1,
+}
+
 export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({
     authenticatedUser,
     telemetryRecorder,
@@ -54,12 +60,6 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({
     }
 
     const [loading, setLoading] = useState(false)
-
-    // Mapping for telemetry
-    const failureReasons = {
-        untranslateable: 0,
-        unreachable: 1,
-    }
 
     const onSubmit = useCallback(() => {
         const sanitizedInput = input.trim()

--- a/client/web/src/cody/search/CodySearchPage.tsx
+++ b/client/web/src/cody/search/CodySearchPage.tsx
@@ -75,7 +75,6 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({
             !isPrivateInstance ? { input: sanitizedInput } : null,
             !isPrivateInstance ? { input: sanitizedInput } : null
         )
-        // TODO VERIFY WE DONT WANT THE INPUT?
         telemetryRecorder.recordEvent('cody.search', 'submit')
         setLoading(true)
         translateToQuery(sanitizedInput, authenticatedUser).then(
@@ -88,7 +87,6 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({
                         !isPrivateInstance ? { input: sanitizedInput, translatedQuery: query } : null,
                         !isPrivateInstance ? { input: sanitizedInput, translatedQuery: query } : null
                     )
-                    // TODO VERIFY WE DONT WANT THE INPUT?
                     telemetryRecorder.recordEvent('cody.search', 'success')
                     setCodySearchInput(JSON.stringify({ input: sanitizedInput, translatedQuery: query }))
                     navigate({
@@ -101,7 +99,6 @@ export const CodySearchPage: React.FunctionComponent<CodeSearchPageProps> = ({
                         !isPrivateInstance ? { input: sanitizedInput, reason: 'untranslatable' } : null,
                         !isPrivateInstance ? { input: sanitizedInput, reason: 'untranslatable' } : null
                     )
-                    // TODO VERIFY WE DONT WANT THE INPUT?
                     telemetryRecorder.recordEvent('cody.search', 'fail', {
                         metadata: { reason: failureReasons.untranslateable },
                     })

--- a/client/web/src/cody/sidebar/CodySidebar.tsx
+++ b/client/web/src/cody/sidebar/CodySidebar.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 
 import { CodyLogo } from '@sourcegraph/cody-ui/dist/icons/CodyLogo'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, Icon, Tooltip, Badge } from '@sourcegraph/wildcard'
 
 import { ChatUI, ScrollDownButton } from '../components/ChatUI'
@@ -16,12 +17,12 @@ import styles from './CodySidebar.module.scss'
 
 export const SCROLL_THRESHOLD = 100
 
-interface CodySidebarProps {
+interface CodySidebarProps extends TelemetryV2Props {
     onClose?: () => void
     authenticatedUser: AuthenticatedUser | null
 }
 
-export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose, authenticatedUser }) => {
+export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose, authenticatedUser, telemetryRecorder }) => {
     const codySidebarStore = useCodySidebar()
     const {
         initializeNewChat,
@@ -145,7 +146,11 @@ export const CodySidebar: React.FC<CodySidebarProps> = ({ onClose, authenticated
                         deleteHistoryItem={deleteHistoryItem}
                     />
                 ) : (
-                    <ChatUI codyChatStore={codySidebarStore} authenticatedUser={authenticatedUser} />
+                    <ChatUI
+                        codyChatStore={codySidebarStore}
+                        authenticatedUser={authenticatedUser}
+                        telemetryRecorder={telemetryRecorder}
+                    />
                 )}
             </div>
             {showScrollDownButton && <ScrollDownButton onClick={() => scrollToBottom('smooth')} />}

--- a/client/web/src/cody/sidebar/Provider.tsx
+++ b/client/web/src/cody/sidebar/Provider.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState, useCallback, useMemo } from 'react'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 
 import { useCodyChat, type CodyChatStore, codyChatStoreMock } from '../useCodyChat'
 
@@ -24,12 +25,16 @@ const CodySidebarContext = React.createContext<CodySidebarStore | null>({
     setFocusProvided: () => {},
 })
 
-interface ICodySidebarStoreProviderProps {
+interface ICodySidebarStoreProviderProps extends TelemetryV2Props {
     children?: React.ReactNode
     authenticatedUser: AuthenticatedUser | null
 }
 
-export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> = ({ authenticatedUser, children }) => {
+export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> = ({
+    authenticatedUser,
+    children,
+    telemetryRecorder,
+}) => {
     const [isSidebarOpen, setIsSidebarOpenState] = useTemporarySetting('cody.showSidebar', false)
     const [inputNeedsFocus, setInputNeedsFocus] = useState(false)
     const { setSidebarSize } = useSidebarSize()
@@ -48,7 +53,7 @@ export const CodySidebarStoreProvider: React.FC<ICodySidebarStoreProviderProps> 
 
     const onEvent = useCallback(() => setIsSidebarOpen(true), [setIsSidebarOpen])
 
-    const codyChatStore = useCodyChat({ userID: authenticatedUser?.id, onEvent })
+    const codyChatStore = useCodyChat({ userID: authenticatedUser?.id, onEvent, telemetryRecorder })
 
     const state = useMemo<CodySidebarStore>(
         () => ({

--- a/client/web/src/cody/subscription/CancelProModal.tsx
+++ b/client/web/src/cody/subscription/CancelProModal.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { Modal, Button, H2, Text } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -14,9 +15,11 @@ import styles from './CodySubscriptionPage.module.scss'
 export function CancelProModal({
     authenticatedUser,
     onClose,
+    telemetryRecorder,
 }: {
     authenticatedUser: AuthenticatedUser
     onClose: () => void
+    telemetryRecorder: TelemetryRecorder
 }): JSX.Element {
     const [changeCodyPlan, { data }] = useMutation<ChangeCodyPlanResult, ChangeCodyPlanVariables>(CHANGE_CODY_PLAN)
 
@@ -62,6 +65,9 @@ export function CancelProModal({
                                         tier: 'free',
                                     }
                                 )
+                                telemetryRecorder.recordEvent('cody.plan-selection.cancel-pro-modal', 'confirm', {
+                                    metadata: { tier: 0 }, // 1 is used for Pro tier
+                                })
 
                                 changeCodyPlan({ variables: { pro: false, id: authenticatedUser.id } })
                             }}

--- a/client/web/src/cody/subscription/CancelProModal.tsx
+++ b/client/web/src/cody/subscription/CancelProModal.tsx
@@ -65,7 +65,7 @@ export function CancelProModal({
                                         tier: 'free',
                                     }
                                 )
-                                telemetryRecorder.recordEvent('cody.plan-selection.cancel-pro-modal', 'confirm', {
+                                telemetryRecorder.recordEvent('cody.planSelection.cancelProModal', 'confirm', {
                                     metadata: { tier: 0 }, // 1 is used for Pro tier
                                 })
 

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -6,6 +6,7 @@ import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Badge,
     Button,
@@ -37,7 +38,7 @@ import { UpgradeToProModal } from './UpgradeToProModal'
 
 import styles from './CodySubscriptionPage.module.scss'
 
-interface CodySubscriptionPageProps {
+interface CodySubscriptionPageProps extends TelemetryV2Props {
     isSourcegraphDotCom: boolean
     authenticatedUser?: AuthenticatedUser | null
 }
@@ -55,6 +56,7 @@ export const useCodyPaymentsUrl = (): string => {
 export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageProps> = ({
     isSourcegraphDotCom,
     authenticatedUser,
+    telemetryRecorder,
 }) => {
     const parameters = useSearchParameters()
 
@@ -67,7 +69,8 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
 
     useEffect(() => {
         eventLogger.log(EventName.CODY_SUBSCRIPTION_PAGE_VIEWED, { utm_source }, { utm_source })
-    }, [utm_source])
+        telemetryRecorder.recordEvent('cody.planSelection', 'view')
+    }, [utm_source, telemetryRecorder])
 
     const { data, error: dataError } = useQuery<UserCodyPlanResult, UserCodyPlanVariables>(USER_CODY_PLAN, {})
 
@@ -250,6 +253,10 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 size="small"
                                                 onClick={() => {
                                                     eventLogger.log(EventName.CODY_MANAGE_SUBSCRIPTION_CLICKED)
+                                                    telemetryRecorder.recordEvent(
+                                                        'cody.planSelection.manageSubscription',
+                                                        'click'
+                                                    )
                                                     window.location.href = manageSubscriptionRedirectURL
                                                 }}
                                             >
@@ -261,6 +268,10 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 variant="primary"
                                                 onClick={() => {
                                                     eventLogger.log(EventName.CODY_SUBSCRIPTION_ADD_CREDIT_CARD_CLICKED)
+                                                    telemetryRecorder.recordEvent(
+                                                        'cody.planSelection.addCreditCard',
+                                                        'click'
+                                                    )
                                                     window.location.href = manageSubscriptionRedirectURL
                                                 }}
                                             >
@@ -287,6 +298,9 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                             tier: 'free',
                                                         }
                                                     )
+                                                    telemetryRecorder.recordEvent('cody.planSelection', 'click', {
+                                                        metadata: { tier: 0 },
+                                                    })
                                                     if (arePaymentsEnabled) {
                                                         window.location.href = manageSubscriptionRedirectURL
                                                         return
@@ -309,6 +323,9 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                                 { tier: 'pro' },
                                                 { tier: 'pro' }
                                             )
+                                            telemetryRecorder.recordEvent('cody.planSelection', 'click', {
+                                                metadata: { tier: 1 },
+                                            })
                                             if (arePaymentsEnabled) {
                                                 window.location.href = manageSubscriptionRedirectURL
                                                 return
@@ -429,6 +446,9 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                         { tier: 'enterprise' },
                                         { tier: 'enterprise' }
                                     )
+                                    telemetryRecorder.recordEvent('cody.planSelection', 'click', {
+                                        metadata: { tier: 2 },
+                                    })
                                 }}
                             >
                                 Request info
@@ -525,6 +545,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                         setShowCancelPro(false)
                     }}
                     authenticatedUser={authenticatedUser}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
         </>

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -537,6 +537,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                         setShowUpgradeToPro(false)
                     }}
                     authenticatedUser={authenticatedUser}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
             {showCancelPro && (

--- a/client/web/src/cody/subscription/UpgradeToProModal.tsx
+++ b/client/web/src/cody/subscription/UpgradeToProModal.tsx
@@ -2,6 +2,7 @@ import { mdiCalendarMonth, mdiClose, mdiCreditCardOff, mdiTag, mdiTrendingUp } f
 import classNames from 'classnames'
 
 import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { Button, H1, H2, Icon, Modal, Text } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -19,10 +20,12 @@ export function UpgradeToProModal({
     authenticatedUser,
     onClose,
     onSuccess,
+    telemetryRecorder,
 }: {
     authenticatedUser: AuthenticatedUser
     onClose: () => void
     onSuccess: () => void
+    telemetryRecorder: TelemetryRecorder
 }): JSX.Element {
     const [changeCodyPlan, { data }] = useMutation<ChangeCodyPlanResult, ChangeCodyPlanVariables>(CHANGE_CODY_PLAN)
 
@@ -156,6 +159,13 @@ export function UpgradeToProModal({
                                             },
                                             {
                                                 tier: 'pro',
+                                            }
+                                        )
+                                        telemetryRecorder.recordEvent(
+                                            'cody.plan-selection.upgrade-to-pro-modal',
+                                            'click',
+                                            {
+                                                metadata: { tier: 1 },
                                             }
                                         )
 

--- a/client/web/src/cody/subscription/UpgradeToProModal.tsx
+++ b/client/web/src/cody/subscription/UpgradeToProModal.tsx
@@ -161,9 +161,13 @@ export function UpgradeToProModal({
                                                 tier: 'pro',
                                             }
                                         )
-                                        telemetryRecorder.recordEvent('cody.planSelection.upgradeToProModal', 'click', {
-                                            metadata: { tier: 1 },
-                                        })
+                                        telemetryRecorder.recordEvent(
+                                            'cody.planSelection.upgradeToProModal',
+                                            'submit',
+                                            {
+                                                metadata: { tier: 1 },
+                                            }
+                                        )
 
                                         changeCodyPlan({ variables: { pro: true, id: authenticatedUser.id } })
                                     }}

--- a/client/web/src/cody/subscription/UpgradeToProModal.tsx
+++ b/client/web/src/cody/subscription/UpgradeToProModal.tsx
@@ -161,13 +161,9 @@ export function UpgradeToProModal({
                                                 tier: 'pro',
                                             }
                                         )
-                                        telemetryRecorder.recordEvent(
-                                            'cody.plan-selection.upgrade-to-pro-modal',
-                                            'click',
-                                            {
-                                                metadata: { tier: 1 },
-                                            }
-                                        )
+                                        telemetryRecorder.recordEvent('cody.planSelection.upgradeToProModal', 'click', {
+                                            metadata: { tier: 1 },
+                                        })
 
                                         changeCodyPlan({ variables: { pro: true, id: authenticatedUser.id } })
                                     }}

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -416,7 +416,6 @@ export const useCodyChat = ({
 
     const toggleIncludeInferredRepository = useCallback<CodyClient['toggleIncludeInferredRepository']>(() => {
         const action = scope.includeInferredRepository ? 'disabled' : 'enabled'
-        // TODO CHECK THIS AGAINST SLACK THREAD
         logTranscriptEvent(
             scope.includeInferredRepository
                 ? EventName.CODY_CHAT_SCOPE_INFERRED_REPO_DISABLED

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -204,13 +204,13 @@ export const useCodyChat = ({
             }
             eventLogger.log(v1EventLabel, { transcriptId: transcript.id, ...eventProperties })
 
-            var numericID = new Date(transcript.id).getTime()
+            let numericID = new Date(transcript.id).getTime()
             if (isNaN(numericID)) {
                 numericID = 0
             }
             telemetryRecorder.recordEvent(feature, action, { metadata: { transcriptId: numericID / 1000 } })
         },
-        [transcript]
+        [transcript, telemetryRecorder]
     )
 
     const loadTranscriptFromHistory = useCallback(

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -51,8 +51,8 @@ export interface CodyChatStore
     loadTranscriptFromHistory: (id: string) => Promise<void>
     logTranscriptEvent: (
         v1EventLabel: string,
-        feature: codyTranscriptEventFeatures,
-        action: codyTranscriptEventActions,
+        feature: CodyTranscriptEventFeatures,
+        action: CodyTranscriptEventActions,
         eventProperties?: { [key: string]: any }
     ) => void
     initializeNewChat: () => void
@@ -103,15 +103,16 @@ interface CodyChatProps extends TelemetryV2Props {
 const CODY_TRANSCRIPT_HISTORY_KEY = 'cody.chat.history'
 const SAVE_MAX_TRANSCRIPT_HISTORY = 20
 
-type codyTranscriptEventFeatures =
+export type CodyTranscriptEventFeatures =
     | 'cody.chat'
     | 'cody.chat.item'
     | 'cody.chat.inferredRepo'
     | 'cody.chat.inferredFile'
     | 'cody.chat.getEditorExtensionCTA'
     | 'cody.chat.scope.repo'
+    | 'repo.askCody'
 
-type codyTranscriptEventActions =
+export type CodyTranscriptEventActions =
     | 'view'
     | 'submit'
     | 'edit'
@@ -122,6 +123,7 @@ type codyTranscriptEventActions =
     | 'click'
     | 'disable'
     | 'enable'
+    | 'add'
 
 export const useCodyChat = ({
     userID = 'anonymous',
@@ -193,8 +195,8 @@ export const useCodyChat = ({
     const logTranscriptEvent = useCallback(
         (
             v1EventLabel: string,
-            feature: codyTranscriptEventFeatures,
-            action: codyTranscriptEventActions,
+            feature: CodyTranscriptEventFeatures,
+            action: CodyTranscriptEventActions,
             eventProperties?: { [key: string]: any }
         ) => {
             if (!transcript) {

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -49,7 +49,12 @@ export interface CodyChatStore
     clearHistory: () => void
     deleteHistoryItem: (id: string) => void
     loadTranscriptFromHistory: (id: string) => Promise<void>
-    logTranscriptEvent: (v1EventLabel: string, feature: string, action: string, eventProperties?: { [key: string]: any }) => void
+    logTranscriptEvent: (
+        v1EventLabel: string,
+        feature: string,
+        action: string,
+        eventProperties?: { [key: string]: any }
+    ) => void
     initializeNewChat: () => void
 }
 
@@ -171,7 +176,7 @@ export const useCodyChat = ({
                 return
             }
             eventLogger.log(v1EventLabel, { transcriptId: transcript.id, ...eventProperties })
-            telemetryRecorder.recordEvent(feature, action, { metadata: { transcriptId: transcript.id }})
+            telemetryRecorder.recordEvent(feature, action, { metadata: { transcriptId: transcript.id } })
         },
         [transcript]
     )
@@ -288,7 +293,7 @@ export const useCodyChat = ({
                 await updateTranscriptInHistory(transcript)
             }
 
-            logTranscriptEvent(EventName.CODY_CHAT_SUBMIT, , 'cody-chat', 'submit')
+            logTranscriptEvent(EventName.CODY_CHAT_SUBMIT, 'cody-chat', 'submit')
             return transcript
         },
         [submitMessageInternal, updateTranscriptInHistory, logTranscriptEvent]
@@ -415,7 +420,9 @@ export const useCodyChat = ({
         logTranscriptEvent(
             scope.includeInferredRepository
                 ? EventName.CODY_CHAT_SCOPE_INFERRED_REPO_DISABLED
-                : EventName.CODY_CHAT_SCOPE_INFERRED_REPO_ENABLED, 'cody-chat.inferred-repo', action
+                : EventName.CODY_CHAT_SCOPE_INFERRED_REPO_ENABLED,
+            'cody-chat.inferred-repo',
+            action
         )
 
         toggleIncludeInferredRepositoryInternal()
@@ -433,7 +440,9 @@ export const useCodyChat = ({
         logTranscriptEvent(
             scope.includeInferredFile
                 ? EventName.CODY_CHAT_SCOPE_INFERRED_FILE_DISABLED
-                : EventName.CODY_CHAT_SCOPE_INFERRED_FILE_ENABLED, 'cody-chat.inferred-file', action
+                : EventName.CODY_CHAT_SCOPE_INFERRED_FILE_ENABLED,
+            'cody-chat.inferred-file',
+            action
         )
 
         toggleIncludeInferredFileInternal()

--- a/client/web/src/cody/useCodyChat.tsx
+++ b/client/web/src/cody/useCodyChat.tsx
@@ -247,7 +247,7 @@ export const useCodyChat = ({
                 return
             }
 
-            logTranscriptEvent(EventName.CODY_CHAT_HISTORY_ITEM_DELETED, 'cody-chat.item', 'delete')
+            logTranscriptEvent(EventName.CODY_CHAT_HISTORY_ITEM_DELETED, 'cody.chat.item', 'delete')
 
             setTranscriptHistoryState((history: TranscriptJSON[]) => {
                 const updatedHistory = [...history.filter(transcript => transcript.id !== id)]
@@ -293,7 +293,7 @@ export const useCodyChat = ({
                 await updateTranscriptInHistory(transcript)
             }
 
-            logTranscriptEvent(EventName.CODY_CHAT_SUBMIT, 'cody-chat', 'submit')
+            logTranscriptEvent(EventName.CODY_CHAT_SUBMIT, 'cody.chat', 'submit')
             return transcript
         },
         [submitMessageInternal, updateTranscriptInHistory, logTranscriptEvent]
@@ -307,7 +307,7 @@ export const useCodyChat = ({
                 await updateTranscriptInHistory(transcript)
             }
 
-            logTranscriptEvent(EventName.CODY_CHAT_EDIT, 'cody-chat', 'edit')
+            logTranscriptEvent(EventName.CODY_CHAT_EDIT, 'cody.chat', 'edit')
             return transcript
         },
         [editMessageInternal, updateTranscriptInHistory, logTranscriptEvent]
@@ -328,7 +328,7 @@ export const useCodyChat = ({
 
         pushTranscriptToHistory(newTranscript).catch(noop)
 
-        logTranscriptEvent(EventName.CODY_CHAT_INITIALIZED, 'cody-chat', 'initialize')
+        logTranscriptEvent(EventName.CODY_CHAT_INITIALIZED, 'cody.chat', 'initialize')
         return newTranscript
     }, [initializeNewChatInternal, pushTranscriptToHistory, scope, transcript, logTranscriptEvent])
 
@@ -420,7 +420,7 @@ export const useCodyChat = ({
             scope.includeInferredRepository
                 ? EventName.CODY_CHAT_SCOPE_INFERRED_REPO_DISABLED
                 : EventName.CODY_CHAT_SCOPE_INFERRED_REPO_ENABLED,
-            'cody-chat.inferred-repo',
+            'cody.chat.inferredRepo',
             action
         )
 
@@ -440,7 +440,7 @@ export const useCodyChat = ({
             scope.includeInferredFile
                 ? EventName.CODY_CHAT_SCOPE_INFERRED_FILE_DISABLED
                 : EventName.CODY_CHAT_SCOPE_INFERRED_FILE_ENABLED,
-            'cody-chat.inferred-file',
+            'cody.chat.inferredFile',
             action
         )
 

--- a/client/web/src/cody/widgets/CodyRecipesWidget.tsx
+++ b/client/web/src/cody/widgets/CodyRecipesWidget.tsx
@@ -5,6 +5,7 @@ import React, { useEffect } from 'react'
 import { mdiCardBulletedOutline, mdiDotsVertical, mdiProgressPencil, mdiShuffleVariant } from '@mdi/js'
 
 import { TranslateToLanguage } from '@sourcegraph/cody-shared/dist/chat/recipes/translate'
+import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
@@ -15,10 +16,14 @@ import { Recipe } from './components/Recipe'
 import { RecipeAction } from './components/RecipeAction'
 import { Recipes } from './components/Recipes'
 
-export const CodyRecipesWidget: React.FC<{ editor?: CodeMirrorEditor }> = ({ editor }) => {
+export const CodyRecipesWidget: React.FC<{ editor?: CodeMirrorEditor; telemetryRecorder: TelemetryRecorder }> = ({
+    editor,
+    telemetryRecorder,
+}) => {
     useEffect(() => {
         eventLogger.log(EventName.CODY_CHAT_EDITOR_WIDGET_VIEWED)
-    }, [])
+        telemetryRecorder.recordEvent('cody.chat.editor-widget', 'view')
+    }, [telemetryRecorder])
 
     // dirty fix becasue it is rendered under a separate React DOM tree.
     const codySidebarStore = (window as any).codySidebarStore as ReturnType<typeof useCodySidebar>

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -496,7 +496,10 @@ const RepoUserContainer: FC<RepoUserContainerProps> = ({
                     {() => (
                         <AskCodyButton
                             onClick={() => {
-                                logTranscriptEvent(EventName.CODY_SIDEBAR_CHAT_OPENED, { repo, path: filePath })
+                                logTranscriptEvent(EventName.CODY_SIDEBAR_CHAT_OPENED, 'repo.askCody', 'click', {
+                                    repo,
+                                    path: filePath,
+                                })
                                 setIsCodySidebarOpen(true)
                             }}
                         />
@@ -606,6 +609,7 @@ const RepoUserContainer: FC<RepoUserContainerProps> = ({
                         <CodySidebar
                             onClose={() => setIsCodySidebarOpen(false)}
                             authenticatedUser={props.authenticatedUser}
+                            telemetryRecorder={props.platformContext.telemetryRecorder}
                         />
                     </Panel>
                 </RepoContainerRootPortal>

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -27,7 +27,7 @@ import type { PlatformContext, PlatformContextProps } from '@sourcegraph/shared/
 import { Shortcut } from '@sourcegraph/shared/src/react-shortcuts'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import type { TemporarySettingsSchema } from '@sourcegraph/shared/src/settings/temporary/TemporarySettings'
-import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryV2Props, noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -374,6 +374,8 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             codeFoldingExtension(),
             isCodyEnabled()
                 ? codyWidgetExtension(
+                      // TODO: replace with real telemetryRecorder
+                      noOpTelemetryRecorder,
                       editorRef.current
                           ? new CodeMirrorEditor({
                                 view: editorRef.current,

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -461,5 +461,5 @@ function CodyDashboardOrUpsellPage(props: LegacyLayoutRouteContext): JSX.Element
     if (!isCodyEnabled) {
         return <CodyUpsellPage />
     }
-    return <CodyDashboardPage {...props} />
+    return <CodyDashboardPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
 }

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -343,7 +343,9 @@ export const routes: RouteObject[] = [
         path: PageRoutes.CodySearch,
         element: (
             <LegacyRoute
-                render={props => <CodySearchPage {...props} />}
+                render={props => (
+                    <CodySearchPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
+                )}
                 condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
             />
         ),
@@ -373,7 +375,13 @@ export const routes: RouteObject[] = [
         path: PageRoutes.CodyChat + '/*',
         element: (
             <LegacyRoute
-                render={props => <CodyChatPage {...props} context={window.context} />}
+                render={props => (
+                    <CodyChatPage
+                        {...props}
+                        context={window.context}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
+                    />
+                )}
                 condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
             />
         ),
@@ -382,7 +390,9 @@ export const routes: RouteObject[] = [
         path: PageRoutes.CodyManagement,
         element: (
             <LegacyRoute
-                render={props => <CodyManagementPage {...props} />}
+                render={props => (
+                    <CodyManagementPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
+                )}
                 condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
             />
         ),
@@ -391,7 +401,9 @@ export const routes: RouteObject[] = [
         path: PageRoutes.CodySubscription,
         element: (
             <LegacyRoute
-                render={props => <CodySubscriptionPage {...props} />}
+                render={props => (
+                    <CodySubscriptionPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
+                )}
                 condition={({ licenseFeatures }) => licenseFeatures.isCodyEnabled}
             />
         ),

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -408,7 +408,10 @@ export const routes: RouteObject[] = [
         element: (
             <LegacyRoute
                 render={props => (
-                    <CodySidebarStoreProvider authenticatedUser={props.authenticatedUser}>
+                    <CodySidebarStoreProvider
+                        authenticatedUser={props.authenticatedUser}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
+                    >
                         <RepoContainer {...props} />
                     </CodySidebarStoreProvider>
                 )}


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally