### PR TITLE
Store data about profanities and session control phrases

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -268,12 +268,10 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 				prompt := strings.ToLower(body.BuildPrompt())
 				prof := d.ExtractProfanity(prompt)
 				if prof != "" {
-					requestMetadata["is_profane"] = true
 					requestMetadata["profanity"] = prof
 				}
 				for _, p := range patternsToDetect {
 					if strings.Contains(prompt, p) {
-						requestMetadata["detected_phrases"] = true
 						pat := p
 						if len(p) > 5 {
 							pat = p[:5]

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -54,6 +54,9 @@ var hopHeaders = map[string]struct{}{
 	"Upgrade":             {},
 }
 
+// Trim detected phrases to this many characters (to avoid storing too much repetitive data in BigQuery)
+const detectedPhrasePrefixLength = 5
+
 // upstreamHandlerMethods declares a set of methods that are used throughout the
 // lifecycle of a request to an upstream API. All methods are required, and called
 // in the order they are defined here.
@@ -273,8 +276,8 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 				for _, p := range patternsToDetect {
 					if strings.Contains(prompt, p) {
 						pat := p
-						if len(p) > 5 {
-							pat = p[:5]
+						if len(p) > detectedPhrasePrefixLength {
+							pat = p[:detectedPhrasePrefixLength]
 						}
 						requestMetadata["detected_phrase"] = pat
 						break

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -266,12 +266,19 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 
 			if feature == codygateway.FeatureChatCompletions {
 				prompt := strings.ToLower(body.BuildPrompt())
-				if d.IsProfane(prompt) {
+				prof := d.ExtractProfanity(prompt)
+				if prof != "" {
 					requestMetadata["is_profane"] = true
+					requestMetadata["profanity"] = prof
 				}
 				for _, p := range patternsToDetect {
 					if strings.Contains(prompt, p) {
 						requestMetadata["detected_phrases"] = true
+						pat := p
+						if len(p) > 5 {
+							pat = p[:5]
+						}
+						requestMetadata["detected_phrase"] = pat
 						break
 					}
 				}


### PR DESCRIPTION
When we detect NSFW content / session control phrases, include information about what was detected.

## Test plan

- local testing 
- e2e tests