### PR TITLE
ci: disable posting of annotations by aspect buildkite plugin

### DIFF
--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -8,6 +8,7 @@ plugins:
     from: github.com/aspect-build/plugin-fix-visibility
     version: v0.1.0
   - name: buildkite
+    version: 2cb7de11bb73b2730320b29d8780602a88209747
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
     properties:
       buildkite_analytics_env_name: BUILDKITE_ANALYTICS_TOKEN_SOURCEGRAPH_BAZEL

--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -12,3 +12,4 @@ plugins:
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
     properties:
       buildkite_analytics_env_name: BUILDKITE_ANALYTICS_TOKEN_SOURCEGRAPH_BAZEL
+      enable_annotations: false

--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -8,7 +8,6 @@ plugins:
     from: github.com/aspect-build/plugin-fix-visibility
     version: v0.1.0
   - name: buildkite
-    version: v0.0.9
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
     properties:
       buildkite_analytics_env_name: BUILDKITE_ANALYTICS_TOKEN_SOURCEGRAPH_BAZEL

--- a/.aspect/cli/config.yaml
+++ b/.aspect/cli/config.yaml
@@ -8,7 +8,7 @@ plugins:
     from: github.com/aspect-build/plugin-fix-visibility
     version: v0.1.0
   - name: buildkite
-    version: 2cb7de11bb73b2730320b29d8780602a88209747
+    version: v0.0.10-alpha
     from: github.com/sourcegraph/aspect-cli-plugin-buildkite
     properties:
       buildkite_analytics_env_name: BUILDKITE_ANALYTICS_TOKEN_SOURCEGRAPH_BAZEL


### PR DESCRIPTION
Disables the following annotations:
![Screenshot 2024-03-06 at 15 06 26](https://github.com/sourcegraph/sourcegraph/assets/1001709/4d6de01c-58fc-4492-9e9f-82fc81fcb0b2)
![Screenshot 2024-03-06 at 15 06 14](https://github.com/sourcegraph/sourcegraph/assets/1001709/72c72402-5081-4e20-9bfb-bb080466b0f0)

See https://github.com/sourcegraph/aspect-cli-plugin-buildkite/pull/4 for config option
## Test plan
Build should not have empty failure annotation
