### PR TITLE
Ara/redact access token backport

### DIFF
--- a/dev/backcompat/bazel-backcompat.sh
+++ b/dev/backcompat/bazel-backcompat.sh
@@ -31,7 +31,6 @@ fi
 echo "--- :git::rewind: checkout v${tag}"
 # --no-overlay makes so that git ensures the files match what is in the tree exactly, removing files that do not match
 git checkout --force "v${tag}"
-
 echo "--- :git: checkout migrations, patches and scripts at ${current_commit}"
 # --no-overlay makes so that git ensures the files match what is in the tree exactly, removing files that do not match
 git checkout --force --no-overlay "${current_commit}" -- migrations/ dev/backcompat/patch_flakes.sh dev/backcompat/patches dev/backcompat/flakes.json


### PR DESCRIPTION
Making a backport PR for access token redaction([link](https://github.com/sourcegraph/sourcegraph/pull/60397#pullrequestreview-1875705060))

<img width="871" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/11155207/775c9d2a-132a-4ec2-9e1a-e5fba003e293">


## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
