### PR TITLE
Increase Enteprise Code Completions limit to 1000

### DIFF
--- a/internal/licensing/codygateway.go
+++ b/internal/licensing/codygateway.go
@@ -91,7 +91,7 @@ func NewCodyGatewayCodeRateLimit(plan Plan, userCount *int, licenseTags []string
 	default:
 		return CodyGatewayRateLimit{
 			AllowedModels:   models,
-			Limit:           int64(100 * uc),
+			Limit:           int64(1000 * uc),
 			IntervalSeconds: 60 * 60 * 24, // day
 		}
 	}

--- a/internal/licensing/codygateway_test.go
+++ b/internal/licensing/codygateway_test.go
@@ -109,7 +109,7 @@ func TestCodyGatewayCodeRateLimit(t *testing.T) {
 			plan: "unknown",
 			want: CodyGatewayRateLimit{
 				AllowedModels:   []string{"anthropic/claude-instant-v1", "anthropic/claude-instant-1", "anthropic/claude-instant-1.2", "fireworks/starcoder"},
-				Limit:           100,
+				Limit:           1000,
 				IntervalSeconds: 60 * 60 * 24,
 			},
 		},


### PR DESCRIPTION
Increase default Code Completions limit for Enterprise Cody customers to 1000/user/day.

## Test plan

- existing unit tests were updated
- tested manually