### PR TITLE
Fix Cody PLG "Manage subscription" button

### DIFF
--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -51,10 +51,6 @@ import { CHANGE_CODY_PLAN, USER_CODY_PLAN, USER_CODY_USAGE } from '../subscripti
 
 import styles from './CodyManagementPage.module.scss'
 
-
-
-
-
 interface CodyManagementPageProps {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
@@ -205,8 +201,8 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                     variant="primary"
                                     size="sm"
                                     href={manageSubscriptionRedirectURL}
-                                    onClick={e => {
-                                        e.preventDefault()
+                                    onClick={event => {
+                                        event.preventDefault()
                                         eventLogger.log(EventName.CODY_MANAGE_SUBSCRIPTION_CLICKED)
                                         window.location.href = manageSubscriptionRedirectURL
                                     }}

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -200,7 +200,9 @@ export const CodyManagementPage: React.FunctionComponent<CodyManagementPageProps
                                 <ButtonLink
                                     variant="primary"
                                     size="sm"
-                                    onClick={() => {
+                                    href={manageSubscriptionRedirectURL}
+                                    onClick={e => {
+                                        e.preventDefault()
                                         eventLogger.log(EventName.CODY_MANAGE_SUBSCRIPTION_CLICKED)
                                         window.location.href = manageSubscriptionRedirectURL
                                     }}

--- a/client/web/src/cody/management/CodyManagementPage.tsx
+++ b/client/web/src/cody/management/CodyManagementPage.tsx
@@ -51,6 +51,10 @@ import { CHANGE_CODY_PLAN, USER_CODY_PLAN, USER_CODY_USAGE } from '../subscripti
 
 import styles from './CodyManagementPage.module.scss'
 
+
+
+
+
 interface CodyManagementPageProps {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null


### PR DESCRIPTION
Fixes [this](https://sourcegraph.slack.com/archives/C05PC7AKFQV/p1709108448338019) problem where the "manage subscription" button on `/cody/manage` didn't link to the right page.

The problem was a missing `event.preventDefault()` call but I also noticed that on hovering the button, the wrong URL was displayed as the target, so fixed that, too.

## Test plan

Tested it locally.