### PR TITLE
rel: remove call to generate stitch from legacy tooling

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -1111,7 +1111,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                     version,
                     'internal/database/migration/shared/data/cmd/generator/consts.go'
                 ),
-                'cd internal/database/migration/shared && go run ./data/cmd/generator --write-frozen=false',
+                `bazel run //dev:write_all_generated`,
             ]
             const srcCliSteps = await bakeSrcCliSteps(config)
 
@@ -1136,7 +1136,7 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
             }
 
             const sets = await createChangesets({
-                requiredCommands: ['comby', 'go'],
+                requiredCommands: ['comby', 'go', 'bazel'],
                 changes: [
                     {
                         ...prDetails,


### PR DESCRIPTION
The part that generates the stitch graph is now handled fully by Bazel, so we don't need to explicitly call the generator when running the legacy tooling.

## Test plan

TODO

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
