### PR TITLE
gitserver: Small code cleanup

### DIFF
--- a/cmd/gitserver/internal/cleanup.go
+++ b/cmd/gitserver/internal/cleanup.go
@@ -456,10 +456,8 @@ func cleanupRepos(
 			return false, nil
 		}
 
-		// name is the relative path to ReposDir, but without the .git suffix.
-		repo := gitserverfs.RepoNameFromDir(reposDir, dir)
 		recloneLogger := logger.With(
-			log.String("repo", string(repo)),
+			log.String("repo", string(repoName)),
 			log.Time("cloned", recloneTime),
 			log.String("reason", reason),
 		)
@@ -475,7 +473,7 @@ func cleanupRepos(
 
 		cmdCtx, cancel := context.WithTimeout(ctx, conf.GitLongCommandTimeout())
 		defer cancel()
-		if _, err := cloneRepo(cmdCtx, repo, CloneOptions{Block: true, Overwrite: true}); err != nil {
+		if _, err := cloneRepo(cmdCtx, repoName, CloneOptions{Block: true, Overwrite: true}); err != nil {
 			return true, err
 		}
 		reposRecloned.Inc()

--- a/cmd/gitserver/internal/integration_tests/tree_test.go
+++ b/cmd/gitserver/internal/integration_tests/tree_test.go
@@ -392,8 +392,6 @@ func TestRepository_FileSystem_gitSubmodules(t *testing.T) {
 }
 
 func TestReadDir_SubRepoFiltering(t *testing.T) {
-	InitGitserver()
-
 	ctx := actor.WithActor(context.Background(), &actor.Actor{
 		UID: 1,
 	})

--- a/cmd/gitserver/shared/shared.go
+++ b/cmd/gitserver/shared/shared.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/sourcegraph/log"
@@ -165,29 +164,20 @@ func Main(ctx context.Context, observationCtx *observation.Context, ready servic
 			config.SyncRepoStateBatchSize,
 			config.SyncRepoStateUpdatePerSecond,
 		),
-	}
-
-	if runtime.GOOS == "windows" {
-		// See https://github.com/sourcegraph/sourcegraph/issues/54317 for details.
-		logger.Warn("Janitor is disabled on windows")
-	} else {
-		routines = append(
-			routines,
-			server.NewJanitor(
-				ctx,
-				server.JanitorConfig{
-					ShardID:                        hostname,
-					JanitorInterval:                config.JanitorInterval,
-					ReposDir:                       config.ReposDir,
-					DesiredPercentFree:             config.JanitorReposDesiredPercentFree,
-					DisableDeleteReposOnWrongShard: config.JanitorDisableDeleteReposOnWrongShard,
-				},
-				db,
-				recordingCommandFactory,
-				gitserver.CloneRepo,
-				logger,
-			),
-		)
+		server.NewJanitor(
+			ctx,
+			server.JanitorConfig{
+				ShardID:                        hostname,
+				JanitorInterval:                config.JanitorInterval,
+				ReposDir:                       config.ReposDir,
+				DesiredPercentFree:             config.JanitorReposDesiredPercentFree,
+				DisableDeleteReposOnWrongShard: config.JanitorDisableDeleteReposOnWrongShard,
+			},
+			db,
+			recordingCommandFactory,
+			gitserver.CloneRepo,
+			logger,
+		),
 	}
 
 	// Register recorder in all routines that support it.


### PR DESCRIPTION
- App is no longer, and janitor really has to run, we shouldn't comment it out
- Tree test double-initialized the gitserver
- Removed duplicate reponame variable

## Test plan

Small code style changes, CI will find issues.