### PR TITLE
msp/monitoring: add MetricAbsence condition type, add missing executions alert

### DIFF
--- a/dev/managedservicesplatform/internal/resource/alertpolicy/BUILD.bazel
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     name = "alertpolicy",
     srcs = [
         "alertpolicy.go",
+        "conditionbuilder.go",
+        "metricabsence.go",
         "responsecode.go",
         "thresholdaggregation.go",
     ],
@@ -24,8 +26,8 @@ go_library(
 go_test(
     name = "alertpolicy_test",
     srcs = [
+        "conditionbuilder_test.go",
         "responsecode_test.go",
-        "thresholdaggregation_test.go",
     ],
     embed = [":alertpolicy"],
     deps = [

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/conditionbuilder.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/conditionbuilder.go
@@ -1,0 +1,160 @@
+package alertpolicy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringalertpolicy"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+type ResourceKind string
+
+const (
+	CloudRunService ResourceKind = "cloud-run-service"
+	CloudRunJob     ResourceKind = "cloud-run-job"
+	CloudRedis      ResourceKind = "cloud-redis"
+
+	// CloudSQL represents a Cloud SQL instance.
+	CloudSQL ResourceKind = "cloud-sql"
+	// CloudSQLDatabase represents a database within a Cloud SQL instance.
+	CloudSQLDatabase ResourceKind = "cloud-sql-database"
+
+	URLUptime ResourceKind = "url-uptime"
+)
+
+type TriggerKind int
+
+const (
+	// TriggerKindAnyViolation is trigger { count: 1 } - any violation will
+	// cause an alert to fire. This is the default.
+	TriggerKindAnyViolation TriggerKind = iota
+	// TriggerKindAllInViolation is trigger { percent: 100 } - all time series
+	// must be in violation for alert to fire.
+	TriggerKindAllInViolation
+)
+
+// ConditionBuilder are the options available to all GCP alert policy builder
+// alerts, i.e. https://console.cloud.google.com/monitoring/alerting/policies/create
+// alerts that don't use PromQL/MQL.
+type ConditionBuilder struct {
+	// ResourceKind identifies what is being monitored. Optional - used for
+	// building required filters.
+	ResourceKind ResourceKind
+	// ResourceName is the identifier for the monitored resource of ResourceKind.
+	// Only required if ResourceKind is provided - used for building required
+	// filters.
+	ResourceName string
+	// Filters are additional custom filters.
+	Filters map[string]string
+
+	// Aggregations
+	GroupByFields []string
+	Aligner       Aligner
+	Reducer       Reducer
+	Period        string
+
+	// Trigger is the strategy for determining if an alert should fire based
+	// on the thresholds.
+	Trigger TriggerKind
+}
+
+// buildGCPAlertBuilderFilters creates the Filter string for alert builder policies
+// i.e. non-MQL and non-PromQL alerts
+func (c ConditionBuilder) buildFilter() string {
+	filters := make([]string, 0)
+	for key, val := range c.Filters {
+		filters = append(filters, fmt.Sprintf(`%s = "%s"`, key, val))
+	}
+
+	// Sort to ensure stable output for testing, because
+	// config.ThresholdAggregation.Filters is a map.
+	sort.Strings(filters)
+
+	switch c.ResourceKind {
+	case CloudRunService:
+		filters = append(filters,
+			`resource.type = "cloud_run_revision"`,
+			fmt.Sprintf(`resource.labels.service_name = starts_with("%s")`, c.ResourceName),
+		)
+	case CloudRunJob:
+		filters = append(filters,
+			`resource.type = "cloud_run_job"`,
+			fmt.Sprintf(`resource.labels.job_name = starts_with("%s")`, c.ResourceName),
+		)
+	case CloudRedis:
+		filters = append(filters,
+			`resource.type = "redis_instance"`,
+			fmt.Sprintf(`resource.labels.instance_id = "%s"`, c.ResourceName),
+		)
+	case CloudSQL:
+		filters = append(filters,
+			`resource.type = "cloudsql_database"`,
+			fmt.Sprintf(`resource.labels.database_id = "%s"`, c.ResourceName))
+	case CloudSQLDatabase:
+		filters = append(filters,
+			`resource.type = "cloudsql_instance_database"`,
+			fmt.Sprintf(`resource.labels.resource_id = "%s"`, c.ResourceName))
+	case URLUptime:
+		filters = append(filters,
+			`resource.type = "uptime_url"`,
+			fmt.Sprintf(`metric.labels.check_id = "%s"`, c.ResourceName),
+		)
+	}
+
+	return strings.Join(filters, " AND ")
+}
+
+func (c ConditionBuilder) buildThresholdAggregations() []monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdAggregations {
+	return []monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdAggregations{
+		{
+			AlignmentPeriod:    pointers.Ptr(c.Period),
+			PerSeriesAligner:   pointers.NonZeroPtr(string(c.Aligner)),
+			CrossSeriesReducer: pointers.NonZeroPtr(string(c.Reducer)),
+			GroupByFields:      pointers.Ptr(pointers.Slice(c.GroupByFields)),
+		},
+	}
+}
+
+func (c ConditionBuilder) buildAbsentAggregations() []monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionAbsentAggregations {
+	return []monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionAbsentAggregations{
+		{
+			AlignmentPeriod:    pointers.Ptr(c.Period),
+			PerSeriesAligner:   pointers.NonZeroPtr(string(c.Aligner)),
+			CrossSeriesReducer: pointers.NonZeroPtr(string(c.Reducer)),
+			GroupByFields:      pointers.Ptr(pointers.Slice(c.GroupByFields)),
+		},
+	}
+}
+
+func (c ConditionBuilder) buildThresholdTrigger() *monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger {
+	switch c.Trigger {
+	case TriggerKindAllInViolation:
+		return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
+			Percent: pointers.Float64(100),
+		}
+	case TriggerKindAnyViolation:
+		fallthrough
+	default:
+		return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
+			Count: pointers.Float64(1),
+		}
+	}
+}
+
+func (c ConditionBuilder) buildAbsentTrigger() *monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionAbsentTrigger {
+	switch c.Trigger {
+	case TriggerKindAllInViolation:
+		return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionAbsentTrigger{
+			Percent: pointers.Float64(100),
+		}
+	case TriggerKindAnyViolation:
+		fallthrough
+	default:
+		return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionAbsentTrigger{
+			Count: pointers.Float64(1),
+		}
+	}
+}

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/conditionbuilder_test.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/conditionbuilder_test.go
@@ -6,42 +6,38 @@ import (
 	"github.com/hexops/autogold/v2"
 )
 
-func TestBuildThresholdAggregationFilter(t *testing.T) {
+func TestBuildConditionBuilderFilter(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		config Config
+		config ConditionBuilder
 		want   autogold.Value
 	}{
 		{
 			name: "Service Metric",
-			config: Config{
-				ThresholdAggregation: &ThresholdAggregation{
-					ResourceName: "my-service-name",
-					ResourceKind: CloudRunService,
-					Filters: map[string]string{
-						"metric.type": "run.googleapis.com/container/startup_latencies",
-					},
+			config: ConditionBuilder{
+				ResourceName: "my-service-name",
+				ResourceKind: CloudRunService,
+				Filters: map[string]string{
+					"metric.type": "run.googleapis.com/container/startup_latencies",
 				},
 			},
 			want: autogold.Expect(`metric.type = "run.googleapis.com/container/startup_latencies" AND resource.type = "cloud_run_revision" AND resource.labels.service_name = starts_with("my-service-name")`),
 		},
 		{
 			name: "Job Metric",
-			config: Config{
-				ThresholdAggregation: &ThresholdAggregation{
-					ResourceName: "my-job-name",
-					ResourceKind: CloudRunJob,
-					Filters: map[string]string{
-						"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
-						"metric.labels.result": "failed",
-					},
+			config: ConditionBuilder{
+				ResourceName: "my-job-name",
+				ResourceKind: CloudRunJob,
+				Filters: map[string]string{
+					"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
+					"metric.labels.result": "failed",
 				},
 			},
 			want: autogold.Expect(`metric.labels.result = "failed" AND metric.type = "run.googleapis.com/job/completed_task_attempt_count" AND resource.type = "cloud_run_job" AND resource.labels.job_name = starts_with("my-job-name")`),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildThresholdAggregationFilter(&tc.config)
+			got := tc.config.buildFilter()
 			tc.want.Equal(t, got)
 		})
 	}

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/metricabsence.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/metricabsence.go
@@ -1,0 +1,19 @@
+package alertpolicy
+
+import (
+	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringalertpolicy"
+
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
+)
+
+func newMetricAbsenceCondition(config *Config) *monitoringalertpolicy.MonitoringAlertPolicyConditions {
+	return &monitoringalertpolicy.MonitoringAlertPolicyConditions{
+		DisplayName: pointers.Ptr(config.Name),
+		ConditionAbsent: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionAbsent{
+			Aggregations: config.MetricAbsence.buildAbsentAggregations(),
+			Duration:     pointers.Ptr(config.MetricAbsence.Duration),
+			Filter:       pointers.Ptr(config.MetricAbsence.buildFilter()),
+			Trigger:      config.MetricAbsence.buildAbsentTrigger(),
+		},
+	}
+}

--- a/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation.go
+++ b/dev/managedservicesplatform/internal/resource/alertpolicy/thresholdaggregation.go
@@ -1,10 +1,6 @@
 package alertpolicy
 
 import (
-	"fmt"
-	"sort"
-	"strings"
-
 	"github.com/sourcegraph/managed-services-platform-cdktf/gen/google/monitoringalertpolicy"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -49,78 +45,12 @@ func newThresholdAggregationCondition(config *Config) (*monitoringalertpolicy.Mo
 	return &monitoringalertpolicy.MonitoringAlertPolicyConditions{
 		DisplayName: pointers.Ptr(config.Name),
 		ConditionThreshold: &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThreshold{
-			Aggregations: []monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdAggregations{
-				{
-					AlignmentPeriod:    pointers.Ptr(config.ThresholdAggregation.Period),
-					PerSeriesAligner:   pointers.NonZeroPtr(string(config.ThresholdAggregation.Aligner)),
-					CrossSeriesReducer: pointers.NonZeroPtr(string(config.ThresholdAggregation.Reducer)),
-					GroupByFields:      pointers.Ptr(pointers.Slice(config.ThresholdAggregation.GroupByFields)),
-				},
-			},
+			Aggregations:   config.ThresholdAggregation.buildThresholdAggregations(),
 			Comparison:     pointers.Ptr(string(config.ThresholdAggregation.Comparison)),
 			Duration:       pointers.Ptr(config.ThresholdAggregation.Duration),
-			Filter:         pointers.Ptr(buildThresholdAggregationFilter(config)),
+			Filter:         pointers.Ptr(config.ThresholdAggregation.buildFilter()),
 			ThresholdValue: pointers.Float64(config.ThresholdAggregation.Threshold),
-			Trigger: func() *monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger {
-				switch config.ThresholdAggregation.Trigger {
-				case TriggerKindAllInViolation:
-					return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
-						Percent: pointers.Float64(100),
-					}
-
-				case TriggerKindAnyViolation:
-					fallthrough
-				default:
-					return &monitoringalertpolicy.MonitoringAlertPolicyConditionsConditionThresholdTrigger{
-						Count: pointers.Float64(1),
-					}
-				}
-			}(),
+			Trigger:        config.ThresholdAggregation.buildThresholdTrigger(),
 		},
 	}, nil
-}
-
-// buildThresholdAggregationFilter creates the Filter string for a ThresholdAggregation alert condition
-func buildThresholdAggregationFilter(config *Config) string {
-	filters := make([]string, 0)
-	for key, val := range config.ThresholdAggregation.Filters {
-		filters = append(filters, fmt.Sprintf(`%s = "%s"`, key, val))
-	}
-
-	// Sort to ensure stable output for testing, because
-	// config.ThresholdAggregation.Filters is a map.
-	sort.Strings(filters)
-
-	switch config.ThresholdAggregation.ResourceKind {
-	case CloudRunService:
-		filters = append(filters,
-			`resource.type = "cloud_run_revision"`,
-			fmt.Sprintf(`resource.labels.service_name = starts_with("%s")`, config.ThresholdAggregation.ResourceName),
-		)
-	case CloudRunJob:
-		filters = append(filters,
-			`resource.type = "cloud_run_job"`,
-			fmt.Sprintf(`resource.labels.job_name = starts_with("%s")`, config.ThresholdAggregation.ResourceName),
-		)
-	case CloudRedis:
-		filters = append(filters,
-			`resource.type = "redis_instance"`,
-			fmt.Sprintf(`resource.labels.instance_id = "%s"`, config.ThresholdAggregation.ResourceName),
-		)
-	case CloudSQL:
-		filters = append(filters,
-			`resource.type = "cloudsql_database"`,
-			fmt.Sprintf(`resource.labels.database_id = "%s"`, config.ThresholdAggregation.ResourceName))
-	case CloudSQLDatabase:
-		filters = append(filters,
-			`resource.type = "cloudsql_instance_database"`,
-			fmt.Sprintf(`resource.labels.resource_id = "%s"`, config.ThresholdAggregation.ResourceName))
-	case URLUptime:
-		filters = append(filters,
-			`resource.type = "uptime_url"`,
-			fmt.Sprintf(`metric.labels.check_id = "%s"`, config.ThresholdAggregation.ResourceName),
-		)
-	}
-
-	return strings.Join(filters, " AND ")
 }

--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -149,6 +149,7 @@ func (r *Renderer) RenderEnvironment(
 		CloudSQLMaxConections: pointers.DerefZero(pointers.DerefZero(env.Resources).PostgreSQL).MaxConnections,
 		ServiceHealthProbes:   pointers.DerefZero(env.EnvironmentServiceSpec).HealthProbes,
 		SentryProject:         cloudrunOutput.SentryProject,
+		JobSchedule:           pointers.DerefZero(env.EnvironmentJobSpec).Schedule,
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to create monitoring stack")
 	}

--- a/dev/managedservicesplatform/spec/BUILD.bazel
+++ b/dev/managedservicesplatform/spec/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//lib/pointers",
         "@com_github_alecthomas_units//:units",
         "@com_github_grafana_regexp//:regexp",
+        "@com_github_hashicorp_cronexpr//:cronexpr",
         "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/dev/managedservicesplatform/spec/environment.go
+++ b/dev/managedservicesplatform/spec/environment.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/alecthomas/units"
+	"github.com/hashicorp/cronexpr"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/imageupdater"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -561,11 +563,80 @@ type EnvironmentJobSpec struct {
 	Schedule *EnvironmentJobScheduleSpec `yaml:"schedule,omitempty"`
 }
 
+func (s *EnvironmentJobSpec) Validate() []error {
+	if s == nil {
+		return nil
+	}
+
+	var errs []error
+	errs = append(errs, s.Schedule.Validate()...)
+	return errs
+}
+
 type EnvironmentJobScheduleSpec struct {
 	// Cron is a cron schedule in the form of "* * * * *".
+	//
+	// Protip: use https://crontab.guru
 	Cron string `yaml:"cron"`
 	// Deadline of each attempt, in seconds.
 	Deadline *int `yaml:"deadline,omitempty"`
+}
+
+func (s *EnvironmentJobScheduleSpec) Validate() []error {
+	if s == nil {
+		return nil
+	}
+
+	var errs []error
+	if _, err := s.FindMaxCronInterval(); err != nil {
+		errs = append(errs, errors.Wrap(err, "schedule.cron: invalid schedule"))
+	}
+	return errs
+}
+
+// FindMaxCronInterval tries to find the largest gap between events in the cron
+// schedule. It may return 'nil, nil' if no configuration is available.
+func (s *EnvironmentJobScheduleSpec) FindMaxCronInterval() (*time.Duration, error) {
+	if s == nil {
+		return nil, nil
+	}
+
+	expr, err := cronexpr.Parse(s.Cron)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid cron schedule")
+	}
+
+	// get 64 scheduled events to try and see what the largest gap is - this
+	// is not performance sensitive, we just need to be able to reliably find
+	// the largest interval. some silly crons won't generate reliable intervals
+	// but this will hopefully give us a realistic indicator that we can error
+	// out on below.
+	scheduled := expr.NextN(time.Now(), 64)
+
+	// scheduled is in chronological order, so we can compare subsequent events
+	// to find the largest gap in this cron.
+	var maxGap time.Duration
+	for i := 0; i < len(scheduled)-2; i += 1 {
+		t1 := scheduled[i]
+		t2 := scheduled[i+1]
+		gap := t2.Sub(t1)
+		if gap > maxGap {
+			maxGap = gap
+		}
+	}
+
+	// should not be possible to have <1m schedule
+	if maxGap < time.Minute {
+		return nil, errors.Newf("the longest interval must be >1m, got %s", maxGap.String())
+	}
+
+	// once we get into the monthly territory, things might get funky - forbid
+	// these very long intervals for now
+	if maxGap > 27*24*time.Hour {
+		return nil, errors.Newf("the longest interval must be <28 days, got %s", maxGap.String())
+	}
+
+	return &maxGap, nil
 }
 
 type EnvironmentResourcesSpec struct {

--- a/dev/managedservicesplatform/stacks/monitoring/cloudsql.go
+++ b/dev/managedservicesplatform/stacks/monitoring/cloudsql.go
@@ -33,12 +33,14 @@ func createCloudSQLAlerts(
 			Name:        "Cloud SQL - Memory Utilization",
 			Description: "Cloud SQL instance memory utilization is above acceptable threshold.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters: map[string]string{
-					"metric.type": "cloudsql.googleapis.com/database/memory/utilization",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{
+						"metric.type": "cloudsql.googleapis.com/database/memory/utilization",
+					},
+					Aligner: alertpolicy.MonitoringAlignMean,
+					Reducer: alertpolicy.MonitoringReduceNone,
+					Period:  "60s",
 				},
-				Aligner:   alertpolicy.MonitoringAlignMean,
-				Reducer:   alertpolicy.MonitoringReduceNone,
-				Period:    "60s",
 				Threshold: 0.8,
 			},
 		},
@@ -47,12 +49,14 @@ func createCloudSQLAlerts(
 			Name:        "Cloud SQL - CPU Utilization",
 			Description: "Cloud SQL instance CPU utilization is above acceptable threshold.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters: map[string]string{
-					"metric.type": "cloudsql.googleapis.com/database/cpu/utilization",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{
+						"metric.type": "cloudsql.googleapis.com/database/cpu/utilization",
+					},
+					Aligner: alertpolicy.MonitoringAlignMean,
+					Reducer: alertpolicy.MonitoringReduceNone,
+					Period:  "60s",
 				},
-				Aligner:   alertpolicy.MonitoringAlignMean,
-				Reducer:   alertpolicy.MonitoringReduceNone,
-				Period:    "60s",
 				Threshold: 0.9,
 				Duration:  "180s", // pegged at high usage
 			},
@@ -62,12 +66,14 @@ func createCloudSQLAlerts(
 			Name:        "Cloud SQL - Server Availability",
 			Description: "Cloud SQL instance is down.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters: map[string]string{
-					"metric.type": "cloudsql.googleapis.com/database/up",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{
+						"metric.type": "cloudsql.googleapis.com/database/up",
+					},
+					Aligner: alertpolicy.MonitoringAlignMin,
+					Reducer: alertpolicy.MonitoringReduceNone,
+					Period:  "60s",
 				},
-				Aligner: alertpolicy.MonitoringAlignMin,
-				Reducer: alertpolicy.MonitoringReduceNone,
-				Period:  "60s",
 				// 1 == up, 0 == down
 				Comparison: alertpolicy.ComparisonLT,
 				Threshold:  1,
@@ -78,12 +84,14 @@ func createCloudSQLAlerts(
 			Name:        "Cloud SQL - Disk Utilization",
 			Description: "Cloud SQL instance disk utilization is above acceptable threshold.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters: map[string]string{
-					"metric.type": "cloudsql.googleapis.com/database/disk/utilization",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{
+						"metric.type": "cloudsql.googleapis.com/database/disk/utilization",
+					},
+					Aligner: alertpolicy.MonitoringAlignMean,
+					Reducer: alertpolicy.MonitoringReduceNone,
+					Period:  "300s",
 				},
-				Aligner:   alertpolicy.MonitoringAlignMean,
-				Reducer:   alertpolicy.MonitoringReduceNone,
-				Period:    "300s",
 				Threshold: 0.95,
 			},
 		},
