### PR TITLE
Log when refresh is blocked by cooldown

### DIFF
--- a/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -68,7 +68,7 @@ func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 
 func (s *Source) Update(ctx context.Context, act *actor.Actor) error {
 	if act.LastUpdated != nil && time.Since(*act.LastUpdated) < s.coolDownInterval {
-		s.log.Debug("actor recently updated, skipping update", log.Duration("secondsSinceUpdate", time.Since(*act.LastUpdated).Seconds()))
+		s.log.Debug("actor recently updated, skipping update", log.Duration("secondsSinceUpdate", time.Since(*act.LastUpdated)))
 		return actor.ErrActorRecentlyUpdated{
 			RetryAt: act.LastUpdated.Add(s.coolDownInterval),
 		}

--- a/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
+++ b/cmd/cody-gateway/internal/actor/dotcomuser/dotcomuser.go
@@ -68,6 +68,7 @@ func (s *Source) Get(ctx context.Context, token string) (*actor.Actor, error) {
 
 func (s *Source) Update(ctx context.Context, act *actor.Actor) error {
 	if act.LastUpdated != nil && time.Since(*act.LastUpdated) < s.coolDownInterval {
+		s.log.Debug("actor recently updated, skipping update", log.Duration("secondsSinceUpdate", time.Since(*act.LastUpdated).Seconds()))
 		return actor.ErrActorRecentlyUpdated{
 			RetryAt: act.LastUpdated.Add(s.coolDownInterval),
 		}


### PR DESCRIPTION
Log when rate-limit refresh is blocked (so we can create a log-based metric).

## Test plan

- tested locally
- e2e tests pass