### PR TITLE
v2t: add v2t to the rest of src/components

### DIFF
--- a/client/web/src/components/SelfHostedCta/SelfHostedCta.story.tsx
+++ b/client/web/src/components/SelfHostedCta/SelfHostedCta.story.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import type { Decorator, Meta } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Text } from '@sourcegraph/wildcard'
 
@@ -21,7 +22,12 @@ export default config
 export const Basic: React.FunctionComponent<React.PropsWithChildren<Partial<SelfHostedCtaProps>>> = (
     props
 ): JSX.Element => (
-    <SelfHostedCta telemetryService={NOOP_TELEMETRY_SERVICE} page="storybook" {...props}>
+    <SelfHostedCta
+        telemetryService={NOOP_TELEMETRY_SERVICE}
+        telemetryRecorder={noOpTelemetryRecorder}
+        page="storybook"
+        {...props}
+    >
         <Text className="mb-2">
             <strong>Run Sourcegraph self-hosted for more enterprise features</strong>
         </Text>

--- a/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
+++ b/client/web/src/components/SelfHostedCta/SelfHostedCta.tsx
@@ -3,24 +3,33 @@ import React from 'react'
 import { mdiArrowRight } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, Icon, H3 } from '@sourcegraph/wildcard'
 
 import { MarketingBlock } from '../MarketingBlock'
 
-export interface SelfHostedCtaProps extends TelemetryProps {
+export interface SelfHostedCtaProps extends TelemetryProps, TelemetryV2Props {
     className?: string
     contentClassName?: string
-    // the name of the page the CTA will be posted. DO NOT include full URLs
-    // here, because this will be logged to our analytics systems. We do not
-    // want to expose private repo names or search queries to our analytics.
-    page: string
+    // The name of the page the CTA will be posted. Add more as needed. DO NOT
+    // include full URLs here, because this will be logged to our analytics
+    // systems. We do not want to expose private repo names or search queries
+    // to our analytics.
+    page: 'organizations' | 'storybook'
+}
+
+// pages as numbers for v2 telemetry
+const V2Pages: { [k in SelfHostedCtaProps['page']]: number } = {
+    organizations: 0,
+    storybook: 1,
 }
 
 export const SelfHostedCta: React.FunctionComponent<React.PropsWithChildren<SelfHostedCtaProps>> = ({
     className,
     contentClassName,
     telemetryService,
+    telemetryRecorder,
     page,
     children,
 }) => {
@@ -28,10 +37,12 @@ export const SelfHostedCta: React.FunctionComponent<React.PropsWithChildren<Self
 
     const gettingStartedCTAOnClick = (): void => {
         telemetryService.log('InstallSourcegraphCTAClicked', { page }, { page })
+        telemetryRecorder.recordEvent('selfHostedCTA.install', 'click', { metadata: { page: V2Pages[page] } })
     }
 
     const helpGettingStartedCTAOnClick = (): void => {
         telemetryService.log('HelpGettingStartedCTA', { page }, { page })
+        telemetryRecorder.recordEvent('selfHostedCTA.talkToADev', 'click', { metadata: { page: V2Pages[page] } })
     }
 
     return (

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -5,6 +5,7 @@ import { RouterProvider, createMemoryRouter, type MemoryRouterProps } from 'reac
 
 import { EMPTY_SETTINGS_CASCADE, SettingsProvider } from '@sourcegraph/shared/src/settings/settings'
 import { MockedStoryProvider, type MockedStoryProviderProps } from '@sourcegraph/shared/src/stories'
+import { noOpTelemetryRecorder, TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE, type TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeContext, ThemeSetting } from '@sourcegraph/shared/src/theme'
 import { WildcardThemeContext } from '@sourcegraph/wildcard'
@@ -26,7 +27,8 @@ if (!window.context) {
 
 export type WebStoryChildrenProps = BreadcrumbSetters &
     BreadcrumbsProps &
-    TelemetryProps & {
+    TelemetryProps &
+    TelemetryV2Props & {
         isLightTheme: boolean
     }
 
@@ -64,6 +66,7 @@ export const WebStory: FC<WebStoryProps> = ({
                     {...breadcrumbSetters}
                     isLightTheme={isLightTheme}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             ),
         },

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.story.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.story.tsx
@@ -1,5 +1,6 @@
 import type { Decorator, Meta } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../components/WebStory'
@@ -15,4 +16,6 @@ const config: Meta = {
 
 export default config
 
-export const Basic = (): JSX.Element => <AboutOrganizationPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+export const Basic = (): JSX.Element => (
+    <AboutOrganizationPage telemetryService={NOOP_TELEMETRY_SERVICE} telemetryRecorder={noOpTelemetryRecorder} />
+)

--- a/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
+++ b/client/web/src/user/settings/aboutOrganization/AboutOrganizationPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Text } from '@sourcegraph/wildcard'
 
@@ -8,14 +9,16 @@ import { SelfHostedCta } from '../../../components/SelfHostedCta'
 
 import styles from './AboutOrganizationPage.module.scss'
 
-interface AboutOrganizationPageProps extends TelemetryProps {}
+interface AboutOrganizationPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export const AboutOrganizationPage: React.FunctionComponent<React.PropsWithChildren<AboutOrganizationPageProps>> = ({
     telemetryService,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('AboutOrg')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('settings.aboutOrganizations', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <>
@@ -30,6 +33,7 @@ export const AboutOrganizationPage: React.FunctionComponent<React.PropsWithChild
                 contentClassName={styles.selfHostedCtaContent}
                 page="organizations"
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             >
                 <Text className="mb-2">
                     <strong>Need more enterprise features? Run Sourcegraph self-hosted</strong>

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -31,6 +31,11 @@ const UserSettingsSecurityPage = lazyComponent(
     'UserSettingsSecurityPage'
 )
 
+const AboutOrganizationPage = lazyComponent(
+    () => import('./aboutOrganization/AboutOrganizationPage'),
+    'AboutOrganizationPage'
+)
+
 const shouldRenderBatchChangesPage = ({
     batchChangesEnabled,
     user: { viewerCanAdminister },
@@ -77,7 +82,9 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     },
     {
         path: 'about-organizations',
-        render: lazyComponent(() => import('./aboutOrganization/AboutOrganizationPage'), 'AboutOrganizationPage'),
+        render: props => (
+            <AboutOrganizationPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
+        ),
     },
     {
         path: 'permissions',


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally