### PR TITLE
gitserver: Reduce "normalization" of repo names

### DIFF
--- a/cmd/gitserver/internal/gitserverfs/fs_test.go
+++ b/cmd/gitserver/internal/gitserverfs/fs_test.go
@@ -17,6 +17,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
+func TestRepoPathNameMapping(t *testing.T) {
+	reposDir := "/data/repos"
+	require.Equal(t, "/data/repos/github.com/sourcegraph/sourcegraph/.git", RepoDirFromName(reposDir, "github.com/sourcegraph/sourcegraph").Path())
+	require.Equal(t, api.RepoName("github.com/sourcegraph/sourcegraph"), RepoNameFromDir(reposDir, "/data/repos/github.com/sourcegraph/sourcegraph/.git"))
+
+	require.Equal(t, "/data/repos/github.com/sourcegraph/sourcegraph/.git", RepoDirFromName(reposDir, "github.com/sourcegraph/sourcegraph.git").Path())
+
+	require.Equal(t, "/data/repos/github.com/sourcegraph/sourcegraph/.git", RepoDirFromName(reposDir, "github.com/sourcegraph/sourcegraph/").Path())
+
+	require.Equal(t, "/data/repos/github.com/sourcegraph/sourcegraph.exe/.git", RepoDirFromName(reposDir, "github.com/sourcegraph/sourcegraph.exe").Path())
+
+	require.Equal(t, "/data/repos/github.staging.sgdev.org/sg-test/sourcegraph.com-replica/.git", RepoDirFromName(reposDir, "github.staging.sgdev.org/sg-test/sourcegraph.com-replica").Path())
+}
+
 func TestIgnorePath(t *testing.T) {
 	reposDir := "/data/repos"
 

--- a/cmd/gitserver/internal/search.go
+++ b/cmd/gitserver/internal/search.go
@@ -84,7 +84,6 @@ func (s *Server) SearchWithObservability(ctx context.Context, tr trace.Trace, ar
 // search handles the core logic of the search. It is passed a matchesBuf so it doesn't need to
 // concern itself with event types, and all instrumentation is handled in the calling function.
 func (s *Server) search(ctx context.Context, args *protocol.SearchRequest, onMatch func(*protocol.CommitMatch) error) (limitHit bool, err error) {
-	args.Repo = protocol.NormalizeRepo(args.Repo)
 	if args.Limit == 0 {
 		args.Limit = math.MaxInt32
 	}

--- a/cmd/gitserver/internal/server.go
+++ b/cmd/gitserver/internal/server.go
@@ -488,7 +488,6 @@ func (s *Server) IsRepoCloneable(ctx context.Context, repo api.RepoName) (protoc
 func (s *Server) RepoUpdate(ctx context.Context, req *protocol.RepoUpdateRequest) (resp protocol.RepoUpdateResponse) {
 	logger := s.logger.Scoped("handleRepoUpdate")
 
-	req.Repo = protocol.NormalizeRepo(req.Repo)
 	dir := gitserverfs.RepoDirFromName(s.reposDir, req.Repo)
 
 	if !repoCloned(dir) {
@@ -1187,7 +1186,6 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName, revspec string) error
 			return err
 		}
 
-		repo = protocol.NormalizeRepo(repo)
 		dir := gitserverfs.RepoDirFromName(s.reposDir, repo)
 
 		remoteURL, err := s.getRemoteURL(ctx, repo)

--- a/internal/gitserver/addrs.go
+++ b/internal/gitserver/addrs.go
@@ -175,6 +175,7 @@ func (g *GitserverAddresses) AddrForRepo(ctx context.Context, repoName api.RepoN
 	addrForRepoInvoked.Inc()
 
 	// Normalizing the name in case the caller didn't.
+	// TODO: I don't think we need/should do that.
 	name := string(protocol.NormalizeRepo(repoName))
 	if pinnedAddr, ok := g.PinnedServers[name]; ok {
 		return pinnedAddr

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -598,20 +598,18 @@ func (c *RemoteGitCommand) sendExec(ctx context.Context) (_ io.ReadCloser, err e
 		}
 	}()
 
-	repoName := protocol.NormalizeRepo(c.repo)
-
 	// Check that ctx is not expired.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
-	client, err := c.execer.ClientForRepo(ctx, repoName)
+	client, err := c.execer.ClientForRepo(ctx, c.repo)
 	if err != nil {
 		return nil, err
 	}
 
 	req := &proto.ExecRequest{
-		Repo:      string(repoName),
+		Repo:      string(c.repo),
 		Args:      stringsToByteSlices(c.args[1:]),
 		NoTimeout: c.noTimeout,
 	}
@@ -653,9 +651,7 @@ func (c *clientImplementor) Search(ctx context.Context, args *protocol.SearchReq
 	})
 	defer endObservation(1, observation.Args{})
 
-	repoName := protocol.NormalizeRepo(args.Repo)
-
-	client, err := c.ClientForRepo(ctx, repoName)
+	client, err := c.ClientForRepo(ctx, args.Repo)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This normalization might've been useful 5 years ago when gitserver tried to clone whatever it was given, but since then we introduced the DB layer where we have to go through the GetRemoteURL func. That one verifies that a repo is meant to be cloned into the sg instance, but it ALSO requires that the repo name is a LITERAL match. When we make modifications to the repo name, it will no longer match. That also applies to various of our gitserver_repos queries, which are all depending on LITERAL name matches.

Ideally, we remove this altogether, and instead use a "verify the path is safe" only.

Closes https://github.com/sourcegraph/sourcegraph/issues/35960

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
