### PR TITLE
Remove high volume event that isn't used

### DIFF
--- a/internal/completions/client/observe.go
+++ b/internal/completions/client/observe.go
@@ -41,15 +41,6 @@ func (o *observedClient) Stream(ctx context.Context, feature types.CompletionsFe
 	tracedSend := func(event types.CompletionResponse) error {
 		if event.StopReason != "" {
 			tr.AddEvent("stopped", attribute.String("reason", event.StopReason))
-
-			o.events.Record(ctx, "cody.completions", "stream", &telemetry.EventParameters{
-				Metadata: telemetry.EventMetadata{
-					"feature": float64(feature.ID()),
-				},
-				PrivateMetadata: map[string]any{
-					"stop_reason": event.StopReason,
-				},
-			})
 		} else {
 			tr.AddEvent("completion", attribute.Int("len", len(event.Completion)))
 		}


### PR DESCRIPTION
Discussion at https://sourcegraph.slack.com/archives/C05BGNBEPKL/p1708975582881559

>Since the start of the month, we recorded 29.6m cody.completions : stream events as of Friday from the Sourcegraph backend ([see here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@ee9199762853c10e6a737f341ceb0808ceca20ea/-/blob/internal/completions/client/observe.go?L45-52)).  
>
>This single event represents 24% of all rows in our table. 

## Test plan

CI, and ran Sourcegraph locally to confirm no errors