### PR TITLE
v2t: add v2t to src/enterprise/rbac, /repo, and /search-jobs

### DIFF
--- a/client/web/src/enterprise/rbac/SiteAdminRolesPage.story.tsx
+++ b/client/web/src/enterprise/rbac/SiteAdminRolesPage.story.tsx
@@ -2,7 +2,7 @@ import type { Decorator, Meta, StoryFn } from '@storybook/react'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
-import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../components/WebStory'
@@ -59,7 +59,7 @@ export const RolesPage: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>
-                <SiteAdminRolesPage telemetryService={NOOP_TELEMETRY_SERVICE} />
+                <SiteAdminRolesPage telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
+++ b/client/web/src/enterprise/rbac/SiteAdminRolesPage.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useCallback } from 'react'
 import { mdiPlus } from '@mdi/js'
 import { groupBy, noop } from 'lodash'
 
-import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { PageHeader, Button, Icon, ProductStatusBadge, ErrorAlert, LoadingSpinner, Link } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../components/PageTitle'
@@ -14,14 +14,14 @@ import { RoleNode } from './components/RoleNode'
 
 import styles from './SiteAdminRolesPage.module.scss'
 
-export interface SiteAdminRolesPageProps extends TelemetryProps {}
+export interface SiteAdminRolesPageProps extends TelemetryV2Props {}
 
 export const SiteAdminRolesPage: React.FunctionComponent<React.PropsWithChildren<SiteAdminRolesPageProps>> = ({
-    telemetryService,
+    telemetryRecorder,
 }) => {
     useEffect(() => {
-        telemetryService.logPageView('SiteAdminRoles')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.roles', 'view')
+    }, [telemetryRecorder])
 
     const [permissions, setPermissions] = useState<PermissionsMap>({} as PermissionsMap)
 
@@ -77,7 +77,12 @@ export const SiteAdminRolesPage: React.FunctionComponent<React.PropsWithChildren
             </PageHeader>
 
             {showCreateRoleModal && !loading && (
-                <CreateRoleModal onCancel={closeModal} afterCreate={afterCreate} allPermissions={permissions} />
+                <CreateRoleModal
+                    onCancel={closeModal}
+                    afterCreate={afterCreate}
+                    allPermissions={permissions}
+                    telemetryRecorder={telemetryRecorder}
+                />
             )}
 
             {error && <ErrorAlert error={error} />}
@@ -85,7 +90,13 @@ export const SiteAdminRolesPage: React.FunctionComponent<React.PropsWithChildren
             {!loading && data && (
                 <ul className="list-unstyled">
                     {data.roles.nodes.map(node => (
-                        <RoleNode key={node.id} node={node} refetch={refetch} allPermissions={permissions} />
+                        <RoleNode
+                            key={node.id}
+                            node={node}
+                            refetch={refetch}
+                            allPermissions={permissions}
+                            telemetryRecorder={telemetryRecorder}
+                        />
                     ))}
                 </ul>
             )}

--- a/client/web/src/enterprise/rbac/components/CreateRoleModal.story.tsx
+++ b/client/web/src/enterprise/rbac/components/CreateRoleModal.story.tsx
@@ -3,6 +3,7 @@ import { noop } from 'lodash'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
@@ -37,7 +38,12 @@ export const CreateRoleModalStory: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>
-                <CreateRoleModal onCancel={noop} afterCreate={noop} allPermissions={mockPermissionsMap} />
+                <CreateRoleModal
+                    onCancel={noop}
+                    afterCreate={noop}
+                    allPermissions={mockPermissionsMap}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/enterprise/rbac/components/CreateRoleModal.tsx
+++ b/client/web/src/enterprise/rbac/components/CreateRoleModal.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { noop } from 'lodash'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Button,
     Modal,
@@ -22,7 +23,7 @@ import { useCreateRole, type PermissionsMap } from '../backend'
 
 import { PermissionsList } from './Permissions'
 
-export interface CreateRoleModalProps {
+export interface CreateRoleModalProps extends TelemetryV2Props {
     onCancel: () => void
     afterCreate: () => void
     allPermissions: PermissionsMap
@@ -42,12 +43,14 @@ export const CreateRoleModal: React.FunctionComponent<React.PropsWithChildren<Cr
     onCancel,
     afterCreate,
     allPermissions,
+    telemetryRecorder,
 }) => {
     const labelId = 'createRole'
 
     const [createRole, { loading, error }] = useCreateRole(afterCreate)
     const onSubmit = (values: CreateRoleModalFormValues): SubmissionResult => {
         const { name, permissions } = values
+        telemetryRecorder.recordEvent('admin.roles', 'create')
         // We handle any error by destructuring the query result directly
         createRole({ variables: { name, permissions } }).catch(noop)
     }

--- a/client/web/src/enterprise/rbac/components/RoleNode.story.tsx
+++ b/client/web/src/enterprise/rbac/components/RoleNode.story.tsx
@@ -3,6 +3,7 @@ import { noop } from 'lodash'
 import { MATCH_ANY_PARAMETERS, WildcardMockLink } from 'wildcard-mock-link'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
@@ -45,7 +46,12 @@ export const SystemRole: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>
-                <RoleNode allPermissions={mockPermissionsMap} node={systemRole} refetch={noop} />
+                <RoleNode
+                    allPermissions={mockPermissionsMap}
+                    node={systemRole}
+                    refetch={noop}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>
         )}
     </WebStory>
