### PR TITLE
v2t: add v2t to src/enterprise/insights

### DIFF
--- a/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsAppRouter.tsx
@@ -4,6 +4,7 @@ import { gql, useLazyQuery } from '@apollo/client'
 import { Route, Routes, Navigate } from 'react-router-dom'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -28,7 +29,7 @@ const EditInsightLazyPage = lazyComponent(
     'EditInsightPage'
 )
 
-export interface CodeInsightsAppRouter extends TelemetryProps {
+export interface CodeInsightsAppRouter extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
 }
 
@@ -39,7 +40,7 @@ const rootPagePathsToTab = {
 }
 
 export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter>(props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const fetched = useLicense()
     const api = useApi()
@@ -55,20 +56,36 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
             <Routes>
                 <Route index={true} element={<CodeInsightsSmartRoutingRedirect />} />
 
-                <Route path="create/*" element={<CreationRoutes telemetryService={telemetryService} />} />
+                <Route
+                    path="create/*"
+                    element={
+                        <CreationRoutes telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
+                    }
+                />
 
                 <Route path="dashboards/:dashboardId/edit" element={<EditDashboardPage />} />
 
                 <Route
                     path="add-dashboard"
-                    element={<InsightsDashboardCreationPage telemetryService={telemetryService} />}
+                    element={
+                        <InsightsDashboardCreationPage
+                            telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
+                        />
+                    }
                 />
 
                 {Object.entries(rootPagePathsToTab).map(([path, activeTab]) => (
                     <Route
                         key="hardcoded-key"
                         path={path}
-                        element={<CodeInsightsRootPage activeTab={activeTab} telemetryService={telemetryService} />}
+                        element={
+                            <CodeInsightsRootPage
+                                activeTab={activeTab}
+                                telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
+                            />
+                        }
                     />
                 ))}
 
@@ -77,14 +94,22 @@ export const CodeInsightsAppRouter = withAuthenticatedUser<CodeInsightsAppRouter
                     path="edit/:insightId"
                     element={<RedirectRoute getRedirectURL={({ params }) => `/insights/${params.insightId}/edit`} />}
                 />
-                <Route path=":insightId/edit" element={<EditInsightLazyPage />} />
+                <Route path=":insightId/edit" element={<EditInsightLazyPage telemetryRecorder={telemetryRecorder} />} />
 
                 <Route
                     // Deprecated URL, delete this in the 4.10
                     path="insight/:insightId"
                     element={<RedirectRoute getRedirectURL={({ params }) => `/insights/${params.insightId}`} />}
                 />
-                <Route path=":insightId" element={<CodeInsightIndependentPage telemetryService={telemetryService} />} />
+                <Route
+                    path=":insightId"
+                    element={
+                        <CodeInsightIndependentPage
+                            telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
+                        />
+                    }
+                />
 
                 <Route path="*" element={<NotFoundPage pageType="code insights" />} />
             </Routes>

--- a/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
+++ b/client/web/src/enterprise/insights/CodeInsightsRouter.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -12,22 +13,29 @@ const CodeInsightsDotComGetStartedLazy = lazyComponent(
     'CodeInsightsDotComGetStarted'
 )
 
-export interface CodeInsightsRouterProps extends TelemetryProps {
+export interface CodeInsightsRouterProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
 }
 
 export const CodeInsightsRouter: FC<CodeInsightsRouterProps> = props => {
-    const { authenticatedUser, telemetryService } = props
+    const { authenticatedUser, telemetryService, telemetryRecorder } = props
 
     if (!window.context?.codeInsightsEnabled) {
         return (
             <CodeInsightsDotComGetStartedLazy
                 telemetryService={telemetryService}
                 authenticatedUser={authenticatedUser}
+                telemetryRecorder={telemetryRecorder}
             />
         )
     }
 
-    return <CodeInsightsAppLazyRouter authenticatedUser={authenticatedUser} telemetryService={telemetryService} />
+    return (
+        <CodeInsightsAppLazyRouter
+            authenticatedUser={authenticatedUser}
+            telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
+        />
+    )
 }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/SmartInsightsViewGrid.story.tsx
@@ -1,6 +1,7 @@
 import type { MockedResponse } from '@apollo/client/testing/core'
 import type { Meta } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -1195,6 +1196,7 @@ export const SmartInsightsViewGridExample = (): JSX.Element => (
             persistSizeAndOrder={false}
             insights={INSIGHT_CONFIGURATIONS}
             telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
         />
     </MockedTestProvider>
 )

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/SmartInsight.tsx
@@ -2,6 +2,7 @@ import { type HTMLAttributes, forwardRef, useEffect } from 'react'
 
 import { useMergeRefs } from 'use-callback-ref'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useSearchParameters } from '@sourcegraph/wildcard'
 
@@ -11,7 +12,7 @@ import { BackendInsightView } from './backend-insight/BackendInsight'
 import { LangStatsInsightCard } from './lang-stats-insight-card/LangStatsInsightCard'
 import { ViewGridItem } from './view-grid/ViewGrid'
 
-export interface SmartInsightProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
+export interface SmartInsightProps extends TelemetryProps, TelemetryV2Props, HTMLAttributes<HTMLElement> {
     insight: Insight
     resizing?: boolean
 }
