### PR TITLE
syntax-highlighter: use tini and entrypoint script

### DIFF
--- a/docker-images/syntax-highlighter/BUILD.bazel
+++ b/docker-images/syntax-highlighter/BUILD.bazel
@@ -94,31 +94,26 @@ oci_tarball(
     repo_tags = ["scip-ctags:candidate"],
 )
 
+filegroup(
+    name = "syntect_server_entrypoint",
+    srcs = ["syntect_server_entrypoint.sh"],
+)
+
 pkg_tar(
     name = "tar_syntect_server",
-    srcs = [":syntect_server"],
+    srcs = [
+        ":syntect_server",
+        ":syntect_server_entrypoint",
+    ],
 )
 
 oci_image(
     name = "image",
     base = "@wolfi_syntax_highlighter_base",
     entrypoint = [
-        "/bin/sh",
-        "-c",
-        " ".join([
-            "/usr/local/bin/http-server-stabilizer",
-            "-listen=:9238",
-            "-prometheus-app-name=syntax_highlighter",
-            # The more workers, the more resilient syntect_server is to getting stuck on
-            # bad grammar/file combinations. If it happens with four workers, only 1/4th of
-            # requests will be affected for a short period of time. Each worker can require
-            # at peak around 1.1 GiB of memory.
-            "-workers=$WORKERS",
-            "--",
-            "env",
-            "ROCKET_PORT={{.Port}}",  # {{.Port}} is a templated variable used by http-server-stabilizer
-            "/syntect_server",
-        ]),
+        "/sbin/tini",
+        "--",
+        "/syntect_server_entrypoint.sh",
     ],
     env = {
         "ROCKET_ENV": "production",
@@ -134,6 +129,10 @@ oci_image(
         # See https://github.com/sourcegraph/sourcegraph/issues/2615 for details on
         # what we observed when this was enabled with the default 5s.
         "ROCKET_KEEP_ALIVE": "0",
+        # The more workers, the more resilient syntect_server is to getting stuck on
+        # bad grammar/file combinations. If it happens with four workers, only 1/4th of
+        # requests will be affected for a short period of time. Each worker can require
+        # at peak around 1.1 GiB of memory.
         "WORKERS": "4",
         "QUIET": "true",
     },

--- a/docker-images/syntax-highlighter/syntect_server_entrypoint.sh
+++ b/docker-images/syntax-highlighter/syntect_server_entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# This entrypoint exists to inject the environment variable WORKERS as a
+# command line argument.
+
+# Note: {{.Port}} is a templated variable used by http-server-stabilizer
+
+exec /usr/local/bin/http-server-stabilizer \
+     -listen=:9238 \
+     -prometheus-app-name=syntax_highlighter \
+     -workers="$WORKERS" \
+     -- \
+     env \
+     "ROCKET_PORT={{.Port}}" \
+     /syntect_server


### PR DESCRIPTION
All our containers should be using tini as PID 1 to cleanup zombies. In the case of syntax-highlighter we did not. Additionally we did some janky inline shell script so we could inject the $WORKERS envvar as an argument.

This commits moves the janky script into an entrypoint script and calls it via tini. Additionally it uses exec so we don't have a parent shell messing with signals.

I picked the name syntect_server_entrypoint since I had some concerns this file would end up in the server docker image, so wanted to give it a unique name. This may make it possible for us to use this script as well in server if we choose to.

Test Plan: built the image and ran it. Then checked we had the process running with child workers correctly.

``` shell
bazel build //docker-images/syntax-highlighter:image_tarball
docker load --input $(bazel cquery //docker-images/syntax-highlighter:image_tarball --output=files)
docker run --rm=true syntect-server:candidate
```


Then on the running container:

``` shellsession
$ docker exec trusting_leavitt ps aux
PID   USER     TIME  COMMAND
    1 root      0:00 /sbin/tini -- /syntect_server_entrypoint.sh
    7 root      0:00 /usr/local/bin/http-server-stabilizer -listen=:9238 -prometheus-app-name=syntax_highlighter -workers=4 -- env ROCKET_PORT={{.Port}} /syntect_server
   14 root      0:02 /syntect_server
   15 root      0:02 /syntect_server
   17 root      0:02 /syntect_server
   18 root      0:02 /syntect_server
  157 root      0:00 ps aux
```

