### PR TITLE
Remove code for logging completions

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/regexp"
 	"github.com/sourcegraph/log"
-	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/shared/config"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/anthropic"
 
@@ -226,7 +225,7 @@ func (a *AnthropicHandlerMethods) transformBody(body *anthropicRequest, identifi
 		UserID: identifier,
 	}
 }
-func (a *AnthropicHandlerMethods) getRequestMetadata(_ context.Context, _ log.Logger, _ *actor.Actor, _ codygateway.Feature, body anthropicRequest) (model string, additionalMetadata map[string]any) {
+func (a *AnthropicHandlerMethods) getRequestMetadata(body anthropicRequest) (model string, additionalMetadata map[string]any) {
 	return body.Model, map[string]any{
 		"stream":               body.Stream,
 		"max_tokens_to_sample": body.MaxTokensToSample,

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/log"
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/shared/config"
 
-	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/openai"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -127,7 +126,7 @@ func (_ *OpenAIHandlerMethods) transformBody(body *openaiRequest, identifier str
 	// We forward the actor ID to support tracking.
 	body.User = identifier
 }
-func (_ *OpenAIHandlerMethods) getRequestMetadata(_ context.Context, _ log.Logger, _ *actor.Actor, _ codygateway.Feature, body openaiRequest) (model string, additionalMetadata map[string]any) {
+func (_ *OpenAIHandlerMethods) getRequestMetadata(body openaiRequest) (model string, additionalMetadata map[string]any) {
 	return body.Model, map[string]any{"stream": body.Stream}
 }
 

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -79,7 +79,7 @@ type upstreamHandlerMethods[ReqT UpstreamRequest] interface {
 	// to be reported here - instead, use parseResponseAndUsage to extract usage,
 	// which for some providers we can only know after the fact based on what
 	// upstream tells us.
-	getRequestMetadata(context.Context, log.Logger, *actor.Actor, codygateway.Feature, ReqT) (model string, additionalMetadata map[string]any)
+	getRequestMetadata(ReqT) (model string, additionalMetadata map[string]any)
 	// parseResponseAndUsage should extract details from the response we get back from
 	// upstream as well as overall usage for tracking purposes.
 	//
@@ -247,7 +247,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 			methods.transformRequest(req)
 
 			// Retrieve metadata from the initial request.
-			model, requestMetadata := methods.getRequestMetadata(r.Context(), logger, act, feature, body)
+			model, requestMetadata := methods.getRequestMetadata(body)
 
 			// Match the model against the allowlist of models, which are configured
 			// with the Cody Gateway model format "$PROVIDER/$MODEL_NAME". Models

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -76,7 +76,6 @@ type AnthropicConfig struct {
 type FireworksConfig struct {
 	AllowedModels                          []string
 	AccessToken                            string
-	LogSelfServeCodeCompletionRequests     bool
 	StarcoderCommunitySingleTenantPercent  int
 	StarcoderEnterpriseSingleTenantPercent int
 }
@@ -161,7 +160,6 @@ func (c *Config) Load() {
 			"accounts/fireworks/models/mixtral-8x7b-instruct",
 		}, ","),
 		"Fireworks models that can be used."))
-	c.Fireworks.LogSelfServeCodeCompletionRequests = c.GetBool("CODY_GATEWAY_FIREWORKS_LOG_SELF_SERVE_COMPLETION_REQUESTS", "false", "Whether we should log self-serve code completion requests.")
 	if c.Fireworks.AccessToken != "" && len(c.Fireworks.AllowedModels) == 0 {
 		c.AddError(errors.New("must provide allowed models for Fireworks"))
 	}


### PR DESCRIPTION
Removes code for logging Fireworks code completion requests (no longer needed). 
Also, simplifies `upstreamHandlerMethods.getRequestMetadata` signature for all implementations.

## Test plan

- unit tests
- e2e tests locally