### PR TITLE
syntax-highlighter: Turn off Rocket logging with QUIET=true

### DIFF
--- a/docker-images/syntax-highlighter/src/main.rs
+++ b/docker-images/syntax-highlighter/src/main.rs
@@ -72,12 +72,14 @@ fn rocket() -> _ {
         .get(&tree_sitter_all_languages::ParserId::Go);
 
     // Only list features if QUIET != "true"
+    let mut config: rocket::config::Config = Default::default();
     match std::env::var("QUIET") {
-        Ok(v) if v == "true" => {}
+        Ok(v) if v == "true" => config.log_level = rocket::log::LogLevel::Off,
         _ => syntect_server::list_features(),
     };
 
     rocket::build()
+        .configure(config)
         .mount("/", routes![syntect, lsif, scip, health])
         .register("/", catchers![not_found])
 }


### PR DESCRIPTION
With this change, we can remove the extra shell layer around the highlighter.

## Test plan

`cd docker-images/syntax-highlighter` and compare output of `cargo run --bin syntect_server` and `QUIET=true cargo run --bin syntect_server`. The latter should not have any logging as requested in https://github.com/sourcegraph/sourcegraph/issues/60407#issuecomment-1952248780