### PR TITLE
release: Remove indexer updates from release process

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -55,7 +55,6 @@ import {
     bakeSrcCliSteps,
     batchChangesInAppChangelog,
     combyReplace,
-    indexerUpdate,
 } from './static-updates'
 import {
     backportStatus,
@@ -1118,14 +1117,12 @@ ${patchRequestIssues.map(issue => `* #${issue.number}`).join('\n')}`
                 ...multiVersionSteps,
                 ...srcCliSteps,
                 ...batchChangesInAppChangelog(new SemVer(release.version.version).inc('minor'), true), // in the next main branch this will reflect the guessed next version
-                indexerUpdate(),
             ]
 
             const releaseBranchEdits: Edit[] = [
                 ...multiVersionSteps,
                 ...srcCliSteps,
                 ...batchChangesInAppChangelog(release.version, false),
-                indexerUpdate(),
             ]
 
             const prDetails = {

--- a/dev/release/src/static-updates.ts
+++ b/dev/release/src/static-updates.ts
@@ -150,8 +150,3 @@ export function combyReplace(pattern: string, replace: string, path: string): Ed
     const sub = pattern.replace(':[1]', replace)
     return `comby -in-place "${pattern}" "${sub}" ${path}`
 }
-
-export function indexerUpdate(): Edit {
-    // eslint-disable-next-line no-template-curly-in-string
-    return 'cd internal/codeintel/autoindexing/internal/inference/libs/ && DOCKER_USER=${CR_USERNAME} DOCKER_PASS=${CR_PASSWORD} ./update-shas.sh'
-}


### PR DESCRIPTION
The Graph team can handle updating the SHAs on an as-needed
basis, similar to how it is done on the main branch.

Discussed here: https://github.com/sourcegraph/sourcegraph/pull/60542

## Test plan

n/a