### PR TITLE
web: upgrade date-fns to v3

### DIFF
--- a/client/branded/src/components/Timestamp/Timestamp.tsx
+++ b/client/branded/src/components/Timestamp/Timestamp.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 
-import { format, addMinutes, parseISO } from 'date-fns'
-import formatDistance from 'date-fns/formatDistance'
-import formatDistanceStrict from 'date-fns/formatDistanceStrict'
+import { format, addMinutes, parseISO, formatDistance, formatDistanceStrict } from 'date-fns'
 
 import { Tooltip } from '@sourcegraph/wildcard'
 

--- a/client/branded/src/search-ui/components/LastSyncedIcon.tsx
+++ b/client/branded/src/search-ui/components/LastSyncedIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { mdiCloudAlert, mdiCloudClock } from '@mdi/js'
 import classNames from 'classnames'
-import format from 'date-fns/format'
+import { format } from 'date-fns'
 
 import { Icon, Tooltip } from '@sourcegraph/wildcard'
 

--- a/client/web-sveltekit/src/lib/Timestamp.svelte
+++ b/client/web-sveltekit/src/lib/Timestamp.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <script lang="ts">
-    import { addMinutes, format, formatDistance, formatDistanceStrict } from 'date-fns/esm'
+    import { addMinutes, format, formatDistance, formatDistanceStrict } from 'date-fns'
     import { currentDate } from './stores'
     import Tooltip from './Tooltip.svelte'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/Duration.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/Duration.tsx
@@ -1,7 +1,6 @@
 import type { FunctionComponent } from 'react'
 
-import { intervalToDuration } from 'date-fns'
-import formatDuration from 'date-fns/formatDuration'
+import { intervalToDuration, formatDuration } from 'date-fns'
 
 import { Tooltip } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/codeintel/configuration/components/DurationSelect.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/components/DurationSelect.tsx
@@ -1,8 +1,7 @@
 import { type FunctionComponent, useState } from 'react'
 
 import classNames from 'classnames'
-import { intervalToDuration } from 'date-fns'
-import formatDuration from 'date-fns/formatDuration'
+import { intervalToDuration, formatDuration } from 'date-fns'
 
 import { Select, Input } from '@sourcegraph/wildcard'
 

--- a/client/web/src/enterprise/insights/components/creation-ui/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
+++ b/client/web/src/enterprise/insights/components/creation-ui/code-insight-time-step-picker/get-interval-descrtiption-text/get-interval-description-text.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react'
 
+import { Duration } from 'date-fns'
+
 import type { InsightStep } from '../../../../pages/insights/creation/search-insight'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/client/web/src/enterprise/productSubscription/ExpirationDate.tsx
+++ b/client/web/src/enterprise/productSubscription/ExpirationDate.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import format from 'date-fns/format'
+import { format } from 'date-fns'
 
 import { formatRelativeExpirationDate, isProductLicenseExpired } from '../../productSubscription/helpers'
 

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -2,8 +2,7 @@ import React, { useState, useCallback } from 'react'
 
 import { mdiChatQuestionOutline } from '@mdi/js'
 import classNames from 'classnames'
-import addDays from 'date-fns/addDays'
-import endOfDay from 'date-fns/endOfDay'
+import { addDays, endOfDay } from 'date-fns'
 import { noop } from 'lodash'
 
 import { useMutation } from '@sourcegraph/http-client'

--- a/client/web/src/global/GlobalAlerts.tsx
+++ b/client/web/src/global/GlobalAlerts.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 
 import classNames from 'classnames'
