### PR TITLE
ci: debug logging for sg lint changed files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -229,8 +229,6 @@ gazelle(
 sh_binary(
     name = "configure",
     srcs = ["//dev/ci:bazel-configure.sh"],
-    data = ["@go_sdk//:bin/go"],
-    env = {"GO": "$(rootpath @go_sdk//:bin/go)"},
 )
 
 go_library(

--- a/dev/ci/bazel-configure.sh
+++ b/dev/ci/bazel-configure.sh
@@ -2,9 +2,6 @@
 
 set -o errexit -o nounset -o pipefail
 
-# Add go to PATH
-readonly runfiles_dir="${PWD}"
-PATH="$(dirname "${runfiles_dir}/${GO}"):${PATH}"
 # Remove bazelisk from path
 PATH=$(echo "${PATH}" | awk -v RS=: -v ORS=: '/bazelisk/ {next} {print}')
 export PATH

--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -105,6 +105,12 @@ func NewConfig(now time.Time) Config {
 
 	diff, changedFilesByDiffType := changed.ParseDiff(changedFiles)
 
+	fmt.Printf("Parsed diff:\n\tgit command: %v\n\tchanged files: %v\n\tdiff changes: %q\n",
+		append([]string{"git"}, diffCommand...),
+		changedFiles,
+		diff.String(),
+	)
+
 	return Config{
 		RunType: runType,
 

--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -110,6 +110,7 @@ func NewConfig(now time.Time) Config {
 		changedFiles,
 		diff.String(),
 	)
+	fmt.Fprint(os.Stderr, "The generated build pipeline will now follow, see you next time!")
 
 	return Config{
 		RunType: runType,

--- a/dev/ci/internal/ci/config.go
+++ b/dev/ci/internal/ci/config.go
@@ -105,7 +105,7 @@ func NewConfig(now time.Time) Config {
 
 	diff, changedFilesByDiffType := changed.ParseDiff(changedFiles)
 
-	fmt.Printf("Parsed diff:\n\tgit command: %v\n\tchanged files: %v\n\tdiff changes: %q\n",
+	fmt.Fprintf(os.Stderr, "Parsed diff:\n\tgit command: %v\n\tchanged files: %v\n\tdiff changes: %q\n",
 		append([]string{"git"}, diffCommand...),
 		changedFiles,
 		diff.String(),


### PR DESCRIPTION
I've been unable to reproduce why `sg lint` appears to be running more lints than expected for a given diff, so lets add some friendly debug logging so we can investigate 😊 

## Test plan

:eye: CI :eye:
