### PR TITLE
Cleanup internalapi after gRPC migration

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -2,7 +2,6 @@ package httpapi
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/url"
 	"path"
@@ -12,18 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	proto "github.com/sourcegraph/sourcegraph/internal/api/internalapi/v1"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
-
-// TODO: Can be removed after 5.3 is cut.
-func serveConfiguration(w http.ResponseWriter, _ *http.Request) error {
-	raw := conf.Raw()
-	err := json.NewEncoder(w).Encode(raw)
-	if err != nil {
-		return errors.Wrap(err, "Encode")
-	}
-	return nil
-}
 
 // configServer implements proto.ConfigServiceServer to serve config to other clients in the cluster.
 type configServer struct {

--- a/internal/api/BUILD.bazel
+++ b/internal/api/BUILD.bazel
@@ -3,10 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "api",
-    srcs = [
-        "api.go",
-        "httpapi_schema.go",
-    ],
+    srcs = ["api.go"],
     importpath = "github.com/sourcegraph/sourcegraph/internal/api",
     visibility = ["//:__subpackages__"],
     deps = [

--- a/internal/api/httpapi_schema.go
+++ b/internal/api/httpapi_schema.go
@@ -1,7 +1,0 @@
-package api
-
-type ExternalServiceConfigsRequest struct {
-	Kind    string `json:"kind"`
-	Limit   int    `json:"limit"`
-	AfterID int    `json:"after_id"`
-}

--- a/internal/api/internalapi/client.go
+++ b/internal/api/internalapi/client.go
@@ -17,13 +17,9 @@ import (
 )
 
 var frontendInternal = func() *url.URL {
-	rawURL := env.Get("SRC_FRONTEND_INTERNAL", defaultFrontendInternal(), "HTTP address for internal frontend HTTP API.")
+	rawURL := env.Get("SRC_FRONTEND_INTERNAL", "sourcegraph-frontend-internal", "HTTP address for internal frontend HTTP API.")
 	return mustParseSourcegraphInternalURL(rawURL)
 }()
-
-func defaultFrontendInternal() string {
-	return "sourcegraph-frontend-internal"
-}
 
 type internalClient struct {
 	// URL is the root to the internal API frontend server.

--- a/internal/codemonitors/background/email.go
+++ b/internal/codemonitors/background/email.go
@@ -124,7 +124,7 @@ func sendEmail(ctx context.Context, db database.DB, userID int32, template txtyp
 		if errcode.IsNotFound(err) {
 			return errors.Errorf("unable to send email to user ID %d with unknown email address", userID)
 		}
-		return errors.Errorf("internalapi.Client.UserEmailsGetEmail for userID=%d: %w", userID, err)
+		return errors.Errorf("get primary email for userID=%d: %w", userID, err)
 	}
 	if !verified {
 		return errors.Newf("unable to send email to user ID %d's unverified primary email address", userID)
@@ -135,7 +135,7 @@ func sendEmail(ctx context.Context, db database.DB, userID int32, template txtyp
 		Template: template,
 		Data:     data,
 	}); err != nil {
-		return errors.Errorf("internalapi.Client.SendEmail to email=%q userID=%d: %w", email, userID, err)
+		return errors.Errorf("send mail to email=%q userID=%d: %w", email, userID, err)
 	}
 	return nil
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -197,14 +197,3 @@ func HandleHelpFlag() {
 		}
 	}
 }
-
-// HackClearEnvironCache can be used to clear the environ cache if os.Setenv was called and you want
-// subsequent env.Get calls to return the new value. It is a hack but useful because some env.Get
-// calls are hard to remove from static init time, and the ones we've moved to post-init we want to
-// be able to use the default values we set in package singleprogram.
-//
-// TODO(sqs): TODO(single-binary): this indicates our initialization order could be better, hence this
-// is labeled as a hack.
-func HackClearEnvironCache() {
-	environ = nil
-}

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -72,9 +72,6 @@ func render(fromAddress, fromName string, message Message) (*email.Email, error)
 // should use this directly to send emails.  Source is used to categorize metrics, and
 // should indicate the product feature that is sending this email.
 //
-// Callers that do not live in the frontend should call internalapi.Client.SendEmail
-// instead.
-//
 // 🚨 SECURITY: If the email address is associated with a user, make sure to assess whether
 // the email should be verified or not, and conduct the appropriate checks before sending.
 // This helps reduce the chance that we damage email sender reputations when attempting to

--- a/internal/txemail/txtypes/types.go
+++ b/internal/txemail/txtypes/types.go
@@ -5,13 +5,6 @@ import (
 	texttemplate "text/template"
 )
 
-// InternalAPIMessage describes an email message to be sent via the 'internal.send-email'
-// endpoint.
-type InternalAPIMessage struct {
-	Source string
-	Message
-}
-
 // Message describes an email message to be sent.
 type Message struct {
 	To         []string // email "To" recipients


### PR DESCRIPTION
We no longer need this endpoint. Also found a few other things related to internalapi on the way that could use a cleanup.

## Test plan

Integration tests should verify that conf works just as before.