### PR TITLE
telemetry-gateway: add metric for published message sizes

### DIFF
--- a/cmd/telemetry-gateway/internal/events/BUILD.bazel
+++ b/cmd/telemetry-gateway/internal/events/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_sourcegraph_conc//pool",
         "@com_google_cloud_go_pubsub//:pubsub",
+        "@io_opentelemetry_go_otel_metric//:metric",
         "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/cmd/telemetry-gateway/service/BUILD.bazel
+++ b/cmd/telemetry-gateway/service/BUILD.bazel
@@ -23,5 +23,7 @@ go_library(
         "//lib/errors",
         "//lib/managedservicesplatform/runtime",
         "@com_github_sourcegraph_log//:log",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel_metric//:metric",
     ],
 )


### PR DESCRIPTION
Follow-up to https://sourcegraph.slack.com/archives/C06CCJR4K9R/p1707987648387399

## Test plan

`sg run telemetry-gateway`, metric initialization works (the main potential failure point)