### PR TITLE
Enable auth token redirects to VSCodium

### DIFF
--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -66,7 +66,7 @@ const REQUESTERS: Record<string, TokenRequester> = {
         callbackType: 'new-tab',
     },
     CODY_VSCODIUM: {
-        name: 'Cody - VS Code Extension',
+        name: 'Cody - VSCodium Extension',
         redirectURL: 'vscodium://sourcegraph.cody-ai?code=$TOKEN',
         successMessage: 'Now opening VS Code...',
         infoMessage:

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenCallbackPage.tsx
@@ -65,6 +65,14 @@ const REQUESTERS: Record<string, TokenRequester> = {
             'Please make sure you have VS Code running on your machine if you do not see an open dialog in your browser.',
         callbackType: 'new-tab',
     },
+    CODY_VSCODIUM: {
+        name: 'Cody - VS Code Extension',
+        redirectURL: 'vscodium://sourcegraph.cody-ai?code=$TOKEN',
+        successMessage: 'Now opening VS Code...',
+        infoMessage:
+            'Please make sure you have VS Code running on your machine if you do not see an open dialog in your browser.',
+        callbackType: 'new-tab',
+    },
     CODY_INSIDERS: {
         name: 'Cody - VS Code Insiders Extension',
         redirectURL: 'vscode-insiders://sourcegraph.cody-ai?code=$TOKEN',


### PR DESCRIPTION
Part of sourcegraph/cody#3119

## Test plan

1. `sg start dotcom`
2. Open a browser, navigate to `https://sourcegraph.test:3443/.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=CODY_VSCODIUM`
3. Sign in, for example user: sourcegraph, pass: sourcegraphsourcegraph
4. Fill out the sign on survey
5. Verify that you are redirected to a link like `vscodium://sourcegraph.cody-ai/...` etc. If you have VSCodium installed, this will open VSCodium.