### PR TITLE
sg: bazelisk check skipped on nix develop

### DIFF
--- a/dev/sg/internal/check/common.go
+++ b/dev/sg/internal/check/common.go
@@ -316,7 +316,13 @@ var Python = Combine(
 	CompareSemanticVersionWithASDF("python", "python --version"),
 )
 
-var Bazelisk = WrapErrMessage(Combine(InPath("bazel"), CommandOutputContains("bazel version", "Bazelisk version")), "sg setup --fix")
+var Bazelisk = WrapErrMessage(Combine(
+	InPath("bazel"),
+	SkipOnNix(
+		"nix ensures we are on the correct version",
+		CommandOutputContains("bazel version", "Bazelisk version"),
+	),
+), "sg setup --fix")
 
 func Caddy(_ context.Context) error {
 	certPath, err := caddySourcegraphCertificatePath()

--- a/dev/sg/internal/check/helpers.go
+++ b/dev/sg/internal/check/helpers.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -52,4 +53,16 @@ func WrapErrMessage(check CheckFunc, message string) CheckFunc {
 		}
 		return nil
 	}
+}
+
+// SkipOnNix will not run check if running inside of our nix develop
+// environment. reason is not read, but is used to document why at the
+// callsite.
+func SkipOnNix(reason string, check CheckFunc) CheckFunc {
+	if os.Getenv("SRC_NIX_DEVELOP") == "1" {
+		return func(ctx context.Context) error {
+			return nil
+		}
+	}
+	return check
 }

--- a/dev/sg/internal/check/helpers.go
+++ b/dev/sg/internal/check/helpers.go
@@ -59,7 +59,7 @@ func WrapErrMessage(check CheckFunc, message string) CheckFunc {
 // environment. reason is not read, but is used to document why at the
 // callsite.
 func SkipOnNix(reason string, check CheckFunc) CheckFunc {
-	if os.Getenv("SRC_NIX_DEVELOP") == "1" {
+	if os.Getenv("IN_NIX_SHELL") != "" && os.Getenv("name") == "sourcegraph-dev-env" {
 		return func(ctx context.Context) error {
 			return nil
 		}

--- a/shell.nix
+++ b/shell.nix
@@ -144,5 +144,8 @@ mkShell.override { stdenv = if hostPlatform.isMacOS then pkgs.clang11Stdenv else
   # https://sourcegraph.com/github.com/bazelbuild/bazel@1a4da7f331c753c92e2c91efcad434dc29d10d43/-/blob/scripts/packages/bazel.sh?L23-28
   USE_BAZEL_VERSION = if hostPlatform.isMacOS then "" else pkgs.bazel_7.version;
 
+  # Signals we are inside nix develop
+  SRC_NIX_DEVELOP = "1";
+
   LIBTOOL = if hostPlatform.isMacOS then "/usr/bin/libtool" else "";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -144,8 +144,5 @@ mkShell.override { stdenv = if hostPlatform.isMacOS then pkgs.clang11Stdenv else
   # https://sourcegraph.com/github.com/bazelbuild/bazel@1a4da7f331c753c92e2c91efcad434dc29d10d43/-/blob/scripts/packages/bazel.sh?L23-28
   USE_BAZEL_VERSION = if hostPlatform.isMacOS then "" else pkgs.bazel_7.version;
 
-  # Signals we are inside nix develop
-  SRC_NIX_DEVELOP = "1";
-
   LIBTOOL = if hostPlatform.isMacOS then "/usr/bin/libtool" else "";
 }


### PR DESCRIPTION
If using nix develop we can defer to our nix environment correctly installing bazel. In particular on linux nix directly installs the correct version of nix and we do not use bazelisk.

Test Plan: "sg start enterprise-bazel" on nixos