### PR TITLE
Update help router for dev to use new docs repo

### DIFF
--- a/cmd/frontend/internal/app/ui/help.go
+++ b/cmd/frontend/internal/app/ui/help.go
@@ -48,7 +48,7 @@ func serveHelp(w http.ResponseWriter, r *http.Request) {
 	if version.IsDev(versionStr) && !envvar.SourcegraphDotComMode() {
 		dest = &url.URL{
 			Scheme: "http",
-			Host:   "localhost:5080", // local documentation server (defined in Procfile) -- CI:LOCALHOST_OK
+			Host:   "localhost:3000", // local documentation server (defined in Procfile) -- CI:LOCALHOST_OK
 			Path:   path.Join("/", docRevPrefix, page),
 		}
 	} else {

--- a/cmd/frontend/internal/app/ui/help_test.go
+++ b/cmd/frontend/internal/app/ui/help_test.go
@@ -31,7 +31,7 @@ func TestServeHelp(t *testing.T) {
 		if want := http.StatusTemporaryRedirect; rw.Code != want {
 			t.Errorf("got %d, want %d", rw.Code, want)
 		}
-		if got, want := rw.Header().Get("Location"), "http://localhost:5080/foo/bar"; got != want {
+		if got, want := rw.Header().Get("Location"), "http://localhost:3000/foo/bar"; got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
 	})


### PR DESCRIPTION
It was hardcoded to 5080 because the docs were included in the monorepo. Now that docs are in their own repo with their own web app, they use a different port.
Currently, that is the default Next.js port 3000.
That might change, depending on what developers do in the docs repo. Note that this change means that in order to use the new docs, you will need to clone the sourcegraph/docs repo, and follow its README to run it in dev mode.



## Test plan

- clone docs repo (https://github.com/sourcegraph/docs)
- build and run docs site according to its README
  - `asdf install`
  - `pnpm install`
  - `pnpm run dev`
- run `sg start`
- click on help link (I used https://sourcegraph.test:3443/help/api/graphql)
- verify that it loads the new docs site