### PR TITLE
gitserver: Normalize revisionnotfound errors

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/mergebase_test.go
+++ b/cmd/gitserver/internal/git/gitcli/mergebase_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestGitCLIBackend_MergeBase(t *testing.T) {
@@ -49,5 +51,26 @@ func TestGitCLIBackend_MergeBase(t *testing.T) {
 		base, err := backend.MergeBase(ctx, "master", "b2")
 		require.NoError(t, err)
 		require.Equal(t, api.CommitID(""), base)
+	})
+	t.Run("not found revspec", func(t *testing.T) {
+		// Prepare repo state:
+		backend := BackendWithRepoCommands(t,
+			"echo line1 > f",
+			"git add f",
+			"git commit -m foo --author='Foo Author <foo@sourcegraph.com>'",
+			"git checkout -b b2",
+			"echo line2 >> f",
+			"git add f",
+			"git commit -m foo --author='Foo Author <foo@sourcegraph.com>'",
+			"git checkout master",
+		)
+
+		_, err := backend.MergeBase(ctx, "master", "notfound")
+		require.Error(t, err)
+		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+
+		_, err = backend.MergeBase(ctx, "notfound", "master")
+		require.Error(t, err)
+		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
 	})
 }

--- a/cmd/gitserver/internal/git/iface.go
+++ b/cmd/gitserver/internal/git/iface.go
@@ -20,6 +20,8 @@ type GitBackend interface {
 	GetObject(ctx context.Context, objectName string) (*gitdomain.GitObject, error)
 	// MergeBase finds the merge base commit for the given base and head revspecs.
 	// Returns an empty string and no error if no common merge-base was found.
+	// If one of the two given revspecs does not exist, a RevisionNotFoundError
+	// is returned.
 	MergeBase(ctx context.Context, baseRevspec, headRevspec string) (api.CommitID, error)
 	// Blame returns a reader for the blame info of the given path.
 	// BlameHunkReader must always be closed.

--- a/cmd/gitserver/internal/server_grpc.go
+++ b/cmd/gitserver/internal/server_grpc.go
@@ -799,6 +799,18 @@ func (gs *grpcServer) MergeBase(ctx context.Context, req *proto.MergeBaseRequest
 
 	sha, err := backend.MergeBase(ctx, string(req.GetBase()), string(req.GetHead()))
 	if err != nil {
+		var e *gitdomain.RevisionNotFoundError
+		if errors.As(err, &e) {
+			s, err := status.New(codes.NotFound, "revision not found").WithDetails(&proto.RevisionNotFoundPayload{
+				Repo: req.GetRepoName(),
+				Spec: e.Spec,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return nil, s.Err()
+		}
+
 		gs.svc.LogIfCorrupt(ctx, repoName, err)
 		// TODO: Better error checking.
 		return nil, err

--- a/internal/gitserver/commands_test.go
+++ b/internal/gitserver/commands_test.go
@@ -2332,6 +2332,23 @@ func TestClient_MergeBase(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, api.CommitID(""), sha)
 	})
+	t.Run("revision not found", func(t *testing.T) {
+		source := NewTestClientSource(t, []string{"gitserver"}, func(o *TestClientSourceOptions) {
+			o.ClientFunc = func(cc *grpc.ClientConn) proto.GitserverServiceClient {
+				c := NewMockGitserverServiceClient()
+				s, err := status.New(codes.NotFound, "bad revision").WithDetails(&proto.RevisionNotFoundPayload{Repo: "repo", Spec: "deadbeef"})
+				require.NoError(t, err)
+				c.MergeBaseFunc.SetDefaultReturn(nil, s.Err())
+				return c
+			}
+		})
+
+		c := NewTestClient(t).WithClientSource(source)
+
+		_, err := c.MergeBase(context.Background(), "repo", "master", "b2")
+		require.Error(t, err)
+		require.True(t, errors.HasType(err, &gitdomain.RevisionNotFoundError{}))
+	})
 }
 
 func TestClient_NewFileReader(t *testing.T) {


### PR DESCRIPTION
Aligning with other functions, we now return a RevisionNotFoundError instead of an unwrapped command error.

## Test plan

Added tests.
