### PR TITLE
gitserver: Reduce logspam from expected errors

### DIFF
--- a/cmd/gitserver/internal/git/observability.go
+++ b/cmd/gitserver/internal/git/observability.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -305,9 +306,12 @@ func newOperations(observationCtx *observation.Context) *operations {
 			Metrics:           redMetrics,
 			ErrorFilter: func(err error) observation.ErrorFilterBehaviour {
 				if errors.HasType(err, &gitdomain.RevisionNotFoundError{}) {
-					return observation.EmitForLogs
+					return observation.EmitForNone
 				}
-				return observation.EmitForAllExceptLogs
+				if os.IsNotExist(err) {
+					return observation.EmitForNone
+				}
+				return observation.EmitForDefault
 			},
 		})
 	}


### PR DESCRIPTION
We started logging these, but RevisionNotFound is actually a well-expected case so let's not log it. NotFound errors from os are also expected for some methods, so skipping over those as well.

Closes https://github.com/sourcegraph/sourcegraph/issues/60598

## Test plan

Ran the stack and checked for logspam.
