### PR TITLE
gitserver: Modernize GetObject

### DIFF
--- a/cmd/gitserver/internal/git/gitcli/exec.go
+++ b/cmd/gitserver/internal/git/gitcli/exec.go
@@ -42,7 +42,7 @@ var (
 		"merge-base":   {"--"},
 		"show-ref":     {"--heads"},
 		"shortlog":     {"-s", "-n", "-e", "--no-merges", "--after", "--before"},
-		"cat-file":     {"-p"},
+		"cat-file":     {"-p", "-t"},
 		"lfs":          {},
 
 		// Commands used by GitConfigStore:

--- a/cmd/gitserver/internal/git/gitcli/object.go
+++ b/cmd/gitserver/internal/git/gitcli/object.go
@@ -4,62 +4,29 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"fmt"
-	"os/exec"
-	"strings"
+	"io"
 
-	"github.com/sourcegraph/log"
-	"go.opentelemetry.io/otel/attribute"
-
-	"github.com/sourcegraph/sourcegraph/cmd/gitserver/internal/common"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/gitdomain"
-	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/wrexec"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func (g *gitCLIBackend) GetObject(ctx context.Context, objectName string) (*gitdomain.GitObject, error) {
-	return getObject(ctx, g.rcf, g.dir, getObjectType, revParse, g.repoName, objectName)
-}
-
-func getObject(ctx context.Context, rcf *wrexec.RecordingCommandFactory, dir common.GitDir, getObjectType getObjectTypeFunc, revParse revParseFunc, repo api.RepoName, objectName string) (_ *gitdomain.GitObject, err error) {
-	tr, ctx := trace.New(ctx, "GetObject",
-		attribute.String("objectName", objectName))
-	defer tr.EndWithErr(&err)
-
 	if err := checkSpecArgSafety(objectName); err != nil {
 		return nil, err
 	}
 
-	sha, err := revParse(ctx, rcf, repo, dir, objectName)
+	sha, err := g.revParse(ctx, objectName)
 	if err != nil {
-		if gitdomain.IsRepoNotExist(err) {
-			return nil, err
-		}
-		if strings.Contains(sha, "unknown revision") {
-			return nil, &gitdomain.RevisionNotFoundError{Repo: repo, Spec: objectName}
-		}
-		return nil, err
-	}
-
-	sha = strings.TrimSpace(sha)
-	if !gitdomain.IsAbsoluteRevision(sha) {
-		if sha == "HEAD" {
-			// We don't verify the existence of HEAD, but if HEAD doesn't point to anything
-			// git just returns `HEAD` as the output of rev-parse. An example where this
-			// occurs is an empty repository.
-			return nil, &gitdomain.RevisionNotFoundError{Repo: repo, Spec: objectName}
-		}
-		return nil, &gitdomain.BadCommitError{Spec: objectName, Commit: api.CommitID(sha), Repo: repo}
+		return nil, errors.Wrap(err, "getting object ID")
 	}
 
 	oid, err := decodeOID(sha)
 	if err != nil {
-		return nil, errors.Wrap(err, "decoding oid")
+		return nil, errors.Wrap(err, "failed to decode OID")
 	}
 
-	objectType, err := getObjectType(ctx, rcf, repo, dir, oid.String())
+	objectType, err := g.getObjectType(ctx, oid.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "getting object type")
 	}
@@ -68,42 +35,31 @@ func getObject(ctx context.Context, rcf *wrexec.RecordingCommandFactory, dir com
 		ID:   oid,
 		Type: objectType,
 	}, nil
-
 }
-
-type getObjectTypeFunc func(ctx context.Context, rcf *wrexec.RecordingCommandFactory, repo api.RepoName, dir common.GitDir, objectID string) (gitdomain.ObjectType, error)
 
 // getObjectType returns the object type given an objectID.
-func getObjectType(ctx context.Context, rcf *wrexec.RecordingCommandFactory, repo api.RepoName, dir common.GitDir, objectID string) (gitdomain.ObjectType, error) {
-	cmd := exec.Command("git", "cat-file", "-t", "--", objectID)
-	dir.Set(cmd)
-	wrappedCmd := rcf.WrapWithRepoName(context.Background(), log.NoOp(), repo, cmd)
-	out, err := wrappedCmd.CombinedOutput()
+func (g *gitCLIBackend) getObjectType(ctx context.Context, objectID string) (gitdomain.ObjectType, error) {
+	r, err := g.NewCommand(ctx, WithArguments("cat-file", "-t", "--", objectID))
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", wrappedCmd.Args, out))
+		return "", err
 	}
 
-	objectType := gitdomain.ObjectType(bytes.TrimSpace(out))
-	return objectType, nil
-}
-
-type revParseFunc func(ctx context.Context, rcf *wrexec.RecordingCommandFactory, repo api.RepoName, dir common.GitDir, rev string) (string, error)
-
-// revParse will run rev-parse on the given rev.
-func revParse(ctx context.Context, rcf *wrexec.RecordingCommandFactory, repo api.RepoName, dir common.GitDir, rev string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", rev)
-	dir.Set(cmd)
-	wrappedCmd := rcf.WrapWithRepoName(context.Background(), log.NoOp(), repo, cmd)
-	out, err := wrappedCmd.CombinedOutput()
+	stdout, err := io.ReadAll(r)
 	if err != nil {
-		return "", errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", wrappedCmd.Args, out))
+		var e *CommandFailedError
+		if errors.As(err, &e) && e.ExitStatus == 128 && (bytes.Contains(e.Stderr, []byte("Not a valid object name")) ||
+			bytes.Contains(e.Stderr, []byte("git cat-file: could not get object info"))) {
+			return "", &gitdomain.RevisionNotFoundError{Repo: g.repoName, Spec: objectID}
+		}
+
+		return "", err
 	}
 
-	return string(out), nil
+	return gitdomain.ObjectType(bytes.TrimSpace(stdout)), nil
 }
 
-func decodeOID(sha string) (gitdomain.OID, error) {
-	oidBytes, err := hex.DecodeString(sha)
+func decodeOID(sha api.CommitID) (gitdomain.OID, error) {
+	oidBytes, err := hex.DecodeString(string(sha))
 	if err != nil {
 		return gitdomain.OID{}, err
 	}

--- a/cmd/gitserver/internal/git/gitcli/resolverevision.go
+++ b/cmd/gitserver/internal/git/gitcli/resolverevision.go
@@ -29,6 +29,10 @@ func (g *gitCLIBackend) ResolveRevision(ctx context.Context, spec string) (api.C
 		return "", err
 	}
 
+	return g.revParse(ctx, spec)
+}
+
+func (g *gitCLIBackend) revParse(ctx context.Context, spec string) (api.CommitID, error) {
 	r, err := g.NewCommand(ctx, WithArguments("rev-parse", spec, "--"))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
- Makes it use the getCommand helper which runs proper command args validation and is embedded in observability
- Makes the test suite simpler and more aligned

## Test plan

Added/modified tests, existing other tests still pass.

