### PR TITLE
Follow-up fixes for detection

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -134,7 +134,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 		patternsToDetect[i] = strings.ToLower(patternsToDetect[i])
 	}
 	if len(patternsToDetect) > 0 {
-		baseLogger.Debug("initialing pattern detector", log.Strings("patterns", patternsToDetect))
+		baseLogger.Debug("initializing pattern detector", log.Strings("patterns", patternsToDetect))
 	}
 
 	return featurelimiter.Handle(

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -130,6 +130,12 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 	for i := range allowedModels {
 		allowedModels[i] = fmt.Sprintf("%s/%s", upstreamName, allowedModels[i])
 	}
+	for i := range patternsToDetect {
+		patternsToDetect[i] = strings.ToLower(patternsToDetect[i])
+	}
+	if len(patternsToDetect) > 0 {
+		baseLogger.Debug("initialing pattern detector", log.Strings("patterns", patternsToDetect))
+	}
 
 	return featurelimiter.Handle(
 		baseLogger,
@@ -253,13 +259,14 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 
 			// Retrieve metadata from the initial request.
 			model, requestMetadata := methods.getRequestMetadata(body)
-			prompt := body.BuildPrompt()
+			prompt := strings.ToLower(body.BuildPrompt())
 			if goaway.IsProfane(prompt) {
 				requestMetadata["is_profane"] = true
 			}
 			for _, p := range patternsToDetect {
 				if strings.Contains(prompt, p) {
 					requestMetadata["detected_phrases"] = true
+					break
 				}
 			}
 


### PR DESCRIPTION
Follow-up for https://github.com/sourcegraph/sourcegraph/pull/60547:

- lower case comparison
- log the actual patterns on start-up
- early exit

## Test plan

- tested locally