### PR TITLE
Replace /get-cody links with /cody/manage

### DIFF
--- a/client/web/src/cody/chat/CodyChatPage.tsx
+++ b/client/web/src/cody/chat/CodyChatPage.tsx
@@ -283,7 +283,7 @@ export const CodyChatPage: React.FunctionComponent<CodyChatPageProps> = ({
                             </Text>
                             <div className="mb-2">
                                 <Link
-                                    to="/get-cody"
+                                    to="/cody/manage"
                                     className={classNames(
                                         'd-inline-flex align-items-center text-merged',
                                         styles.ctaLink

--- a/client/web/src/cody/widgets/CodyRecipesWidget.tsx
+++ b/client/web/src/cody/widgets/CodyRecipesWidget.tsx
@@ -87,7 +87,7 @@ export const CodyRecipesWidget: React.FC<{ editor?: CodeMirrorEditor }> = ({ edi
                     onClick={() => void executeRecipe('find-code-smells', { scope: { editor } })}
                     disabled={isMessageInProgress}
                 />
-                <RecipeAction title="Get Cody in your editor" to="/get-cody" disabled={isMessageInProgress} />
+                <RecipeAction title="Get Cody in your editor" to="/cody/manage" disabled={isMessageInProgress} />
             </Recipe>
         </Recipes>
     )

--- a/client/web/src/marketing/toast/CodySurveyToast.tsx
+++ b/client/web/src/marketing/toast/CodySurveyToast.tsx
@@ -333,7 +333,7 @@ export const CodySurveyToast: React.FC<
 
     const handleSubmitEnd = (): void => {
         // Redirects once user submits the post-sign-up form
-        const returnTo = getReturnTo(location, PageRoutes.GetCody)
+        const returnTo = getReturnTo(location, PageRoutes.CodyManagement)
         window.location.replace(returnTo)
     }
 


### PR DESCRIPTION
`/get-cody` is just a redirect to `/cody/manage`.
Cody clients probably contain a lot of links to `/get-cody` so we still need that redirect (and will need it for a year plus) but within the web app, we can go to the management page directly.

## Test plan

Not tested yet!