### PR TITLE
v2 telemetry: add v2 telemetry to all monaco editors

### DIFF
--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -4,6 +4,7 @@ import type { FetchResult } from '@apollo/client'
 import { useNavigate } from 'react-router-dom'
 
 import { logger, renderMarkdown } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Container, H3, H4, Markdown, PageHeader } from '@sourcegraph/wildcard'
 
@@ -16,7 +17,7 @@ import { ExternalServiceCard } from './ExternalServiceCard'
 import { ExternalServiceForm } from './ExternalServiceForm'
 import type { AddExternalServiceOptions } from './externalServices'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     externalService: AddExternalServiceOptions
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
@@ -34,6 +35,7 @@ export const AddExternalServicePage: FC<Props> = ({
     autoFocusForm,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
+    telemetryRecorder,
 }) => {
     const [config, setConfig] = useState(externalService.defaultConfig)
     const [displayName, setDisplayName] = useState(externalService.defaultDisplayName)
@@ -42,7 +44,8 @@ export const AddExternalServicePage: FC<Props> = ({
 
     useEffect(() => {
         telemetryService.logPageView('AddExternalService')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.external-services.add', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     useEffect(() => {
         setConfig(externalService.defaultConfig)
@@ -79,15 +82,17 @@ export const AddExternalServicePage: FC<Props> = ({
                 },
                 onCompleted: data => {
                     telemetryService.log('AddExternalServiceSucceeded')
+                    telemetryRecorder.recordEvent('admin.external-services.add', 'success')
                     refreshSiteFlags(client).catch((error: Error) => logger.error(error))
                     navigate(`/site-admin/external-services/${data.addExternalService.id}`)
                 },
                 onError: () => {
                     telemetryService.log('AddExternalServiceFailed')
+                    telemetryRecorder.recordEvent('admin.external-services.add', 'fail')
                 },
             })
         },
-        [addExternalService, telemetryService, getExternalServiceInput, client, navigate]
+        [addExternalService, telemetryService, getExternalServiceInput, client, navigate, telemetryRecorder]
     )
     const createdExternalService = addExternalServiceResult?.addExternalService
 
@@ -128,6 +133,7 @@ export const AddExternalServicePage: FC<Props> = ({
                         )}
                         <ExternalServiceForm
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                             error={error}
                             input={getExternalServiceInput()}
                             editorActions={externalService.editorActions}

--- a/client/web/src/components/externalServices/AddExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicePage.tsx
@@ -44,7 +44,7 @@ export const AddExternalServicePage: FC<Props> = ({
 
     useEffect(() => {
         telemetryService.logPageView('AddExternalService')
-        telemetryRecorder.recordEvent('admin.external-services.add', 'view')
+        telemetryRecorder.recordEvent('admin.externalServices.add', 'view')
     }, [telemetryService, telemetryRecorder])
 
     useEffect(() => {
@@ -82,13 +82,13 @@ export const AddExternalServicePage: FC<Props> = ({
                 },
                 onCompleted: data => {
                     telemetryService.log('AddExternalServiceSucceeded')
-                    telemetryRecorder.recordEvent('admin.external-services.add', 'success')
+                    telemetryRecorder.recordEvent('admin.externalServices.add', 'success')
                     refreshSiteFlags(client).catch((error: Error) => logger.error(error))
                     navigate(`/site-admin/external-services/${data.addExternalService.id}`)
                 },
                 onError: () => {
                     telemetryService.log('AddExternalServiceFailed')
-                    telemetryRecorder.recordEvent('admin.external-services.add', 'fail')
+                    telemetryRecorder.recordEvent('admin.externalServices.add', 'fail')
                 },
             })
         },

--- a/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.story.tsx
@@ -1,5 +1,6 @@
 import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../WebStory'
@@ -28,6 +29,7 @@ export const Overview: StoryFn = () => (
             <AddExternalServicesPage
                 {...webProps}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 codeHostExternalServices={codeHostExternalServices}
                 nonCodeHostExternalServices={nonCodeHostExternalServices}
                 autoFocusForm={false}
@@ -44,6 +46,7 @@ export const AddConnectionBykind: StoryFn = () => (
             <AddExternalServicesPage
                 {...webProps}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
                 codeHostExternalServices={codeHostExternalServices}
                 nonCodeHostExternalServices={nonCodeHostExternalServices}
                 autoFocusForm={false}

--- a/client/web/src/components/externalServices/AddExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/AddExternalServicesPage.tsx
@@ -8,6 +8,7 @@ import { useLocation } from 'react-router-dom'
 
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Alert, H3, Text, Container, PageHeader } from '@sourcegraph/wildcard'
 
@@ -17,7 +18,7 @@ import { AddExternalServicePage } from './AddExternalServicePage'
 import { ExternalServiceGroup, type AddExternalServiceOptionsWithID } from './ExternalServiceGroup'
 import { allExternalServices, type AddExternalServiceOptions, gitHubAppConfig } from './externalServices'
 
-export interface AddExternalServicesPageProps extends TelemetryProps {
+export interface AddExternalServicesPageProps extends TelemetryProps, TelemetryV2Props {
     /**
      * The list of code host external services to be displayed.
      * Pick items from externalServices.codeHostExternalServices.
@@ -46,6 +47,7 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
     autoFocusForm,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
+    telemetryRecorder,
 }) => {
     const { search } = useLocation()
     const [hasDismissedPrivacyWarning, setHasDismissedPrivacyWarning] = useTemporarySetting(
@@ -83,6 +85,7 @@ export const AddExternalServicesPage: FC<AddExternalServicesPageProps> = ({
         return (
             <AddExternalServicePage
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 externalService={externalService}
                 autoFocusForm={autoFocusForm}
                 externalServicesFromFile={externalServicesFromFile}

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.story.tsx
@@ -2,6 +2,7 @@ import type { Decorator, StoryFn, Meta } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -94,6 +95,7 @@ export const ViewConfig: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={newFetchMock(externalService)}>
         <ExternalServiceEditPage
             telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
             autoFocusForm={false}
             externalServicesFromFile={false}
             allowEditExternalServicesWithFile={false}
@@ -107,6 +109,7 @@ export const ConfigWithInvalidUrl: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={newFetchMock({ ...externalService, config: '{"url": "invalid-url"}' })}>
         <ExternalServiceEditPage
             telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
             autoFocusForm={false}
             externalServicesFromFile={false}
             allowEditExternalServicesWithFile={false}
@@ -120,6 +123,7 @@ export const ConfigWithWarning: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={newFetchMock({ ...externalService, warning: 'Invalid config we could not sync stuff' })}>
         <ExternalServiceEditPage
             telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
             autoFocusForm={false}
             externalServicesFromFile={false}
             allowEditExternalServicesWithFile={false}
@@ -133,6 +137,7 @@ export const EditingDisabled: StoryFn<WebStoryChildrenProps> = props => (
     <MockedTestProvider link={newFetchMock({ ...externalService, warning: 'Invalid config we could not sync stuff' })}>
         <ExternalServiceEditPage
             telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
             autoFocusForm={false}
             externalServicesFromFile={true}
             allowEditExternalServicesWithFile={false}

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -2,6 +2,7 @@ import React, { type FC, useEffect, useState, useCallback, useMemo } from 'react
 
 import { useNavigate, useParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, ErrorAlert, PageHeader, ButtonLink } from '@sourcegraph/wildcard'
 
@@ -21,7 +22,7 @@ import { ExternalServiceForm } from './ExternalServiceForm'
 import { resolveExternalServiceCategory } from './externalServices'
 import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
 
@@ -34,13 +35,15 @@ export const ExternalServiceEditPage: FC<Props> = ({
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
     autoFocusForm,
+    telemetryRecorder,
 }) => {
     const { externalServiceID } = useParams()
     const navigate = useNavigate()
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.external-service.edit', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const [externalService, setExternalService] = useState<ExternalServiceFieldsWithConfig>()
 
@@ -144,6 +147,7 @@ export const ExternalServiceEditPage: FC<Props> = ({
                         externalServicesFromFile={externalServicesFromFile}
                         allowEditExternalServicesWithFile={allowEditExternalServicesWithFile}
                         additionalFormComponent={externalServiceCategory.additionalFormComponent}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 )}
                 <ExternalServiceWebhook externalService={externalService} className="mt-3" />

--- a/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceEditPage.tsx
@@ -42,7 +42,7 @@ export const ExternalServiceEditPage: FC<Props> = ({
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
-        telemetryRecorder.recordEvent('admin.external-service.edit', 'view')
+        telemetryRecorder.recordEvent('admin.externalService.edit', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const [externalService, setExternalService] = useState<ExternalServiceFieldsWithConfig>()

--- a/client/web/src/components/externalServices/ExternalServiceForm.test.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.test.tsx
@@ -2,6 +2,7 @@ import * as H from 'history'
 import { noop } from 'rxjs'
 import { describe, expect, test, vi } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
@@ -37,6 +38,7 @@ describe('ExternalServiceForm', () => {
                 mode="create"
                 loading={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )
         expect(component.asFragment()).toMatchSnapshot()
@@ -53,6 +55,7 @@ describe('ExternalServiceForm', () => {
                 mode="create"
                 loading={false}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )
         expect(component.asFragment()).toMatchSnapshot()
@@ -69,6 +72,7 @@ describe('ExternalServiceForm', () => {
                 mode="create"
                 loading={true}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )
         expect(component.asFragment()).toMatchSnapshot()

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -5,6 +5,7 @@ import addFormats from 'ajv-formats'
 import { parse } from 'jsonc-parser'
 
 import type { ErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -28,7 +29,10 @@ import { ExternalServiceEditingDisabledAlert } from './ExternalServiceEditingDis
 import { ExternalServiceEditingTemporaryAlert } from './ExternalServiceEditingTemporaryAlert'
 import type { AddExternalServiceOptions } from './externalServices'
 
-interface Props extends Pick<AddExternalServiceOptions, 'jsonSchema' | 'editorActions'>, TelemetryProps {
+interface Props
+    extends Pick<AddExternalServiceOptions, 'jsonSchema' | 'editorActions'>,
+        TelemetryProps,
+        TelemetryV2Props {
     input: AddExternalServiceInput
     externalServiceID?: string
     error?: ErrorLike
@@ -69,6 +73,7 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
     allowEditExternalServicesWithFile,
     autoFocus = true,
     additionalFormComponent,
+    telemetryRecorder,
 }) => {
     const isLightTheme = useIsLightTheme()
     const onDisplayNameChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
@@ -142,6 +147,7 @@ export const ExternalServiceForm: React.FunctionComponent<React.PropsWithChildre
                     actions={editorActions}
                     className="test-external-service-editor"
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     explanation={
                         <Text className="form-text text-muted">
                             <small>

--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -4,6 +4,7 @@ import { of } from 'rxjs'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -156,6 +157,7 @@ export const ExternalServiceWithRepos: StoryFn<WebStoryChildrenProps> = props =>
             queryExternalServiceSyncJobs={queryExternalServiceSyncJobs}
             afterDeleteRoute="/site-admin/after-delete"
             telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
             externalServicesFromFile={false}
             allowEditExternalServicesWithFile={false}
         />

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Subject } from 'rxjs'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Alert, Button, Container, ErrorAlert, H2, H3, Icon, Link, PageHeader, Tooltip } from '@sourcegraph/wildcard'
@@ -35,7 +36,7 @@ import { ExternalServiceWebhook } from './ExternalServiceWebhook'
 
 import styles from './ExternalServicePage.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     afterDeleteRoute: string
 
     externalServicesFromFile: boolean
@@ -52,6 +53,7 @@ const NotFoundPage: FC = () => (
 export const ExternalServicePage: FC<Props> = props => {
     const {
         telemetryService,
+        telemetryRecorder,
         afterDeleteRoute,
         externalServicesFromFile,
         allowEditExternalServicesWithFile,
@@ -64,7 +66,8 @@ export const ExternalServicePage: FC<Props> = props => {
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.external-service', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const [syncInProgress, setSyncInProgress] = useState<boolean>(false)
     // Callback used in ExternalServiceSyncJobsList to update the state in current component.
@@ -281,6 +284,7 @@ export const ExternalServicePage: FC<Props> = props => {
                         isLightTheme={isLightTheme}
                         className="test-external-service-editor"
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 )}
                 <ExternalServiceWebhook externalService={externalService} className="mt-3" />

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -66,7 +66,7 @@ export const ExternalServicePage: FC<Props> = props => {
 
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalService')
-        telemetryRecorder.recordEvent('admin.external-service', 'view')
+        telemetryRecorder.recordEvent('admin.externalService', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const [syncInProgress, setSyncInProgress] = useState<boolean>(false)

--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -3,6 +3,7 @@ import { subMinutes } from 'date-fns'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -44,6 +45,7 @@ export const ListOfExternalServices: StoryFn = () => (
     >
         <ExternalServicesPage
             telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
             externalServicesFromFile={false}
             allowEditExternalServicesWithFile={false}
         />

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -3,6 +3,7 @@ import { type FC, useEffect } from 'react'
 import { mdiPlus } from '@mdi/js'
 import { Navigate, useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, ButtonLink, Icon, PageHeader, Container } from '@sourcegraph/wildcard'
 
@@ -22,7 +23,7 @@ import { ExternalServiceEditingDisabledAlert } from './ExternalServiceEditingDis
 import { ExternalServiceEditingTemporaryAlert } from './ExternalServiceEditingTemporaryAlert'
 import { ExternalServiceNode } from './ExternalServiceNode'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     externalServicesFromFile: boolean
     allowEditExternalServicesWithFile: boolean
 }
@@ -32,12 +33,14 @@ interface Props extends TelemetryProps {
  */
 export const ExternalServicesPage: FC<Props> = ({
     telemetryService,
+    telemetryRecorder,
     externalServicesFromFile,
     allowEditExternalServicesWithFile,
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalServices')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.external-services', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const location = useLocation()
     const searchParameters = new URLSearchParams(location.search)

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -39,7 +39,7 @@ export const ExternalServicesPage: FC<Props> = ({
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('SiteAdminExternalServices')
-        telemetryRecorder.recordEvent('admin.external-services', 'view')
+        telemetryRecorder.recordEvent('admin.externalServices', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const location = useLocation()

--- a/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/ConfigurationEditor.tsx
@@ -2,6 +2,7 @@ import { type FunctionComponent, useCallback, useMemo, useState } from 'react'
 
 import type { editor } from 'monaco-editor'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { LoadingSpinner, screenReaderAnnounce, ErrorAlert, BeforeUnloadPrompt } from '@sourcegraph/wildcard'
@@ -16,7 +17,7 @@ import allConfigSchema from '../schema.json'
 
 import { IndexConfigurationSaveToolbar, type IndexConfigurationSaveToolbarProps } from './IndexConfigurationSaveToolbar'
 
-export interface ConfigurationEditorProps extends TelemetryProps {
+export interface ConfigurationEditorProps extends TelemetryProps, TelemetryV2Props {
     repoId: string
     authenticatedUser: AuthenticatedUser | null
 }
@@ -25,6 +26,7 @@ export const ConfigurationEditor: FunctionComponent<ConfigurationEditorProps> = 
     repoId,
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const isLightTheme = useIsLightTheme()
     const { inferredConfiguration, loadingInferred, inferredError } = useInferredConfig(repoId)
@@ -103,6 +105,7 @@ export const ConfigurationEditor: FunctionComponent<ConfigurationEditorProps> = 
                         height={600}
                         isLightTheme={isLightTheme}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                         customSaveToolbar={authenticatedUser?.siteAdmin ? customToolbar : undefined}
                         onDirtyChange={setDirty}
                         onEditor={setEditor}

--- a/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptEditor.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/inference-script/InferenceScriptEditor.tsx
@@ -1,5 +1,6 @@
 import { type FunctionComponent, useCallback, useMemo, useState } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { screenReaderAnnounce, ErrorAlert } from '@sourcegraph/wildcard'
@@ -14,7 +15,7 @@ import { DynamicallyImportedMonacoSettingsEditor } from '../../../../../settings
 import { INFERENCE_SCRIPT } from '../../hooks/useInferenceScript'
 import { useUpdateInferenceScript } from '../../hooks/useUpdateInferenceScript'
 
-export interface InferenceScriptEditorProps extends TelemetryProps {
+export interface InferenceScriptEditorProps extends TelemetryProps, TelemetryV2Props {
     script: string
     authenticatedUser: AuthenticatedUser | null
     setPreviewScript: (script: string) => void
@@ -25,6 +26,7 @@ export const InferenceScriptEditor: FunctionComponent<InferenceScriptEditorProps
     setPreviewScript,
     authenticatedUser,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const { updateInferenceScript, isUpdating, updatingError } = useUpdateInferenceScript()
 
@@ -77,6 +79,7 @@ export const InferenceScriptEditor: FunctionComponent<InferenceScriptEditorProps
                 height={600}
                 isLightTheme={isLightTheme}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 customSaveToolbar={authenticatedUser?.siteAdmin ? customToolbar : undefined}
                 onDirtyChange={setDirty}
             />

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
@@ -1,5 +1,6 @@
 import { type FunctionComponent, useState } from 'react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ErrorAlert, Link, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
 
@@ -60,6 +61,7 @@ export const CodeIntelInferenceConfigurationPage: FunctionComponent<CodeIntelInf
                 script={inferenceScript}
                 authenticatedUser={authenticatedUser}
                 setPreviewScript={setPreviewScript}
+                telemetryRecorder={noOpTelemetryRecorder}
                 {...props}
             />
 

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
@@ -2,6 +2,7 @@ import { type FunctionComponent, useEffect, useState } from 'react'
 
 import { useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Link, Tabs, TabList, Tab, TabPanels, TabPanel } from '@sourcegraph/wildcard'
 
@@ -11,15 +12,18 @@ import { CodeIntelConfigurationPageHeader } from '../components/CodeIntelConfigu
 import { ConfigurationEditor } from '../components/ConfigurationEditor'
 import { ConfigurationForm } from '../components/ConfigurationForm'
 
-export interface CodeIntelRepositoryIndexConfigurationPageProps extends TelemetryProps {
+export interface CodeIntelRepositoryIndexConfigurationPageProps extends TelemetryProps, TelemetryV2Props {
     repo: { id: string }
     authenticatedUser: AuthenticatedUser | null
 }
 
 export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
     CodeIntelRepositoryIndexConfigurationPageProps
-> = ({ repo, authenticatedUser, telemetryService, ...props }) => {
-    useEffect(() => telemetryService.logViewEvent('CodeIntelRepositoryIndexConfiguration'), [telemetryService])
+> = ({ repo, authenticatedUser, telemetryService, telemetryRecorder, ...props }) => {
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelRepositoryIndexConfiguration')
+        telemetryRecorder.recordEvent('repo.codeintel-index-config', 'view')
+    }, [telemetryService, telemetryRecorder])
     const location = useLocation()
 
     const [activeTabIndex, setActiveTabIndex] = useState<number>(0)
@@ -79,6 +83,7 @@ export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
                             repoId={repo.id}
                             authenticatedUser={authenticatedUser}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                             {...props}
                         />
                     </TabPanel>

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
@@ -22,7 +22,7 @@ export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
 > = ({ repo, authenticatedUser, telemetryService, telemetryRecorder, ...props }) => {
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelRepositoryIndexConfiguration')
-        telemetryRecorder.recordEvent('repo.codeintel-index-config', 'view')
+        telemetryRecorder.recordEvent('repo.codeintelIndexConfig', 'view')
     }, [telemetryService, telemetryRecorder])
     const location = useLocation()
 

--- a/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/repo/RepositoryCodeIntelArea.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 
 import { Routes, Route, Navigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -20,7 +21,7 @@ import type { CodeIntelPreciseIndexPageProps } from '../indexes/pages/CodeIntelP
 
 import { CodeIntelSidebar, type CodeIntelSideBarGroups } from './CodeIntelSidebar'
 
-export interface CodeIntelAreaRouteContext extends TelemetryProps {
+export interface CodeIntelAreaRouteContext extends TelemetryProps, TelemetryV2Props {
     repo: { id: string; name: string }
     authenticatedUser: AuthenticatedUser | null
 }
@@ -112,7 +113,7 @@ export const codeIntelAreaRoutes: readonly CodeIntelAreaRoute[] = [
 /**
  * Properties passed to all page components in the repository code navigation area.
  */
-export interface RepositoryCodeIntelAreaPageProps extends BreadcrumbSetters, TelemetryProps {
+export interface RepositoryCodeIntelAreaPageProps extends BreadcrumbSetters, TelemetryProps, TelemetryV2Props {
     /** The active repository. */
     repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null

--- a/client/web/src/enterprise/repo/enterpriseRepoContainerRoutes.tsx
+++ b/client/web/src/enterprise/repo/enterpriseRepoContainerRoutes.tsx
@@ -32,7 +32,9 @@ export const enterpriseRepoContainerRoutes: readonly RepoContainerRoute[] = [
     },
     {
         path: '/-/code-graph/*',
-        render: context => <RepositoryCodeIntelArea {...context} />,
+        render: context => (
+            <RepositoryCodeIntelArea {...context} telemetryRecorder={context.platformContext.telemetryRecorder} />
+        ),
     },
     {
         path: '/-/embeddings/*',

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -16,6 +16,7 @@ import {
 } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { QueryState, SearchContextProps } from '@sourcegraph/shared/src/search'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -472,6 +473,8 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                                 onChange={onRepositoriesConfigChange}
                                 validateRepositories={validateRepositories}
                                 repositories={searchContext?.repositories}
+                                // TODO (dadlerj) replace with real telemetryRecorder
+                                telemetryRecorder={noOpTelemetryRecorder}
                             />
                         </div>
                     </div>

--- a/client/web/src/enterprise/searchContexts/SearchContextRepositoriesFormArea.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextRepositoriesFormArea.tsx
@@ -6,6 +6,7 @@ import type { Observable } from 'rxjs'
 import { delay, mergeMap, startWith, tap } from 'rxjs/operators'
 
 import type { SearchContextRepositoryRevisionsFields } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, useEventObservable, Alert, Icon } from '@sourcegraph/wildcard'
 
@@ -73,7 +74,7 @@ const actions: {
     },
 ]
 
-export interface SearchContextRepositoriesFormAreaProps extends TelemetryProps {
+export interface SearchContextRepositoriesFormAreaProps extends TelemetryProps, TelemetryV2Props {
     isLightTheme: boolean
     repositories: SearchContextRepositoryRevisionsFields[] | undefined
     validateRepositories: () => Observable<Error[]>
@@ -82,7 +83,7 @@ export interface SearchContextRepositoriesFormAreaProps extends TelemetryProps {
 
 export const SearchContextRepositoriesFormArea: React.FunctionComponent<
     React.PropsWithChildren<SearchContextRepositoriesFormAreaProps>
-> = ({ isLightTheme, telemetryService, repositories, onChange, validateRepositories }) => {
+> = ({ isLightTheme, telemetryService, repositories, onChange, validateRepositories, telemetryRecorder }) => {
     const [hasTestedConfig, setHasTestedConfig] = useState(false)
     const [triggerTestConfig, triggerTestConfigErrors] = useEventObservable(
         useCallback(
@@ -139,6 +140,7 @@ export const SearchContextRepositoriesFormArea: React.FunctionComponent<
                 height={300}
                 isLightTheme={isLightTheme}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 blockNavigationIfDirty={false}
             />
             {triggerTestConfigErrors && triggerTestConfigErrors !== LOADING && triggerTestConfigErrors.length > 0 && (

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -291,6 +291,7 @@ export const routes: RouteObject[] = [
                         sideBarGroups={props.siteAdminSideBarGroups}
                         overviewComponents={props.siteAdminOverviewComponents}
                         codeInsightsEnabled={window.context.codeInsightsEnabled}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
                     />
                 )}
             />

--- a/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
+++ b/client/web/src/settings/DynamicallyImportedMonacoSettingsEditor.tsx
@@ -5,6 +5,7 @@ import type * as _monaco from 'monaco-editor'
 import { Subscription } from 'rxjs'
 
 import { logger } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, BeforeUnloadPrompt } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,8 @@ const disposableToFunc = (disposable: _monaco.IDisposable) => () => disposable.d
 
 interface Props<T extends object>
     extends Pick<_monacoSettingsEditorModule.Props, 'id' | 'readOnly' | 'height' | 'jsonSchema' | 'language'>,
-        TelemetryProps {
+        TelemetryProps,
+        TelemetryV2Props {
     value: string
     isLightTheme: boolean
 
@@ -213,7 +215,8 @@ export class DynamicallyImportedMonacoSettingsEditor<T extends object = {}> exte
                                     label,
                                     id,
                                     run,
-                                    this.props.telemetryService
+                                    this.props.telemetryService,
+                                    this.props.telemetryRecorder
                                 )
                             }
 

--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -7,6 +7,7 @@ import { Subject, Subscription } from 'rxjs'
 import { distinctUntilChanged, distinctUntilKeyChanged, map, startWith } from 'rxjs/operators'
 
 import { MonacoEditor } from '@sourcegraph/shared/src/components/MonacoEditor'
+import { TelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import jsonSchemaMetaSchema from '../../../../schema/json-schema-draft-07.schema.json'
@@ -212,13 +213,15 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
         label: string,
         id: string,
         run: ConfigInsertionFunction,
-        telemetryService: TelemetryService
+        telemetryService: TelemetryService,
+        telemetryRecorder: TelemetryRecorder
     ): void {
         inputEditor.addAction({
             label,
             id,
             run: editor => {
                 telemetryService.log('SiteConfigurationActionExecuted')
+                telemetryRecorder.recordEvent('settings-editor.action', 'execute')
                 editor.focus()
                 editor.pushUndoStop()
                 const { edits, selectText, cursorOffset } = run(editor.getValue())

--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -221,7 +221,7 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
             id,
             run: editor => {
                 telemetryService.log('SiteConfigurationActionExecuted')
-                telemetryRecorder.recordEvent('settings-editor.action', 'execute')
+                telemetryRecorder.recordEvent('settingsEditor.action', 'execute')
                 editor.focus()
                 editor.pushUndoStop()
                 const { edits, selectText, cursorOffset } = run(editor.getValue())

--- a/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/RemoteRepositoriesStep.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@apollo/client'
 import classNames from 'classnames'
 import { Routes, Route, matchPath, useLocation } from 'react-router-dom'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Container, Text } from '@sourcegraph/wildcard'
 
@@ -81,13 +82,21 @@ export const RemoteRepositoriesStep: FC<RemoteRepositoriesStepProps> = ({
                         <Route index={true} element={<CodeHostsPicker />} />
                         <Route
                             path=":codeHostType/create"
-                            element={<CodeHostCreation telemetryService={telemetryService} />}
+                            element={
+                                <CodeHostCreation
+                                    telemetryService={telemetryService}
+                                    // TODO (dadlerj) replace with real telemetryRecorder
+                                    telemetryRecorder={noOpTelemetryRecorder}
+                                />
+                            }
                         />
                         <Route
                             path=":codehostId/edit"
                             element={
                                 <CodeHostEdit
                                     telemetryService={telemetryService}
+                                    // TODO (dadlerj) replace with real telemetryRecorder
+                                    telemetryRecorder={noOpTelemetryRecorder}
                                     onCodeHostDelete={setCodeHostToDelete}
                                 />
                             }

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 
 import { useMutation } from '@sourcegraph/http-client'
 import { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Alert, Button, type FormChangeEvent, H4, Link, useLocalStorage } from '@sourcegraph/wildcard'
 
@@ -20,14 +21,36 @@ import { getRepositoriesSettings } from './github/helpers'
 
 import styles from './CodeHostCreation.module.scss'
 
-interface CodeHostCreationProps extends TelemetryProps {}
+interface CodeHostCreationProps extends TelemetryProps, TelemetryV2Props {}
+
+// For telemetry
+const v2CodeHostKind: { [key in ExternalServiceKind]: number } = {
+    AWSCODECOMMIT: 0,
+    AZUREDEVOPS: 1,
+    BITBUCKETCLOUD: 2,
+    BITBUCKETSERVER: 3,
+    GERRIT: 4,
+    GITHUB: 5,
+    GITLAB: 6,
+    GITOLITE: 7,
+    GOMODULES: 8,
+    JVMPACKAGES: 9,
+    NPMPACKAGES: 10,
+    OTHER: 11,
+    PAGURE: 12,
+    PERFORCE: 13,
+    PHABRICATOR: 14,
+    PYTHONPACKAGES: 15,
+    RUBYPACKAGES: 16,
+    RUSTPACKAGES: 17,
+}
 
 /**
  * Renders creation UI for any supported code hosts (GitHub, Gitlab) based on
  * "codeHostType" URL param see root component routing logic.
  */
 export const CodeHostCreation: FC<CodeHostCreationProps> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const { codeHostType } = useParams()
     const codeHostKind = getCodeHostKindFromURLParam(codeHostType!)
@@ -38,7 +61,10 @@ export const CodeHostCreation: FC<CodeHostCreationProps> = props => {
         }
 
         telemetryService.log('SetupWizardCodeHostCreation', { kind: codeHostKind }, { kind: codeHostKind })
-    }, [telemetryService, codeHostKind])
+        telemetryRecorder.recordEvent('setup-wizard.code-host-creation', 'view', {
+            metadata: { kind: v2CodeHostKind[codeHostKind] },
+        })
+    }, [telemetryService, codeHostKind, telemetryRecorder])
 
     if (codeHostKind === null) {
         return (
@@ -52,7 +78,11 @@ export const CodeHostCreation: FC<CodeHostCreationProps> = props => {
     // We render content inside react fragment because this view is rendered
     // within Container UI (avoid unnecessary DOM nesting)
     return (
-        <CodeHostCreationView codeHostKind={codeHostKind} telemetryService={telemetryService}>
+        <CodeHostCreationView
+            codeHostKind={codeHostKind}
+            telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
+        >
             {state => (
                 <footer className={styles.footer}>
                     <LoaderButton
@@ -73,7 +103,7 @@ export const CodeHostCreation: FC<CodeHostCreationProps> = props => {
     )
 }
 
-interface CodeHostCreationFormProps extends TelemetryProps {
+interface CodeHostCreationFormProps extends TelemetryProps, TelemetryV2Props {
     codeHostKind: ExternalServiceKind
     children: (state: CodeHostJSONFormState) => ReactNode
 }
@@ -84,7 +114,7 @@ interface CodeHostCreationFormProps extends TelemetryProps {
  * UI with pickers and other form UI.
  */
 const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
-    const { codeHostKind, children, telemetryService } = props
+    const { codeHostKind, children, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const externalServiceOptions = defaultExternalServices[codeHostKind]
@@ -162,12 +192,25 @@ const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
             }
 
             telemetryService.log('SetupWizardConnectRemoteCodeHost', eventProperties, eventProperties)
+            telemetryRecorder.recordEvent('setup-wizard.code-host', 'connect', {
+                metadata: {
+                    kind: v2CodeHostKind[codeHostKind],
+                    isAffiliatedRepositories: isAffiliatedRepositories ? 1 : 0,
+                    isOrgsRepositories: isOrgsRepositories ? 1 : 0,
+                    isSetRepositories: isSetRepositories ? 1 : 0,
+                },
+            })
         } else {
             telemetryService.log(
                 'SetupWizardConnectRemoteCodeHost',
                 { code_host: codeHostKind },
                 { code_host: codeHostKind }
             )
+            telemetryRecorder.recordEvent('setup-wizard.code-host-creation', 'connect', {
+                metadata: {
+                    kind: v2CodeHostKind[codeHostKind],
+                },
+            })
         }
 
         // Reset local storage values
@@ -195,6 +238,7 @@ const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
             externalServiceOptions={defaultExternalServices[codeHostKind]}
             onChange={handleFormChange}
             onSubmit={handleFormSubmit}
+            telemetryRecorder={telemetryRecorder}
         >
             {children}
         </CodeHostJSONForm>

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/CodeHostCreation.tsx
@@ -61,7 +61,7 @@ export const CodeHostCreation: FC<CodeHostCreationProps> = props => {
         }
 
         telemetryService.log('SetupWizardCodeHostCreation', { kind: codeHostKind }, { kind: codeHostKind })
-        telemetryRecorder.recordEvent('setup-wizard.code-host-creation', 'view', {
+        telemetryRecorder.recordEvent('setupWizard.codeHost.creation', 'view', {
             metadata: { kind: v2CodeHostKind[codeHostKind] },
         })
     }, [telemetryService, codeHostKind, telemetryRecorder])
@@ -192,7 +192,7 @@ const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
             }
 
             telemetryService.log('SetupWizardConnectRemoteCodeHost', eventProperties, eventProperties)
-            telemetryRecorder.recordEvent('setup-wizard.code-host', 'connect', {
+            telemetryRecorder.recordEvent('setupWizard.codeHost.creation', 'connect', {
                 metadata: {
                     kind: v2CodeHostKind[codeHostKind],
                     isAffiliatedRepositories: isAffiliatedRepositories ? 1 : 0,
@@ -206,7 +206,7 @@ const CodeHostCreationView: FC<CodeHostCreationFormProps> = props => {
                 { code_host: codeHostKind },
                 { code_host: codeHostKind }
             )
-            telemetryRecorder.recordEvent('setup-wizard.code-host-creation', 'connect', {
+            telemetryRecorder.recordEvent('setupWizard.codeHost.creation', 'connect', {
                 metadata: {
                     kind: v2CodeHostKind[codeHostKind],
                 },

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/common/CodeHostConnection.tsx
@@ -2,6 +2,7 @@ import { type FC, type ReactElement, type ReactNode, useState } from 'react'
 
 import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -38,7 +39,7 @@ export interface CodeHostJSONFormState {
     submitErrors: SubmissionErrors
 }
 
-interface CodeHostJSONFormProps {
+interface CodeHostJSONFormProps extends TelemetryV2Props {
     initialValues: CodeHostConnectFormFields
     children: (state: CodeHostJSONFormState) => ReactNode
     externalServiceOptions: AddExternalServiceOptions
@@ -69,6 +70,7 @@ export function CodeHostJSONForm(props: CodeHostJSONFormProps): ReactElement {
                 displayNameField={displayName}
                 configurationField={configuration}
                 externalServiceOptions={externalServiceOptions}
+                telemetryRecorder={props.telemetryRecorder}
             />
 
             <>
@@ -82,7 +84,7 @@ export function CodeHostJSONForm(props: CodeHostJSONFormProps): ReactElement {
     )
 }
 
-interface CodeHostJSONFormContentProps {
+interface CodeHostJSONFormContentProps extends TelemetryV2Props {
     displayNameField: useFieldAPI<string>
     configurationField: useFieldAPI<string>
     externalServiceOptions: AddExternalServiceOptions
@@ -119,6 +121,7 @@ export function CodeHostJSONFormContent(props: CodeHostJSONFormContentProps): Re
                     blockNavigationIfDirty={false}
                     onChange={configurationField.input.onChange}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={props.telemetryRecorder}
                     className={styles.configurationGroupEditor}
                     explanation={
                         <Text className="form-text text-muted" size="small">

--- a/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
+++ b/client/web/src/setup-wizard/components/remote-repositories-step/components/code-hosts/github/GithubConnectView.tsx
@@ -14,6 +14,7 @@ import { parse as parseJSONC } from 'jsonc-parser'
 
 import { modify } from '@sourcegraph/common'
 import { gql, useLazyQuery } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Tabs,
@@ -170,6 +171,8 @@ export const GithubConnectForm: FC<GithubConnectFormProps> = props => {
                         displayNameField={displayName}
                         configurationField={configuration}
                         externalServiceOptions={codeHostExternalServices.github}
+                        // TODO (dadlerj) replace with real telemetryRecorder
+                        telemetryRecorder={noOpTelemetryRecorder}
                     />
                 </TabPanel>
                 <>

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -7,6 +7,7 @@ import { Routes, Route } from 'react-router-dom'
 import type { SiteSettingFields } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -49,7 +50,8 @@ export interface SiteAdminAreaRouteContext
     extends PlatformContextProps,
         SettingsCascadeProps,
         BatchChangesProps,
-        TelemetryProps {
+        TelemetryProps,
+        TelemetryV2Props {
     site: Pick<SiteSettingFields, '__typename' | 'id'>
     authenticatedUser: AuthenticatedUser
     isSourcegraphDotCom: boolean
@@ -69,7 +71,12 @@ export interface SiteAdminAreaRouteContext
 
 export interface SiteAdminAreaRoute extends RouteV6Descriptor<SiteAdminAreaRouteContext> {}
 
-interface SiteAdminAreaProps extends PlatformContextProps, SettingsCascadeProps, BatchChangesProps, TelemetryProps {
+interface SiteAdminAreaProps
+    extends PlatformContextProps,
+        SettingsCascadeProps,
+        BatchChangesProps,
+        TelemetryProps,
+        TelemetryV2Props {
     routes: readonly SiteAdminAreaRoute[]
     sideBarGroups: SiteAdminSideBarGroups
     overviewComponents: readonly React.ComponentType<React.PropsWithChildren<unknown>>[]
@@ -139,6 +146,7 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<React.PropsWithChildre
         site: { __typename: 'Site' as const, id: window.context.siteGQLID },
         overviewComponents: props.overviewComponents,
         telemetryService: props.telemetryService,
+        telemetryRecorder: props.telemetryRecorder,
         codeInsightsEnabled: props.codeInsightsEnabled,
         endUserOnboardingEnabled,
         license: getLicenseFeatures(),

--- a/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
+++ b/client/web/src/site-admin/SiteAdminExternalServicesArea.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import { LoadingSpinner, ErrorAlert } from '@sourcegraph/wildcard'
@@ -32,7 +33,7 @@ const AddExternalServicesPage = lazyComponent(
     'AddExternalServicesPage'
 )
 
-interface Props extends TelemetryProps, PlatformContextProps, SettingsCascadeProps {
+interface Props extends TelemetryProps, TelemetryV2Props, PlatformContextProps, SettingsCascadeProps {
     authenticatedUser: AuthenticatedUser
 }
 

--- a/client/web/src/site-admin/SiteAdminReportBugPage.tsx
+++ b/client/web/src/site-admin/SiteAdminReportBugPage.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react'
 import { mapValues, values } from 'lodash'
 
 import type { ExternalServiceKind } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { LoadingSpinner, useObservable, Alert, Link, H2, Text } from '@sourcegraph/wildcard'
@@ -109,10 +110,11 @@ const allConfigSchema = {
         .reduce((allDefinitions, definitions) => ({ ...allDefinitions, ...definitions }), {}),
 }
 
-interface Props extends TelemetryProps {}
+interface Props extends TelemetryProps, TelemetryV2Props {}
 
 export const SiteAdminReportBugPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     telemetryService,
+    telemetryRecorder,
 }) => {
     const isLightTheme = useIsLightTheme()
     const allConfig = useObservable(useMemo(fetchAllConfigAndSettings, []))
@@ -152,6 +154,7 @@ export const SiteAdminReportBugPage: React.FunctionComponent<React.PropsWithChil
                     isLightTheme={isLightTheme}
                     readOnly={true}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
         </div>


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally