### PR TITLE
ci: fix executors image family for nightly builds

### DIFF
--- a/dev/ci/internal/ci/executor_operations.go
+++ b/dev/ci/internal/ci/executor_operations.go
@@ -122,7 +122,7 @@ func executorDockerMirrorImageFamilyForConfig(c Config) string {
 // This defaults to `-nightly`, and will be `-$MAJOR-$MINOR` for a tagged release
 // build.
 func executorImageFamilyForConfig(c Config) string {
-	imageFamily := "sourcegraph-executors-test-nightly"
+	imageFamily := "sourcegraph-executors-nightly"
 	if c.RunType.Is(runtype.TaggedRelease) {
 		ver, err := semver.NewVersion(c.Version)
 		if err != nil {


### PR DESCRIPTION
Accidental left-over while QA'ing the original PR.

Fixes https://github.com/sourcegraph/devx-support/issues/658 

## Test plan

CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
