### PR TITLE
Svelte: use JSON_SCIP format for highlighting

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
@@ -34,14 +34,14 @@ fragment BlobPage_Blob on GitBlob {
     languages
 }
 
-query BlobSyntaxHighlightQuery($repoName: String!, $revspec: String!, $path: String!, $disableTimeout: Boolean!) {
+query BlobSyntaxHighlightQuery($repoName: String!, $revspec: String!, $path: String!, $disableTimeout: Boolean!, $format: HighlightResponseFormat = JSON_SCIP) {
     repository(name: $repoName) {
         id
         commit(rev: $revspec) {
             id
             blob(path: $path) {
                 canonicalURL
-                highlight(disableTimeout: $disableTimeout) {
+                highlight(disableTimeout: $disableTimeout, format: $format) {
                     aborted
                     lsif
                 }


### PR DESCRIPTION
Fixes #60430 

## Test plan

Unhighlighted code is now correctly highlighted.

![CleanShot 2024-03-05 at 13 20 08@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/6ebae165-374c-4eb0-aa7e-991f4e692f55)
