### PR TITLE
Fix the docs banner

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -1536,6 +1536,7 @@ pre.chroma.sgquery button {
 
      #content > .breadcrumbs {
         display:flex;
+        margin-top:2rem;
     }
 }
 

--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -53,7 +53,7 @@
 
         <!-- Default to light theme if no JavaScript -->
 		<body class="theme-light">
-             <nav class="notice" style="display: flex; flex-direction: row; width: 100%; position: absolute; z-index: 9999; background: #ec624d; padding: 0.5rem; text-align: center; margin: 0 auto .5rem; color: black;">
+             <nav class="notice" style="display: flex; flex-direction: row; width: 100%; position: fixed; z-index: 9999; background: #ec624d; padding: 0.5rem; text-align: center; margin: 0 auto .5rem; color: black;">
                     <p style="text-align: center; display: flex; margin: 0 auto; align-items: center;">⚠️ You're viewing our old docs, which we no longer maintain. For all the new updates, read our <a style="background: black; padding: 0.2rem 0.6rem; border-radius: 5px; margin-left: 0.5rem; color: white;" href="https://sourcegraph.com/docs/">Latest Docs »</a></p>
             </nav>
             <script>


### PR DESCRIPTION
This PR makes the docs banner fixed as you scroll. Also, fix the margin for breadcrumbs with the banner notice. 

## Reference

- https://sourcegraph.slack.com/archives/C01DXLN3D0T/p1708634123363059?thread_ts=1708093272.257949&cid=C01DXLN3D0T

## Test plan

Docs banner fixed

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->


## Preview 🤩
[Preview Link](https://docs.sourcegraph.com/@fix-banner)