### PR TITLE
tracer/exporters: use internalerrs loggers on OTEL gRPC exporter

### DIFF
--- a/internal/tracer/oteldefaults/exporters/BUILD.bazel
+++ b/internal/tracer/oteldefaults/exporters/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/sourcegraph/sourcegraph/internal/tracer/oteldefaults/exporters",
     visibility = ["//:__subpackages__"],
     deps = [
+        "//internal/grpc/internalerrs",
         "//internal/otlpenv",
         "//lib/errors",
         "@com_github_grafana_regexp//:regexp",
@@ -23,5 +24,6 @@ go_library(
         "@io_opentelemetry_go_otel_exporters_prometheus//:prometheus",
         "@io_opentelemetry_go_otel_sdk//trace",
         "@io_opentelemetry_go_otel_sdk_metric//:metric",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/internal/tracer/oteldefaults/exporters/otlp.go
+++ b/internal/tracer/oteldefaults/exporters/otlp.go
@@ -9,7 +9,9 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	oteltracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/grpc"
 
+	"github.com/sourcegraph/sourcegraph/internal/grpc/internalerrs"
 	"github.com/sourcegraph/sourcegraph/internal/otlpenv"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -39,8 +41,13 @@ func NewOTLPTraceExporter(ctx context.Context, logger log.Logger) (oteltracesdk.
 	// Work with different protocols
 	switch protocol {
 	case otlpenv.ProtocolGRPC:
+		otlpLogger := logger.Scoped("otlp")
 		opts := []otlptracegrpc.Option{
 			otlptracegrpc.WithEndpoint(trimmedEndpoint),
+			otlptracegrpc.WithDialOption(
+				grpc.WithStreamInterceptor(internalerrs.LoggingStreamClientInterceptor(otlpLogger)),
+				grpc.WithUnaryInterceptor(internalerrs.LoggingUnaryClientInterceptor(otlpLogger)),
+			),
 		}
 		if insecure {
 			opts = append(opts, otlptracegrpc.WithInsecure())


### PR DESCRIPTION
In dotcom, the OTEL SDK reports:

```
traces export: rpc error: code = Internal desc = grpc: error while marshaling: string field contains invalid UTF-8
```

This isn't super helpful for narrowing down where these invalid attributes are coming from.

Luckily, we have some middleware providing some slightly more detailed diagnostics in `grpc/internalerrs`, including detailed logging for this exact problem - this hooks that middleware into the OTEL SDK to help us pin down the source of this issue.

## Test plan

```
sg start
```

Tried a `trace=1` search, nothing bad happened. This middleware is already used extensively elsewhere, and we have an escape hatch via `SRC_GRPC_INTERNAL_ERROR_LOGGING_ENABLED`. Confirmed there's no logspam from failed export due to lack of an active collector in local dev.