### PR TITLE
Sign melange packages

### DIFF
--- a/dev/ci/scripts/wolfi/build-package.sh
+++ b/dev/ci/scripts/wolfi/build-package.sh
@@ -4,6 +4,8 @@ set -euf -o pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
+IS_MAIN=$([ "$BRANCH" = "$MAIN_BRANCH" ] && echo "true" || echo "false")
+
 tmpdir=$(mktemp -d -t melange-bin.XXXXXXXX)
 # shellcheck disable=SC2317
 # false positive by shellcheck https://github.com/koalaman/shellcheck/issues/2660
@@ -61,8 +63,15 @@ fi
 
 echo " * Building melange package '$name'"
 
+# Sign index, using separate keys from GCS for staging and prod repos
+if [[ "$IS_MAIN" == "true" ]]; then
+  key_path="/keys/sourcegraph-melange-prod.rsa"
+else
+  key_path="/keys/sourcegraph-melange-dev.rsa"
+fi
+
 # Build package
-melange build "$name.yaml" --arch x86_64 --generate-index false
+melange build "$name.yaml" --arch x86_64 --generate-index false --signing-key "$key_path"
 
 # Upload package as build artifact
 buildkite-agent artifact upload packages/*/*

--- a/wolfi-packages/p4cli.yaml
+++ b/wolfi-packages/p4cli.yaml
@@ -1,7 +1,7 @@
 package:
   name: p4cli
   version: 23.1
-  epoch: 0
+  epoch: 1
   description: "Command line interface for Perforce"
   target-architecture:
     - x86_64


### PR DESCRIPTION
Start signing individual packages in addition to signing the apkindex.

## Test plan

- Check packages built by CI locally

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