@@ -57,7 +63,12 @@ export const NonSystemRole: StoryFn = () => (
     <WebStory>
         {() => (
             <MockedTestProvider link={mocks}>
-                <RoleNode node={nonSystemRole} refetch={noop} allPermissions={mockPermissionsMap} />
+                <RoleNode
+                    node={nonSystemRole}
+                    refetch={noop}
+                    allPermissions={mockPermissionsMap}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.story.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.story.tsx
@@ -2,6 +2,7 @@ import { MockedResponse } from '@apollo/client/testing'
 import type { Decorator, StoryFn, Meta } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import { WebStory } from '../../../components/WebStory'
@@ -142,7 +143,7 @@ export const WithLogs: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={[REPOSITORY_RECORDED_COMMANDS_MOCK]}>
-                <RepoSettingsLogsPage repo={repo} />
+                <RepoSettingsLogsPage repo={repo} telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>
         )}
     </WebStory>
@@ -152,7 +153,7 @@ export const Disabled: StoryFn = args => (
     <WebStory>
         {() => (
             <MockedTestProvider mocks={[REPOSITORY_RECORDED_COMMANDS_DISABLED_MOCK]}>
-                <RepoSettingsLogsPage repo={repo} />
+                <RepoSettingsLogsPage repo={repo} telemetryRecorder={noOpTelemetryRecorder} />
             </MockedTestProvider>
         )}
     </WebStory>

--- a/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.test.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.test.tsx
@@ -1,6 +1,5 @@
 import type { MockedResponse } from '@apollo/client/testing'
 import { render, waitFor, screen } from '@testing-library/react'
-import { noop } from 'lodash'
 import { BrowserRouter } from 'react-router-dom'
 import { describe, expect, test } from 'vitest'
 

--- a/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.test.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.test.tsx
@@ -1,9 +1,11 @@
 import type { MockedResponse } from '@apollo/client/testing'
 import { render, waitFor, screen } from '@testing-library/react'
+import { noop } from 'lodash'
 import { BrowserRouter } from 'react-router-dom'
 import { describe, expect, test } from 'vitest'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
 import {
@@ -109,7 +111,7 @@ describe('RepoSettingsLogsPage', () => {
         const cmp = render(
             <BrowserRouter>
                 <MockedTestProvider mocks={[mockRecordedCommandsQuery]}>
-                    <RepoSettingsLogsPage repo={mockRepo} />
+                    <RepoSettingsLogsPage repo={mockRepo} telemetryRecorder={noOpTelemetryRecorder} />
                 </MockedTestProvider>
             </BrowserRouter>
         )
@@ -151,7 +153,7 @@ describe('RepoSettingsLogsPage', () => {
         const cmp = render(
             <BrowserRouter>
                 <MockedTestProvider mocks={[mockRecordedCommandsQuery]}>
-                    <RepoSettingsLogsPage repo={mockRepo} />
+                    <RepoSettingsLogsPage repo={mockRepo} telemetryRecorder={noOpTelemetryRecorder} />
                 </MockedTestProvider>
             </BrowserRouter>
         )
@@ -193,7 +195,7 @@ describe('RepoSettingsLogsPage', () => {
         const cmp = render(
             <BrowserRouter>
                 <MockedTestProvider mocks={[mockRecordedCommandsQuery]}>
-                    <RepoSettingsLogsPage repo={mockRepo} />
+                    <RepoSettingsLogsPage repo={mockRepo} telemetryRecorder={noOpTelemetryRecorder} />
                 </MockedTestProvider>
             </BrowserRouter>
         )

--- a/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsLogsPage.tsx
@@ -6,6 +6,7 @@ import { parseISO } from 'date-fns'
 import { useSearchParams } from 'react-router-dom'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Text,
     PageHeader,
@@ -27,23 +28,22 @@ import { LogOutput } from '../../../components/LogOutput'
 import { PageTitle } from '../../../components/PageTitle'
 import type { SettingsAreaRepositoryFields, RepositoryRecordedCommandFields } from '../../../graphql-operations'
 import { LogsPageTabs } from '../../../repo/constants'
-import { eventLogger } from '../../../tracking/eventLogger'
 
 import { useFetchRecordedCommands } from './backend'
 import { formatDuration } from './utils'
 
 import styles from './RepoSettingsLogsPage.module.scss'
 
-export interface RepoSettingsLogsPageProps {
+export interface RepoSettingsLogsPageProps extends TelemetryV2Props {
     repo: SettingsAreaRepositoryFields
 }
 
 /**
  * The repository settings log page.
  */
-export const RepoSettingsLogsPage: FC<RepoSettingsLogsPageProps> = ({ repo }) => {
+export const RepoSettingsLogsPage: FC<RepoSettingsLogsPageProps> = ({ repo, telemetryRecorder }) => {
     const [activeTabIndex, setActiveTabIndex] = useState<number>(LogsPageTabs.COMMANDS)
-    useEffect(() => eventLogger.logPageView('RepoSettingsLogs'), [])
+    useEffect(() => telemetryRecorder.recordEvent('repo.settings.logs', 'view'), [telemetryRecorder])
     const [searchParams, setSearchParams] = useSearchParams()
     const activeTab = searchParams.get('activeTab') ?? LogsPageTabs.COMMANDS.toString()
 

--- a/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/repo/settings/RepoSettingsPermissionsPage.tsx
@@ -41,7 +41,6 @@ import { ActionContainer } from '../../../repo/settings/components/ActionContain
 import { scheduleRepositoryPermissionsSync } from '../../../site-admin/backend'
 import { PermissionsSyncJobsTable } from '../../../site-admin/permissions-center/PermissionsSyncJobsTable'
 import { Table, type IColumn } from '../../../site-admin/UserManagement/components/Table'
-import { eventLogger } from '../../../tracking/eventLogger'
 import { PermissionReasonBadgeProps } from '../../settings/permissons'
 
 import { RepoPermissionsInfoQuery } from './backend'
@@ -62,7 +61,9 @@ export const RepoSettingsPermissionsPage: FC<RepoSettingsPermissionsPageProps> =
     telemetryService,
     telemetryRecorder,
 }) => {
-    useEffect(() => eventLogger.logViewEvent('RepoSettingsPermissions'))
+    useEffect(() => {
+        telemetryRecorder.recordEvent('repo.settings.permissions', 'view')
+    }, [telemetryRecorder])
 
     const [{ query }, setSearchQuery] = useURLSyncedState({ query: '' })
     const debouncedQuery = useDebounce(query, 300)

--- a/client/web/src/enterprise/search-jobs/SearchJobsPage.story.tsx
+++ b/client/web/src/enterprise/search-jobs/SearchJobsPage.story.tsx
@@ -2,6 +2,7 @@ import type { MockedResponse } from '@apollo/client/testing'
 import type { Meta, StoryFn } from '@storybook/react'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 
@@ -273,6 +274,10 @@ const USER_PICKER_QUERY_MOCK: MockedResponse<GetUsersListResult, GetUsersListVar
 
 export const SearchJobsListPage: StoryFn = () => (
     <MockedTestProvider mocks={[SEARCH_JOBS_MOCK, USER_PICKER_QUERY_MOCK]}>
-        <SearchJobsPage isAdmin={false} telemetryService={NOOP_TELEMETRY_SERVICE} />
+        <SearchJobsPage
+            isAdmin={false}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            telemetryRecorder={noOpTelemetryRecorder}
+        />
     </MockedTestProvider>
 )

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -184,6 +184,7 @@ export const routes: RouteObject[] = [
                     <SearchJob
                         isAdmin={props.authenticatedUser?.siteAdmin ?? false}
                         telemetryService={props.telemetryService}
+                        telemetryRecorder={props.platformContext.telemetryRecorder}
                     />
                 )}
                 condition={isSearchJobsEnabled}

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -515,7 +515,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         path: '/roles',
         exact: true,
-        render: props => <SiteAdminRolesPage {...props} />,
+        render: props => <SiteAdminRolesPage telemetryRecorder={props.platformContext.telemetryRecorder} />,
     },
 
     // Own analytics


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally