### PR TITLE
Search: avoid crashing on frontend panic

### DIFF
--- a/cmd/frontend/internal/compute/streaming/BUILD.bazel
+++ b/cmd/frontend/internal/compute/streaming/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//internal/trace",
         "//lib/errors",
         "//lib/pointers",
+        "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_conc//stream",
         "@com_github_sourcegraph_log//:log",
         "@io_opentelemetry_go_otel//attribute",

--- a/internal/search/backend/BUILD.bazel
+++ b/internal/search/backend/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "@com_github_mitchellh_hashstructure//:hashstructure",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
-        "@com_github_sourcegraph_conc//:conc",
         "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_zoekt//:zoekt",

--- a/internal/search/backend/BUILD.bazel
+++ b/internal/search/backend/BUILD.bazel
@@ -34,6 +34,8 @@ go_library(
         "@com_github_mitchellh_hashstructure//:hashstructure",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
+        "@com_github_sourcegraph_conc//:conc",
+        "@com_github_sourcegraph_conc//pool",
         "@com_github_sourcegraph_log//:log",
         "@com_github_sourcegraph_zoekt//:zoekt",
         "@com_github_sourcegraph_zoekt//cmd/zoekt-sourcegraph-indexserver/protos/sourcegraph/zoekt/configuration/v1:configuration",

--- a/internal/search/backend/aggregate.go
+++ b/internal/search/backend/aggregate.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/sourcegraph/conc"
 	"github.com/sourcegraph/zoekt"
 )
 
@@ -148,10 +147,8 @@ func newFlushCollectSender(opts *zoekt.SearchOptions, endpoints []string, maxSiz
 		timerCancel:  timerCancel}
 
 	// As an escape hatch, stop collecting after twice the FlushWallTime. This protects against
-	// cases where an endpoint stops being responsive so we never receive its results. Even though
-	// it's a non-blocking goroutine, we use a WaitGroup to properly propagate panics.
-	wg := conc.NewWaitGroup()
-	wg.Go(func() {
+	// cases where an endpoint stops being responsive so we never receive its results.
+	go func() {
 		timer := time.NewTimer(2 * opts.FlushWallTime)
 		select {
 		case <-timerCancel:
@@ -161,7 +158,7 @@ func newFlushCollectSender(opts *zoekt.SearchOptions, endpoints []string, maxSiz
 			flushSender.stopCollectingAndFlush(zoekt.FlushReasonTimerExpired)
 			flushSender.mu.Unlock()
 		}
-	})
+	}()
 	return flushSender
 }
 

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -61,7 +61,7 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 	var mu sync.Mutex
 	dedupper := dedupper{}
 
-	pl := pool.NewWithResults[error]()
+	pl := pool.New().WithErrors()
 	for endpoint, client := range clients {
 		e := endpoint
 		c := client
@@ -89,12 +89,7 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 		})
 	}
 
-	errs := pl.Wait()
-	var multiError errors.MultiError
-	for _, err := range errs {
-		multiError = errors.Append(multiError, err)
-	}
-	return multiError
+	return pl.Wait()
 }
 
 type queueSearchResult struct {

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sourcegraph/conc/pool"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
 	"github.com/sourcegraph/zoekt/stream"
@@ -60,9 +61,11 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 	var mu sync.Mutex
 	dedupper := dedupper{}
 
-	ch := make(chan error, len(clients))
-	for endpoint, c := range clients {
-		go func(endpoint string, c zoekt.Streamer) {
+	pl := pool.NewWithResults[error]()
+	for endpoint, client := range clients {
+		e := endpoint
+		c := client
+		pl.Go(func() error {
 			err := c.StreamSearch(ctx, q, opts, stream.SenderFunc(func(sr *zoekt.SearchResult) {
 				// This shouldn't happen, but skip event if sr is nil.
 				if sr == nil {
@@ -70,28 +73,28 @@ func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *
 				}
 
 				mu.Lock()
-				sr.Files = dedupper.Dedup(endpoint, sr.Files)
+				sr.Files = dedupper.Dedup(e, sr.Files)
 				mu.Unlock()
 
-				flushSender.Send(endpoint, sr)
+				flushSender.Send(e, sr)
 			}))
 
 			if isZoektRolloutError(ctx, err) {
-				flushSender.Send(endpoint, crashEvent())
-				err = nil
+				flushSender.Send(e, crashEvent())
+				return nil
 			}
 
-			flushSender.SendDone(endpoint)
-			ch <- err
-		}(endpoint, c)
+			flushSender.SendDone(e)
+			return err
+		})
 	}
 
-	var errs errors.MultiError
-	for i := 0; i < cap(ch); i++ {
-		errs = errors.Append(errs, <-ch)
+	errs := pl.Wait()
+	var multiError errors.MultiError
+	for _, err := range errs {
+		multiError = errors.Append(multiError, err)
 	}
-
-	return errs
+	return multiError
 }
 
 type queueSearchResult struct {


### PR DESCRIPTION
Because of a recent regression, frontend could panic when streaming back search
matches. These panics occur in a raw goroutine, which we didn't manually
propagate. So the panics caused frontend to crash.

This PR updates the relevant places to use `conc` objects, which properly
propagate panics. I did a "best effort" based on the original issue and didn't
audit all frontend search code.

Related to INC-258
Related to #60605

## Test plan

Happy path is covered by existing tests like `aggregate_test.go` and
`horizontal_test.go`. Manually repro'd the original issue #60605 with the
search `repo:sourcegraph/sourcegraph camden cheek file:contains.content(>\n)`
and checked frontend no longer crashes. Also manually tested code insights.
