### PR TITLE
lib/output: detectCapabilities on output writer

### DIFF
--- a/lib/output/capabilities.go
+++ b/lib/output/capabilities.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"io"
 	"os"
 	"strconv"
 
@@ -29,11 +30,11 @@ type capabilities struct {
 // detectCapabilities lazily evaluates capabilities using the given options. This means
 // that if an override is indicated in opts, no inference of the relevant capabilities
 // is done at all.
-func detectCapabilities(opts OutputOpts) (caps capabilities, err error) {
+func detectCapabilities(w io.Writer, opts OutputOpts) (caps capabilities, err error) {
 	// Set atty
 	caps.Isatty = opts.ForceTTY
-	if !opts.ForceTTY {
-		caps.Isatty = isatty.IsTerminal(os.Stdout.Fd())
+	if fder, hasFd := w.(interface{ Fd() uintptr }); !opts.ForceTTY && hasFd {
+		caps.Isatty = isatty.IsTerminal(fder.Fd())
 	}
 
 	// Default width and height

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -91,7 +91,7 @@ var newOutputPlatformQuirks func(o *Output) error
 // newCapabilityWatcher returns a channel that receives a message when
 // capabilities are updated. By default, no watching functionality is
 // available.
-var newCapabilityWatcher = func(opts OutputOpts) chan capabilities { return nil }
+var newCapabilityWatcher = func(w io.Writer, opts OutputOpts) chan capabilities { return nil }
 
 func NewOutput(w io.Writer, opts OutputOpts) *Output {
 	// Not being able to detect capabilities is alright. It might mean output will look
@@ -99,7 +99,7 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 	// Before, we logged an error
 	// "An error was returned when detecting the terminal size and capabilities"
 	// but it was super noisy and confused people into thinking something would be broken.
-	caps, _ := detectCapabilities(opts)
+	caps, _ := detectCapabilities(w, opts)
 
 	o := &Output{caps: caps, verbose: opts.Verbose, w: w}
 	if newOutputPlatformQuirks != nil {
@@ -110,7 +110,7 @@ func NewOutput(w io.Writer, opts OutputOpts) *Output {
 
 	// Set up a watcher so we can adjust the size of the output if the terminal
 	// is resized.
-	if c := newCapabilityWatcher(opts); c != nil {
+	if c := newCapabilityWatcher(w, opts); c != nil {
 		go func() {
 			for caps := range c {
 				o.caps = caps

--- a/lib/output/output_unix.go
+++ b/lib/output/output_unix.go
@@ -4,6 +4,7 @@
 package output
 
 import (
+	"io"
 	"os"
 	"os/signal"
 	"sync"
@@ -30,7 +31,7 @@ func init() {
 		once sync.Once
 	)
 
-	newCapabilityWatcher = func(opts OutputOpts) chan capabilities {
+	newCapabilityWatcher = func(w io.Writer, opts OutputOpts) chan capabilities {
 		// Lazily initialise the required global state if we haven't already.
 		once.Do(func() {
 			mu.Lock()
@@ -46,7 +47,7 @@ func init() {
 			go func() {
 				for {
 					<-c
-					caps, err := detectCapabilities(opts)
+					caps, err := detectCapabilities(w, opts)
 					// We won't bother reporting an error here; there's no harm
 					// in the previous capabilities being used besides possibly
 					// being ugly.

--- a/lib/output/output_unix_test.go
+++ b/lib/output/output_unix_test.go
@@ -20,7 +20,7 @@ func TestCapabilityWatcher(t *testing.T) {
 	received := make(chan capabilities)
 
 	createWatcher := func(opts OutputOpts) {
-		c := newCapabilityWatcher(opts)
+		c := newCapabilityWatcher(os.Stdout, opts)
 		if c == nil {
 			t.Error("unexpected nil watcher channel")
 		}


### PR DESCRIPTION
I had go tests failing inside of the emacs compilation-mode buffer. It was due to detecting the capabilities of the terminal incorrectly, leading to us capturing output in tests with extra escape codes. This lead to tests failing since we would assert on the output captured.

From reading the logic of when we pass in a different std.Output, we should in fact be detecting capabilities on it. It is possible now that we incorrectly detect when wrapping the writer. However, from looking at call sites we don't do that outside of tests.

Test Plan: go test