### PR TITLE
update description for sg backport

### DIFF
--- a/dev/sg/sg_backport.go
+++ b/dev/sg/sg_backport.go
@@ -28,7 +28,7 @@ var releaseBranchFlag = cli.StringFlag{
 var backportCommand = &cli.Command{
 	Name:     "backport",
 	Category: category.Dev,
-	Usage:    "Backport commits from master to release branches.\nsg backport -r 5.3 -p 60932",
+	Usage:    "Backport commits from main to release branches.\nsg backport -r 5.3 -p 60932",
 	Action: func(cmd *cli.Context) error {
 		prNumber := pullRequestIDFlag.Get(cmd)
 		releaseBranch := releaseBranchFlag.Get(cmd)


### PR DESCRIPTION
Replace the use of `master` with `main` in the `sg backport` description.

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
Just a text update