### PR TITLE
Remove errant comma from scim_postman_collection.json

### DIFF
--- a/doc/dev/background-information/scim_postman_collection.json
+++ b/doc/dev/background-information/scim_postman_collection.json
@@ -453,7 +453,7 @@
 		},
 		{
 			"key": "token",
-			"value": "TODO paste random token here",
+			"value": "TODO paste random token here"
 		},
 		{
 			"key": "user_id",


### PR DESCRIPTION
Removed a comma that prevents Postman from importing the collection as valid.



## Test plan

- Download Postman
- Attempt to import new collection JSON (copy and paste the text into the import window)
- Collection should be imported as valid (previously it would not be)

## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@nb/remove-errant-comma-from-scim-postman)