### PR TITLE
Batch changes: paginate when listing github apps

### DIFF
--- a/cmd/worker/internal/githubapps/worker/installation_backfill_test.go
+++ b/cmd/worker/internal/githubapps/worker/installation_backfill_test.go
@@ -23,9 +23,9 @@ type mockGitHubClient struct {
 }
 
 func (m *mockGitHubClient) GetAppInstallations(ctx context.Context, page int) ([]*github.Installation, bool, error) {
-	args := m.Called(ctx)
+	args := m.Called(ctx, page)
 	if args.Get(0) != nil {
-		return args.Get(0).([]*github.Installation), args.Get(1).(bool), args.Error(1)
+		return args.Get(0).([]*github.Installation), args.Get(1).(bool), args.Error(2)
 	}
 	return nil, false, args.Error(1)
 }

--- a/cmd/worker/internal/githubapps/worker/installation_backfill_test.go
+++ b/cmd/worker/internal/githubapps/worker/installation_backfill_test.go
@@ -22,12 +22,12 @@ type mockGitHubClient struct {
 	mock.Mock
 }
 
-func (m *mockGitHubClient) GetAppInstallations(ctx context.Context) ([]*github.Installation, error) {
+func (m *mockGitHubClient) GetAppInstallations(ctx context.Context, page int) ([]*github.Installation, bool, error) {
 	args := m.Called(ctx)
 	if args.Get(0) != nil {
-		return args.Get(0).([]*github.Installation), args.Error(1)
+		return args.Get(0).([]*github.Installation), args.Get(1).(bool), args.Error(1)
 	}
-	return nil, args.Error(1)
+	return nil, false, args.Error(1)
 }
 
 func TestGitHubInstallationWorker(t *testing.T) {

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -894,7 +894,7 @@ func (c *V3Client) GetAppInstallation(ctx context.Context, installationID int64)
 // GetAppInstallations fetches a list of GitHub App instalaltions for the
 // authenticated GitHub App.
 //
-// API docs: https://docs.github.com/en/rest/reference/apps#get-an-installation-for-the-authenticated-app
+// API docs: https://docs.github.com/en/rest/apps/apps#list-installations-for-the-authenticated-app
 func (c *V3Client) GetAppInstallations(ctx context.Context, page int) (ins []*github.Installation, hasNextPage bool, _ error) {
 	respState, err := c.get(ctx, fmt.Sprintf("app/installations?page=%d", page), &ins)
 	if err != nil {

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -895,12 +895,12 @@ func (c *V3Client) GetAppInstallation(ctx context.Context, installationID int64)
 // authenticated GitHub App.
 //
 // API docs: https://docs.github.com/en/rest/reference/apps#get-an-installation-for-the-authenticated-app
-func (c *V3Client) GetAppInstallations(ctx context.Context) ([]*github.Installation, error) {
-	var ins []*github.Installation
-	if _, err := c.get(ctx, "app/installations", &ins); err != nil {
-		return nil, err
+func (c *V3Client) GetAppInstallations(ctx context.Context, page int) (ins []*github.Installation, hasNextPage bool, _ error) {
+	respState, err := c.get(ctx, fmt.Sprintf("app/installations?page=%d", page), &ins)
+	if err != nil {
+		return nil, false, err
 	}
-	return ins, nil
+	return ins, respState.hasNextPage(), nil
 }
 
 // CreateAppInstallationAccessToken creates an access token for the installation.

--- a/internal/github_apps/store/BUILD.bazel
+++ b/internal/github_apps/store/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//internal/github_apps/types",
         "//internal/types",
         "//lib/errors",
+        "@com_github_google_go_github_v55//github",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_sourcegraph_log//:log",
     ],

--- a/internal/github_apps/store/store.go
+++ b/internal/github_apps/store/store.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/google/go-github/v55/github"
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/log"
@@ -458,7 +459,22 @@ func (s *gitHubAppsStore) SyncInstallations(ctx context.Context, app ghtypes.Git
 		return errors.Append(errs, err)
 	}
 
-	remoteInstallations, err := client.GetAppInstallations(ctx)
+	getAllAppInstallations := func() ([]*github.Installation, error) {
+		var allInstallations []*github.Installation
+		for page := 0; ; page++ {
+			installationPage, hasNextPage, err := client.GetAppInstallations(ctx, page)
+			if err != nil {
+				return nil, err
+			}
+			allInstallations = append(allInstallations, installationPage...)
+			if !hasNextPage {
+				break
+			}
+		}
+		return allInstallations, nil
+	}
+
+	remoteInstallations, err := getAllAppInstallations()
 	if err != nil {
 		logger.Error("Fetching App Installations from GitHub", log.Error(err), log.String("appName", app.Name), log.Int("id", app.ID))
 		errs = errors.Append(errs, err)

--- a/internal/github_apps/store/store.go
+++ b/internal/github_apps/store/store.go
@@ -459,17 +459,15 @@ func (s *gitHubAppsStore) SyncInstallations(ctx context.Context, app ghtypes.Git
 		return errors.Append(errs, err)
 	}
 
-	getAllAppInstallations := func() ([]*github.Installation, error) {
-		var allInstallations []*github.Installation
-		for page := 0; ; page++ {
-			installationPage, hasNextPage, err := client.GetAppInstallations(ctx, page)
+	getAllAppInstallations := func() (allInstallations []*github.Installation, err error) {
+		hasNextPage := true
+		for page := 1; hasNextPage; page++ {
+			var installations []*github.Installation
+			installations, hasNextPage, err = client.GetAppInstallations(ctx, page)
 			if err != nil {
 				return nil, err
 			}
-			allInstallations = append(allInstallations, installationPage...)
-			if !hasNextPage {
-				break
-			}
+			allInstallations = append(allInstallations, installations...)
 		}
 		return allInstallations, nil
 	}

--- a/internal/github_apps/store/store_test.go
+++ b/internal/github_apps/store/store_test.go
@@ -677,12 +677,12 @@ type mockGitHubClient struct {
 	mock.Mock
 }
 
-func (m *mockGitHubClient) GetAppInstallations(ctx context.Context) ([]*github.Installation, error) {
+func (m *mockGitHubClient) GetAppInstallations(ctx context.Context, page int) ([]*github.Installation, bool, error) {
 	args := m.Called(ctx)
 	if args.Get(0) != nil {
-		return args.Get(0).([]*github.Installation), args.Error(1)
+		return args.Get(0).([]*github.Installation), args.Get(1).(bool), args.Error(1)
 	}
-	return nil, args.Error(1)
+	return nil, false, args.Error(1)
 }
 
 func TestSyncInstallations(t *testing.T) {
@@ -703,7 +703,7 @@ func TestSyncInstallations(t *testing.T) {
 			name: "no installations",
 			githubClient: func() *mockGitHubClient {
 				client := &mockGitHubClient{}
-				client.On("GetAppInstallations", ctx).Return([]*github.Installation{}, nil)
+				client.On("GetAppInstallations", ctx).Return([]*github.Installation{}, false, nil)
 				return client
 			}(),
 			expectedInstallIDs: []int{},
@@ -720,7 +720,7 @@ func TestSyncInstallations(t *testing.T) {
 				client := &mockGitHubClient{}
 				client.On("GetAppInstallations", ctx).Return([]*github.Installation{
 					{ID: github.Int64(1)},
-				}, nil)
+				}, false, nil)
 				return client
 			}(),
 			expectedInstallIDs: []int{1},
@@ -739,7 +739,7 @@ func TestSyncInstallations(t *testing.T) {
 					{ID: github.Int64(2)},
 					{ID: github.Int64(3)},
 					{ID: github.Int64(4)},
-				}, nil)
+				}, false, nil)
 				return client
 			}(),
 			expectedInstallIDs: []int{2, 3, 4},

--- a/internal/github_apps/store/store_test.go
+++ b/internal/github_apps/store/store_test.go
@@ -678,9 +678,9 @@ type mockGitHubClient struct {
 }
 
 func (m *mockGitHubClient) GetAppInstallations(ctx context.Context, page int) ([]*github.Installation, bool, error) {
-	args := m.Called(ctx)
+	args := m.Called(ctx, page)
 	if args.Get(0) != nil {
-		return args.Get(0).([]*github.Installation), args.Get(1).(bool), args.Error(1)
+		return args.Get(0).([]*github.Installation), args.Get(1).(bool), args.Error(2)
 	}
 	return nil, false, args.Error(1)
 }
@@ -703,7 +703,7 @@ func TestSyncInstallations(t *testing.T) {
 			name: "no installations",
 			githubClient: func() *mockGitHubClient {
 				client := &mockGitHubClient{}
-				client.On("GetAppInstallations", ctx).Return([]*github.Installation{}, false, nil)
+				client.On("GetAppInstallations", ctx, 1).Return([]*github.Installation{}, false, nil)
 				return client
 			}(),
 			expectedInstallIDs: []int{},
@@ -718,7 +718,7 @@ func TestSyncInstallations(t *testing.T) {
 			name: "one installation",
 			githubClient: func() *mockGitHubClient {
 				client := &mockGitHubClient{}
-				client.On("GetAppInstallations", ctx).Return([]*github.Installation{
+				client.On("GetAppInstallations", ctx, 1).Return([]*github.Installation{
 					{ID: github.Int64(1)},
 				}, false, nil)
 				return client
@@ -735,7 +735,7 @@ func TestSyncInstallations(t *testing.T) {
 			name: "multiple installations",
 			githubClient: func() *mockGitHubClient {
 				client := &mockGitHubClient{}
-				client.On("GetAppInstallations", ctx).Return([]*github.Installation{
+				client.On("GetAppInstallations", ctx, 1).Return([]*github.Installation{
 					{ID: github.Int64(2)},
 					{ID: github.Int64(3)},
 					{ID: github.Int64(4)},
@@ -746,6 +746,28 @@ func TestSyncInstallations(t *testing.T) {
 			app: ghtypes.GitHubApp{
 				AppID:      3,
 				Name:       "Test App With Multiple Installs",
+				BaseURL:    "https://example.com",
+				PrivateKey: "private-key",
+			},
+		},
+		{
+			name: "paged installations",
+			githubClient: func() *mockGitHubClient {
+				client := &mockGitHubClient{}
+				client.On("GetAppInstallations", ctx, 1).Return([]*github.Installation{
+					{ID: github.Int64(1)},
+					{ID: github.Int64(2)},
+				}, true, nil)
+				client.On("GetAppInstallations", ctx, 2).Return([]*github.Installation{
+					{ID: github.Int64(3)},
+					{ID: github.Int64(4)},
+				}, false, nil)
+				return client
+			}(),
+			expectedInstallIDs: []int{1, 2, 3, 4},
+			app: ghtypes.GitHubApp{
+				AppID:      4,
+				Name:       "Test App With Paged Installs",
 				BaseURL:    "https://example.com",
 				PrivateKey: "private-key",
 			},

--- a/internal/github_apps/types/types.go
+++ b/internal/github_apps/types/types.go
@@ -44,5 +44,5 @@ type GitHubAppInstallation struct {
 }
 
 type GitHubAppClient interface {
-	GetAppInstallations(context.Context) ([]*gogithub.Installation, error)
+	GetAppInstallations(ctx context.Context, page int) (_ []*gogithub.Installation, hasNextPage bool, _ error)
 }


### PR DESCRIPTION
Because we were not paginating, we would end up deleting all installations when there were more than 30 (default page size).

## Test plan

Added a unit test and @BolajiOlajide manually tested the fix.

[Walkthrough of Bolaji running a dead simple test](https://www.loom.com/share/4d1254e072db4973b1f17645b13b5654?sid=d392589a-bd31-48e2-a3a1-071a1d3bf678)
