### PR TITLE
ci: disable Workflows runner observabilty to resolve slow post-task agent health check

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -5,6 +5,8 @@ bazel:
 env:
   REDIS_CACHE_ENDPOINT: ":6379"
   GIT_PAGER: ""
+# Temporary work-around to resolve a slow post task agent health check
+observability: false
 tasks:
   # Checks that BUILD files are formatted
   - buildifier:


### PR DESCRIPTION
We the slow agent health check post-task happen at one other deployment and have not tracked down the root cause yet but it does seem to be related to the observability code that runs at that time.

## Test plan

CI