### PR TITLE
Svelte: fix no matches messages with show more

### DIFF
--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
@@ -53,7 +53,14 @@
                 </li>
             {/each}
         </ul>
-        {#if showMore}
+        {#if filteredItems.length === 0}
+            <small class="filter-message">
+                <div class="header"><strong>No matches in search results.</strong></div>
+                Try expanding your search using the
+                <Button variant="link" display="inline" on:click={() => filterInputRef.focus()}>search bar</Button>
+                above.
+            </small>
+        {:else if showMore}
             {#if filteredItems.length > limitedItems.length}
                 <small class="filter-message">
                     {filteredItems.length - limitedItems.length} not shown. Use
@@ -64,17 +71,10 @@
             <footer class="show-more">
                 <Button variant="link" on:click={() => (showMore = false)}>Show less</Button>
             </footer>
-        {:else if !showMore && filteredItems.length > limitedItems.length}
+        {:else if filteredItems.length > limitedItems.length}
             <footer class="show-more">
                 <Button variant="link" on:click={() => (showMore = true)}>Show more</Button>
             </footer>
-        {:else if filteredItems.length === 0}
-            <small class="filter-message">
-                <div class="header"><strong>No matches in search results.</strong></div>
-                Try expanding your search using the
-                <Button variant="link" display="inline" on:click={() => filterInputRef.focus()}>search bar</Button>
-                above.
-            </small>
         {/if}
     </article>
 {/if}


### PR DESCRIPTION
Tiny fix for when to show conditional messages. Previously, we would not show the "no matches" message if the user had activated "Show more". This just modifies the conditional so that we always show that message if no results match their filter.

## Test plan

Before:
<img width="410" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/d77f434b-e487-4b1c-ae50-3bd09c4764c0">


After:

<img width="415" alt="image" src="https://github.com/sourcegraph/sourcegraph/assets/12631702/d5e56d15-877e-4727-a2c4-dcc1bb24c30d">
