### PR TITLE
Fix model allowlist for fireworks + use virtual model string in e2e

### DIFF
--- a/cmd/cody-gateway/qa/fireworks.go
+++ b/cmd/cody-gateway/qa/fireworks.go
@@ -17,7 +17,7 @@ func (fc FireworksGatewayFeatureClient) GetRequest(f codygateway.Feature, req *h
 		body := fmt.Sprintf(`{
 			"prompt":"def bubble_sort(arr):\n>",
 			"maxTokensToSample":30,
-			"model":"accounts/fireworks/models/starcoder-16b-w8a16",
+			"model":"starcoder",
 			"temperature":0.2,
 			"topP":0.95,
 			"stream":%t

--- a/cmd/cody-gateway/shared/config/BUILD.bazel
+++ b/cmd/cody-gateway/shared/config/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//internal/codygateway",
+        "//internal/completions/client/fireworks",
         "//internal/env",
         "//internal/trace/policy",
         "//lib/errors",

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/codygateway"
+	"github.com/sourcegraph/sourcegraph/internal/completions/client/fireworks"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/trace/policy"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -149,18 +150,22 @@ func (c *Config) Load() {
 	c.Fireworks.AccessToken = c.GetOptional("CODY_GATEWAY_FIREWORKS_ACCESS_TOKEN", "The Fireworks access token to be used.")
 	c.Fireworks.AllowedModels = splitMaybe(c.Get("CODY_GATEWAY_FIREWORKS_ALLOWED_MODELS",
 		strings.Join([]string{
-			"accounts/fireworks/models/starcoder-16b-w8a16",
-			"accounts/fireworks/models/starcoder-7b-w8a16",
-			"accounts/fireworks/models/starcoder-3b-w8a16",
-			"accounts/fireworks/models/starcoder-1b-w8a16",
-			"accounts/sourcegraph/models/starcoder-7b",
-			"accounts/sourcegraph/models/starcoder-16b",
+			// Virtual model strings. Setting these will allow one or more of the specific models
+			// and allows Cody Gateway to decide which specific model to route the request to.
+			"starcoder",
+			// Fireworks multi-tenant models:
+			fireworks.Starcoder16b,
+			fireworks.Starcoder7b,
+			fireworks.Starcoder16bSingleTenant,
 			"accounts/fireworks/models/llama-v2-7b-code",
 			"accounts/fireworks/models/llama-v2-13b-code",
 			"accounts/fireworks/models/llama-v2-13b-code-instruct",
 			"accounts/fireworks/models/llama-v2-34b-code-instruct",
 			"accounts/fireworks/models/mistral-7b-instruct-4k",
 			"accounts/fireworks/models/mixtral-8x7b-instruct",
+			// Deprecated model strings
+			"accounts/fireworks/models/starcoder-3b-w8a16",
+			"accounts/fireworks/models/starcoder-1b-w8a16",
 		}, ","),
 		"Fireworks models that can be used."))
 	if c.Fireworks.AccessToken != "" && len(c.Fireworks.AllowedModels) == 0 {


### PR DESCRIPTION
Fix bad Fireworks model list. 
Update end-to-end tests to use the virtual model string.

## Test plan

- manual test
- e2e test
