### PR TITLE
Blob view: bandaid selection coloring

### DIFF
--- a/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.tsx
+++ b/client/branded/src/search-ui/input/BaseCodeMirrorQueryInput.tsx
@@ -54,10 +54,10 @@ const staticExtensions: Extension = [
             padding: 0,
         },
         '&.cm-focused .cm-selectionLayer .cm-selectionBackground': {
-            backgroundColor: 'var(--code-selection-bg-2)',
+            backgroundColor: 'var(--code-selection-bg-2) !important',
         },
         '.cm-selectionLayer .cm-selectionBackground': {
-            backgroundColor: 'var(--code-selection-bg)',
+            backgroundColor: 'var(--code-selection-bg) !important',
         },
     }),
 ]

--- a/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
+++ b/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
@@ -36,10 +36,10 @@
                 padding: 0,
             },
             '&.cm-focused .cm-selectionLayer .cm-selectionBackground': {
-                backgroundColor: 'var(--code-selection-bg-2)',
+                backgroundColor: 'var(--code-selection-bg-2) !important',
             },
             '.cm-selectionLayer .cm-selectionBackground': {
-                backgroundColor: 'var(--code-selection-bg)',
+                backgroundColor: 'var(--code-selection-bg) !important',
             },
         }),
         defaultTheme,

--- a/client/web/src/repo/blob/codemirror/codeintel/keybindings.ts
+++ b/client/web/src/repo/blob/codemirror/codeintel/keybindings.ts
@@ -135,7 +135,7 @@ const theme = EditorView.theme({
         },
     },
     '.cm-selectionLayer .cm-selectionBackground': {
-        background: 'var(--code-selection-bg-2)',
+        background: 'var(--code-selection-bg-2) !important',
     },
 })
 


### PR DESCRIPTION
Codemirror applies its own styling for selections, and when the blob view is focused, that styling is higher precedence than the overrides we provide. More confusingly, sometimes (it's not deterministic) the codemirror styling does not respect the light/dark theme settings, which makes selection look very broken. It's still not clear to me why the theme variable is not being respected, but given our proximity to code freeze, this just adds an `!important` to our theme overrides to make it not feel super broken.

[Slack thread](https://sourcegraph.slack.com/archives/C05MHAP318B/p1707329576741979)

Before:
![image](https://github.com/sourcegraph/sourcegraph/assets/12631702/096de27f-554a-4c4c-896e-427d781f332d)

A capture of the CSS selector that was problematic:
<img width="479" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/59cfa635-fe7c-44e6-9fa9-4d5c0c7828b8">


## Test plan

Visually checked that there are no more dark backgrounds and opened the console to double check that the `!important` was showing up and causing that style to apply at higher precedence than the built-in themes

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
