### PR TITLE
grpc: Bump streamio code to latest version

### DIFF
--- a/internal/grpc/streamio/BUILD.bazel
+++ b/internal/grpc/streamio/BUILD.bazel
@@ -13,5 +13,8 @@ go_test(
     timeout = "short",
     srcs = ["streamio_test.go"],
     embed = [":streamio"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//lib/errors",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/internal/grpc/streamio/streamio_test.go
+++ b/internal/grpc/streamio/streamio_test.go
@@ -9,10 +9,13 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"testing/iotest"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func TestReceiveSources(t *testing.T) {
@@ -35,38 +38,50 @@ func TestReceiveSources(t *testing.T) {
 }
 
 func TestReadSizes(t *testing.T) {
-	testData := "Hello this is the test data that will be received. It goes on for a while bla bla bla."
-	for n := 1; n < 100; n *= 3 {
-		desc := fmt.Sprintf("reads of size %d", n)
-		result := &bytes.Buffer{}
-		reader := &opaqueReader{NewReader(receiverFromReader(strings.NewReader(testData)))}
-		_, err := io.CopyBuffer(&opaqueWriter{result}, reader, make([]byte, n))
+	readSizes := func(t *testing.T, newReader func(string) io.Reader) {
+		testData := "Hello this is the test data that will be received. It goes on for a while bla bla bla."
 
-		require.NoError(t, err, desc)
-		require.Equal(t, testData, result.String())
+		for n := 1; n < 100; n *= 3 {
+			desc := fmt.Sprintf("reads of size %d", n)
+			result := &bytes.Buffer{}
+			reader := &opaqueReader{NewReader(receiverFromReader(newReader(testData)))}
+			n, err := io.CopyBuffer(&opaqueWriter{result}, reader, make([]byte, n))
+
+			require.NoError(t, err, desc)
+			require.Equal(t, testData, result.String())
+			require.EqualValues(t, len(testData), n)
+		}
 	}
+
+	t.Run("normal reader", func(t *testing.T) {
+		readSizes(t, func(s string) io.Reader {
+			return strings.NewReader(s)
+		})
+	})
+
+	t.Run("err reader", func(t *testing.T) {
+		readSizes(t, func(s string) io.Reader {
+			return iotest.DataErrReader(strings.NewReader(s))
+		})
+	})
 }
 
-func TestWriterTo(t *testing.T) {
-	testData := "Hello this is the test data that will be received. It goes on for a while bla bla bla."
-	testCases := []struct {
-		desc string
-		r    io.Reader
-	}{
-		{desc: "base", r: strings.NewReader(testData)},
-		{desc: "dataerr", r: iotest.DataErrReader(strings.NewReader(testData))},
-		{desc: "onebyte", r: iotest.OneByteReader(strings.NewReader(testData))},
-		{desc: "dataerr(onebyte)", r: iotest.DataErrReader(iotest.OneByteReader(strings.NewReader(testData)))},
-	}
+func TestRead_rememberError(t *testing.T) {
+	firstRead := true
+	myError := errors.New("hello world")
+	r := NewReader(func() ([]byte, error) {
+		if firstRead {
+			firstRead = false
+			return nil, myError
+		}
+		panic("should never be reached")
+	})
 
-	for _, tc := range testCases {
-		result := &bytes.Buffer{}
-		reader := NewReader(receiverFromReader(tc.r))
-		n, err := reader.(io.WriterTo).WriteTo(result)
-
-		require.NoError(t, err, tc.desc)
-		require.Equal(t, int64(len(testData)), n, tc.desc)
-		require.Equal(t, testData, result.String(), tc.desc)
+	// Intentionally call Read more than once. We want the error to be
+	// sticky.
+	for i := 0; i < 10; i++ {
+		_, err := r.Read(nil)
+		require.Equal(t, err, myError)
 	}
 }
 
@@ -106,6 +121,27 @@ func TestWriterChunking(t *testing.T) {
 	}
 }
 
+func TestNewSyncWriter(t *testing.T) {
+	var m sync.Mutex
+	testData := "Hello this is some test data"
+	ts := &testSender{}
+
+	w := NewSyncWriter(&m, func(p []byte) error {
+		// As there is no way to check whether a mutex is locked already, we can just try to
+		// unlock it here. If the mutex wasn't locked, it would cause a runtime error. As
+		// there's no concurrent writers in this test, this is safe to do.
+		m.Unlock()
+		m.Lock()
+
+		return ts.send(p)
+	})
+
+	_, err := io.CopyBuffer(&opaqueWriter{w}, strings.NewReader(testData), make([]byte, 10))
+	require.NoError(t, err)
+
+	require.Equal(t, testData, string(bytes.Join(ts.sends, nil)))
+}
+
 type testSender struct {
 	sends [][]byte
 }
@@ -115,34 +151,4 @@ func (ts *testSender) send(p []byte) error {
 	copy(buf, p)
 	ts.sends = append(ts.sends, buf)
 	return nil
-}
-
-func TestReadFrom(t *testing.T) {
-	defer func(oldBufferSize int) {
-		WriteBufferSize = oldBufferSize
-	}(WriteBufferSize)
-	WriteBufferSize = 5
-
-	testData := "Hello this is the test data that will be received. It goes on for a while bla bla bla."
-	testCases := []struct {
-		desc string
-		r    io.Reader
-	}{
-		{desc: "base", r: strings.NewReader(testData)},
-		{desc: "dataerr", r: iotest.DataErrReader(strings.NewReader(testData))},
-		{desc: "onebyte", r: iotest.OneByteReader(strings.NewReader(testData))},
-		{desc: "dataerr(onebyte)", r: iotest.DataErrReader(iotest.OneByteReader(strings.NewReader(testData)))},
-	}
-
-	for _, tc := range testCases {
-		ts := &testSender{}
-		n, err := NewWriter(ts.send).(io.ReaderFrom).ReadFrom(tc.r)
-
-		require.NoError(t, err, tc.desc)
-		require.Equal(t, int64(len(testData)), n, tc.desc)
-		require.Equal(t, testData, string(bytes.Join(ts.sends, nil)), tc.desc)
-		for _, send := range ts.sends {
-			require.True(t, len(send) <= WriteBufferSize, "send calls may not exceed WriteBufferSize")
-		}
-	}
 }


### PR DESCRIPTION
As I dug into why we're allocating a ton of memory in io.Copy when forwarding the stdout from exec calls to the writer, I found that we allocate 128kb every time, while many calls actually only write 40 bytes (a commit SHA).

![Screenshot 2024-02-19 at 18 54 08@2x](https://github.com/sourcegraph/sourcegraph/assets/19534377/0f6bd80f-5be1-4daf-b031-e7ae28b6edd5)


I then looked at gitaly and noticed that we use a very old version of their implementation and that they saw the same on their end and fixed it.

So here we go, updating it to the latest.
Note that we currently don't need the NewSyncWriter, but I kept it anyways, maybe it reminds us of the importance if we ever need it.

List of commits from gitaly: https://gitlab.com/gitlab-org/gitaly/-/commits/master/streamio/stream.go?ref_type=heads

---

streamio: Implement synchronized writer
Writing to gRPC streams concurrently isn't allowed, which is why we need to synchronize those writes. Doing so with the `NewWriter()` is repetitive, so this commit implements a new function `NewSyncWrite()` which receives a mutex in addition to the callback function. The mutex is then locked and unlocked previous to invoking the callback.

---

streamio: Simplify implementation of ReadFrom
The ReadFrom implementation is quite hard to read as the loop depends on state from the previous iteration. This commit refactors the code to not do so anymore by always sending data if we've read something, even if there was a read error.

---

streamio: Clarify why read errors are deferred
The implementation of `Read()` only returns read errors in case no data is left in the buffer. This is required such that we correctly drain any buffered data and only return the error when no data is left. This may not be immediately clear, so this commit puts a comment on this and adds a testcase which exercises this code path.

---

streamio: remove custom ReadFrom and WriteTo
This replaces sendWriter.ReadFrom and receiveReader.WriteTo with trivial implementations based on io.Copy, to be removed in 14.0.

The purpose of the io.ReaderFrom and io.WriterTo interfaces is to optimize away a buffer allocation in io.Copy, and/or being able to do something smart like calling sendfile(2). Without them, io.Copy allocates a 32KB buffer and reads into / writes from that buffer in a loop.

The thing is, sendWriter.ReadFrom and receiveReader.WriteTo neither make a difference for allocations, nor do they do something "smart".

First of all, sendWriter.ReadFrom was not helping the buffer allocation efficiency because it allocated its own 128KB buffer. In fact, sendWriter.ReadFrom is equivalent to what io.Copy does on the inside, so we might as well let io.Copy do that.

That leaves receiveReader.WriteTo as a potentially useful optimization. It does prevent io.Copy from allocating that 32KB buffer. However, everytime it calls receiver(), gRPC allocat...

---

Remove streamio ReaderFrom and WriterTo
These were set to be removed in v14.

Changelog: removed

---

streamio.Reader: remember errors
If there has been an error, subsequent calls to Read should keep returning that error.

Changelog: fixed

## Test plan

Verified locally that sourcegraph still works for basic clickops. CI will verify that archive fetching etc still behaves as previously. I will take another look at the cloud profiler once this has been rolled out.

