### PR TITLE
Get Stevey a bigger bubble

### DIFF
--- a/client/web/src/cody/components/GettingStarted.module.scss
+++ b/client/web/src/cody/components/GettingStarted.module.scss
@@ -11,6 +11,9 @@
 
 .icon-section {
     margin-bottom: 3rem !important;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
 }
 
 .section {
@@ -21,22 +24,14 @@
 
 .greeting {
     &-container {
-        grid-column: 2 / 2;
-        grid-row: 1 / 1;
-        margin: 0 0 -1.5rem -0.5rem !important;
-    }
-
-    &-icon {
-        grid-column: 1/1;
-        grid-row: 1/1;
+        position: relative;
     }
 
     &-text {
-        grid-column: 1/1;
-        grid-row: 1/1;
-        align-self: center;
         color: var(--white);
-        margin: 0 0 0.5rem 2rem;
+        position: absolute;
+        top: 1rem;
+        left: 2rem;
     }
 }
 

--- a/client/web/src/cody/components/GettingStarted.tsx
+++ b/client/web/src/cody/components/GettingStarted.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import classNames from 'classnames'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
-import { H4, H5, RadioButton, Text, Button, Grid, Icon, Link } from '@sourcegraph/wildcard'
+import { H4, H5, RadioButton, Text, Button, Icon, Link } from '@sourcegraph/wildcard'
 
 import { CodyColorIcon, CodySpeechBubbleIcon } from '../chat/CodyPageIcon'
 
@@ -15,8 +15,6 @@ import styles from './GettingStarted.module.scss'
 type ConversationScope = 'general' | 'repo'
 
 const DEFAULT_VERTICAL_OFFSET = '1rem'
-
-/* eslint-disable  @sourcegraph/sourcegraph/check-help-links */
 
 export const GettingStarted: React.FC<
     ScopeSelectorProps & {
@@ -113,19 +111,15 @@ export const GettingStarted: React.FC<
             {/* eslint-disable-next-line react/forbid-dom-props */}
             <div ref={contentRef} style={{ margin: `${contentVerticalOffset} 20%` }}>
                 {isCodyChatPage ? null : (
-                    <Grid templateColumns="1fr 1fr" spacing={0} className={styles.iconSection}>
-                        <Grid templateColumns="1fr" spacing={0} className={styles.greetingContainer}>
-                            <div className={styles.greetingIcon}>
-                                <Icon as={CodySpeechBubbleIcon} className="h-auto w-auto" aria-hidden="true" />
-                            </div>
+                    <div className={styles.iconSection}>
+                        <Icon as={CodyColorIcon} aria-hidden="true" className={styles.codyIcon} />
+                        <div className={styles.greetingContainer}>
+                            <Icon as={CodySpeechBubbleIcon} className="h-auto w-auto" aria-hidden="true" />
                             <Text as="span" className={styles.greetingText}>
                                 Hi! I'm Cody
                             </Text>
-                        </Grid>
-                        <div className={styles.codyIconContainer}>
-                            <Icon as={CodyColorIcon} aria-hidden="true" className={styles.codyIcon} />
                         </div>
-                    </Grid>
+                    </div>
                 )}
 
                 {isCodyChatPage ? (


### PR DESCRIPTION
Issue: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1707499933575329

As reported, the text comes out of the bubble for Cody Web.
![image](https://github.com/sourcegraph/sourcegraph/assets/22571395/c4a5bfae-5739-4d88-875f-197f6e7d1af0)

After testing, I found that the bug is on Firefox because the browsers treat Grids differently. 

I have replaced grid-based CSS with a basic flex model with position absolute to fit text nicely into the bubble. 

Tested on all browsers at various zoom levels.

## Test plan
- Open Cody Web in the sidebar on file view. 
- Create new chat
- The bubble should cover the whole "Hi I'm Cody" text.
- Test on all the browsers.
