### PR TITLE
Update Manage Subscription buttons

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 
-import { mdiHelpCircleOutline, mdiInformationOutline, mdiOpenInNew } from '@mdi/js'
+import { mdiHelpCircleOutline, mdiInformationOutline, mdiOpenInNew, mdiCreditCardOutline } from '@mdi/js'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
@@ -190,7 +190,8 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                         </div>
                         {userIsOnProTier && (
                             <div>
-                                <ButtonLink to="/cody/subscription" variant="secondary" outline={true} size="sm">
+                                <ButtonLink to="/cody/subscription" variant="primary" size="sm">
+                                    <Icon svgPath={mdiCreditCardOutline} className="mr-1" aria-hidden={true} />
                                     Manage subscription
                                 </ButtonLink>
                             </div>
@@ -505,6 +506,7 @@ const DoNotLoseCodyProBanner: React.FunctionComponent<{
                 </div>
                 <div>
                     <ButtonLink to={manageSubscriptionRedirectURL} variant="primary" size="sm">
+                        <Icon svgPath={mdiCreditCardOutline} className="mr-1" aria-hidden={true} />
                         Add Credit Card
                     </ButtonLink>
                 </div>

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react'
 import React, { useEffect, useState } from 'react'
 
-import { mdiInformationOutline, mdiTrendingUp } from '@mdi/js'
+import { mdiArrowLeft, mdiInformationOutline, mdiTrendingUp, mdiCreditCardOutline } from '@mdi/js'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
@@ -10,6 +10,7 @@ import {
     Badge,
     Button,
     ButtonLink,
+    Link,
     H1,
     H2,
     Icon,
@@ -90,7 +91,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
     }
 
     const isProUser = data.currentUser.codySubscription?.plan === CodySubscriptionPlan.PRO
-    const hasNotAddedCreditCard = data.currentUser.codySubscription?.status === CodySubscriptionStatus.PENDING
+    const hasAddedCreditCard = data.currentUser.codySubscription?.status !== CodySubscriptionStatus.PENDING
 
     return (
         <>
@@ -99,9 +100,20 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                 <PageHeader
                     className="mb-4"
                     actions={
-                        <ButtonLink to="/cody/manage" variant="secondary" outline={true} size="sm">
-                            Dashboard
-                        </ButtonLink>
+                        isProUser &&
+                        arePaymentsEnabled &&
+                        hasAddedCreditCard && (
+                            <Button
+                                variant="primary"
+                                onClick={() => {
+                                    eventLogger.log(EventName.CODY_MANAGE_SUBSCRIPTION_CLICKED)
+                                    window.location.href = manageSubscriptionRedirectURL
+                                }}
+                            >
+                                <Icon svgPath={mdiCreditCardOutline} className="mr-1" aria-hidden={true} />
+                                Manage subscription
+                            </Button>
+                        )
                     }
                 >
                     <PageHeader.Heading as="h2" styleAs="h1">
@@ -110,6 +122,11 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                         </div>
                     </PageHeader.Heading>
                 </PageHeader>
+
+                <Link to="/cody/manage" className="my-4">
+                    <Icon className="mr-1 text-link" svgPath={mdiArrowLeft} aria-hidden={true} />
+                    Back to Cody Dashboard
+                </Link>
 
                 <div className={classNames('d-flex mt-4', styles.responsiveContainer)}>
                     <div className="border d-flex flex-column flex-1 bg-1 rounded">
@@ -232,17 +249,35 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                                     </Text>
                                 )}
                                 {isProUser ? (
-                                    arePaymentsEnabled && hasNotAddedCreditCard ? (
-                                        <Button
-                                            className="flex-1 mt-1"
-                                            variant="primary"
-                                            onClick={() => {
-                                                eventLogger.log(EventName.CODY_SUBSCRIPTION_ADD_CREDIT_CARD_CLICKED)
-                                                window.location.href = manageSubscriptionRedirectURL
-                                            }}
-                                        >
-                                            Add credit card
-                                        </Button>
+                                    arePaymentsEnabled ? (
+                                        hasAddedCreditCard ? (
+                                            <Text
+                                                className="mb-0 text-muted d-inline cursor-pointer"
+                                                size="small"
+                                                onClick={() => {
+                                                    eventLogger.log(EventName.CODY_MANAGE_SUBSCRIPTION_CLICKED)
+                                                    window.location.href = manageSubscriptionRedirectURL
+                                                }}
+                                            >
+                                                Manage subscription
+                                            </Text>
+                                        ) : (
+                                            <Button
+                                                className="flex-1 mt-1"
+                                                variant="primary"
+                                                onClick={() => {
+                                                    eventLogger.log(EventName.CODY_SUBSCRIPTION_ADD_CREDIT_CARD_CLICKED)
+                                                    window.location.href = manageSubscriptionRedirectURL
+                                                }}
+                                            >
+                                                <Icon
+                                                    svgPath={mdiCreditCardOutline}
+                                                    className="mr-1"
+                                                    aria-hidden={true}
+                                                />
+                                                Add credit card
+                                            </Button>
+                                        )
                                     ) : (
                                         <div>
                                             <Text

--- a/client/web/src/util/constants.ts
+++ b/client/web/src/util/constants.ts
@@ -44,6 +44,7 @@ export const enum EventName {
     CODY_SUBSCRIPTION_PLAN_CLICKED = 'CodyPlanSelectionClicked',
     CODY_SUBSCRIPTION_PLAN_CONFIRMED = 'CodyPlanSelectionConfirmed',
     CODY_SUBSCRIPTION_ADD_CREDIT_CARD_CLICKED = 'CodyAddCreditCard',
+    CODY_MANAGE_SUBSCRIPTION_CLICKED = 'CodyManageSubscriptionClicked',
     CODY_ONBOARDING_WELCOME_VIEWED = 'CodyWelcomeViewed',
     CODY_ONBOARDING_PURPOSE_VIEWED = 'CodyUseCaseViewed',
     CODY_ONBOARDING_PURPOSE_SELECTED = 'CodyUseCaseSelected',


### PR DESCRIPTION
closes: https://github.com/sourcegraph/accounts.sourcegraph.com/issues/491

Change the colour of the Manage Subscription Button on `/cody/manage` to blue and add cc icon.
![CleanShot 2024-02-12 at 23 44 04@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/50e519f4-8e50-4283-a99c-5f2cc2a9fadc)


For Pro users add a primary Manage Subscription button on the right side of the header on `cody/subscription` and add a link back to the dashboard below the header. 

![CleanShot 2024-02-12 at 23 45 26@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/4a695c77-8b2b-417e-b997-cb058fcc0845)


Take care of all the feature flags and states while doing the above changes.

## Test plan

- Turn on use-ssc-for-subscription-on-web feature flag
- Upgrade to pro and add credit card
- Verify that the above buttons and links are working as expected.

