### PR TITLE
lib/output: ForceTTY can be used to disable Isatty

### DIFF
--- a/dev/sg/internal/std/BUILD.bazel
+++ b/dev/sg/internal/std/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["output.go"],
     importpath = "github.com/sourcegraph/sourcegraph/dev/sg/internal/std",
     visibility = ["//dev/sg:__subpackages__"],
-    deps = ["//lib/output"],
+    deps = [
+        "//lib/output",
+        "//lib/pointers",
+    ],
 )

--- a/dev/sg/internal/std/output.go
+++ b/dev/sg/internal/std/output.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 // Output is a wrapper with convenience functions for sg output.
@@ -51,7 +52,7 @@ func NewFixedOutput(dst io.Writer, verbose bool) *Output {
 // TTY and color, useful for testing and getting simpler output.
 func NewSimpleOutput(dst io.Writer, verbose bool) *Output {
 	opts := newStaticOutputOptions(verbose)
-	opts.ForceTTY = false
+	opts.ForceTTY = pointers.Ptr(false)
 	opts.ForceColor = false
 
 	return &Output{
@@ -64,7 +65,7 @@ func NewSimpleOutput(dst io.Writer, verbose bool) *Output {
 func newStaticOutputOptions(verbose bool) output.OutputOpts {
 	return output.OutputOpts{
 		ForceColor:          true,
-		ForceTTY:            true,
+		ForceTTY:            pointers.Ptr(true),
 		Verbose:             verbose,
 		ForceWidth:          80,
 		ForceHeight:         25,

--- a/lib/output/capabilities.go
+++ b/lib/output/capabilities.go
@@ -31,8 +31,9 @@ type capabilities struct {
 // is done at all.
 func detectCapabilities(opts OutputOpts) (caps capabilities, err error) {
 	// Set atty
-	caps.Isatty = opts.ForceTTY
-	if !opts.ForceTTY {
+	if opts.ForceTTY != nil {
+		caps.Isatty = *opts.ForceTTY
+	} else {
 		caps.Isatty = isatty.IsTerminal(os.Stdout.Fd())
 	}
 

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -59,8 +59,8 @@ var _ sync.Locker = &Output{}
 type OutputOpts struct {
 	// ForceColor ignores all terminal detection and enabled coloured output.
 	ForceColor bool
-	// ForceTTY ignores all terminal detection and enables TTY output.
-	ForceTTY bool
+	// ForceTTY ignores all terminal detection if non-nil and sets TTY output.
+	ForceTTY *bool
 
 	// ForceHeight ignores all terminal detection and sets the height to this value.
 	ForceHeight int

--- a/lib/output/outputtest/BUILD.bazel
+++ b/lib/output/outputtest/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
     embed = [":outputtest"],
     deps = [
         "//lib/output",
+        "//lib/pointers",
         "@com_github_google_go_cmp//cmp",
     ],
 )

--- a/lib/output/outputtest/buffer_test.go
+++ b/lib/output/outputtest/buffer_test.go
@@ -6,13 +6,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/lib/output"
+	"github.com/sourcegraph/sourcegraph/lib/pointers"
 )
 
 func TestBuffer_Lines(t *testing.T) {
 	buf := &Buffer{}
 
 	out := output.NewOutput(buf, output.OutputOpts{
-		ForceTTY:    true,
+		ForceTTY:    pointers.Ptr(true),
 		ForceColor:  true,
 		ForceHeight: 25,
 		ForceWidth:  80,


### PR DESCRIPTION
For tests we do not want to use the detection on os.Stdout to change what output we capture and assert against. In particular when running the sg tests for me under emacs's compilation-mode I get failures due to extra escape codes.

This is a different take on ensuring tests do not have Isatty enabled. The previous attempt used the passed in writer to determine this. However, on further inspection of call sites we somewhat regularly captures the output and then only show it if something went wrong. In those cases we should preserve Isatty of stdout so the errors look prettier.

Test Plan: go test -short ./...
