### PR TITLE
msp: always route traffic to the latest revision on deploment

### DIFF
--- a/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
+++ b/dev/managedservicesplatform/stacks/cloudrun/internal/builder/service/service.go
@@ -136,6 +136,18 @@ func (b *serviceBuilder) Build(stack cdktf.TerraformStack, vars builder.Variable
 		//  Disallows direct traffic from public internet, we have a LB set up for that.
 		Ingress: pointers.Ptr("INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"),
 
+		// Send all traffic to the latest revison.
+		// This is needed to override changes to traffic configuration from the UI. Otherwise,
+		// it's possible that traffic will always be routed to a stale revision after new deployment.
+		//
+		// https://cloud.google.com/run/docs/rollouts-rollbacks-traffic-migration#send-to-latest
+		Traffic: []*cloudrunv2service.CloudRunV2ServiceTraffic{
+			{
+				Percent: pointers.Float64(100),
+				Type:    pointers.Ptr("TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"),
+			},
+		},
+
 		Template: &cloudrunv2service.CloudRunV2ServiceTemplate{
 			// Act under our provisioned service account
 			ServiceAccount: pointers.Ptr(vars.ServiceAccount.Email),


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C05GJPTSZCZ/p1708009262460989

https://cloud.google.com/run/docs/rollouts-rollbacks-traffic-migration#send-to-latest

per GCP docs

## Test plan

it rendered:

```diff
--- a/services/cloud-ops/terraform/prod/stacks/cloudrun/cdk.tf.json
+++ b/services/cloud-ops/terraform/prod/stacks/cloudrun/cdk.tf.json
@@ -379,7 +379,13 @@
             "connector": "${google_vpc_access_connector.cloudrun-connector.self_link}",
             "egress": "PRIVATE_RANGES_ONLY"
           }
-        }
+        },
+        "traffic": [
+          {
+            "percent": 100,
+            "type": "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+          }
+        ]
       }
     },
     "google_cloud_run_v2_service_iam_member": {
```

Then, we can test it manually by:

- clickops and pin to an older revision
- run terraform apply, it should route to the latest revision

@bobheadxi what's the test procedure for MSP today?
