### PR TITLE
search: better handling of keyword boundaries

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -254,8 +254,7 @@ func (p *parser) matchKeyword(keyword keyword) bool {
 
 // matchUnaryKeyword is like match but expects the keyword to be followed by whitespace.
 func (p *parser) matchUnaryKeyword(keyword keyword) bool {
-	if p.pos != 0 && !(isSpace(p.buf[p.pos-1:p.pos]) || p.buf[p.pos-1] == '(') {
-		// "not" must be preceded by a space or ( anywhere except the beginning of the string
+	if p.pos != 0 && !(isSpace(p.buf[p.pos-1:p.pos]) || isRightParen(p.buf[p.pos-1:p.pos]) || isLeftParen(p.buf[p.pos-1:p.pos])) {
 		return false
 	}
 	v, err := p.peek(len(string(keyword)))
@@ -1139,7 +1138,7 @@ func (p *parser) parseAnd() ([]Node, error) {
 	if left == nil {
 		return nil, &ExpectedOperand{Msg: fmt.Sprintf("expected operand at %d", p.pos)}
 	}
-	if !p.expect(AND) {
+	if !(p.expect(AND) || p.expect(NOT)) {
 		return left, nil
 	}
 	right, err := p.parseAnd()

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -118,11 +118,15 @@ const (
 	NOT    keyword = "not"
 )
 
+// isSpace returns true if the buffer only contains UTF-8 encoded whitespace as
+// defined by unicode.IsSpace.
 func isSpace(buf []byte) bool {
-	for i := 0; i < len(buf); i++ {
-		if !unicode.IsSpace(rune(buf[i])) {
+	for len(buf) > 0 {
+		r, n := utf8.DecodeRune(buf)
+		if !unicode.IsSpace(r) {
 			return false
 		}
+		buf = buf[n:]
 	}
 	return true
 }

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -119,18 +119,22 @@ const (
 )
 
 func isSpace(buf []byte) bool {
-	r, _ := utf8.DecodeRune(buf)
-	return unicode.IsSpace(r)
-}
-
-func isRightParen(buf []byte) bool {
-	r, _ := utf8.DecodeRune(buf)
-	return r == ')'
+	for i := 0; i < len(buf); i++ {
+		if !unicode.IsSpace(rune(buf[i])) {
+			return false
+		}
+	}
+	return true
 }
 
 func isLeftParen(buf []byte) bool {
 	r, _ := utf8.DecodeRune(buf)
 	return r == '('
+}
+
+func isRightParen(buf []byte) bool {
+	r, _ := utf8.DecodeRune(buf)
+	return r == ')'
 }
 
 // skipSpace returns the number of whitespace bytes skipped from the beginning of a buffer buf.
@@ -233,9 +237,10 @@ func (p *parser) expect(keyword keyword) bool {
 	return true
 }
 
-// matchKeyword is like match but expects the keyword to be preceded and followed by whitespace.
+// matchKeyword is like match but checks whether the keyword has a valid prefix
+// and suffix.
 func (p *parser) matchKeyword(keyword keyword) bool {
-	if p.pos == 0 {
+	if isSpace(p.buf[:p.pos]) {
 		return false
 	}
 	if !(isSpace(p.buf[p.pos-1:p.pos]) || isRightParen(p.buf[p.pos-1:p.pos])) {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1143,7 +1143,7 @@ func (p *parser) parseAnd() ([]Node, error) {
 	if left == nil {
 		return nil, &ExpectedOperand{Msg: fmt.Sprintf("expected operand at %d", p.pos)}
 	}
-	if !(p.expect(AND) || p.expect(NOT)) {
+	if !p.expect(AND) {
 		return left, nil
 	}
 	right, err := p.parseAnd()

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -1023,3 +1023,25 @@ func TestParseKeywordPattern(t *testing.T) {
 		autogold.ExpectFile(t, autogold.Raw(test(`"foo \"bar\""`)))
 	})
 }
+
+func TestIsSpace(t *testing.T) {
+	cases := []struct {
+		input []byte
+		want  bool
+	}{
+		{[]byte{'\xa0'}, false},
+		{[]byte{' ', ' '}, true},
+		{[]byte{' ', '\t'}, true},
+		{[]byte{' ', '\t', '\f', '\r'}, true},
+		{[]byte{' ', '\t', '\f', '\r', 'a'}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.input), func(t *testing.T) {
+			got := isSpace([]byte(tc.input))
+			if got != tc.want {
+				t.Errorf("got %t, want %t, first byte %d", got, tc.want, rune(tc.input[0]))
+			}
+		})
+	}
+}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -813,6 +813,10 @@ func TestParseParensKeyword(t *testing.T) {
 	autogold.Expect(`(or "a" "b" "c")`).Equal(t, test("(a or b) or c"))
 	autogold.Expect(`(or (and "a" "b") "c" "d")`).Equal(t, test("(a and b or c) or d"))
 	autogold.Expect(`(or "a" (and "b" "c") "d")`).Equal(t, test("(a or b and c)or d"))
+
+	// first token
+	autogold.Expect(`(and "and" "b")`).Equal(t, test("  and b"))
+	autogold.Expect(`(and "and" "b")`).Equal(t, test("and b"))
 }
 
 func TestParseAndOrLiteral(t *testing.T) {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -803,6 +803,10 @@ func TestParseParensKeyword(t *testing.T) {
 	autogold.Expect(`(and (or "a" "b") (not "c"))`).Equal(t, test("(a or b) not c"))
 	autogold.Expect(`(and (or "a" "b") (not "c"))`).Equal(t, test("(a or b)not c"))
 	autogold.Expect(`(and "a" (not "b") (not "c"))`).Equal(t, test("(a not b)not c"))
+	autogold.Expect(`(and (not "a") "b")`).Equal(t, test("not a b"))
+	autogold.Expect(`(or "a" (not "b"))`).Equal(t, test("a or not b"))
+	autogold.Expect(`(not "b")`).Equal(t, test("not b"))
+	autogold.Expect(`(not "b")`).Equal(t, test(" not b"))
 
 	autogold.Expect(`(or "a" "bandc")`).Equal(t, test("a or (bandc)"))
 	autogold.Expect(`(and "a" "andor" "b")`).Equal(t, test("a andor b"))

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -802,6 +802,7 @@ func TestParseParensKeyword(t *testing.T) {
 
 	autogold.Expect(`(and (or "a" "b") (not "c"))`).Equal(t, test("(a or b) not c"))
 	autogold.Expect(`(and (or "a" "b") (not "c"))`).Equal(t, test("(a or b)not c"))
+	autogold.Expect(`(and "a" (not "b") (not "c"))`).Equal(t, test("(a not b)not c"))
 
 	autogold.Expect(`(or "a" "bandc")`).Equal(t, test("a or (bandc)"))
 	autogold.Expect(`(and "a" "andor" "b")`).Equal(t, test("a andor b"))
@@ -812,7 +813,6 @@ func TestParseParensKeyword(t *testing.T) {
 	autogold.Expect(`(or "a" "b" "c")`).Equal(t, test("(a or b) or c"))
 	autogold.Expect(`(or (and "a" "b") "c" "d")`).Equal(t, test("(a and b or c) or d"))
 	autogold.Expect(`(or "a" (and "b" "c") "d")`).Equal(t, test("(a or b and c)or d"))
-
 }
 
 func TestParseAndOrLiteral(t *testing.T) {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -767,6 +767,8 @@ func TestParseParensKeyword(t *testing.T) {
 
 	// parentheses
 	autogold.Expect(`"()"`).Equal(t, test("()"))
+	autogold.Expect(`"()"`).Equal(t, test("(())"))
+	autogold.Expect(`"()"`).Equal(t, test("(     )"))
 	autogold.Expect(`(and "()" "=>" "{}")`).Equal(t, test("() => {}"))
 	autogold.Expect(`(and "err" "error," "ok" "bool")`).Equal(t, test("(err error, ok bool)"))
 
@@ -785,6 +787,32 @@ func TestParseParensKeyword(t *testing.T) {
 	autogold.Expect(`"\"\"foo\""`).Equal(t, test(`""foo"`))
 	autogold.Expect(`"\"\"foo\"\""`).Equal(t, test(`""foo""`))
 	autogold.Expect(`"\"foo\"bar\"bas\""`).Equal(t, test(`"foo"bar"bas"`))
+
+	// detect keywords at boundaries
+	autogold.Expect(`(and (or "a" "b") "c")`).Equal(t, test("(a or b) and c"))
+	autogold.Expect(`(and (or "a" "b") "c")`).Equal(t, test("(a or b)and c"))
+	autogold.Expect(`(and "c" (or "a" "b"))`).Equal(t, test("c and(a or b)"))
+	autogold.Expect(`(and "c" (or "a" "b"))`).Equal(t, test("c and (a or b)"))
+	autogold.Expect(`(and (or "a" "b") (or "c" "d"))`).Equal(t, test("(a or b)and(c or d)"))
+
+	autogold.Expect(`(or (and "a" "b") "c")`).Equal(t, test("(a and b) or c"))
+	autogold.Expect(`(or (and "a" "b") "c")`).Equal(t, test("(a and b)or c"))
+	autogold.Expect(`(or (and "a" "and") "c")`).Equal(t, test("(a and)or c"))
+	autogold.Expect(`(or "a" (and "b" "c"))`).Equal(t, test("a or(b and c)"))
+
+	autogold.Expect(`(and (or "a" "b") (not "c"))`).Equal(t, test("(a or b) not c"))
+	autogold.Expect(`(and (or "a" "b") (not "c"))`).Equal(t, test("(a or b)not c"))
+
+	autogold.Expect(`(or "a" "bandc")`).Equal(t, test("a or (bandc)"))
+	autogold.Expect(`(and "a" "andor" "b")`).Equal(t, test("a andor b"))
+	autogold.Expect(`(and "a" "(and" "b")`).Equal(t, test("a (and b"))
+	autogold.Expect(`unsupported expression. The combination of parentheses in the query has an unclear meaning. Use "..." to quote patterns that contain parentheses`).Equal(t, test("a )and b"))
+
+	autogold.Expect(`(or "a" "b" "c")`).Equal(t, test("(a or b)or c"))
+	autogold.Expect(`(or "a" "b" "c")`).Equal(t, test("(a or b) or c"))
+	autogold.Expect(`(or (and "a" "b") "c" "d")`).Equal(t, test("(a and b or c) or d"))
+	autogold.Expect(`(or "a" (and "b" "c") "d")`).Equal(t, test("(a or b and c)or d"))
+
 }
 
 func TestParseAndOrLiteral(t *testing.T) {


### PR DESCRIPTION
This fixes a bug in the backend parser to recognise "AND" and "OR" even if they aren't preceded by whitespace. Previously, a query such as "(a or b)and c" was not parsed correctly, because "and" was preceded by ")", which resulted in surprising results.

They key idea of the fix is to recognise parenthesis as proper boundaries and to not advance the parser immediately once we encounter a right parenthesis, but instead to let the caller advance. This way, the caller can construct an operator (`(or a b)` in this case) before continuing with the parsing. This mirrors the behavior of the other keywords that can break the loop in the leaf parser.

The handling of whitespace in our parser is very fragile. A more thorough fix would be to introduce a lexer to eliminate the significance of whitespace from the parser logic. However, we are planning to replace the parser soon. Right now it makes sense to fix this bug within the current framework.

## Test plan
- new units tests
- all existing test pass 
