### PR TITLE
server: use syntect_server binary

### DIFF
--- a/cmd/server/BUILD.bazel
+++ b/cmd/server/BUILD.bazel
@@ -113,12 +113,10 @@ container_dependencies(DEPS)
 
 container_dependencies(ZOEKT_DEPS)
 
-# This one is a special case because inside server images, the procfile expects to find it
-# under syntax-highlighter instead of syntect_server.
 pkg_tar(
     name = "tar_syntax-highlighter",
     srcs = ["//docker-images/syntax-highlighter:syntect_server"],
-    remap_paths = {"/syntect_server": "/usr/local/bin/syntax_highlighter"},
+    package_dir = "/usr/local/bin",
 )
 
 pkg_tar(

--- a/cmd/server/image_tests/test_services.sh
+++ b/cmd/server/image_tests/test_services.sh
@@ -12,7 +12,7 @@ services=(
   scip-ctags
   searcher
   symbols
-  syntax_highlighter
+  syntect_server
   worker
 )
 

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -164,7 +164,7 @@ func Main() {
 		`worker: worker`,
 		`repo-updater: repo-updater`,
 		`precise-code-intel-worker: precise-code-intel-worker`,
-		`syntax_highlighter: sh -c 'env QUIET=true ROCKET_ENV=production ROCKET_PORT=9238 ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_SECRET_KEY='"'"'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='"'"' ROCKET_KEEP_ALIVE=0 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' syntax_highlighter | grep -v "Rocket has launched" | grep -v "Warning: environment is"' | grep -v 'Configured for production'`,
+		`syntect-server: sh -c 'env QUIET=true ROCKET_ENV=production ROCKET_PORT=9238 ROCKET_LIMITS='"'"'{json=10485760}'"'"' ROCKET_SECRET_KEY='"'"'SeerutKeyIsI7releuantAndknvsuZPluaseIgnorYA='"'"' ROCKET_KEEP_ALIVE=0 ROCKET_ADDRESS='"'"'"127.0.0.1"'"'"' syntect_server | grep -v "Rocket has launched" | grep -v "Warning: environment is"' | grep -v 'Configured for production'`,
 		postgresExporterLine,
 	}
 	procfile = append(procfile, ProcfileAdditions...)


### PR DESCRIPTION
I noticed this comment that we remap the binary name in bazel for server. Well we can just update server and make it consistent with everything else.

Test Plan: CI