### PR TITLE
Revert "syntax-highlighter: Turn off Rocket logging with QUIET=true (#60660)"

### DIFF
--- a/docker-images/syntax-highlighter/src/main.rs
+++ b/docker-images/syntax-highlighter/src/main.rs
@@ -72,14 +72,12 @@ fn rocket() -> _ {
         .get(&tree_sitter_all_languages::ParserId::Go);
 
     // Only list features if QUIET != "true"
-    let mut config: rocket::config::Config = Default::default();
     match std::env::var("QUIET") {
-        Ok(v) if v == "true" => config.log_level = rocket::log::LogLevel::Off,
+        Ok(v) if v == "true" => {}
         _ => syntect_server::list_features(),
     };
 
     rocket::build()
-        .configure(config)
         .mount("/", routes![syntect, lsif, scip, health])
         .register("/", catchers![not_found])
 }


### PR DESCRIPTION
This reverts commit c19a432ab777335573aa4e6ffcf4668f1cb7be8a.

## Test plan

Run the following locally:

```
bazel build //docker-images/syntax-highlighter:image_tarball
docker load --input $(bazel cquery //docker-images/syntax-highlighter:image_tarball --output=files)
docker run --detach --name=syntax-highlighter -p 9238:9238 syntect-server:candidate
curl http://localhost:9238/health
```

This prints OK after this revert, but not before.