### PR TITLE
executors: fix path to aws_regions.json in ami.push targets

### DIFF
--- a/cmd/executor/docker-mirror/BUILD.bazel
+++ b/cmd/executor/docker-mirror/BUILD.bazel
@@ -25,6 +25,7 @@ sh_binary(
         "$(location //dev/tools:gcloud)",
     ],
     data = [
+        "aws_regions.json",
         # aws-cli is baked in the agents, because it's not that easy to get Bazel to install it.
         "//dev/tools:gcloud",
     ],

--- a/cmd/executor/docker-mirror/_ami.push.sh
+++ b/cmd/executor/docker-mirror/_ami.push.sh
@@ -17,7 +17,7 @@ GOOGLE_IMAGE_NAME="${NAME}"
 "$gcloud" compute images update --project=sourcegraph-ci "${GOOGLE_IMAGE_NAME}" --family="${IMAGE_FAMILY}"
 
 if [ "${EXECUTOR_IS_TAGGED_RELEASE}" = "true" ]; then
-  REGIONS=$(jq -r '.[]' <aws_regions.json)
+  REGIONS=$(jq -r '.[]' <cmd/executor/docker-mirror/aws_regions.json)
   for region in $REGIONS; do
     AWS_AMI_ID=$(aws ec2 --region="${region}" describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)
     # Make AMI usable outside of Sourcegraph.

--- a/cmd/executor/vm-image/BUILD.bazel
+++ b/cmd/executor/vm-image/BUILD.bazel
@@ -39,6 +39,7 @@ sh_binary(
         "$(location //dev/tools:gcloud)",
     ],
     data = [
+        "aws_regions.json",
         # aws-cli is baked in the agents, because it's not that easy to get Bazel to install it.
         "//dev/tools:gcloud",
     ],

--- a/cmd/executor/vm-image/_ami.push.sh
+++ b/cmd/executor/vm-image/_ami.push.sh
@@ -36,7 +36,7 @@ echo "Added GCP compute image to image family ${IMAGE_FAMILY}"
 
 # Set the AMIs to public.
 if [ "${EXECUTOR_IS_TAGGED_RELEASE}" = "true" ]; then
-  REGIONS=$(jq -r '.[]' <aws_regions.json)
+  REGIONS=$(jq -r '.[]' <cmd/executor/vm-image/aws_regions.json)
   for region in $REGIONS; do
     echo "Getting AMI ID in region ${region}"
     AWS_AMI_ID=$(aws ec2 --region="${region}" describe-images --filter "Name=name,Values=${NAME}" --query 'Images[*].[ImageId]' --output text)


### PR DESCRIPTION
Bazel ami.push targets were missing the file and pointing at wrong location

## Test plan

Tested manually on buildkite agent by @jhchabran 

![image](https://github.com/sourcegraph/sourcegraph/assets/18282288/6a269f0e-9d40-45b3-9019-06cc67578953)
