### PR TITLE
tracer: instrument tracer and exporter with basic counters

### DIFF
--- a/internal/tracer/BUILD.bazel
+++ b/internal/tracer/BUILD.bazel
@@ -27,6 +27,8 @@ go_library(
         "//schema",
         "@com_github_go_logr_logr//:logr",
         "@com_github_go_logr_stdr//:stdr",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_log//std",
         "@io_opentelemetry_go_otel//:otel",


### PR DESCRIPTION
Gives us some basic instrumentation into what's going on internally.

## Test plan

if someone could run `sg run otel-collector jaeger prometheus grafana` + `sg start` and make sure these metrics get reported that would be great 🙏 Looking at some SAMS problems right now