### PR TITLE
[Backport 5.3] update roles page description

### DIFF
--- a/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
+++ b/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
@@ -59,9 +59,8 @@ export const SiteAdminRolesPage: React.FunctionComponent<React.PropsWithChildren
                     <>
                         Roles are a part of the{' '}
                         <Link to="/help/admin/access_control">Role-Based Access Control system</Link> for Sourcegraph
-                        and represent a set of in-product permissions. Roles are currently only available for Batch
-                        Changes functionality. Use the <Link to="/site-admin/users">user administration page</Link> to
-                        assign roles.
+                        and represent a set of in-product permissions. Use the{' '}
+                        <Link to="/site-admin/users">user administration page</Link> to assign roles.
                     </>
                 }
                 actions={


### PR DESCRIPTION
Roles isn't exclusively available to Batch Changes anymore.  A number of services/products have since adopted RBAC so I'm updating the UI here.

## Test plan

UI update.


Backport 1833f32 from #60756