### PR TITLE
Remove strikethrough

### DIFF
--- a/client/web/src/cody/subscription/CodySubscriptionPage.module.scss
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.module.scss
@@ -38,10 +38,6 @@
     }
 }
 
-.pro-pricing {
-    text-decoration: line-through;
-}
-
 .upgrade-modal {
     width: 50rem;
 }

--- a/client/web/src/cody/subscription/CodySubscriptionPage.tsx
+++ b/client/web/src/cody/subscription/CodySubscriptionPage.tsx
@@ -224,13 +224,7 @@ export const CodySubscriptionPage: React.FunctionComponent<CodySubscriptionPageP
                             </div>
                             <div className="d-flex flex-column border-bottom py-4">
                                 <div className="mb-1">
-                                    <H2
-                                        className={classNames('text-muted d-inline mb-0', {
-                                            [styles.proPricing]: !hasTrialEnded,
-                                        })}
-                                    >
-                                        $9
-                                    </H2>
+                                    <H2 className="text-muted d-inline mb-0">$9</H2>
                                     <Text className="mb-0 text-muted d-inline">/month</Text>
                                 </div>
                                 {!hasTrialEnded && (

--- a/client/web/src/cody/subscription/UpgradeToProModal.tsx
+++ b/client/web/src/cody/subscription/UpgradeToProModal.tsx
@@ -55,7 +55,7 @@ export function UpgradeToProModal({
                                     </Text>
                                 </div>
                                 <div className="mb-1">
-                                    <H2 className={classNames('text-muted d-inline mb-0', styles.proPricing)}>$9</H2>
+                                    <H2 className="text-muted d-inline mb-0">$9</H2>
                                     <Text className="mb-0 text-muted d-inline">/month</Text>
                                 </div>
                                 <Text className="mb-4 text-muted" size="small">


### PR DESCRIPTION
closes: https://github.com/sourcegraph/accounts.sourcegraph.com/issues/560

Remove Strikethrough from $9.

![CleanShot 2024-02-19 at 16 45 07@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/cba01b4d-912c-4d7f-a80d-0b3cf96110eb)


## Test plan

Ran locally