### PR TITLE
Svelte: respect trace=1 query param

### DIFF
--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -523,6 +523,7 @@ export function buildSearchURLQuery(
     query: string,
     patternType: SearchPatternType,
     caseSensitive: boolean,
+
     searchContextSpec?: string,
     searchMode?: SearchMode
 ): string {

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -523,7 +523,6 @@ export function buildSearchURLQuery(
     query: string,
     patternType: SearchPatternType,
     caseSensitive: boolean,
-
     searchContextSpec?: string,
     searchMode?: SearchMode
 ): string {

--- a/client/web-sveltekit/src/lib/search/state.ts
+++ b/client/web-sveltekit/src/lib/search/state.ts
@@ -37,7 +37,7 @@ export class QueryState {
     private defaultQuery = ''
     private defaultSearchContext = 'global'
 
-    private constructor(public readonly options: Partial<Options>, public settings: QuerySettings) {}
+    private constructor(public readonly options: Partial<Options>, public settings: QuerySettings) { }
 
     public static init(options: Partial<Options>, settings: QuerySettings): QueryState {
         return new QueryState(options, settings)
@@ -151,18 +151,17 @@ export function queryStateStore(initial: Partial<Options> = {}, settings: QueryS
 export function getQueryURL(
     queryState: Pick<QueryState, 'searchMode' | 'query' | 'caseSensitive' | 'patternType' | 'searchContext'>,
     enforceCache = false
-): string {
-    const searchQueryParameter = buildSearchURLQuery(
+): URL {
+    let url = new URL('/search')
+    url.search = buildSearchURLQuery(
         queryState.query,
         queryState.patternType,
         queryState.caseSensitive,
         queryState.searchContext,
         queryState.searchMode
     )
-
-    let url = '/search?' + searchQueryParameter
     if (enforceCache) {
-        url += `&${USE_CLIENT_CACHE_QUERY_PARAMETER}`
+        url.searchParams.append(USE_CLIENT_CACHE_QUERY_PARAMETER, '1')
     }
     return url
 }

--- a/client/web-sveltekit/src/lib/search/state.ts
+++ b/client/web-sveltekit/src/lib/search/state.ts
@@ -37,7 +37,7 @@ export class QueryState {
     private defaultQuery = ''
     private defaultSearchContext = 'global'
 
-    private constructor(public readonly options: Partial<Options>, public settings: QuerySettings) { }
+    private constructor(public readonly options: Partial<Options>, public settings: QuerySettings) {}
 
     public static init(options: Partial<Options>, settings: QuerySettings): QueryState {
         return new QueryState(options, settings)

--- a/client/web-sveltekit/src/lib/search/state.ts
+++ b/client/web-sveltekit/src/lib/search/state.ts
@@ -161,7 +161,7 @@ export function getQueryURL(
         queryState.searchMode
     )
     if (enforceCache) {
-        url.searchParams.append(USE_CLIENT_CACHE_QUERY_PARAMETER, '1')
+        url.searchParams.append(USE_CLIENT_CACHE_QUERY_PARAMETER, '')
     }
     return url
 }

--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -94,6 +94,7 @@ export const load: PageLoad = ({ url, depends }) => {
     const hasQuery = url.searchParams.has('q')
     const caseSensitiveURL = url.searchParams.get('case') === 'yes'
     const forceCache = url.searchParams.has(USE_CLIENT_CACHE_QUERY_PARAMETER)
+    const trace = url.searchParams.get('trace') ?? undefined
 
     if (hasQuery) {
         const parsedQuery = parseExtendedSearchURL(url)
@@ -122,7 +123,8 @@ export const load: PageLoad = ({ url, depends }) => {
             version: LATEST_VERSION,
             patternType,
             caseSensitive,
-            trace: '',
+            trace,
+            // TODO(@camdencheek): populate these from local storage
             featureOverrides: [],
             chunkMatches: true,
             searchMode,


### PR DESCRIPTION
This propagates the `trace=1` from the URL query to the search stream request.

I also looked into maintaining the `trace=1` when submitting a query (new navigation), but I wasn't sure what the best way to do that is. The React webapp maintains that query param across navigations, but it's not clear to me whether that's actually a good pattern. If I understand correctly, we would need to check and forward the `&trace=1` at every place we navigate, which would be pretty overwhelming. 

The trace setting is independent of search query params. Is there a good pattern for storing/fetching/forwarding pieces of state in the URL?

Contributes to [#60732](https://github.com/sourcegraph/sourcegraph/issues/60732)

## Test plan

Added `&trace=1` to a search URL and checked that the returned trace URL works.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
