### PR TITLE
Quickfix for attribution panics

### DIFF
--- a/cmd/frontend/internal/guardrails/init.go
+++ b/cmd/frontend/internal/guardrails/init.go
@@ -81,6 +81,9 @@ func (e *enterpriseInitialization) Service() attribution.Service {
 	if e.endpoint == "" || e.token == "" {
 		return attribution.Uninitialized{}
 	}
+	if e.client == nil {
+		return attribution.Uninitialized{}
+	}
 	return attribution.NewGatewayProxy(e.observationCtx, e.client)
 }
 

--- a/internal/codygateway/client.go
+++ b/internal/codygateway/client.go
@@ -141,6 +141,9 @@ func (c *client) Attribution(ctx context.Context, snippet string, limit int) (At
 		return Attribution{}, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
+	if c.cli == nil {
+		return Attribution{}, errors.New("no http client")
+	}
 	resp, err := c.cli.Do(req)
 	if err != nil {
 		return Attribution{}, err


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/60439

- Return error in case `http.Doer` is not set. Not sure how that can be but the error indicates it's nil sometimes.
- Return uninitialized attribution client, if HTTP client was not created.

## Test plan

- [x] Manual check