@@ -21,7 +22,7 @@ export interface SmartInsightProps extends TelemetryProps, HTMLAttributes<HTMLEl
  * actions.
  */
 export const SmartInsight = forwardRef<HTMLElement, SmartInsightProps>((props, reference) => {
-    const { insight, resizing = false, telemetryService, children, ...attributes } = props
+    const { insight, resizing = false, telemetryService, telemetryRecorder, children, ...attributes } = props
 
     const mergedReference = useMergeRefs([reference])
     const search = useSearchParameters()
@@ -42,11 +43,21 @@ export const SmartInsight = forwardRef<HTMLElement, SmartInsightProps>((props, r
     return (
         <ViewGridItem id={insight.id} ref={mergedReference} {...attributes}>
             {isBackendInsight(insight) ? (
-                <BackendInsightView insight={insight} resizing={resizing} telemetryService={telemetryService}>
+                <BackendInsightView
+                    insight={insight}
+                    resizing={resizing}
+                    telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
+                >
                     {children}
                 </BackendInsightView>
             ) : (
-                <LangStatsInsightCard insight={insight} resizing={resizing} telemetryService={telemetryService}>
+                <LangStatsInsightCard
+                    insight={insight}
+                    resizing={resizing}
+                    telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
+                >
                     {children}
                 </LangStatsInsightCard>
             )}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.story.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import type { MockedResponse } from '@apollo/client/testing'
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { H2 } from '@sourcegraph/wildcard'
@@ -243,6 +244,7 @@ const TestBackendInsight: React.FunctionComponent<React.PropsWithChildren<unknow
         style={{ width: 400, height: 400 }}
         insight={INSIGHT_CONFIGURATION_MOCK}
         telemetryService={NOOP_TELEMETRY_SERVICE}
+        telemetryRecorder={noOpTelemetryRecorder}
     />
 )
 
@@ -1338,6 +1340,7 @@ export const BackendInsightDemoCasesShowcase: StoryFn = () => (
                 style={{ width: 400, height: 400 }}
                 insight={COMPONENT_MIGRATION_INSIGHT_CONFIGURATION}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         </MockedTestProvider>
 
@@ -1346,6 +1349,7 @@ export const BackendInsightDemoCasesShowcase: StoryFn = () => (
                 style={{ width: 400, height: 400 }}
                 insight={DATA_FETCHING_INSIGHT_CONFIGURATION}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         </MockedTestProvider>
 
@@ -1354,6 +1358,7 @@ export const BackendInsightDemoCasesShowcase: StoryFn = () => (
                 style={{ width: 400, height: 400 }}
                 insight={TERRAFORM_INSIGHT_CONFIGURATION}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         </MockedTestProvider>
     </div>
@@ -1398,6 +1403,7 @@ export const BackendInsightVitrine: StoryFn = () => (
                     style={{ width: 400, height: 400 }}
                     insight={{ ...INSIGHT_CONFIGURATION_MOCK, isFrozen: true }}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
+                    telemetryRecorder={noOpTelemetryRecorder}
                 />
             </MockedTestProvider>
         </article>

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -5,6 +5,7 @@ import { useMergeRefs } from 'use-callback-ref'
 
 import { isDefined } from '@sourcegraph/common'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, useDebounce, useDeepMemo, Text } from '@sourcegraph/wildcard'
 
@@ -36,13 +37,13 @@ import {
 
 import styles from './BackendInsight.module.scss'
 
-interface BackendInsightProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
+interface BackendInsightProps extends TelemetryProps, TelemetryV2Props, HTMLAttributes<HTMLElement> {
     insight: BackendInsight
     resizing?: boolean
 }
 
 export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((props, ref) => {
-    const { telemetryService, insight, resizing, children, className, ...attributes } = props
+    const { telemetryService, telemetryRecorder, insight, resizing, children, className, ...attributes } = props
 
     const { currentDashboard } = useContext(InsightContext)
     const { updateInsight } = useContext(CodeInsightsBackendContext)
@@ -122,6 +123,7 @@ export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((
         await updateInsight({ insightId: insight.id, nextInsightData: insightWithNewFilters }).toPromise()
 
         telemetryService.log('CodeInsightsSearchBasedFilterUpdating')
+        telemetryRecorder.recordEvent('insights.searchBasedfilter', 'update')
         setOriginalInsightFilters(filters)
         setIsFiltersOpen(false)
     }
@@ -137,12 +139,14 @@ export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((
         })
 
         telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
+        telemetryRecorder.recordEvent('insights.searchBasedfilter', 'create') // TODO RENAME?
         setOriginalInsightFilters(filters)
         setIsFiltersOpen(false)
     }
 
     const { trackMouseLeave, trackMouseEnter, trackDatumClicks } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -123,7 +123,7 @@ export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((
         await updateInsight({ insightId: insight.id, nextInsightData: insightWithNewFilters }).toPromise()
 
         telemetryService.log('CodeInsightsSearchBasedFilterUpdating')
-        telemetryRecorder.recordEvent('insights.searchBasedfilter', 'update')
+        telemetryRecorder.recordEvent('insights.searchBasedfilter', 'update', { metadata: { location: 0 } })
         setOriginalInsightFilters(filters)
         setIsFiltersOpen(false)
     }
@@ -139,7 +139,7 @@ export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((
         })
 
         telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
-        telemetryRecorder.recordEvent('insights.searchBasedfilter', 'create') // TODO RENAME?
+        telemetryRecorder.recordEvent('insights.createFromFilter.searchBased', 'submit', { metadata: { location: 0 } })
         setOriginalInsightFilters(filters)
         setIsFiltersOpen(false)
     }

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/backend-insight/BackendInsight.tsx
@@ -208,6 +208,7 @@ export const BackendInsightView = forwardRef<HTMLElement, BackendInsightProps>((
                             currentDashboard={currentDashboard}
                             zeroYAxisMin={zeroYAxisMin}
                             onToggleZeroYAxisMin={() => setZeroYAxisMin(!zeroYAxisMin)}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     </>
                 )}

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/ConfirmRemoveModal.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/ConfirmRemoveModal.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { H3, Text } from '@sourcegraph/wildcard'
 
 import type { Insight, InsightDashboard } from '../../../../core'
 import { useRemoveInsightFromDashboard } from '../../../../hooks/use-remove-insight'
 import { ConfirmationModal, type ConfirmationModalProps } from '../../../modals/ConfirmationModal'
 
-interface ConfirmRemoveModalProps extends Pick<ConfirmationModalProps, 'showModal' | 'onCancel'> {
+interface ConfirmRemoveModalProps extends TelemetryV2Props, Pick<ConfirmationModalProps, 'showModal' | 'onCancel'> {
     insight: Insight
     dashboard: InsightDashboard | null
 }
@@ -16,8 +17,9 @@ export const ConfirmRemoveModal: React.FunctionComponent<React.PropsWithChildren
     dashboard,
     showModal,
     onCancel,
+    telemetryRecorder,
 }) => {
-    const { remove, loading } = useRemoveInsightFromDashboard()
+    const { remove, loading } = useRemoveInsightFromDashboard(telemetryRecorder)
 
     return (
         <ConfirmationModal

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/insight-context-menu/InsightContextMenu.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { noop } from 'lodash'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Link,
     Menu,
@@ -37,7 +38,7 @@ import { ConfirmRemoveModal } from './ConfirmRemoveModal'
 
 import styles from './InsightContextMenu.module.scss'
 
-export interface InsightCardMenuProps {
+export interface InsightCardMenuProps extends TelemetryV2Props {
     insight: Insight
     currentDashboard: InsightDashboard | null
     zeroYAxisMin: boolean
@@ -48,7 +49,7 @@ export interface InsightCardMenuProps {
  * Renders context menu (three dots menu) for particular insight card.
  */
 export const InsightContextMenu: FC<InsightCardMenuProps> = props => {
-    const { insight, currentDashboard, zeroYAxisMin, onToggleZeroYAxisMin = noop } = props
+    const { insight, currentDashboard, zeroYAxisMin, onToggleZeroYAxisMin = noop, telemetryRecorder } = props
 
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
     const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
@@ -186,6 +187,7 @@ export const InsightContextMenu: FC<InsightCardMenuProps> = props => {
                 insight={insight}
                 showModal={showDeleteConfirm}
                 onCancel={() => setShowDeleteConfirm(false)}
+                telemetryRecorder={telemetryRecorder}
             />
 
             <ConfirmRemoveModal
@@ -193,6 +195,7 @@ export const InsightContextMenu: FC<InsightCardMenuProps> = props => {
                 dashboard={currentDashboard}
                 showModal={showRemoveConfirm}
                 onCancel={() => setShowRemoveConfirm(false)}
+                telemetryRecorder={telemetryRecorder}
             />
 
             <ShareLinkModal

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/lang-stats-insight-card/LangStatsInsightCard.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/lang-stats-insight-card/LangStatsInsightCard.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useContext, useState, type HTMLAttributes } from 'react'
 
 import { useMergeRefs } from 'use-callback-ref'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, ParentSize, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -23,13 +24,13 @@ import { InsightContext } from '../InsightContext'
 
 import styles from './LangStatsInsightCard.module.scss'
 
-interface BuiltInInsightProps extends TelemetryProps, HTMLAttributes<HTMLElement> {
+interface BuiltInInsightProps extends TelemetryProps, TelemetryV2Props, HTMLAttributes<HTMLElement> {
     insight: LangStatsInsight
     resizing: boolean
 }
 
 export const LangStatsInsightCard = forwardRef<HTMLElement, BuiltInInsightProps>((props, ref) => {
-    const { insight, resizing, telemetryService, children, ...attributes } = props
+    const { insight, resizing, telemetryService, telemetryRecorder, children, ...attributes } = props
 
     const { currentDashboard } = useContext(InsightContext)
     const cardRef = useMergeRefs([ref])
@@ -46,6 +47,7 @@ export const LangStatsInsightCard = forwardRef<HTMLElement, BuiltInInsightProps>
 
     const { trackDatumClicks, trackMouseLeave, trackMouseEnter } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
 

--- a/client/web/src/enterprise/insights/components/insights-view-grid/components/lang-stats-insight-card/LangStatsInsightCard.tsx
+++ b/client/web/src/enterprise/insights/components/insights-view-grid/components/lang-stats-insight-card/LangStatsInsightCard.tsx
@@ -78,6 +78,7 @@ export const LangStatsInsightCard = forwardRef<HTMLElement, BuiltInInsightProps>
                         currentDashboard={currentDashboard}
                         zeroYAxisMin={zeroYAxisMin}
                         onToggleZeroYAxisMin={() => setZeroYAxisMin(!zeroYAxisMin)}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 )}
             </InsightCardHeader>

--- a/client/web/src/enterprise/insights/components/modals/ConfirmDeleteModal.tsx
+++ b/client/web/src/enterprise/insights/components/modals/ConfirmDeleteModal.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { noop } from 'lodash'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { H3, Text } from '@sourcegraph/wildcard'
 
 import type { Insight } from '../../core'
@@ -11,7 +12,7 @@ import { ConfirmationModal } from './ConfirmationModal'
 
 type MinimalInsightFields = Pick<Insight, 'title' | 'id' | 'type'>
 
-interface ConfirmDeleteModalProps {
+interface ConfirmDeleteModalProps extends TelemetryV2Props {
     insight: MinimalInsightFields
     showModal: boolean
     onCancel?: () => void
@@ -23,8 +24,9 @@ export const ConfirmDeleteModal: React.FunctionComponent<ConfirmDeleteModalProps
     showModal,
     onCancel = noop,
     onConfirm = noop,
+    telemetryRecorder,
 }) => {
-    const { delete: handleDelete, loading } = useDeleteInsight()
+    const { delete: handleDelete, loading } = useDeleteInsight(telemetryRecorder)
 
     const handleConfirm = async (): Promise<void> => {
         if (loading) {

--- a/client/web/src/enterprise/insights/hooks/use-delete-insight.ts
+++ b/client/web/src/enterprise/insights/hooks/use-delete-insight.ts
@@ -53,7 +53,7 @@ export function useDeleteInsight(
                 setError(error)
             }
         },
-        [loading, deleteInsight]
+        [loading, deleteInsight, telemetryRecorder]
     )
 
     return { delete: handleDelete, loading, error }

--- a/client/web/src/enterprise/insights/hooks/use-delete-insight.ts
+++ b/client/web/src/enterprise/insights/hooks/use-delete-insight.ts
@@ -1,10 +1,13 @@
 import { useCallback, useContext, useState } from 'react'
 
 import { type ErrorLike, logger } from '@sourcegraph/common'
+import { BillingCategory, BillingProduct } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryRecorder } from '@sourcegraph/telemetry'
 
 import { eventLogger } from '../../../tracking/eventLogger'
 import { CodeInsightsBackendContext, type Insight } from '../core'
 import { getTrackingTypeByInsightType } from '../pings'
+import { V2InsightType } from '../pings/types'
 
 type DeletionInsight = Pick<Insight, 'id' | 'type'>
 
@@ -18,7 +21,9 @@ export interface UseDeleteInsightAPI {
  * Returns delete handler that deletes insight from all subject settings and from all dashboards
  * that include this insight.
  */
-export function useDeleteInsight(): UseDeleteInsightAPI {
+export function useDeleteInsight(
+    telemetryRecorder: TelemetryRecorder<BillingCategory, BillingProduct>
+): UseDeleteInsightAPI {
     const { deleteInsight } = useContext(CodeInsightsBackendContext)
 
     const [loading, setLoading] = useState<boolean>(false)
@@ -39,6 +44,9 @@ export function useDeleteInsight(): UseDeleteInsightAPI {
                 const insightType = getTrackingTypeByInsightType(insight.type)
 
                 eventLogger.log('InsightRemoval', { insightType }, { insightType })
+                telemetryRecorder.recordEvent('insight', 'delete', {
+                    metadata: { insightType: V2InsightType[insightType] },
+                })
             } catch (error) {
                 // TODO [VK] Improve error UI for deleting
                 logger.error(error)

--- a/client/web/src/enterprise/insights/hooks/use-remove-insight.ts
+++ b/client/web/src/enterprise/insights/hooks/use-remove-insight.ts
@@ -58,7 +58,7 @@ export function useRemoveInsightFromDashboard(
                 setError(error)
             }
         },
-        [loading, removeInsightFromDashboard]
+        [loading, removeInsightFromDashboard, telemetryRecorder]
     )
 
     return { remove: handleRemove, loading, error }

--- a/client/web/src/enterprise/insights/hooks/use-remove-insight.ts
+++ b/client/web/src/enterprise/insights/hooks/use-remove-insight.ts
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useState } from 'react'
 
 import { type ErrorLike, logger } from '@sourcegraph/common'
-import { BillingCategory } from '@sourcegraph/shared/src/telemetry'
+import { BillingCategory, BillingProduct } from '@sourcegraph/shared/src/telemetry'
 import { TelemetryRecorder } from '@sourcegraph/telemetry'
 
 import { eventLogger } from '../../../tracking/eventLogger'
@@ -49,7 +49,7 @@ export function useRemoveInsightFromDashboard(
                 const insightType = getTrackingTypeByInsightType(insight.type)
 
                 eventLogger.log('InsightRemovalFromDashboard', { insightType }, { insightType })
-                telemetryRecorder.recordEvent('insight', 'remove', {
+                telemetryRecorder.recordEvent('insight', 'removeFromDashboard', {
                     metadata: { insightType: V2InsightType[insightType] },
                 })
             } catch (error) {

--- a/client/web/src/enterprise/insights/hooks/use-remove-insight.ts
+++ b/client/web/src/enterprise/insights/hooks/use-remove-insight.ts
@@ -1,10 +1,13 @@
 import { useCallback, useContext, useState } from 'react'
 
 import { type ErrorLike, logger } from '@sourcegraph/common'
+import { BillingCategory } from '@sourcegraph/shared/src/telemetry'
+import { TelemetryRecorder } from '@sourcegraph/telemetry'
 
 import { eventLogger } from '../../../tracking/eventLogger'
 import { CodeInsightsBackendContext, type Insight, type InsightDashboard } from '../core'
 import { getTrackingTypeByInsightType } from '../pings'
+import { V2InsightType } from '../pings/types'
 
 interface RemoveInsightInput {
     insight: Pick<Insight, 'id' | 'title' | 'type'>
@@ -17,7 +20,9 @@ export interface useRemoveInsightFromDashboardAPI {
     error: ErrorLike | undefined
 }
 
-export function useRemoveInsightFromDashboard(): useRemoveInsightFromDashboardAPI {
+export function useRemoveInsightFromDashboard(
+    telemetryRecorder: TelemetryRecorder<BillingCategory, BillingProduct>
+): useRemoveInsightFromDashboardAPI {
     const { removeInsightFromDashboard } = useContext(CodeInsightsBackendContext)
 
     const [loading, setLoading] = useState<boolean>(false)
@@ -44,6 +49,9 @@ export function useRemoveInsightFromDashboard(): useRemoveInsightFromDashboardAP
                 const insightType = getTrackingTypeByInsightType(insight.type)
 
                 eventLogger.log('InsightRemovalFromDashboard', { insightType }, { insightType })
+                telemetryRecorder.recordEvent('insight', 'remove', {
+                    metadata: { insightType: V2InsightType[insightType] },
+                })
             } catch (error) {
                 // TODO [VK] Improve error UI for removing
                 logger.error(error)

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.test.tsx
@@ -9,6 +9,7 @@ import sinon from 'sinon'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { MockIntersectionObserver } from '@sourcegraph/shared/src/testing/MockIntersectionObserver'
 
@@ -102,6 +103,7 @@ describe('CodeInsightsRootPage', () => {
             <CodeInsightsRootPage
                 activeTab={CodeInsightsRootPageTab.Dashboards}
                 telemetryService={mockTelemetryService}
+                telemetryRecorder={noOpTelemetryRecorder}
             />,
             {
                 route: '/insights/dashboards/foo',
@@ -117,6 +119,7 @@ describe('CodeInsightsRootPage', () => {
             <CodeInsightsRootPage
                 activeTab={CodeInsightsRootPageTab.Dashboards}
                 telemetryService={mockTelemetryService}
+                telemetryRecorder={noOpTelemetryRecorder}
             />,
             {
                 route: '/insights/dashboards/foo',

--- a/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
+++ b/client/web/src/enterprise/insights/pages/CodeInsightsRootPage.tsx
@@ -3,6 +3,7 @@ import { Suspense, type FC, memo, useMemo } from 'react'
 import { mdiPlus } from '@mdi/js'
 import { useParams, useNavigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 import {
@@ -41,13 +42,13 @@ export enum CodeInsightsRootPageTab {
     GettingStarted,
 }
 
-interface CodeInsightsRootPageProps extends TelemetryProps {
+interface CodeInsightsRootPageProps extends TelemetryProps, TelemetryV2Props {
     dashboardId?: string
     activeTab: CodeInsightsRootPageTab
 }
 
 export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props => {
-    const { activeTab, telemetryService } = props
+    const { activeTab, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const { dashboardId } = useParams()
@@ -81,7 +82,11 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props =>
             <PageHeader
                 path={[{ icon: CodeInsightsIcon, text: 'Insights' }]}
                 actions={
-                    <CodeInsightHeaderActions dashboardId={absoluteDashboardId} telemetryService={telemetryService} />
+                    <CodeInsightHeaderActions
+                        dashboardId={absoluteDashboardId}
+                        telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
+                    />
                 }
                 className={styles.header}
             />
@@ -100,14 +105,21 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props =>
                 </TabList>
                 <TabPanels className={styles.tabPanels}>
                     <TabPanel tabIndex={-1}>
-                        <DashboardsView dashboardId={dashboardId} telemetryService={telemetryService} />
+                        <DashboardsView
+                            dashboardId={dashboardId}
+                            telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
+                        />
                     </TabPanel>
                     <TabPanel tabIndex={-1}>
-                        <AllInsightsView telemetryService={telemetryService} />
+                        <AllInsightsView telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
                     </TabPanel>
                     <TabPanel tabIndex={-1}>
                         <Suspense fallback={<LoadingSpinner aria-label="Loading Code Insights Getting started page" />}>
-                            <LazyCodeInsightsGettingStartedPage telemetryService={telemetryService} />
+                            <LazyCodeInsightsGettingStartedPage
+                                telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
+                            />
                         </Suspense>
                     </TabPanel>
                 </TabPanels>
@@ -116,12 +128,12 @@ export const CodeInsightsRootPage: FC<CodeInsightsRootPageProps> = memo(props =>
     )
 })
 
-interface CodeInsightHeaderActionsProps extends TelemetryProps {
+interface CodeInsightHeaderActionsProps extends TelemetryProps, TelemetryV2Props {
     dashboardId?: string
 }
 
 const CodeInsightHeaderActions: FC<CodeInsightHeaderActionsProps> = props => {
-    const { dashboardId, telemetryService } = props
+    const { dashboardId, telemetryService, telemetryRecorder } = props
 
     const { insight } = useUiFeatures()
     const creationPermission = useObservable(useMemo(() => insight.getCreationPermissions(), [insight]))
@@ -145,7 +157,10 @@ const CodeInsightHeaderActions: FC<CodeInsightHeaderActionsProps> = props => {
                     as={Link}
                     to={encodeDashboardIdQueryParam('/insights/create', dashboardId)}
                     variant="primary"
-                    onClick={() => telemetryService.log('InsightAddMoreClick')}
+                    onClick={() => {
+                        telemetryService.log('InsightAddMoreClick')
+                        telemetryRecorder.recordEvent('insight.add', 'click')
+                    }}
                     disabled={!available}
                 >
                     <Icon aria-hidden={true} svgPath={mdiPlus} /> Create insight

--- a/client/web/src/enterprise/insights/pages/all-insights-view/AllInsightsView.tsx
+++ b/client/web/src/enterprise/insights/pages/all-insights-view/AllInsightsView.tsx
@@ -4,6 +4,7 @@ import { mdiPlus } from '@mdi/js'
 
 import { isDefined } from '@sourcegraph/common'
 import { dataOrThrowErrors } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Card, Icon, Link, LoadingSpinner, Button, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -20,7 +21,7 @@ import { GET_ALL_INSIGHT_CONFIGURATIONS } from './query'
 
 import styles from './AllInsightsView.module.scss'
 
-interface AllInsightsViewProps extends TelemetryProps {}
+interface AllInsightsViewProps extends TelemetryProps, TelemetryV2Props {}
 
 export const AllInsightsView: FC<AllInsightsViewProps> = props => {
     const { connection, loading, hasNextPage, error, fetchMore } = useShowMorePagination<
@@ -55,6 +56,7 @@ export const AllInsightsView: FC<AllInsightsViewProps> = props => {
                 insights={insights}
                 persistSizeAndOrder={false}
                 telemetryService={props.telemetryService}
+                telemetryRecorder={props.telemetryRecorder}
             />
 
             <footer className={styles.footer}>

--- a/client/web/src/enterprise/insights/pages/all-insights-view/AllInsightsView.tsx
+++ b/client/web/src/enterprise/insights/pages/all-insights-view/AllInsightsView.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react'
+import { useEffect, type FC } from 'react'
 
 import { mdiPlus } from '@mdi/js'
 
@@ -38,6 +38,8 @@ export const AllInsightsView: FC<AllInsightsViewProps> = props => {
         },
         options: { fetchPolicy: 'cache-and-network' },
     })
+
+    useEffect(() => props.telemetryRecorder.recordEvent('insights.allInsights', 'view'), [props.telemetryRecorder])
 
     if (connection === undefined) {
         return <LoadingSpinner aria-hidden={true} inline={false} />

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.story.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 import { of } from 'rxjs'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../components/WebStory'
@@ -39,7 +40,10 @@ export const InsightsDashboardCreationLicensed: StoryFn = () => {
 
     return (
         <CodeInsightsBackendStoryMock mocks={codeInsightsBackend}>
-            <InsightsDashboardCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+            <InsightsDashboardCreationPage
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
         </CodeInsightsBackendStoryMock>
     )
 }
@@ -49,7 +53,10 @@ export const InsightsDashboardCreationUnlicensed: StoryFn = () => {
 
     return (
         <CodeInsightsBackendStoryMock mocks={codeInsightsBackend}>
-            <InsightsDashboardCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+            <InsightsDashboardCreationPage
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
+            />
         </CodeInsightsBackendStoryMock>
     )
 }

--- a/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/creation/InsightsDashboardCreationPage.tsx
@@ -3,6 +3,7 @@ import React, { useContext, useMemo } from 'react'
 import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Container, Button, LoadingSpinner, useObservable, Link, Tooltip } from '@sourcegraph/wildcard'
 
@@ -19,12 +20,12 @@ import {
 
 import styles from './InsightsDashboardCreationPage.module.scss'
 
-interface InsightsDashboardCreationPageProps extends TelemetryProps {}
+interface InsightsDashboardCreationPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export const InsightsDashboardCreationPage: React.FunctionComponent<
     React.PropsWithChildren<InsightsDashboardCreationPageProps>
 > = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const { dashboard } = useUiFeatures()
@@ -43,6 +44,7 @@ export const InsightsDashboardCreationPage: React.FunctionComponent<
         const createdDashboard = await createDashboard({ name, owners: [owner] }).toPromise()
 
         telemetryService.log('CodeInsightsDashboardCreationPageSubmitClick')
+        telemetryRecorder.recordEvent('insights.dashboard', 'create')
 
         // Navigate user to the dashboard page with new created dashboard
         navigate(`/insights/dashboards/${createdDashboard.id}`)

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/DashboardsContentPage.test.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/DashboardsContentPage.test.tsx
@@ -9,6 +9,7 @@ import sinon from 'sinon'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { MockIntersectionObserver } from '@sourcegraph/shared/src/testing/MockIntersectionObserver'
 import { type RenderWithBrandedContextResult, renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
@@ -169,7 +170,11 @@ const renderDashboardsContent = (
     ...renderWithBrandedContext(
         <MockedTestProvider mocks={mocks}>
             <Wrapper>
-                <DashboardsView dashboardId={dashboardID} telemetryService={mockTelemetryService} />
+                <DashboardsView
+                    dashboardId={dashboardID}
+                    telemetryService={mockTelemetryService}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </Wrapper>
         </MockedTestProvider>
     ),

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/DashboardsView.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/DashboardsView.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 
 import { Navigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner } from '@sourcegraph/wildcard'
 
@@ -10,7 +11,7 @@ import { isPersonalDashboard, useInsightDashboards } from '../../../core'
 
 import { DashboardsContent } from './components/dashboards-content/DashboardsContent'
 
-export interface DashboardsViewProps extends TelemetryProps {
+export interface DashboardsViewProps extends TelemetryProps, TelemetryV2Props {
     /**
      * Possible dashboard id. All insights on the page will be got from
      * dashboard's info from the user or org settings by the dashboard id.
@@ -21,7 +22,7 @@ export interface DashboardsViewProps extends TelemetryProps {
 }
 
 export const DashboardsView: FC<DashboardsViewProps> = props => {
-    const { dashboardId, telemetryService } = props
+    const { dashboardId, telemetryService, telemetryRecorder } = props
 
     const { dashboards } = useInsightDashboards()
 
@@ -51,6 +52,7 @@ export const DashboardsView: FC<DashboardsViewProps> = props => {
                 currentDashboard={currentDashboard}
                 dashboards={dashboards}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
             />
         </>
     )

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/DashboardsContent.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/DashboardsContent.tsx
@@ -6,6 +6,7 @@ import ViewDashboardOutlineIcon from 'mdi-react/ViewDashboardOutlineIcon'
 import { useNavigate } from 'react-router-dom'
 
 import { useTemporarySetting } from '@sourcegraph/shared/src/settings/temporary/useTemporarySetting'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Tooltip } from '@sourcegraph/wildcard'
 
@@ -23,13 +24,13 @@ import { DashboardInsights } from './components/dashboard-inisghts/DashboardInsi
 
 import styles from './DashboardsContent.module.scss'
 
-export interface DashboardsContentProps extends TelemetryProps {
+export interface DashboardsContentProps extends TelemetryProps, TelemetryV2Props {
     currentDashboard: CustomInsightDashboard | undefined
     dashboards: CustomInsightDashboard[]
 }
 
 export const DashboardsContent: FC<DashboardsContentProps> = props => {
-    const { currentDashboard, dashboards, telemetryService } = props
+    const { currentDashboard, dashboards, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const [, setLasVisitedDashboard] = useTemporarySetting('insights.lastVisitedDashboardId', null)
@@ -40,7 +41,10 @@ export const DashboardsContent: FC<DashboardsContentProps> = props => {
     const [isDeleteDashboardActive, setDeleteDashboardActive] = useState<boolean>(false)
     const [dashboardGridApi, setDashboardGridApi] = useState<GridApi>()
 
-    useEffect(() => telemetryService.logViewEvent('Insights'), [telemetryService])
+    useEffect(() => {
+        telemetryService.logViewEvent('Insights')
+        telemetryRecorder.recordEvent('insights.dashboard', 'view')
+    }, [telemetryService, telemetryRecorder])
     useEffect(() => setLasVisitedDashboard(currentDashboard?.id ?? null), [currentDashboard, setLasVisitedDashboard])
 
     const handleDashboardSelect = (dashboard: CustomInsightDashboard): void =>
@@ -113,6 +117,7 @@ export const DashboardsContent: FC<DashboardsContentProps> = props => {
                 <DashboardInsights
                     currentDashboard={currentDashboard}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     className={styles.insights}
                     onAddInsightRequest={() => setAddInsightsState(true)}
                     onDashboardCreate={setDashboardGridApi}

--- a/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
+++ b/client/web/src/enterprise/insights/pages/dashboards/dashboard-view/components/dashboards-content/components/dashboard-inisghts/DashboardInsights.tsx
@@ -1,6 +1,7 @@
 import { type FC, useContext, useMemo } from 'react'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, useObservable } from '@sourcegraph/wildcard'
 
@@ -8,7 +9,7 @@ import { SmartInsightsViewGrid, InsightContext, type GridApi } from '../../../..
 import { CodeInsightsBackendContext, type CustomInsightDashboard } from '../../../../../../../core'
 import { EmptyCustomDashboard } from '../empty-insight-dashboard/EmptyInsightDashboard'
 
-interface DashboardInsightsProps extends TelemetryProps {
+interface DashboardInsightsProps extends TelemetryProps, TelemetryV2Props {
     currentDashboard: CustomInsightDashboard
     className?: string
     onAddInsightRequest?: () => void
@@ -16,7 +17,8 @@ interface DashboardInsightsProps extends TelemetryProps {
 }
 
 export const DashboardInsights: FC<DashboardInsightsProps> = props => {
-    const { currentDashboard, telemetryService, className, onAddInsightRequest, onDashboardCreate } = props
+    const { currentDashboard, telemetryService, telemetryRecorder, className, onAddInsightRequest, onDashboardCreate } =
+        props
 
     const { getInsights } = useContext(CodeInsightsBackendContext)
     const codeInsightsCompute = useExperimentalFeatures(settings => settings.codeInsightsCompute ?? false)
@@ -45,6 +47,7 @@ export const DashboardInsights: FC<DashboardInsightsProps> = props => {
                     id={currentDashboard.id}
                     insights={insights}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     className={className}
                     onGridCreate={onDashboardCreate}
                 />

--- a/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/CreationRoutes.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import { Routes, Route } from 'react-router-dom'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { lazyComponent } from '@sourcegraph/shared/src/util/lazyComponent'
 
@@ -11,20 +12,25 @@ import { InsightCreationPageType } from './InsightCreationPage'
 const IntroCreationLazyPage = lazyComponent(() => import('./intro/IntroCreationPage'), 'IntroCreationPage')
 const InsightCreationLazyPage = lazyComponent(() => import('./InsightCreationPage'), 'InsightCreationPage')
 
-interface CreationRoutesProps extends TelemetryProps {}
+interface CreationRoutesProps extends TelemetryProps, TelemetryV2Props {}
 
 /**
  * Code insight sub-router for the creation area/routes.
  * Renders code insights creation routes (insight creation UI pages, creation intro page)
  */
 export const CreationRoutes: FC<CreationRoutesProps> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const codeInsightsCompute = useExperimentalFeatures(settings => settings.codeInsightsCompute)
 
     return (
         <Routes>
-            <Route index={true} element={<IntroCreationLazyPage telemetryService={telemetryService} />} />
+            <Route
+                index={true}
+                element={
+                    <IntroCreationLazyPage telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
+                }
+            />
 
             <Route
                 path="search"
@@ -32,6 +38,7 @@ export const CreationRoutes: FC<CreationRoutesProps> = props => {
                     <InsightCreationLazyPage
                         mode={InsightCreationPageType.Search}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 }
             />
@@ -42,6 +49,7 @@ export const CreationRoutes: FC<CreationRoutesProps> = props => {
                     <InsightCreationLazyPage
                         mode={InsightCreationPageType.CaptureGroup}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 }
             />
@@ -52,6 +60,7 @@ export const CreationRoutes: FC<CreationRoutesProps> = props => {
                     <InsightCreationLazyPage
                         mode={InsightCreationPageType.LangStats}
                         telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 }
             />
@@ -63,6 +72,7 @@ export const CreationRoutes: FC<CreationRoutesProps> = props => {
                         <InsightCreationLazyPage
                             mode={InsightCreationPageType.Compute}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     }
                 />

--- a/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/InsightCreationPage.tsx
@@ -3,6 +3,7 @@ import { type FC, useContext } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { CodeInsightsBackendContext, type CreationInsightInput } from '../../../core'
@@ -25,12 +26,12 @@ interface InsightCreateEvent {
     insight: CreationInsightInput
 }
 
-interface InsightCreationPageProps extends TelemetryProps {
+interface InsightCreationPageProps extends TelemetryProps, TelemetryV2Props {
     mode: InsightCreationPageType
 }
 
 export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
-    const { mode, telemetryService } = props
+    const { mode, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const { createInsight } = useContext(CodeInsightsBackendContext)
@@ -72,6 +73,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
             <CaptureGroupCreationPage
                 backUrl={backCreateUrl}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 onInsightCreateRequest={handleInsightCreateRequest}
                 onSuccessfulCreation={handleInsightSuccessfulCreation}
                 onCancel={handleCancel}
@@ -84,6 +86,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
             <SearchInsightCreationPage
                 backUrl={backCreateUrl}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 onInsightCreateRequest={handleInsightCreateRequest}
                 onSuccessfulCreation={handleInsightSuccessfulCreation}
                 onCancel={handleCancel}
@@ -96,6 +99,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
             <ComputeInsightCreationPage
                 backUrl={backCreateUrl}
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 onInsightCreateRequest={handleInsightCreateRequest}
                 onSuccessfulCreation={handleInsightSuccessfulCreation}
                 onCancel={handleCancel}
@@ -107,6 +111,7 @@ export const InsightCreationPage: FC<InsightCreationPageProps> = props => {
         <LangStatsInsightCreationPage
             backUrl={backCreateUrl}
             telemetryService={telemetryService}
+            telemetryRecorder={telemetryRecorder}
             onInsightCreateRequest={handleInsightCreateRequest}
             onSuccessfulCreation={handleInsightSuccessfulCreation}
             onCancel={handleCancel}

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.story.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react'
 import { noop } from 'lodash'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../../components/WebStory'
@@ -31,6 +32,7 @@ export const CaptureGroupCreationPage: StoryFn = () => {
             onSuccessfulCreation={noop}
             onInsightCreateRequest={() => Promise.resolve()}
             onCancel={noop}
+            telemetryRecorder={noOpTelemetryRecorder}
         />
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
@@ -1,5 +1,6 @@
-import { type FC, useEffect, useMemo } from 'react'
+import { type FC, useEffect, useMemo, useCallback } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Link,
@@ -22,7 +23,7 @@ import { useCaptureInsightInitialValues } from './hooks/use-capture-insight-init
 import type { CaptureGroupFormFields } from './types'
 import { getSanitizedCaptureGroupInsight } from './utils/capture-group-insight-sanitizer'
 
-interface CaptureGroupCreationPageProps extends TelemetryProps {
+interface CaptureGroupCreationPageProps extends TelemetryProps, TelemetryV2Props {
     backUrl: string
     onInsightCreateRequest: (event: { insight: MinimalCaptureGroupInsightData }) => Promise<unknown>
     onSuccessfulCreation: () => void
@@ -30,7 +31,8 @@ interface CaptureGroupCreationPageProps extends TelemetryProps {
 }
 
 export const CaptureGroupCreationPage: FC<CaptureGroupCreationPageProps> = props => {
-    const { backUrl, telemetryService, onInsightCreateRequest, onSuccessfulCreation, onCancel } = props
+    const { backUrl, telemetryService, telemetryRecorder, onInsightCreateRequest, onSuccessfulCreation, onCancel } =
+        props
 
     const { licensed, insight } = useUiFeatures()
     const creationPermission = useObservable(useMemo(() => insight.getCreationPermissions(), [insight]))
@@ -39,31 +41,37 @@ export const CaptureGroupCreationPage: FC<CaptureGroupCreationPageProps> = props
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeInsightsCaptureGroupCreationPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('insights.create.captureGroup', 'view')
+    }, [telemetryService, telemetryRecorder])
 
-    const handleSubmit = async (values: CaptureGroupFormFields): Promise<SubmissionErrors | void> => {
-        const insight = getSanitizedCaptureGroupInsight(values)
+    const handleSubmit = useCallback(
+        async (values: CaptureGroupFormFields): Promise<SubmissionErrors> => {
+            // const handleSubmit = async (values: CaptureGroupFormFields): Promise<SubmissionErrors | void> => {
+            const insight = getSanitizedCaptureGroupInsight(values)
 
-        await onInsightCreateRequest({ insight })
+            await onInsightCreateRequest({ insight })
 
-        setInitialFormValues(undefined)
-        telemetryService.log('CodeInsightsCaptureGroupCreationPageSubmitClick')
-        telemetryService.log(
-            'InsightAddition',
-            { insightType: CodeInsightTrackType.CaptureGroupInsight },
-            { insightType: CodeInsightTrackType.CaptureGroupInsight }
-        )
+            setInitialFormValues(undefined)
+            telemetryRecorder.recordEvent('insights.create.captureGroup', 'submit')
+            telemetryService.log('CodeInsightsCaptureGroupCreationPageSubmitClick')
+            telemetryService.log(
+                'InsightAddition',
+                { insightType: CodeInsightTrackType.CaptureGroupInsight },
+                { insightType: CodeInsightTrackType.CaptureGroupInsight }
+            )
 
-        onSuccessfulCreation()
-    }
+            onSuccessfulCreation()
+        },
+        [onInsightCreateRequest, onSuccessfulCreation, setInitialFormValues, telemetryRecorder, telemetryService]
+    )
 
-    const handleCancel = (): void => {
+    const handleCancel = useCallback(() => {
         // Clear initial values if user successfully created search insight
         setInitialFormValues(undefined)
         telemetryService.log('CodeInsightsCaptureGroupCreationPageCancelClick')
-
+        telemetryRecorder.recordEvent('insights.create.captureGroup', 'cancel')
         onCancel()
-    }
+    }, [setInitialFormValues, telemetryRecorder, telemetryService, onCancel])
 
     const handleChange = (event: FormChangeEvent<CaptureGroupFormFields>): void => {
         setInitialFormValues(event.values)

--- a/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/capture-group/CaptureGroupCreationPage.tsx
@@ -46,7 +46,6 @@ export const CaptureGroupCreationPage: FC<CaptureGroupCreationPageProps> = props
 
     const handleSubmit = useCallback(
         async (values: CaptureGroupFormFields): Promise<SubmissionErrors> => {
-            // const handleSubmit = async (values: CaptureGroupFormFields): Promise<SubmissionErrors | void> => {
             const insight = getSanitizedCaptureGroupInsight(values)
 
             await onInsightCreateRequest({ insight })

--- a/client/web/src/enterprise/insights/pages/insights/creation/compute/ComputeInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/compute/ComputeInsightCreationPage.story.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import delay from 'delay'
 import { noop } from 'lodash'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../../components/WebStory'
@@ -38,6 +39,7 @@ export const ComputeInsightCreationPage: StoryFn = () => {
             onInsightCreateRequest={fakeAPIRequest}
             onSuccessfulCreation={noop}
             onCancel={noop}
+            telemetryRecorder={noOpTelemetryRecorder}
         />
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../../components/WebStory'
@@ -28,7 +29,7 @@ export const IntroPageLicensed: StoryFn = () => {
 
     return (
         <CodeInsightsBackendContext.Provider value={API}>
-            <IntroCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+            <IntroCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} telemetryRecorder={noOpTelemetryRecorder} />
         </CodeInsightsBackendContext.Provider>
     )
 }
@@ -38,7 +39,7 @@ export const IntroPageUnLicensed: StoryFn = () => {
 
     return (
         <CodeInsightsBackendContext.Provider value={API}>
-            <IntroCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+            <IntroCreationPage telemetryService={NOOP_TELEMETRY_SERVICE} telemetryRecorder={noOpTelemetryRecorder} />
         </CodeInsightsBackendContext.Provider>
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/intro/IntroCreationPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { PageHeader, Link } from '@sourcegraph/wildcard'
 
@@ -19,11 +20,11 @@ import {
 
 import styles from './IntroCreationPage.module.scss'
 
-interface IntroCreationPageProps extends TelemetryProps {}
+interface IntroCreationPageProps extends TelemetryProps, TelemetryV2Props {}
 
 /** Displays intro page for insights creation UI. */
 export const IntroCreationPage: React.FunctionComponent<React.PropsWithChildren<IntroCreationPageProps>> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
     const { search } = useLocation()
@@ -31,27 +32,32 @@ export const IntroCreationPage: React.FunctionComponent<React.PropsWithChildren<
 
     const handleCreateSearchBasedInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateSearchBasedInsightClick')
+        telemetryRecorder.recordEvent('insights.create.searchBased', 'click')
         navigate(`/insights/create/search${search}`)
     }
 
     const handleCaptureGroupInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateCaptureGroupInsightClick')
+        telemetryRecorder.recordEvent('insights.create.captureGroup', 'click')
         navigate(`/insights/create/capture-group${search}`)
     }
 
     const handleCreateComputeInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateComputeInsightClick')
+        telemetryRecorder.recordEvent('insights.create.compute', 'click')
         navigate(`/insights/create/group-results${search}`)
     }
 
     const handleCreateCodeStatsInsightClick = (): void => {
         telemetryService.log('CodeInsightsCreateCodeStatsInsightClick')
+        telemetryRecorder.recordEvent('insights.create.codeStats', 'click')
         navigate(`/insights/create/lang-stats${search}`)
     }
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeInsightsCreationPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('insights.create', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <CodeInsightsPage className={styles.container}>

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.story.tsx
@@ -4,6 +4,7 @@ import delay from 'delay'
 import { noop } from 'lodash'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -67,6 +68,7 @@ export const LangStatsInsightCreationPage: StoryFn = () => {
                 onCancel={noop}
                 onSuccessfulCreation={noop}
                 telemetryService={NOOP_TELEMETRY_SERVICE}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         </MockedTestProvider>
     )

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -74,7 +74,7 @@ export const LangStatsInsightCreationPage: FC<LangStatsInsightCreationPageProps>
 
             // Clear initial values if user successfully created search insight
             setInitialFormValues(undefined)
-            telemetryRecorder.recordEvent('insights.create.codeStats', 'create', {
+            telemetryRecorder.recordEvent('insights.create.codeStats', 'submit', {
                 metadata: { type: V2InsightType[CodeInsightTrackType.LangStatsInsight] },
             })
             telemetryService.log('CodeInsightsCodeStatsCreationPageSubmitClick')

--- a/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -1,5 +1,6 @@
 import { type FC, useCallback, useEffect, useMemo } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useLocalStorage, Link, PageHeader, useObservable, FORM_ERROR } from '@sourcegraph/wildcard'
 
@@ -9,6 +10,7 @@ import { CodeInsightCreationMode, CodeInsightsCreationActions, CodeInsightsPage 
 import type { MinimalLangStatsInsightData } from '../../../../core'
 import { useUiFeatures } from '../../../../hooks'
 import { CodeInsightTrackType } from '../../../../pings'
+import { V2InsightType } from '../../../../pings/types'
 
 import {
     LangStatsInsightCreationContent,
@@ -21,7 +23,7 @@ export interface InsightCreateEvent {
     insight: MinimalLangStatsInsightData
 }
 
-export interface LangStatsInsightCreationPageProps extends TelemetryProps {
+export interface LangStatsInsightCreationPageProps extends TelemetryProps, TelemetryV2Props {
     backUrl: string
 
     /**
@@ -44,7 +46,8 @@ export interface LangStatsInsightCreationPageProps extends TelemetryProps {
 }
 
 export const LangStatsInsightCreationPage: FC<LangStatsInsightCreationPageProps> = props => {
-    const { backUrl, telemetryService, onInsightCreateRequest, onCancel, onSuccessfulCreation } = props
+    const { backUrl, telemetryService, telemetryRecorder, onInsightCreateRequest, onCancel, onSuccessfulCreation } =
+        props
 
     const { licensed, insight } = useUiFeatures()
     const creationPermission = useObservable(useMemo(() => insight.getCreationPermissions(), [insight]))
@@ -60,7 +63,8 @@ export const LangStatsInsightCreationPage: FC<LangStatsInsightCreationPageProps>
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeInsightsCodeStatsCreationPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('insights.create.codeStats', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const handleSubmit = useCallback<LangStatsInsightCreationContentProps['onSubmit']>(
         async values => {
@@ -70,6 +74,9 @@ export const LangStatsInsightCreationPage: FC<LangStatsInsightCreationPageProps>
 
             // Clear initial values if user successfully created search insight
             setInitialFormValues(undefined)
+            telemetryRecorder.recordEvent('insights.create.codeStats', 'create', {
+                metadata: { type: V2InsightType[CodeInsightTrackType.LangStatsInsight] },
+            })
             telemetryService.log('CodeInsightsCodeStatsCreationPageSubmitClick')
             telemetryService.log(
                 'InsightAddition',
@@ -79,16 +86,17 @@ export const LangStatsInsightCreationPage: FC<LangStatsInsightCreationPageProps>
 
             onSuccessfulCreation()
         },
-        [onInsightCreateRequest, onSuccessfulCreation, setInitialFormValues, telemetryService]
+        [onInsightCreateRequest, onSuccessfulCreation, setInitialFormValues, telemetryService, telemetryRecorder]
     )
 
     const handleCancel = useCallback(() => {
         // Clear initial values if user successfully created search insight
         setInitialFormValues(undefined)
         telemetryService.log('CodeInsightsCodeStatsCreationPageCancelClick')
+        telemetryRecorder.recordEvent('insights.create.codeStats', 'cancel')
 
         onCancel()
-    }, [setInitialFormValues, telemetryService, onCancel])
+    }, [setInitialFormValues, telemetryService, telemetryRecorder, onCancel])
 
     return (
         <CodeInsightsPage>

--- a/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/creation/search-insight/SearchInsightCreationPage.story.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import delay from 'delay'
 import { noop } from 'lodash'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../../components/WebStory'
@@ -38,6 +39,7 @@ export const SearchInsightCreationPage: StoryFn = () => {
             onInsightCreateRequest={fakeAPIRequest}
             onSuccessfulCreation={noop}
             onCancel={noop}
+            telemetryRecorder={noOpTelemetryRecorder}
         />
     )
 }

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/EditInsightPage.tsx
@@ -3,6 +3,7 @@ import { type FC, useContext, useMemo } from 'react'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import { useParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { LoadingSpinner, useObservable, Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
 import { HeroPage } from '../../../../../components/HeroPage'
@@ -24,7 +25,9 @@ import { EditLangStatsInsight } from './components/EditLangStatsInsight'
 import { EditSearchBasedInsight } from './components/EditSearchInsight'
 import { useEditPageHandlers } from './hooks/use-edit-page-handlers'
 
-export const EditInsightPage: FC = () => {
+interface EditInsightPageProps extends TelemetryV2Props {}
+
+export const EditInsightPage: FC<EditInsightPageProps> = ({ telemetryRecorder }) => {
     /** Normalized insight id <type insight>.insight.<name of insight> */
     const { insightId } = useParams()
 
@@ -32,7 +35,7 @@ export const EditInsightPage: FC = () => {
     const { licensed, insight: insightFeatures } = useUiFeatures()
 
     const insight = useObservable(useMemo(() => getInsightById(insightId!), [getInsightById, insightId]))
-    const { handleSubmit, handleCancel } = useEditPageHandlers({ id: insight?.id })
+    const { handleSubmit, handleCancel } = useEditPageHandlers({ id: insight?.id, telemetryRecorder })
 
     const editPermission = useObservable(
         useMemo(() => insightFeatures.getEditPermissions(insight), [insightFeatures, insight])

--- a/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
+++ b/client/web/src/enterprise/insights/pages/insights/edit-insight/hooks/use-edit-page-handlers.ts
@@ -2,23 +2,29 @@ import { useContext } from 'react'
 
 import { useNavigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { SubmissionErrors } from '@sourcegraph/wildcard'
 
 import { eventLogger } from '../../../../../../tracking/eventLogger'
 import { CodeInsightsBackendContext, type CreationInsightInput } from '../../../../core'
 import { useQueryParameters } from '../../../../hooks'
 import { getTrackingTypeByInsightType } from '../../../../pings'
+import { V2InsightType } from '../../../../pings/types'
 
 export interface useHandleSubmitOutput {
     handleSubmit: (newInsight: CreationInsightInput) => Promise<SubmissionErrors>
     handleCancel: () => void
 }
 
+interface Props extends TelemetryV2Props {
+    id: string | undefined
+}
+
 /**
  * Returns submit and cancel handlers for the insight edit submit page.
  */
-export function useEditPageHandlers(props: { id: string | undefined }): useHandleSubmitOutput {
-    const { id } = props
+export function useEditPageHandlers(props: Props): useHandleSubmitOutput {
+    const { id, telemetryRecorder } = props
     const { updateInsight } = useContext(CodeInsightsBackendContext)
     const navigate = useNavigate()
 
@@ -37,6 +43,7 @@ export function useEditPageHandlers(props: { id: string | undefined }): useHandl
 
         const insightType = getTrackingTypeByInsightType(newInsight.type)
         eventLogger.log('InsightEdit', { insightType }, { insightType })
+        telemetryRecorder.recordEvent('insight', 'edit', { metadata: { type: V2InsightType[insightType] } })
         navigate(redirectUrl)
     }
 

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -31,7 +31,7 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
     useEffect(() => {
         telemetryService.logPageView('StandaloneInsightPage')
         telemetryRecorder.recordEvent('insight', 'view')
-    }, [telemetryService])
+    }, [telemetryService, telemetryRecorder])
 
     if (insight === undefined) {
         return <LoadingSpinner inline={false} />

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -30,7 +30,7 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
 
     useEffect(() => {
         telemetryService.logPageView('StandaloneInsightPage')
-        telemetryRecorder.recordEvent('insights.standalone', 'view')
+        telemetryRecorder.recordEvent('insight', 'view')
     }, [telemetryService])
 
     if (insight === undefined) {

--- a/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/CodeInsightIndependentPage.tsx
@@ -2,6 +2,7 @@ import { type FunctionComponent, useContext, useEffect, useMemo } from 'react'
 
 import { useParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LoadingSpinner, PageHeader, useObservable } from '@sourcegraph/wildcard'
 
@@ -17,10 +18,10 @@ import { Standalone404Insight } from './components/standalone-404-insight/Standa
 
 import styles from './CodeInsightIndependentPage.module.scss'
 
-interface CodeInsightIndependentPage extends TelemetryProps {}
+interface CodeInsightIndependentPage extends TelemetryProps, TelemetryV2Props {}
 
 export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependentPage> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     const { insightId } = useParams()
     const { getInsightById } = useContext(CodeInsightsBackendContext)
@@ -29,6 +30,7 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
 
     useEffect(() => {
         telemetryService.logPageView('StandaloneInsightPage')
+        telemetryRecorder.recordEvent('insights.standalone', 'view')
     }, [telemetryService])
 
     if (insight === undefined) {
@@ -44,18 +46,29 @@ export const CodeInsightIndependentPage: FunctionComponent<CodeInsightIndependen
             <PageTitle title={`${insight.title} - Code Insights`} />
             <PageHeader
                 path={[{ to: '/insights/all', icon: CodeInsightsIcon }, { text: insight.title }]}
-                actions={<CodeInsightIndependentPageActions insight={insight} telemetryService={telemetryService} />}
+                actions={
+                    <CodeInsightIndependentPageActions
+                        insight={insight}
+                        telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
+                    />
+                }
             />
 
             <StandaloneInsightDashboardPills
                 telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
                 dashboards={insight.dashboards}
                 insightId={insight.id}
                 className={styles.dashboards}
             />
 
             <div className={styles.content}>
-                <SmartStandaloneInsight insight={insight} telemetryService={telemetryService} />
+                <SmartStandaloneInsight
+                    insight={insight}
+                    telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
+                />
             </div>
         </CodeInsightsPage>
     )

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/SmartStandaloneInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/SmartStandaloneInsight.tsx
@@ -1,5 +1,6 @@
 import type { FunctionComponent } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { type Insight, isBackendInsight } from '../../../../core'
@@ -7,18 +8,32 @@ import { type Insight, isBackendInsight } from '../../../../core'
 import { StandaloneBackendInsight } from './standalone-backend-insight/StandaloneBackendInsight'
 import { StandaloneLangStatsInsight } from './standalone-lang-stats-insight/StandaloneLangStatsInsight'
 
-interface SmartStandaloneInsightProps extends TelemetryProps {
+interface SmartStandaloneInsightProps extends TelemetryProps, TelemetryV2Props {
     insight: Insight
     className?: string
 }
 
 export const SmartStandaloneInsight: FunctionComponent<SmartStandaloneInsightProps> = props => {
-    const { insight, telemetryService, className } = props
+    const { insight, telemetryService, telemetryRecorder, className } = props
 
     if (isBackendInsight(insight)) {
-        return <StandaloneBackendInsight insight={insight} telemetryService={telemetryService} className={className} />
+        return (
+            <StandaloneBackendInsight
+                insight={insight}
+                telemetryService={telemetryService}
+                className={className}
+                telemetryRecorder={telemetryRecorder}
+            />
+        )
     }
 
     // Search based extension and lang stats insight are handled by built-in fetchers
-    return <StandaloneLangStatsInsight insight={insight} telemetryService={telemetryService} className={className} />
+    return (
+        <StandaloneLangStatsInsight
+            insight={insight}
+            telemetryService={telemetryService}
+            className={className}
+            telemetryRecorder={telemetryRecorder}
+        />
+    )
 }

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -4,6 +4,7 @@ import { mdiLinkVariant } from '@mdi/js'
 import { escapeRegExp } from 'lodash'
 import { useNavigate } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, Icon, Tooltip } from '@sourcegraph/wildcard'
 
@@ -14,12 +15,12 @@ import { useCopyURLHandler } from '../../../../../hooks/use-copy-url-handler'
 
 import styles from './CodeInsightIndependentPageActions.module.scss'
 
-interface Props extends TelemetryProps {
+interface Props extends TelemetryProps, TelemetryV2Props {
     insight: Insight
 }
 
 export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props => {
-    const { insight, telemetryService } = props
+    const { insight, telemetryService, telemetryRecorder } = props
 
     const navigate = useNavigate()
 
@@ -44,6 +45,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
 
     const handleEditClick = (): void => {
         telemetryService.log('StandaloneInsightPageEditClick')
+        telemetryRecorder.recordEvent('insights.standalone', 'edit')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -45,7 +45,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
 
     const handleEditClick = (): void => {
         telemetryService.log('StandaloneInsightPageEditClick')
-        telemetryRecorder.recordEvent('insights.standalone', 'edit')
+        telemetryRecorder.recordEvent('insight', 'edit')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/actions/CodeInsightIndependentPageActions.tsx
@@ -84,6 +84,7 @@ export const CodeInsightIndependentPageActions: FunctionComponent<Props> = props
                 showModal={showDeleteConfirm}
                 onConfirm={() => navigate('/insights/all')}
                 onCancel={() => setShowDeleteConfirm(false)}
+                telemetryRecorder={telemetryRecorder}
             />
         </div>
     )

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
@@ -24,7 +24,7 @@ export const StandaloneInsightDashboardPills: FunctionComponent<StandaloneInsigh
 
     const handleDashboardClick = (): void => {
         telemetryService.log('StandaloneInsightDashboardClick')
-        telemetryRecorder.recordEvent('insights.standalone.dashboard', 'click')
+        telemetryRecorder.recordEvent('insight.dashboardsButton', 'click')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/dashboard-pills/StandaloneInsightDashboardPills.tsx
@@ -3,6 +3,7 @@ import type { FunctionComponent, HTMLAttributes } from 'react'
 import { mdiViewDashboard } from '@mdi/js'
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Icon, Link, Text } from '@sourcegraph/wildcard'
 
@@ -10,16 +11,20 @@ import type { InsightDashboardReference } from '../../../../../core'
 
 import styles from './StandaloneInsightDashboardPills.module.scss'
 
-interface StandaloneInsightDashboardPillsProps extends HTMLAttributes<HTMLDivElement>, TelemetryProps {
+interface StandaloneInsightDashboardPillsProps
+    extends HTMLAttributes<HTMLDivElement>,
+        TelemetryProps,
+        TelemetryV2Props {
     dashboards: InsightDashboardReference[]
     insightId: string
 }
 
 export const StandaloneInsightDashboardPills: FunctionComponent<StandaloneInsightDashboardPillsProps> = props => {
-    const { dashboards, insightId, className, telemetryService, ...attributes } = props
+    const { dashboards, insightId, className, telemetryService, telemetryRecorder, ...attributes } = props
 
     const handleDashboardClick = (): void => {
         telemetryService.log('StandaloneInsightDashboardClick')
+        telemetryRecorder.recordEvent('insights.standalone.dashboard', 'click')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -124,7 +124,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         await updateInsight({ insightId: insight.id, nextInsightData: { ...insight, filters } }).toPromise()
         setOriginalInsightFilters(filters)
         telemetryService.log('CodeInsightsSearchBasedFilterUpdating')
-        telemetryRecorder.recordEvent('insights.searchBasedFilter', 'save')
+        telemetryRecorder.recordEvent('insights.searchBasedFilter', 'update', { metadata: { location: 1 } })
     }
 
     const handleInsightFilterCreation = async (values: DrillDownInsightCreationFormValues): Promise<void> => {

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { useNavigate } from 'react-router-dom'
 
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Card, CardBody, useDebounce, useDeepMemo, type FormChangeEvent } from '@sourcegraph/wildcard'
 
@@ -41,13 +42,13 @@ import { StandaloneInsightContextMenu } from '../context-menu/StandaloneInsightC
 
 import styles from './StandaloneBackendInsight.module.scss'
 
-interface StandaloneBackendInsight extends TelemetryProps {
+interface StandaloneBackendInsight extends TelemetryProps, TelemetryV2Props {
     insight: BackendInsight
     className?: string
 }
 
 export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackendInsight> = props => {
-    const { telemetryService, insight, className } = props
+    const { telemetryService, telemetryRecorder, insight, className } = props
     const navigate = useNavigate()
     const { updateInsight } = useContext(CodeInsightsBackendContext)
     const [saveAsNewView] = useSaveInsightAsNewView({ dashboard: null })
@@ -109,6 +110,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
 
     const { trackMouseLeave, trackMouseEnter, trackDatumClicks } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
 
@@ -122,6 +124,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         await updateInsight({ insightId: insight.id, nextInsightData: { ...insight, filters } }).toPromise()
         setOriginalInsightFilters(filters)
         telemetryService.log('CodeInsightsSearchBasedFilterUpdating')
+        telemetryRecorder.recordEvent('insights.standalone.searchBasedFilter', 'save')
     }
 
     const handleInsightFilterCreation = async (values: DrillDownInsightCreationFormValues): Promise<void> => {
@@ -135,6 +138,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         setOriginalInsightFilters(filters)
         navigate('/insights/all')
         telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
+        telemetryRecorder.recordEvent('insights.standalone.searchBasedFilter', 'create')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-backend-insight/StandaloneBackendInsight.tsx
@@ -124,7 +124,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         await updateInsight({ insightId: insight.id, nextInsightData: { ...insight, filters } }).toPromise()
         setOriginalInsightFilters(filters)
         telemetryService.log('CodeInsightsSearchBasedFilterUpdating')
-        telemetryRecorder.recordEvent('insights.standalone.searchBasedFilter', 'save')
+        telemetryRecorder.recordEvent('insights.searchBasedFilter', 'save')
     }
 
     const handleInsightFilterCreation = async (values: DrillDownInsightCreationFormValues): Promise<void> => {
@@ -138,7 +138,7 @@ export const StandaloneBackendInsight: React.FunctionComponent<StandaloneBackend
         setOriginalInsightFilters(filters)
         navigate('/insights/all')
         telemetryService.log('CodeInsightsSearchBasedFilterInsightCreation')
-        telemetryRecorder.recordEvent('insights.standalone.searchBasedFilter', 'create')
+        telemetryRecorder.recordEvent('insights.createFromFilter.searchBased', 'submit', { metadata: { location: 1 } })
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-lang-stats-insight/StandaloneLangStatsInsight.tsx
+++ b/client/web/src/enterprise/insights/pages/insights/insight/components/standalone-lang-stats-insight/StandaloneLangStatsInsight.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 
 import classNames from 'classnames'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ParentSize, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -19,13 +20,13 @@ import { StandaloneInsightContextMenu } from '../context-menu/StandaloneInsightC
 
 import styles from './StandaloneLangStatsInsight.module.scss'
 
-interface StandaloneLangStatsInsightProps extends TelemetryProps {
+interface StandaloneLangStatsInsightProps extends TelemetryProps, TelemetryV2Props {
     insight: LangStatsInsight
     className?: string
 }
 
 export function StandaloneLangStatsInsight(props: StandaloneLangStatsInsightProps): React.ReactElement {
-    const { insight, telemetryService, className } = props
+    const { insight, telemetryService, telemetryRecorder, className } = props
 
     const { state } = useLivePreviewLangStatsInsight(insight)
 
@@ -34,6 +35,7 @@ export function StandaloneLangStatsInsight(props: StandaloneLangStatsInsightProp
 
     const { trackDatumClicks, trackMouseLeave, trackMouseEnter } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType: getTrackingTypeByInsightType(insight.type),
     })
 

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../components/WebStory'
@@ -14,5 +15,9 @@ const meta: Meta = {
 export default meta
 
 export const CodeInsightsDotComGetStartedStory = () => (
-    <CodeInsightsDotComGetStarted telemetryService={NOOP_TELEMETRY_SERVICE} authenticatedUser={null} />
+    <CodeInsightsDotComGetStarted
+        telemetryService={NOOP_TELEMETRY_SERVICE}
+        authenticatedUser={null}
+        telemetryRecorder={noOpTelemetryRecorder}
+    />
 )

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/CodeInsightsDotComGetStarted.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react'
 import classNames from 'classnames'
 
 import type { AuthenticatedUser } from '@sourcegraph/shared/src/auth'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Card, CardBody, Link, PageHeader } from '@sourcegraph/wildcard'
 
@@ -20,19 +21,20 @@ import styles from './CodeInsightsDotComGetStarted.module.scss'
 
 const DOT_COM_CONTEXT = { mode: CodeInsightsLandingPageType.Cloud }
 
-export interface CodeInsightsDotComGetStartedProps extends TelemetryProps {
+export interface CodeInsightsDotComGetStartedProps extends TelemetryProps, TelemetryV2Props {
     authenticatedUser: AuthenticatedUser | null
 }
 
 export const CodeInsightsDotComGetStarted: React.FunctionComponent<
     React.PropsWithChildren<CodeInsightsDotComGetStartedProps>
 > = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
     const isSourcegraphDotCom = window.context.sourcegraphDotComMode
 
     useEffect(() => {
         telemetryService.logViewEvent('CloudInsightsGetStartedPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('cloudInsights.getStarted', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <CodeInsightsLandingPageContext.Provider value={DOT_COM_CONTEXT}>
@@ -46,7 +48,12 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<
                                 as={Link}
                                 to="https://sourcegraph.com"
                                 variant="primary"
-                                onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'TryInsights' })}
+                                onClick={() => {
+                                    eventLogger.log('ClickedOnEnterpriseCTA', { location: 'TryInsights' })
+                                    telemetryRecorder.recordEvent('insights.enterpriseCTA', 'click', {
+                                        metadata: { location: 0 },
+                                    })
+                                }}
                             >
                                 Get Sourcegraph Enterprise
                             </Button>
@@ -85,14 +92,22 @@ export const CodeInsightsDotComGetStarted: React.FunctionComponent<
                         To track Insights across your team's private repositories,{' '}
                         <Link
                             to="https://sourcegraph.com"
-                            onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'Insights' })}
+                            onClick={() => {
+                                eventLogger.log('ClickedOnEnterpriseCTA', { location: 'Insights' })
+                                telemetryRecorder.recordEvent('insights.enterpriseCTA', 'click', {
+                                    metadata: { location: 0 },
+                                })
+                            }}
                         >
                             get Sourcegraph Enterprise
                         </Link>
                         .
                     </CallToActionBanner>
 
-                    <CodeInsightsExamplesPicker telemetryService={telemetryService} />
+                    <CodeInsightsExamplesPicker
+                        telemetryService={telemetryService}
+                        telemetryRecorder={telemetryRecorder}
+                    />
                 </main>
             </Page>
         </CodeInsightsLandingPageContext.Provider>

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/CodeInsightsExamplesPicker.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/CodeInsightsExamplesPicker.tsx
@@ -3,6 +3,7 @@ import { type FunctionComponent, useLayoutEffect, useState } from 'react'
 import classNames from 'classnames'
 import { throttle } from 'lodash'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Card, CardBody, Link, H2 } from '@sourcegraph/wildcard'
 
@@ -13,10 +14,10 @@ import { EXAMPLES } from './examples'
 
 import styles from './CodeInsightsExamplesPicker.module.scss'
 
-interface CodeInsightsExamplesPickerProps extends TelemetryProps {}
+interface CodeInsightsExamplesPickerProps extends TelemetryProps, TelemetryV2Props {}
 
 export const CodeInsightsExamplesPicker: FunctionComponent<CodeInsightsExamplesPickerProps> = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
     const [activeExampleIndex, setActiveExampleIndex] = useState(0)
     const [windowSize, setWindowSize] = useState(0)
 
@@ -32,6 +33,7 @@ export const CodeInsightsExamplesPicker: FunctionComponent<CodeInsightsExamplesP
     const handleUseCaseButtonClick = (useCaseIndex: number): void => {
         setActiveExampleIndex(useCaseIndex)
         telemetryService.log('CloudCodeInsightsGetStartedUseCase')
+        telemetryRecorder.recordEvent('codeInsights.getStarted.useCase', 'click')
     }
 
     const isMobileLayout = windowSize <= 900
@@ -78,10 +80,13 @@ export const CodeInsightsExamplesPicker: FunctionComponent<CodeInsightsExamplesP
                     {...EXAMPLES[activeExampleIndex]}
                     className={styles.section}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
 
-            {isMobileLayout && <CodeInsightsExamplesSlider telemetryService={telemetryService} />}
+            {isMobileLayout && (
+                <CodeInsightsExamplesSlider telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
+            )}
         </Card>
     )
 }

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../../../../components/WebStory'
@@ -15,6 +16,9 @@ export default meta
 
 export const CodeInsightsExampleSliderExample = () => (
     <div style={{ width: 500 }}>
-        <CodeInsightsExamplesSlider telemetryService={NOOP_TELEMETRY_SERVICE} />
+        <CodeInsightsExamplesSlider
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
+        />
     </div>
 )

--- a/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/dot-com-get-started/components/code-insights-examples-picker/code-insights-examples-slider/CodeInsightsExamplesSlider.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef, useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
 import { useMergeRefs } from 'use-callback-ref'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, type ForwardReferenceComponent, H3 } from '@sourcegraph/wildcard'
 
@@ -11,12 +12,12 @@ import { EXAMPLES } from '../examples'
 
 import styles from './CodeInsightsExamplesSlider.module.scss'
 
-interface CodeInsightsExamplesSliderProps extends TelemetryProps {}
+interface CodeInsightsExamplesSliderProps extends TelemetryProps, TelemetryV2Props {}
 
 export const CodeInsightsExamplesSlider: React.FunctionComponent<
     React.PropsWithChildren<CodeInsightsExamplesSliderProps>
 > = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
     const itemElementReferences = useRef<Map<number, HTMLElement | null>>(new Map())
     const [activeExampleIndex, setActiveExampleIndex] = useState<number>(0)
 
@@ -27,6 +28,7 @@ export const CodeInsightsExamplesSlider: React.FunctionComponent<
         if (nextElementReference) {
             nextElementReference.scrollIntoView({ block: 'nearest', inline: 'start' })
             telemetryService.log('CloudCodeInsightsGetStartedUseCase')
+            telemetryRecorder.recordEvent('cloudInsights.getStarted.useCase.back', 'click')
         }
     }
 
@@ -37,6 +39,7 @@ export const CodeInsightsExamplesSlider: React.FunctionComponent<
         if (nextElementReference) {
             nextElementReference.scrollIntoView({ block: 'nearest', inline: 'start' })
             telemetryService.log('CloudCodeInsightsGetStartedUseCase')
+            telemetryRecorder.recordEvent('cloudInsights.getStarted.useCase.forward', 'click')
         }
     }
 
@@ -83,6 +86,7 @@ export const CodeInsightsExamplesSlider: React.FunctionComponent<
                             {...example}
                             className={styles.sliderChart}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     </CodeInsightsExamplesSliderItem>
                 ))}

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.story.tsx
@@ -2,6 +2,7 @@ import type { MockedResponse } from '@apollo/client/testing'
 import type { Meta } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -44,6 +45,9 @@ const FirstExampleRepositoryMock: MockedResponse<GetExampleRepositoryResult> = {
 
 export const CodeInsightsGettingStartedPageStory = () => (
     <MockedTestProvider mocks={[FirstExampleRepositoryMock]}>
-        <CodeInsightsGettingStartedPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+        <CodeInsightsGettingStartedPage
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
+        />
     </MockedTestProvider>
 )

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/CodeInsightsGettingStartedPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { PageTitle } from '../../../../../components/PageTitle'
@@ -10,23 +11,32 @@ import { DynamicCodeInsightExample } from './components/dynamic-code-insight-exa
 
 import styles from './CodeInsightsGettingStartedPage.module.scss'
 
-interface CodeInsightsGettingStartedPageProps extends TelemetryProps {}
+interface CodeInsightsGettingStartedPageProps extends TelemetryProps, TelemetryV2Props {}
 
 export const CodeInsightsGettingStartedPage: React.FunctionComponent<
     React.PropsWithChildren<CodeInsightsGettingStartedPageProps>
 > = props => {
-    const { telemetryService } = props
+    const { telemetryService, telemetryRecorder } = props
 
     useEffect(() => {
         telemetryService.logViewEvent('InsightsGetStartedPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('insights.getStarted', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     return (
         <main className="pb-5">
             <PageTitle title="Code Insights" />
-            <DynamicCodeInsightExample telemetryService={telemetryService} />
-            <CodeInsightsExamples telemetryService={telemetryService} className={styles.section} />
-            <CodeInsightsTemplates telemetryService={telemetryService} className={styles.section} />
+            <DynamicCodeInsightExample telemetryService={telemetryService} telemetryRecorder={telemetryRecorder} />
+            <CodeInsightsExamples
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+                className={styles.section}
+            />
+            <CodeInsightsTemplates
+                telemetryService={telemetryService}
+                telemetryRecorder={telemetryRecorder}
+                className={styles.section}
+            />
         </main>
     )
 }

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.story.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.story.tsx
@@ -1,5 +1,6 @@
 import type { Meta } from '@storybook/react'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { WebStory } from '../../../../../../../components/WebStory'
@@ -13,4 +14,6 @@ const meta: Meta = {
 
 export default meta
 
-export const StandardExample = () => <CodeInsightsExamples telemetryService={NOOP_TELEMETRY_SERVICE} />
+export const StandardExample = () => (
+    <CodeInsightsExamples telemetryService={NOOP_TELEMETRY_SERVICE} telemetryRecorder={noOpTelemetryRecorder} />
+)

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/CodeInsightsExamples.tsx
@@ -2,6 +2,7 @@ import type { FunctionComponent } from 'react'
 
 import { useLocation } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Link, H2, Text } from '@sourcegraph/wildcard'
 
@@ -14,7 +15,10 @@ import { ALPINE_VERSIONS_INSIGHT, CSS_MODULES_VS_GLOBAL_STYLES_INSIGHT } from '.
 
 import styles from './CodeInsightsExamples.module.scss'
 
-export interface CodeInsightsExamplesProps extends TelemetryProps, React.HTMLAttributes<HTMLElement> {}
+export interface CodeInsightsExamplesProps
+    extends TelemetryProps,
+        TelemetryV2Props,
+        React.HTMLAttributes<HTMLElement> {}
 
 const SEARCH_INSIGHT_CREATION_UI_URL_PARAMETERS = encodeSearchInsightUrl({
     title: CSS_MODULES_VS_GLOBAL_STYLES_INSIGHT.title,
@@ -33,7 +37,7 @@ const CAPTURE_GROUP_INSIGHT_CREATION_UI_URL_PARAMETERS = encodeCaptureInsightURL
  * code insights landing pages.
  */
 export const CodeInsightsExamples: FunctionComponent<CodeInsightsExamplesProps> = props => {
-    const { telemetryService, ...otherProps } = props
+    const { telemetryService, telemetryRecorder, ...otherProps } = props
     const { pathname, search } = useLocation()
 
     return (
@@ -50,6 +54,7 @@ export const CodeInsightsExamples: FunctionComponent<CodeInsightsExamplesProps> 
                     content={CSS_MODULES_VS_GLOBAL_STYLES_INSIGHT}
                     templateLink={`/insights/create/search?${SEARCH_INSIGHT_CREATION_UI_URL_PARAMETERS}`}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     className={styles.card}
                 />
 
@@ -58,6 +63,7 @@ export const CodeInsightsExamples: FunctionComponent<CodeInsightsExamplesProps> 
                     content={ALPINE_VERSIONS_INSIGHT}
                     templateLink={`/insights/create/capture-group?${CAPTURE_GROUP_INSIGHT_CREATION_UI_URL_PARAMETERS}`}
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     className={styles.card}
                 />
             </div>

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/code-insight-example-card/CodeInsightExampleCard.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-examples/code-insight-example-card/CodeInsightExampleCard.tsx
@@ -1,6 +1,7 @@
 import { type FunctionComponent, useContext } from 'react'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/branded'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { Button, Link, LegendItem, LegendList, ParentSize, LegendItemPoint } from '@sourcegraph/wildcard'
 
@@ -37,7 +38,7 @@ export const CodeInsightExampleCard: FunctionComponent<CodeInsightExampleProps> 
     return <CodeInsightCaptureExample {...props} />
 }
 
-interface CodeInsightSearchExampleProps extends TelemetryProps {
+interface CodeInsightSearchExampleProps extends TelemetryProps, TelemetryV2Props {
     type: InsightType.SearchBased
     content: SearchInsightExampleContent<any>
     templateLink?: string
@@ -45,7 +46,7 @@ interface CodeInsightSearchExampleProps extends TelemetryProps {
 }
 
 const CodeInsightSearchExample: FunctionComponent<CodeInsightSearchExampleProps> = props => {
-    const { templateLink, className, content, telemetryService } = props
+    const { templateLink, className, content, telemetryService, telemetryRecorder } = props
     const seriesToggleState = useSeriesToggle()
 
     const { mode } = useContext(CodeInsightsLandingPageContext)
@@ -54,6 +55,7 @@ const CodeInsightSearchExample: FunctionComponent<CodeInsightSearchExampleProps>
 
     const { trackMouseEnter, trackMouseLeave } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType:
             mode === CodeInsightsLandingPageType.Cloud
                 ? CodeInsightTrackType.CloudLandingPageInsight
@@ -62,6 +64,7 @@ const CodeInsightSearchExample: FunctionComponent<CodeInsightSearchExampleProps>
 
     const handleTemplateLinkClick = (): void => {
         telemetryService.log(bigTemplateClickPingName)
+        telemetryRecorder.recordEvent('insights.getStarted.bigTemplate', 'click')
     }
 
     return (
@@ -115,7 +118,7 @@ const CodeInsightSearchExample: FunctionComponent<CodeInsightSearchExampleProps>
     )
 }
 
-interface CodeInsightCaptureExampleProps extends TelemetryProps {
+interface CodeInsightCaptureExampleProps extends TelemetryProps, TelemetryV2Props {
     type: InsightType.CaptureGroup
     content: CaptureGroupExampleContent<any>
     templateLink?: string
@@ -128,6 +131,7 @@ const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProp
         templateLink,
         className,
         telemetryService,
+        telemetryRecorder,
     } = props
     const seriesToggleState = useSeriesToggle()
 
@@ -136,6 +140,7 @@ const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProp
 
     const { trackMouseEnter, trackMouseLeave } = useCodeInsightViewPings({
         telemetryService,
+        telemetryRecorder,
         insightType:
             mode === CodeInsightsLandingPageType.Cloud
                 ? CodeInsightTrackType.CloudLandingPageInsight
@@ -144,6 +149,7 @@ const CodeInsightCaptureExample: FunctionComponent<CodeInsightCaptureExampleProp
 
     const handleTemplateLinkClick = (): void => {
         telemetryService.log(bigTemplateClickPingName)
+        telemetryRecorder.recordEvent('insights.getStarted.bigTemplate', 'click')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -166,7 +166,7 @@ const TemplateCard: React.FunctionComponent<React.PropsWithChildren<TemplateCard
 
     const handleUseTemplateLinkClick = (): void => {
         telemetryService.log('InsightGetStartedTemplateClick')
-        telemetryRecorder.recordEvent('insights.getSTarted.template', 'click')
+        telemetryRecorder.recordEvent('insights.getStarted.template', 'click')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/code-insights-templates/CodeInsightsTemplates.tsx
@@ -5,6 +5,7 @@ import copy from 'copy-to-clipboard'
 
 import { SyntaxHighlightedSearchQuery } from '@sourcegraph/branded'
 import { useExperimentalFeatures } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -50,10 +51,10 @@ function getTemplateURL(template: Template): string {
     }
 }
 
-interface CodeInsightsTemplates extends TelemetryProps, React.HTMLAttributes<HTMLElement> {}
+interface CodeInsightsTemplates extends TelemetryProps, TelemetryV2Props, React.HTMLAttributes<HTMLElement> {}
 
 export const CodeInsightsTemplates: React.FunctionComponent<React.PropsWithChildren<CodeInsightsTemplates>> = props => {
-    const { telemetryService, ...otherProps } = props
+    const { telemetryService, telemetryRecorder, ...otherProps } = props
     const tabChangePingName = useLogEventName('InsightsGetStartedTabClick')
     const goCodeCheckerTemplates = useExperimentalFeatures(features => features.goCodeCheckerTemplates)
     const templateSections = getTemplateSections(goCodeCheckerTemplates)
@@ -62,6 +63,7 @@ export const CodeInsightsTemplates: React.FunctionComponent<React.PropsWithChild
         const template = templateSections[index]
 
         telemetryService.log(tabChangePingName, { tabName: template.title }, { tabName: template.title })
+        telemetryRecorder.recordEvent('insights.getStarted.tab', 'click', { metadata: { tab: index } })
     }
 
     return (
@@ -85,12 +87,14 @@ export const CodeInsightsTemplates: React.FunctionComponent<React.PropsWithChild
                     ))}
                 </TabList>
                 <TabPanels>
-                    {templateSections.map(section => (
+                    {templateSections.map((section, index) => (
                         <TemplatesPanel
                             key={section.title}
                             sectionTitle={section.title}
+                            sectionIndex={index}
                             templates={section.templates}
                             telemetryService={telemetryService}
+                            telemetryRecorder={telemetryRecorder}
                         />
                     ))}
                 </TabPanels>
@@ -99,13 +103,14 @@ export const CodeInsightsTemplates: React.FunctionComponent<React.PropsWithChild
     )
 }
 
-interface TemplatesPanelProps extends TelemetryProps {
+interface TemplatesPanelProps extends TelemetryProps, TelemetryV2Props {
     sectionTitle: string
+    sectionIndex: number
     templates: Template[]
 }
 
 const TemplatesPanel: React.FunctionComponent<React.PropsWithChildren<TemplatesPanelProps>> = props => {
-    const { templates, sectionTitle, telemetryService } = props
+    const { templates, sectionTitle, sectionIndex, telemetryService, telemetryRecorder } = props
     const [allVisible, setAllVisible] = useState(false)
     const tabMoreClickPingName = useLogEventName('InsightsGetStartedTabMoreClick')
 
@@ -115,6 +120,7 @@ const TemplatesPanel: React.FunctionComponent<React.PropsWithChildren<TemplatesP
     const handleShowMoreButtonClick = (): void => {
         if (!allVisible) {
             telemetryService.log(tabMoreClickPingName, { tabName: sectionTitle }, { tabName: sectionTitle })
+            telemetryRecorder.recordEvent('insights.getStarted.tab.more', 'click', { metadata: { tab: sectionIndex } })
         }
 
         setAllVisible(!allVisible)
@@ -123,7 +129,12 @@ const TemplatesPanel: React.FunctionComponent<React.PropsWithChildren<TemplatesP
     return (
         <TabPanel className={styles.cards}>
             {templates.slice(0, maxNumberOfCards).map(template => (
-                <TemplateCard key={template.title} template={template} telemetryService={telemetryService} />
+                <TemplateCard
+                    key={template.title}
+                    template={template}
+                    telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
+                />
             ))}
 
             {hasMoreLessButton && (
@@ -140,12 +151,12 @@ const TemplatesPanel: React.FunctionComponent<React.PropsWithChildren<TemplatesP
     )
 }
 
-interface TemplateCardProps extends TelemetryProps {
+interface TemplateCardProps extends TelemetryProps, TelemetryV2Props {
     template: Template
 }
 
 const TemplateCard: React.FunctionComponent<React.PropsWithChildren<TemplateCardProps>> = props => {
-    const { template, telemetryService } = props
+    const { template, telemetryService, telemetryRecorder } = props
     const { mode } = useContext(CodeInsightsLandingPageContext)
 
     const series =
@@ -155,6 +166,7 @@ const TemplateCard: React.FunctionComponent<React.PropsWithChildren<TemplateCard
 
     const handleUseTemplateLinkClick = (): void => {
         telemetryService.log('InsightGetStartedTemplateClick')
+        telemetryRecorder.recordEvent('insights.getSTarted.template', 'click')
     }
 
     return (
@@ -166,7 +178,12 @@ const TemplateCard: React.FunctionComponent<React.PropsWithChildren<TemplateCard
                 {series.map(
                     line =>
                         line.query && (
-                            <QueryPanel key={line.query} query={line.query} telemetryService={telemetryService} />
+                            <QueryPanel
+                                key={line.query}
+                                query={line.query}
+                                telemetryService={telemetryService}
+                                telemetryRecorder={telemetryRecorder}
+                            />
                         )
                 )}
             </div>
@@ -187,7 +204,7 @@ const TemplateCard: React.FunctionComponent<React.PropsWithChildren<TemplateCard
     )
 }
 
-interface QueryPanelProps extends TelemetryProps {
+interface QueryPanelProps extends TelemetryProps, TelemetryV2Props {
     query: string
 }
 
@@ -195,7 +212,7 @@ const copyTooltip = 'Copy query'
 const copyCompletedTooltip = 'Copied!'
 
 const QueryPanel: React.FunctionComponent<React.PropsWithChildren<QueryPanelProps>> = props => {
-    const { query, telemetryService } = props
+    const { query, telemetryService, telemetryRecorder } = props
 
     const templateCopyClickEvenName = useLogEventName('InsightGetStartedTemplateCopyClick')
     const [currentCopyTooltip, setCurrentCopyTooltip] = useState(copyTooltip)
@@ -207,6 +224,7 @@ const QueryPanel: React.FunctionComponent<React.PropsWithChildren<QueryPanelProp
 
         event.preventDefault()
         telemetryService.log(templateCopyClickEvenName)
+        telemetryRecorder.recordEvent('insights.getStarted.template', 'copy')
     }
 
     return (

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 import { noop } from 'rxjs'
 
 import { gql, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -39,10 +40,13 @@ const INITIAL_INSIGHT_VALUES: CodeInsightExampleFormValues = {
     query: 'TODO',
 }
 
-interface DynamicCodeInsightExampleProps extends TelemetryProps, React.HTMLAttributes<HTMLDivElement> {}
+interface DynamicCodeInsightExampleProps
+    extends TelemetryProps,
+        TelemetryV2Props,
+        React.HTMLAttributes<HTMLDivElement> {}
 
 export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = props => {
-    const { telemetryService, ...otherProps } = props
+    const { telemetryService, telemetryRecorder, ...otherProps } = props
 
     const { repositoryUrl, loading: repositoryValueLoading } = useExampleRepositoryUrl()
 
@@ -81,17 +85,20 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
     useEffect(() => {
         if (debouncedQuery !== INITIAL_INSIGHT_VALUES.query) {
             telemetryService.log('InsightsGetStartedPageQueryModification')
+            telemetryRecorder.recordEvent('insights.getStarted.query', 'modify')
         }
-    }, [debouncedQuery, telemetryService])
+    }, [debouncedQuery, telemetryService, telemetryRecorder])
 
     useEffect(() => {
         if (debouncedRepositories !== INITIAL_INSIGHT_VALUES.repositories) {
             telemetryService.log('InsightsGetStartedPageRepositoriesModification')
+            telemetryRecorder.recordEvent('insights.getStarted.reposistories', 'modify')
         }
-    }, [debouncedRepositories, telemetryService])
+    }, [debouncedRepositories, telemetryService, telemetryRecorder])
 
     const handleGetStartedClick = (): void => {
         telemetryService.log('InsightsGetStartedPrimaryCTAClick')
+        telemetryRecorder.recordEvent('insights.getStarted.primaryCTA', 'click')
     }
 
     const hasValidLivePreview =
@@ -105,6 +112,7 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
             <form ref={form.ref} noValidate={true} onSubmit={form.handleSubmit} className={styles.chartSection}>
                 <DynamicInsightPreview
                     telemetryService={telemetryService}
+                    telemetryRecorder={telemetryRecorder}
                     disabled={!hasValidLivePreview}
                     repositories={repositories.input.value}
                     query={query.input.value}

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicCodeInsightExample.tsx
@@ -92,7 +92,7 @@ export const DynamicCodeInsightExample: FC<DynamicCodeInsightExampleProps> = pro
     useEffect(() => {
         if (debouncedRepositories !== INITIAL_INSIGHT_VALUES.repositories) {
             telemetryService.log('InsightsGetStartedPageRepositoriesModification')
-            telemetryRecorder.recordEvent('insights.getStarted.reposistories', 'modify')
+            telemetryRecorder.recordEvent('insights.getStarted.repositories', 'modify')
         }
     }, [debouncedRepositories, telemetryService, telemetryRecorder])
 

--- a/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicInsightPreview.tsx
+++ b/client/web/src/enterprise/insights/pages/landing/getting-started/components/dynamic-code-insight-example/DynamicInsightPreview.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { type Series, useDeepMemo, ErrorAlert } from '@sourcegraph/wildcard'
 
@@ -32,7 +33,7 @@ const createExampleDataSeries = (query: string): SeriesWithStroke[] => [
     },
 ]
 
-interface DynamicInsightPreviewProps extends TelemetryProps {
+interface DynamicInsightPreviewProps extends TelemetryProps, TelemetryV2Props {
     disabled: boolean
     repositories: string[]
     query: string
@@ -40,7 +41,7 @@ interface DynamicInsightPreviewProps extends TelemetryProps {
 }
 
 export const DynamicInsightPreview: FC<DynamicInsightPreviewProps> = props => {
-    const { disabled, repositories, query, className, telemetryService } = props
+    const { disabled, repositories, query, className, telemetryService, telemetryRecorder } = props
 
     // Compare live insight settings with deep check to avoid unnecessary
     // search insight content fetching
@@ -59,6 +60,7 @@ export const DynamicInsightPreview: FC<DynamicInsightPreviewProps> = props => {
     const { trackMouseEnter, trackMouseLeave, trackDatumClicks } = useCodeInsightViewPings({
         telemetryService,
         insightType: CodeInsightTrackType.InProductLandingPageInsight,
+        telemetryRecorder,
     })
 
     return (

--- a/client/web/src/enterprise/insights/pings/types.ts
+++ b/client/web/src/enterprise/insights/pings/types.ts
@@ -9,6 +9,15 @@ export enum CodeInsightTrackType {
     CloudLandingPageInsight = 'CloudLandingPageInsight',
 }
 
+export const V2InsightType: { [k in CodeInsightTrackType]: number } = {
+    SearchBased: 0,
+    LangStats: 1,
+    CaptureGroup: 2,
+    ComputeInsight: 3,
+    InProductLandingPageInsight: 4,
+    CloudLandingPageInsight: 5,
+}
+
 export const getTrackingTypeByInsightType = (insightType: InsightType): CodeInsightTrackType => {
     switch (insightType) {
         case InsightType.CaptureGroup: {

--- a/client/web/src/enterprise/insights/pings/use-code-insight-view-pings.ts
+++ b/client/web/src/enterprise/insights/pings/use-code-insight-view-pings.ts
@@ -50,7 +50,7 @@ export function useCodeInsightViewPings(props: UseCodeInsightViewPingsInput): Pi
         telemetryRecorder.recordEvent('insight.dataPoint', 'click', {
             metadata: { insightType: V2InsightType[insightType] },
         })
-    }, [insightType, telemetryService])
+    }, [insightType, telemetryService, telemetryRecorder])
 
     const trackFilterChanges = useDebouncedCallback(() => {
         telemetryService.log('InsightFiltersChange', { insightType }, { insightType })

--- a/client/web/src/enterprise/insights/pings/use-code-insight-view-pings.ts
+++ b/client/web/src/enterprise/insights/pings/use-code-insight-view-pings.ts
@@ -2,11 +2,12 @@ import { useCallback, useRef } from 'react'
 
 import { useDebouncedCallback } from 'use-debounce'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
-import type { CodeInsightTrackType } from './types'
+import { V2InsightType, type CodeInsightTrackType } from './types'
 
-interface UseCodeInsightViewPingsInput extends TelemetryProps {
+interface UseCodeInsightViewPingsInput extends TelemetryProps, TelemetryV2Props {
     /**
      * View tracking type is used to send a proper pings event (InsightHover, InsightDataPointClick)
      * with view type as a tracking variable.
@@ -25,7 +26,7 @@ interface PingHandlers {
  * Shared logic for tracking insight related ping events on the insight card component.
  */
 export function useCodeInsightViewPings(props: UseCodeInsightViewPingsInput): PingHandlers {
-    const { insightType, telemetryService } = props
+    const { insightType, telemetryService, telemetryRecorder } = props
     const timeoutID = useRef<number>()
 
     const trackMouseEnter = useCallback(() => {
@@ -34,8 +35,11 @@ export function useCodeInsightViewPings(props: UseCodeInsightViewPingsInput): Pi
         // the view quickly, clear the timeout for logging the event
         timeoutID.current = window.setTimeout(() => {
             telemetryService.log('InsightHover', { insightType }, { insightType })
+            telemetryRecorder.recordEvent('insight', 'hover', {
+                metadata: { insightType: V2InsightType[insightType] },
+            })
         }, 500)
-    }, [insightType, telemetryService])
+    }, [insightType, telemetryService, telemetryRecorder])
 
     const trackMouseLeave = useCallback(() => {
         window.clearTimeout(timeoutID.current)
@@ -43,10 +47,16 @@ export function useCodeInsightViewPings(props: UseCodeInsightViewPingsInput): Pi
 
     const trackDatumClicks = useCallback(() => {
         telemetryService.log('InsightDataPointClick', { insightType }, { insightType })
+        telemetryRecorder.recordEvent('insight.dataPoint', 'click', {
+            metadata: { insightType: V2InsightType[insightType] },
+        })
     }, [insightType, telemetryService])
 
     const trackFilterChanges = useDebouncedCallback(() => {
         telemetryService.log('InsightFiltersChange', { insightType }, { insightType })
+        telemetryRecorder.recordEvent('insight.filters', 'change', {
+            metadata: { insightType: V2InsightType[insightType] },
+        })
     }, 1000)
 
     return {

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -169,7 +169,9 @@ export const routes: RouteObject[] = [
         path: PageRoutes.Insights,
         element: (
             <LegacyRoute
-                render={props => <CodeInsightsRouter {...props} />}
+                render={props => (
+                    <CodeInsightsRouter {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
+                )}
                 condition={({ codeInsightsEnabled }) => !!codeInsightsEnabled}
             />
         ),


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally