### PR TITLE
ci: Disable flaky 'highlights correct line for Go' test

### DIFF
--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -470,6 +470,8 @@ describe('Repository component', () => {
         }
 
         const highlightSymbolTests = [
+            // todo: re-enable once flake is identified
+            /*
             {
                 name: 'highlights correct line for Go',
                 filePath:
@@ -477,6 +479,7 @@ describe('Repository component', () => {
                 symbol: 'diffTimeParseLayout',
                 line: 65,
             },
+            */
             {
                 name: 'highlights correct line for TypeScript',
                 filePath:

--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -471,6 +471,7 @@ describe('Repository component', () => {
 
         const highlightSymbolTests = [
             // todo: re-enable once flake is identified
+            // https://github.com/sourcegraph/sourcegraph/issues/60824
             /*
             {
                 name: 'highlights correct line for Go',


### PR DESCRIPTION
This test seemed to have caused a lot of failures since March 1st (2024).  I looked at a couple of test failures since then and they were all related to that test. `//testing:e2e_test` had been quite reliable until then.

<img width="1212" alt="Screenshot 2024-03-04 at 11 04 42" src="https://github.com/sourcegraph/sourcegraph/assets/179026/10333e89-63fb-4a61-9203-93e81d013841">


I wasn't able to identify what the issue is.

[Test analytics](https://buildkite.com/organizations/sourcegraph/analytics/suites/sourcegraph-bazel/tests/0189f3a8-28d8-7392-be6a-e1ab56d20fab?branch=all+branches)

## Test plan

CI
