### PR TITLE
telemetry-gateway: log reported instance URL in request start log

### DIFF
--- a/cmd/telemetry-gateway/internal/server/server.go
+++ b/cmd/telemetry-gateway/internal/server/server.go
@@ -91,8 +91,10 @@ func (s *Server) RecordEvents(stream telemetrygatewayv1.TelemeteryGatewayService
 				}
 				// Attach instance ID to all subsequent log messages
 				logger = logger.With(log.String("instanceID", identifier.InstanceId))
-				// Record start of stream + salesforce opportunity once
+				// Record start of stream + additional diagnostics details
+				// like salesforce info and external URL once
 				logger.Info("handling events submission stream for licensed instance",
+					log.String("instanceExternalURL", identifier.ExternalUrl),
 					log.Stringp("license.salesforceOpportunityID", licenseInfo.SalesforceOpportunityID),
 					log.Stringp("license.salesforceSubscriptionID", licenseInfo.SalesforceSubscriptionID))
 


### PR DESCRIPTION
Discussed [here](https://sourcegraph.slack.com/archives/CN4FC7XT4/p1707990139798159) - this helps with identifying the impact of issues and diagnostics, as it can be tricky to link and instance ID back to a customer, and not all licenses have a Salesforce ID yet it seems.

We only log the URL once, instead of attaching it to the logger, to avoid having this sent to Sentry for now (out of an abundance of precaution)

## Test plan

n/a