### PR TITLE
backcompat: make step non-async

### DIFF
--- a/dev/backcompat/bazel-backcompat.sh
+++ b/dev/backcompat/bazel-backcompat.sh
@@ -5,7 +5,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 bazelrcs=(--bazelrc=.bazelrc)
 current_commit=$(git rev-parse HEAD)
-tag="5.1.0"
+tag="5.3.0"
 
 function restore_current_commit() {
   git checkout --force "${current_commit}"

--- a/dev/backcompat/bazel-backcompat.sh
+++ b/dev/backcompat/bazel-backcompat.sh
@@ -53,6 +53,4 @@ bazel "${bazelrcs[@]}" \
   //cmd/... \
   //lib/... \
   //internal/... \
-  //enterprise/cmd/... \
-  //enterprise/internal/...\
   -//cmd/migrator/...

--- a/dev/backcompat/patch_flakes.sh
+++ b/dev/backcompat/patch_flakes.sh
@@ -64,7 +64,7 @@ function disable_test_path() {
 if [ -f "${FLAKE_FILE}" ]; then
   echo "Disabling tests listed in flakefile ${FLAKE_FILE} for tag ${version}"
 
-  pairs=$(jq -r --arg version "${version}" '.[$version][] | "\(.path):\(.prefix)"' "${FLAKE_FILE}" )
+  pairs=$(jq -r --arg version "${version}" 'select(.[$version] != null) | .[$version][] | "\(.path):\(.prefix)"' "${FLAKE_FILE}" )
   for pair in $pairs; do
     IFS=' ' read -ra parts <<<"${pair/:/ }"
     disable_test_path "${parts[0]}" "${parts[1]}"

--- a/dev/ci/internal/ci/misc_operations.go
+++ b/dev/ci/internal/ci/misc_operations.go
@@ -23,7 +23,7 @@ func triggerBackCompatTest(buildOpts bk.BuildOptions, isAspectWorkflows bool) fu
 		if !isAspectWorkflows {
 			steps = append(steps, bk.DependsOn("bazel-prechecks"))
 		}
-		pipeline.AddTrigger(":bazel::snail: Async BackCompat Tests", "sourcegraph-backcompat", steps...)
+		pipeline.AddTrigger(":bazel::snail: BackCompat Tests", "sourcegraph-backcompat", steps...)
 	}
 }
 

--- a/dev/ci/internal/ci/misc_operations.go
+++ b/dev/ci/internal/ci/misc_operations.go
@@ -14,7 +14,7 @@ func triggerBackCompatTest(buildOpts bk.BuildOptions, isAspectWorkflows bool) fu
 	}
 	return func(pipeline *bk.Pipeline) {
 		steps := []bk.StepOpt{
-			bk.Async(true),
+			bk.Async(false),
 			bk.Key("trigger-backcompat"),
 			bk.AllowDependencyFailure(),
 			bk.Build(buildOpts),

--- a/dev/ci/internal/ci/misc_operations.go
+++ b/dev/ci/internal/ci/misc_operations.go
@@ -23,7 +23,7 @@ func triggerBackCompatTest(buildOpts bk.BuildOptions, isAspectWorkflows bool) fu
 		if !isAspectWorkflows {
 			steps = append(steps, bk.DependsOn("bazel-prechecks"))
 		}
-		pipeline.AddTrigger(":bazel::snail: BackCompat Tests", "sourcegraph-backcompat", steps...)
+		pipeline.AddTrigger(":bazel::hourglass_flowing_sand: BackCompat Tests", "sourcegraph-backcompat", steps...)
 	}
 }
 


### PR DESCRIPTION
Missed a series of failures on https://buildkite.com/sourcegraph/sourcegraph-backcompat/builds/23295
## Test plan
Primary build should wait for this step to complete
