### PR TITLE
Enforce authz check for individual codehosts

### DIFF
--- a/cmd/frontend/graphqlbackend/code_hosts.go
+++ b/cmd/frontend/graphqlbackend/code_hosts.go
@@ -121,6 +121,11 @@ func UnmarshalCodeHostID(gqlID graphql.ID) (id int32, err error) {
 }
 
 func CodeHostByID(ctx context.Context, db database.DB, id graphql.ID) (*codeHostResolver, error) {
+	// Security 🚨: Code Hosts may only be viewed by site admins for now.
+	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, db); err != nil {
+		return nil, err
+	}
+
 	intID, err := UnmarshalCodeHostID(id)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Make sure we match the same requirements as for listing the codehosts. Updated test cases to prevent future regressions.

See  https://github.com/sourcegraph/security-issues/issues/384 for more information!

## Test plan
CI tests

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
