### PR TITLE
Search results: Update filter actions background

### DIFF
--- a/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
+++ b/client/branded/src/search-ui/results/filters/NewSearchFilters.module.scss
@@ -52,7 +52,7 @@
     bottom: 0;
     padding: 1rem 0.75rem;
     border-top: 1px solid var(--border-color);
-    background-color: var(--code-bg);
+    background-color: var(--color-bg-1);
 
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
The background color behind the "Move filters to query" button is too prominent and has been updated to match the rest of the panel.

## Before

### Light Mode
(Remains unchanged, `code-bg` and `color-bg-1` both output white in light mode)

### Dark Mode
<img width="323" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/0ba53871-d51e-417c-a52a-3b6c2c3ef7fd">


## After

### Light Mode
(Remains unchanged, `code-bg` and `color-bg-1` both output white in light mode)

### Dark Mode

<img width="337" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/5337876/8800de57-0280-43a5-8e21-8457fad8a0e8">


## Test plan
- Locally tested