### PR TITLE
Svelte: add display limit and content length limit

### DIFF
--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -126,6 +126,8 @@ export const load: PageLoad = ({ url, depends }) => {
             featureOverrides: [],
             chunkMatches: true,
             searchMode,
+            displayLimit: 500,
+            maxLineLen: 1000,
         }
 
         // We create a new stream only if

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -75,15 +75,18 @@
     let visible = false
     let highlightedHTMLRows: Promise<string[][]> | undefined
     $: if (visible) {
-        // We rely on fetchFileRangeMatches to cache the result for us so that repeated
-        // calls will not result in repeated network requests.
-        highlightedHTMLRows = fetchFileRangeMatches({
-            result,
-            ranges: expandedMatchGroups.map(group => ({
-                startLine: group.startLine,
-                endLine: group.endLine,
-            })),
-        })
+        // If the file contains some large lines, avoid stressing syntax-highlighter and the browser.
+        if (!result.chunkMatches?.some(chunk => chunk.contentTruncated)) {
+            // We rely on fetchFileRangeMatches to cache the result for us so that repeated
+            // calls will not result in repeated network requests.
+            highlightedHTMLRows = fetchFileRangeMatches({
+                result,
+                ranges: expandedMatchGroups.map(group => ({
+                    startLine: group.startLine,
+                    endLine: group.endLine,
+                })),
+            })
+        }
     }
 </script>
 


### PR DESCRIPTION
This adds a display limit (currently unlimited) and a line length limit (currently unlimited) to the search requests from the Svelte webapp. Currently, we're trying to stream the entire result set back to the client, which can be quite large. Additionally, rendering and highlighting long lines can be expensive.

## Test plan

Clicked around, testing that the webapp no longer seized up on large result sets.