### PR TITLE
telemetry-gateway: fixup error initialization

### DIFF
--- a/cmd/telemetry-gateway/internal/events/events.go
+++ b/cmd/telemetry-gateway/internal/events/events.go
@@ -81,7 +81,7 @@ func (p *Publisher) Publish(ctx context.Context, events []*telemetrygatewayv1.Ev
 			// then pretend the event succeeded. Pending decision from data team
 			// on what to do with these: https://sourcegraph.slack.com/archives/CN4FC7XT4/p1707986514302069
 			if len(payload) >= googlepubsub.MaxPublishRequestBytes {
-				return errors.Wrapf(err, "event %s/%s is oversized (ID: %s, size: %s)",
+				return errors.Newf("event %s/%s is oversized (ID: %s, size: %s)",
 					// Mark values as safe for cockroachdb Sentry reporting
 					redact.Safe(event.GetFeature()),
 					redact.Safe(event.GetAction()),


### PR DESCRIPTION
🤦 wrapping nil error always returns nil - fixup for #60546 

## Test plan

n/a