### PR TITLE
V2t src/enterprise code monitoring

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorList.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react'
 import { useLocation } from 'react-router-dom'
 import { of } from 'rxjs'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Container, Link, H2, H3 } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -21,9 +22,10 @@ import { CodeMonitorNode, type CodeMonitorNodeProps } from './CodeMonitoringNode
 import type { CodeMonitoringPageProps } from './CodeMonitoringPage'
 
 interface CodeMonitorListProps
-    extends Required<
-        Pick<CodeMonitoringPageProps, 'fetchUserCodeMonitors' | 'fetchCodeMonitors' | 'toggleCodeMonitorEnabled'>
-    > {
+    extends TelemetryV2Props,
+        Required<
+            Pick<CodeMonitoringPageProps, 'fetchUserCodeMonitors' | 'fetchCodeMonitors' | 'toggleCodeMonitorEnabled'>
+        > {
     authenticatedUser: AuthenticatedUser | null
 }
 
@@ -38,6 +40,7 @@ export const CodeMonitorList: React.FunctionComponent<React.PropsWithChildren<Co
     fetchUserCodeMonitors,
     fetchCodeMonitors,
     toggleCodeMonitorEnabled,
+    telemetryRecorder,
 }) => {
     const location = useLocation()
     const isSourcegraphDotCom: boolean = window.context?.sourcegraphDotComMode || false
@@ -81,9 +84,12 @@ export const CodeMonitorList: React.FunctionComponent<React.PropsWithChildren<Co
                                 To monitor changes across your private repositories,{' '}
                                 <Link
                                     to="https://sourcegraph.com"
-                                    onClick={() =>
+                                    onClick={() => {
                                         eventLogger.log('ClickedOnEnterpriseCTA', { location: 'Monitoring' })
-                                    }
+                                        telemetryRecorder.recordEvent('codeMonitor.enterpriseCTA', 'click', {
+                                            metadata: { location: 1 },
+                                        })
+                                    }}
                                 >
                                     get Sourcegraph Enterprise
                                 </Link>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringGettingStarted.tsx
@@ -4,6 +4,7 @@ import { mdiPlus } from '@mdi/js'
 import classNames from 'classnames'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import { Link, Button, CardBody, Card, Icon, H2, H3, H4, Text } from '@sourcegraph/wildcard'
 
@@ -12,7 +13,7 @@ import { eventLogger } from '../../tracking/eventLogger'
 
 import styles from './CodeMonitoringGettingStarted.module.scss'
 
-interface CodeMonitoringGettingStartedProps {
+interface CodeMonitoringGettingStartedProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 
@@ -65,14 +66,15 @@ const createCodeMonitorUrl = (example: ExampleCodeMonitor): string => {
 
 export const CodeMonitoringGettingStarted: React.FunctionComponent<
     React.PropsWithChildren<CodeMonitoringGettingStartedProps>
-> = ({ authenticatedUser }) => {
+> = ({ authenticatedUser, telemetryRecorder }) => {
     const isLightTheme = useIsLightTheme()
     const isSourcegraphDotCom: boolean = window.context?.sourcegraphDotComMode || false
     const assetsRoot = window.context?.assetsRoot || ''
 
     const logExampleMonitorClicked = useCallback(() => {
         eventLogger.log('CodeMonitoringExampleMonitorClicked')
-    }, [])
+        telemetryRecorder.recordEvent('codeMonitor.example', 'click')
+    }, [telemetryRecorder])
 
     const ctaBannerUrl = 'https://sourcegraph.com/get-started?t=enterprise'
 
@@ -110,9 +112,12 @@ export const CodeMonitoringGettingStarted: React.FunctionComponent<
                     To monitor changes across your team's private repositories,{' '}
                     <Link
                         to={ctaBannerUrl}
-                        onClick={() =>
+                        onClick={() => {
                             eventLogger.log('ClickedOnEnterpriseCTA', { location: 'MonitoringGettingStarted' })
-                        }
+                            telemetryRecorder.recordEvent('codeMonitor.enterpriseCTA', 'click', {
+                                metadata: { location: 0 },
+                            })
+                        }}
                     >
                         get Sourcegraph Enterprise
                     </Link>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.story.tsx
@@ -3,6 +3,7 @@ import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 
 import type { AuthenticatedUser } from '../../auth'
 import { WebStory } from '../../components/WebStory'
@@ -86,7 +87,11 @@ const siteAdminProps = {
 }
 
 export const LessThan10Results: StoryFn = () => (
-    <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsShortList} />}</WebStory>
+    <WebStory>
+        {props => (
+            <CodeMonitoringPage {...props} {...additionalPropsShortList} telemetryRecorder={noOpTelemetryRecorder} />
+        )}
+    </WebStory>
 )
 
 LessThan10Results.storyName = 'Code monitoring list page - less than 10 results'
@@ -98,7 +103,11 @@ LessThan10Results.parameters = {
 }
 
 export const MoreThan10Results: StoryFn = () => (
-    <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsLongList} />}</WebStory>
+    <WebStory>
+        {props => (
+            <CodeMonitoringPage {...props} {...additionalPropsLongList} telemetryRecorder={noOpTelemetryRecorder} />
+        )}
+    </WebStory>
 )
 
 MoreThan10Results.storyName = 'Code monitoring list page - more than 10 results'
