### PR TITLE
Allow to get Blame information for a whole file

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6063,7 +6063,7 @@ type GitBlob implements TreeEntry & File2 {
     """
     Blame the blob.
     """
-    blame(startLine: Int!, endLine: Int!, ignoreWhitespace: Boolean = false): [Hunk!]!
+    blame(startLine: Int, endLine: Int, ignoreWhitespace: Boolean = false): [Hunk!]!
     """
     Highlight the blob contents.
     """


### PR DESCRIPTION
This allows to get blame for the entire file without specifying `1` and `100000` as the range.

## Test plan

Verified manually in my local instance.

