### PR TITLE
bazel: transition oci_image ourselves instead of via with_cfg.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -159,13 +159,6 @@ http_archive(
     url = "https://github.com/keith/rules_multirun/archive/refs/tags/0.6.1.tar.gz",
 )
 
-http_archive(
-    name = "with_cfg.bzl",
-    sha256 = "c6b80cad298afa8a46bc01cd96df4f4d8660651101f6bf5af58f2724e349017d",
-    strip_prefix = "with_cfg.bzl-0.2.1",
-    url = "https://github.com/fmeum/with_cfg.bzl/releases/download/v0.2.1/with_cfg.bzl-v0.2.1.tar.gz",
-)
-
 # hermetic_cc_toolchain setup ================================
 HERMETIC_CC_TOOLCHAIN_VERSION = "v2.2.1"
 


### PR DESCRIPTION
with_cfg.bzl is a lot of complicated starlark which we can avoid having to try understand when debugging needs arise by doing what it does by-hand and specific to what we need (aka super cut down and simplified).

Extracted from https://github.com/sourcegraph/sourcegraph/compare/jcjh/msp-bazel-delivery#diff-1a8a445b4ce2a72080eca8ae2a3ae24bc904175e9d9aa2dd1938a29746ae86a3 while we were debugging why AW delivery was being problematic (this wasnt the reason, but I did this change in case it _was_ causing issues and itd be more understandable to read)

## Test plan

`bazel run //cmd/batcheshelper:image_tarball && docker run batcheshelper:candidate --help`
