### PR TITLE
remove ?utm_source=server for dotcom -> dotcom CTA link

### DIFF
--- a/client/web/src/storm/pages/SearchPage/CodyUpsell.tsx
+++ b/client/web/src/storm/pages/SearchPage/CodyUpsell.tsx
@@ -16,7 +16,7 @@ interface CodyUpsellProps {
 export const CodyUpsell: FC<CodyUpsellProps> = ({ isSourcegraphDotCom }) => {
     const isLightTheme = useIsLightTheme()
     // On DotCom, we want to redirect to the PLG page. On Enterprise instances, we redirect to their Cody dashboard page.
-    const exploreCodyLink = isSourcegraphDotCom ? 'https://sourcegraph.com/cody?utm_source=server' : '/cody'
+    const exploreCodyLink = isSourcegraphDotCom ? 'https://sourcegraph.com/cody' : '/cody'
     return (
         <section className={styles.upsell}>
             <section className={styles.upsellMeta}>


### PR DESCRIPTION
Hope you're the right person Bolaji, GitHub suggested you. Should just be a stamp.

See discussion at https://sourcegraph.slack.com/archives/C0678ATBXCG/p1708381486675609

## Test plan

CI