### PR TITLE
search: validate "content:" queries

### DIFF
--- a/internal/search/query/BUILD.bazel
+++ b/internal/search/query/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//internal/lazyregexp",
         "//internal/search/filter",
         "//internal/search/limits",
+        "//internal/search/result",
         "//lib/errors",
         "@com_github_go_enry_go_enry_v2//:go-enry",
         "@com_github_go_enry_go_enry_v2//data",


### PR DESCRIPTION
We don't actually support "content:" queries. Instead how it works is that if "content:" is specified we adjust the type of the query to type:file. This commit adds some validation that we don't use this outside of type:file or the default type.

Test Plan: TODO