@@ -95,13 +103,15 @@ This can be caused by an increase in the number of active service instances.
 
 Try increasing the 'resource.postgreSQL.maxConnections' configuration parameter.`,
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters: map[string]string{
-					// Despite the name, the metric is titled 'PostgreSQL Connections'
-					"metric.type": "cloudsql.googleapis.com/database/postgresql/num_backends",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{
+						// Despite the name, the metric is titled 'PostgreSQL Connections'
+						"metric.type": "cloudsql.googleapis.com/database/postgresql/num_backends",
+					},
+					Aligner: alertpolicy.MonitoringAlignMax,
+					Reducer: alertpolicy.MonitoringReduceSum, // count across all
+					Period:  "120s",
 				},
-				Aligner: alertpolicy.MonitoringAlignMax,
-				Reducer: alertpolicy.MonitoringReduceSum, // count across all
-				Period:  "120s",
 				Threshold: 0.9 * float64(pointers.Deref(vars.CloudSQLMaxConections,
 					100)), // 100 seems to be the Cloud SQL default
 			},
@@ -140,16 +150,18 @@ Try increasing the 'resource.postgreSQL.maxConnections' configuration parameter.
 			Name:        "Cloud SQL - Sustained Per-Query Lock Times",
 			Description: "Cloud SQL database queries are encountering lock times above acceptable thresholds over a window.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters: map[string]string{
-					"metric.type": "cloudsql.googleapis.com/database/postgresql/insights/perquery/lock_time",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{
+						"metric.type": "cloudsql.googleapis.com/database/postgresql/insights/perquery/lock_time",
+					},
+					GroupByFields: []string{
+						"metric.label.querystring",
+						"metric.label.user",
+					},
+					Aligner: alertpolicy.MonitoringAlignRate,
+					Reducer: alertpolicy.MonitoringReduceMean,
+					Period:  "60s",
 				},
-				GroupByFields: []string{
-					"metric.label.querystring",
-					"metric.label.user",
-				},
-				Aligner: alertpolicy.MonitoringAlignRate,
-				Reducer: alertpolicy.MonitoringReduceMean,
-				Period:  "60s",
 				// Threshold of 0.2 seconds
 				Threshold: 0.2 * 1_000_000, // metric is in microseconds (us)
 				Duration:  "180s",
@@ -160,16 +172,18 @@ Try increasing the 'resource.postgreSQL.maxConnections' configuration parameter.
 			Name:        "Cloud SQL - Spike in Per-Query Lock Time",
 			Description: "Cloud SQL database queries encountered lock times well above acceptable thresholds.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters: map[string]string{
-					"metric.type": "cloudsql.googleapis.com/database/postgresql/insights/perquery/lock_time",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{
+						"metric.type": "cloudsql.googleapis.com/database/postgresql/insights/perquery/lock_time",
+					},
+					GroupByFields: []string{
+						"metric.label.querystring",
+						"metric.label.user",
+					},
+					Aligner: alertpolicy.MonitoringAlignRate,
+					Reducer: alertpolicy.MonitoringReduceMean,
+					Period:  "120s",
 				},
-				GroupByFields: []string{
-					"metric.label.querystring",
-					"metric.label.user",
-				},
-				Aligner: alertpolicy.MonitoringAlignRate,
-				Reducer: alertpolicy.MonitoringReduceMean,
-				Period:  "120s",
 				// Threshold of 1 seconds - this is _very_ high
 				Threshold: 1 * 1_000_000, // metric is in microseconds (us)
 			},

--- a/dev/managedservicesplatform/stacks/monitoring/common.go
+++ b/dev/managedservicesplatform/stacks/monitoring/common.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/spec"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func createCommonAlerts(
@@ -34,10 +35,12 @@ func createCommonAlerts(
 			Name:        "High Container CPU Utilization",
 			Description: "High CPU Usage - it may be neccessary to reduce load or increase CPU allocation",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters:   map[string]string{"metric.type": "run.googleapis.com/container/cpu/utilizations"},
-				Aligner:   alertpolicy.MonitoringAlignPercentile99,
-				Reducer:   alertpolicy.MonitoringReduceMax,
-				Period:    "60s",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{"metric.type": "run.googleapis.com/container/cpu/utilizations"},
+					Aligner: alertpolicy.MonitoringAlignPercentile99,
+					Reducer: alertpolicy.MonitoringReduceMax,
+					Period:  "60s",
+				},
 				Duration:  "600s",
 				Threshold: 0.9,
 			},
@@ -47,10 +50,12 @@ func createCommonAlerts(
 			Name:        "High Container Memory Utilization",
 			Description: "High Memory Usage - it may be neccessary to reduce load or increase memory allocation",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters:   map[string]string{"metric.type": "run.googleapis.com/container/memory/utilizations"},
-				Aligner:   alertpolicy.MonitoringAlignPercentile99,
-				Reducer:   alertpolicy.MonitoringReduceMax,
-				Period:    "300s",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{"metric.type": "run.googleapis.com/container/memory/utilizations"},
+					Aligner: alertpolicy.MonitoringAlignPercentile99,
+					Reducer: alertpolicy.MonitoringReduceMax,
+					Period:  "300s",
+				},
 				Threshold: 0.8,
 			},
 		},
@@ -59,10 +64,12 @@ func createCommonAlerts(
 			Name:        "Container Startup Latency",
 			Description: "Service containers are taking longer than configured timeouts to start up.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters: map[string]string{"metric.type": "run.googleapis.com/container/startup_latencies"},
-				Aligner: alertpolicy.MonitoringAlignPercentile99,
-				Reducer: alertpolicy.MonitoringReduceMax,
-				Period:  "60s",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{"metric.type": "run.googleapis.com/container/startup_latencies"},
+					Aligner: alertpolicy.MonitoringAlignPercentile99,
+					Reducer: alertpolicy.MonitoringReduceMax,
+					Period:  "60s",
+				},
 				Threshold: func() float64 {
 					if serviceKind == alertpolicy.CloudRunJob {
 						// jobs measure container startup, not service startup,
@@ -93,7 +100,7 @@ func createCommonAlerts(
 			ProjectID:            vars.ProjectID,
 			NotificationChannels: channels,
 		}); err != nil {
-			return err
+			return errors.Wrap(err, config.ID)
 		}
 	}
 

--- a/dev/managedservicesplatform/stacks/monitoring/job.go
+++ b/dev/managedservicesplatform/stacks/monitoring/job.go
@@ -1,10 +1,14 @@
 package monitoring
 
 import (
+	"fmt"
+	"math"
+
 	"github.com/hashicorp/terraform-cdk-go/cdktf"
 
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resource/alertpolicy"
 	"github.com/sourcegraph/sourcegraph/dev/managedservicesplatform/internal/resourceid"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func createJobAlerts(
@@ -23,21 +27,61 @@ func createJobAlerts(
 		Description: "Cloud Run Job executions failed",
 		ProjectID:   vars.ProjectID,
 		ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-			ResourceName: vars.Service.ID,
-			ResourceKind: alertpolicy.CloudRunJob,
-			Filters: map[string]string{
-				"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
-				"metric.labels.result": "failed",
+			ConditionBuilder: alertpolicy.ConditionBuilder{
+				ResourceName: vars.Service.ID,
+				ResourceKind: alertpolicy.CloudRunJob,
+				Filters: map[string]string{
+					"metric.type":          "run.googleapis.com/job/completed_task_attempt_count",
+					"metric.labels.result": "failed",
+				},
+				GroupByFields: []string{"metric.label.result"},
+				Aligner:       alertpolicy.MonitoringAlignCount,
+				Reducer:       alertpolicy.MonitoringReduceSum,
+				Period:        "60s",
 			},
-			GroupByFields: []string{"metric.label.result"},
-			Aligner:       alertpolicy.MonitoringAlignCount,
-			Reducer:       alertpolicy.MonitoringReduceSum,
-			Period:        "60s",
-			Threshold:     0,
+			Threshold:  0,
+			Comparison: alertpolicy.ComparisonGT,
 		},
 		NotificationChannels: channels,
 	}); err != nil {
-		return err
+		return errors.Wrap(err, "job_failures")
+	}
+
+	interval, err := vars.JobSchedule.FindMaxCronInterval()
+	if err != nil {
+		return errors.Wrap(err, "JobSchedule.FindMaxCronInterval")
+	}
+	if interval != nil {
+		// Use the duration calculated from the cron, with some leeway. Use
+		// math.Ceil just in case, as Minutes() may give us floats
+		absentMinutes := int(math.Ceil(interval.Minutes())) + 10
+
+		if _, err := alertpolicy.New(stack, id, &alertpolicy.Config{
+			Service:       vars.Service,
+			EnvironmentID: vars.EnvironmentID,
+
+			ID:          "job_execution_absence",
+			Name:        "Cloud Run Job Execution Absence",
+			Description: fmt.Sprintf("No Cloud Run Job executions were detected in expected window (%dm)", absentMinutes),
+			ProjectID:   vars.ProjectID,
+			MetricAbsence: &alertpolicy.MetricAbsence{
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					ResourceName: vars.Service.ID,
+					ResourceKind: alertpolicy.CloudRunJob,
+					Filters: map[string]string{
+						"metric.type": "run.googleapis.com/job/completed_task_attempt_count",
+					},
+					Aligner: alertpolicy.MonitoringAlignCount,
+					Reducer: alertpolicy.MonitoringReduceSum,
+					Period:  "60s",
+				},
+				// Must be in seconds
+				Duration: fmt.Sprintf("%ds", absentMinutes*60),
+			},
+			NotificationChannels: channels,
+		}); err != nil {
+			return errors.Wrap(err, "job_execution_absence")
+		}
 	}
 
 	return nil

--- a/dev/managedservicesplatform/stacks/monitoring/monitoring.go
+++ b/dev/managedservicesplatform/stacks/monitoring/monitoring.go
@@ -112,6 +112,9 @@ type Variables struct {
 	ServiceHealthProbes *spec.EnvironmentServiceHealthProbesSpec
 	// SentryProject is the project in Sentry for the service environment
 	SentryProject sentryproject.Project
+	// JobSchedule is used to determine if an alert on job absence should be
+	// provisioned and the appropriate thresholds.
+	JobSchedule *spec.EnvironmentJobScheduleSpec
 }
 
 const StackName = "monitoring"

--- a/dev/managedservicesplatform/stacks/monitoring/redis.go
+++ b/dev/managedservicesplatform/stacks/monitoring/redis.go
@@ -26,10 +26,12 @@ func createRedisAlerts(
 			Name:        "Cloud Redis - System Memory Utilization",
 			Description: "Redis System memory utilization is above the set threshold. The utilization is measured on a scale of 0 to 1.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters:   map[string]string{"metric.type": "redis.googleapis.com/stats/memory/system_memory_usage_ratio"},
-				Aligner:   alertpolicy.MonitoringAlignMean,
-				Reducer:   alertpolicy.MonitoringReduceNone,
-				Period:    "300s",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{"metric.type": "redis.googleapis.com/stats/memory/system_memory_usage_ratio"},
+					Aligner: alertpolicy.MonitoringAlignMean,
+					Reducer: alertpolicy.MonitoringReduceNone,
+					Period:  "300s",
+				},
 				Threshold: 0.8,
 			},
 		},
@@ -38,12 +40,14 @@ func createRedisAlerts(
 			Name:        "Cloud Redis - System CPU Utilization",
 			Description: "Redis Engine CPU Utilization goes above the set threshold. The utilization is measured on a scale of 0 to 1.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters:       map[string]string{"metric.type": "redis.googleapis.com/stats/cpu_utilization_main_thread"},
-				GroupByFields: []string{"resource.label.instance_id", "resource.label.node_id"},
-				Aligner:       alertpolicy.MonitoringAlignRate,
-				Reducer:       alertpolicy.MonitoringReduceSum,
-				Period:        "300s",
-				Threshold:     0.9,
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters:       map[string]string{"metric.type": "redis.googleapis.com/stats/cpu_utilization_main_thread"},
+					GroupByFields: []string{"resource.label.instance_id", "resource.label.node_id"},
+					Aligner:       alertpolicy.MonitoringAlignRate,
+					Reducer:       alertpolicy.MonitoringReduceSum,
+					Period:        "300s",
+				},
+				Threshold: 0.9,
 			},
 		},
 		{
@@ -51,9 +55,11 @@ func createRedisAlerts(
 			Name:        "Cloud Redis - Standard Instance Failover",
 			Description: "Instance failover occured for a standard tier Redis instance.",
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				Filters:   map[string]string{"metric.type": "redis.googleapis.com/replication/role"},
-				Aligner:   alertpolicy.MonitoringAlignStddev,
-				Period:    "300s",
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					Filters: map[string]string{"metric.type": "redis.googleapis.com/replication/role"},
+					Aligner: alertpolicy.MonitoringAlignStddev,
+					Period:  "300s",
+				},
 				Threshold: 0,
 			},
 		},

--- a/dev/managedservicesplatform/stacks/monitoring/service.go
+++ b/dev/managedservicesplatform/stacks/monitoring/service.go
@@ -31,13 +31,15 @@ func createServiceAlerts(
 			Description: "There are a lot of Cloud Run instances running - we may need to increase per-instance requests make make sure we won't hit the configured max instance count",
 			ProjectID:   vars.ProjectID,
 			ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-				ResourceName: vars.Service.ID,
-				ResourceKind: alertpolicy.CloudRunService,
+				ConditionBuilder: alertpolicy.ConditionBuilder{
+					ResourceName: vars.Service.ID,
+					ResourceKind: alertpolicy.CloudRunService,
 
-				Filters: map[string]string{"metric.type": "run.googleapis.com/container/instance_count"},
-				Aligner: alertpolicy.MonitoringAlignMax,
-				Reducer: alertpolicy.MonitoringReduceMax,
-				Period:  "60s",
+					Filters: map[string]string{"metric.type": "run.googleapis.com/container/instance_count"},
+					Aligner: alertpolicy.MonitoringAlignMax,
+					Reducer: alertpolicy.MonitoringReduceMax,
+					Period:  "60s",
+				},
 				// Fire when we are 1 instance away from hitting the limit.
 				Threshold:  float64(*vars.MaxInstanceCount - 1),
 				Comparison: alertpolicy.ComparisonGT,
@@ -57,13 +59,15 @@ func createServiceAlerts(
 		Description: "There are requests pending - we may need to increase  Cloud Run instance count, request concurrency, or investigate further.",
 		ProjectID:   vars.ProjectID,
 		ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-			ResourceName: vars.Service.ID,
-			ResourceKind: alertpolicy.CloudRunService,
+			ConditionBuilder: alertpolicy.ConditionBuilder{
+				ResourceName: vars.Service.ID,
+				ResourceKind: alertpolicy.CloudRunService,
 
-			Filters:    map[string]string{"metric.type": "run.googleapis.com/pending_queue/pending_requests"},
-			Aligner:    alertpolicy.MonitoringAlignSum,
-			Reducer:    alertpolicy.MonitoringReduceSum,
-			Period:     "60s",
+				Filters: map[string]string{"metric.type": "run.googleapis.com/pending_queue/pending_requests"},
+				Aligner: alertpolicy.MonitoringAlignSum,
+				Reducer: alertpolicy.MonitoringReduceSum,
+				Period:  "60s",
+			},
 			Threshold:  5,
 			Comparison: alertpolicy.ComparisonGT,
 		},
@@ -151,25 +155,27 @@ func createExternalHealthcheckAlert(
 		Severity: alertpolicy.SeverityLevelCritical,
 
 		ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-			ResourceKind: alertpolicy.URLUptime,
-			ResourceName: *uptimeCheck.UptimeCheckId(),
+			ConditionBuilder: alertpolicy.ConditionBuilder{
+				ResourceKind: alertpolicy.URLUptime,
+				ResourceName: *uptimeCheck.UptimeCheckId(),
 
-			Filters: map[string]string{
-				"metric.type": "monitoring.googleapis.com/uptime_check/check_passed",
+				Filters: map[string]string{
+					"metric.type": "monitoring.googleapis.com/uptime_check/check_passed",
+				},
+				Aligner: alertpolicy.MonitoringAlignFractionTrue,
+				// Checks run once every 60s, if 2/3 fail we are in trouble.
+				Period: "180s",
+				// We want to alert when all locations go down, but right now that
+				// sends 6 notifications when the alert fires, which is annoying -
+				// there seems to be no way to change this. So we group by the check
+				// target anyway.
+				Trigger:       alertpolicy.TriggerKindAllInViolation,
+				GroupByFields: []string{"metric.labels.host"},
+				Reducer:       alertpolicy.MonitoringReduceMean,
 			},
-			Aligner:    alertpolicy.MonitoringAlignFractionTrue,
+			Threshold:  0.4,
 			Duration:   "0s",
 			Comparison: alertpolicy.ComparisonLT,
-			// Checks run once every 60s, if 2/3 fail we are in trouble.
-			Period:    "180s",
-			Threshold: 0.4,
-			// We want to alert when all locations go down, but right now that
-			// sends 6 notifications when the alert fires, which is annoying -
-			// there seems to be no way to change this. So we group by the check
-			// target anyway.
-			Trigger:       alertpolicy.TriggerKindAllInViolation,
-			GroupByFields: []string{"metric.labels.host"},
-			Reducer:       alertpolicy.MonitoringReduceMean,
 		},
 		NotificationChannels: channels,
 	}); err != nil {
@@ -214,17 +220,19 @@ func createCloudRunPreconditionFailedAlert(
 		Description: `Cloud Run instance failed to start due to a precondition failure.
 This is unlikely to cause immediate downtime, and may auto-resolve if no new instances are created and/or we return to a healthy state, but you should follow up to ensure the latest Cloud Run revision is healthy.`,
 		ThresholdAggregation: &alertpolicy.ThresholdAggregation{
-			Filters: map[string]string{
-				"metric.type": metric.Metric,
-				// HACK: Strangely, this seems required on our log-based metric
-				"resource.type": "cloud_run_revision",
+			ConditionBuilder: alertpolicy.ConditionBuilder{
+				Filters: map[string]string{
+					"metric.type": metric.Metric,
+					// HACK: Strangely, this seems required on our log-based metric
+					"resource.type": "cloud_run_revision",
+				},
+				Aligner: alertpolicy.MonitoringAlignMax,
+				Reducer: alertpolicy.MonitoringReduceSum,
+				Period:  "60s",
+				Trigger: alertpolicy.TriggerKindAnyViolation,
 			},
-			Aligner:    alertpolicy.MonitoringAlignMax,
-			Reducer:    alertpolicy.MonitoringReduceSum,
-			Period:     "60s",
 			Threshold:  0, // any occurence is bad
 			Comparison: alertpolicy.ComparisonGT,
-			Trigger:    alertpolicy.TriggerKindAnyViolation,
 		},
 		NotificationChannels: channels,
 	}); err != nil {


### PR DESCRIPTION
Prevents the issue we ran into in https://sourcegraph.slack.com/archives/C05GJPTSZCZ/p1707907271464879 from going unnoticed again:

1. Adds a `MetricAbsence` condition type for us to use internally
  a. In doing so, I realized we can shape our abstraction around the GCP UI with the new `ConditionBuilder` type. This is basically what you see in the UI when you create a policy by hand. This is now shared between `MetricAbsence` and `ThresholdAggregation`
2. Adds `FindMaxCronInterval()` on the job schedule spec, which validates cron specs, tries to ensure they are of a certain window, and provides the "maximum interval" it detects.
3. Use `FindMaxCronInterval()` to define an alert where if no executions are detected within that interval + 10 minutes, the alert will fire.

## Test plan

`sg msp generate -all` has no diff except for gatekeeper (our only Job). I put gatekeeper into CLI-apply mode and applied the alert, which looks right:

<img width="1495" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/23356519/7aacc37a-05ca-4057-aba6-adf848cf9199">
