### PR TITLE
release: commit version mutations from bake-content step

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -54,6 +54,9 @@
         "version": "5.3.0",
         "previous": "5.2.7"
       }
-    ]
+    ],
+    "googleExecutorVersion": "5.3.0",
+    "awsExecutorVersion": "5.3.0",
+    "srcCliVersion": "5.3.0"
   }
 }


### PR DESCRIPTION
The step mutated the release config to include these fields. We should either commit this or remove the part of the tool which mutates the config.

Test Plan: n/a