### PR TITLE
Search: skip context lines when converting to line matches

### DIFF
--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -264,7 +264,7 @@ func (h ChunkMatch) MatchedContent() []string {
 // LineMatch representation for clients without breaking backwards compatibility.
 func (h ChunkMatch) AsLineMatches() []*LineMatch {
 	lines := strings.Split(h.Content, "\n")
-	lineMatches := make([]*LineMatch, len(lines))
+	lineMatches := make([]*LineMatch, 0, len(lines))
 	for i, line := range lines {
 		lineNumber := h.ContentStart.Line + i
 		offsetAndLengths := [][2]int32{}
@@ -287,10 +287,12 @@ func (h ChunkMatch) AsLineMatches() []*LineMatch {
 				}
 			}
 		}
-		lineMatches[i] = &LineMatch{
-			Preview:          line,
-			LineNumber:       int32(lineNumber),
-			OffsetAndLengths: offsetAndLengths,
+		if len(offsetAndLengths) > 0 {
+			lineMatches = append(lineMatches, &LineMatch{
+				Preview:          line,
+				LineNumber:       int32(lineNumber),
+				OffsetAndLengths: offsetAndLengths,
+			})
 		}
 	}
 	return lineMatches

--- a/internal/search/result/file_test.go
+++ b/internal/search/result/file_test.go
@@ -83,10 +83,20 @@ func TestConvertMatches(t *testing.T) {
 				Preview:          "line1",
 				LineNumber:       1,
 				OffsetAndLengths: [][2]int32{{0, 5}},
-			}, {
-				Preview:          "line2",
-				LineNumber:       2,
-				OffsetAndLengths: [][2]int32{},
+			}},
+		}, {
+			input: ChunkMatch{
+				Content:      "line1\nline2",
+				ContentStart: Location{Line: 1},
+				Ranges: Ranges{{
+					Start: Location{0, 1, 0},
+					End:   Location{1, 1, 1},
+				}},
+			},
+			output: []*LineMatch{{
+				Preview:          "line1",
+				LineNumber:       1,
+				OffsetAndLengths: [][2]int32{{0, 1}},
 			}},
 		}}
 


### PR DESCRIPTION
After adding context lines to chunk matches, we are now returning line matches that don't contain any of the actual matches. They have an empty `OffsetAndLengths` field, which means no part of that line actually matched, but we are still returning the unmatched line when splitting a chunk match into line matches.

This PR is a small change to skip any lines in the chunk that have no matched ranges when converting to line matches.

## Test plan

Added a unit test.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
