### PR TITLE
Remove dotcom specific gmail abuse check

### DIFF
--- a/cmd/frontend/auth/BUILD.bazel
+++ b/cmd/frontend/auth/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//internal/extsvc",
         "//internal/featureflag",
         "//internal/lazyregexp",
-        "//internal/security",
         "//internal/session",
         "//internal/telemetry",
         "//internal/telemetry/teestore",

--- a/cmd/frontend/auth/BUILD.bazel
+++ b/cmd/frontend/auth/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//internal/conf",
         "//internal/database",
         "//internal/deviceid",
-        "//internal/dotcom",
         "//internal/errcode",
         "//internal/extsvc",
         "//internal/featureflag",

--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
-	"github.com/sourcegraph/sourcegraph/internal/security"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/teestore"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/telemetryrecorder"
@@ -35,53 +33,6 @@ type GetAndSaveUserOp struct {
 	ExternalAccountData extsvc.AccountData
 	CreateIfNotExist    bool
 	LookUpByUsername    bool
-}
-
-// Checks if the user's email defined in the GetAndSaveUserOp is banned.
-// This is done by first checking a list of banned email domains.
-// If the domain is not banned, we then check if the email is a Google account
-// that's hosted on a non-gmail.com domain. Then, if too many signups have
-// happend recently, we prevent the signup.
-func checkIfEmailDomainIsBanned(ctx context.Context, recorder *telemetry.BestEffortEventRecorder, op GetAndSaveUserOp, acct *extsvc.Account) (string, error) {
-	domain, _ := security.ParseEmailDomain(op.UserProps.Email)
-
-	banned, err := security.IsEmailBanned(op.UserProps.Email)
-	if err != nil {
-		return "could not determine if email domain is banned", err
-	}
-
-	if banned {
-		recorder.Record(ctx, telemetry.FeaturesSignUpBlockedBannedDomain, telemetry.ActionFailed, &telemetry.EventParameters{
-			PrivateMetadata: map[string]any{
-				"serviceType": acct.AccountSpec.ServiceType,
-				"serviceId":   acct.AccountSpec.ServiceID,
-				"emailDomain": domain,
-			},
-		})
-
-		return "this email address is not allowed to register", errors.New("email domain banned")
-	}
-
-	if acct.AccountSpec.ServiceID == "https://accounts.google.com" && domain != "gmail.com" {
-		banned, err := security.IsEmailBlockedDueToTooManySignups(op.UserProps.Email)
-		if err != nil {
-			return "could not determine if email domain is banned", err
-		}
-
-		if banned {
-			recorder.Record(ctx, telemetry.FeaturesSignUpBlockedTooManySignups, telemetry.ActionFailed, &telemetry.EventParameters{
-				PrivateMetadata: map[string]any{
-					"serviceType": acct.AccountSpec.ServiceType,
-					"serviceId":   acct.AccountSpec.ServiceID,
-					"emailDomain": domain,
-				},
-			})
-
-			return "There seem to be too many signups occurring today. Please try again at a later time.", errors.New("Email not allowed to register due to too many signups")
-		}
-	}
-
-	return "", nil
 }
 
 // GetAndSaveUser accepts authentication information associated with a given user, validates and applies
@@ -176,13 +127,6 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (n
 
 		act := &sgactor.Actor{
 			SourcegraphOperator: acct.AccountSpec.ServiceType == auth.SourcegraphOperatorProviderType,
-		}
-
-		if dotcom.SourcegraphDotComMode() {
-			reason, err := checkIfEmailDomainIsBanned(ctx, recorder, op, acct)
-			if err != nil {
-				return 0, false, false, reason, err
-			}
 		}
 
 		// Fourth and finally, create a new user account and return it.

--- a/internal/auth/userpasswd/BUILD.bazel
+++ b/internal/auth/userpasswd/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "//internal/featureflag",
         "//internal/lazyregexp",
         "//internal/rcache",
-        "//internal/security",
         "//internal/session",
         "//internal/suspiciousnames",
         "//internal/telemetry",

--- a/internal/auth/userpasswd/handlers.go
+++ b/internal/auth/userpasswd/handlers.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
-	"github.com/sourcegraph/sourcegraph/internal/security"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry"
 	"github.com/sourcegraph/sourcegraph/internal/telemetry/teestore"
 
@@ -217,14 +216,6 @@ func unsafeSignUp(
 			return errors.New(defaultErrorMessage), http.StatusInternalServerError, nil
 		}
 		newUserData.EmailVerificationCode = code
-	}
-
-	if banned, err := security.IsEmailBanned(creds.Email); err != nil {
-		logger.Error("failed to check if email domain is banned", log.Error(err))
-		return errors.New("could not determine if email domain is banned"), http.StatusInternalServerError, nil
-	} else if banned {
-		logger.Error("user tried to register with banned email domain", log.String("email", creds.Email))
-		return errors.New("this email address is not allowed to register"), http.StatusBadRequest, nil
 	}
 
 	// Prevent abuse (users adding emails of other people whom they want to annoy) with the

--- a/internal/security/BUILD.bazel
+++ b/internal/security/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//internal/dotcom",
         "//internal/errcode",
         "//internal/lazyregexp",
