### PR TITLE
ci: generate different steps depending on what pipeline we're in

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
         label: ":oncoming_police_car: commit check"
         agents: { queue: aspect-small }
         command: |
-          echo "--- :git: check we're after commit
+          echo "--- :git: check we're after commit"
           if git merge-base --is-ancestor 20a3c0836eaa300beecf88e21f78dcd708b047d3 HEAD; then
             echo "✅ We are after the commit."
           else

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,7 @@
 
 steps:
   - group: "Pipeline setup"
+    if: pipeline.slug == "sourcegraph"
     steps:
       - label: ':bazel::pipeline: Generate pipeline'
         key: 'pipeline-gen'
@@ -17,9 +18,41 @@ steps:
         # as possible, so as to better assess pipeline load e.g. to scale the Buildkite fleet.
         priority: 10
         command: './dev/ci/gen-pipeline.sh'
-  - group: "Aspect"
+  - group: "Aspect :nail_care: "
     if: pipeline.slug == "aspect-experimental"
     steps:
-      - label: ':aspect: Setup workflows'
-        key: 'aspect-setup'
-        command: 'echo "--- :dynamite:"'
+      - key: "git-ensure-commit"
+        label: ":oncoming_police_car: commit check"
+        agents: { queue: aspect-small }
+        command: |
+          echo "--- :git: check we're after commit
+          if git merge-base --is-ancestor c844eaf2958bdc37fbc65488b98804a846ae9681 HEAD; then
+            echo ":white_checkmark: We are after the commit."
+          else
+            echo ":x: HEAD commit should be after c844eaf2958bdc37fbc65488b98804a846ae9681"
+            exit 1
+          fi
+
+      - group: ":construction: workflows"
+        depends_on: "git-ensure-commit"
+        steps:
+        - key: aspect-workflows-setup
+          label: ":aspect: Setup Aspect Workflows"
+          commands:
+            - "rosetta steps | buildkite-agent pipeline upload"
+          agents:
+            queue: aspect-small
+        - label: ":pipeline: Generate pipeline"
+          if: build.branch !~ /^main(-dry-run\/)?.*/ && build.branch != "wb/aspect/gen-pipeline"
+          commands:
+            - "./dev/ci/gen-pipeline.sh"
+          agents:
+            queue: bazel
+          env:
+            ASPECT_WORKFLOWS_BUILD: "1"
+        - label: ":pipeline: Generate pipeline(Aspect)"
+          if: build.branch == "wb/aspect/gen-pipeline"
+          commands:
+            - "./dev/ci/gen-pipeline.sh"
+          agents:
+            queue: aspect-default

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
         # as possible, so as to better assess pipeline load e.g. to scale the Buildkite fleet.
         priority: 10
         command: './dev/ci/gen-pipeline.sh'
-  - group: "Aspect :nail_care: "
+  - group: ":aspect: Aspect Workflows "
     if: pipeline.slug == "aspect-experimental"
     steps:
       - key: "after-commit-check"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,9 +27,9 @@ steps:
         command: |
           echo "--- :git: check we're after commit
           if git merge-base --is-ancestor 20a3c0836eaa300beecf88e21f78dcd708b047d3 HEAD; then
-            echo ":white_checkmark: We are after the commit."
+            echo "✅ We are after the commit."
           else
-            echo ":x: HEAD commit should be after 20a3c0836eaa300beecf88e21f78dcd708b047d3"
+            echo "❌ HEAD commit should be after 20a3c0836eaa300beecf88e21f78dcd708b047d3"
             exit 1
           fi
 
@@ -43,16 +43,10 @@ steps:
           agents:
             queue: aspect-small
         - label: ":pipeline: Generate pipeline"
-          if: build.branch !~ /^main(-dry-run\/)?.*/ && build.branch != "wb/aspect/gen-pipeline"
+          if: build.branch !~ /^main(-dry-run\/)?.*/
           commands:
             - "./dev/ci/gen-pipeline.sh"
           agents:
             queue: bazel
           env:
             ASPECT_WORKFLOWS_BUILD: "1"
