### PR TITLE
Allow Bedrock completions provider to accept a full endpoint url

### DIFF
--- a/internal/completions/client/awsbedrock/BUILD.bazel
+++ b/internal/completions/client/awsbedrock/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//dev:go_defs.bzl", "go_test")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -15,5 +16,15 @@ go_library(
         "@com_github_aws_aws_sdk_go_v2_aws_protocol_eventstream//:eventstream",
         "@com_github_aws_aws_sdk_go_v2_config//:config",
         "@com_github_aws_aws_sdk_go_v2_credentials//:credentials",
+    ],
+)
+
+go_test(
+    name = "awsbedrock_test",
+    srcs = ["bedrock_test.go"],
+    embed = [":awsbedrock"],
+    deps = [
+        "@com_github_aws_aws_sdk_go_v2_config//:config",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/completions/client/awsbedrock/BUILD.bazel
+++ b/internal/completions/client/awsbedrock/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//internal/completions/types",
         "//internal/httpcli",
         "//lib/errors",
+        "@com_github_aws_aws_sdk_go_v2//aws",
         "@com_github_aws_aws_sdk_go_v2//aws/signer/v4:signer",
         "@com_github_aws_aws_sdk_go_v2_aws_protocol_eventstream//:eventstream",
         "@com_github_aws_aws_sdk_go_v2_config//:config",

--- a/internal/completions/client/awsbedrock/bedrock_test.go
+++ b/internal/completions/client/awsbedrock/bedrock_test.go
@@ -1,0 +1,43 @@
+package awsbedrock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAwsConfigOptsForKeyConfig(t *testing.T) {
+
+	t.Run("With endpoint as URL", func(t *testing.T) {
+		endpoint := "https://example.com"
+		accessToken := "key:secret"
+
+		defaultConfig, err := config.LoadDefaultConfig(context.Background(), awsConfigOptsForKeyConfig(endpoint, accessToken)...)
+		require.NoError(t, err)
+		// The endpoint resolver should be set if the endpoint is a URL
+		require.NotNil(t, defaultConfig.EndpointResolverWithOptions)
+		// The endpoint for any service should be the URL
+		awsEndpoint, err := defaultConfig.EndpointResolverWithOptions.ResolveEndpoint("test", "some-region", nil)
+		require.NoError(t, err)
+		require.Equal(t, awsEndpoint.URL, endpoint)
+		// The region should not be set if the endpoint is a URL this needs to be specified in AWS_REGION env variable
+		require.Empty(t, defaultConfig.Region)
+
+	})
+
+	t.Run("With endpoint as region", func(t *testing.T) {
+		endpoint := "us-east-1"
+		accessToken := "key:secret"
+
+		defaultConfig, err := config.LoadDefaultConfig(context.Background(), awsConfigOptsForKeyConfig(endpoint, accessToken)...)
+		require.NoError(t, err)
+		// The endpoint resolver should not be set if the endpoint is a region
+		require.Nil(t, defaultConfig.EndpointResolverWithOptions)
+		// The region should be set if the endpoint is a region
+		require.Equal(t, defaultConfig.Region, endpoint)
+
+	})
+
+}

--- a/internal/completions/client/awsbedrock/bedrock_test.go
+++ b/internal/completions/client/awsbedrock/bedrock_test.go
@@ -22,8 +22,6 @@ func TestAwsConfigOptsForKeyConfig(t *testing.T) {
 		awsEndpoint, err := defaultConfig.EndpointResolverWithOptions.ResolveEndpoint("test", "some-region", nil)
 		require.NoError(t, err)
 		require.Equal(t, awsEndpoint.URL, endpoint)
-		// The region should not be set if the endpoint is a URL this needs to be specified in AWS_REGION env variable
-		require.Empty(t, defaultConfig.Region)
 
 	})
 


### PR DESCRIPTION
This allows a full endpoint to provided to the completions configuration instead of a aws region.  The reason for this change is to support scenarios where the default bedrock endpoints are not reachable from the frontend deployment.  When specifying the endpoint it is necessary to set the AWS_REGION environment variable to the region that the Bedrock models are in.
## Test plan
These commits manually were tested in a reference environment with a tunnel between GCP and AWS that approximated the type of environment this is intended to support
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
