### PR TITLE
Allow site-admins to view user events on Dotcom

### DIFF
--- a/cmd/frontend/graphqlbackend/event_logs.go
+++ b/cmd/frontend/graphqlbackend/event_logs.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 )
 
 type eventLogsArgs struct {
@@ -15,18 +14,10 @@ type eventLogsArgs struct {
 }
 
 func (r *UserResolver) EventLogs(ctx context.Context, args *eventLogsArgs) (*userEventLogsConnectionResolver, error) {
-	// 🚨 SECURITY: Only the authenticated user can view their event logs on
-	// Sourcegraph.com.
-	if dotcom.SourcegraphDotComMode() {
-		if err := auth.CheckSameUser(ctx, r.user.ID); err != nil {
-			return nil, err
-		}
-	} else {
-		// 🚨 SECURITY: Only the authenticated user and site admins can view users'
-		// event logs.
-		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
-			return nil, err
-		}
+	// 🚨 SECURITY: Only the authenticated user and site admins can view users'
+	// event logs.
+	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
+		return nil, err
 	}
 
 	var opt database.EventLogsListOptions

--- a/cmd/frontend/graphqlbackend/event_logs_test.go
+++ b/cmd/frontend/graphqlbackend/event_logs_test.go
@@ -24,20 +24,23 @@ func TestUser_EventLogs(t *testing.T) {
 		defer dotcom.MockSourcegraphDotComMode(orig) // reset
 
 		tests := []struct {
-			name  string
-			ctx   context.Context
-			setup func()
+			name       string
+			ctx        context.Context
+			shouldFail bool
+			setup      func()
 		}{
 			{
-				name: "unauthenticated",
-				ctx:  context.Background(),
+				name:       "unauthenticated",
+				ctx:        context.Background(),
+				shouldFail: true,
 				setup: func() {
 					users.GetByIDFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
 				},
 			},
 			{
-				name: "another user",
-				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+				name:       "another user",
+				ctx:        actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+				shouldFail: true,
 				setup: func() {
 					users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
 						return &types.User{ID: id}, nil
@@ -45,8 +48,9 @@ func TestUser_EventLogs(t *testing.T) {
 				},
 			},
 			{
-				name: "site admin",
-				ctx:  actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+				name:       "site admin",
+				ctx:        actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+				shouldFail: false,
 				setup: func() {
 					users.GetByIDFunc.SetDefaultHook(func(ctx context.Context, id int32) (*types.User, error) {
 						return &types.User{ID: id, SiteAdmin: true}, nil
@@ -58,10 +62,16 @@ func TestUser_EventLogs(t *testing.T) {
 			t.Run(test.name, func(t *testing.T) {
 				test.setup()
 
-				_, err := NewUserResolver(test.ctx, db, &types.User{ID: 1}).EventLogs(test.ctx, nil)
-				got := fmt.Sprintf("%v", err)
-				want := "must be authenticated as user with id 1"
-				assert.Equal(t, want, got)
+				_, err := NewUserResolver(test.ctx, db, &types.User{ID: 1}).EventLogs(test.ctx, &eventLogsArgs{})
+
+				if !test.shouldFail {
+					assert.NoError(t, err)
+
+				} else {
+					got := fmt.Sprintf("%v", err)
+					want := "must be authenticated as the authorized user or site admin"
+					assert.Equal(t, want, got)
+				}
 			})
 		}
 	})


### PR DESCRIPTION
This feature was introduced in 2021 when we still had private code on Dotcom. We no longer have private code on Dotcom and it can be useful to view user events when investigating an incident.

## Test plan
CI tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
