### PR TITLE
Re-enables syntax highlighter in bazel commandset + bump rules_rust

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,8 +106,8 @@ http_archive(
 
 http_archive(
     name = "rules_rust",
-    sha256 = "75177226380b771be36d7efc538da842c433f14cd6c36d7660976efb53defe86",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.34.1/rules_rust-v0.34.1.tar.gz"],
+    integrity = "sha256-ZQGWDD5NoySV0eEAfe0HaaU0yxlcMN6jaqVPnYo/A2E=",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.38.0/rules_rust-v0.38.0.tar.gz"],
 )
 
 # Container rules

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1125,7 +1125,7 @@ commandsets:
       - gitserver-1
       - searcher
       - symbols
-      # - syntax-highlighter
+      - syntax-highlighter
     commands:
       - web
       - zoekt-index-0


### PR DESCRIPTION
There was an issue with the Rust rules, that caused failures with `bazel query ...` which is now fixed by using the latest `rule_rust`, enabling us to use the bazel command for `syntax-highlighter`. 

## Test plan

Ran locally + CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
