### PR TITLE
Svelte: fix code submission

### DIFF
--- a/client/web-sveltekit/src/lib/search/state.ts
+++ b/client/web-sveltekit/src/lib/search/state.ts
@@ -152,7 +152,7 @@ export function getQueryURL(
     queryState: Pick<QueryState, 'searchMode' | 'query' | 'caseSensitive' | 'patternType' | 'searchContext'>,
     enforceCache = false
 ): URL {
-    let url = new URL('/search')
+    let url = new URL('/search', location.href)
     url.search = buildSearchURLQuery(
         queryState.query,
         queryState.patternType,


### PR DESCRIPTION
I introduced a bug in #60871 that was causing submitting a search to fail. TIL that `new URL` does not work with a relative URL by default!

## Test plan

Submitting a search on the home page now works. I think we actually have a playwright test for this, but apparently it's not hooked up to CI yet.