### PR TITLE
 web: subscriptions: fix: make all license expiration calculations use utc instead of the browser's local timezone

### DIFF
--- a/client/branded/BUILD.bazel
+++ b/client/branded/BUILD.bazel
@@ -167,6 +167,7 @@ ts_project(
         "//:node_modules/@codemirror/lint",
         "//:node_modules/@codemirror/state",
         "//:node_modules/@codemirror/view",
+        "//:node_modules/@date-fns/utc",
         "//:node_modules/@mdi/js",
         "//:node_modules/@reach/visually-hidden",
         "//:node_modules/@types/classnames",

--- a/client/branded/src/components/Timestamp/Timestamp.tsx
+++ b/client/branded/src/components/Timestamp/Timestamp.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 
-import { format, addMinutes, parseISO, formatDistance, formatDistanceStrict } from 'date-fns'
+import { UTCDate } from '@date-fns/utc'
+import { format, parseISO, formatDistance, formatDistanceStrict } from 'date-fns'
 
 import { Tooltip } from '@sourcegraph/wildcard'
 
@@ -69,7 +70,7 @@ export const Timestamp: React.FunctionComponent<React.PropsWithChildren<Timestam
     const tooltip = useMemo(() => {
         let parsedDate = typeof date === 'string' ? parseISO(date) : new Date(date)
         if (utc) {
-            parsedDate = addMinutes(parsedDate, parsedDate.getTimezoneOffset())
+            parsedDate = new UTCDate(date)
         }
         const dateHasTime = date.toString().includes('T')
         const defaultFormat = dateHasTime ? TimestampFormat.FULL_DATE_TIME : TimestampFormat.FULL_DATE

--- a/client/web/BUILD.bazel
+++ b/client/web/BUILD.bazel
@@ -1755,6 +1755,7 @@ ts_project(
         "//:node_modules/@codemirror/search",
         "//:node_modules/@codemirror/state",
         "//:node_modules/@codemirror/view",
+        "//:node_modules/@date-fns/utc",
         "//:node_modules/@graphiql/react",
         "//:node_modules/@lezer/common",  #keep
         "//:node_modules/@lezer/highlight",

--- a/client/web/src/enterprise/dotcom/productSubscriptions/ProductLicenseValidity.tsx
+++ b/client/web/src/enterprise/dotcom/productSubscriptions/ProductLicenseValidity.tsx
@@ -67,7 +67,7 @@ export const ProductLicenseValidity: React.FunctionComponent<
     return (
         <div className={className}>
             {variant !== 'no-icon' && <ValidityIcon isExpired={isExpired} isRevoked={isRevoked} />}
-            {getText(isExpired, isRevoked)}, <Timestamp date={timestamp} noAbout={true} noAgo={true} />{' '}
+            {getText(isExpired, isRevoked)}, <Timestamp date={timestamp} noAbout={true} noAgo={true} utc={true} />{' '}
             {timestampSuffix}
             {!isExpired && isRevoked && revokeReason && (
                 <>

--- a/client/web/src/enterprise/productSubscription/ExpirationDate.tsx
+++ b/client/web/src/enterprise/productSubscription/ExpirationDate.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { UTCDate } from '@date-fns/utc'
 import { format } from 'date-fns'
 
 import { formatRelativeExpirationDate, isProductLicenseExpired } from '../../productSubscription/helpers'
@@ -22,15 +23,21 @@ export const ExpirationDate: React.FunctionComponent<
         lowercase?: boolean
     }>
 > = ({ date, showTime, showRelative, showPrefix, lowercase }) => {
+    const dateInUTC = new UTCDate(date)
+
     let text: string | undefined
     if (showPrefix) {
-        text = isProductLicenseExpired(date) ? 'Expired on ' : 'Valid until '
+        text = isProductLicenseExpired(dateInUTC) ? 'Expired on ' : 'Valid until '
     }
     return (
         <span>
             {text && lowercase ? text.toLowerCase() : text}
-            {showTime ? format(date, 'PPpp') : <span title={format(date, 'PPpp')}>{format(date, 'yyyy-MM-dd')}</span>}
-            {showRelative && ` (${formatRelativeExpirationDate(date)})`}
+            {showTime ? (
+                format(dateInUTC, 'PPpp zzz')
+            ) : (
+                <span title={format(dateInUTC, 'PPpp zzz')}>{format(dateInUTC, 'yyyy-MM-dd zzz')}</span>
+            )}
+            {showRelative && ` (${formatRelativeExpirationDate(dateInUTC)})`}
         </span>
     )
 }

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react'
 
+import { UTCDate } from '@date-fns/utc'
 import { mdiChatQuestionOutline } from '@mdi/js'
 import classNames from 'classnames'
 import { addDays, endOfDay } from 'date-fns'
@@ -93,7 +94,7 @@ const getEmptyFormData = (account: string, latestLicense: License | undefined): 
         salesforceOpportunityID: latestLicense?.info?.salesforceOpportunityID ?? '',
         plan: latestLicense?.info?.tags.find(tag => tag.startsWith('plan:'))?.slice('plan:'.length) ?? '',
         userCount: latestLicense?.info?.userCount ?? 1,
-        expiresAt: endOfDay(Date.now()),
+        expiresAt: endOfDay(new UTCDate(UTCDate.now())),
         trial: latestLicense?.info?.tags.includes(TAG_TRIAL.tagValue) ?? false,
         trueUp: latestLicense?.info?.tags.includes(TAG_TRUEUP.tagValue) ?? false,
         airGapped: latestLicense?.info?.tags.includes(TAG_AIR_GAPPED.tagValue) ?? false,
@@ -225,17 +226,30 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
     const setValidDays = useCallback((validDays: number): void => {
         setFormData(formData => ({
             ...formData,
-            expiresAt: addDaysAndRoundToEndOfDay(validDays),
+            expiresAt: addDaysAndRoundToEndOfDayInUTC(validDays),
         }))
     }, [])
     const onExpiresAtChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
-        event =>
+        event => {
+            // The event.target.valueAsDate property returns a native Javascript Date object.
+            // However, we can't use the endOfDay() date-fns utility with it since by default it
+            // does all calculations using the browser's local timezone, not UTC.
+            //
+            // However, as of date-fns@v3, they introduced a new Date wrapper, UTCDate. When using this wrapper,
+            // all of the date-fns calculations will do them with respect to UTC (which is the desired behavior with
+            // expiration dates).
+
+            const date = event.target.valueAsDate
+                ? event.target.valueAsDate
+                : getEmptyFormData(subscriptionAccount, latestLicense).expiresAt
+
+            const expiresAt = endOfDay(new UTCDate(date))
+
             setFormData(formData => ({
                 ...formData,
-                expiresAt: endOfDay(
-                    event.target.valueAsDate || getEmptyFormData(subscriptionAccount, latestLicense).expiresAt
-                ),
-            })),
+                expiresAt: expiresAt,
+            }))
+        },
         [subscriptionAccount, latestLicense]
     )
 
@@ -507,8 +521,8 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                                         description="When this license expires. Sourcegraph will disable beyond this date. Usually the end date of the contract."
                                         label="Expires At"
                                         id="site-admin-create-product-subscription-page__expiresAt"
-                                        min={formatDateForInput(addDaysAndRoundToEndOfDay(1))}
-                                        max={formatDateForInput(addDaysAndRoundToEndOfDay(2000))}
+                                        min={formatDateForInput(addDaysAndRoundToEndOfDayInUTC(1))}
+                                        max={formatDateForInput(addDaysAndRoundToEndOfDayInUTC(2000))}
                                         value={formatDateForInput(formData.expiresAt)}
                                         onChange={onExpiresAtChange}
                                         required={true}
@@ -612,10 +626,13 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
 }
 
 /**
- * Adds 1 day to the current date, then rounds it up to midnight in the client's timezone. This is a
+ * Adds 1 day to the current date, then rounds it up to midnight in UTC. This is a
  * generous interpretation of "valid for N days" to avoid confusion over timezones or "will it
  * expire at the beginning of the day or at the end of the day?"
  */
-const addDaysAndRoundToEndOfDay = (amount: number): Date => endOfDay(addDays(Date.now(), amount))
+const addDaysAndRoundToEndOfDayInUTC = (amount: number): UTCDate => {
+    const now = new UTCDate(UTCDate.now())
+    return endOfDay(addDays(now, amount))
+}
 
 const formatDateForInput = (date: Date): string => date.toISOString().slice(0, 10)

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -239,15 +239,23 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
             // all of the date-fns calculations will do them with respect to UTC (which is the desired behavior with
             // expiration dates).
 
-            const date = event.target.valueAsDate
-                ? event.target.valueAsDate
+            // The value field from the date picker input element is in the format
+            // yyyy-mm-dd, so we can use it to directly construct a new UTCDate object
+            // with the appropriate date.
+            //
+            // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#value
+            // for more information.
+            const dateRegex = /\d{4}-\d{2}-\d{2}/
+
+            const date: Date = dateRegex.test(event.target.value)
+                ? new UTCDate(event.target.value)
                 : getEmptyFormData(subscriptionAccount, latestLicense).expiresAt
 
             const expiresAt = endOfDay(new UTCDate(date))
 
             setFormData(formData => ({
                 ...formData,
-                expiresAt: expiresAt,
+                expiresAt,
             }))
         },
         [subscriptionAccount, latestLicense]

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionNode.tsx
@@ -44,7 +44,7 @@ export const SiteAdminProductSubscriptionNode: React.FunctionComponent<
         </td>
         <td className="text-nowrap">
             {node.activeLicense?.info ? (
-                <Timestamp date={node.activeLicense.info.expiresAt} />
+                <Timestamp date={node.activeLicense.info.expiresAt} utc={true} />
             ) : (
                 <span className="text-muted font-italic">None</span>
             )}

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserProductSubscriptionStatus.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/UserProductSubscriptionStatus.test.tsx.snap
@@ -27,9 +27,9 @@ exports[`UserProductSubscriptionStatus > toggle > license key hidden 1`] = `
           <span>
             expired on 
             <span
-              title="Jan 1, 1970, 12:00:23 AM"
+              title="Jan 1, 1970, 12:00:23 AM GMT+0"
             >
-              1970-01-01
+              1970-01-01 GMT+0
             </span>
              (36 years ago)
           </span>
@@ -100,9 +100,9 @@ exports[`UserProductSubscriptionStatus > toggle > license key revealed 1`] = `
           <span>
             expired on 
             <span
