### PR TITLE
Chore: error on unknown protocol rather than panic

### DIFF
--- a/internal/tracer/oteldefaults/exporters/otlp.go
+++ b/internal/tracer/oteldefaults/exporters/otlp.go
@@ -55,6 +55,8 @@ func NewOTLPTraceExporter(ctx context.Context, logger log.Logger) (oteltracesdk.
 			opts = append(opts, otlptracehttp.WithInsecure())
 		}
 		client = otlptracehttp.NewClient(opts...)
+	default:
+		return nil, errors.Newf("unexpected protocol %q", protocol)
 	}
 
 	// Initialize the exporter


### PR DESCRIPTION
Using the `http/proto` protocol caused a panic because the client was nil after this switch. This just modifies the switch to return an error instead.

## Test plan

N/A