### PR TITLE
Reduce info logspam from logging in worker

### DIFF
--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -326,7 +326,7 @@ func (w *Worker[T]) dequeueAndHandle() (dequeued bool, err error) {
 
 	// Set up observability
 	w.options.Metrics.numJobs.Inc()
-	processLog.Info("Dequeued record for processing", log.String("id", record.RecordUID()))
+	processLog.Debug("Dequeued record for processing", log.String("id", record.RecordUID()))
 	processArgs := observation.Args{
 		Attrs: []attribute.KeyValue{attribute.String("record.id", record.RecordUID())},
 	}


### PR DESCRIPTION
This seems quite noisy and clearly like a debug signal, so moving it to debug level instead.

```
[         worker] INFO worker.repo-perms-syncer workerutil/worker.go:329 Dequeued record for processing {"TraceId": "fdcacc27c3b381f2746ff76e8573eaed", "SpanId": "b98a6da2a9121465", "name": "user_permissions_sync_job_worker", "id": "208561"}
```

## Test plan

No noise in my terminal anymore.