### PR TITLE
msp/loadbalancer: add config to enable logging

### DIFF
--- a/dev/managedservicesplatform/internal/resource/loadbalancer/loadbalancer.go
+++ b/dev/managedservicesplatform/internal/resource/loadbalancer/loadbalancer.go
@@ -42,6 +42,8 @@ type Config struct {
 	CloudflareProxied bool
 	// Production is true if environments[].category is `internal` or `external` but not `test`
 	Production bool
+	// EnableLogging enables always-on logging for the backend.
+	EnableLogging bool
 }
 
 type SSLCertificate interface {
@@ -100,6 +102,11 @@ func New(scope constructs.Construct, id resourceid.ID, config Config) (*Output, 
 				}
 				return nil
 			}(),
+			LogConfig: &computebackendservice.ComputeBackendServiceLogConfig{
+				// https://cloud.google.com/load-balancing/docs/https/https-logging-monitoring#viewing_logs
+				Enable:     config.EnableLogging,
+				SampleRate: pointers.Float64(1), // always-sample when logging is enabled
+			},
 
 			Backend: []*computebackendservice.ComputeBackendServiceBackend{{
 				Group: endpointGroup.Id(),

--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -263,6 +263,10 @@ type EnvironmentServiceDomainSpec struct {
 	// Type is one of 'none' or 'cloudflare'. If empty, defaults to 'none'.
 	Type       EnvironmentDomainType            `yaml:"type"`
 	Cloudflare *EnvironmentDomainCloudflareSpec `yaml:"cloudflare,omitempty"`
+
+	// Networking configures additional networking configuration.
+	// Only applicable if a domain 'type' is configured.
+	Networking *EnvironmentDomainNetworkingSpec `yaml:"networking,omitempty"`
 }
 
 // GetDNSName generates the DNS name for the environment. If nil or not configured,
@@ -293,10 +297,6 @@ type EnvironmentDomainCloudflareSpec struct {
 	//
 	// Default: true
 	Proxied *bool `yaml:"proxied,omitempty"`
-
-	// Required configures whether traffic can only be allowed through Cloudflare.
-	// TODO: Unimplemented.
-	Required bool `yaml:"required,omitempty"`
 }
 
 // ShouldProxy evaluates whether Cloudflare WAF proxying should be used.
@@ -305,6 +305,14 @@ func (e *EnvironmentDomainCloudflareSpec) ShouldProxy() bool {
 		return false
 	}
 	return pointers.Deref(e.Proxied, true)
+}
+
+type EnvironmentDomainNetworkingSpec struct {
+	// LoadBalancerLogging enables logs on load balancers:
+	// https://cloud.google.com/load-balancing/docs/https/https-logging-monitoring#viewing_logs
+	//
+	// Defaults to false. When enabled, no sampling is configured.
+	LoadBalancerLogging *bool `yaml:"loadBalancerLogging,omitempty"`
 }
 
 type EnvironmentInstancesSpec struct {

--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
@@ -281,6 +281,7 @@ func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variable
 			SSLCertificate:    sslCertificate,
 			CloudflareProxied: domain.Cloudflare.ShouldProxy(),
 			Production:        vars.Environment.Category.IsProduction(),
+			EnableLogging:     pointers.DerefZero(pointers.DerefZero(domain.Networking).LoadBalancerLogging),
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "loadbalancer.New")


### PR DESCRIPTION
These can be pretty high-volume, so I think it might be best to leave it opt-in for now

## Test plan

click-ops the equivalent change