### PR TITLE
Update database schemas for migrator to 5.3.0

### DIFF
--- a/tools/release/schema_deps.bzl
+++ b/tools/release/schema_deps.bzl
@@ -8,6 +8,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def schema_deps():
     http_file(
         name = "schemas_archive",
-        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.2.7.tar.gz"],
-        sha256 = "f54994171850e3475a9b446c29e4db4c1ea0ea039ce1cc5355f71f5b4725b117",
+        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.3.0.tar.gz"],
+        sha256 = "6c1c855b7636fc60e2f08f0961e05c019df7ef431a766f485855f871c7c1122f",
     )


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/sourcegraph/pull/60087 for 5.3.0 

Release tooling: tooling affecting internal/database/migration/shared/data/cmd/generator/consts.go is still required to be run before the final release.

## Test plan

CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
