### PR TITLE
gitserver: Remove ResolveRevisions from client

### DIFF
--- a/cmd/gitserver/internal/integration_tests/BUILD.bazel
+++ b/cmd/gitserver/internal/integration_tests/BUILD.bazel
@@ -62,7 +62,6 @@ go_test(
         "//internal/extsvc",
         "//internal/gitserver",
         "//internal/gitserver/gitdomain",
-        "//internal/gitserver/protocol",
         "//internal/gitserver/v1:gitserver",
         "//internal/grpc",
         "//internal/grpc/defaults",

--- a/internal/batches/sources/mocks_test.go
+++ b/internal/batches/sources/mocks_test.go
@@ -10986,9 +10986,6 @@ type MockGitserverClient struct {
 	// ResolveRevisionFunc is an instance of a mock function object
 	// controlling the behavior of the method ResolveRevision.
 	ResolveRevisionFunc *GitserverClientResolveRevisionFunc
-	// ResolveRevisionsFunc is an instance of a mock function object
-	// controlling the behavior of the method ResolveRevisions.
-	ResolveRevisionsFunc *GitserverClientResolveRevisionsFunc
 	// RevListFunc is an instance of a mock function object controlling the
 	// behavior of the method RevList.
 	RevListFunc *GitserverClientRevListFunc
@@ -11228,11 +11225,6 @@ func NewMockGitserverClient() *MockGitserverClient {
 		},
 		ResolveRevisionFunc: &GitserverClientResolveRevisionFunc{
 			defaultHook: func(context.Context, api.RepoName, string, gitserver.ResolveRevisionOptions) (r0 api.CommitID, r1 error) {
-				return
-			},
-		},
-		ResolveRevisionsFunc: &GitserverClientResolveRevisionsFunc{
-			defaultHook: func(context.Context, api.RepoName, []protocol.RevisionSpecifier) (r0 []string, r1 error) {
 				return
 			},
 		},
@@ -11493,11 +11485,6 @@ func NewStrictMockGitserverClient() *MockGitserverClient {
 				panic("unexpected invocation of MockGitserverClient.ResolveRevision")
 			},
 		},
-		ResolveRevisionsFunc: &GitserverClientResolveRevisionsFunc{
-			defaultHook: func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error) {
-				panic("unexpected invocation of MockGitserverClient.ResolveRevisions")
-			},
-		},
 		RevListFunc: &GitserverClientRevListFunc{
 			defaultHook: func(context.Context, string, string, func(commit string) (bool, error)) error {
 				panic("unexpected invocation of MockGitserverClient.RevList")
@@ -11669,9 +11656,6 @@ func NewMockGitserverClientFrom(i gitserver.Client) *MockGitserverClient {
 		},
 		ResolveRevisionFunc: &GitserverClientResolveRevisionFunc{
 			defaultHook: i.ResolveRevision,
-		},
-		ResolveRevisionsFunc: &GitserverClientResolveRevisionsFunc{
-			defaultHook: i.ResolveRevisions,
 		},
 		RevListFunc: &GitserverClientRevListFunc{
 			defaultHook: i.RevList,
@@ -16560,120 +16544,6 @@ func (c GitserverClientResolveRevisionFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c GitserverClientResolveRevisionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// GitserverClientResolveRevisionsFunc describes the behavior when the
-// ResolveRevisions method of the parent MockGitserverClient instance is
-// invoked.
-type GitserverClientResolveRevisionsFunc struct {
-	defaultHook func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error)
-	hooks       []func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error)
-	history     []GitserverClientResolveRevisionsFuncCall
-	mutex       sync.Mutex
-}
-
-// ResolveRevisions delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockGitserverClient) ResolveRevisions(v0 context.Context, v1 api.RepoName, v2 []protocol.RevisionSpecifier) ([]string, error) {
-	r0, r1 := m.ResolveRevisionsFunc.nextHook()(v0, v1, v2)
-	m.ResolveRevisionsFunc.appendCall(GitserverClientResolveRevisionsFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the ResolveRevisions
-// method of the parent MockGitserverClient instance is invoked and the hook
-// queue is empty.
-func (f *GitserverClientResolveRevisionsFunc) SetDefaultHook(hook func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ResolveRevisions method of the parent MockGitserverClient instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *GitserverClientResolveRevisionsFunc) PushHook(hook func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *GitserverClientResolveRevisionsFunc) SetDefaultReturn(r0 []string, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *GitserverClientResolveRevisionsFunc) PushReturn(r0 []string, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error) {
-		return r0, r1
-	})
-}
-
-func (f *GitserverClientResolveRevisionsFunc) nextHook() func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *GitserverClientResolveRevisionsFunc) appendCall(r0 GitserverClientResolveRevisionsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of GitserverClientResolveRevisionsFuncCall
-// objects describing the invocations of this function.
-func (f *GitserverClientResolveRevisionsFunc) History() []GitserverClientResolveRevisionsFuncCall {
-	f.mutex.Lock()
-	history := make([]GitserverClientResolveRevisionsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// GitserverClientResolveRevisionsFuncCall is an object that describes an
-// invocation of method ResolveRevisions on an instance of
-// MockGitserverClient.
-type GitserverClientResolveRevisionsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.RepoName
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 []protocol.RevisionSpecifier
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []string
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c GitserverClientResolveRevisionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c GitserverClientResolveRevisionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/gitserver/commands.go
+++ b/internal/gitserver/commands.go
@@ -34,7 +34,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/byteutils"
 	"github.com/sourcegraph/sourcegraph/internal/fileutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
-	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	proto "github.com/sourcegraph/sourcegraph/internal/gitserver/v1"
 	"github.com/sourcegraph/sourcegraph/internal/grpc/streamio"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -435,12 +434,6 @@ func (c *clientImplementor) DiffSymbols(ctx context.Context, repo api.RepoName, 
 		},
 	})
 	defer endObservation(1, observation.Args{})
-
-	// Ensure commits exist to provide a better error message
-	_, err = c.ResolveRevisions(ctx, repo, []protocol.RevisionSpecifier{{RevSpec: string(commitA)}, {RevSpec: string(commitB)}})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to lookup revisions for git diff on %s between %s and %s", repo, commitA, commitB)
-	}
 
 	command := c.gitCommand(repo, "diff", "-z", "--name-status", "--no-renames", string(commitA), string(commitB))
 	out, err := command.Output(ctx)

