### PR TITLE
Add double hash index for CodyGatewayDotcomUserByToken

### DIFF
--- a/internal/database/migration/shared/data/stitched-migration-graph.json
+++ b/internal/database/migration/shared/data/stitched-migration-graph.json
@@ -11136,6 +11136,23 @@
 				],
 				"IsCreateIndexConcurrently": false,
 				"IndexMetadata": null
+			},
+			{
+				"ID": 1708596613,
+				"Name": "access_tokens_double_hash_index",
+				"UpQuery": "CREATE INDEX CONCURRENTLY IF NOT EXISTS access_tokens_lookup_double_hash ON access_tokens USING HASH (digest(value_sha256, 'sha256'))\n    WHERE\n    deleted_at IS NULL;",
+				"DownQuery": "DROP INDEX IF EXISTS access_tokens_lookup_double_hash;",
+				"Privileged": false,
+				"NonIdempotent": false,
+				"Parents": [
+					1695911128,
+					1707759188
+				],
+				"IsCreateIndexConcurrently": true,
+				"IndexMetadata": {
+					"TableName": "access_tokens",
+					"IndexName": "access_tokens_lookup_double_hash"
+				}
 			}
 		],
 		"BoundsByRev": {
@@ -11387,8 +11404,7 @@
 			"v5.3.0": {
 				"RootID": 1648051770,
 				"LeafIDs": [
-					1695911128,
-					1707759188
+					1708596613
 				],
 				"PreCreation": false
 			}

--- a/internal/database/schema.json
+++ b/internal/database/schema.json
@@ -1707,6 +1707,16 @@
           "IndexDefinition": "CREATE INDEX access_tokens_lookup ON access_tokens USING hash (value_sha256) WHERE deleted_at IS NULL",
           "ConstraintType": "",
           "ConstraintDefinition": ""
+        },
+        {
+          "Name": "access_tokens_lookup_double_hash",
+          "IsPrimaryKey": false,
+          "IsUnique": false,
+          "IsExclusion": false,
+          "IsDeferrable": false,
+          "IndexDefinition": "CREATE INDEX access_tokens_lookup_double_hash ON access_tokens USING hash (digest(value_sha256, 'sha256'::text)) WHERE deleted_at IS NULL",
+          "ConstraintType": "",
+          "ConstraintDefinition": ""
         }
       ],
       "Constraints": [

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -39,6 +39,7 @@ Indexes:
     "access_tokens_pkey" PRIMARY KEY, btree (id)
     "access_tokens_value_sha256_key" UNIQUE CONSTRAINT, btree (value_sha256)
     "access_tokens_lookup" hash (value_sha256) WHERE deleted_at IS NULL
+    "access_tokens_lookup_double_hash" hash (digest(value_sha256, 'sha256'::text)) WHERE deleted_at IS NULL
 Foreign-key constraints:
     "access_tokens_creator_user_id_fkey" FOREIGN KEY (creator_user_id) REFERENCES users(id)
     "access_tokens_subject_user_id_fkey" FOREIGN KEY (subject_user_id) REFERENCES users(id)

--- a/migrations/frontend/1708596613_access_tokens_double_hash_index/down.sql
+++ b/migrations/frontend/1708596613_access_tokens_double_hash_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS access_tokens_lookup_double_hash;

--- a/migrations/frontend/1708596613_access_tokens_double_hash_index/metadata.yaml
+++ b/migrations/frontend/1708596613_access_tokens_double_hash_index/metadata.yaml
@@ -1,0 +1,3 @@
+name: access_tokens_double_hash_index
+parents: [1695911128, 1707759188]
+createIndexConcurrently: true

--- a/migrations/frontend/1708596613_access_tokens_double_hash_index/up.sql
+++ b/migrations/frontend/1708596613_access_tokens_double_hash_index/up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS access_tokens_lookup_double_hash ON access_tokens USING HASH (digest(value_sha256, 'sha256'))
+    WHERE
+    deleted_at IS NULL;

--- a/migrations/frontend/squashed.sql
+++ b/migrations/frontend/squashed.sql
@@ -5889,6 +5889,8 @@ CREATE INDEX access_requests_status ON access_requests USING btree (status);
 
 CREATE INDEX access_tokens_lookup ON access_tokens USING hash (value_sha256) WHERE (deleted_at IS NULL);
 
+CREATE INDEX access_tokens_lookup_double_hash ON access_tokens USING hash (digest(value_sha256, 'sha256'::text)) WHERE (deleted_at IS NULL);
+
 CREATE INDEX app_id_idx ON github_app_installs USING btree (app_id);
 
 CREATE UNIQUE INDEX assigned_owners_file_path_owner ON assigned_owners USING btree (file_path_id, owner_user_id);


### PR DESCRIPTION
This adds an index that can be used to reduce the number of SHA256 hashes computed by CodyGatewayDotcomUserByToken, reducing query latency and CPU usage.

Slack [conversation](https://sourcegraph.slack.com/archives/C05497E9MDW/p1708526972279079).

Query plan after:
```
Nested Loop  (cost=6006.56..9238.90 rows=1248 width=20) (actual time=0.719..0.961 rows=0 loops=1)
  ->  HashAggregate  (cost=6006.14..6018.62 rows=1248 width=8) (actual time=0.719..0.960 rows=0 loops=1)
        Group Key: t2.id
        ->  Gather  (cost=1023.02..6003.02 rows=1248 width=8) (actual time=0.710..0.951 rows=0 loops=1)
              Workers Planned: 1
              Workers Launched: 0
              ->  Nested Loop  (cost=23.02..4878.22 rows=734 width=8) (actual time=0.329..0.330 rows=0 loops=1)
                    ->  Nested Loop  (cost=22.59..3246.99 rows=735 width=12) (actual time=0.329..0.330 rows=0 loops=1)
                          ->  Parallel Bitmap Heap Scan on access_tokens t2  (cost=22.17..1615.76 rows=735 width=16) (actual time=0.328..0.329 rows=0 loops=1)
                                Recheck Cond: ((digest(value_sha256, 'sha256'::text) = 'HASH'::bytea) AND (deleted_at IS NULL))
                                Filter: ((expires_at IS NULL) OR (expires_at > now()))
                                ->  Bitmap Index Scan on access_tokens_lookup_double_hash  (cost=0.00..21.86 rows=1448 width=0) (actual time=0.008..0.008 rows=0 loops=1)
                                      Index Cond: (digest(value_sha256, 'sha256'::text) = 'HASH'::bytea)
                          ->  Index Scan using users_pkey on users subject_user  (cost=0.42..2.22 rows=1 width=4) (never executed)
                                Index Cond: (id = t2.subject_user_id)
                                Filter: (deleted_at IS NULL)
                    ->  Index Scan using users_pkey on users creator_user  (cost=0.42..2.22 rows=1 width=4) (never executed)
                          Index Cond: (id = t2.creator_user_id)
                          Filter: (deleted_at IS NULL)
  ->  Index Scan using access_tokens_pkey on access_tokens t  (cost=0.42..2.59 rows=1 width=20) (never executed)
        Index Cond: (id = t2.id)
Planning Time: 0.860 ms
Execution Time: 1.112 ms
```
Query plan before:
```
Nested Loop  (cost=224517.94..230437.11 rows=2320 width=20) (actual time=252.693..254.900 rows=0 loops=1)
  ->  HashAggregate  (cost=224517.51..224540.71 rows=2320 width=8) (actual time=252.693..254.898 rows=0 loops=1)
        Group Key: t2.id
        ->  Gather  (cost=1000.85..224511.71 rows=2320 width=8) (actual time=252.675..254.880 rows=0 loops=1)
              Workers Planned: 2
              Workers Launched: 1
              ->  Nested Loop  (cost=0.84..223279.71 rows=967 width=8) (actual time=246.746..246.748 rows=0 loops=2)
                    ->  Nested Loop  (cost=0.42..221348.69 rows=968 width=12) (actual time=246.746..246.747 rows=0 loops=2)
                          ->  Parallel Seq Scan on access_tokens t2  (cost=0.00..219417.66 rows=968 width=16) (actual time=246.744..246.745 rows=0 loops=2)
                                Filter: ((deleted_at IS NULL) AND ((expires_at IS NULL) OR (expires_at > now())) AND (digest(value_sha256, 'sha256'::text) = '\Nested Loop  (cost=224517.94..230437.11 rows=2320 width=20) (actual time=252.693..254.900 rows=0 loops=1)
  ->  HashAggregate  (cost=224517.51..224540.71 rows=2320 width=8) (actual time=252.693..254.898 rows=0 loops=1)
        Group Key: t2.id
        ->  Gather  (cost=1000.85..224511.71 rows=2320 width=8) (actual time=252.675..254.880 rows=0 loops=1)
              Workers Planned: 2
              Workers Launched: 1
              ->  Nested Loop  (cost=0.84..223279.71 rows=967 width=8) (actual time=246.746..246.748 rows=0 loops=2)
                    ->  Nested Loop  (cost=0.42..221348.69 rows=968 width=12) (actual time=246.746..246.747 rows=0 loops=2)
                          ->  Parallel Seq Scan on access_tokens t2  (cost=0.00..219417.66 rows=968 width=16) (actual time=246.744..246.745 rows=0 loops=2)
                                Filter: ((deleted_at IS NULL) AND ((expires_at IS NULL) OR (expires_at > now())) AND (digest(value_sha256, 'sha256'::text) = 'HASH'::bytea))
                                Rows Removed by Filter: 155946
                          ->  Index Scan using users_pkey on users subject_user  (cost=0.42..1.99 rows=1 width=4) (never executed)
                                Index Cond: (id = t2.subject_user_id)
                                Filter: (deleted_at IS NULL)
                    ->  Index Scan using users_pkey on users creator_user  (cost=0.42..1.99 rows=1 width=4) (never executed)
                          Index Cond: (id = t2.creator_user_id)
                          Filter: (deleted_at IS NULL)
  ->  Index Scan using access_tokens_pkey on access_tokens t  (cost=0.42..2.55 rows=1 width=20) (never executed)
        Index Cond: (id = t2.id)
Planning Time: 1.382 ms
Execution Time: 258.626 ms'::bytea))
                                Rows Removed by Filter: 155946
                          ->  Index Scan using users_pkey on users subject_user  (cost=0.42..1.99 rows=1 width=4) (never executed)
                                Index Cond: (id = t2.subject_user_id)
                                Filter: (deleted_at IS NULL)
                    ->  Index Scan using users_pkey on users creator_user  (cost=0.42..1.99 rows=1 width=4) (never executed)
                          Index Cond: (id = t2.creator_user_id)
                          Filter: (deleted_at IS NULL)
  ->  Index Scan using access_tokens_pkey on access_tokens t  (cost=0.42..2.55 rows=1 width=20) (never executed)
        Index Cond: (id = t2.id)
Planning Time: 1.382 ms
Execution Time: 258.626 ms
```
## Test plan

- tested locally
- manually created on sourcegraph.com