### PR TITLE
Link to SSC

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -25,7 +25,6 @@ import {
 import type { AuthenticatedUser } from '../../auth'
 import { Page } from '../../components/Page'
 import { PageTitle } from '../../components/PageTitle'
-import { CodySubscriptionStatus, CodySubscriptionPlan } from '../../graphql-operations'
 import type {
     ChangeCodyPlanResult,
     ChangeCodyPlanVariables,
@@ -34,6 +33,7 @@ import type {
     UserCodyUsageResult,
     UserCodyUsageVariables,
 } from '../../graphql-operations'
+import { CodySubscriptionStatus, CodySubscriptionPlan } from '../../graphql-operations'
 import { eventLogger } from '../../tracking/eventLogger'
 import { EventName } from '../../util/constants'
 import {
@@ -93,9 +93,12 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
 
     const subscription = data?.currentUser?.codySubscription
 
+    const codyPaymentsUrl = useCodyPaymentsUrl()
+    const manageSubscriptionRedirectURL = `${codyPaymentsUrl}/cody/subscription`
+
     useEffect(() => {
         if (!arePaymentsEnabled && enrollPro && data?.currentUser && subscription?.plan !== CodySubscriptionPlan.PRO) {
-            changeCodyPlan({ variables: { pro: true, id: data?.currentUser?.id } })
+            void changeCodyPlan({ variables: { pro: true, id: data?.currentUser?.id } })
         }
     }, [arePaymentsEnabled, data?.currentUser, changeCodyPlan, enrollPro, subscription])
 
@@ -190,7 +193,14 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                         </div>
                         {userIsOnProTier && (
                             <div>
-                                <ButtonLink to="/cody/subscription" variant="primary" size="sm">
+                                <ButtonLink
+                                    variant="primary"
+                                    size="sm"
+                                    onClick={() => {
+                                        eventLogger.log(EventName.CODY_MANAGE_SUBSCRIPTION_CLICKED)
+                                        window.location.href = manageSubscriptionRedirectURL
+                                    }}
+                                >
                                     <Icon svgPath={mdiCreditCardOutline} className="mr-1" aria-hidden={true} />
                                     Manage subscription
                                 </ButtonLink>

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -355,14 +355,14 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                     </div>
                     {editorGroups.map((group, index) => (
                         <div
-                            key={index}
+                            key={group.map(editor => editor.name).join('-')}
                             className={classNames('d-flex mt-3', styles.responsiveContainer, {
                                 'border-bottom pb-3': index < group.length - 1,
                             })}
                         >
                             {group.map((editor, index) => (
                                 <div
-                                    key={index}
+                                    key={editor.name}
                                     className={classNames('d-flex flex-column flex-1 pt-3 px-3', {
                                         'border-left': index !== 0,
                                     })}
@@ -427,7 +427,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                         selectedEditorStep !== null &&
                                         editor.instructions && (
                                             <Modal
-                                                key={index + '-modal'}
+                                                key={editor.name + '-modal'}
                                                 isOpen={true}
                                                 aria-label={`${editor.name} Info`}
                                                 className={styles.modal}
@@ -446,6 +446,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                             ))}
                             {group.length < 4
                                 ? [...new Array(4 - group.length)].map((_, index) => (
+                                      // eslint-disable-next-line react/no-array-index-key
                                       <div key={index} className="flex-1 p-3" />
                                   ))
                                 : null}


### PR DESCRIPTION
Fixes the problem mentioned [here](https://sourcegraph.slack.com/archives/C06HHK23QR4/p1708082073088569), that this button:
![image](https://github.com/sourcegraph/sourcegraph/assets/2552265/a2a89afb-9888-4e38-917d-97ec1e06f491)

should link the SSC site, not dotcom's /subscription page.

I've also fixed a few linter warnings.

## Test plan

Didn't test this because my dev env is still in ruins. I'll want to get it confirmed first that we need this, and then I can test it better.