### PR TITLE
Set returnTo when redirecting to a third-party auth provider on dotcom

### DIFF
--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -97,7 +97,13 @@ export const SignInPage: React.FunctionComponent<React.PropsWithChildren<SignInP
     const thirdPartyAuthProviders = nonBuiltinAuthProviders.filter(provider => shouldShowProvider(provider))
     // If there is only one auth provider that is going to be displayed on dotcom, we want to redirect to it directly.
     if (context.sourcegraphDotComMode && thirdPartyAuthProviders.length === 1) {
-        window.location.replace(thirdPartyAuthProviders[0].authenticationURL)
+        // Add '?returnTo=' + encodeURIComponent(returnTo) to thirdPartyAuthProviders[0].authenticationURL in a safe way.
+        const redirectUrl = new URL(thirdPartyAuthProviders[0].authenticationURL)
+        if (returnTo) {
+            redirectUrl.searchParams.set('returnTo', returnTo)
+        }
+        window.location.replace(redirectUrl)
+
         return (
             <>
                 <PageTitle title="Signing in..." />


### PR DESCRIPTION
- Fixes https://github.com/sourcegraph/accounts.sourcegraph.com/issues/520

Add the `returnTo` URL param if we have a return URL.

## Test plan

- Tested the logic locally with several test URLs with their query string empty and not.
- Couldn't test it end-to-end because I have issues with my local env I haven't resolved.