@@ -110,7 +119,15 @@ MoreThan10Results.parameters = {
 }
 
 export const PageLoading: StoryFn = () => (
-    <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsAlwaysLoading} />}</WebStory>
+    <WebStory>
+        {props => (
+            <CodeMonitoringPage
+                {...props}
+                {...additionalPropsAlwaysLoading}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
+    </WebStory>
 )
 
 PageLoading.storyName = 'Code monitoring list page - loading'
@@ -122,7 +139,11 @@ PageLoading.parameters = {
 }
 
 export const ListPageEmptyShowGettingStarted: StoryFn = () => (
-    <WebStory>{props => <CodeMonitoringPage {...props} {...additionalPropsEmptyList} />}</WebStory>
+    <WebStory>
+        {props => (
+            <CodeMonitoringPage {...props} {...additionalPropsEmptyList} telemetryRecorder={noOpTelemetryRecorder} />
+        )}
+    </WebStory>
 )
 
 ListPageEmptyShowGettingStarted.storyName = 'Code monitoring list page - empty, show getting started'
@@ -135,7 +156,14 @@ ListPageEmptyShowGettingStarted.parameters = {
 
 export const ListPageUnauthenticatedShowGettingStarted: StoryFn = () => (
     <WebStory initialEntries={['/code-monitoring']}>
-        {props => <CodeMonitoringPage {...props} {...additionalProps} authenticatedUser={null} />}
+        {props => (
+            <CodeMonitoringPage
+                {...props}
+                {...additionalProps}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
+        )}
     </WebStory>
 )
 
@@ -144,7 +172,14 @@ ListPageUnauthenticatedShowGettingStarted.storyName =
 
 export const EmptyListPage: StoryFn = () => (
     <WebStory initialEntries={['/code-monitoring/getting-started']}>
-        {props => <CodeMonitoringPage {...props} {...additionalPropsEmptyList} testForceTab="list" />}
+        {props => (
+            <CodeMonitoringPage
+                {...props}
+                {...additionalPropsEmptyList}
+                telemetryRecorder={noOpTelemetryRecorder}
+                testForceTab="list"
+            />
+        )}
     </WebStory>
 )
 
@@ -159,7 +194,13 @@ EmptyListPage.parameters = {
 export const EmptyListPageUnauthenticated: StoryFn = () => (
     <WebStory initialEntries={['/code-monitoring/getting-started']}>
         {props => (
-            <CodeMonitoringPage {...props} {...additionalPropsEmptyList} authenticatedUser={null} testForceTab="list" />
+            <CodeMonitoringPage
+                {...props}
+                {...additionalPropsEmptyList}
+                authenticatedUser={null}
+                telemetryRecorder={noOpTelemetryRecorder}
+                testForceTab="list"
+            />
         )}
     </WebStory>
 )
@@ -174,7 +215,14 @@ EmptyListPageUnauthenticated.parameters = {
 
 export const SiteAdminUser: StoryFn = () => (
     <WebStory initialEntries={['/code-monitoring']}>
-        {props => <CodeMonitoringPage {...props} {...siteAdminProps} testForceTab="list" />}
+        {props => (
+            <CodeMonitoringPage
+                {...props}
+                {...siteAdminProps}
+                telemetryRecorder={noOpTelemetryRecorder}
+                testForceTab="list"
+            />
+        )}
     </WebStory>
 )
 

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -5,6 +5,7 @@ import sinon from 'sinon'
 import { describe, expect, test } from 'vitest'
 
 import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 
 import type { AuthenticatedUser } from '../../auth'
 import type { ListCodeMonitors, ListUserCodeMonitorsVariables } from '../../graphql-operations'
@@ -50,7 +51,11 @@ describe('CodeMonitoringListPage', () => {
     test('Clicking enabled toggle calls toggleCodeMonitorEnabled', () => {
         const component = render(
             <MemoryRouter initialEntries={['/code-monitoring?tab=list']}>
-                <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(1)} />
+                <CodeMonitoringPage
+                    {...additionalProps}
+                    fetchUserCodeMonitors={generateMockFetchMonitors(1)}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MemoryRouter>
         )
         const toggle = component.getByTestId('toggle-monitor-enabled')
@@ -61,7 +66,11 @@ describe('CodeMonitoringListPage', () => {
     test('Switching tabs from getting started to empty list works', () => {
         const component = render(
             <MemoryRouter initialEntries={['/code-monitoring?tab=getting-started']}>
-                <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(0)} />
+                <CodeMonitoringPage
+                    {...additionalProps}
+                    fetchUserCodeMonitors={generateMockFetchMonitors(0)}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MemoryRouter>
         )
         const codeMonitorsButton = component.getByRole('button', { name: 'Code monitors' })
@@ -74,7 +83,11 @@ describe('CodeMonitoringListPage', () => {
     test('Switching tabs from list to getting started works', () => {
         const component = render(
             <MemoryRouter initialEntries={['/code-monitoring?tab=list']}>
-                <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(0)} />
+                <CodeMonitoringPage
+                    {...additionalProps}
+                    fetchUserCodeMonitors={generateMockFetchMonitors(0)}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MemoryRouter>
         )
         const gettingStartedButton = component.getByRole('button', { name: 'Getting started' })

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -142,7 +142,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                 }
             }
         }
-    }, [currentTab, userHasCodeMonitors])
+    }, [currentTab, userHasCodeMonitors, telemetryRecorder])
 
     const showList = userHasCodeMonitors !== undefined && !isErrorLike(userHasCodeMonitors) && currentTab === 'list'
 

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -9,6 +9,7 @@ import { catchError, map } from 'rxjs/operators'
 import { asError, isErrorLike } from '@sourcegraph/common'
 import type { Settings } from '@sourcegraph/shared/src/schema/settings.schema'
 import type { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     PageHeader,
     LoadingSpinner,
@@ -65,7 +66,7 @@ function setSelectedLocationTab(location: Location, navigate: NavigateFunction, 
     }
 }
 
-export interface CodeMonitoringPageProps extends SettingsCascadeProps<Settings> {
+export interface CodeMonitoringPageProps extends SettingsCascadeProps<Settings>, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     fetchUserCodeMonitors?: typeof _fetchUserCodeMonitors
     fetchCodeMonitors?: typeof _fetchCodeMonitors
@@ -80,6 +81,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
     fetchCodeMonitors = _fetchCodeMonitors,
     toggleCodeMonitorEnabled = _toggleCodeMonitorEnabled,
     testForceTab,
+    telemetryRecorder,
 }) => {
     const userHasCodeMonitors = useObservable(
         useMemo(
@@ -126,14 +128,17 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
             switch (currentTab) {
                 case 'getting-started': {
                     eventLogger.logPageView('CodeMonitoringGettingStartedPage')
+                    telemetryRecorder.recordEvent('codeMonitor.gettingStarted', 'view')
                     break
                 }
                 case 'logs': {
                     eventLogger.logPageView('CodeMonitoringLogsPage')
+                    telemetryRecorder.recordEvent('codeMonitor.logs', 'view')
                     break
                 }
                 case 'list': {
                     eventLogger.logPageView('CodeMonitoringPage')
+                    telemetryRecorder.recordEvent('codeMonitor.list', 'view')
                 }
             }
         }
@@ -211,7 +216,10 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                     </div>
 
                     {currentTab === 'getting-started' && (
-                        <CodeMonitoringGettingStarted authenticatedUser={authenticatedUser} />
+                        <CodeMonitoringGettingStarted
+                            authenticatedUser={authenticatedUser}
+                            telemetryRecorder={telemetryRecorder}
+                        />
                     )}
 
                     {currentTab === 'logs' && <CodeMonitoringLogs />}
@@ -222,6 +230,7 @@ export const CodeMonitoringPage: React.FunctionComponent<React.PropsWithChildren
                             fetchUserCodeMonitors={fetchUserCodeMonitors}
                             fetchCodeMonitors={fetchCodeMonitors}
                             toggleCodeMonitorEnabled={toggleCodeMonitorEnabled}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     )}
                 </div>

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.story.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryFn } from '@storybook/react'
 import sinon from 'sinon'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import type { AuthenticatedUser } from '../../auth'
 import { WebStory } from '../../components/WebStory'
 
@@ -31,6 +33,7 @@ export const CreateCodeMonitorPageStory: StoryFn = () => (
                 }
                 createCodeMonitor={sinon.fake()}
                 isSourcegraphDotCom={false}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -5,6 +5,7 @@ import { NEVER, of } from 'rxjs'
 import sinon from 'sinon'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { assertAriaDisabled } from '@sourcegraph/testing'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
@@ -57,7 +58,10 @@ describe.skip('CreateCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/new" element={<CreateCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/new"
+                        element={<CreateCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             {
@@ -87,7 +91,10 @@ describe.skip('CreateCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/new" element={<CreateCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/new"
+                        element={<CreateCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             {
@@ -114,7 +121,10 @@ describe.skip('CreateCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/new" element={<CreateCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/new"
+                        element={<CreateCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             { route: '/code-monitoring/new' }

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -4,6 +4,7 @@ import { VisuallyHidden } from '@reach/visually-hidden'
 import { useLocation } from 'react-router-dom'
 import type { Observable } from 'rxjs'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { PageHeader, Link } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -17,7 +18,7 @@ import { convertActionsForCreate } from './action-converters'
 import { createCodeMonitor as _createCodeMonitor } from './backend'
 import { CodeMonitorForm } from './components/CodeMonitorForm'
 
-interface CreateCodeMonitorPageProps {
+interface CreateCodeMonitorPageProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
 
     createCodeMonitor?: typeof _createCodeMonitor
@@ -27,7 +28,7 @@ interface CreateCodeMonitorPageProps {
 
 const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<
     React.PropsWithChildren<CreateCodeMonitorPageProps>
-> = ({ authenticatedUser, createCodeMonitor = _createCodeMonitor, isSourcegraphDotCom }) => {
+> = ({ authenticatedUser, createCodeMonitor = _createCodeMonitor, isSourcegraphDotCom, telemetryRecorder }) => {
     const location = useLocation()
 
     const triggerQuery = useMemo(
@@ -40,18 +41,20 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<
         [location.search]
     )
 
-    useEffect(
-        () =>
-            eventLogger.logPageView('CreateCodeMonitorPage', {
-                hasTriggerQuery: !!triggerQuery,
-                hasDescription: !!description,
-            }),
-        [triggerQuery, description]
-    )
+    useEffect(() => {
+        eventLogger.logPageView('CreateCodeMonitorPage', {
+            hasTriggerQuery: !!triggerQuery,
+            hasDescription: !!description,
+        })
+        telemetryRecorder.recordEvent('codeMonitor.create', 'view', {
+            metadata: { hasTriggerQuery: triggerQuery ? 1 : 0, hasDescription: description ? 1 : 0 },
+        })
+    }, [triggerQuery, description])
 
     const createMonitorRequest = useCallback(
         (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> => {
             eventLogger.log('CreateCodeMonitorFormSubmitted')
+            telemetryRecorder.recordEvent('codeMonitor.create', 'submit')
             return createCodeMonitor({
                 monitor: {
                     namespace: authenticatedUser.id,

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.tsx
@@ -49,7 +49,7 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<
         telemetryRecorder.recordEvent('codeMonitor.create', 'view', {
             metadata: { hasTriggerQuery: triggerQuery ? 1 : 0, hasDescription: description ? 1 : 0 },
         })
-    }, [triggerQuery, description])
+    }, [triggerQuery, description, telemetryRecorder])
 
     const createMonitorRequest = useCallback(
         (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> => {
@@ -66,7 +66,7 @@ const AuthenticatedCreateCodeMonitorPage: React.FunctionComponent<
                 actions: convertActionsForCreate(codeMonitor.actions.nodes, authenticatedUser.id),
             })
         },
-        [authenticatedUser.id, createCodeMonitor]
+        [authenticatedUser.id, createCodeMonitor, telemetryRecorder]
     )
 
     return (

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.story.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryFn } from '@storybook/react'
 import { NEVER, of } from 'rxjs'
 import { fake } from 'sinon'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+
 import { WebStory } from '../../components/WebStory'
 
 import { ManageCodeMonitorPage } from './ManageCodeMonitorPage'
@@ -30,6 +32,7 @@ export const ManageCodeMonitorPageStory: StoryFn = () => (
                 fetchCodeMonitor={fake(() => of(mockCodeMonitor))}
                 deleteCodeMonitor={fake(() => NEVER)}
                 isSourcegraphDotCom={false}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.test.tsx
@@ -5,6 +5,7 @@ import { of } from 'rxjs'
 import sinon from 'sinon'
 import { afterEach, beforeEach, describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { assertAriaDisabled, assertAriaEnabled } from '@sourcegraph/testing'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
@@ -54,7 +55,10 @@ describe('ManageCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/:id" element={<ManageCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/:id"
+                        element={<ManageCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             { route: '/code-monitoring/test-monitor-id' }
@@ -76,7 +80,10 @@ describe('ManageCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/:id" element={<ManageCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/:id"
+                        element={<ManageCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             { route: '/code-monitoring/test-monitor-id' }
@@ -128,7 +135,10 @@ describe('ManageCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/:id" element={<ManageCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/:id"
+                        element={<ManageCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             { route: '/code-monitoring/test-monitor-id' }
@@ -142,7 +152,10 @@ describe('ManageCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/:id" element={<ManageCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/:id"
+                        element={<ManageCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             { route: '/code-monitoring/test-monitor-id' }
@@ -157,7 +170,10 @@ describe('ManageCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/:id" element={<ManageCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/:id"
+                        element={<ManageCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             { route: '/code-monitoring/test-monitor-id' }
@@ -174,7 +190,10 @@ describe('ManageCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/:id" element={<ManageCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/:id"
+                        element={<ManageCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             { route: '/code-monitoring/test-monitor-id' }
@@ -192,7 +211,10 @@ describe('ManageCodeMonitorPage', () => {
         renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/:id" element={<ManageCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/:id"
+                        element={<ManageCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                 </Routes>
             </MockedTestProvider>,
             { route: '/code-monitoring/test-monitor-id' }
@@ -208,7 +230,10 @@ describe('ManageCodeMonitorPage', () => {
         const { locationRef } = renderWithBrandedContext(
             <MockedTestProvider>
                 <Routes>
-                    <Route path="/code-monitoring/:id" element={<ManageCodeMonitorPage {...props} />} />
+                    <Route
+                        path="/code-monitoring/:id"
+                        element={<ManageCodeMonitorPage {...props} telemetryRecorder={noOpTelemetryRecorder} />}
+                    />
                     <Route path="/code-monitoring" element={null} />
                 </Routes>
             </MockedTestProvider>,

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -6,6 +6,7 @@ import type { Observable } from 'rxjs'
 import { startWith, catchError, tap } from 'rxjs/operators'
 
 import { asError, isErrorLike } from '@sourcegraph/common'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { PageHeader, Link, LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../auth'
@@ -23,7 +24,7 @@ import {
 } from './backend'
 import { CodeMonitorForm } from './components/CodeMonitorForm'
 
-interface ManageCodeMonitorPageProps {
+interface ManageCodeMonitorPageProps extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
 
     fetchCodeMonitor?: typeof _fetchCodeMonitor
@@ -41,10 +42,14 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
     updateCodeMonitor = _updateCodeMonitor,
     deleteCodeMonitor = _deleteCodeMonitor,
     isSourcegraphDotCom,
+    telemetryRecorder,
 }) => {
     const LOADING = 'loading' as const
 
-    useEffect(() => eventLogger.logPageView('ManageCodeMonitorPage'), [])
+    useEffect(() => {
+        eventLogger.logPageView('ManageCodeMonitorPage')
+        telemetryRecorder.recordEvent('codeMonitor.manage', 'view')
+    }, [telemetryRecorder])
 
     const { id } = useParams()
 
@@ -80,6 +85,7 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
     const updateMonitorRequest = React.useCallback(
         (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> => {
             eventLogger.log('ManageCodeMonitorFormSubmitted')
+            telemetryRecorder.recordEvent('codeMonitor.manage.form', 'submit')
             return updateCodeMonitor(
                 {
                     id: id!,
@@ -93,15 +99,16 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
                 convertActionsForUpdate(codeMonitor.actions.nodes, authenticatedUser.id)
             )
         },
-        [authenticatedUser.id, id, updateCodeMonitor]
+        [authenticatedUser.id, id, updateCodeMonitor, telemetryRecorder]
     )
 
     const deleteMonitorRequest = React.useCallback(
         (id: string): Observable<void> => {
             eventLogger.log('ManageCodeMonitorDeleteSubmitted')
+            telemetryRecorder.recordEvent('codeMonitor.manage.delete', 'submit')
             return deleteCodeMonitor(id)
         },
-        [deleteCodeMonitor]
+        [deleteCodeMonitor, telemetryRecorder]
     )
 
     return (

--- a/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/ManageCodeMonitorPage.tsx
@@ -85,7 +85,7 @@ const AuthenticatedManageCodeMonitorPage: React.FunctionComponent<
     const updateMonitorRequest = React.useCallback(
         (codeMonitor: CodeMonitorFields): Observable<Partial<CodeMonitorFields>> => {
             eventLogger.log('ManageCodeMonitorFormSubmitted')
-            telemetryRecorder.recordEvent('codeMonitor.manage.form', 'submit')
+            telemetryRecorder.recordEvent('codeMonitor.manage.update', 'submit')
             return updateCodeMonitor(
                 {
                     id: id!,

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -28,9 +28,33 @@ export const GlobalCodeMonitoringArea: React.FunctionComponent<React.PropsWithCh
     <div className="w-100">
         <Page>
             <Routes>
-                <Route path="" element={<CodeMonitoringPage {...outerProps} />} />
-                <Route path="new" element={<CreateCodeMonitorPage {...outerProps} />} />
-                <Route path=":id" element={<ManageCodeMonitorPage {...outerProps} />} />
+                <Route
+                    path=""
+                    element={
+                        <CodeMonitoringPage
+                            {...outerProps}
+                            telemetryRecorder={outerProps.platformContext.telemetryRecorder}
+                        />
+                    }
+                />
+                <Route
+                    path="new"
+                    element={
+                        <CreateCodeMonitorPage
+                            {...outerProps}
+                            telemetryRecorder={outerProps.platformContext.telemetryRecorder}
+                        />
+                    }
+                />
+                <Route
+                    path=":id"
+                    element={
+                        <ManageCodeMonitorPage
+                            {...outerProps}
+                            telemetryRecorder={outerProps.platformContext.telemetryRecorder}
+                        />
+                    }
+                />
             </Routes>
         </Page>
     </div>


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally