### PR TITLE
nix: add docker-credential-helpers package

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -137,7 +137,7 @@ mkShell.override { stdenv = if hostPlatform.isMacOS then pkgs.clang11Stdenv else
   # Some of the bazel actions require some tools assumed to be in the PATH defined by the "strict action env" that we enable
   # through --incompatible_strict_action_env. We can poke a custom PATH through with --action_env=PATH=$BAZEL_ACTION_PATH.
   # See https://sourcegraph.com/github.com/bazelbuild/bazel@6.1.2/-/blob/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java?L532-547
-  BAZEL_ACTION_PATH = with pkgs; lib.makeBinPath [ bashInteractive stdenv.cc coreutils unzip zip curl gzip gnutar gnugrep gnused git patch openssh findutils perl python39 which postgresql_13 ];
+  BAZEL_ACTION_PATH = with pkgs; lib.makeBinPath [ bashInteractive stdenv.cc coreutils unzip zip curl gzip gnutar gnugrep gnused git patch openssh findutils perl python39 which postgresql_13 docker-credential-helpers ];
 
   # bazel complains when the bazel version differs even by a patch version to whats defined in .bazelversion,
   # so we tell it to h*ck off here.


### PR DESCRIPTION

## Test plan
`sg start otel` works since it runs wolfi and wolfi wants to access the osx keychain to load the image into docker
