### PR TITLE
Add v2t to src/enterprise/codeintel

### DIFF
--- a/client/web/src/enterprise/codeintel/admin/AdminCodeIntelArea.tsx
+++ b/client/web/src/enterprise/codeintel/admin/AdminCodeIntelArea.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import { Routes, Route, Navigate, useParams } from 'react-router-dom'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -16,7 +17,7 @@ import type { CodeIntelPreciseIndexesPageProps } from '../indexes/pages/CodeInte
 import type { CodeIntelPreciseIndexPageProps } from '../indexes/pages/CodeIntelPreciseIndexPage'
 import type { CodeIntelRankingPageProps } from '../ranking/pages/CodeIntelRankingPage'
 
-export interface AdminCodeIntelAreaRouteContext extends TelemetryProps {
+export interface AdminCodeIntelAreaRouteContext extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -19,6 +19,7 @@ import { Subject } from 'rxjs'
 
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { GitObjectType } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps, TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge, Button, Container, ErrorAlert, H3, Icon, Link, PageHeader, Text, Tooltip } from '@sourcegraph/wildcard'
 
@@ -36,7 +37,7 @@ import { hasGlobalPolicyViolation } from '../shared'
 
 import styles from './CodeIntelConfigurationPage.module.scss'
 
-export interface CodeIntelConfigurationPageProps extends TelemetryProps {
+export interface CodeIntelConfigurationPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     queryPolicies?: typeof defaultQueryPolicies
     repo?: { id: string; name: string }
@@ -50,8 +51,12 @@ export const CodeIntelConfigurationPage: FunctionComponent<CodeIntelConfiguratio
     repo,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
     telemetryService,
+    telemetryRecorder,
 }) => {
-    useEffect(() => telemetryService.logViewEvent('CodeIntelConfiguration'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelConfiguration')
+        telemetryRecorder.recordEvent('codeIntel.configuration', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const navigate = useNavigate()
     const location = useLocation()

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -11,6 +11,7 @@ import { useLazyQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { displayRepoName, RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { GitObjectType } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Alert,
@@ -57,7 +58,7 @@ const DEBOUNCED_WAIT = 250
 
 const MS_IN_HOURS = 60 * 60 * 1000
 
-export interface CodeIntelConfigurationPolicyPageProps extends TelemetryProps {
+export interface CodeIntelConfigurationPolicyPageProps extends TelemetryProps, TelemetryV2Props {
     repo?: { id: string; name: string }
     authenticatedUser: AuthenticatedUser | null
     indexingEnabled?: boolean
@@ -76,12 +77,16 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<CodeIntelConfig
     allowGlobalPolicies = window.context?.codeIntelAutoIndexingAllowGlobalPolicies,
     domain = 'scip',
     telemetryService,
+    telemetryRecorder,
 }) => {
     const navigate = useNavigate()
     const location = useLocation()
     const { id } = useParams<{ id: string }>()
 
-    useEffect(() => telemetryService.logViewEvent('CodeIntelConfigurationPolicy'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelConfigurationPolicy')
+        telemetryRecorder.recordEvent('codeIntel.configurationPolicy', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     // Handle local policy state
     const [policy, setPolicy] = useState<CodeIntelligenceConfigurationPolicyFields | undefined>()

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
@@ -1,6 +1,6 @@
 import { type FunctionComponent, useState } from 'react'
 
-import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryV2Props, noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ErrorAlert, Link, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
 
@@ -12,7 +12,7 @@ import { useInferenceScript } from '../hooks/useInferenceScript'
 
 import styles from './CodeIntelInferenceConfigurationPage.module.scss'
 
-export interface CodeIntelInferenceConfigurationPageProps extends TelemetryProps {
+export interface CodeIntelInferenceConfigurationPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 
@@ -61,7 +61,6 @@ export const CodeIntelInferenceConfigurationPage: FunctionComponent<CodeIntelInf
                 script={inferenceScript}
                 authenticatedUser={authenticatedUser}
                 setPreviewScript={setPreviewScript}
-                telemetryRecorder={noOpTelemetryRecorder}
                 {...props}
             />
 

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
@@ -1,6 +1,6 @@
-import { type FunctionComponent, useState } from 'react'
+import { type FunctionComponent, useState, useEffect } from 'react'
 
-import { TelemetryV2Props, noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ErrorAlert, Link, LoadingSpinner, PageHeader } from '@sourcegraph/wildcard'
 
@@ -23,6 +23,10 @@ export const CodeIntelInferenceConfigurationPage: FunctionComponent<CodeIntelInf
     const { inferenceScript, loadingScript, fetchError } = useInferenceScript()
     const [previewScript, setPreviewScript] = useState<string | null>(null)
     const inferencePreview = previewScript !== null ? previewScript : inferenceScript
+
+    useEffect(() => {
+        props.telemetryRecorder.recordEvent('codeIntel.inferenceConfiguration', 'view')
+    }, [props.telemetryRecorder])
 
     return (
         <>

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
@@ -32,10 +32,12 @@ export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
         const tab = new URLSearchParams(location.search).get('tab')
         if (tab === 'form') {
             setActiveTabIndex(0)
+            telemetryRecorder.recordEvent('codeIntel.repoIndexConfig.tab', 'click', { metadata: { tab: 0 } })
         } else if (tab === 'raw') {
             setActiveTabIndex(1)
+            telemetryRecorder.recordEvent('codeIntel.repoIndexConfig.tab', 'click', { metadata: { tab: 1 } })
         }
-    }, [location.search])
+    }, [location.search, telemetryRecorder])
 
     return (
         <>

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
@@ -22,7 +22,7 @@ export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
 > = ({ repo, authenticatedUser, telemetryService, telemetryRecorder, ...props }) => {
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelRepositoryIndexConfiguration')
-        telemetryRecorder.recordEvent('repo.codeintelIndexConfig', 'view')
+        telemetryRecorder.recordEvent('codeIntel.repoIndexConfig', 'view')
     }, [telemetryService, telemetryRecorder])
     const location = useLocation()
 

--- a/client/web/src/enterprise/codeintel/dashboard/pages/GlobalDashboardPage.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/pages/GlobalDashboardPage.tsx
@@ -4,6 +4,7 @@ import { mdiChevronRight, mdiCircleOffOutline } from '@mdi/js'
 
 import { useQuery } from '@sourcegraph/http-client'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Badge, Container, ErrorAlert, H3, Icon, Link, LoadingSpinner, PageHeader, Text } from '@sourcegraph/wildcard'
 
@@ -78,17 +79,19 @@ const DashboardNode: React.FunctionComponent<DashboardNodeProps> = props => {
     )
 }
 
-export interface GlobalDashboardPageProps extends TelemetryProps {
+export interface GlobalDashboardPageProps extends TelemetryProps, TelemetryV2Props {
     indexingEnabled?: boolean
 }
 
 export const GlobalDashboardPage: React.FunctionComponent<GlobalDashboardPageProps> = ({
     telemetryService,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         telemetryService.logPageView('CodeIntelGlobalDashboard')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('codeIntel.globalDashboard', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, error, loading } = useQuery<GlobalCodeIntelStatusResult>(globalCodeIntelStatusQuery, {
         notifyOnNetworkStatusChange: false,

--- a/client/web/src/enterprise/codeintel/dashboard/pages/RepoDashboardPage.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/pages/RepoDashboardPage.tsx
@@ -6,6 +6,7 @@ import { type Location, useLocation, useNavigate } from 'react-router-dom'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Alert,
@@ -28,7 +29,7 @@ import { useRepoCodeIntelStatus } from '../hooks/useRepoCodeIntelStatus'
 
 import styles from './RepoDashboardPage.module.scss'
 
-export interface RepoDashboardPageProps extends TelemetryProps {
+export interface RepoDashboardPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     repo: { id: string; name: string }
     now?: () => Date
@@ -98,10 +99,12 @@ export const RepoDashboardPage: React.FunctionComponent<RepoDashboardPageProps> 
     authenticatedUser,
     now,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
         telemetryService.logPageView('CodeIntelRepoDashboard')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('codeIntel.repoDashboard', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const location = useLocation()
     const navigate = useNavigate()

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexPage.tsx
@@ -8,6 +8,7 @@ import { takeWhile } from 'rxjs/operators'
 
 import { type ErrorLike, isErrorLike } from '@sourcegraph/common'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Alert,
@@ -48,7 +49,7 @@ import { useReindexPreciseIndex as defaultUseReindexPreciseIndex } from '../hook
 
 import styles from './CodeIntelPreciseIndexPage.module.scss'
 
-export interface CodeIntelPreciseIndexPageProps extends TelemetryProps {
+export interface CodeIntelPreciseIndexPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     now?: () => Date
     queryDependencyGraph?: typeof defaultQueryDependencyGraph
@@ -71,12 +72,16 @@ export const CodeIntelPreciseIndexPage: FunctionComponent<CodeIntelPreciseIndexP
     useReindexPreciseIndex = defaultUseReindexPreciseIndex,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const { id } = useParams<{ id: string }>()
     const navigate = useNavigate()
     const location = useLocation()
 
-    useEffect(() => telemetryService.logViewEvent('CodeIntelPreciseIndexPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelPreciseIndexPage')
+        telemetryRecorder.recordEvent('codeIntel.preciseIndex', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const apolloClient = useApolloClient()
     const { handleReindexPreciseIndex, reindexError } = useReindexPreciseIndex()

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
@@ -11,6 +11,7 @@ import { isErrorLike } from '@sourcegraph/common'
 import { gql, useQuery } from '@sourcegraph/http-client'
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -59,7 +60,7 @@ export const INDEXER_LIST = gql`
     }
 `
 
-export interface CodeIntelPreciseIndexesPageProps extends TelemetryProps {
+export interface CodeIntelPreciseIndexesPageProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     repo?: { id: string; name: string }
     queryPreciseIndexes?: typeof defaultQueryPreciseIndexes
@@ -125,9 +126,13 @@ export const CodeIntelPreciseIndexesPage: FunctionComponent<CodeIntelPreciseInde
     useReindexPreciseIndexes = defaultUseReindexPreciseIndexes,
     indexingEnabled = window.context?.codeIntelAutoIndexingEnabled,
     telemetryService,
+    telemetryRecorder,
 }) => {
     const location = useLocation()
-    useEffect(() => telemetryService.logViewEvent('CodeIntelPreciseIndexesPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelPreciseIndexesPage')
+        telemetryRecorder.recordEvent('codeIntel.preciseIndexes', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const apolloClient = useApolloClient()
     const { handleDeletePreciseIndex, deleteError } = useDeletePreciseIndex()

--- a/client/web/src/enterprise/codeintel/ranking/pages/CodeIntelRankingPage.tsx
+++ b/client/web/src/enterprise/codeintel/ranking/pages/CodeIntelRankingPage.tsx
@@ -6,6 +6,7 @@ import { format, formatDistance, parseISO } from 'date-fns'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps, TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Badge,
@@ -36,7 +37,7 @@ import {
 
 import styles from './CodeIntelRankingPage.module.scss'
 
-export interface CodeIntelRankingPageProps extends TelemetryProps {
+export interface CodeIntelRankingPageProps extends TelemetryProps, TelemetryV2Props {
     useRankingSummary?: typeof defaultUseRankingSummary
     telemetryService: TelemetryService
 }
@@ -44,8 +45,12 @@ export interface CodeIntelRankingPageProps extends TelemetryProps {
 export const CodeIntelRankingPage: FunctionComponent<CodeIntelRankingPageProps> = ({
     useRankingSummary = defaultUseRankingSummary,
     telemetryService,
+    telemetryRecorder,
 }) => {
-    useEffect(() => telemetryService.logViewEvent('CodeIntelRankingPage'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('CodeIntelRankingPage')
+        telemetryRecorder.recordEvent('codeIntel.ranking', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error, refetch } = useRankingSummary({})
 

--- a/client/web/src/enterprise/cody/repo/CodyRepoArea.tsx
+++ b/client/web/src/enterprise/cody/repo/CodyRepoArea.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 
 import { Navigate, Route, Routes } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -15,7 +16,7 @@ import { CodyConfigurationPage } from '../configuration/pages/CodyConfigurationP
 
 import { CodyRepoSidebar, type CodyRepoSidebarGroups } from './CodyRepoSidebar'
 
-export interface CodyRepoAreaRouteContext extends TelemetryProps {
+export interface CodyRepoAreaRouteContext extends TelemetryProps, TelemetryV2Props {
     repo: { id: string; name: string }
     authenticatedUser: AuthenticatedUser | null
 }
@@ -45,7 +46,7 @@ export const codyRepoAreaRoutes: readonly CodyRepoAreaRoute[] = [
     },
 ]
 
-export interface CodyRepoAreaProps extends BreadcrumbSetters, TelemetryProps {
+export interface CodyRepoAreaProps extends BreadcrumbSetters, TelemetryProps, TelemetryV2Props {
     repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null
 }

--- a/client/web/src/enterprise/repo/enterpriseRepoContainerRoutes.tsx
+++ b/client/web/src/enterprise/repo/enterpriseRepoContainerRoutes.tsx
@@ -38,7 +38,7 @@ export const enterpriseRepoContainerRoutes: readonly RepoContainerRoute[] = [
     },
     {
         path: '/-/embeddings/*',
-        render: context => <CodyRepoArea {...context} />,
+        render: context => <CodyRepoArea {...context} telemetryRecorder={context.platformContext.telemetryRecorder} />,
     },
     {
         path: '/-/batch-changes',


### PR DESCRIPTION
Note that this PR builds on top of https://github.com/sourcegraph/sourcegraph/pull/60382/files#diff-a354ffdebcc1d98d0e3632043847fe31b6b4a09ac8586b777538ebf182218a6a because that PR hasn't been merged yet and included edits to a number of files in this folder.

Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally