### PR TITLE
insights: remove config watcher

### DIFF
--- a/internal/insights/scheduler/backfill_state_inprogress_handler.go
+++ b/internal/insights/scheduler/backfill_state_inprogress_handler.go
@@ -56,8 +56,6 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		MaxNumRetries:     3,
 	})
 
-	handlerConfig := newHandlerConfig()
-
 	task := &inProgressHandler{
 		workerStore:        workerStore,
 		backfillStore:      backfillStore,
@@ -66,7 +64,7 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		backfillRunner:     config.BackfillRunner,
 		repoStore:          config.RepoStore,
 		clock:              glock.NewRealClock(),
-		config:             handlerConfig,
+		config:             newHandlerConfig,
 	}
 
 	worker := dbworker.NewWorker(ctx, workerStore, workerutil.Handler[*BaseJob](task), workerutil.WorkerOptions{
@@ -84,28 +82,6 @@ func makeInProgressWorker(ctx context.Context, config JobMonitorConfig) (*worker
 		Metrics:  dbworker.NewResetterMetrics(config.ObservationCtx, name),
 	})
 
-	configLogger := log.Scoped("insightsInProgressConfigWatcher")
-	mu := sync.Mutex{}
-	conf.Watch(func() {
-		mu.Lock()
-		defer mu.Unlock()
-		oldVal := task.config.interruptAfter
-		newVal := getInterruptAfter()
-		task.config.interruptAfter = newVal
-
-		oldPageSize := task.config.pageSize
-		newPageSize := getPageSize()
-		task.config.pageSize = newPageSize
-
-		oldRepoConcurrency := task.config.repoConcurrency
-		newRepoConcurrency := getRepoConcurrency()
-		task.config.repoConcurrency = newRepoConcurrency
-
-		configLogger.Info("insights backfiller interrupt time changed", log.Duration("old", oldVal), log.Duration("new", newVal))
-		configLogger.Info("insights backfiller repo page size changed", log.Int("old", oldPageSize), log.Int("new", newPageSize))
-		configLogger.Info("insights backfiller repo concurrency changed", log.Int("old", oldRepoConcurrency), log.Int("new", newRepoConcurrency))
-	})
-
 	return worker, resetter, workerStore
 }
 
@@ -116,7 +92,7 @@ type inProgressHandler struct {
 	repoStore          database.RepoStore
 	insightsStore      store.Interface
 	backfillRunner     pipeline.Backfiller
-	config             handlerConfig
+	config             func() handlerConfig
 
 	clock glock.Clock
 }
@@ -141,7 +117,7 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, job *
 	if err != nil {
 		return err
 	}
-	execution.config = h.config
+	execution.config = h.config()
 
 	logger.Info("insights backfill progress handler loaded",
 		log.Int("recordId", job.RecordID()),
@@ -167,7 +143,9 @@ func (h *inProgressHandler) Handle(ctx context.Context, logger log.Logger, job *
 type nextNFunc func(pageSize int, config iterator.IterationConfig) ([]api.RepoID, bool, iterator.FinishNFunc)
 
 func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfillExecution) (interrupt bool, err error) {
-	timeExpired := h.clock.After(h.config.interruptAfter)
+	config := h.config()
+
+	timeExpired := h.clock.After(config.interruptAfter)
 
 	itrConfig := iterator.IterationConfig{
 		MaxFailures: 3,
@@ -255,10 +233,10 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 	}
 
 	execution.logger.Debug("starting primary loop", log.Int("seriesId", execution.series.ID), log.Int("backfillId", execution.backfill.Id))
-	if interrupted, err := itrLoop(h.config.pageSize, h.config.repoConcurrency, execution.itr.NextPageWithFinish); err != nil {
+	if interrupted, err := itrLoop(config.pageSize, config.repoConcurrency, execution.itr.NextPageWithFinish); err != nil {
 		return false, errors.Wrap(err, "InProgressHandler.PrimaryLoop")
 	} else if interrupted {
-		execution.logger.Info("interrupted insight series backfill", execution.logFields(log.Duration("interruptAfter", h.config.interruptAfter))...)
+		execution.logger.Info("interrupted insight series backfill", execution.logFields(log.Duration("interruptAfter", config.interruptAfter))...)
 		return true, nil
 	}
 
@@ -266,7 +244,7 @@ func (h *inProgressHandler) doExecution(ctx context.Context, execution *backfill
 	if interrupted, err := itrLoop(1, 1, retryAdapter(execution.itr.NextRetryWithFinish)); err != nil {
 		return false, errors.Wrap(err, "InProgressHandler.RetryLoop")
 	} else if interrupted {
-		execution.logger.Info("interrupted insight series backfill retry", execution.logFields(log.Duration("interruptAfter", h.config.interruptAfter))...)
+		execution.logger.Info("interrupted insight series backfill retry", execution.logFields(log.Duration("interruptAfter", config.interruptAfter))...)
 		return true, nil
 	}
 


### PR DESCRIPTION
The computed state is so cheap that we might as well just compute it each time we want to access it. The main difference is we won't log insights backfiller changing. However, the old code just always logged at startup and whenever any site config changed. It also feels somewhat low value, so I think its fine just not to log.

Additionally the old code protected writes to task.config via a mutex, but never used that mutex for reads. So it was in fact racey.

FYI I came across this because I was looking into reducing the logspam in our product.

Test Plan: go test