### PR TITLE
telemetry-gateway: mark handlePublishEvents spans as failed on error

### DIFF
--- a/cmd/telemetry-gateway/internal/server/BUILD.bazel
+++ b/cmd/telemetry-gateway/internal/server/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_metric//:metric",
-        "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
     ],

--- a/cmd/telemetry-gateway/internal/server/publish_events.go
+++ b/cmd/telemetry-gateway/internal/server/publish_events.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sourcegraph/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway/internal/events"
 	telemetrygatewayv1 "github.com/sourcegraph/sourcegraph/internal/telemetrygateway/v1"
@@ -53,8 +52,8 @@ func handlePublishEvents(
 		log.Int("failed", len(summary.failedEvents)),
 	}
 	if len(summary.failedEvents) > 0 {
-		tr.RecordError(errors.New(summary.message),
-			trace.WithAttributes(attribute.Int("failed", len(summary.failedEvents))))
+		tr.SetError(errors.New(summary.message)) // mark span as failed
+		tr.SetAttributes(attribute.Int("failed", len(summary.failedEvents)))
 		logger.Error(summary.message, append(summaryFields, summary.errorFields...)...)
 	} else {
 		logger.Info(summary.message, summaryFields...)


### PR DESCRIPTION
Currently, failures don't get marked as a failed span. This is mostly a visibility improvement.

## Test plan

n/a