### PR TITLE
ci: Disable typescript symbol sidebar test

### DIFF
--- a/client/web/src/end-to-end/code-intel/repository-component.test.ts
+++ b/client/web/src/end-to-end/code-intel/repository-component.test.ts
@@ -469,10 +469,10 @@ describe('Repository component', () => {
             })
         }
 
+        // todo: re-enable once flake is identified
+        // https://github.com/sourcegraph/sourcegraph/issues/60824
+        /*
         const highlightSymbolTests = [
-            // todo: re-enable once flake is identified
-            // https://github.com/sourcegraph/sourcegraph/issues/60824
-            /*
             {
                 name: 'highlights correct line for Go',
                 filePath:
@@ -480,7 +480,6 @@ describe('Repository component', () => {
                 symbol: 'diffTimeParseLayout',
                 line: 65,
             },
-            */
             {
                 name: 'highlights correct line for TypeScript',
                 filePath:
@@ -508,6 +507,7 @@ describe('Repository component', () => {
                 expect(selectedLine).not.toBeNull()
             })
         }
+        */
     })
 
     describe('hovers', () => {


### PR DESCRIPTION
See #60823. Looking at [test analytics](https://buildkite.com/organizations/sourcegraph/analytics/suites/sourcegraph-bazel/tests/0189f3a8-28d8-7392-be6a-e1ab56d20fab?branch=all+branches) it appears that now the other symbol sidebar test causes issues. This PR disabled it too (I think we can keep the existing issue to track both).

## Test plan

CI