-import { parseISO } from 'date-fns'
-import differenceInDays from 'date-fns/differenceInDays'
+import { parseISO, differenceInDays } from 'date-fns'
 
 import { renderMarkdown } from '@sourcegraph/common'
 import { gql, useQuery } from '@sourcegraph/http-client'

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -665,6 +665,11 @@ describe('Batches', () => {
 
                 // Switch to view burndown chart.
                 await driver.page.click('[data-testid="wildcard-tab-list"] [data-testid="wildcard-tab"]:nth-child(2)')
+                await driver.page.waitForTimeout(3000) // hack to wait for chart to load to that we can take a screenshot
+                await percySnapshotWithVariants(
+                    driver.page,
+                    `Batch changes ${entityType} chart details page (first shot)`
+                )
                 await driver.page.waitForSelector('.test-batches-chart', { visible: true })
 
                 // Switch to view executions.
@@ -721,6 +726,11 @@ describe('Batches', () => {
                         // Wait for page to be fully loaded.
                         waitUntil: 'networkidle0',
                     }
+                )
+                await driver.page.waitForTimeout(3000) // hack to wait for chart to load to that we can take a screenshot
+                await percySnapshotWithVariants(
+                    driver.page,
+                    `Batch changes ${entityType} chart details page (second shot)`
                 )
                 await driver.page.waitForSelector('.test-batches-chart', { visible: true })
                 await driver.page.goto(

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -163,6 +163,7 @@ const ChangesetCountsOverTime: (variables: ChangesetCountsOverTimeVariables) => 
         __typename: 'BatchChange',
         changesetCountsOverTime: [
             {
+                __typename: 'ChangesetCounts',
                 closed: 12,
                 date: subDays(now, 2).toISOString(),
                 merged: 10,
@@ -173,6 +174,7 @@ const ChangesetCountsOverTime: (variables: ChangesetCountsOverTimeVariables) => 
                 draft: 10,
             },
             {
+                __typename: 'ChangesetCounts',
                 closed: 12,
                 date: subDays(now, 1).toISOString(),
                 merged: 10,
@@ -665,11 +667,6 @@ describe('Batches', () => {
 
                 // Switch to view burndown chart.
                 await driver.page.click('[data-testid="wildcard-tab-list"] [data-testid="wildcard-tab"]:nth-child(2)')
-                await driver.page.waitForTimeout(3000) // hack to wait for chart to load to that we can take a screenshot
-                await percySnapshotWithVariants(
-                    driver.page,
-                    `Batch changes ${entityType} chart details page (first shot)`
-                )
                 await driver.page.waitForSelector('.test-batches-chart', { visible: true })
 
                 // Switch to view executions.
@@ -726,11 +723,6 @@ describe('Batches', () => {
                         // Wait for page to be fully loaded.
                         waitUntil: 'networkidle0',
                     }
-                )
-                await driver.page.waitForTimeout(3000) // hack to wait for chart to load to that we can take a screenshot
-                await percySnapshotWithVariants(
-                    driver.page,
-                    `Batch changes ${entityType} chart details page (second shot)`
                 )
                 await driver.page.waitForSelector('.test-batches-chart', { visible: true })
                 await driver.page.goto(

--- a/client/web/src/productSubscription/helpers.ts
+++ b/client/web/src/productSubscription/helpers.ts
@@ -1,6 +1,4 @@
-import { parseISO } from 'date-fns'
-import formatDistanceStrict from 'date-fns/formatDistanceStrict'
-import isAfter from 'date-fns/isAfter'
+import { parseISO, formatDistanceStrict, isAfter } from 'date-fns'
 
 import { numberWithCommas, pluralize } from '@sourcegraph/common'
 

--- a/client/web/src/repo/blob/blameRecency.tsx
+++ b/client/web/src/repo/blob/blameRecency.tsx
@@ -1,4 +1,4 @@
-import subYears from 'date-fns/subYears'
+import { subYears } from 'date-fns'
 
 // We use an exponential scale to get more diverse colors for more recent changes.
 //

--- a/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminBackgroundJobsPage.tsx
@@ -11,7 +11,7 @@ import {
     mdiNumeric,
     mdiShape,
 } from '@mdi/js'
-import format from 'date-fns/format'
+import { format } from 'date-fns'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { pluralize } from '@sourcegraph/common'

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -2,8 +2,7 @@ import React, { type FunctionComponent, useCallback, useEffect, useMemo, useStat
 
 import { mdiOpenInNew, mdiCheckCircle, mdiChevronUp, mdiChevronDown, mdiAlertOctagram, mdiContentCopy } from '@mdi/js'
 import classNames from 'classnames'
-import { parseISO } from 'date-fns'
-import formatDistance from 'date-fns/formatDistance'
+import { parseISO, formatDistance } from 'date-fns'
 import type {
     SetAutoUpgradeResult,
     SetAutoUpgradeVariables,

--- a/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
+++ b/client/web/src/site-admin/analytics/AnalyticsOverviewPage/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo } from 'react'
 
 import { mdiAccount, mdiCommentOutline, mdiSourceRepository } from '@mdi/js'
 import classNames from 'classnames'
-import format from 'date-fns/format'
+import { format } from 'date-fns'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { AnchorLink, Card, H2, Link, LoadingSpinner, Text } from '@sourcegraph/wildcard'

--- a/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
+++ b/client/web/src/site-admin/permissions-center/PermissionsSyncJobsTable.tsx
@@ -3,8 +3,7 @@ import React, { type ChangeEvent, type FC, useCallback, useEffect, useRef, useSt
 import type { ApolloError } from '@apollo/client/errors'
 import { mdiCancel, mdiClose, mdiDetails, mdiMapSearch, mdiReload, mdiSecurity } from '@mdi/js'
 import classNames from 'classnames'
-import { intervalToDuration } from 'date-fns'
-import formatDuration from 'date-fns/formatDuration'
+import { intervalToDuration, formatDuration } from 'date-fns'
 import { capitalize, noop } from 'lodash'
 import { animated, useSpring } from 'react-spring'
 

--- a/client/web/src/site/LicenseExpirationAlert.tsx
+++ b/client/web/src/site/LicenseExpirationAlert.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import classNames from 'classnames'
-import formatDistanceStrict from 'date-fns/formatDistanceStrict'
+import { formatDistanceStrict } from 'date-fns'
 
 import { Link } from '@sourcegraph/wildcard'
 

--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
     "d3-shape": "^1.2.0",
     "d3-time-format": "^3.0.0",
     "d3-voronoi": "^1.1.2",
-    "date-fns": "^2.16.1",
+    "date-fns": "^3.3.1",
     "delay": "^4.4.1",
     "detect-indent": "^6.1.0",
     "downshift": "^3.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,8 +215,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.4
       date-fns:
-        specifier: ^2.16.1
-        version: 2.29.3
+        specifier: ^3.3.1
+        version: 3.3.1
       delay:
         specifier: ^4.4.1
         version: 4.4.1
@@ -14059,6 +14059,11 @@ packages:
   /date-fns@2.29.3:
     resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
     engines: {node: '>=0.11'}
+    dev: true
+
+  /date-fns@3.3.1:
+    resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
+    dev: false
 
   /dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}


### PR DESCRIPTION
This PR bumps our https://date-fns.org/ package to v3 which was just released in December: https://blog.date-fns.org/v3-is-out/. We need this for its new integration with UTCDate (see https://github.com/sourcegraph/sourcegraph/pull/60532) - which is required for the license key expiration fix (see https://github.com/sourcegraph/sourcegraph/pull/60533)

CI was also complaining about some build issues after upgrading the package, so this PR also adjusts some import statements to resolve them.

```
  Type 'typeof import("/tmp/bazel-working-directory/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/date-fns@3.3.1/node_modules/date-fns/formatDistanceStrict")' has no call signatures.
client/branded/src/components/Timestamp/Timestamp.tsx(101,17): error TS2349: This expression is not callable.
  Type 'typeof import("/tmp/bazel-working-directory/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/date-fns@3.3.1/node_modules/date-fns/formatDistance")' has no call signatures.
client/branded/src/search-ui/components/LastSyncedIcon.tsx(16,27): error TS2349: This expression is not callable.
  Type 'typeof import("/tmp/bazel-working-directory/__main__/bazel-out/k8-fastbuild/bin/node_modules/.aspect_rules_js/date-fns@3.3.1/node_modules/date-fns/format")' has no call signatures.
```


## Test plan
CI
