### PR TITLE
msp/alertpolicy: unify on generalized policy builder, with custom condition builders

### DIFF
--- a/dev/managedservicesplatform/internal/resource/alertpolicy/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/BUILD.bazel
@@ -3,7 +3,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "alertpolicy",
-    srcs = ["alertpolicy.go"],
+    srcs = [
+        "alertpolicy.go",
+        "responsecode.go",
+        "thresholdaggregation.go",
+    ],
     importpath = "github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy",
     visibility = ["//dev/managedservicesplatform:__subpackages__"],
     deps = [
@@ -19,7 +23,10 @@ go_library(
 
 go_test(
     name = "alertpolicy_test",
-    srcs = ["alertpolicy_test.go"],
+    srcs = [
+        "responsecode_test.go",
+        "thresholdaggregation_test.go",
+    ],
     embed = [":alertpolicy"],
     deps = [
         "//lib/pointers",

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/alertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/alertpolicy.go
@@ -230,6 +230,8 @@ func New(scope constructs.Construct, id resourceid.ID, config *Config) (*Output,
 		}
 	case config.ResponseCodeMetric != nil:
 		condition = newResponseCodeMetricCondition(config)
+	default:
+		return nil, errors.New("no condition configuration provided")
 	}
 
 	// Build the final alert policy

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/alertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/alertpolicy.go
@@ -149,7 +149,6 @@ If you need additional assistance, reach out to #discuss-core-services.`,
 type NotificationChannels map[SeverityLevel][]monitoringnotificationchannel.MonitoringNotificationChannel
 
 // Config for a Monitoring Alert Policy
-// Must define either `ThresholdAggregation` or `ResponseCodeMetric`
 type Config struct {
 	Service       spec.ServiceSpec
 	EnvironmentID string
@@ -258,9 +257,6 @@ func New(scope constructs.Construct, id resourceid.ID, config *Config) (*Output,
 				AutoClose: pointers.Ptr("86400s"), // 24 hours
 			},
 			NotificationChannels: notificationChannelIDs(config.NotificationChannels[config.Severity]),
-			// For now, set all MSP alerts as WARNING. In the future, we should
-			// have different severity levels.
-			// https://github.com/sourcegraph/managed-services/issues/385
 			// Possible values: ["CRITICAL", "ERROR", "WARNING"]
 			Severity: pointers.Ptr(string(config.Severity)),
 

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/alertpolicy.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/alertpolicy.go
@@ -2,9 +2,6 @@ package alertpolicy
 
 import (
 	"fmt"
-	"sort"
-	"strconv"
-	"strings"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 
@@ -78,12 +75,16 @@ const (
 type ThresholdAggregation struct {
 	Filters       map[string]string
 	GroupByFields []string
-	Comparison    Comparison
-	Aligner       Aligner
-	Reducer       Reducer
-	Period        string
-	Threshold     float64
-	Duration      string
+
+	// Aggregations
+	Aligner   Aligner
+	Reducer   Reducer
+	Period    string
+	Threshold float64
+
+	Duration string
+
+	Comparison Comparison
 
 	// Trigger is the strategy for determining if an alert should fire based
 	// on the thresholds.
@@ -217,50 +218,23 @@ func New(scope constructs.Construct, id resourceid.ID, config *Config) (*Output,
 		config.Severity = SeverityLevelWarning
 	}
 
-	if config.ThresholdAggregation != nil {
-		if len(config.ThresholdAggregation.Filters) == 0 {
-			return nil, errors.New("must specify at least one filter for threshold aggregation")
+	// Build the condition, each of which may have special handling and additional
+	// defaults based on recommendations and other best practices
+	var condition *monitoringalertpolicy.MonitoringAlertPolicyConditions
+	switch {
+	case config.ThresholdAggregation != nil:
+		var err error
+		condition, err = newThresholdAggregationCondition(config)
+		if err != nil {
+			return nil, errors.Wrap(err, "newThresholdAggregationCondition")
 		}
-
-		if _, ok := config.ThresholdAggregation.Filters["metric.type"]; !ok {
-			return nil, errors.New("must specify filter for `metric.type`")
-		}
-		return newThresholdAggregationAlert(scope, id, config)
-	}
-	return newResponseCodeMetricAlert(scope, id, config)
-}
-
-// threshholdAggregation defines a monitoring alert policy based on a single metric threshold
-func newThresholdAggregationAlert(scope constructs.Construct, id resourceid.ID, config *Config) (*Output, error) {
-	// Set some defaults
-	switch config.ResourceKind {
-	case CloudRunService:
-		config.ThresholdAggregation.GroupByFields = append(
-			[]string{"resource.label.revision_name"},
-			config.ThresholdAggregation.GroupByFields...)
-
-	case CloudSQLDatabase:
-		config.ThresholdAggregation.GroupByFields = append(
-			[]string{"resource.label.database"},
-			config.ThresholdAggregation.GroupByFields...)
-
-	case CloudRunJob, CloudRedis, URLUptime, CloudSQL, "":
-		// No defaults
-
-	default:
-		return nil, errors.Newf("invalid service kind %q", config.ResourceKind)
+	case config.ResponseCodeMetric != nil:
+		condition = newResponseCodeMetricCondition(config)
 	}
 
-	if config.ThresholdAggregation.Comparison == "" {
-		config.ThresholdAggregation.Comparison = ComparisonGT
-	}
-
-	if config.ThresholdAggregation.Duration == "" {
-		config.ThresholdAggregation.Duration = "0s"
-	}
-
-	_ = monitoringalertpolicy.NewMonitoringAlertPolicy(scope,
-		id.TerraformID(config.ID), &monitoringalertpolicy.MonitoringAlertPolicyConfig{
+	// Build the final alert policy
+	_ = monitoringalertpolicy.NewMonitoringAlertPolicy(scope, id.TerraformID(config.ID),
+		&monitoringalertpolicy.MonitoringAlertPolicyConfig{
 			Project:     pointers.Ptr(config.ProjectID),
 			DisplayName: pointers.Ptr(config.Name),
 			Documentation: &monitoringalertpolicy.MonitoringAlertPolicyDocumentation{
@@ -286,178 +260,12 @@ func newThresholdAggregationAlert(scope constructs.Construct, id resourceid.ID, 
 			// have different severity levels.
 			// https://github.com/sourcegraph/managed-services/issues/385
 			// Possible values: ["CRITICAL", "ERROR", "WARNING"]
-			Severity: pointers.Ptr("WARNING"),
+			Severity: pointers.Ptr(string(config.Severity)),
 
 			// Conditions
-			Combiner: pointers.Ptr("OR"),
-			Conditions: []monitoringalertpolicy.MonitoringAlertPolicyConditions{
-				{
-					DisplayName: pointers.Ptr(config.Name),
-					ConditionThreshold: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThreshold{
-						Aggregations: []monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdAggregations{
-							{
-								AlignmentPeriod:    pointers.Ptr(config.ThresholdAggregation.Period),
-								PerSeriesAligner:   pointers.NonZeroPtr(string(config.ThresholdAggregation.Aligner)),
-								CrossSeriesReducer: pointers.NonZeroPtr(string(config.ThresholdAggregation.Reducer)),
-								GroupByFields:      pointers.Ptr(pointers.Slice(config.ThresholdAggregation.GroupByFields)),
-							},
-						},
-						Comparison:     pointers.Ptr(string(config.ThresholdAggregation.Comparison)),
-						Duration:       pointers.Ptr(config.ThresholdAggregation.Duration),
-						Filter:         pointers.Ptr(buildFilter(config)),
-						ThresholdValue: pointers.Float64(config.ThresholdAggregation.Threshold),
-						Trigger: func() *monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger {
-							switch config.ThresholdAggregation.Trigger {
-							case TriggerKindAllInViolation:
-								return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
-									Percent: pointers.Float64(100),
-								}
-
-							case TriggerKindAnyViolation:
-								fallthrough
-							default:
-								return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
-									Count: pointers.Float64(1),
-								}
-							}
-						}(),
-					},
-				},
-			},
+			Combiner:   pointers.Ptr("OR"),
+			Conditions: []*monitoringalertpolicy.MonitoringAlertPolicyConditions{condition},
 		})
+
 	return &Output{}, nil
-}
-
-// buildFilter creates the Filter string for a ThresholdAggregation monitoring alert policy
-func buildFilter(config *Config) string {
-	filters := make([]string, 0)
-	for key, val := range config.ThresholdAggregation.Filters {
-		filters = append(filters, fmt.Sprintf(`%s = "%s"`, key, val))
-	}
-
-	// Sort to ensure stable output for testing, because
-	// config.ThresholdAggregation.Filters is a map.
-	sort.Strings(filters)
-
-	switch config.ResourceKind {
-	case CloudRunService:
-		filters = append(filters,
-			`resource.type = "cloud_run_revision"`,
-			fmt.Sprintf(`resource.labels.service_name = starts_with("%s")`, config.ResourceName),
-		)
-	case CloudRunJob:
-		filters = append(filters,
-			`resource.type = "cloud_run_job"`,
-			fmt.Sprintf(`resource.labels.job_name = starts_with("%s")`, config.ResourceName),
-		)
-	case CloudRedis:
-		filters = append(filters,
-			`resource.type = "redis_instance"`,
-			fmt.Sprintf(`resource.labels.instance_id = "%s"`, config.ResourceName),
-		)
-	case CloudSQL:
-		filters = append(filters,
-			`resource.type = "cloudsql_database"`,
-			fmt.Sprintf(`resource.labels.database_id = "%s"`, config.ResourceName))
-	case CloudSQLDatabase:
-		filters = append(filters,
-			`resource.type = "cloudsql_instance_database"`,
-			fmt.Sprintf(`resource.labels.resource_id = "%s"`, config.ResourceName))
-	case URLUptime:
-		filters = append(filters,
-			`resource.type = "uptime_url"`,
-			fmt.Sprintf(`metric.labels.check_id = "%s"`, config.ResourceName),
-		)
-	}
-
-	return strings.Join(filters, " AND ")
-}
-
-// newResponseCodeMetricAlert defines the MonitoringAlertPolicy for response code metrics
-// Supports a single Code e.g. 404 or an entire Code Class e.g. 4xx
-// Optionally when using a Code Class, codes to exclude can be defined
-func newResponseCodeMetricAlert(scope constructs.Construct, id resourceid.ID, config *Config) (*Output, error) {
-	query := responseCodeBuilder(config)
-
-	if config.ResponseCodeMetric.Duration == nil {
-		config.ResponseCodeMetric.Duration = pointers.Ptr("60s")
-	}
-
-	_ = monitoringalertpolicy.NewMonitoringAlertPolicy(scope,
-		id.TerraformID(config.ID), &monitoringalertpolicy.MonitoringAlertPolicyConfig{
-			Project:     pointers.Ptr(config.ProjectID),
-			DisplayName: pointers.Ptr(config.Name),
-			Documentation: &monitoringalertpolicy.MonitoringAlertPolicyDocumentation{
-				Subject:  pointers.Ptr(config.makeDocsSubject()),
-				Content:  pointers.Ptr(config.Description),
-				MimeType: pointers.Ptr("text/markdown"),
-			},
-			Combiner: pointers.Ptr("OR"),
-			Conditions: []monitoringalertpolicy.MonitoringAlertPolicyConditions{
-				{
-					DisplayName: pointers.Ptr(config.Name),
-					ConditionMonitoringQueryLanguage: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionMonitoringQueryLanguage{
-						Query:    pointers.Ptr(query),
-						Duration: config.ResponseCodeMetric.Duration,
-						Trigger: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionMonitoringQueryLanguageTrigger{
-							Count: pointers.Float64(1),
-						},
-					},
-				},
-			},
-			AlertStrategy: &monitoringalertpolicy.MonitoringAlertPolicyAlertStrategy{
-				AutoClose: pointers.Ptr("86400s"),
-			},
-			NotificationChannels: notificationChannelIDs(config.NotificationChannels[config.Severity]),
-		})
-	return &Output{}, nil
-}
-
-// responseCodeBuilder builds the MQL for a response code metric alert
-func responseCodeBuilder(config *Config) string {
-	var builder strings.Builder
-
-	builder.WriteString(`fetch cloud_run_revision
-| metric 'run.googleapis.com/request_count'
-| group_by 15s, [value_request_count_aggregate: aggregate(value.request_count)]
-| every 15s
-| {
-`)
-	if config.ResponseCodeMetric.CodeClass != nil {
-		builder.WriteString("  group_by [metric.response_code, metric.response_code_class],\n")
-	} else {
-		builder.WriteString("  group_by [metric.response_code],\n")
-	}
-	builder.WriteString("  [response_code_count_aggregate: aggregate(value_request_count_aggregate)]\n")
-	if config.ResponseCodeMetric.Code != nil {
-		builder.WriteString(fmt.Sprintf("  | filter (metric.response_code = '%d')\n", *config.ResponseCodeMetric.Code))
-	} else {
-		builder.WriteString(fmt.Sprintf("  | filter (metric.response_code_class = '%s')\n", *config.ResponseCodeMetric.CodeClass))
-	}
-	if config.ResponseCodeMetric.ExcludeCodes != nil && len(config.ResponseCodeMetric.ExcludeCodes) > 0 {
-		for _, code := range config.ResponseCodeMetric.ExcludeCodes {
-			builder.WriteString(fmt.Sprintf("  | filter (metric.response_code != '%s')\n", code))
-		}
-	}
-	builder.WriteString(`; group_by [],
-  [value_request_count_aggregate_aggregate: aggregate(value_request_count_aggregate)]
-}
-| join
-| value [response_code_ratio: val(0) / val(1)]
-`)
-	builder.WriteString(fmt.Sprintf("| condition gt(val(), %s)\n", strconv.FormatFloat(config.ResponseCodeMetric.Ratio, 'f', -1, 64)))
-	return builder.String()
-}
-
-// notificationChannelIDs collects the IDs of the given notification channels.
-// Returns nil if there are no channels.
-func notificationChannelIDs(channels []monitoringnotificationchannel.MonitoringNotificationChannel) *[]*string {
-	if len(channels) == 0 {
-		return nil
-	}
-	var ids []*string
-	for _, c := range channels {
-		ids = append(ids, c.Id())
-	}
-	return &ids
 }

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/responsecode.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/responsecode.go
@@ -1,0 +1,83 @@
+package alertpolicy
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringalertpolicy"
+	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringnotificationchannel"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+// newResponseCodeMetricCondition defines the alert condition for response code metrics
+// Supports a single Code e.g. 404 or an entire Code Class e.g. 4xx
+// Optionally when using a Code Class, codes to exclude can be defined
+func newResponseCodeMetricCondition(config *Config) *monitoringalertpolicy.MonitoringAlertPolicyConditions {
+	query := responseCodeMQLBuilder(config)
+
+	if config.ResponseCodeMetric.Duration == nil {
+		config.ResponseCodeMetric.Duration = pointers.Ptr("60s")
+	}
+
+	return &monitoringalertpolicy.MonitoringAlertPolicyConditions{
+		DisplayName: pointers.Ptr(config.Name),
+		ConditionMonitoringQueryLanguage: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionMonitoringQueryLanguage{
+			Query:    pointers.Ptr(query),
+			Duration: config.ResponseCodeMetric.Duration,
+			Trigger: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionMonitoringQueryLanguageTrigger{
+				Count: pointers.Float64(1),
+			},
+		},
+	}
+}
+
+// responseCodeMQLBuilder builds the MQL for a response code metric alert
+func responseCodeMQLBuilder(config *Config) string {
+	var builder strings.Builder
+
+	builder.WriteString(`fetch cloud_run_revision
+| metric 'run.googleapis.com/request_count'
+| group_by 15s, [value_request_count_aggregate: aggregate(value.request_count)]
+| every 15s
+| {
+`)
+	if config.ResponseCodeMetric.CodeClass != nil {
+		builder.WriteString("  group_by [metric.response_code, metric.response_code_class],\n")
+	} else {
+		builder.WriteString("  group_by [metric.response_code],\n")
+	}
+	builder.WriteString("  [response_code_count_aggregate: aggregate(value_request_count_aggregate)]\n")
+	if config.ResponseCodeMetric.Code != nil {
+		builder.WriteString(fmt.Sprintf("  | filter (metric.response_code = '%d')\n", *config.ResponseCodeMetric.Code))
+	} else {
+		builder.WriteString(fmt.Sprintf("  | filter (metric.response_code_class = '%s')\n", *config.ResponseCodeMetric.CodeClass))
+	}
+	if config.ResponseCodeMetric.ExcludeCodes != nil && len(config.ResponseCodeMetric.ExcludeCodes) > 0 {
+		for _, code := range config.ResponseCodeMetric.ExcludeCodes {
+			builder.WriteString(fmt.Sprintf("  | filter (metric.response_code != '%s')\n", code))
+		}
+	}
+	builder.WriteString(`; group_by [],
+  [value_request_count_aggregate_aggregate: aggregate(value_request_count_aggregate)]
+}
+| join
+| value [response_code_ratio: val(0) / val(1)]
+`)
+	builder.WriteString(fmt.Sprintf("| condition gt(val(), %s)\n", strconv.FormatFloat(config.ResponseCodeMetric.Ratio, 'f', -1, 64)))
+	return builder.String()
+}
+
+// notificationChannelIDs collects the IDs of the given notification channels.
+// Returns nil if there are no channels.
+func notificationChannelIDs(channels []monitoringnotificationchannel.MonitoringNotificationChannel) *[]*string {
+	if len(channels) == 0 {
+		return nil
+	}
+	var ids []*string
+	for _, c := range channels {
+		ids = append(ids, c.Id())
+	}
+	return &ids
+}

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/responsecode_test.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/responsecode_test.go
@@ -8,48 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
-func TestBuildFilter(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		config Config
-		want   autogold.Value
-	}{
-		{
-			name: "Service Metric",
-			config: Config{
-				ResourceName: "my-service-name",
-				ResourceKind: CloudRunService,
-				ThresholdAggregation: &ThresholdAggregation{
-					Filters: map[string]string{
-						"metric.type": "run.googleapis.com/container/startup_latencies",
-					},
-				},
-			},
-			want: autogold.Expect(`metric.type = "run.googleapis.com/container/startup_latencies" AND resource.type = "cloud_run_revision" AND resource.labels.service_name = starts_with("my-service-name")`),
-		},
-		{
-			name: "Job Metric",
-			config: Config{
-				ResourceName: "my-job-name",
-				ResourceKind: CloudRunJob,
-				ThresholdAggregation: &ThresholdAggregation{
-					Filters: map[string]string{
-						"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
-						"metric.labels.result": "failed",
-					},
-				},
-			},
-			want: autogold.Expect(`metric.labels.result = "failed" AND metric.type = "run.googleapis.com/job/completed_task_attempt_count" AND resource.type = "cloud_run_job" AND resource.labels.job_name = starts_with("my-job-name")`),
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := buildFilter(&tc.config)
-			tc.want.Equal(t, got)
-		})
-	}
-}
-
-func TestResponseCodeBuilder(t *testing.T) {
+func TestResponseCodeMQLBuilder(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		ResponseCodeMetric
@@ -126,7 +85,7 @@ func TestResponseCodeBuilder(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := responseCodeBuilder(&Config{
+			got := responseCodeMQLBuilder(&Config{
 				ResourceName:       "test-service",
 				ResponseCodeMetric: &tc.ResponseCodeMetric,
 			})

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/responsecode_test.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/responsecode_test.go
@@ -86,7 +86,6 @@ func TestResponseCodeMQLBuilder(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := responseCodeMQLBuilder(&Config{
-				ResourceName:       "test-service",
 				ResponseCodeMetric: &tc.ResponseCodeMetric,
 			})
 			tc.want.Equal(t, got)

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation.go
@@ -21,7 +21,7 @@ func newThresholdAggregationCondition(config *Config) (*monitoringalertpolicy.Mo
 	}
 
 	// Set some defaults for threshold aggregations
-	switch config.ResourceKind {
+	switch config.ThresholdAggregation.ResourceKind {
 	case CloudRunService:
 		config.ThresholdAggregation.GroupByFields = append(
 			[]string{"resource.label.revision_name"},
@@ -36,7 +36,7 @@ func newThresholdAggregationCondition(config *Config) (*monitoringalertpolicy.Mo
 		// No defaults
 
 	default:
-		return nil, errors.Newf("invalid service kind %q", config.ResourceKind)
+		return nil, errors.Newf("invalid service kind %q", config.ThresholdAggregation.ResourceKind)
 	}
 
 	if config.ThresholdAggregation.Comparison == "" {
@@ -91,34 +91,34 @@ func buildThresholdAggregationFilter(config *Config) string {
 	// config.ThresholdAggregation.Filters is a map.
 	sort.Strings(filters)
 
-	switch config.ResourceKind {
+	switch config.ThresholdAggregation.ResourceKind {
 	case CloudRunService:
 		filters = append(filters,
 			`resource.type = "cloud_run_revision"`,
-			fmt.Sprintf(`resource.labels.service_name = starts_with("%s")`, config.ResourceName),
+			fmt.Sprintf(`resource.labels.service_name = starts_with("%s")`, config.ThresholdAggregation.ResourceName),
 		)
 	case CloudRunJob:
 		filters = append(filters,
 			`resource.type = "cloud_run_job"`,
-			fmt.Sprintf(`resource.labels.job_name = starts_with("%s")`, config.ResourceName),
+			fmt.Sprintf(`resource.labels.job_name = starts_with("%s")`, config.ThresholdAggregation.ResourceName),
 		)
 	case CloudRedis:
 		filters = append(filters,
 			`resource.type = "redis_instance"`,
-			fmt.Sprintf(`resource.labels.instance_id = "%s"`, config.ResourceName),
+			fmt.Sprintf(`resource.labels.instance_id = "%s"`, config.ThresholdAggregation.ResourceName),
 		)
 	case CloudSQL:
 		filters = append(filters,
 			`resource.type = "cloudsql_database"`,
-			fmt.Sprintf(`resource.labels.database_id = "%s"`, config.ResourceName))
+			fmt.Sprintf(`resource.labels.database_id = "%s"`, config.ThresholdAggregation.ResourceName))
 	case CloudSQLDatabase:
 		filters = append(filters,
 			`resource.type = "cloudsql_instance_database"`,
-			fmt.Sprintf(`resource.labels.resource_id = "%s"`, config.ResourceName))
+			fmt.Sprintf(`resource.labels.resource_id = "%s"`, config.ThresholdAggregation.ResourceName))
 	case URLUptime:
 		filters = append(filters,
 			`resource.type = "uptime_url"`,
-			fmt.Sprintf(`metric.labels.check_id = "%s"`, config.ResourceName),
+			fmt.Sprintf(`metric.labels.check_id = "%s"`, config.ThresholdAggregation.ResourceName),
 		)
 	}
 

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation.go
@@ -1,0 +1,126 @@
+package alertpolicy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringalertpolicy"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func newThresholdAggregationCondition(config *Config) (*monitoringalertpolicy.MonitoringAlertPolicyConditions, error) {
+	if len(config.ThresholdAggregation.Filters) == 0 {
+		return nil, errors.New("must specify at least one filter for threshold aggregation")
+	}
+
+	if _, ok := config.ThresholdAggregation.Filters["metric.type"]; !ok {
+		return nil, errors.New("must specify filter for `metric.type`")
+	}
+
+	// Set some defaults for threshold aggregations
+	switch config.ResourceKind {
+	case CloudRunService:
+		config.ThresholdAggregation.GroupByFields = append(
+			[]string{"resource.label.revision_name"},
+			config.ThresholdAggregation.GroupByFields...)
+
+	case CloudSQLDatabase:
+		config.ThresholdAggregation.GroupByFields = append(
+			[]string{"resource.label.database"},
+			config.ThresholdAggregation.GroupByFields...)
+
+	case CloudRunJob, CloudRedis, URLUptime, CloudSQL, "":
+		// No defaults
+
+	default:
+		return nil, errors.Newf("invalid service kind %q", config.ResourceKind)
+	}
+
+	if config.ThresholdAggregation.Comparison == "" {
+		config.ThresholdAggregation.Comparison = ComparisonGT
+	}
+
+	if config.ThresholdAggregation.Duration == "" {
+		config.ThresholdAggregation.Duration = "0s"
+	}
+	return &monitoringalertpolicy.MonitoringAlertPolicyConditions{
+		DisplayName: pointers.Ptr(config.Name),
+		ConditionThreshold: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThreshold{
+			Aggregations: []monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdAggregations{
+				{
+					AlignmentPeriod:    pointers.Ptr(config.ThresholdAggregation.Period),
+					PerSeriesAligner:   pointers.NonZeroPtr(string(config.ThresholdAggregation.Aligner)),
+					CrossSeriesReducer: pointers.NonZeroPtr(string(config.ThresholdAggregation.Reducer)),
+					GroupByFields:      pointers.Ptr(pointers.Slice(config.ThresholdAggregation.GroupByFields)),
+				},
+			},
+			Comparison:     pointers.Ptr(string(config.ThresholdAggregation.Comparison)),
+			Duration:       pointers.Ptr(config.ThresholdAggregation.Duration),
+			Filter:         pointers.Ptr(buildThresholdAggregationFilter(config)),
+			ThresholdValue: pointers.Float64(config.ThresholdAggregation.Threshold),
+			Trigger: func() *monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger {
+				switch config.ThresholdAggregation.Trigger {
+				case TriggerKindAllInViolation:
+					return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
+						Percent: pointers.Float64(100),
+					}
+
+				case TriggerKindAnyViolation:
+					fallthrough
+				default:
+					return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
+						Count: pointers.Float64(1),
+					}
+				}
+			}(),
+		},
+	}, nil
+}
+
+// buildThresholdAggregationFilter creates the Filter string for a ThresholdAggregation alert condition
+func buildThresholdAggregationFilter(config *Config) string {
+	filters := make([]string, 0)
+	for key, val := range config.ThresholdAggregation.Filters {
+		filters = append(filters, fmt.Sprintf(`%s = "%s"`, key, val))
+	}
+
+	// Sort to ensure stable output for testing, because
+	// config.ThresholdAggregation.Filters is a map.
+	sort.Strings(filters)
+
+	switch config.ResourceKind {
+	case CloudRunService:
+		filters = append(filters,
+			`resource.type = "cloud_run_revision"`,
+			fmt.Sprintf(`resource.labels.service_name = starts_with("%s")`, config.ResourceName),
+		)
+	case CloudRunJob:
+		filters = append(filters,
+			`resource.type = "cloud_run_job"`,
+			fmt.Sprintf(`resource.labels.job_name = starts_with("%s")`, config.ResourceName),
+		)
+	case CloudRedis:
+		filters = append(filters,
+			`resource.type = "redis_instance"`,
+			fmt.Sprintf(`resource.labels.instance_id = "%s"`, config.ResourceName),
+		)
+	case CloudSQL:
+		filters = append(filters,
+			`resource.type = "cloudsql_database"`,
+			fmt.Sprintf(`resource.labels.database_id = "%s"`, config.ResourceName))
+	case CloudSQLDatabase:
+		filters = append(filters,
+			`resource.type = "cloudsql_instance_database"`,
+			fmt.Sprintf(`resource.labels.resource_id = "%s"`, config.ResourceName))
+	case URLUptime:
+		filters = append(filters,
+			`resource.type = "uptime_url"`,
+			fmt.Sprintf(`metric.labels.check_id = "%s"`, config.ResourceName),
+		)
+	}
+
+	return strings.Join(filters, " AND ")
+}

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation_test.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation_test.go
@@ -1,0 +1,48 @@
+package alertpolicy
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold/v2"
+)
+
+func TestBuildThresholdAggregationFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config Config
+		want   autogold.Value
+	}{
+		{
+			name: "Service Metric",
+			config: Config{
+				ResourceName: "my-service-name",
+				ResourceKind: CloudRunService,
+				ThresholdAggregation: &ThresholdAggregation{
+					Filters: map[string]string{
+						"metric.type": "run.googleapis.com/container/startup_latencies",
+					},
+				},
+			},
+			want: autogold.Expect(`metric.type = "run.googleapis.com/container/startup_latencies" AND resource.type = "cloud_run_revision" AND resource.labels.service_name = starts_with("my-service-name")`),
+		},
+		{
+			name: "Job Metric",
+			config: Config{
+				ResourceName: "my-job-name",
+				ResourceKind: CloudRunJob,
+				ThresholdAggregation: &ThresholdAggregation{
+					Filters: map[string]string{
+						"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
+						"metric.labels.result": "failed",
+					},
+				},
+			},
+			want: autogold.Expect(`metric.labels.result = "failed" AND metric.type = "run.googleapis.com/job/completed_task_attempt_count" AND resource.type = "cloud_run_job" AND resource.labels.job_name = starts_with("my-job-name")`),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildThresholdAggregationFilter(&tc.config)
+			tc.want.Equal(t, got)
+		})
+	}
+}

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation_test.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation_test.go
@@ -15,9 +15,9 @@ func TestBuildThresholdAggregationFilter(t *testing.T) {
 		{
 			name: "Service Metric",
 			config: Config{
-				ResourceName: "my-service-name",
-				ResourceKind: CloudRunService,
 				ThresholdAggregation: &ThresholdAggregation{
+					ResourceName: "my-service-name",
+					ResourceKind: CloudRunService,
 					Filters: map[string]string{
 						"metric.type": "run.googleapis.com/container/startup_latencies",
 					},
@@ -28,9 +28,9 @@ func TestBuildThresholdAggregationFilter(t *testing.T) {
 		{
 			name: "Job Metric",
 			config: Config{
-				ResourceName: "my-job-name",
-				ResourceKind: CloudRunJob,
 				ThresholdAggregation: &ThresholdAggregation{
+					ResourceName: "my-job-name",
+					ResourceKind: CloudRunJob,
 					Filters: map[string]string{
 						"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
 						"metric.labels.result": "failed",

--- a/dev/managedservicesplatform/stacks/monitoring/cloudsql.go
+++ b/dev/managedservicesplatform/stacks/monitoring/cloudsql.go
@@ -107,11 +107,11 @@ Try increasing the 'resource.postgreSQL.maxConnections' configuration parameter.
 			},
 		},
 	} {
-		if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{
-			// Resource we are targetting in this helper
-			ResourceKind: alertpolicy.CloudSQL,
-			ResourceName: cloudSQLResourceName,
+		// Resource we are targeting in this helper
+		config.ThresholdAggregation.ResourceKind = alertpolicy.CloudSQL
+		config.ThresholdAggregation.ResourceName = cloudSQLResourceName
 
+		if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{
 			// Alert policy
 			ID:                   config.ID,
 			Name:                 config.Name,
@@ -175,11 +175,11 @@ Try increasing the 'resource.postgreSQL.maxConnections' configuration parameter.
 			},
 		},
 	} {
-		if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{
-			// Resource we are targetting in this helper
-			ResourceKind: alertpolicy.CloudSQLDatabase,
-			ResourceName: cloudSQLResourceName,
+		// Resource we are targeting in this helper
+		config.ThresholdAggregation.ResourceKind = alertpolicy.CloudSQLDatabase
+		config.ThresholdAggregation.ResourceName = cloudSQLResourceName
 
+		if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{
 			// Alert policy
 			ID:                   config.ID,
 			Name:                 config.Name,

--- a/dev/managedservicesplatform/stacks/monitoring/common.go
+++ b/dev/managedservicesplatform/stacks/monitoring/common.go
@@ -76,11 +76,11 @@ func createCommonAlerts(
 			},
 		},
 	} {
-		if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{
-			// Resource we are targetting in this helper
-			ResourceKind: serviceKind,
-			ResourceName: vars.Service.ID,
+		// Resource we are targeting in this helper
+		config.ThresholdAggregation.ResourceKind = serviceKind
+		config.ThresholdAggregation.ResourceName = vars.Service.ID
 
+		if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{
 			// Alert policy
 			ID:                   config.ID,
 			Name:                 config.Name,

--- a/dev/managedservicesplatform/stacks/monitoring/job.go
+++ b/dev/managedservicesplatform/stacks/monitoring/job.go
@@ -18,13 +18,13 @@ func createJobAlerts(
 		Service:       vars.Service,
 		EnvironmentID: vars.EnvironmentID,
 
-		ID:           "job_failures",
-		Name:         "Cloud Run Job Failures",
-		Description:  "Cloud Run Job executions failed",
-		ProjectID:    vars.ProjectID,
-		ResourceName: vars.Service.ID,
-		ResourceKind: alertpolicy.CloudRunJob,
+		ID:          "job_failures",
+		Name:        "Cloud Run Job Failures",
+		Description: "Cloud Run Job executions failed",
+		ProjectID:   vars.ProjectID,
 		ThresholdAggregation: &alertpolicy.ThresholdAggregation{
+			ResourceName: vars.Service.ID,
+			ResourceKind: alertpolicy.CloudRunJob,
 			Filters: map[string]string{
 				"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
 				"metric.labels.result": "failed",

--- a/dev/managedservicesplatform/stacks/monitoring/redis.go
+++ b/dev/managedservicesplatform/stacks/monitoring/redis.go
@@ -58,10 +58,11 @@ func createRedisAlerts(
 			},
 		},
 	} {
+		// Resource we are targeting in this helper
+		config.ThresholdAggregation.ResourceKind = alertpolicy.CloudRedis
+		config.ThresholdAggregation.ResourceName = *vars.RedisInstanceID
+
 		if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{
-			// Resource we are targetting in this helper
-			ResourceKind: alertpolicy.CloudRedis,
-			ResourceName: *vars.RedisInstanceID,
 
 			// Alert policy
 			ID:                   config.ID,

--- a/dev/managedservicesplatform/stacks/monitoring/response_codes.go
+++ b/dev/managedservicesplatform/stacks/monitoring/response_codes.go
@@ -18,12 +18,11 @@ func createResponseCodeAlerts(
 			Service:       vars.Service,
 			EnvironmentID: vars.EnvironmentID,
 
-			ID:           config.ID,
-			ProjectID:    vars.ProjectID,
-			Name:         config.Name,
-			Description:  config.Description,
-			ResourceName: vars.Service.ID,
-			ResourceKind: alertpolicy.CloudRunService,
+			ID:          config.ID,
+			ProjectID:   vars.ProjectID,
+			Name:        config.Name,
+			Description: config.Description,
+
 			ResponseCodeMetric: &alertpolicy.ResponseCodeMetric{
 				Code:         config.Code,
 				CodeClass:    config.CodeClass,

--- a/dev/managedservicesplatform/stacks/monitoring/service.go
+++ b/dev/managedservicesplatform/stacks/monitoring/service.go
@@ -26,13 +26,14 @@ func createServiceAlerts(
 			Service:       vars.Service,
 			EnvironmentID: vars.EnvironmentID,
 
-			ID:           "instance_count",
-			Name:         "Container Instance Count",
-			Description:  "There are a lot of Cloud Run instances running - we may need to increase per-instance requests make make sure we won't hit the configured max instance count",
-			ProjectID:    vars.ProjectID,
-			ResourceName: vars.Service.ID,
-			ResourceKind: alertpolicy.CloudRunService,
+			ID:          "instance_count",
+			Name:        "Container Instance Count",
+			Description: "There are a lot of Cloud Run instances running - we may need to increase per-instance requests make make sure we won't hit the configured max instance count",
+			ProjectID:   vars.ProjectID,
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
+				ResourceName: vars.Service.ID,
+				ResourceKind: alertpolicy.CloudRunService,
+
 				Filters: map[string]string{"metric.type": "run.googleapis.com/container/instance_count"},
 				Aligner: alertpolicy.MonitoringAlignMax,
 				Reducer: alertpolicy.MonitoringReduceMax,
@@ -51,13 +52,14 @@ func createServiceAlerts(
 		Service:       vars.Service,
 		EnvironmentID: vars.EnvironmentID,
 
-		ID:           "cloud_run_pending_requests",
-		Name:         "Cloud Run Pending Requests",
-		Description:  "There are requests pending - we may need to increase  Cloud Run instance count, request concurrency, or investigate further.",
-		ProjectID:    vars.ProjectID,
-		ResourceName: vars.Service.ID,
-		ResourceKind: alertpolicy.CloudRunService,
+		ID:          "cloud_run_pending_requests",
+		Name:        "Cloud Run Pending Requests",
+		Description: "There are requests pending - we may need to increase  Cloud Run instance count, request concurrency, or investigate further.",
+		ProjectID:   vars.ProjectID,
 		ThresholdAggregation: &alertpolicy.ThresholdAggregation{
+			ResourceName: vars.Service.ID,
+			ResourceKind: alertpolicy.CloudRunService,
+
 			Filters:    map[string]string{"metric.type": "run.googleapis.com/pending_queue/pending_requests"},
 			Aligner:    alertpolicy.MonitoringAlignSum,
 			Reducer:    alertpolicy.MonitoringReduceSum,
@@ -148,10 +150,10 @@ func createExternalHealthcheckAlert(
 		// If a service is not reachable, it's definitely a problem.
 		Severity: alertpolicy.SeverityLevelCritical,
 
-		ResourceKind: alertpolicy.URLUptime,
-		ResourceName: *uptimeCheck.UptimeCheckId(),
-
 		ThresholdAggregation: &alertpolicy.ThresholdAggregation{
+			ResourceKind: alertpolicy.URLUptime,
+			ResourceName: *uptimeCheck.UptimeCheckId(),
+
 			Filters: map[string]string{
 				"metric.type": "monitoring.googleapis.com/uptime_check/check_passed",
 			},


### PR DESCRIPTION
Previously, different conditions would have completely different code paths for generating the policy, which lead to some drift in the ones we pay less attention to (like response code) and a lot of copy-pasta.

This change adjusts our internal abstraction to center around condition builders, and switch on the type of the alert to generate the condition that then goes into the a unified alert policy format. This will make it easier for us to build more alerts on different condition types.

In doing this I notice that `ResourceKind`, `ResourceName` are threshold-aggregation-specific, so I've moved those downwards as well.

## Test plan

`sg msp generate -all` changes only the response code alerts to have additional labels, and also updates the severity level for the external uptime alert to match the config (previous oversight)