### PR TITLE
aw: use two different jobs for e2e and normal testing

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -31,6 +31,11 @@ tasks:
       include_eternal_tests: true
       targets:
         - //...
+        - -//testing/...
+  - test:
+      include_eternal_tests: true
+      targets:
+        - //testing/...
         # This target should only really run when on main which we aren't handling. For the time being while we
         # evaluate Aspect Workflows it is ok
         # TODO(burmudar): Let this only run on main branch

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -31,6 +31,7 @@ tasks:
       include_eternal_tests: true
       targets:
         - //...
+        # exclude testing as it is executed in a seperate job
         - -//testing/...
   - test:
       include_eternal_tests: true


### PR DESCRIPTION
As per the feedback given over https://sourcegraph.slack.com/archives/C07KZF47K/p1707468139054549?thread_ts=1707435487.087259&cid=C07KZF47K this would be really helpful.

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