-        - label: ":pipeline: Generate pipeline(Aspect)"
-          if: build.branch == "wb/aspect/gen-pipeline"
-          commands:
-            - "./dev/ci/gen-pipeline.sh"
-          agents:
-            queue: aspect-default

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
             exit 1
           fi
 
-      - key: aspect-workflows-setup
+      - key: aspect-workflows-upload
         depends_on: "after-commit-check"
         label: ":aspect: Setup Aspect Workflows"
         commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,10 +26,10 @@ steps:
         agents: { queue: aspect-small }
         command: |
           echo "--- :git: check we're after commit
-          if git merge-base --is-ancestor c844eaf2958bdc37fbc65488b98804a846ae9681 HEAD; then
+          if git merge-base --is-ancestor 20a3c0836eaa300beecf88e21f78dcd708b047d3 HEAD; then
             echo ":white_checkmark: We are after the commit."
           else
-            echo ":x: HEAD commit should be after c844eaf2958bdc37fbc65488b98804a846ae9681"
+            echo ":x: HEAD commit should be after 20a3c0836eaa300beecf88e21f78dcd708b047d3"
             exit 1
           fi
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,20 +33,19 @@ steps:
             exit 1
           fi
 
-      - group: ":construction: workflows"
+      - key: aspect-workflows-setup
         depends_on: "after-commit-check"
-        steps:
-        - key: aspect-workflows-setup
-          label: ":aspect: Setup Aspect Workflows"
-          commands:
-            - "rosetta steps | buildkite-agent pipeline upload"
-          agents:
-            queue: aspect-small
-        - label: ":pipeline: Generate pipeline"
-          if: build.branch !~ /^main(-dry-run\/)?.*/
-          commands:
-            - "./dev/ci/gen-pipeline.sh"
-          agents:
-            queue: bazel
-          env:
-            ASPECT_WORKFLOWS_BUILD: "1"
+        label: ":aspect: Setup Aspect Workflows"
+        commands:
+          - "rosetta steps | buildkite-agent pipeline upload"
+        agents:
+          queue: aspect-small
+      - label: ":pipeline: Generate pipeline"
+        depends_on: "after-commit-check"
+        if: build.branch !~ /^main(-dry-run\/)?.*/
+        commands:
+          - "./dev/ci/gen-pipeline.sh"
+        agents:
+          queue: bazel
+        env:
+          ASPECT_WORKFLOWS_BUILD: "1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,3 +17,9 @@ steps:
         # as possible, so as to better assess pipeline load e.g. to scale the Buildkite fleet.
         priority: 10
         command: './dev/ci/gen-pipeline.sh'
+  - group: "Aspect"
+    if: pipeline.slug == "aspect-experimental"
+    steps:
+      - label: ':aspect: Setup workflows'
+        key: 'aspect-setup'
+        command: 'echo "--- :dynamite:"'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,7 @@ steps:
   - group: "Aspect :nail_care: "
     if: pipeline.slug == "aspect-experimental"
     steps:
-      - key: "git-ensure-commit"
+      - key: "after-commit-check"
         label: ":oncoming_police_car: commit check"
         agents: { queue: aspect-small }
         command: |
@@ -34,7 +34,7 @@ steps:
           fi
 
       - group: ":construction: workflows"
-        depends_on: "git-ensure-commit"
+        depends_on: "after-commit-check"
         steps:
         - key: aspect-workflows-setup
           label: ":aspect: Setup Aspect Workflows"


### PR DESCRIPTION
This change mostly affects the Aspect Pipeline, moving the initial steps being defined in the UI to having them in the `buildkite.yml` file.

Once this is merged the UI steps will be updated to prefer uploading the pipeline rather than raw steps
## Test plan
- [sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds/262493)
- [aspect pipeline](https://buildkite.com/sourcegraph/aspect-experimental/builds/8813) on this branch - notice that the pipeline is uploaded
- [aspect pipeline](https://buildkite.com/sourcegraph/aspect-experimental/builds/8814) not on this branch - notice different steps being used