### PR TITLE
search: use annotation IsContent for "content:" patterns

### DIFF
--- a/internal/compute/query.go
+++ b/internal/compute/query.go
@@ -108,7 +108,7 @@ var ComputePredicateRegistry = query.PredicateRegistry{
 }
 
 func parseContentPredicate(pattern *query.Pattern) (string, string, bool) {
-	if !pattern.Annotation.Labels.IsSet(query.IsAlias) {
+	if !pattern.Annotation.Labels.IsSet(query.IsContent) {
 		// pattern is not set via `content:`, so it cannot be a replace command.
 		return "", "", false
 	}

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -728,13 +728,13 @@ func computeResultTypes(b query.Basic, searchType query.SearchType) result.Types
 
 	if len(types) == 0 && b.Pattern != nil {
 		// When the pattern is set via `content:`, we set the annotation on
-		// the pattern to IsAlias. So if all Patterns are from content: we
+		// the pattern to IsContent. So if all Patterns are from content: we
 		// should only search TypeFile.
 		hasPattern := false
 		allIsAlias := true
 		query.VisitPattern([]query.Node{b.Pattern}, func(value string, negated bool, annotation query.Annotation) {
 			hasPattern = true
-			allIsAlias = allIsAlias && annotation.Labels.IsSet(query.IsAlias)
+			allIsAlias = allIsAlias && annotation.Labels.IsSet(query.IsContent)
 		})
 		if hasPattern && allIsAlias {
 			return result.TypeFile

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -731,12 +731,12 @@ func computeResultTypes(b query.Basic, searchType query.SearchType) result.Types
 		// the pattern to IsContent. So if all Patterns are from content: we
 		// should only search TypeFile.
 		hasPattern := false
-		allIsAlias := true
+		allIsContent := true
 		query.VisitPattern([]query.Node{b.Pattern}, func(value string, negated bool, annotation query.Annotation) {
 			hasPattern = true
-			allIsAlias = allIsAlias && annotation.Labels.IsSet(query.IsContent)
+			allIsContent = allIsContent && annotation.Labels.IsSet(query.IsContent)
 		})
-		if hasPattern && allIsAlias {
+		if hasPattern && allIsContent {
 			return result.TypeFile
 		}
 	}

--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -21,6 +21,8 @@ const (
 	Standard
 	QuotesAsLiterals
 	Boost
+	// IsContent is set on patterns that come from content:
+	IsContent
 )
 
 var allLabels = map[labels]string{
@@ -37,6 +39,7 @@ var allLabels = map[labels]string{
 	Standard:                  "Standard",
 	QuotesAsLiterals:          "QuotesAsLiterals",
 	Boost:                     "Boost",
+	IsContent:                 "IsContent",
 }
 
 func (l *labels) IsSet(label labels) bool {

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -19,12 +19,12 @@ func stringHumanPattern(nodes []Node) string {
 			if n.Annotation.Labels.IsSet(Regexp) {
 				v = Delimit(v, '/')
 			}
-			if _, _, ok := ScanBalancedPattern([]byte(v)); !ok && !n.Annotation.Labels.IsSet(IsAlias) && n.Annotation.Labels.IsSet(Literal) {
+			if _, _, ok := ScanBalancedPattern([]byte(v)); !ok && !n.Annotation.Labels.IsSet(IsContent) && n.Annotation.Labels.IsSet(Literal) {
 				v = fmt.Sprintf(`content:%s`, strconv.Quote(v))
 				if n.Negated {
 					v = "-" + v
 				}
-			} else if n.Annotation.Labels.IsSet(IsAlias) {
+			} else if n.Annotation.Labels.IsSet(IsContent) {
 				v = fmt.Sprintf("content:%s", v)
 				if n.Negated {
 					v = "-" + v

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -21,7 +21,7 @@ func SubstituteAliases(searchType SearchType) func(nodes []Node) []Node {
 				} else {
 					annotation.Labels.Set(Literal)
 				}
-				annotation.Labels.Set(IsAlias)
+				annotation.Labels.Set(IsContent)
 				return Pattern{Value: value, Negated: negated, Annotation: annotation}
 			}
 			if canonical, ok := aliases[field]; ok {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -49,10 +49,10 @@ func TestSubstituteAliases(t *testing.T) {
 	autogold.Expect(`[{"and":[{"field":"repo","value":"repo","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}},{"field":"file","value":"file","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":7},"end":{"line":0,"column":13}}}]}]`).
 		Equal(t, test("r:repo f:file", SearchTypeRegex))
 
-	autogold.Expect(`[{"and":[{"field":"repo","value":"repo","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}},{"value":"^a-regexp:tbf$","negated":false,"labels":["IsAlias","Regexp"],"range":{"start":{"line":0,"column":7},"end":{"line":0,"column":29}}}]}]`).
+	autogold.Expect(`[{"and":[{"field":"repo","value":"repo","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}},{"value":"^a-regexp:tbf$","negated":false,"labels":["IsContent","Regexp"],"range":{"start":{"line":0,"column":7},"end":{"line":0,"column":29}}}]}]`).
 		Equal(t, test("r:repo content:^a-regexp:tbf$", SearchTypeRegex))
 
-	autogold.Expect(`[{"and":[{"field":"repo","value":"repo","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}},{"value":"^not-actually-a-regexp:tbf$","negated":false,"labels":["IsAlias","Literal"],"range":{"start":{"line":0,"column":7},"end":{"line":0,"column":42}}}]}]`).
+	autogold.Expect(`[{"and":[{"field":"repo","value":"repo","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":6}}},{"value":"^not-actually-a-regexp:tbf$","negated":false,"labels":["IsContent","Literal"],"range":{"start":{"line":0,"column":7},"end":{"line":0,"column":42}}}]}]`).
 		Equal(t, test("r:repo content:^not-actually-a-regexp:tbf$", SearchTypeLiteral))
 
 	autogold.Expect(`[{"field":"file","value":"foo","negated":false,"labels":["IsAlias"],"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":8}}}]`).

--- a/internal/search/smartsearch/rules.go
+++ b/internal/search/smartsearch/rules.go
@@ -73,7 +73,7 @@ func unquotePatterns(b query.Basic) *query.Basic {
 
 	changed := false // track whether we've successfully changed any pattern, which means this rule applies.
 	newParseTree := query.MapPattern(rawParseTree, func(value string, negated bool, annotation query.Annotation) query.Node {
-		if annotation.Labels.IsSet(query.Quoted) && !annotation.Labels.IsSet(query.IsAlias) {
+		if annotation.Labels.IsSet(query.Quoted) && !annotation.Labels.IsSet(query.IsContent) {
 			changed = true
 			annotation.Labels.Unset(query.Quoted)
 			annotation.Labels.Set(query.Literal)


### PR DESCRIPTION
It seems we lazily used IsAlias as the annotation before since we had the invariant that for Patterns the only time that happens is for content. However, this was really confusing to work out and its easy to add in a new annotation.

Test Plan: go test

Follow up from https://github.com/sourcegraph/sourcegraph/pull/60782