### PR TITLE
database: return not found error for repos.GetBy{ID,Name}

### DIFF
--- a/cmd/gitserver/internal/cleanup.go
+++ b/cmd/gitserver/internal/cleanup.go
@@ -358,7 +358,8 @@ func cleanupRepos(
 			return false, nil
 		}
 
-		_, err := db.GitserverRepos().GetByName(ctx, gitserverfs.RepoNameFromDir(reposDir, dir))
+		repoName := gitserverfs.RepoNameFromDir(reposDir, dir)
+		_, err := db.GitserverRepos().GetByName(ctx, repoName)
 		// Repo still exists, nothing to do.
 		if err == nil {
 			return false, nil
@@ -366,7 +367,7 @@ func cleanupRepos(
 
 		// Failed to talk to DB, skip this repo.
 		if !errcode.IsNotFound(err) {
-			logger.Warn("failed to look up repo", log.Error(err), log.String("repo", string(dir)))
+			logger.Warn("failed to look up repo", log.Error(err), log.String("repo", string(repoName)))
 			return false, nil
 		}
 

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -326,7 +326,7 @@ ORDER BY gr.repo_id ASC
 func (s *gitserverRepoStore) GetByID(ctx context.Context, id api.RepoID) (*types.GitserverRepo, error) {
 	repo, _, err := scanGitserverRepo(s.QueryRow(ctx, sqlf.Sprintf(getGitserverRepoByIDQueryFmtstr, id)))
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, &ErrGitserverRepoNotFound{}
 		}
 		return nil, err
@@ -356,7 +356,7 @@ WHERE gr.repo_id = %s
 func (s *gitserverRepoStore) GetByName(ctx context.Context, name api.RepoName) (*types.GitserverRepo, error) {
 	repo, _, err := scanGitserverRepo(s.QueryRow(ctx, sqlf.Sprintf(getGitserverRepoByNameQueryFmtstr, name)))
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, &ErrGitserverRepoNotFound{}
 		}
 		return nil, err

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/types/typestest"
@@ -448,6 +449,11 @@ func TestGitserverReposGetByID(t *testing.T) {
 	if diff := cmp.Diff(gitserverRepo, fromDB, cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt", "CorruptionLogs")); diff != "" {
 		t.Fatal(diff)
 	}
+
+	_, err = db.GitserverRepos().GetByID(ctx, gitserverRepo.RepoID+1)
+	if !errcode.IsNotFound(err) {
+		t.Fatal("expected not found error for non-existant ID", err)
+	}
 }
 
 func TestGitserverReposGetByName(t *testing.T) {
@@ -470,6 +476,11 @@ func TestGitserverReposGetByName(t *testing.T) {
 
 	if diff := cmp.Diff(gitserverRepo, fromDB, cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt", "CorruptionLogs")); diff != "" {
 		t.Fatal(diff)
+	}
+
+	_, err = db.GitserverRepos().GetByName(ctx, repo.Name+"404")
+	if !errcode.IsNotFound(err) {
+		t.Fatal("expected not found error for non-existant repo name", err)
 	}
 }
 


### PR DESCRIPTION
I was looking at some logs and noticed the gitserver janitor job constantly logging that it failed to lookup a repo. I checked and it correctly said these repos no longer existed, but this was logging when things go wrong. Turns out in a refactor from August 2022 (cd1131217d73) we wrapped the error type in scanGitserverRepos, but didn't update the call sites of it to take into account wrapped errors.

This means since then lookups of missing repos via the normal GetBy methods have not been returning missing repo errors! This likely has a bunch of ramifications that I haven't explored yet.

In the case of gitserver janitor, I believe we would never delete missing repositories now. There is a decent chance this will free up a bunch of disk space for all sourcegraph instances. Atleast for the logs I saw on s2, this is a big chunk of repos.

Minor change: I adjusted the janitor log which was reporting this to actually report the repo name instead of the directory.

Test Plan: updated the unit tests to assert on missing repo errors.