--- a/internal/gitserver/internal_test.go
+++ b/internal/gitserver/internal_test.go
@@ -1,11 +1,8 @@
 package gitserver
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func BenchmarkAddrForKey(b *testing.B) {
@@ -20,16 +17,5 @@ func BenchmarkAddrForKey(b *testing.B) {
 				addrForKey("foo", nodes)
 			}
 		})
-	}
-}
-
-func Test_readResponseBody(t *testing.T) {
-	// The \n in the end is important to test that readResponseBody correctly removes it from the returned string.
-	reader := bytes.NewReader([]byte("A test string that is more than 40 bytes long. Lorem ipsum whatever whatever\n"))
-
-	expected := "A test string that is more than 40 bytes long. Lorem ipsum whatever whatever"
-	got := readResponseBody(reader)
-	if diff := cmp.Diff([]byte(expected), []byte(got)); diff != "" {
-		t.Fatalf("Mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/gitserver/mocks_temp.go
+++ b/internal/gitserver/mocks_temp.go
@@ -154,9 +154,6 @@ type MockClient struct {
 	// ResolveRevisionFunc is an instance of a mock function object
 	// controlling the behavior of the method ResolveRevision.
 	ResolveRevisionFunc *ClientResolveRevisionFunc
-	// ResolveRevisionsFunc is an instance of a mock function object
-	// controlling the behavior of the method ResolveRevisions.
-	ResolveRevisionsFunc *ClientResolveRevisionsFunc
 	// RevListFunc is an instance of a mock function object controlling the
 	// behavior of the method RevList.
 	RevListFunc *ClientRevListFunc
@@ -396,11 +393,6 @@ func NewMockClient() *MockClient {
 		},
 		ResolveRevisionFunc: &ClientResolveRevisionFunc{
 			defaultHook: func(context.Context, api.RepoName, string, ResolveRevisionOptions) (r0 api.CommitID, r1 error) {
-				return
-			},
-		},
-		ResolveRevisionsFunc: &ClientResolveRevisionsFunc{
-			defaultHook: func(context.Context, api.RepoName, []protocol.RevisionSpecifier) (r0 []string, r1 error) {
 				return
 			},
 		},
@@ -661,11 +653,6 @@ func NewStrictMockClient() *MockClient {
 				panic("unexpected invocation of MockClient.ResolveRevision")
 			},
 		},
-		ResolveRevisionsFunc: &ClientResolveRevisionsFunc{
-			defaultHook: func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error) {
-				panic("unexpected invocation of MockClient.ResolveRevisions")
-			},
-		},
 		RevListFunc: &ClientRevListFunc{
 			defaultHook: func(context.Context, string, string, func(commit string) (bool, error)) error {
 				panic("unexpected invocation of MockClient.RevList")
@@ -836,9 +823,6 @@ func NewMockClientFrom(i Client) *MockClient {
 		},
 		ResolveRevisionFunc: &ClientResolveRevisionFunc{
 			defaultHook: i.ResolveRevision,
-		},
-		ResolveRevisionsFunc: &ClientResolveRevisionsFunc{
-			defaultHook: i.ResolveRevisions,
 		},
 		RevListFunc: &ClientRevListFunc{
 			defaultHook: i.RevList,
@@ -5643,117 +5627,6 @@ func (c ClientResolveRevisionFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c ClientResolveRevisionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// ClientResolveRevisionsFunc describes the behavior when the
-// ResolveRevisions method of the parent MockClient instance is invoked.
-type ClientResolveRevisionsFunc struct {
-	defaultHook func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error)
-	hooks       []func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error)
-	history     []ClientResolveRevisionsFuncCall
-	mutex       sync.Mutex
-}
-
-// ResolveRevisions delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockClient) ResolveRevisions(v0 context.Context, v1 api.RepoName, v2 []protocol.RevisionSpecifier) ([]string, error) {
-	r0, r1 := m.ResolveRevisionsFunc.nextHook()(v0, v1, v2)
-	m.ResolveRevisionsFunc.appendCall(ClientResolveRevisionsFuncCall{v0, v1, v2, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the ResolveRevisions
-// method of the parent MockClient instance is invoked and the hook queue is
-// empty.
-func (f *ClientResolveRevisionsFunc) SetDefaultHook(hook func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// ResolveRevisions method of the parent MockClient instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *ClientResolveRevisionsFunc) PushHook(hook func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *ClientResolveRevisionsFunc) SetDefaultReturn(r0 []string, r1 error) {
-	f.SetDefaultHook(func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *ClientResolveRevisionsFunc) PushReturn(r0 []string, r1 error) {
-	f.PushHook(func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error) {
-		return r0, r1
-	})
-}
-
-func (f *ClientResolveRevisionsFunc) nextHook() func(context.Context, api.RepoName, []protocol.RevisionSpecifier) ([]string, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *ClientResolveRevisionsFunc) appendCall(r0 ClientResolveRevisionsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of ClientResolveRevisionsFuncCall objects
-// describing the invocations of this function.
-func (f *ClientResolveRevisionsFunc) History() []ClientResolveRevisionsFuncCall {
-	f.mutex.Lock()
-	history := make([]ClientResolveRevisionsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// ClientResolveRevisionsFuncCall is an object that describes an invocation
-// of method ResolveRevisions on an instance of MockClient.
-type ClientResolveRevisionsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 api.RepoName
-	// Arg2 is the value of the 3rd argument passed to this method
-	// invocation.
-	Arg2 []protocol.RevisionSpecifier
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []string
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c ClientResolveRevisionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c ClientResolveRevisionsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/gitserver/observability.go
+++ b/internal/gitserver/observability.go
@@ -50,7 +50,6 @@ type operations struct {
 	perforceGetChangelist    *observation.Operation
 	createCommitFromPatch    *observation.Operation
 	getObject                *observation.Operation
-	resolveRevisions         *observation.Operation
 	commitGraph              *observation.Operation
 	refDescriptions          *observation.Operation
 	branchesContaining       *observation.Operation
@@ -148,7 +147,6 @@ func newOperations(observationCtx *observation.Context) *operations {
 		perforceGetChangelist:    op("PerforceGetChangelist"),
 		createCommitFromPatch:    op("CreateCommitFromPatch"),
 		getObject:                op("GetObject"),
-		resolveRevisions:         op("ResolveRevisions"),
 		commitGraph:              op("CommitGraph"),
 		refDescriptions:          op("RefDescriptions"),
 		branchesContaining:       op("BranchesContaining"),

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -16,7 +16,7 @@ import (
 
 type SearchRequest struct {
 	Repo                 api.RepoName
-	Revisions            []RevisionSpecifier
+	Revisions            []string
 	Query                Node
 	IncludeDiff          bool
 	Limit                int
@@ -26,7 +26,7 @@ type SearchRequest struct {
 func (r *SearchRequest) ToProto() *proto.SearchRequest {
 	revs := make([]*proto.RevisionSpecifier, 0, len(r.Revisions))
 	for _, rev := range r.Revisions {
-		revs = append(revs, rev.ToProto())
+		revs = append(revs, &proto.RevisionSpecifier{RevSpec: rev})
 	}
 	return &proto.SearchRequest{
 		Repo:                 string(r.Repo),
@@ -44,9 +44,9 @@ func SearchRequestFromProto(p *proto.SearchRequest) (*SearchRequest, error) {
 		return nil, err
 	}
 
-	revisions := make([]RevisionSpecifier, 0, len(p.GetRevisions()))
+	revisions := make([]string, 0, len(p.GetRevisions()))
 	for _, rev := range p.GetRevisions() {
-		revisions = append(revisions, RevisionSpecifierFromProto(rev))
+		revisions = append(revisions, rev.GetRevSpec())
 	}
 
 	return &SearchRequest{
@@ -57,24 +57,6 @@ func SearchRequestFromProto(p *proto.SearchRequest) (*SearchRequest, error) {
 		Limit:                int(p.GetLimit()),
 		IncludeModifiedFiles: p.GetIncludeModifiedFiles(),
 	}, nil
-}
-
-type RevisionSpecifier struct {
-	// RevSpec is a revision range specifier suitable for passing to git. See
-	// the manpage gitrevisions(7).
-	RevSpec string
-}
-
-func (r *RevisionSpecifier) ToProto() *proto.RevisionSpecifier {
-	return &proto.RevisionSpecifier{
-		RevSpec: r.RevSpec,
-	}
-}
-
-func RevisionSpecifierFromProto(p *proto.RevisionSpecifier) RevisionSpecifier {
-	return RevisionSpecifier{
-		RevSpec: p.GetRevSpec(),
-	}
 }
 
 type SearchEventMatches []CommitMatch

--- a/internal/gitserver/protocol/gitserver_test.go
+++ b/internal/gitserver/protocol/gitserver_test.go
@@ -13,7 +13,7 @@ import (
 func TestSearchRequestProtoRoundtrip(t *testing.T) {
 	req := &SearchRequest{
 		Repo:      "test1",
-		Revisions: []RevisionSpecifier{{RevSpec: "ABC"}},
+		Revisions: []string{"ABC"},
 		Query: &Operator{
 			Kind: And,
 			Operands: []Node{

--- a/internal/gitserver/search/search.go
+++ b/internal/gitserver/search/search.go
@@ -85,7 +85,7 @@ type CommitSearcher struct {
 	Logger               log.Logger
 	RepoDir              string
 	Query                MatchTree
-	Revisions            []protocol.RevisionSpecifier
+	Revisions            []string
 	IncludeDiff          bool
 	IncludeModifiedFiles bool
 	RepoName             api.RepoName
@@ -141,6 +141,18 @@ func (cs *CommitSearcher) gitArgs() []string {
 		args = append(args, "--name-status")
 	}
 	return args
+}
+
+func revsToGitArgs(revs []string) []string {
+	revArgs := make([]string, 0, len(revs))
+	for _, rev := range revs {
+		if rev != "" {
+			revArgs = append(revArgs, rev)
+		} else {
+			revArgs = append(revArgs, "HEAD")
+		}
+	}
+	return revArgs
 }
 
 func (cs *CommitSearcher) feedBatches(ctx context.Context, jobs chan job, resultChans chan chan *protocol.CommitMatch) (err error) {
@@ -261,18 +273,6 @@ func (cs *CommitSearcher) runJobs(ctx context.Context, jobs chan job) error {
 		errs = errors.Append(errs, runJob(j))
 	}
 	return errs
-}
-
-func revsToGitArgs(revs []protocol.RevisionSpecifier) []string {
-	revArgs := make([]string, 0, len(revs))
-	for _, rev := range revs {
-		if rev.RevSpec != "" {
-			revArgs = append(revArgs, rev.RevSpec)
-		} else {
-			revArgs = append(revArgs, "HEAD")
-		}
-	}
-	return revArgs
 }
 
 // RawCommit is a shallow parse of the output of git log

--- a/internal/gitserver/search/search_test.go
+++ b/internal/gitserver/search/search_test.go
@@ -756,19 +756,17 @@ func (authorNameGenerator) Generate(rand *rand.Rand, size int) reflect.Value {
 func Test_revsToGitArgs(t *testing.T) {
 	cases := []struct {
 		name     string
-		revSpecs []protocol.RevisionSpecifier
+		revSpecs []string
 		expected []string
 	}{
 		{
-			name: "explicit HEAD",
-			revSpecs: []protocol.RevisionSpecifier{{
-				RevSpec: "HEAD",
-			}},
+			name:     "explicit HEAD",
+			revSpecs: []string{"HEAD"},
 			expected: []string{"HEAD"},
 		},
 		{
 			name:     "implicit HEAD",
-			revSpecs: []protocol.RevisionSpecifier{{}},
+			revSpecs: []string{""},
 			expected: []string{"HEAD"},
 		},
 	}

--- a/internal/search/commit/BUILD.bazel
+++ b/internal/search/commit/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//internal/api",
         "//internal/database",
         "//internal/errcode",
+        "//internal/gitserver",
         "//internal/gitserver/gitdomain",
         "//internal/gitserver/protocol",
         "//internal/search",


### PR DESCRIPTION
To migrate ResolveRevision to gRPC, I'm removing this endpoint in favor of individual calls
for now.
This will simplify the migration. If someone was requesting hundreds of revs here, this will
actually give us better metrics about that, and we'll be able to fix it again.

## Test plan

Adjusted existing tests.
