### PR TITLE
search: deduplicate symbol results from zoekt

### DIFF
--- a/internal/search/result/symbol.go
+++ b/internal/search/result/symbol.go
@@ -118,6 +118,9 @@ func (s Symbol) LSPKind() lsp.SymbolKind {
 }
 
 func (s Symbol) Range() lsp.Range {
+	// TODO(keegancsmith) For results from zoekt s.Character is not the start
+	// of the symbol, but the start of the match. So doing s.Character +
+	// len(s.Name) is incorrect.
 	return lsp.Range{
 		Start: lsp.Position{Line: s.Line - 1, Character: s.Character},
 		End:   lsp.Position{Line: s.Line - 1, Character: s.Character + len(s.Name)},

--- a/internal/search/zoekt/indexed_search_test.go
+++ b/internal/search/zoekt/indexed_search_test.go
@@ -598,6 +598,18 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 				Start: zoekt.Location{LineNumber: 20, Column: 38},
 			}},
 			SymbolInfo: []*zoekt.Symbol{symbolInfo("baz")},
+		}, {
+			// Test we dedup when we have two results for foobar.
+			Content:      []byte("symbol foobar symbol bam"),
+			ContentStart: zoekt.Location{LineNumber: 25, Column: 1},
+			Ranges: []zoekt.Range{{
+				Start: zoekt.Location{LineNumber: 25, Column: 8},
+			}, {
+				Start: zoekt.Location{LineNumber: 25, Column: 11},
+			}, {
+				Start: zoekt.Location{LineNumber: 25, Column: 23},
+			}},
+			SymbolInfo: []*zoekt.Symbol{symbolInfo("foobar"), symbolInfo("foobar"), symbolInfo("bam")},
 		}},
 	}
 
@@ -623,6 +635,14 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		Name:      "baz",
 		Line:      20,
 		Character: 37,
+	}, {
+		Name:      "foobar",
+		Line:      25,
+		Character: 7,
+	}, {
+		Name:      "bam",
+		Line:      25,
+		Character: 22,
 	},
 	}
 	for i := range want {


### PR DESCRIPTION
A query like `type:symbol repo link picker` is translated into zoekt as

```
(and sym:substr:"repo" sym:substr:"link" sym:substr:"picker")
```

If you have a symbol `RepoLinkPicker` Zoekt's result type will model this as 3 matches (which is correct) but all with the same `SymbolInfo.` When we convert this into Sourcegraph's symbol information we only want to have a match per symbol. Before this change we would translate this into 3 results, internally each having a different Column the match appears at. By the time it would reach the user via the streaming API the column is gone and we just have symbol information, which means effectively we had 3 duplicate results.

This commit makes what Zoekt returns match the expectations of Sourcegraph's symbol results. Note: we have to use a slight heuristic here where we say two symbols are identical if they have the same line number and symbol info.

Also note the TODO I added. The Column returned by Zoekt is where inside of the symbol we found a match. But in downstream parts of the code we seem to treat the Start Column as the start of the symbol. This is hard to fix now, so instead we make a note and just tackle this.

Test Plan: added a unit test. Additionally on my local devserver searching `repo link picker type:symbol` stopped returning duplicate results.

Fixes https://github.com/sourcegraph/sourcegraph/issues/60379
