### PR TITLE
search: consistent telemetry between honeycomb and tracing for zoekt

### DIFF
--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -70,6 +70,16 @@ func (t Trace) SetErrorIfNotContext(err error) {
 	t.SetError(err)
 }
 
+// EndWithErrIfNotContext finishes the span and sets its error value unless it
+// is context.Canceled or context.DeadlineExceeded.
+//
+// It takes a pointer to an error so it can be used directly
+// in a defer statement.
+func (t Trace) EndWithErrIfNotContext(err *error) {
+	t.SetErrorIfNotContext(*err)
+	t.End()
+}
+
 // EndWithErr finishes the span and sets its error value.
 // It takes a pointer to an error so it can be used directly
 // in a defer statement.


### PR DESCRIPTION
This commit has a few changes to how we do telemetry for zoekt.

- SearchOption attributes are part of span creation.
- SearchOption and Stats attributes are filtered to remove default values. This mirrors how we log in net/trace which I find useful when reading options.
- SearchOption add missing fields.
- EndWithErrIfNotContext helper introduced and used for Search and List.
- List uses same pattern for telemetry as Search
- List logs actor
- List correctly logs repos count and always logs stats.crashes.

Test Plan: go test and "HONEYCOMB_LOCAL=true sg start" followed by a search. I then visually eyeballed the log output for events.

See details for the events logged in my devserver

<details>

```
EVENT search-zoekt
  actor: 1
  category: ListAll
  duration_ms: 2
  query: TRUE
  repos: 12
  stats.crashes: 0
EVENT search-zoekt
  actor: 1
  category: SearchAll
  duration_ms: 31
  events: 1
  filematches: 252
  opts.context_lines: 1
  opts.flush_wall_time_ms: 500
  opts.max_doc_display_count: 10000
  opts.max_wall_time_ms: 18122
  opts.shard_max_match_count: 100000
  opts.total_max_match_count: 1000000
  query: (and (or (boost 20.00 substr:"foo bar baz") (and substr:"foo" substr:"bar" substr:"baz")) branch="HEAD" rawConfig:RcOnlyPublic|RcNoForks|RcNoArchived)
  stats.content_bytes_loaded: 5225745
  stats.file_count: 252
  stats.files_considered: 471
  stats.files_loaded: 252
  stats.flush_reason: timer_expired
  stats.index_bytes_loaded: 58742
  stats.match_count: 7083
  stats.match_tree_construction_ms: 1
  stats.match_tree_search_ms: 10
  stats.ngram_lookups: 1564
  stats.ngram_matches: 9062
  stats.shards_scanned: 10
  stats.shards_skipped_filter: 2
  stream.latency_ms: 20
  stream.total_send_time_ms: 11
```

</details>
