### PR TITLE
Revert "Return uninitialized gateway if client is nil"

### DIFF
--- a/cmd/frontend/internal/guardrails/init.go
+++ b/cmd/frontend/internal/guardrails/init.go
@@ -83,9 +83,6 @@ func (e *enterpriseInitialization) Service() attribution.Service {
 	if e.endpoint == "" || e.token == "" {
 		return attribution.Uninitialized{}
 	}
-	if e.client == nil {
-		return attribution.Uninitialized{}
-	}
 	return attribution.NewGatewayProxy(e.observationCtx, e.client)
 }
 


### PR DESCRIPTION
This reverts commit bc599bb8f0e40957d5f711e10636bf3ef5c030d0.

Part of https://github.com/sourcegraph/sourcegraph/issues/60439

This is not needed after a proper fix from @keegancsmith https://github.com/sourcegraph/sourcegraph/pull/60471

## Test plan

- [x] Manual test