### PR TITLE
svelte: Introduce new feature flag for incremental rollout of Svelte on S2

### DIFF
--- a/client/web-sveltekit/src/lib/navigation.ts
+++ b/client/web-sveltekit/src/lib/navigation.ts
@@ -1,0 +1,18 @@
+// SvelteKit is rolled out in two stages:
+// - Routes listed here are enabled by default for everyone on S2 (via the `web-next-enabled` feature flag)
+// - Other routes are only enabled for users with the `web-next` feature flag
+const enabledRouteIDs = new RegExp(
+    [
+        // Add route IDs here that should be enabled
+        // Keep in sync with 'cmd/frontend/internal/app/ui/sveltekit.go'
+        '^/search',
+    ].join('|')
+)
+
+/**
+ * Returns whether the given route is enabled.
+ */
+export function isRouteEnabled(routeID: string): boolean {
+    console.log(routeID, enabledRouteIDs.test(routeID))
+    return enabledRouteIDs.test(routeID)
+}

--- a/client/web-sveltekit/src/params/reporev.ts
+++ b/client/web-sveltekit/src/params/reporev.ts
@@ -1,5 +1,76 @@
 import type { ParamMatcher } from '@sveltejs/kit'
 
+// These are top level paths that are Sourcegraph pages, not repositories.
+// By explicitly excluding then we force SvelteKit to _not_ match them, which
+// will cause SvelteKit to fetch the page from the server, which will then
+// load the React version.
+// Note that any routes in the `routes/` directory will be handled by the
+// SvelteKit app, whether they are in this list or not.
+// This list is taken from 'cmd/frontend/internal/app/ui/router.go'.
+const topLevelPaths = [
+    'insights',
+    'search-jobs',
+    'setup',
+    'batch-changes',
+    'code-monitoring',
+    'notebooks',
+    'request-access',
+    'api/console',
+    'sign-in',
+    'ping-from-self-hosted',
+    'sign-up',
+    'threads',
+    'organizations',
+    'teams',
+    'settings',
+    'site-admin',
+    'snippets',
+    'subscriptions',
+    'views',
+    'own',
+    'contexts',
+    'registry',
+    'search/cody',
+    'app',
+    'cody',
+    'get-cody',
+    'post-sign-up',
+    'unlock-account',
+    'password-reset',
+    'survey',
+    'welcome',
+    'embed',
+    'users',
+    'user',
+    'search',
+
+    // sourcegraph.com specific routes that redirect to subdomains
+    // are ignored (for now)
+
+    // community search contexts
+    'kubernetes',
+    'stanford',
+    'stackstorm',
+    'temporal',
+    'o3de',
+    'chakraui',
+    'julia',
+    'backstage',
+
+    // legacy routes
+    'login',
+    'careers',
+    'extensions',
+
+    // Help pages
+    'help',
+]
+
+const topLevelPathRegex = new RegExp(`^(${topLevelPaths.join('|')})($|/)`)
+
 // This ensures that we never consider paths containing /-/ and pointing
 // to non-existing pages as repo name
-export const match = (param => !param.includes('/-/')) satisfies ParamMatcher
+export const match: ParamMatcher = param => {
+    // Note: param doesn't have a leading slash
+    return !topLevelPathRegex.test(param) && !param.includes('/-/')
+}

