### PR TITLE
Fix trial ended text

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -179,7 +179,11 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                             <H2>My subscription</H2>
                             <Text className="text-muted mb-0">
                                 {userIsOnProTier ? (
-                                    'You are on the Pro tier.'
+                                    hasTrialEnded && hasNotAddedCreditCard ? (
+                                        'Your Cody Pro trial has ended'
+                                    ) : (
+                                        'You are on the Pro tier.'
+                                    )
                                 ) : (
                                     <span>
                                         You are on the Free tier.{' '}
@@ -199,7 +203,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                     </div>
                     <div className={classNames('d-flex align-items-center mt-3', styles.responsiveContainer)}>
                         <div className="d-flex flex-column align-items-center flex-grow-1 p-3">
-                            {userIsOnProTier ? (
+                            {userIsOnProTier && !(hasTrialEnded && hasNotAddedCreditCard) ? (
                                 <ProTierIcon />
                             ) : (
                                 <Text className={classNames(styles.planName, 'mb-0')}>Free</Text>

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -180,7 +180,7 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                             <Text className="text-muted mb-0">
                                 {userIsOnProTier ? (
                                     hasTrialEnded && hasNotAddedCreditCard ? (
-                                        'Your Cody Pro trial has ended'
+                                        'Your Cody Pro trial has ended.'
                                     ) : (
                                         'You are on the Pro tier.'
                                     )
@@ -495,7 +495,7 @@ const DoNotLoseCodyProBanner: React.FunctionComponent<{
                 <div className="d-flex align-items-center text-dark">
                     <div className={styles.creditCardEmoji}>💳</div>
                     <div className="ml-3">
-                        <H3>Don't lose Cody Pro</H3>
+                        <H3>Keep using Cody Pro</H3>
                         <Text className="mb-0">
                             {hasTrialEnded ? (
                                 <span>Enter your credit card details now and keep your Pro subscription.</span>


### PR DESCRIPTION
Issue: https://sourcegraph.slack.com/archives/C05SZB829D0/p1708613278533909

Now that the trial has ended the users who opted Pro earlier but have not put in their credit cards yet are still shown having Pro tier along with the usage limits counter. This is confusing. 


This PR updates the subscription status text to "Your Cody Pro trial has ended" and changes the trier to "Free".

**Before**
![image](https://github.com/sourcegraph/sourcegraph/assets/22571395/2a5124f1-a1fb-42d8-95ac-03e343612c26)

**After** 
![CleanShot 2024-02-22 at 21 53 11@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/7816b1f4-d34d-4af6-af18-156cb0d0b25d)


## Test plan
Ran locally