### PR TITLE
Searcher: fix optimization for empty patterns

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -154,7 +154,7 @@ func regexSearch(
 				}
 
 				if !match && patternMatchesContent {
-					if _, ok := m.(allMatchTree); ok {
+					if _, ok := m.(*allMatchTree); ok {
 						// Avoid loading the file if this pattern always matches
 						match = true
 					} else {


### PR DESCRIPTION
In #59331, we refactored the searcher logic to support AND/ OR patterns in
searcher. While doing so, we accidentally regressed on an optimization that
avoids loading file content when the pattern is empty.

We now have a benchmark for empty patterns, but this benchmark was added
recently and wasn't run during that refactor.

Note: this will be backported to 5.3.

## Test plan

Ran new benchmarks (see below commment)