### PR TITLE
Return better error and status code from dotcom refresh limits api

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -531,7 +531,7 @@ func (r *schemaResolver) ChangeCodyPlan(ctx context.Context, args *changeCodyPla
 		return nil, err
 	}
 
-	if err := cody.RefreshGatewayRateLimits(ctx, userID, r.db); err != nil {
+	if err, _ := cody.RefreshGatewayRateLimits(ctx, userID, r.db); err != nil {
 		// We intentionally don't fail the upgrade flow here, Gateway will pickup
 		// the new limits automatically. (Just later than we'd like.)
 		r.logger.Warn("refresh gateway limits", log.Error(err))

--- a/cmd/frontend/internal/httpapi/ssc.go
+++ b/cmd/frontend/internal/httpapi/ssc.go
@@ -44,9 +44,10 @@ func newSSCRefreshCodyRateLimitHandler(logger log.Logger, db database.DB) http.H
 
 		userID := oidcAccounts[0].UserID
 
-		if err := cody.RefreshGatewayRateLimits(ctx, userID, db); err != nil {
-			logger.Error("error refreshing gateway rate limits", log.Error(err))
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+		if err, statusCode := cody.RefreshGatewayRateLimits(ctx, userID, db); err != nil {
+			logger.Error(fmt.Sprintf("error refreshing gateway rate limits: %d", statusCode), log.Error(err))
+			http.Error(w, err.Error(), statusCode)
+			return
 		}
 
 		w.WriteHeader(http.StatusOK)

--- a/internal/cody/rate_limits.go
+++ b/internal/cody/rate_limits.go
@@ -16,34 +16,34 @@ import (
 )
 
 // RefreshGatewayRateLimits refreshes the rate limits for the user on Cody Gateway.
-func RefreshGatewayRateLimits(ctx context.Context, userID int32, db database.DB) error {
+func RefreshGatewayRateLimits(ctx context.Context, userID int32, db database.DB) (error, int) {
 	completionsConfig := conf.GetCompletionsConfig(conf.Get().SiteConfig())
 	// We don't need to do anything if the target is not Cody Gateway, but it's not an error either.
 	if completionsConfig.Provider != conftypes.CompletionsProviderNameSourcegraph {
-		return nil
+		return nil, http.StatusOK
 	}
 
 	apiTokenSha256, err := db.AccessTokens().GetOrCreateInternalToken(ctx, userID, []string{"user:all"})
 	if err != nil {
-		return errors.Wrap(err, "getting internal access token")
+		return errors.Wrap(err, "getting internal access token"), http.StatusInternalServerError
 	}
 	gatewayToken := accesstoken.DotcomUserGatewayAccessTokenPrefix + hex.EncodeToString(hashutil.ToSHA256Bytes(apiTokenSha256))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, completionsConfig.Endpoint+"/v1/limits/refresh", nil)
 	if err != nil {
-		return err
+		return err, http.StatusInternalServerError
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", gatewayToken))
 
 	resp, err := httpcli.UncachedExternalDoer.Do(req)
 	defer func() { _ = resp.Body.Close() }()
 	if err != nil {
-		return err
+		return err, http.StatusInternalServerError
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("non-200 response refreshing Gateway limits: %d", resp.StatusCode)
+		return errors.Errorf("non-200 response refreshing Gateway limits: %d", resp.StatusCode), resp.StatusCode
 	}
 
-	return nil
+	return nil, http.StatusOK
 }


### PR DESCRIPTION
The refresh rate limits API on dotcom always returns 500 when it fails to update rate limits on dotcom.

Related Issue: https://github.com/sourcegraph/accounts.sourcegraph.com/issues/562

This PR updates the API to return a better error message and status.

This will also propagate the 429 error it receives from the gateway to the caller SSC. 
This will allow SSC to retry at a later time and do better error logging in sentry. 

SSC side of PR: https://github.com/sourcegraph/accounts.sourcegraph.com/pull/579

## Test plan

ran locally