--- a/client/web/src/featureFlags/featureFlags.ts
+++ b/client/web/src/featureFlags/featureFlags.ts
@@ -19,6 +19,7 @@ export const FEATURE_FLAGS = [
     // TODO(fkling): Remove this flag
     'enable-sveltekit-toggle',
     'web-next',
+    'web-next-enabled',
     'web-next-toggle',
     'end-user-onboarding',
     'insight-polling-enabled',

--- a/cmd/frontend/internal/app/ui/sveltekit.go
+++ b/cmd/frontend/internal/app/ui/sveltekit.go
@@ -9,21 +9,25 @@ import (
 	"github.com/sourcegraph/sourcegraph/ui/assets"
 )
 
+// rolledOutRoutes is a set of routes that are enabled via a different feature flag.
+// This allows us to have a two-stage rollout of SvelteKit, where we can enable it for
+// a subset of routes before enabling it for all routes.
+// Should be a subset of sveltekitEnabledRoutes.
+// Keep in sync with 'client/web-sveltekit/src/lib/navigation.ts'
+var rolledOutRoutes = map[string]struct{}{
+	routeSearch:           {},
+}
+
 var sveltekitEnabledRoutes = map[string]struct{}{
 	routeSearch:           {},
 	routeTree:             {},
 	routeBlob:             {},
 	routeRepo:             {},
-	routeRepoSettings:     {},
-	routeRepoCodeGraph:    {},
 	routeRepoCommit:       {},
 	routeRepoBranches:     {},
-	routeRepoBatchChanges: {},
 	routeRepoCommits:      {},
 	routeRepoTags:         {},
-	routeRepoCompare:      {},
 	routeRepoStats:        {},
-	routeRepoOwn:          {},
 }
 
 // useSvelteKit returns true if the route is configured to be supported by useSvelteKit
@@ -33,14 +37,23 @@ func useSvelteKit(r *http.Request) bool {
 	if route == nil {
 		return false
 	}
+	routeName := route.GetName()
 
-	if _, ok := sveltekitEnabledRoutes[route.GetName()]; !ok {
+	if _, ok := sveltekitEnabledRoutes[routeName]; !ok {
 		return false
 	}
 
 	ff := featureflag.FromContext(r.Context())
 
-	return ff.GetBoolOr("enable-sveltekit", false) || ff.GetBoolOr("web-next", false)
+	if ff.GetBoolOr("enable-sveltekit", false) || ff.GetBoolOr("web-next", false) {
+		return true
+	}
+
+	if _, ok := rolledOutRoutes[routeName]; ok {
+		return ff.GetBoolOr("web-next-enabled", false)
+	}
+
+	return false
 }
 
 // renderSvelteKit writes SvelteKit's fallback page to the provided writer

--- a/cmd/frontend/internal/app/ui/sveltekit.go
+++ b/cmd/frontend/internal/app/ui/sveltekit.go
@@ -15,19 +15,19 @@ import (
 // Should be a subset of sveltekitEnabledRoutes.
 // Keep in sync with 'client/web-sveltekit/src/lib/navigation.ts'
 var rolledOutRoutes = map[string]struct{}{
-	routeSearch:           {},
+	routeSearch: {},
 }
 
 var sveltekitEnabledRoutes = map[string]struct{}{
-	routeSearch:           {},
-	routeTree:             {},
-	routeBlob:             {},
-	routeRepo:             {},
-	routeRepoCommit:       {},
-	routeRepoBranches:     {},
-	routeRepoCommits:      {},
-	routeRepoTags:         {},
-	routeRepoStats:        {},
+	routeSearch:       {},
+	routeTree:         {},
+	routeBlob:         {},
+	routeRepo:         {},
+	routeRepoCommit:   {},
+	routeRepoBranches: {},
+	routeRepoCommits:  {},
+	routeRepoTags:     {},
+	routeRepoStats:    {},
 }
 
 // useSvelteKit returns true if the route is configured to be supported by useSvelteKit


### PR DESCRIPTION
Related: #60735

This commit adds a new feature flag, `web-next-enabled`, to have more control over the Svelte rollout. The plan is to enable the Svelte prototype by default on S2 as quickly as possible. However, not all pages are fully converted and we don't to roll out pages that lack features people are using (e.g. the refernece panel). A separate feature flag allows us to enable some pages by default while having the rest be opt-in.

On the Svelte side this is handled the following ways:

1. Non existing routes already trigger a page refresh. I.e. if the user follows a link that is not handled by SvelteKit they'll get the React app automatically. However, the repo route is very "greedy" because it basically matches any path and treats it as repository name. This commit restricts the parameter matching by excluding known top-level paths. I.e. these paths are now considered as "non-existing" by SvelteKit and trigger a reload.
2. Existing but not enabled pages. This is handled in a `beforeNavigation` in the root layout. When the user navigates to a route that exists but not enabled we force a page refresh for the target URL instead.

Note that (1) means that we don't really need `data-sveltekit-reload` anymore to trigger a page refresh, but we also use this attribute to style attributes that lead away from the prototype. I could imagine that we remove this styling for the first rollout on S2 though, in which case we can remove the attributes too.


**Todo in follow up PR**: Update React app to cause page refresh when navigating to SvelteKit support route.


## Test plan

Start SvelteKit dev build so that assets are generated in `client/web/dist`, via `cd client/web-sveltekit && DEPLOY_TYPE=dev pnpm build:watch`
Start dev instance via `sg start enterprise`.
Enable feature flag `web-next-enabled`.
-> Navigating to `/search` loads the SvelteKit app
-> Navigating to search results loads SvelteKit app
-> Navigating to a search result (which loads a repo page) loads the React app

Enable feature flag `web-next`
-> Now navigating to a search result stays within the SvelteKit app

Starting the SvelteKit development build via `cd client/web-sveltekit && pnpm dev` and navigating to a repository page doesn't cause a page reload.
