### PR TITLE
sg/msp: make nobl9 key optional in spec

### DIFF
--- a/dev/managedservicesplatform/spec/monitoring.go
+++ b/dev/managedservicesplatform/spec/monitoring.go
@@ -15,7 +15,7 @@ type MonitoringSpec struct {
 	Alerts MonitoringAlertsSpec `yaml:"alerts"`
 	// Nobl9 determines whether to provision a Nobl9 project.
 	// Currently for trial purposes only
-	Nobl9 bool `yaml:"nobl9"`
+	Nobl9 *bool `yaml:"nobl9,omitempty"`
 }
 
 func (s *MonitoringSpec) Validate() []error {

--- a/dev/managedservicesplatform/stacks/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/stacks/monitoring/monitoring.go
@@ -391,7 +391,7 @@ func NewStack(stacks *stack.Set, vars Variables) (*CrossStackOutput, error) {
 		}
 	}
 
-	if vars.Monitoring.Nobl9 {
+	if pointers.DerefZero(vars.Monitoring.Nobl9) {
 		createNobl9Project(stack, id.Group("nobl9"), vars)
 	}
 


### PR DESCRIPTION
Change Nobl9 to a pointer type to make it optional
## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
- locally tested