-        "//internal/redispool",
         "//lib/errors",
     ],
 )

--- a/internal/security/BUILD.bazel
+++ b/internal/security/BUILD.bazel
@@ -7,9 +7,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/security",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/collections",
         "//internal/conf",
-        "//internal/dotcom",
         "//internal/errcode",
         "//internal/lazyregexp",
         "//lib/errors",
@@ -52,6 +50,5 @@ go_test(
         "//internal/conf",
         "//schema",
         "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -1,12 +1,10 @@
 package security
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -105,7 +103,7 @@ func TestPasswordPolicy(t *testing.T) {
 	var passwordTests = []passwordTest{
 		{"Sup3rstr0ngbutn0teno0ugh", "Your password must include at least 2 special character(s)."},
 		{"id0hav3symb0lsn0w!!works?", "Your password must include one uppercase letter."},
-		{"Andn0w?!!", fmt.Sprintf("Your password may not be less than 15 characters.")},
+		{"Andn0w?!!", "Your password may not be less than 15 characters."},
 		{strings.Repeat("A", 259), "Your password may not be more than 256 characters."},
 	}
 
@@ -161,23 +159,4 @@ func TestAddrValidation(t *testing.T) {
 		})
 	}
 
-}
-
-func TestIsEmailBanned(t *testing.T) {
-	bannedEmailDomains.Add("blocked.com")
-
-	banned, err := IsEmailBanned("user@blocked.com")
-	require.NoError(t, err)
-	require.True(t, banned, "Expected blocked domain to be detected")
-
-	banned, err = IsEmailBanned("user@BlOCked.com")
-	require.NoError(t, err)
-	require.True(t, banned, "Expected blocked domain with uppercase characters to be detected")
-
-	banned, err = IsEmailBanned("user@allowed.com")
-	require.NoError(t, err)
-	require.False(t, banned, "Expected allowed domain to not be blocked")
-
-	banned, err = IsEmailBanned("invalid")
-	require.Error(t, err)
 }

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -13,11 +13,9 @@ type eventFeature string
 const (
 	FeatureExample eventFeature = "exampleFeature"
 
-	FeatureSignIn                       eventFeature = "signIn"
-	FeatureSignOut                      eventFeature = "signOut"
-	FeatureSignUp                       eventFeature = "signUp"
-	FeaturesSignUpBlockedBannedDomain   eventFeature = "signUpBlocked:BannedDomain"
-	FeaturesSignUpBlockedTooManySignups eventFeature = "signUpBlocked:TooManySignups"
+	FeatureSignIn  eventFeature = "signIn"
+	FeatureSignOut eventFeature = "signOut"
+	FeatureSignUp  eventFeature = "signUp"
 )
 
 // eventAction defines the action associated with an event. Values should

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -2674,8 +2674,6 @@ type SiteConfiguration struct {
 	AuthAccessTokens *AuthAccessTokens `json:"auth.accessTokens,omitempty"`
 	// AuthAllowedIpAddress description: IP allowlist for access to the Sourcegraph instance. If set, only requests from these IP addresses will be allowed. By default client IP is infered connected client IP address, and you may configure to use a request header to determine the user IP.
 	AuthAllowedIpAddress *AuthAllowedIpAddress `json:"auth.allowedIpAddress,omitempty"`
-	// AuthDailyEmailDomainSignupLimit description: The maximum number of users that can sign from Google using the same email domain in a 24 hour period.
-	AuthDailyEmailDomainSignupLimit int `json:"auth.dailyEmailDomainSignupLimit,omitempty"`
 	// AuthEnableUsernameChanges description: Enables users to change their username after account creation. Warning: setting this to be true has security implications if you have enabled (or will at any point in the future enable) repository permissions with an option that relies on username equivalency between Sourcegraph and an external service or authentication provider. Do NOT set this to true if you are using non-built-in authentication OR rely on username equivalency for repository permissions.
 	AuthEnableUsernameChanges bool `json:"auth.enableUsernameChanges,omitempty"`
 	// AuthLockout description: The config options for account lockout
@@ -2991,7 +2989,6 @@ func (v *SiteConfiguration) UnmarshalJSON(data []byte) error {
 	delete(m, "auth.accessRequest")
 	delete(m, "auth.accessTokens")
 	delete(m, "auth.allowedIpAddress")
-	delete(m, "auth.dailyEmailDomainSignupLimit")
 	delete(m, "auth.enableUsernameChanges")
 	delete(m, "auth.lockout")
 	delete(m, "auth.minPasswordLength")

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1145,11 +1145,6 @@
         }
       ]
     },
-    "auth.dailyEmailDomainSignupLimit": {
-      "type": "integer",
-      "default": 0,
-      "description": "The maximum number of users that can sign from Google using the same email domain in a 24 hour period."
-    },
     "auth.accessTokens": {
       "description": "Settings for access tokens, which enable external tools to access the Sourcegraph API with the privileges of the user.",
       "type": "object",


### PR DESCRIPTION
This is being handled by accounts now so we can remove the code from Dotcom.


## Test plan
CI tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
