### PR TITLE
release: ignore CHANGELOG.mdx in docs repo when updating server tags

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -738,7 +738,7 @@ cc @${release.captainGitHubUsername}
                         title: defaultPRMessage,
                         edits: [
                             // Update sourcegraph/server:VERSION everywhere except changelog
-                            `find . -type f -name '*.mdx' ! -name 'CHANGELOG.md' -exec ${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version.version}/g' {} +`,
+                            `find . -type f -name '*.mdx' ! -name 'doc/CHANGELOG.md' -exec ${sed} -i -E 's/sourcegraph\\/server:${versionRegex}/sourcegraph\\/server:${release.version.version}/g' {} +`,
                             // Update Sourcegraph versions in installation guides
                             `find ./docs/admin/deploy/ -type f -name '*.mdx' -exec ${sed} -i -E 's/SOURCEGRAPH_VERSION="v${versionRegex}"/SOURCEGRAPH_VERSION="v${release.version.version}"/g' {} +`,
                             `find ./docs/admin/deploy/ -type f -name '*.mdx' -exec ${sed} -i -E 's/--version ${versionRegex}/--version ${release.version.version}/g' {} +`,


### PR DESCRIPTION
We should be ignoring updating `sourcegraph/server` in the changelog for `docs`, this is because we have some entries that specifies changes at a certain version.

## Test plan

We'll find out lol.

![CleanShot 2024-02-13 at 20 47 13@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/b857f6f2-4f00-42bf-9ee4-f44a2f0c593b)
