### PR TITLE
Chore: fix typo causing code intel to be disabled

### DIFF
--- a/client/web/src/LegacySourcegraphWebApp.tsx
+++ b/client/web/src/LegacySourcegraphWebApp.tsx
@@ -215,7 +215,7 @@ export class LegacySourcegraphWebApp extends React.Component<StaticAppConfig, Le
             ...this.props,
             selectedSearchContextSpec: this.state.selectedSearchContextSpec,
             setSelectedSearchContextSpec: this.setSelectedSearchContextSpec,
-            codeIntelligenceEnabled: !!this.props.codeInsightsEnabled,
+            codeIntelligenceEnabled: !!this.props.codeIntelligenceEnabled,
             notebooksEnabled: this.props.notebooksEnabled,
             codeMonitoringEnabled: this.props.codeMonitoringEnabled,
             searchAggregationEnabled: this.props.searchAggregationEnabled,


### PR DESCRIPTION
There was a typo in the context building that caused the Code Graph Data button on the repo page to be disabled. This just fixes that typo.

## Test plan

![CleanShot 2024-02-28 at 07 07 55@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/3da24497-6414-4bdb-915e-f4e24ddf7b11)