### PR TITLE
blob/codeintel: Fix popover links to include specified revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Code Monitors now properly ignores monitors associated with soft-deleted users, which previously would have led to an error on the overview page. [#60405](https://github.com/sourcegraph/sourcegraph/pull/60405)
+- Links in codeintel popovers respect the revision from the URL.
 
 ### Removed
 

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -337,6 +337,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
             repoName: blobInfo.repoName,
             filePath: blobInfo.filePath,
             commitID: blobInfo.commitID,
+            revision: blobInfo.revision,
             languages: blobInfo.languages,
         },
         blobInfo.mode
@@ -560,7 +561,7 @@ function useCodeIntelExtension(
         commitID,
         revision,
         languages,
-    }: { repoName: string; filePath: string; commitID: string; revision?: string; languages: string[] },
+    }: { repoName: string; filePath: string; commitID: string; revision: string; languages: string[] },
     mode: string
 ): Extension {
     const navigate = useNavigate()

--- a/client/web/src/repo/blob/codemirror/utils.ts
+++ b/client/web/src/repo/blob/codemirror/utils.ts
@@ -229,7 +229,7 @@ export function isValidLineRange(
 }
 
 export function locationToURL(
-    documentInfo: { repoName: string; filePath: string; commitID: string; revision?: string },
+    documentInfo: { repoName: string; filePath: string; commitID: string; revision: string },
     location: Location,
     viewState?: BlobViewState
 ): string {


### PR DESCRIPTION
Closes #60541 

The revision from the URL wasn't passed to the codeintel extension.

## Test plan

The links in the tooltip shown at 
https://sourcegraph.test:3443/github.com/uber-go/cff@239d0216e326c2d061a71c62fbfe7b8bbd4771ef/-/blob/internal/package.go?L85:14&popover=pinned contain the revision from the URL.