### PR TITLE
[DO NOT MERGE] Allow a url to be specified for bedrock 

### DIFF
--- a/internal/completions/client/awsbedrock/BUILD.bazel
+++ b/internal/completions/client/awsbedrock/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//internal/completions/types",
         "//internal/httpcli",
         "//lib/errors",
+        "@com_github_aws_aws_sdk_go_v2//aws",
         "@com_github_aws_aws_sdk_go_v2//aws/signer/v4:signer",
         "@com_github_aws_aws_sdk_go_v2_aws_protocol_eventstream//:eventstream",
         "@com_github_aws_aws_sdk_go_v2_config//:config",


### PR DESCRIPTION
Previously Bedrock required putting the aws region in the completions end point.  This is an attempt to allow setting an full url in additional to using the `AWS_REGION` env var.
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
