### PR TITLE
all: update code paths as if qdrant is disabled

### DIFF
--- a/cmd/worker/internal/embeddings/repo/worker.go
+++ b/cmd/worker/internal/embeddings/repo/worker.go
@@ -54,8 +54,9 @@ func (s *repoEmbeddingJob) Routines(_ context.Context, observationCtx *observati
 		return nil, err
 	}
 
-	getQdrantDB := vdb.NewDBFromConfFunc(observationCtx.Logger, vdb.NewNoopDB())
-	getQdrantInserter := func() (vdb.VectorInserter, error) { return getQdrantDB() }
+	// qdrant is going to be removed. For now we only ever set the noop db.
+	qdrantDB := vdb.NewNoopDB()
+	getQdrantInserter := func() (vdb.VectorInserter, error) { return qdrantDB, nil }
 
 	workCtx := actor.WithInternalActor(context.Background())
 	return []goroutine.BackgroundRoutine{

--- a/internal/codycontext/BUILD.bazel
+++ b/internal/codycontext/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//internal/embeddings",
         "//internal/embeddings/db",
         "//internal/embeddings/embed",
-        "//internal/featureflag",
         "//internal/gitserver",
         "//internal/metrics",
         "//internal/observation",


### PR DESCRIPTION
Fully removing our use of qdrant is quite a large change. Instead this does a minimal change by just removing the part of our code which optionally searches via qdrant, and additionally the part which uses a real qdrant client. This effectively makes it so qdrant is always disabled.

In practice, the "GetEmbeddingsConfig" will only return a configuration for dotcom. Currently qdrant is disabled on dotcom, so operationally this is a noop change.

Test Plan: CI and investigating that live environments this is a noop.
