### PR TITLE
Search: solidify conversion to Zoekt queries

### DIFF
--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -38,9 +38,9 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 	// Handle file: and -file: filters.
 	filesInclude, filesExclude := b.IncludeExcludeValues(query.FieldFile)
 	// Handle lang: and -lang: filters.
-	// Languages are already partially expressed with IncludePatterns, but Zoekt creates
-	// more precise language metadata based on file contents analyzed by go-enry, so it's
-	// useful to pass lang: queries down.
+	// By default, languages are converted to file filters. When the 'search-content-based-lang-detection'
+	// feature is enabled, we use Zoekt's native language filters, which are based on the actual language
+	// of the file (as determined by go-enry).
 	langInclude, langExclude := b.IncludeExcludeValues(query.FieldLang)
 	if feat.ContentBasedLangFilters {
 		if len(langInclude) > 0 {

--- a/internal/search/zoekt/query.go
+++ b/internal/search/zoekt/query.go
@@ -47,11 +47,9 @@ func QueryToZoektQuery(b query.Basic, resultTypes result.Types, feat *search.Fea
 		for _, lang := range langInclude {
 			and = append(and, toLangFilter(lang))
 		}
-		if len(langExclude) > 0 {
-			for _, lang := range langExclude {
-				filter := toLangFilter(lang)
-				and = append(and, &zoekt.Not{Child: filter})
-			}
+		for _, lang := range langExclude {
+			filter := toLangFilter(lang)
+			and = append(and, &zoekt.Not{Child: filter})
 		}
 	} else {
 		filesInclude = append(filesInclude, mapSlice(langInclude, query.LangToFileRegexp)...)

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -83,19 +83,31 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Query:   `file:"\\.go(?m:$)"`,
 		},
 		{
-			Name:    "Languages is ignored",
+			Name:    "Languages get passed as lang: query",
 			Type:    search.TextRequest,
-			Pattern: `file:\.go$ lang:go`,
-			Query:   `file:"\\.go(?m:$)" file:"\\.go(?m:$)"`,
-		},
-		{
-			Name:    "language gets passed as both file include and lang: predicate",
-			Type:    search.TextRequest,
-			Pattern: `file:\.go$ lang:go`,
+			Pattern: `lang:go lang:typescript`,
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `file:"\\.go(?m:$)" file:"\\.go(?m:$)" lang:Go`,
+			Query: `lang:Go or lang:Typescript`,
+		},
+		{
+			Name:    "Excluded languages get passed as lang: query",
+			Type:    search.TextRequest,
+			Pattern: `lang:go -lang:typescript -lang:markdown`,
+			Features: search.Features{
+				ContentBasedLangFilters: true,
+			},
+			Query: `lang:Go -(lang:Typescript or lang:markdown)`,
+		},
+		{
+			Name:    "Mixed file and lang filters",
+			Type:    search.TextRequest,
+			Pattern: `file:\.go$ lang:go lang:typescript`,
+			Features: search.Features{
+				ContentBasedLangFilters: true,
+			},
+			Query: `file:"\\.go(?m:$)" (lang:Go or lang:Typescript)`,
 		},
 	}
 	for _, tt := range cases {

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -95,7 +95,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `lang:Go`,
+			Query: `lang:go`,
 		},
 		{
 			Name:    "Multiple languages get passed as lang queries",
@@ -104,7 +104,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `lang:Go lang:Typescript`,
+			Query: `lang:go lang:typescript`,
 		},
 		{
 			Name:    "Excluded languages get passed as lang: query",
@@ -113,7 +113,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `lang:Go -lang:Typescript -lang:markdown`,
+			Query: `lang:go -lang:typescript -lang:markdown`,
 		},
 		{
 			Name:    "Mixed file and lang filters",
@@ -122,7 +122,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `file:"\\.go(?m:$)" lang:Go lang:Typescript`,
+			Query: `file:"\\.go(?m:$)" lang:go lang:typescript`,
 		},
 	}
 	for _, tt := range cases {

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -16,118 +16,118 @@ import (
 
 func TestQueryToZoektQuery(t *testing.T) {
 	cases := []struct {
-		Name     string
-		Type     search.IndexedRequestType
-		Pattern  string
-		Features search.Features
-		Query    string
+		Name           string
+		Type           search.IndexedRequestType
+		Query          string
+		Features       search.Features
+		WantZoektQuery string
 	}{
 		{
-			Name:    "substr",
-			Type:    search.TextRequest,
-			Pattern: `foo patterntype:regexp`,
-			Query:   "foo case:no",
+			Name:           "substr",
+			Type:           search.TextRequest,
+			Query:          `foo patterntype:regexp`,
+			WantZoektQuery: "foo case:no",
 		},
 		{
-			Name:    "symbol substr",
-			Type:    search.SymbolRequest,
-			Pattern: `foo patterntype:regexp type:symbol`,
-			Query:   "sym:foo case:no",
+			Name:           "symbol substr",
+			Type:           search.SymbolRequest,
+			Query:          `foo patterntype:regexp type:symbol`,
+			WantZoektQuery: "sym:foo case:no",
 		},
 		{
-			Name:    "regex",
-			Type:    search.TextRequest,
-			Pattern: `(foo).*?(bar) patterntype:regexp`,
-			Query:   "(foo).*?(bar) case:no",
+			Name:           "regex",
+			Type:           search.TextRequest,
+			Query:          `(foo).*?(bar) patterntype:regexp`,
+			WantZoektQuery: "(foo).*?(bar) case:no",
 		},
 		{
-			Name:    "path",
-			Type:    search.TextRequest,
-			Pattern: `foo file:\.go$ file:\.yaml$ -file:\bvendor\b patterntype:regexp`,
-			Query:   `foo case:no f:\.go$ f:\.yaml$ -f:\bvendor\b`,
+			Name:           "path",
+			Type:           search.TextRequest,
+			Query:          `foo file:\.go$ file:\.yaml$ -file:\bvendor\b patterntype:regexp`,
+			WantZoektQuery: `foo case:no f:\.go$ f:\.yaml$ -f:\bvendor\b`,
 		},
 		{
-			Name:    "case",
-			Type:    search.TextRequest,
-			Pattern: `foo case:yes patterntype:regexp file:\.go$ file:yaml`,
-			Query:   `foo case:yes f:\.go$ f:yaml`,
+			Name:           "case",
+			Type:           search.TextRequest,
+			Query:          `foo case:yes patterntype:regexp file:\.go$ file:yaml`,
+			WantZoektQuery: `foo case:yes f:\.go$ f:yaml`,
 		},
 		{
-			Name:    "casepath",
-			Type:    search.TextRequest,
-			Pattern: `foo case:yes file:\.go$ file:\.yaml$ -file:\bvendor\b patterntype:regexp`,
-			Query:   `foo case:yes f:\.go$ f:\.yaml$ -f:\bvendor\b`,
+			Name:           "casepath",
+			Type:           search.TextRequest,
+			Query:          `foo case:yes file:\.go$ file:\.yaml$ -file:\bvendor\b patterntype:regexp`,
+			WantZoektQuery: `foo case:yes f:\.go$ f:\.yaml$ -f:\bvendor\b`,
 		},
 		{
-			Name:    "path matches only",
-			Type:    search.TextRequest,
-			Pattern: `test type:path`,
-			Query:   `f:test`,
+			Name:           "path matches only",
+			Type:           search.TextRequest,
+			Query:          `test type:path`,
+			WantZoektQuery: `f:test`,
 		},
 		{
-			Name:    "content matches only",
-			Type:    search.TextRequest,
-			Pattern: `test type:file patterntype:literal`,
-			Query:   `c:test`,
+			Name:           "content matches only",
+			Type:           search.TextRequest,
+			Query:          `test type:file patterntype:literal`,
+			WantZoektQuery: `c:test`,
 		},
 		{
-			Name:    "content and path matches",
-			Type:    search.TextRequest,
-			Pattern: `test`,
-			Query:   `test`,
+			Name:           "content and path matches",
+			Type:           search.TextRequest,
+			Query:          `test`,
+			WantZoektQuery: `test`,
 		},
 		{
-			Name:    "Just file",
-			Type:    search.TextRequest,
-			Pattern: `file:\.go$`,
-			Query:   `file:"\\.go(?m:$)"`,
+			Name:           "Just file",
+			Type:           search.TextRequest,
+			Query:          `file:\.go$`,
+			WantZoektQuery: `file:"\\.go(?m:$)"`,
 		},
 		{
-			Name:    "Languages get passed as file filter",
-			Type:    search.TextRequest,
-			Pattern: `file:\.go$ lang:go`,
-			Query:   `file:"\\.go(?m:$)" file:"\\.go(?m:$)"`,
+			Name:           "Languages get passed as file filter",
+			Type:           search.TextRequest,
+			Query:          `file:\.go$ lang:go`,
+			WantZoektQuery: `file:"\\.go(?m:$)" file:"\\.go(?m:$)"`,
 		},
 		{
-			Name:    "Language get passed as lang: query",
-			Type:    search.TextRequest,
-			Pattern: `lang:go`,
-			Features: search.Features{
-				ContentBasedLangFilters: true,
-			},
+			Name:  "Language get passed as lang: query",
+			Type:  search.TextRequest,
 			Query: `lang:go`,
-		},
-		{
-			Name:    "Multiple languages get passed as lang queries",
-			Type:    search.TextRequest,
-			Pattern: `lang:go lang:typescript`,
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
+			WantZoektQuery: `lang:go`,
+		},
+		{
+			Name:  "Multiple languages get passed as lang queries",
+			Type:  search.TextRequest,
 			Query: `lang:go lang:typescript`,
-		},
-		{
-			Name:    "Excluded languages get passed as lang: query",
-			Type:    search.TextRequest,
-			Pattern: `lang:go -lang:typescript -lang:markdown`,
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
+			WantZoektQuery: `lang:go lang:typescript`,
+		},
+		{
+			Name:  "Excluded languages get passed as lang: query",
+			Type:  search.TextRequest,
 			Query: `lang:go -lang:typescript -lang:markdown`,
-		},
-		{
-			Name:    "Mixed file and lang filters",
-			Type:    search.TextRequest,
-			Pattern: `file:\.go$ lang:go lang:typescript`,
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `file:"\\.go(?m:$)" lang:go lang:typescript`,
+			WantZoektQuery: `lang:go -lang:typescript -lang:markdown`,
+		},
+		{
+			Name:  "Mixed file and lang filters",
+			Type:  search.TextRequest,
+			Query: `file:\.go$ lang:go lang:typescript`,
+			Features: search.Features{
+				ContentBasedLangFilters: true,
+			},
+			WantZoektQuery: `file:"\\.go(?m:$)" lang:go lang:typescript`,
 		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			sourceQuery, _ := query.ParseRegexp(tt.Pattern)
+			sourceQuery, _ := query.ParseRegexp(tt.Query)
 			b, _ := query.ToBasicQuery(sourceQuery)
 
 			types, _ := b.ToParseTree().StringValues(query.FieldType)
@@ -137,9 +137,9 @@ func TestQueryToZoektQuery(t *testing.T) {
 				t.Fatal("QueryToZoektQuery failed:", err)
 			}
 
-			zoektQuery, err := zoekt.Parse(tt.Query)
+			zoektQuery, err := zoekt.Parse(tt.WantZoektQuery)
 			if err != nil {
-				t.Fatalf("failed to parse %q: %v", tt.Query, err)
+				t.Fatalf("failed to parse %q: %v", tt.WantZoektQuery, err)
 			}
 
 			if !queryEqual(got, zoektQuery) {

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -83,6 +83,12 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Query:   `file:"\\.go(?m:$)"`,
 		},
 		{
+			Name:    "Languages get passed as file filter",
+			Type:    search.TextRequest,
+			Pattern: `file:\.go$ lang:go`,
+			Query:   `file:"\\.go(?m:$)" file:"\\.go(?m:$)"`,
+		},
+		{
 			Name:    "Languages get passed as lang: query",
 			Type:    search.TextRequest,
 			Pattern: `lang:go lang:typescript`,

--- a/internal/search/zoekt/query_test.go
+++ b/internal/search/zoekt/query_test.go
@@ -89,13 +89,22 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Query:   `file:"\\.go(?m:$)" file:"\\.go(?m:$)"`,
 		},
 		{
-			Name:    "Languages get passed as lang: query",
+			Name:    "Language get passed as lang: query",
+			Type:    search.TextRequest,
+			Pattern: `lang:go`,
+			Features: search.Features{
+				ContentBasedLangFilters: true,
+			},
+			Query: `lang:Go`,
+		},
+		{
+			Name:    "Multiple languages get passed as lang queries",
 			Type:    search.TextRequest,
 			Pattern: `lang:go lang:typescript`,
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `lang:Go or lang:Typescript`,
+			Query: `lang:Go lang:Typescript`,
 		},
 		{
 			Name:    "Excluded languages get passed as lang: query",
@@ -104,7 +113,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `lang:Go -(lang:Typescript or lang:markdown)`,
+			Query: `lang:Go -lang:Typescript -lang:markdown`,
 		},
 		{
 			Name:    "Mixed file and lang filters",
@@ -113,7 +122,7 @@ func TestQueryToZoektQuery(t *testing.T) {
 			Features: search.Features{
 				ContentBasedLangFilters: true,
 			},
-			Query: `file:"\\.go(?m:$)" (lang:Go or lang:Typescript)`,
+			Query: `file:"\\.go(?m:$)" lang:Go lang:Typescript`,
 		},
 	}
 	for _, tt := range cases {


### PR DESCRIPTION
For the 'search-content-based-lang-detection' feature, this PR improves how filters are converted to Zoekt queries:
* Only convert filters to Zoekt lang filters, instead of also including file filters
* Handle excluded filters as well, for example `-lang:go`
* Use 'and' instead of 'or' to combine multiple filters

Relates to https://github.com/sourcegraph/sourcegraph/issues/60341

## Test plan

Added new unit tests, manual testing