-              title="Jan 1, 1970, 12:00:23 AM"
+              title="Jan 1, 1970, 12:00:23 AM GMT+0"
             >
-              1970-01-01
+              1970-01-01 GMT+0
             </span>
              (36 years ago)
           </span>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/60409

[Native Javascript Date objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) have an epoch based internal representation. However, any method calculations are done using the browser's local timezone. This also includes the utility functions that `date-fns` provides (such as `endOfDay`). This lead to confusing behavior, such as license expiration dates accidentally being 9 hours earlier or later than expected (since it depends on the location of the CE creating the key). 

However, this PR fixes the problem by using date-fns v3 (https://github.com/sourcegraph/sourcegraph/pull/60531) along side UTCDate(https://github.com/sourcegraph/sourcegraph/pull/60532). The new `date-fns` major version now adds support for doing calculations calculations in UTC rather than the browser's time zone. See https://blog.date-fns.org/v3-is-out/ for more information.

## Test plan
CI

Using `sg start dotcom`, I created a few license keys and verified that the various expiration dates now make sense with UTC (GMT+0) based calculations - instead of local timezone ones. Here are some screenshots:


<img width="1411" alt="Screenshot 2024-02-14 at 9 04 40 PM" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/3b523d71-9fe6-48bc-bf7c-d5bb0d8a4fcb">
<img width="494" alt="Screenshot 2024-02-14 at 9 05 15 PM" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/19e46bdb-64b9-47e5-b4d9-0632bbe6e767">
<img width="1428" alt="Screenshot 2024-02-14 at 9 05 52 PM" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/8a7529db-6196-4bac-a954-d7ea0dccf1aa">
<img width="489" alt="Screenshot 2024-02-14 at 9 05 07 PM" src="https://github.com/sourcegraph/sourcegraph/assets/9022011/554ad4a9-ac1c-4c56-8923-14e7b73c6ce1">

