### PR TITLE
gitserver: Calculate repo size less frequently in janitor

### DIFF
--- a/cmd/gitserver/internal/cleanup_test.go
+++ b/cmd/gitserver/internal/cleanup_test.go
@@ -60,10 +60,6 @@ func TestCleanup_computeStats(t *testing.T) {
 		}
 	}
 
-	// This may be different in practice, but the way we setup the tests
-	// we only have .git dirs to measure so this is correct.
-	wantGitDirBytes := gitserverfs.DirSize(root)
-
 	logger, capturedLogs := logtest.Captured(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 
@@ -89,6 +85,10 @@ UPDATE gitserver_repos SET repo_size_bytes = 5 where repo_id = 3;
 		gitserver.GitserverAddresses{Addresses: []string{"test-gitserver"}},
 		false,
 	)
+
+	// This may be different in practice, but the way we setup the tests
+	// we only have .git dirs to measure so this is correct.
+	wantGitDirBytes := gitserverfs.DirSize(root)
 
 	for i := 1; i <= 3; i++ {
 		repo, err := db.GitserverRepos().GetByID(context.Background(), api.RepoID(i))


### PR DESCRIPTION
In the janitor, we calculate the repo size. That is quite IO heavy and expensive, and every fetch (basically the only writing operation) runs this, too. So janitor is mostly doing that to ensure that things don't get terribly out of sync, if some issues occur.

Given that, we don't need to run this every time. Instead, we can run it only once a day. In reality, probably less often. We can adjust as needed.

Also moves it to the end of the janitor operations, to collect a size that's not outdated immediately when the next janitor step runs.

## Test plan

Verified the setting works locally.