### PR TITLE
[Backport 5.3] Searcher: fix optimization for empty patterns

### DIFF
--- a/cmd/searcher/internal/search/search_regex.go
+++ b/cmd/searcher/internal/search/search_regex.go
@@ -82,7 +82,7 @@ func regexSearch(
 		files = zf.Files
 	)
 
-	if _, ok := m.(allMatchTree); ok || (patternMatchesPaths && !patternMatchesContent) {
+	if _, ok := m.(*allMatchTree); ok || (patternMatchesPaths && !patternMatchesContent) {
 		// Fast path for only matching file paths (or with a nil pattern, which matches all files,
 		// so is effectively matching only on file paths).
 		for _, f := range files {


### PR DESCRIPTION
In #59331, we refactored the searcher logic to support AND/ OR patterns in
searcher. While doing so, we accidentally regressed on an optimization that
avoids loading file content when the pattern is empty.

We now have a benchmark for empty patterns, but this benchmark was added
recently and wasn't run during that refactor.

## Test plan

CI and benchmarks