### PR TITLE
ci: remove ancestor commit checks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,27 +21,13 @@ steps:
   - group: ":aspect: Aspect Workflows "
     if: pipeline.slug == "aspect-experimental"
     steps:
-      - key: "after-commit-check"
-        label: ":oncoming_police_car: commit check"
-        agents: { queue: aspect-small }
-        command: |
-          echo "--- :git: check we're after commit"
-          if git merge-base --is-ancestor 20a3c0836eaa300beecf88e21f78dcd708b047d3 HEAD; then
-            echo "✅ We are after the commit."
-          else
-            echo "❌ HEAD commit should be after 20a3c0836eaa300beecf88e21f78dcd708b047d3"
-            exit 1
-          fi
-
       - key: aspect-workflows-upload
-        depends_on: "after-commit-check"
         label: ":aspect: Setup Aspect Workflows"
         commands:
           - "rosetta steps | buildkite-agent pipeline upload"
         agents:
           queue: aspect-small
       - label: ":pipeline: Generate pipeline"
-        depends_on: "after-commit-check"
         if: build.branch !~ /^main(-dry-run\/)?.*/
         commands:
           - "./dev/ci/gen-pipeline.sh"


### PR DESCRIPTION
the max depth on aspect-experimental is 100 for the git repo. As @jac reported, since the commit we've check for, we have landed 84 commits and will soon be hitting the 100 depth.

This removes the check. In the uploaded pipeline and the steps of the pipeline on buildkite. Instead the steps on the Aspect Pipeline will now just check if the pipeline to be uploaded has particular steps namely `rosetta` ie:
```yaml
steps:
  - key: ":satellite_antenna: upload pipeline"
    label: ":eyes: check if we're after commit"
    agents: 
      queue: aspect-small
    command: |
        if grep -q "rosetta" .buildkite/pipeline.yml; then
          buildkite-agent pipeline upload
        else 
          echo "❌ Your branch is missing changes from main. Please rebase";
          exit 1
        fi       
```
## Test plan
CI