### PR TITLE
Drop unused users.searchable DB column

### DIFF
--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -28587,19 +28587,6 @@
           "Comment": ""
         },
         {
-          "Name": "searchable",
-          "Index": 19,
-          "TypeName": "boolean",
-          "IsNullable": false,
-          "Default": "true",
-          "CharacterMaximumLength": 0,
-          "IsIdentity": false,
-          "IdentityGeneration": "",
-          "IsGenerated": "NEVER",
-          "GenerationExpression": "",
-          "Comment": ""
-        },
-        {
           "Name": "site_admin",
           "Index": 12,
           "TypeName": "boolean",

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -4349,7 +4349,6 @@ Foreign-key constraints:
  billing_customer_id     | text                     |           |          | 
  invalidated_sessions_at | timestamp with time zone |           | not null | now()
  tos_accepted            | boolean                  |           | not null | false
- searchable              | boolean                  |           | not null | true
  completions_quota       | integer                  |           |          | 
  code_completions_quota  | integer                  |           |          | 
  completed_post_signup   | boolean                  |           | not null | false

--- a/migrations/frontend/1707759188_drop_user_searchable/down.sql
+++ b/migrations/frontend/1707759188_drop_user_searchable/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS searchable boolean DEFAULT true NOT NULL;

--- a/migrations/frontend/1707759188_drop_user_searchable/metadata.yaml
+++ b/migrations/frontend/1707759188_drop_user_searchable/metadata.yaml
@@ -1,0 +1,2 @@
+name: drop_user_searchable
+parents: [1706629467, 1706710430]

--- a/migrations/frontend/1707759188_drop_user_searchable/up.sql
+++ b/migrations/frontend/1707759188_drop_user_searchable/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN IF EXISTS searchable;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -4196,7 +4196,6 @@ CREATE TABLE users (
     billing_customer_id text,
     invalidated_sessions_at timestamp with time zone DEFAULT now() NOT NULL,
     tos_accepted boolean DEFAULT false NOT NULL,
-    searchable boolean DEFAULT true NOT NULL,
     completions_quota integer,
     code_completions_quota integer,
     completed_post_signup boolean DEFAULT false NOT NULL,


### PR DESCRIPTION
We stopped using this over a release ago, so we can now safely drop it from the schema.

Closes https://github.com/sourcegraph/sourcegraph/issues/60141

## Test plan

Backcompat tests.
