### PR TITLE
v2t: add v2t to src/enterprise/own

### DIFF
--- a/client/web/src/enterprise/own/RepositoryOwnEditPage.story.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnEditPage.story.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryFn } from '@storybook/react'
 import { subDays } from 'date-fns'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 
 import { AuthenticatedUser } from '../../auth'
 import { WebStory } from '../../components/WebStory'
@@ -79,6 +80,7 @@ export const EmptyNonAdmin: StoryFn = () => (
                 repo={repo}
                 authenticatedUser={{ siteAdmin: false, permissions: emptyPermissions }}
                 useBreadcrumb={useBreadcrumb}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -92,6 +94,7 @@ export const EmptyAdmin: StoryFn = () => (
                 repo={repo}
                 authenticatedUser={{ siteAdmin: true, permissions: emptyPermissions }}
                 useBreadcrumb={useBreadcrumb}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -127,6 +130,7 @@ export const PopulatedNonAdmin: StoryFn = () => (
                 repo={repo}
                 authenticatedUser={{ siteAdmin: false, permissions: emptyPermissions }}
                 useBreadcrumb={useBreadcrumb}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>
@@ -140,6 +144,7 @@ export const PopulatedAdmin: StoryFn = () => (
                 repo={repo}
                 authenticatedUser={{ siteAdmin: true, permissions: ownershipAssignPermissions }}
                 useBreadcrumb={useBreadcrumb}
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )}
     </WebStory>

--- a/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnEditPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { mdiAccount } from '@mdi/js'
 
@@ -29,11 +29,18 @@ export interface RepositoryOwnAreaPageProps
 
 const EDIT_PAGE_BREADCRUMB = { key: 'edit-own', element: 'Upload CODEOWNERS' }
 
-export const RepositoryOwnEditPage: React.FunctionComponent<
-    Omit<RepositoryOwnAreaPageProps, 'telemetryService' | 'telemetryRecorder'>
-> = ({ useBreadcrumb, repo, authenticatedUser }) => {
+export const RepositoryOwnEditPage: React.FunctionComponent<Omit<RepositoryOwnAreaPageProps, 'telemetryService'>> = ({
+    useBreadcrumb,
+    repo,
+    authenticatedUser,
+    telemetryRecorder,
+}) => {
     const breadcrumbSetters = useBreadcrumb({ key: 'own', element: <Link to={`/${repo.name}/-/own`}>Ownership</Link> })
     breadcrumbSetters.useBreadcrumb(EDIT_PAGE_BREADCRUMB)
+
+    useEffect(() => {
+        telemetryRecorder.recordEvent('repo.ownership.edit', 'view')
+    }, [telemetryRecorder])
 
     return (
         <Page>
@@ -53,7 +60,11 @@ export const RepositoryOwnEditPage: React.FunctionComponent<
                 </H1>
             </PageHeader>
 
-            <RepositoryOwnPageContents repo={repo} authenticatedUser={authenticatedUser} />
+            <RepositoryOwnPageContents
+                repo={repo}
+                authenticatedUser={authenticatedUser}
+                telemetryRecorder={telemetryRecorder}
+            />
         </Page>
     )
 }

--- a/client/web/src/enterprise/own/RepositoryOwnPageContents.tsx
+++ b/client/web/src/enterprise/own/RepositoryOwnPageContents.tsx
@@ -25,8 +25,8 @@ export interface CodeownersIngestedFile {
 }
 
 export const RepositoryOwnPageContents: React.FunctionComponent<
-    Pick<RepositoryOwnAreaPageProps, 'repo' | 'authenticatedUser'>
-> = ({ repo, authenticatedUser }) => {
+    Pick<RepositoryOwnAreaPageProps, 'repo' | 'authenticatedUser' | 'telemetryRecorder'>
+> = ({ repo, authenticatedUser, telemetryRecorder }) => {
     const isAdmin = authenticatedUser?.siteAdmin
 
     const { data, error, loading } = useQuery<GetIngestedCodeownersResult, GetIngestedCodeownersVariables>(
@@ -74,7 +74,10 @@ export const RepositoryOwnPageContents: React.FunctionComponent<
                     {isAdmin && (
                         <UploadFileButton
                             repo={repo}
-                            onComplete={setCodeownersIngestedFile}
+                            onComplete={file => {
+                                setCodeownersIngestedFile(file)
+                                telemetryRecorder.recordEvent('repo.ownership.edit.file', 'upload')
+                            }}
                             fileAlreadyExists={!!codeownersIngestedFile}
                         />
                     )}
@@ -111,7 +114,15 @@ export const RepositoryOwnPageContents: React.FunctionComponent<
                             The following CODEOWNERS file was uploaded to Sourcegraph{' '}
                             <Timestamp date={codeownersIngestedFile.updatedAt} />.
                         </Text>
-                        {isAdmin && <DeleteFileButton repo={repo} onComplete={() => setCodeownersIngestedFile(null)} />}
+                        {isAdmin && (
+                            <DeleteFileButton
+                                repo={repo}
+                                onComplete={() => {
+                                    setCodeownersIngestedFile(null)
+                                    telemetryRecorder.recordEvent('repo.ownership.edit.file', 'delete')
+                                }}
+                            />
+                        )}
                     </div>
                     <IngestedFileViewer contents={codeownersIngestedFile.contents} />
                 </div>

--- a/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.story.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.story.tsx
@@ -2,6 +2,7 @@ import type { MockedResponse } from '@apollo/client/testing'
 import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 
 import { WebStory } from '../../../components/WebStory'
 import type {
@@ -43,7 +44,9 @@ const ownAnalyticsDisabled: MockedResponse<GetOwnSignalConfigurationsResult, Get
 }
 
 export const AnalyticsDisabled: StoryFn = () => (
-    <WebStory mocks={[ownAnalyticsDisabled]}>{() => <OwnAnalyticsPage />}</WebStory>
+    <WebStory mocks={[ownAnalyticsDisabled]}>
+        {() => <OwnAnalyticsPage telemetryRecorder={noOpTelemetryRecorder} />}
+    </WebStory>
 )
 AnalyticsDisabled.storyName = 'AnalyticsDisabled - need to enable own analytics in site admin'
 
@@ -85,7 +88,9 @@ const presentStats: MockedResponse<GetInstanceOwnStatsResult, GetInstanceOwnStat
 }
 
 export const PresentStats: StoryFn = () => (
-    <WebStory mocks={[ownAnalyticsEnabled, presentStats]}>{() => <OwnAnalyticsPage />}</WebStory>
+    <WebStory mocks={[ownAnalyticsEnabled, presentStats]}>
+        {() => <OwnAnalyticsPage telemetryRecorder={noOpTelemetryRecorder} />}
+    </WebStory>
 )
 PresentStats.storyName = 'PresentStats - statistics available'
 
@@ -108,6 +113,8 @@ const zeroStats: MockedResponse<GetInstanceOwnStatsResult, GetInstanceOwnStatsVa
 }
 
 export const ZeroStats: StoryFn = () => (
-    <WebStory mocks={[ownAnalyticsEnabled, zeroStats]}>{() => <OwnAnalyticsPage />}</WebStory>
+    <WebStory mocks={[ownAnalyticsEnabled, zeroStats]}>
+        {() => <OwnAnalyticsPage telemetryRecorder={noOpTelemetryRecorder} />}
+    </WebStory>
 )
 ZeroStats.storyName = 'ZeroStats - no statistics computed yet'

--- a/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
+++ b/client/web/src/enterprise/own/admin-ui/OwnAnalyticsPage.tsx
@@ -1,7 +1,8 @@
-import type { FC } from 'react'
+import { useEffect, type FC } from 'react'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Alert, BarChart, Card, ErrorAlert, Link, LoadingSpinner, Text } from '@sourcegraph/wildcard'
 
 import type {
@@ -21,12 +22,19 @@ interface OwnCoverageDatum {
     tooltip: string
 }
 
-export const OwnAnalyticsPage: FC = () => {
+interface OwnAnalyticsPageProps extends TelemetryV2Props {}
+
+export const OwnAnalyticsPage: FC<OwnAnalyticsPageProps> = ({ telemetryRecorder }) => {
     const { data, loading, error } = useQuery<GetOwnSignalConfigurationsResult>(GET_OWN_JOB_CONFIGURATIONS, {})
     const enabled =
         data?.ownSignalConfigurations.some(
             (config: OwnSignalConfig) => config.name === 'analytics' && config.isEnabled
         ) || false
+
+    useEffect(() => {
+        telemetryRecorder.recordEvent('admin.analytics.own', 'view')
+    }, [telemetryRecorder])
+
     return (
         <>
             {loading && <LoadingSpinner />}

--- a/client/web/src/enterprise/repo/enterpriseRepoContainerRoutes.tsx
+++ b/client/web/src/enterprise/repo/enterpriseRepoContainerRoutes.tsx
@@ -57,6 +57,8 @@ export const enterpriseRepoContainerRoutes: readonly RepoContainerRoute[] = [
     {
         path: '/-/own/edit',
         condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom,
-        render: context => <RepositoryOwnEditPage {...context} />,
+        render: context => (
+            <RepositoryOwnEditPage {...context} telemetryRecorder={context.platformContext.telemetryRecorder} />
+        ),
     },
 ]

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -459,7 +459,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         exact: true,
         path: '/own-signal-page',
-        render: () => <OwnStatusPage />,
+        render: props => <OwnStatusPage telemetryRecorder={props.platformContext.telemetryRecorder} />,
     },
 
     // Code intelligence redirect
@@ -522,7 +522,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         exact: true,
         path: '/analytics/own',
-        render: () => <OwnAnalyticsPage />,
+        render: props => <OwnAnalyticsPage telemetryRecorder={props.platformContext.telemetryRecorder} />,
     },
 ]
 


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally