### PR TITLE
Improve redis image readiness checks

### DIFF
--- a/docker-images/redis-cache/BUILD.bazel
+++ b/docker-images/redis-cache/BUILD.bazel
@@ -8,11 +8,18 @@ filegroup(
     srcs = ["redis.conf"],
 )
 
+filegroup(
+    name = "redis_readiness",
+    srcs = [
+        "readiness.sh",
+    ],
+)
+
 pkg_tar(
     name = "redis_tarball",
     srcs = [
         ":redis_conf",
-        "//docker-images/redis-store:redis_readiness",
+        ":redis_readiness",
     ],
     modes = {
         "/etc/redis/redis.conf": "0644",

--- a/docker-images/redis-cache/BUILD.bazel
+++ b/docker-images/redis-cache/BUILD.bazel
@@ -10,12 +10,17 @@ filegroup(
 
 pkg_tar(
     name = "redis_tarball",
-    srcs = [":redis_conf"],
+    srcs = [
+        ":redis_conf",
+        "//docker-images/redis-store:redis_readiness",
+    ],
     modes = {
         "/etc/redis/redis.conf": "0644",
+        "/usr/local/bin/readiness.sh": "0755",
     },
     remap_paths = {
         "/redis.conf": "/etc/redis/redis.conf",
+        "/readiness.sh": "/usr/local/bin/readiness.sh",
     },
 )
 

--- a/docker-images/redis-cache/image_test.yaml
+++ b/docker-images/redis-cache/image_test.yaml
@@ -6,6 +6,11 @@ commandTests:
     args:
       - --version
 
+  - name: "readiness script available"
+    command: "/usr/local/bin/readiness.sh"
+    expectedError: ["Could not connect to Redis"]
+    exitCode: 1
+
   - name: "not running as root"
     command: "/usr/bin/id"
     args:

--- a/docker-images/redis-cache/readiness.sh
+++ b/docker-images/redis-cache/readiness.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+response=$(
+  redis-cli ping
+)
+if [ "$response" != "PONG" ]; then
+  echo "$response"
+  exit 1
+fi

--- a/docker-images/redis-store/BUILD.bazel
+++ b/docker-images/redis-store/BUILD.bazel
@@ -4,16 +4,26 @@ load("//dev:oci_defs.bzl", "image_repository")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 filegroup(
-    name = "redis_deps",
+    name = "redis_config",
     srcs = [
-        "readiness.sh",
         "redis.conf",
     ],
 )
 
+filegroup(
+    name = "redis_readiness",
+    srcs = [
+        "readiness.sh",
+    ],
+    visibility = ["//docker-images/redis-cache:__pkg__"],
+)
+
 pkg_tar(
     name = "redis_tarball",
-    srcs = [":redis_deps"],
+    srcs = [
+        ":redis_config",
+        ":redis_readiness",
+    ],
     modes = {
         "/etc/redis/redis.conf": "0644",
         "/usr/local/bin/readiness.sh": "0755",

--- a/docker-images/redis-store/BUILD.bazel
+++ b/docker-images/redis-store/BUILD.bazel
@@ -4,18 +4,23 @@ load("//dev:oci_defs.bzl", "image_repository")
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 
 filegroup(
-    name = "redis_conf",
-    srcs = ["redis.conf"],
+    name = "redis_deps",
+    srcs = [
+        "readiness.sh",
+        "redis.conf",
+    ],
 )
 
 pkg_tar(
     name = "redis_tarball",
-    srcs = [":redis_conf"],
+    srcs = [":redis_deps"],
     modes = {
         "/etc/redis/redis.conf": "0644",
+        "/usr/local/bin/readiness.sh": "0755",
     },
     remap_paths = {
         "/redis.conf": "/etc/redis/redis.conf",
+        "/readiness.sh": "/usr/local/bin/readiness.sh",
     },
 )
 

--- a/docker-images/redis-store/BUILD.bazel
+++ b/docker-images/redis-store/BUILD.bazel
@@ -15,7 +15,6 @@ filegroup(
     srcs = [
         "readiness.sh",
     ],
-    visibility = ["//docker-images/redis-cache:__pkg__"],
 )
 
 pkg_tar(

--- a/docker-images/redis-store/image_test.yaml
+++ b/docker-images/redis-store/image_test.yaml
@@ -24,6 +24,14 @@ commandTests:
       - -g
     expectedOutput: ["^1000\n"]
     exitCode: 0
+  - name: "redis-cli readiness check available"
+    command: "redis-cli"
+    args:
+      - --raw
+      - incr
+      - ping
+    expectedError: ["Could not connect to Redis"]
+    exitCode: 1
 
 fileExistenceTests:
 - name: '/etc/redis/redis.conf'

--- a/docker-images/redis-store/image_test.yaml
+++ b/docker-images/redis-store/image_test.yaml
@@ -6,6 +6,11 @@ commandTests:
     args:
       - --version
 
+  - name: "readiness script available"
+    command: "/usr/local/bin/readiness.sh"
+    expectedError: ["Could not connect to Redis"]
+    exitCode: 1
+
   - name: "not running as root"
     command: "/usr/bin/id"
     args:
@@ -24,14 +29,6 @@ commandTests:
       - -g
     expectedOutput: ["^1000\n"]
     exitCode: 0
-  - name: "redis-cli readiness check available"
-    command: "redis-cli"
-    args:
-      - --raw
-      - incr
-      - ping
-    expectedError: ["Could not connect to Redis"]
-    exitCode: 1
 
 fileExistenceTests:
 - name: '/etc/redis/redis.conf'

--- a/docker-images/redis-store/readiness.sh
+++ b/docker-images/redis-store/readiness.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+response=$(
+  redis-cli ping
+)
+if [ "$response" != "PONG" ]; then
+  echo "$response"
+  exit 1
+fi


### PR DESCRIPTION
- [x] Check that `redis-cli --raw incr ping` command works in container image tests
- [x] Add healthcheck script to image as suggested in https://github.com/sourcegraph/deploy-sourcegraph-helm/pull/419

Readiness check testing:

```
$ /usr/local/bin/readiness.sh 
Could not connect to Redis at 127.0.0.1:6379: Connection refused
/redis-data $ echo $?
1

# Start redis
redis-server &

/redis-data $ /usr/local/bin/readiness.sh 
/redis-data $ echo $?
0
```

## Test plan

- CI tests
- Tested readiness check locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 


Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
