### PR TITLE
ci: use .aspect/workflows/bazelrc for Aspect Workflows flags

### DIFF
--- a/.aspect/workflows/bazelrc
+++ b/.aspect/workflows/bazelrc
@@ -1,0 +1,13 @@
+# This flag is required because otherwise the integration tests fail with `fcmod` Operation not permitted
+# which is probably related to the launced containers writing to mapped in directories as root and then
+# when the container exits the files that are left over are root.
+# TODO(burmudar): launch containers with uid/guid mapped in
+common --noexperimental_reuse_sandbox_directories
+
+# build without the bytes
+common --remote_download_outputs=minimal
+common --nobuild_runfile_links
+
+# As per recommendation from https://analyzer.engflow.com/suggestions/829decb5-e3f4-4930-b60c-0494d154f8c1
+common --experimental_profile_include_target_label
+common --noslim_profile

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -2,18 +2,6 @@
 bazel:
   rcfiles:
     - ".aspect/bazelrc/ci.sourcegraph.bazelrc"
-  flags:
-    # This flag is required because otherwise the integration tests fail with `fcmod` Operation not permitted
-    # which is probably related to the launced containers writing to mapped in directories as root and then
-    # when the container exits the files that are left over are root.
-    # TODO(burmudar): launch containers with uid/guid mapped in
-    - --noexperimental_reuse_sandbox_directories
-    # TODO(gregmagolan): can be moved to .aspect/workflows/bazelrc in the future
-    - --remote_download_minimal
-    - --nobuild_runfile_links
-    # As per recommendation from https://analyzer.engflow.com/suggestions/829decb5-e3f4-4930-b60c-0494d154f8c1
-    - --experimental_profile_include_target_label
-    - --noslim_profile
 env:
   REDIS_CACHE_ENDPOINT: ":6379"
   GIT_PAGER: ""


### PR DESCRIPTION
Workflows now looks for a `.aspect/workflows/bazelrc` by convention and uses it if found. This simplifies the config.yaml file.

## Test plan

CI
