### PR TITLE
batches: change criteria for deleting GitHub apps from the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
--
+- GitHub apps installation records will only be deleted from the database if the GitHub App has been uninstalled or if the GitHub app has been deleted. [#60460](https://github.com/sourcegraph/sourcegraph/pull/60460)
 
 ### Fixed
 

--- a/internal/github_apps/store/BUILD.bazel
+++ b/internal/github_apps/store/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//internal/database/dbtest",
         "//internal/github_apps/types",
         "//internal/types",
+        "//lib/errors",
         "@com_github_google_go_github_v55//github",
         "@com_github_keegancsmith_sqlf//:sqlf",
         "@com_github_sourcegraph_log//logtest",

--- a/internal/github_apps/store/BUILD.bazel
+++ b/internal/github_apps/store/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//internal/encryption",
         "//internal/encryption/keyring",
         "//internal/extsvc",
+        "//internal/extsvc/github",
         "//internal/github_apps/types",
         "//internal/types",
         "//lib/errors",
@@ -36,6 +37,7 @@ go_test(
     deps = [
         "//internal/database/basestore",
         "//internal/database/dbtest",
+        "//internal/extsvc/github",
         "//internal/github_apps/types",
         "//internal/types",
         "//lib/errors",

--- a/internal/github_apps/store/store.go
+++ b/internal/github_apps/store/store.go
@@ -477,9 +477,11 @@ func (s *gitHubAppsStore) SyncInstallations(ctx context.Context, app ghtypes.Git
 		logger.Error("Fetching App Installations from GitHub", log.Error(err), log.String("appName", app.Name), log.Int("id", app.ID))
 		errs = errors.Append(errs, err)
 
-		// This likely means the App has been deleted from GitHub, so we should remove all
-		// installations of it from our database, if we have any.
-		if len(dbInstallations) == 0 {
+		// if the error from github is 404 then it means the GitHub app has been deleted. If not, we return
+		// the error and preserve whatever installations we have in the database.
+		// Sample:
+		// {"error": "request to https://ghe.sgdev.org/api/v3/app/installations?page=1 returned status 404: Integration not found", "appName": "BolJHI COMMIT SIgn", "id": 1}
+		if !strings.Contains(err.Error(), "returned status 404: Integration not found") {
 			return errs
 		}
 

--- a/internal/github_apps/store/store_test.go
+++ b/internal/github_apps/store/store_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	ghtypes "github.com/sourcegraph/sourcegraph/internal/github_apps/types"
@@ -698,6 +700,7 @@ func TestSyncInstallations(t *testing.T) {
 		githubClient       *mockGitHubClient
 		expectedInstallIDs []int
 		app                ghtypes.GitHubApp
+		expectedErr        string
 	}{
 		{
 			name: "no installations",
@@ -772,6 +775,22 @@ func TestSyncInstallations(t *testing.T) {
 				PrivateKey: "private-key",
 			},
 		},
+		{
+			name: "deleted github app",
+			githubClient: func() *mockGitHubClient {
+				client := &mockGitHubClient{}
+				client.On("GetAppInstallations", ctx, 1).Return([]*github.Installation{}, false, errors.New("request to https://ghe.sgdev.org/api/v3/app/installations?page=1 returned status 404: Integration not found"))
+				return client
+			}(),
+			expectedInstallIDs: []int{},
+			expectedErr:        "request to https://ghe.sgdev.org/api/v3/app/installations?page=1 returned status 404: Integration not found",
+			app: ghtypes.GitHubApp{
+				AppID:      5,
+				Name:       "Test Deleted GitHub App",
+				BaseURL:    "https://example.com",
+				PrivateKey: "private-key",
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -803,7 +822,12 @@ func TestSyncInstallations(t *testing.T) {
 			}
 
 			errs := store.SyncInstallations(ctx, app, logger, tc.githubClient)
-			require.NoError(t, errs)
+
+			if tc.expectedErr != "" {
+				require.Error(t, errs, tc.expectedErr)
+			} else {
+				require.NoError(t, errs)
+			}
 
 			installations, err := store.GetInstallations(ctx, tc.app.AppID)
 			require.NoError(t, err)


### PR DESCRIPTION
Closes #54066

In the past, when we get an error fetching a GitHub app, we assume the app has been deleted and delete all it's installations from the database. This caused issues for one of our customers.

## Test plan

Manual testing. 

I added a GitHub app for Commit Signing, manually triggered the worker to ensure it refreshes it's installations. Then I faked an error in the code, to see if the installations got deleted when a refresh occurred (they didn't). They only got deleted when the client returns a 404.

![CleanShot 2024-02-12 at 21 30 54@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/d7b6787a-3603-4bfd-9ded-12f69b271d8c)
