### PR TITLE
Render Cody analytics site admin route if Cody is enabled in license

### DIFF
--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -221,6 +221,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         path: '/analytics/cody',
         render: () => <AnalyticsCodyPage />,
+        condition: ({ license }) => license.isCodyEnabled,
     },
     {
         path: '/analytics/code-insights',


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/sourcegraph/pull/60371 ([comment](https://github.com/sourcegraph/sourcegraph/pull/60371/files#r1485710297)).

**Cody feature enabled in license**
<img width="1369" alt="Screenshot 2024-02-12 at 08 30 03" src="https://github.com/sourcegraph/sourcegraph/assets/25318659/39a90b52-eafc-4cb1-87e8-75befb5e7d8b">

**Cody feature disabled in license**
<img width="1046" alt="Screenshot 2024-02-12 at 08 27 39" src="https://github.com/sourcegraph/sourcegraph/assets/25318659/318b3748-f217-47d0-bdb7-64162e2bd5a0">


## Test plan
- CI
- Tested manually: Cody analytics page is not available in the site admin sidebar and via URL  "site-admin/analytics/cody"

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
