### PR TITLE
build: Update snapshot outputs when updating SHAs

### DIFF
--- a/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
+++ b/internal/codeintel/autoindexing/internal/inference/libs/indexes.go
@@ -28,7 +28,7 @@ var defaultIndexers = map[string]string{
 var defaultIndexerSHAs = map[string]string{
 	"sourcegraph/scip-go":         "sha256:39c1495d4c7381c553f44d979c3f301f9bedbd6f25fbab0f92d6e90a555391cc",
 	"sourcegraph/scip-rust":       "sha256:adf0047fc3050ba4f7be71302b42c74b49901f38fb40916d94ac5fc9181ac078",
-	"sourcegraph/scip-java":       "sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702",
+	"sourcegraph/scip-java":       "sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a",
 	"sourcegraph/scip-python":     "sha256:e3c13f0cadca78098439c541d19a72c21672a3263e22aa706760d941581e068d",
 	"sourcegraph/scip-typescript": "sha256:3df8b36a2ad4e073415bfbeaedf38b3cfff3e697614c8f578299f470d140c2c8",
 	"sourcegraph/scip-ruby":       "sha256:ef53e5f1450330ddb4a3edce963b7e10d900d44ff1e7de4960680289ac25f319",

--- a/internal/codeintel/autoindexing/internal/inference/libs/update-shas.sh
+++ b/internal/codeintel/autoindexing/internal/inference/libs/update-shas.sh
@@ -33,3 +33,6 @@ for indexer in scip-go scip-rust scip-java scip-python scip-typescript scip-ruby
 done
 
 go fmt "$SCRIPT_DIR/indexes.go"
+
+echo "Updating SHAs in test snapshots"
+go test "$SCRIPT_DIR/../..." -update

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Gradle.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Gradle.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
+  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Maven.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_Maven.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
+  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_SBT.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_SBT.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
+  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_lsif-java.json.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/JVM_project_with_lsif-java.json.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
+  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_WITHOUT_top-level_build_file.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_WITHOUT_top-level_build_file.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: my-module
-  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
+  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
   indexer_args:
     - scip-java
     - index
@@ -11,7 +11,7 @@
 - steps: []
   local_steps: []
   root: our-module
-  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
+  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
   indexer_args:
     - scip-java
     - index

--- a/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_with_top-level_build_file.yaml
+++ b/internal/codeintel/autoindexing/internal/inference/testdata/Nested_JVM_project_with_top-level_build_file.yaml
@@ -1,7 +1,7 @@
 - steps: []
   local_steps: []
   root: ""
-  indexer: sourcegraph/scip-java@sha256:2aa5f44437e17b7383e0bbe049952e7601186d1134668b332f1b616ed637b702
+  indexer: sourcegraph/scip-java@sha256:808b063b7376cfc0a4937d89ddc3d4dd9652d10609865fae3f3b34302132737a
   indexer_args:
     - scip-java
     - index


### PR DESCRIPTION
Previously, I changed the code to use YAML snapshots instead of
hard-coded structs, so replacing the SHAs in tests just involves
running the test with the `-update` flag documented in the code
instead of tweaking Go code.

## Test plan

n/a