### PR TITLE
Cody Gateway: Log resolved model as header

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -263,6 +263,8 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 				return
 			}
 
+			w.Header().Add("x-cody-resolved-model", gatewayModel)
+
 			var (
 				upstreamStarted    = time.Now()
 				upstreamLatency    time.Duration


### PR DESCRIPTION
Adds a new `x-cody-resolved-model` header so we know what model a request was routed to. I want to use this to be able to group by ST or MT setup in the cody PLG client logs.

## Test plan

```
α dev/sourcegraph 🐙(main)✗
curl -vS -X POST http://localhost:9992/v1/completions/fireworks -H 'Authorization: bearer TOKEN' -d '{"stream":false,"max_tokens":50, "model": "starcoder", "stop_sequences": ["\n\n"], "prompt": "function bubbleSort() {", "stream":true}' -H 'X-sourcegraph-feature: code_completions'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying [::1]:9992...
* connect to ::1 port 9992 failed: Connection refused
*   Trying 127.0.0.1:9992...
* Connected to localhost (127.0.0.1) port 9992
> POST /v1/completions/fireworks HTTP/1.1
> Host: localhost:9992
> User-Agent: curl/8.4.0
> Accept: */*
> Authorization: bearer TOKEN
> X-sourcegraph-feature: code_completions
> Content-Length: 134
> Content-Type: application/x-www-form-urlencoded
>
< HTTP/1.1 200 OK
< Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
< Content-Type: text/event-stream; charset=utf-8
< Date: Mon, 12 Feb 2024 14:14:57 GMT
< Via: 1.1 google, 1.1 google
< X-Accel-Buffering: no
< X-Cody-Resolved-Model: fireworks/accounts/sourcegraph/models/starcoder-16b
< X-Request-Id: e9128eef-717e-4c01-b2f6-a77f818ba8b7
< X-Server-Time-To-First-Token: 0.105
< X-Trace: b4393049e8e561b81f9bcd7692aefe00
< X-Trace-Span: 48e1d283737af2ec
< Transfer-Encoding: chunked
<
data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":"\n                   ","logprobs":null,"finish_reason":null}],"usage":null}

data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":" var allCards = document.","logprobs":null,"finish_reason":null}],"usage":null}

data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":"querySelectorAll('.card');\n                    for","logprobs":null,"finish_reason":null}],"usage":null}

data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":" (var i = 0;","logprobs":null,"finish_reason":null}],"usage":null}

data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":" i < allCards.length-","logprobs":null,"finish_reason":null}],"usage":null}

data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":"1; i++) {\n                        all","logprobs":null,"finish_reason":null}],"usage":null}

data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":"Cards[i].style.","logprobs":null,"finish_reason":null}],"usage":null}

data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":"animationDuration = (i+1","logprobs":null,"finish_reason":null}],"usage":null}

data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":")*.3","logprobs":null,"finish_reason":null}],"usage":null}

data: {"id":"cmpl-af46cd1ba53e149fefc1e9b2","object":"text_completion","created":1707747298,"model":"accounts/sourcegraph/models/starcoder-16b","choices":[{"index":0,"text":"","logprobs":null,"finish_reason":"length"}],"usage":{"prompt_tokens":5,"total_tokens":55,"completion_tokens":50}}

data: [DONE]

* Connection #0 to host localhost left intact
```