### PR TITLE
release: half fix bake*ExecutorsSteps

### DIFF
--- a/dev/release/src/static-updates.ts
+++ b/dev/release/src/static-updates.ts
@@ -49,16 +49,25 @@ export async function bakeAWSExecutorsSteps(config: ReleaseConfig): Promise<void
         title: `executor: v${next.version}`,
         commitMessage: `executor: v${next.version}`,
     }
+    /*
+      TODO prepare-release.sh commits and pushes the change, but
+      createChangesets expects to do this. This needs to be fixed before the
+      next minor release. I propose making prepare-release not commit and
+      push. Or even better just get rid of it since its an overengineered
+      wrapper around a single sed call. Then you can also remove the unshallow
+      call.
+    */
     const sets = await createChangesets({
         requiredCommands: [],
         changes: [
             {
                 ...prDetails,
-                repo: 'sourcegraph',
-                owner: 'terraform-aws-executors',
+                owner: 'sourcegraph',
+                repo: 'terraform-aws-executors',
                 base: 'master',
                 head: `release/prepare-${next.version}`,
-                edits: [`./prepare-release.sh ${next.version}`],
+                // prepare-release.sh needs full history to read tags
+                edits: ['git fetch --unshallow', `./prepare-release.sh ${next.version}`],
                 labels: [releaseBlockerLabel],
                 draft: true,
             },
@@ -87,6 +96,14 @@ export async function bakeGoogleExecutorsSteps(config: ReleaseConfig): Promise<v
         title: `executor: v${next.version}`,
         commitMessage: `executor: v${next.version}`,
     }
+    /*
+      TODO prepare-release.sh commits and pushes the change, but
+      createChangesets expects to do this. This needs to be fixed before the
+      next minor release. I propose making prepare-release not commit and
+      push. Or even better just get rid of it since its an overengineered
+      wrapper around a single sed call. Then you can also remove the unshallow
+      call.
+    */
     const sets = await createChangesets({
         requiredCommands: [],
         changes: [
@@ -96,7 +113,8 @@ export async function bakeGoogleExecutorsSteps(config: ReleaseConfig): Promise<v
                 owner: 'sourcegraph',
                 base: 'master',
                 head: `release/prepare-${next.version}`,
-                edits: [`./prepare-release.sh ${next.version}`],
+                // prepare-release.sh needs full history to read tags
+                edits: ['git fetch --unshallow', `./prepare-release.sh ${next.version}`],
                 labels: [releaseBlockerLabel],
                 draft: true,
             },


### PR DESCRIPTION
Even though this code was added a year ago, it clearly has never actually been run. The first fix is correctly specifying the name of the terraform-aws-executors repository. It had the name and owner mixed up, causing the clone to fail.

The second fix is to fetch the history so that prepare-release.sh actually runs.

Note: this will still just fail. But it gets far along enough in my release now that I can pick up the pieces and manually create PRs. Then I can comment out these steps and run the tool again.

Test Plan: blood, sweat and tears

Part of https://github.com/sourcegraph/sourcegraph/issues/60032