### PR TITLE
Svelte: fixup caching

### DIFF
--- a/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
@@ -10,6 +10,7 @@ import {
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
 
 import { parseExtendedSearchURL } from '..'
+import { USE_CLIENT_CACHE_QUERY_PARAMETER } from '../constants'
 
 export type SectionItem = Omit<Filter, 'count'> & {
     count?: Filter['count']
@@ -53,6 +54,7 @@ export function updateFilterInURL(url: URL, filter: URLQueryFilter, remove: bool
     selectedFilters
         .map(serializeURLFilter)
         .forEach(selectedFilter => newURL.searchParams.append(DYNAMIC_FILTER_URL_QUERY_KEY, selectedFilter))
+    newURL.searchParams.set(USE_CLIENT_CACHE_QUERY_PARAMETER, '')
 
     return newURL
 }

--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -8,6 +8,7 @@ export {
     buildSearchURLQuery,
     makeRepoURI,
 } from '@sourcegraph/shared/src/util/url'
+
 export {
     isCloneInProgressErrorLike,
     isRepoSeeOtherErrorLike,
@@ -26,6 +27,7 @@ export {
     getFileMatchUrl,
     getRepositoryUrl,
     aggregateStreamingSearch,
+    emptyAggregateResults,
     LATEST_VERSION,
     type AggregateStreamingSearchResults,
     type StreamSearchOptions,

--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, type Observable, of, type Subscription } from 'rxjs'
+import { BehaviorSubject, type Observable, of } from 'rxjs'
 import { get } from 'svelte/store'
 
 import { browser } from '$app/environment'
@@ -20,17 +20,13 @@ import {
 
 import type { PageLoad } from './$types'
 
-interface SearchStreamCacheEntry {
-    searchStream: Observable<AggregateStreamingSearchResults>
-    complete: boolean
-}
+type SearchStreamCacheEntry = Observable<AggregateStreamingSearchResults>
 
 /**
  * CachingStreamManager helps caching and canceling search streams in the browser.
  */
 class CachingStreamManager {
     private cache: Map<string, SearchStreamCacheEntry> = new Map()
-    private activeSubscription: { cacheKey: string; subscription: Subscription } | undefined
     private streamManager = new NonCachingStreamManager()
 
     search(
@@ -40,36 +36,17 @@ class CachingStreamManager {
     ): Observable<AggregateStreamingSearchResults> {
         const key = createCacheKey(parsedQuery, searchOptions)
 
-        // Cancel any active query to reduce load on the server
-        {
-            const { cacheKey, subscription } = this.activeSubscription ?? {}
-            if (cacheKey && cacheKey !== key) {
-                subscription?.unsubscribe()
-                // We need to remove the cache entry for ongoing queries otherwise
-                // the cache will contain partial data
-                if (!this.cache.get(cacheKey)?.complete) {
-                    this.cache.delete(cacheKey)
-                }
-            }
-        }
-
-        const searchStream = this.cache.get(key)?.searchStream
+        const searchStream = this.cache.get(key)
 
         if (bypassCache || !searchStream) {
             const stream = this.streamManager.search(parsedQuery, searchOptions)
             const searchStream = new BehaviorSubject<AggregateStreamingSearchResults>(emptyAggregateResults)
-            const cacheEntry: SearchStreamCacheEntry = { searchStream, complete: false }
-            this.cache.set(key, cacheEntry)
-            // Primes the stream
-            const subscription = stream.subscribe({
+            this.cache.set(key, searchStream)
+            stream.subscribe({
                 next: value => {
                     searchStream.next(value)
                 },
-                complete: () => {
-                    cacheEntry.complete = true
-                },
             })
-            this.activeSubscription = { cacheKey: key, subscription }
             return searchStream
         }
 

--- a/client/web-sveltekit/src/routes/search/+page.ts
+++ b/client/web-sveltekit/src/routes/search/+page.ts
@@ -15,12 +15,13 @@ import {
     FilterType,
     getGlobalSearchContextFilter,
     omitFilter,
+    emptyAggregateResults,
 } from '$lib/shared'
 
 import type { PageLoad } from './$types'
 
 interface SearchStreamCacheEntry {
-    searchStream: Observable<AggregateStreamingSearchResults | undefined>
+    searchStream: Observable<AggregateStreamingSearchResults>
     complete: boolean
 }
 
@@ -36,7 +37,7 @@ class CachingStreamManager {
         parsedQuery: ExtendedParsedSearchURL,
         searchOptions: StreamSearchOptions,
         bypassCache: boolean
-    ): Observable<AggregateStreamingSearchResults | undefined> {
+    ): Observable<AggregateStreamingSearchResults> {
         const key = createCacheKey(parsedQuery, searchOptions)
 
         // Cancel any active query to reduce load on the server
@@ -56,7 +57,7 @@ class CachingStreamManager {
 
         if (bypassCache || !searchStream) {
             const stream = this.streamManager.search(parsedQuery, searchOptions)
-            const searchStream = new BehaviorSubject<AggregateStreamingSearchResults | undefined>(undefined)
+            const searchStream = new BehaviorSubject<AggregateStreamingSearchResults>(emptyAggregateResults)
             const cacheEntry: SearchStreamCacheEntry = { searchStream, complete: false }
             this.cache.set(key, cacheEntry)
             // Primes the stream
@@ -83,7 +84,7 @@ class NonCachingStreamManager {
     search(
         parsedQuery: ExtendedParsedSearchURL,
         searchOptions: StreamSearchOptions
-    ): Observable<AggregateStreamingSearchResults | undefined> {
+    ): Observable<AggregateStreamingSearchResults> {
         return aggregateStreamingSearch(of(parsedQuery.filteredQuery ?? ''), searchOptions)
     }
 }

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -26,13 +26,13 @@
     import SearchInput from '$lib/search/input/SearchInput.svelte'
     import { submitSearch, type QueryStateStore } from '$lib/search/state'
     import Separator, { getSeparatorPosition } from '$lib/Separator.svelte'
-    import { type AggregateStreamingSearchResults, type SearchMatch, type Progress } from '$lib/shared'
+    import { type AggregateStreamingSearchResults, type SearchMatch } from '$lib/shared'
 
     import { getSearchResultComponent } from './searchResultFactory'
     import { setSearchResultsContext } from './searchResultsContext'
     import StreamingProgress from './StreamingProgress.svelte'
 
-    export let stream: Observable<AggregateStreamingSearchResults | undefined>
+    export let stream: Observable<AggregateStreamingSearchResults>
     export let queryFromURL: string
     export let selectedFilters: URLQueryFilter[]
     export let queryState: QueryStateStore
@@ -52,17 +52,14 @@
     const sidebarSize = getSeparatorPosition('search-results-sidebar', 0.2)
     $: sidebarWidth = `clamp(14rem, ${$sidebarSize * 100}%, 50%)`
 
-    $: progress = $stream?.progress
-    // NOTE: done is present but apparently not officially exposed. However
-    // $stream.state is always "loading". Need to look into this.
-    $: loading = !(progress as Progress & { done?: boolean })?.done
-    $: results = $stream?.results
+    $: loading = $stream.state === 'loading'
+    $: results = $stream.results
 
     // Logic for maintaining list state (scroll position, rendered items, open
     // items) for backwards navigation.
     $: cacheEntry = cache.get(queryFromURL)
     $: count = cacheEntry?.count ?? DEFAULT_INITIAL_ITEMS_TO_SHOW
-    $: resultsToShow = results ? results.slice(0, count) : null
+    $: resultsToShow = results.slice(0, count)
     $: expandedSet = cacheEntry?.expanded || new Set<SearchMatch>()
 
     setSearchResultsContext({
@@ -112,12 +109,7 @@
 
 <div class="search-results">
     <div style:width={sidebarWidth}>
-        <DynamicFiltersSidebar
-            {selectedFilters}
-            streamFilters={$stream?.filters ?? []}
-            searchQuery={queryFromURL}
-            {loading}
-        />
+        <DynamicFiltersSidebar {selectedFilters} streamFilters={$stream.filters} searchQuery={queryFromURL} {loading} />
     </div>
     <Separator currentPosition={sidebarSize} />
     <div class="results" bind:this={resultContainer}>
@@ -127,29 +119,25 @@
                     <LoadingSpinner inline />
                 </div>
             {/if}
-            {#if progress}
-                <StreamingProgress {progress} on:submit={onResubmitQuery} />
-            {/if}
+            <StreamingProgress progress={$stream.progress} on:submit={onResubmitQuery} />
         </aside>
-        {#if resultsToShow}
-            <ol>
-                {#each resultsToShow as result, i}
-                    {@const component = getSearchResultComponent(result)}
-                    {#if i === resultsToShow.length - 1}
-                        <li use:observeIntersection on:intersecting={loadMore}>
-                            <svelte:component this={component} {result} />
-                        </li>
-                    {:else}
-                        <li><svelte:component this={component} {result} /></li>
-                    {/if}
-                {/each}
-            </ol>
-            {#if resultsToShow.length === 0 && !loading}
-                <div class="no-result">
-                    <Icon svgPath={mdiCloseOctagonOutline} />
-                    <p>No results found</p>
-                </div>
-            {/if}
+        <ol>
+            {#each resultsToShow as result, i}
+                {@const component = getSearchResultComponent(result)}
+                {#if i === resultsToShow.length - 1}
+                    <li use:observeIntersection on:intersecting={loadMore}>
+                        <svelte:component this={component} {result} />
+                    </li>
+                {:else}
+                    <li><svelte:component this={component} {result} /></li>
+                {/if}
+            {/each}
+        </ol>
+        {#if resultsToShow.length === 0 && !loading}
+            <div class="no-result">
+                <Icon svgPath={mdiCloseOctagonOutline} />
+                <p>No results found</p>
+            </div>
         {/if}
     </div>
 </div>


### PR DESCRIPTION
This PR comes in three commits:
1) Add the URL parameter to force use of the cache to navigations from the filters panel. These are not forward/back so we don't use the cache automatically, but toggling them on and off is a very common pattern that we don't want to re-run the query for.
2) Make the stream always defined. Previously, we were using a `BehaviorSubject` with a default value of `undefined`, but we actually have a meaningful value for "a stream that has had no events yet". This simplifies a bunch of signatures and consumers of the stream. This seems unrelated, but it made it easier to reason about the initial state of the observable.
3) Remove the request cancellation logic. I had previously asked for us to cancel in-flight requests when we make a new request to reduce the load on the server, but this also ends up cancelling any request that the page is actively running whenever you hover over a filter. This is particularly nasty because when you click a filter, when the new page loads, you will frequently already be hovering over a different filter, which immediately cancels the initial request and gives you a forever-loading page. We will want to revisit this becasue I don't think we want to be preloading as aggressively as we are for searches (especially when hovering over very expensive searches like diff searches!). We may even want to disable preloading for the filters panel entirely, though I'd be sad to see us do that since it makes it feel very snappy.

Followups:
- Limit the size of the cache
- Consider removing preload for filters or adding back cancellation specifically for preloads initiated from hover

## Test plan

Manual testing. The caching issue was very easy to hit when interacting with the side panel, and everything works as expected now. Toggling a filter on and off is now an instant operation when it hits the cache.