### PR TITLE
Revert "oidc: add prompt login option (#60036)"

### DIFF
--- a/cmd/frontend/internal/auth/openidconnect/middleware.go
+++ b/cmd/frontend/internal/auth/openidconnect/middleware.go
@@ -439,11 +439,9 @@ func RedirectToAuthRequest(w http.ResponseWriter, r *http.Request, p *Provider, 
 	// validating the response to the ID Token request. We re-use the Authn request
 	// state as the nonce.
 	//
-	// The "prompt=login" asks the OP to prompt the user for re-authentication.
-	//
 	// See http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest of the
 	// OIDC spec.
-	authURL := p.oauth2Config().AuthCodeURL(oidcState, oidc.Nonce(oidcState)) + "&prompt=login"
+	authURL := p.oauth2Config().AuthCodeURL(oidcState, oidc.Nonce(oidcState))
 	// Pass along the prompt_auth to OP for the specific type of authentication to
 	// use, e.g. "github", "gitlab", "google".
 	promptAuth := r.URL.Query().Get("prompt_auth")


### PR DESCRIPTION
This reverts commit 4c5a558d5c4cc234f8d0e4edd448b09e892c6554.

After [some discussions](https://sourcegraph.slack.com/archives/C06HHK23QR4/p1707419775776459), asking users to "sign out twice" may end up with less trouble than "always sign in".

## Test plan

CI