### PR TITLE
Auto-update Wolfi base images to latest

### DIFF
--- a/dev/oci_deps.bzl
+++ b/dev/oci_deps.bzl
@@ -41,170 +41,170 @@ def oci_deps():
     """
     oci_pull(
         name = "wolfi_base",
-        digest = "sha256:dc44581c10496b9a85ee63b91ec679f3942b9cef256762956b860db8001a71b4",
+        digest = "sha256:a31afa210aaf90f08bc757cc4de12f84de2d311e51988280d0e429f36ad868ec",
         image = "index.docker.io/sourcegraph/wolfi-sourcegraph-base",
     )
 
     oci_pull(
         name = "wolfi_cadvisor_base",
-        digest = "sha256:5b40d5db451baa54d4ea26da900337c0524b871f2dbe0871ab7022be6dccd0dc",
+        digest = "sha256:ed091dd8a0b408d9a9cccdb3e1b33ee02da6991dc71344873cb7c7154b0d84b7",
         image = "index.docker.io/sourcegraph/wolfi-cadvisor-base",
     )
 
     oci_pull(
         name = "wolfi_symbols_base",
-        digest = "sha256:ab3d9d69e5d216917a59f68d4151e0ab7bb461f55844bfca724d694a48089513",
+        digest = "sha256:2f6fed42dcb55bd2676a27cbcc213f10024139b22b79305c0cbd0c6e0d551136",
         image = "index.docker.io/sourcegraph/wolfi-symbols-base",
     )
 
     oci_pull(
         name = "wolfi_server_base",
-        digest = "sha256:7399778f564fcaa1f41eddc4dc370d3fa3fcebc0062b2ff9aace618728a96d86",
+        digest = "sha256:8a887a147e18cf13bc39ee10965e9fa9e26dd68bd854e7bf438bc9b2bdaac133",
         image = "index.docker.io/sourcegraph/wolfi-server-base",
     )
 
     oci_pull(
         name = "wolfi_gitserver_base",
-        digest = "sha256:2be0320b8fb025f0786c70d485df98c3e69f86569ae661a665e72553056eb16b",
+        digest = "sha256:617db82d904658d803ed3b133a9a4583991ba9fd14b2c35c255e14c407ff811c",
         image = "index.docker.io/sourcegraph/wolfi-gitserver-base",
     )
 
     oci_pull(
         name = "wolfi_grafana_base",
-        digest = "sha256:e9dcc49846ad3013869b2f070dd51eed109e740a2e330f5286a7a9a82b1f4ae5",
+        digest = "sha256:1f56cfd90b7412e9784434c891427142c6e3238d6fb8602bd5e04333a5214daf",
         image = "index.docker.io/sourcegraph/wolfi-grafana-base",
     )
 
     oci_pull(
         name = "wolfi_postgres_exporter_base",
-        digest = "sha256:5b4ca7bb4598c0fe1cc01128527dac093878612ecc6059dcee53480124f6b588",
+        digest = "sha256:226a6f06cad1e96b22446c00340569c64e1047f48f5ac8ce25a900bcc666a255",
         image = "index.docker.io/sourcegraph/wolfi-postgres-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_all_in_one_base",
-        digest = "sha256:73f450e004e076f41a0715e4210f906c27a9c1beb25ed86a6c616298352e268c",
+        digest = "sha256:f1236a7659232568caae67cc3de42e415a53f0a4291fe0c765a3dc5280bd11ff",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-all-in-one-base",
     )
 
     oci_pull(
         name = "wolfi_jaeger_agent_base",
-        digest = "sha256:52e5092360f40b774931fced86983118dbdac382025fac437dc1bb936305a38b",
+        digest = "sha256:0a08f1d419fbcb2df2438fe19ddc8ef13fe89178f4a7dcdfc4bda270bf3c9140",
         image = "index.docker.io/sourcegraph/wolfi-jaeger-agent-base",
     )
 
     oci_pull(
         name = "wolfi_redis_base",
-        digest = "sha256:53951db2752e085b4fb8791e1cd46d521d68f2c160661205f803a377e54ed3e9",
+        digest = "sha256:081b93e4397b83c303c275e10894773ed55b07eee0daa5d608e5f234d4407ee3",
         image = "index.docker.io/sourcegraph/wolfi-redis-base",
     )
 
     oci_pull(
         name = "wolfi_redis_exporter_base",
-        digest = "sha256:4a1b9c391e97994e16cb19fba77fcc05b1af5c2928cf094712b3a182dac6bdd9",
+        digest = "sha256:e116b4e47b4cc8b0de48dae215593c45ff737f87479ff17e0f90a79adf8c5873",
         image = "index.docker.io/sourcegraph/wolfi-redis-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_syntax_highlighter_base",
-        digest = "sha256:aad68d003c7fa26cd22144116332beef0f1e55e48b17d9cb46fd98fbf748c0aa",
+        digest = "sha256:ceda5c21f8461d7351866214c11b65c2c695d4c458808b93e2be6260729cc5cb",
         image = "index.docker.io/sourcegraph/wolfi-syntax-highlighter-base",
     )
 
     oci_pull(
         name = "wolfi_search_indexer_base",
-        digest = "sha256:efc7a8f70279f85eed88a862d77d0fcc8f87582f2df15c774b602cddfa61b305",
+        digest = "sha256:4fbe187a00b9af4e2a88af49b12a601769a283e19f61c4a51fd58afc2e299b05",
         image = "index.docker.io/sourcegraph/wolfi-search-indexer-base",
     )
 
     oci_pull(
         name = "wolfi_repo_updater_base",
-        digest = "sha256:ce106fddf98d4cd0e5793b11fa207171208917a5629863b799071b5306e31991",
+        digest = "sha256:01dc7ff7adeb7557c903a3eec1fce531e5cb0c01dd66eb397150756f8af74dad",
         image = "index.docker.io/sourcegraph/wolfi-repo-updater-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:132757381aefc1f7bff267a09f64a32fe2d57d97a42b9f692d9787bc8b9b1940",
+        digest = "sha256:9f77f0b0cc95fbb5d8083ab9ea6fcd54c1e936b1ae9c52887c0b4e8b6d34b763",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_executor_base",
-        digest = "sha256:25a9928c00b33a49257e92a11597bebe09a1ff8bc1adedf8bc903985adfca72c",
+        digest = "sha256:b979e0cfb730262538e3e6845644d80b99a622476a663433712f6e74f8c0e67d",
         image = "index.docker.io/sourcegraph/wolfi-executor-base",
     )
 
     # ???
     oci_pull(
         name = "wolfi_bundled_executor_base",
-        digest = "sha256:4f5a87784f603433f4b7e515fde56188c8c7413939fe3bfef7bd9f2e9073b626",
+        digest = "sha256:a5c08b69b1083ba22d50bfb94c7c22b4222948b2d664c39936502b3005c3426f",
         image = "index.docker.io/sourcegraph/wolfi-bundled-executor-base",
     )
 
     oci_pull(
         name = "wolfi_executor_kubernetes_base",
-        digest = "sha256:badfaf46388e8a0b5ac96389bd6d364a5f6d4bca56ba62dfe1b8e977910ee804",
+        digest = "sha256:fc6fc2563d33fb0c65f17712ad4390565ab8656d3b5b0b2558227fba65d0d7d6",
         image = "index.docker.io/sourcegraph/wolfi-executor-kubernetes-base",
     )
 
     oci_pull(
         name = "wolfi_batcheshelper_base",
-        digest = "sha256:69675f48a8b0562c34b08ce8f1a6d7607466d3d69635c383e0b6e6552ea3f0f6",
+        digest = "sha256:6030276d0a702cd386ec86907ce6905da21edbf137e73a682fefa31dc7795005",
         image = "index.docker.io/sourcegraph/wolfi-batcheshelper-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_base",
-        digest = "sha256:89051f8231b31e12c3ae9ee3db637823e0490025b0aac51d5d5c8c7d68e63f22",
+        digest = "sha256:419c06e9cd4183cdb5a85be2aaac436d3d24b01d9fe1670b6ab5c76ebc788f3a",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-base",
     )
 
     oci_pull(
         name = "wolfi_prometheus_gcp_base",
-        digest = "sha256:65ee86af8fd1d8a4d81785ae02cce436e5dec42b883228e091b6850bc87aae25",
+        digest = "sha256:9866e52d1e26873f3f92b4bdd9f769169620ee02705724f471f7bcdbb4fcf549",
         image = "index.docker.io/sourcegraph/wolfi-prometheus-gcp-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12_base",
-        digest = "sha256:47e61bc8b4a5f73e5f344f13cf908807d98125c3bb0668bca6a57d81e9cd3e42",
+        digest = "sha256:c85c0b034a7c983e000c46fd11aa175256078f7e9531b41ab2ba70635571db76",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-base",
     )
 
     oci_pull(
         name = "wolfi_postgresql-12-codeinsights_base",
-        digest = "sha256:418be77a09486a48dd53c843909f16b2ad06b5a848f95c7064f250da0853b1bd",
+        digest = "sha256:d007565b59a65389e32b79c371e6c558acf3283cdd856c246d731f49886dddc9",
         image = "index.docker.io/sourcegraph/wolfi-postgresql-12-codeinsights-base",
     )
 
     oci_pull(
         name = "wolfi_node_exporter_base",
-        digest = "sha256:155043d91589010a5a07f78d2861931e69fb2ae6977be7bb18ed318512b12e79",
+        digest = "sha256:f7873465e2a383f2973746d339bd04b2e933e5fe8d4bf73baecd12dbf34ed0da",
         image = "index.docker.io/sourcegraph/wolfi-node-exporter-base",
     )
 
     oci_pull(
         name = "wolfi_opentelemetry_collector_base",
-        digest = "sha256:4a81c147937176777e9fbdbf4066bdbe3eab5dd432f74fa3199f58917f7f1b42",
+        digest = "sha256:e8e15d5301e3128aabfba930c3a9f693bb3dbf0ef3e9cf6e790c84cc48d2ea21",
         image = "index.docker.io/sourcegraph/wolfi-opentelemetry-collector-base",
     )
 
     oci_pull(
         name = "wolfi_searcher_base",
-        digest = "sha256:132757381aefc1f7bff267a09f64a32fe2d57d97a42b9f692d9787bc8b9b1940",
+        digest = "sha256:9f77f0b0cc95fbb5d8083ab9ea6fcd54c1e936b1ae9c52887c0b4e8b6d34b763",
         image = "index.docker.io/sourcegraph/wolfi-searcher-base",
     )
 
     oci_pull(
         name = "wolfi_s3proxy_base",
-        digest = "sha256:50a4535656af20af740d13da7e7bc4abfb2c35b80fef2322f0fd79d688e5a820",
+        digest = "sha256:732027e3a004a60591b1ead52d63ef8ec24768079c0ad6f3d0b1f782745b7d63",
         image = "index.docker.io/sourcegraph/wolfi-blobstore-base",
     )
 
     oci_pull(
         name = "wolfi_qdrant_base",
-        digest = "sha256:c1dc38553bca3097c92be1aa66ec3f198593f16ccbbbe935504316c1218f92bb",
+        digest = "sha256:9a7f31255d025fc762530360d4f056af98ac5ae67c2258ff8eae8afeace60587",
         image = "index.docker.io/sourcegraph/wolfi-qdrant-base",
     )
 


### PR DESCRIPTION
Automatically generated PR to update Wolfi base images to the latest hashes.

Built from Buildkite run [#263011](https://buildkite.com/sourcegraph/sourcegraph/builds/263011).
## Test Plan
- CI build verifies image functionality
- [ ] Confirm PR should be backported to release branch