### PR TITLE
Make dotcom actor refresh cooldown configurable

### DIFF
--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -43,9 +43,8 @@ type Config struct {
 
 	BigQuery struct {
 		ProjectID string
-
-		Dataset string
-		Table   string
+		Dataset   string
+		Table     string
 
 		EventBufferSize    int
 		EventBufferWorkers int
@@ -104,7 +103,7 @@ func (c *Config) Load() {
 	c.Dotcom.InternalMode = c.GetBool("CODY_GATEWAY_DOTCOM_INTERNAL_MODE", "false", "Only allow tokens associated with active internal and dev licenses to be used.") ||
 		c.GetBool("CODY_GATEWAY_DOTCOM_DEV_LICENSES_ONLY", "false", "DEPRECATED, use CODY_GATEWAY_DOTCOM_INTERNAL_MODE")
 	c.Dotcom.ActorRefreshCoolDownInterval = c.GetInterval("CODY_GATEWAY_DOTCOM_ACTOR_COOLDOWN_INTERVAL", "300s",
-		"The Sourcegraph.com access token to be used. If not provided, dotcom-based actor sources will be disabled.")
+		"Cooldown period for refreshing the actor info from dotcom.")
 
 	c.Anthropic.AccessToken = c.Get("CODY_GATEWAY_ANTHROPIC_ACCESS_TOKEN", "", "The Anthropic access token to be used.")
 	c.Anthropic.AllowedModels = splitMaybe(c.Get("CODY_GATEWAY_ANTHROPIC_ALLOWED_MODELS",

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -22,9 +22,10 @@ type Config struct {
 	DiagnosticsSecret string
 
 	Dotcom struct {
-		URL          string
-		AccessToken  string
-		InternalMode bool
+		URL                          string
+		AccessToken                  string
+		InternalMode                 bool
+		ActorRefreshCoolDownInterval time.Duration
 	}
 
 	Anthropic AnthropicConfig
@@ -42,8 +43,9 @@ type Config struct {
 
 	BigQuery struct {
 		ProjectID string
-		Dataset   string
-		Table     string
+
+		Dataset string
+		Table   string
 
 		EventBufferSize    int
 		EventBufferWorkers int
@@ -101,6 +103,8 @@ func (c *Config) Load() {
 	}
 	c.Dotcom.InternalMode = c.GetBool("CODY_GATEWAY_DOTCOM_INTERNAL_MODE", "false", "Only allow tokens associated with active internal and dev licenses to be used.") ||
 		c.GetBool("CODY_GATEWAY_DOTCOM_DEV_LICENSES_ONLY", "false", "DEPRECATED, use CODY_GATEWAY_DOTCOM_INTERNAL_MODE")
+	c.Dotcom.ActorRefreshCoolDownInterval = c.GetInterval("CODY_GATEWAY_DOTCOM_ACTOR_COOLDOWN_INTERVAL", "300s",
+		"The Sourcegraph.com access token to be used. If not provided, dotcom-based actor sources will be disabled.")
 
 	c.Anthropic.AccessToken = c.Get("CODY_GATEWAY_ANTHROPIC_ACCESS_TOKEN", "", "The Anthropic access token to be used.")
 	c.Anthropic.AllowedModels = splitMaybe(c.Get("CODY_GATEWAY_ANTHROPIC_ALLOWED_MODELS",

--- a/cmd/cody-gateway/shared/main.go
+++ b/cmd/cody-gateway/shared/main.go
@@ -135,12 +135,7 @@ func Main(ctx context.Context, obctx *observation.Context, ready service.ReadyFu
 				cfg.Dotcom.InternalMode,
 				cfg.ActorConcurrencyLimit,
 			),
-			dotcomuser.NewSource(obctx.Logger,
-				rcache.NewWithTTL(fmt.Sprintf("dotcom-users:%s", dotcomuser.SourceVersion), int(cfg.SourcesCacheTTL.Seconds())),
-				dotcomClient,
-				cfg.ActorConcurrencyLimit,
-				rs,
-			),
+			dotcomuser.NewSource(obctx.Logger, rcache.NewWithTTL(fmt.Sprintf("dotcom-users:%s", dotcomuser.SourceVersion), int(cfg.SourcesCacheTTL.Seconds())), dotcomClient, cfg.ActorConcurrencyLimit, rs, cfg.Dotcom.ActorRefreshCoolDownInterval),
 		)
 	} else {
 		obctx.Logger.Warn("CODY_GATEWAY_DOTCOM_ACCESS_TOKEN is not set, dotcom-based actor sources are disabled")


### PR DESCRIPTION
Make dotcom actor refresh cooldown configurable - see [Slack](https://sourcegraph.slack.com/archives/C05SZB829D0/p1707552838650569)
## Test plan

- tested locally
- e2e tests