### PR TITLE
Svelte: remove weird background color

### DIFF
--- a/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
+++ b/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
@@ -152,7 +152,6 @@
     .root {
         flex: 1;
         box-sizing: border-box;
-        background-color: var(--color-bg-1);
         min-width: 0;
         padding-left: 1px;
 


### PR DESCRIPTION
This div had a different background color than both its parent divs and child divs, which was causing there to be a weird dark spot in the query input where there was a margin.

## Test plan

Before:
![CleanShot 2024-03-05 at 16 41 25@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/cb9587d1-ef82-4f52-a25e-dbf19620bc6e)

After:
![CleanShot 2024-03-05 at 16 41 15@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/ba8c3baa-e4ca-4b78-baf4-6fdfd9703948)
