### PR TITLE
telemetry-gateway: fast-error on oversized event, improve logging

### DIFF
--- a/cmd/telemetry-gateway/internal/events/BUILD.bazel
+++ b/cmd/telemetry-gateway/internal/events/BUILD.bazel
@@ -13,7 +13,9 @@ go_library(
         "//internal/pubsub",
         "//internal/telemetrygateway/v1:telemetrygateway",
         "//lib/errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_sourcegraph_conc//pool",
+        "@com_google_cloud_go_pubsub//:pubsub",
         "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/cmd/telemetry-gateway/internal/server/server.go
+++ b/cmd/telemetry-gateway/internal/server/server.go
@@ -79,7 +79,7 @@ func (s *Server) RecordEvents(stream telemetrygatewayv1.TelemeteryGatewayService
 			}
 
 			metadata := msg.GetMetadata()
-			logger = logger.With(log.String("request_id", metadata.GetRequestId()))
+			logger = logger.With(log.String("requestID", metadata.GetRequestId()))
 
 			// Validate self-reported instance identifier
 			switch metadata.GetIdentifier().Identifier.(type) {
@@ -89,8 +89,10 @@ func (s *Server) RecordEvents(stream telemetrygatewayv1.TelemeteryGatewayService
 				if err != nil {
 					return status.Errorf(codes.InvalidArgument, "invalid license_key: %s", err)
 				}
+				// Attach instance ID to all subsequent log messages
+				logger = logger.With(log.String("instanceID", identifier.InstanceId))
+				// Record start of stream + salesforce opportunity once
 				logger.Info("handling events submission stream for licensed instance",
-					log.String("instanceID", identifier.InstanceId),
 					log.Stringp("license.salesforceOpportunityID", licenseInfo.SalesforceOpportunityID),
 					log.Stringp("license.salesforceSubscriptionID", licenseInfo.SalesforceSubscriptionID))
 
@@ -99,8 +101,10 @@ func (s *Server) RecordEvents(stream telemetrygatewayv1.TelemeteryGatewayService
 				if identifier.InstanceId == "" {
 					return status.Error(codes.InvalidArgument, "instance_id is required for unlicensed instance")
 				}
-				logger.Info("handling events submission stream for unlicensed instance",
-					log.String("instanceID", identifier.InstanceId))
+				// Attach instance ID to all subsequent log messages
+				logger = logger.With(log.String("instanceID", identifier.InstanceId))
+				// Record start of stream
+				logger.Info("handling events submission stream for unlicensed instance")
 
 			default:
 				logger.Error("unknown identifier type",


### PR DESCRIPTION
Telemetry Gateway recently received an event that, when composed as JSON with license key and everything, seems to be exceeding 10MB in size, which is the Pub/Sub limit: https://sourcegraph.slack.com/archives/C06CCJR4K9R/p1707986358501489?thread_ts=1707984656.886109&cid=C06CCJR4K9R

Pending a decision from the team (https://sourcegraph.slack.com/archives/CN4FC7XT4/p1707986514302069), let's record some details here for now:

1. Return special annotate error with additional details on clearly oversized events, and don't both trying to send it to pub/sub, as that may cause problems if this continues
2. Improve our logger such that all events in a stream are annotated with the instance ID

Note the TODO:

```go
// TODO: We can't error forever, as the instance will keep trying to
// deliver this event - eventually we may just need to take an action,
// then pretend the event succeeded.
```

## Test plan

CI