### PR TITLE
guardrails: move httpclient logic into initializer

### DIFF
--- a/cmd/frontend/internal/guardrails/init.go
+++ b/cmd/frontend/internal/guardrails/init.go
@@ -40,11 +40,7 @@ func Init(
 	} else {
 		// On an Enterprise instance endpoint proxies to gateway, and is re-initialized
 		// in case site-config changes.
-		client := httpcli.ExternalDoer
-		if MockHttpClient != nil {
-			client = MockHttpClient
-		}
-		initLogic := &enterpriseInitialization{observationCtx: observationCtx, httpClient: client}
+		initLogic := &enterpriseInitialization{observationCtx: observationCtx}
 		resolver = resolvers.NewGuardrailsResolver(initLogic.Service())
 		go conf.Watch(func() {
 			resolver.UpdateService(initLogic.Service())
@@ -62,7 +58,6 @@ type enterpriseInitialization struct {
 	client         codygateway.Client
 	endpoint       string
 	token          string
-	httpClient     httpcli.Doer
 }
 
 // Service creates an attribution.Service. It tries to get gateway endpoint from site config
@@ -76,7 +71,14 @@ func (e *enterpriseInitialization) Service() attribution.Service {
 	if e.endpoint != endpoint || e.token != token {
 		e.endpoint = endpoint
 		e.token = token
-		e.client = codygateway.NewClient(e.httpClient, endpoint, token)
+
+		// We are reachout out of the cluster so we need to use ExternalDoer.
+		httpClient := httpcli.ExternalDoer
+		if MockHttpClient != nil {
+			httpClient = MockHttpClient
+		}
+
+		e.client = codygateway.NewClient(httpClient, endpoint, token)
 	}
 	if e.endpoint == "" || e.token == "" {
 		return attribution.Uninitialized{}


### PR DESCRIPTION
This avoids the footgun of forgetting to set it. It didn't need to be part of the struct since its only ever read in one spot.

This fixes the root cause of the quick fix in https://github.com/sourcegraph/sourcegraph/pull/60465

Test Plan: go test