### PR TITLE
executors: fix AMI push script for when aws_regions.json missing

### DIFF
--- a/cmd/executor/vm-image/_ami.push.sh
+++ b/cmd/executor/vm-image/_ami.push.sh
@@ -36,8 +36,8 @@ echo "Added GCP compute image to image family ${IMAGE_FAMILY}"
 
 # Set the AMIs to public.
 if [ "${EXECUTOR_IS_TAGGED_RELEASE}" = "true" ]; then
-  regions=$(jq -r '.[]' <aws_regions.json)
-  for region in $regions; do
+  REGIONS=$(jq -r '.[]' <aws_regions.json)
+  for region in $REGIONS; do
     echo "Getting AMI ID in region ${region}"
     AWS_AMI_ID=$(aws ec2 --region="${region}" describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
     echo "Found AMI! ID: ${AWS_AMI_ID}"

--- a/cmd/executor/vm-image/_ami.push.sh
+++ b/cmd/executor/vm-image/_ami.push.sh
@@ -36,7 +36,8 @@ echo "Added GCP compute image to image family ${IMAGE_FAMILY}"
 
 # Set the AMIs to public.
 if [ "${EXECUTOR_IS_TAGGED_RELEASE}" = "true" ]; then
-  for region in $(jq -r '.[]' <aws_regions.json); do
+  regions=$(jq -r '.[]' <aws_regions.json)
+  for region in $regions; do
     echo "Getting AMI ID in region ${region}"
     AWS_AMI_ID=$(aws ec2 --region="${region}" describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
     echo "Found AMI! ID: ${AWS_AMI_ID}"


### PR DESCRIPTION
Causing error to not cause the script to fail if the file was missing

## Test plan

https://stackoverflow.com/questions/44014857/function-invocation-in-for-loop-does-not-fail-even-with-set-e