### PR TITLE
squirrel: Allow .hxx extension for C++

### DIFF
--- a/client/shared/src/codeintel/legacy-extensions/language-specs/cpp.ts
+++ b/client/shared/src/codeintel/legacy-extensions/language-specs/cpp.ts
@@ -43,6 +43,7 @@ export const cppSpec: LanguageSpec = {
         'hh',
         'h',
         'hpp',
+        'hxx',
         'ino', // Arduino
         'm', // Objective-C
         'pc', // Pro-C by Oracle RDBMS

--- a/client/shared/src/languages.ts
+++ b/client/shared/src/languages.ts
@@ -145,6 +145,7 @@ function getModeFromExtension(extension: string): string | undefined {
         case 'hh':
         case 'h':
         case 'hpp':
+        case 'hxx':
         // https://github.com/sourcegraph/customer/issues/124
         case 'pc':
         case 'pcc': {

--- a/cmd/symbols/squirrel/language-file-extensions.json
+++ b/cmd/symbols/squirrel/language-file-extensions.json
@@ -52,6 +52,7 @@
     "hh",
     "h",
     "hpp",
+    "hxx",
     // For Pro*C/C++ which was requested by a customer
     // See: https://github.com/sourcegraph/customer/issues/124
     // And https://web.archive.org/web/20231107051418/https://otl.sourceforge.net/otl3_ex59.htm

--- a/internal/codeintel/uploads/shared/indexers2.go
+++ b/internal/codeintel/uploads/shared/indexers2.go
@@ -80,7 +80,7 @@ func NamesForKey(key string) []string {
 }
 
 var extensions = map[string][]string{
-	"C++":        {".c", ".cp", ".cpp", ".cxx", ".h", ".hpp"},
+	"C++":        {".c", ".cp", ".cpp", ".cxx", ".h", ".hpp", ".hxx"},
 	"Dart":       {".dart"},
 	"DotNet":     {".cs", ".fs"},
 	"Go":         {".go"},


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/60661

## Test plan

Hovers start showing up on my local instance
![](https://github.com/sourcegraph/sourcegraph/assets/93103176/2ac1ff58-3b6d-4dce-b417-272ecda5d1f9)

You can test that they currently don't work on Sourcegraph.com

https://sourcegraph.com/github.com/Fytch/ProgramOptions.hxx@cafa8436dd96a65f1f4c1b921eef90dd85b58197/-/blob/include/ProgramOptions.hxx?L272