### PR TITLE
licensing: Rename new plans

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/plandata.ts
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/plandata.ts
@@ -130,17 +130,17 @@ export const ALL_PLANS: Plan[] = [
         ],
     },
     {
-        name: 'Code Intelligence Platform (aka enterprise-1)',
+        name: 'Code Search Enterprise (aka enterprise-1)',
         label: 'enterprise-1',
         additionalTags: [TAG_TRIAL, TAG_AIR_GAPPED, TAG_DISABLE_TELEMETRY_EXPORT, TAG_TRUEUP, TAG_DEV, TAG_INTERNAL],
     },
     {
-        name: 'Cody Only Enterprise',
+        name: 'Cody Enterprise',
         label: 'cody-enterprise-0',
         additionalTags: [TAG_TRIAL, TAG_AIR_GAPPED, TAG_DISABLE_TELEMETRY_EXPORT, TAG_TRUEUP, TAG_DEV, TAG_INTERNAL],
     },
     {
-        name: 'Code AI Enterprise',
+        name: 'Code Intelligence Platform',
         label: 'code-ai-enterprise-0',
         additionalTags: [TAG_TRIAL, TAG_AIR_GAPPED, TAG_DISABLE_TELEMETRY_EXPORT, TAG_TRUEUP, TAG_DEV, TAG_INTERNAL],
     },

--- a/internal/licensing/data.go
+++ b/internal/licensing/data.go
@@ -34,8 +34,8 @@ const (
 	// PlanCodyEnterprise is the cody-only plan.
 	PlanCodyEnterprise Plan = "cody-enterprise-0"
 
-	// PlanCodeAIEnterprise is the full package plan. It includes code search and cody.
-	PlanCodeAIEnterprise Plan = "code-ai-enterprise-0"
+	// PlanCodeIntelligencePlatform is the full package plan. It includes code search and cody.
+	PlanCodeIntelligencePlatform Plan = "code-ai-enterprise-0"
 )
 
 var AllPlans = []Plan{
@@ -50,7 +50,7 @@ var AllPlans = []Plan{
 	PlanEnterprise0,
 	PlanEnterprise1,
 	PlanCodyEnterprise,
-	PlanCodeAIEnterprise,
+	PlanCodeIntelligencePlatform,
 }
 
 // The list of features. For each feature, add a new const here and the checking logic in
@@ -146,7 +146,7 @@ var planDetails = map[Plan]PlanDetails{
 	// - max 10 batch changes on enterprise-0 vs unlimited batch changes.
 	// - No code insights on enterprise-0
 	PlanEnterprise1: {
-		DisplayName: "Sourcegraph Enterprise",
+		DisplayName: "Code Search Enterprise",
 		Features: []Feature{
 			FeatureACLs,
 			FeatureCodeInsights,
@@ -210,8 +210,8 @@ var planDetails = map[Plan]PlanDetails{
 			&FeaturePrivateRepositories{Unrestricted: true},
 		},
 	},
-	PlanCodeAIEnterprise: {
-		DisplayName: "Code AI Enterprise",
+	PlanCodeIntelligencePlatform: {
+		DisplayName: "Code Intelligence Platform",
 		Features: []Feature{
 			FeatureSSO,
 			FeatureACLs,

--- a/internal/licensing/tags_test.go
+++ b/internal/licensing/tags_test.go
@@ -33,11 +33,11 @@ func TestProductNameWithBrand(t *testing.T) {
 		{licenseTags: []string{"plan:enterprise-0", "dev", "trial"}, want: "Sourcegraph Enterprise (trial, dev use only)"},
 		{licenseTags: []string{"plan:enterprise-0", "internal"}, want: "Sourcegraph Enterprise (internal use only)"},
 
-		{licenseTags: []string{"plan:enterprise-1"}, want: "Sourcegraph Enterprise"},
-		{licenseTags: []string{"plan:enterprise-1", "trial"}, want: "Sourcegraph Enterprise (trial)"},
-		{licenseTags: []string{"plan:enterprise-1", "dev"}, want: "Sourcegraph Enterprise (dev use only)"},
-		{licenseTags: []string{"plan:enterprise-1", "dev", "trial"}, want: "Sourcegraph Enterprise (trial, dev use only)"},
-		{licenseTags: []string{"plan:enterprise-1", "internal"}, want: "Sourcegraph Enterprise (internal use only)"},
+		{licenseTags: []string{"plan:enterprise-1"}, want: "Code Search Enterprise"},
+		{licenseTags: []string{"plan:enterprise-1", "trial"}, want: "Code Search Enterprise (trial)"},
+		{licenseTags: []string{"plan:enterprise-1", "dev"}, want: "Code Search Enterprise (dev use only)"},
+		{licenseTags: []string{"plan:enterprise-1", "dev", "trial"}, want: "Code Search Enterprise (trial, dev use only)"},
+		{licenseTags: []string{"plan:enterprise-1", "internal"}, want: "Code Search Enterprise (internal use only)"},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("licenseTags=%v", test.licenseTags), func(t *testing.T) {


### PR DESCRIPTION
These are the final names.

![Screenshot 2024-02-08 at 23 59 31@2x](https://github.com/sourcegraph/sourcegraph/assets/19534377/b95ca63a-b1a2-4a85-a99e-c060a638dfc2)


## Test plan

Verified manually that both on the admin side and on the instance side the license name shows correctly.