### PR TITLE
honey: HONEYCOMB_LOCAL which logs events to stderr

### DIFF
--- a/internal/honey/event.go
+++ b/internal/honey/event.go
@@ -1,6 +1,11 @@
 package honey
 
 import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
 	"github.com/honeycombio/libhoney-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -77,6 +82,15 @@ func (w eventWrapper) SetSampleRate(rate uint) {
 }
 
 func (w eventWrapper) Send() error {
+	if local {
+		var fields []string
+		for k, v := range w.event.Fields() {
+			fields = append(fields, fmt.Sprintf("  %s: %v", k, v))
+		}
+		slices.Sort(fields)
+		_, _ = fmt.Fprintf(os.Stderr, "EVENT %s\n%s\n", w.event.Dataset, strings.Join(fields, "\n"))
+		return nil
+	}
 	return w.event.Send()
 }
 

--- a/internal/honey/honey.go
+++ b/internal/honey/honey.go
@@ -15,11 +15,12 @@ var (
 	apiKey  = env.Get("HONEYCOMB_TEAM", "", "The key used for Honeycomb event tracking.")
 	suffix  = env.Get("HONEYCOMB_SUFFIX", "", "Suffix to append to honeycomb datasets. Used to differentiate between prod/dogfood/dev/etc.")
 	disable = env.Get("HONEYCOMB_DISABLE", "", "Ignore that HONEYCOMB_TEAM is set and return false for Enabled. Used by specific instrumentation which ignores what Enabled returns and will log based on other criteria.")
+	local   = env.MustGetBool("HONEYCOMB_LOCAL", false, "Ignore HONEYCOMB_TEAM and log to stderr for each send.")
 )
 
 // Enabled returns true if honeycomb has been configured to run.
 func Enabled() bool {
-	return apiKey != "" && disable == ""
+	return (local || apiKey != "") && disable == ""
 }
 
 func init() {


### PR DESCRIPTION
I found this very useful in my dev environment to debug some searches. Initially I added in a new event type. However, we do some transformations in our eventWrapper which I wanted to preserve. So instead at time of Send we decide if we should send to honeycomb or just log to stderr.

Note: this produces a lot of log output due to background processes running commands against git/etc.

Test Plan: "HONEYCOMB_LOCAL=true sg start enterprise" and see events in console when I do searches.
