### PR TITLE
ci: remove include_eternal_tests as it is no longer needed in Aspect Workflows 5.9.18

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -18,13 +18,11 @@ tasks:
       fix_target: //:configure
   # Checks that all tests are passing
   - test:
-      include_eternal_tests: true
       targets:
         - //...
         # exclude testing as it is executed in a seperate job
         - -//testing/...
   - test:
-      include_eternal_tests: true
       name: Integration/E2E
       targets:
         - //testing/...

--- a/dev/sg/internal/images/BUILD.bazel
+++ b/dev/sg/internal/images/BUILD.bazel
@@ -35,7 +35,7 @@ go_library(
 
 go_test(
     name = "images_test",
-    timeout = "short",
+    timeout = "eternal",
     srcs = [
         "images_test.go",
         "pure_docker_test.go",


### PR DESCRIPTION
`include_eternal_tests` is now deprecated and Workflows no longer filters eternal tests out by default as of 5.9.18.

## Test plan

CI