### PR TITLE
frontend: GetAggregatedCodyStats: add nil guard for events

### DIFF
--- a/internal/usagestats/aggregated_cody.go
+++ b/internal/usagestats/aggregated_cody.go
@@ -22,6 +22,11 @@ func GetAggregatedCodyStats(ctx context.Context, db database.DB) (*types.CodyUsa
 		Monthly: newCodyEventPeriod(),
 	}
 
+	if events == nil {
+		// If there are no events, return the empty stats.
+		return stats, nil
+	}
+
 	stats.Daily.StartTime = events.Day
 	stats.Daily.TotalCodyUsers.EventsCount = &events.TotalDay
 	stats.Daily.TotalCodyUsers.UserCount = &events.UniquesDay


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/60825

If there are no entries in the cody stats table (as is the case if it hasn't been used yet), events will be nil:

https://github.com/sourcegraph/sourcegraph/blob/33b92afbc955f613ff4b9f1d099747b60fdf6564/internal/database/event_logs.go#L1444-L1449

If this is the case, then we simply return the default value of the aggregated cody stats type:

```
events, err := db.EventLogs().AggregatedCodyUsage(ctx, time.Now().UTC())
	if err != nil {
		return nil, err
	}
stats := &types.CodyUsageStatistics{
		Daily:   newCodyEventPeriod(),
		Weekly:  newCodyEventPeriod(),
		Monthly: newCodyEventPeriod(),
	}

if events == nil {
   // If there are no events, return the empty stats.
  return stats, nil
}
```

It seems like these stats are only used for bigquery analysis, so hopefully using the default value is safe for that purpose?

## Test plan

Run `sg start` again, see no panics on start up.