### PR TITLE
v2t: add v2t to src/components/gitHubApps

### DIFF
--- a/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/CreateGitHubAppPage.tsx
@@ -2,6 +2,7 @@ import React, { type FC, useState, useCallback, useRef, useEffect } from 'react'
 
 import { noop } from 'lodash'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Alert,
     Container,
@@ -31,7 +32,7 @@ interface FormOptions {
     webhookURL?: string
 }
 
-export interface CreateGitHubAppPageProps {
+export interface CreateGitHubAppPageProps extends TelemetryV2Props {
     /** The events that the new GitHub App should subscribe to by default. */
     defaultEvents: string[]
     /** The permissions that the new GitHub App will request by default. */
@@ -77,6 +78,7 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
     defaultAppName = 'Sourcegraph',
     baseURL,
     validateURL,
+    telemetryRecorder,
 }) => {
     const ref = useRef<HTMLFormElement>(null)
     const formInput = useRef<HTMLInputElement>(null)
@@ -88,7 +90,10 @@ export const CreateGitHubAppPage: FC<CreateGitHubAppPageProps> = ({
     const [isPublic, setIsPublic] = useState<boolean>(false)
     const [error, setError] = useState<string>()
 
-    useEffect(() => eventLogger.logPageView('SiteAdminCreateGiHubApp'), [])
+    useEffect(() => {
+        eventLogger.logPageView('SiteAdminCreateGiHubApp')
+        telemetryRecorder.recordEvent('admin.GitHubApp.create', 'view')
+    }, [telemetryRecorder])
 
     const originURL = window.location.origin
     const getManifest = useCallback(

--- a/client/web/src/components/gitHubApps/GitHubAppPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppPage.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import type { ErrorLike } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Container,
@@ -38,7 +39,7 @@ import { RemoveGitHubAppModal } from './RemoveGitHubAppModal'
 
 import styles from './GitHubAppCard.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     /**
      * The parent breadcrumb item to show for this page in the header.
      */
@@ -47,14 +48,20 @@ interface Props extends TelemetryProps {
     headerAnnotation?: React.ReactNode
 }
 
-export const GitHubAppPage: FC<Props> = ({ telemetryService, headerParentBreadcrumb, headerAnnotation }) => {
+export const GitHubAppPage: FC<Props> = ({
+    telemetryService,
+    telemetryRecorder,
+    headerParentBreadcrumb,
+    headerAnnotation,
+}) => {
     const { appID } = useParams()
     const navigate = useNavigate()
     const [removeModalOpen, setRemoveModalOpen] = useState<boolean>(false)
 
     useEffect(() => {
         telemetryService.logPageView('SiteAdminGitHubApp')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.GitHubApp', 'view')
+    }, [telemetryService, telemetryRecorder])
     const [fetchError, setError] = useState<ErrorLike>()
 
     const { data, loading, error } = useQuery<GitHubAppByIDResult, GitHubAppByIDVariables>(GITHUB_APP_BY_ID_QUERY, {

--- a/client/web/src/components/gitHubApps/GitHubAppsPage.tsx
+++ b/client/web/src/components/gitHubApps/GitHubAppsPage.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { useLocation } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { ButtonLink, Container, ErrorAlert, Icon, Link, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
 
 import { type GitHubAppsResult, type GitHubAppsVariables, GitHubAppDomain } from '../../graphql-operations'
@@ -24,11 +25,11 @@ import { GitHubAppFailureAlert } from './GitHubAppFailureAlert'
 
 import styles from './GitHubAppsPage.module.scss'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     batchChangesEnabled: boolean
 }
 
-export const GitHubAppsPage: React.FC<Props> = ({ batchChangesEnabled }) => {
+export const GitHubAppsPage: React.FC<Props> = ({ batchChangesEnabled, telemetryRecorder }) => {
     const { data, loading, error, refetch } = useQuery<GitHubAppsResult, GitHubAppsVariables>(GITHUB_APPS_QUERY, {
         variables: {
             domain: GitHubAppDomain.REPOS,
@@ -38,7 +39,8 @@ export const GitHubAppsPage: React.FC<Props> = ({ batchChangesEnabled }) => {
 
     useEffect(() => {
         eventLogger.logPageView('SiteAdminGitHubApps')
-    }, [])
+        telemetryRecorder.recordEvent('admin.GitHubApps', 'view')
+    }, [telemetryRecorder])
 
     const location = useLocation()
     const success = new URLSearchParams(location.search).get('success') === 'true'

--- a/client/web/src/enterprise/batches/settings/BatchChangesCreateGitHubAppPage.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesCreateGitHubAppPage.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 
 import { useLocation } from 'react-router-dom'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { FeedbackBadge, Link } from '@sourcegraph/wildcard'
 
 import { CreateGitHubAppPage } from '../../../components/gitHubApps/CreateGitHubAppPage'
@@ -64,6 +65,7 @@ export const BatchChangesCreateGitHubAppPage: React.FunctionComponent = () => {
             defaultAppName="Sourcegraph Commit Signing"
             baseURL={baseURL?.length ? baseURL : undefined}
             validateURL={validateURL}
+            telemetryRecorder={noOpTelemetryRecorder}
         />
     )
 }

--- a/client/web/src/site-admin/SiteAdminGitHubAppsArea.tsx
+++ b/client/web/src/site-admin/SiteAdminGitHubAppsArea.tsx
@@ -68,7 +68,15 @@ export const SiteAdminGitHubAppsArea: FC<Props> = props => {
 
     return (
         <Routes>
-            <Route index={true} element={<GitHubAppsPage batchChangesEnabled={props.batchChangesEnabled} />} />
+            <Route
+                index={true}
+                element={
+                    <GitHubAppsPage
+                        batchChangesEnabled={props.batchChangesEnabled}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
+                    />
+                }
+            />
 
             <Route
                 path="new"
@@ -77,6 +85,7 @@ export const SiteAdminGitHubAppsArea: FC<Props> = props => {
                         defaultEvents={DEFAULT_EVENTS}
                         defaultPermissions={DEFAULT_PERMISSIONS}
                         appDomain={GitHubAppDomain.REPOS}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
                         {...props}
                     />
                 }
@@ -86,6 +95,7 @@ export const SiteAdminGitHubAppsArea: FC<Props> = props => {
                 element={
                     <GitHubAppPage
                         headerParentBreadcrumb={{ to: '/site-admin/github-apps', text: 'GitHub Apps' }}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
                         {...props}
                     />
                 }

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -427,6 +427,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
                 headerParentBreadcrumb={{ to: '/site-admin/batch-changes', text: 'Batch Changes settings' }}
                 headerAnnotation={<FeedbackBadge status="beta" feedback={{ mailto: 'support@sourcegraph.com' }} />}
                 telemetryService={props.telemetryService}
+                telemetryRecorder={props.platformContext.telemetryRecorder}
             />
         ),
         condition: ({ batchChangesEnabled }) => batchChangesEnabled,


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally