### PR TITLE
rename "Subscriptions" to "Enterprise licenses" to avoid confusion with Cody Pro

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 
 import { mdiPlus } from '@mdi/js'
 
-import { Button, Link, Icon, PageHeader, Container } from '@sourcegraph/wildcard'
+import { Button, Container, Icon, Link, PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../../auth'
 import { FilteredConnection } from '../../../../components/FilteredConnection'
@@ -24,7 +24,8 @@ interface Props {
 }
 
 /**
- * Displays the product subscriptions that have been created on Sourcegraph.com.
+ * Displays the enterprise licenses (formerly known as "product subscriptions") that have been
+ * created on Sourcegraph.com.
  */
 export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     authenticatedUser,
@@ -33,14 +34,14 @@ export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<React.Pr
 
     return (
         <div className="site-admin-product-subscriptions-page">
-            <PageTitle title="Product subscriptions" />
+            <PageTitle title="Enterprise licenses" />
             <PageHeader
                 headingElement="h2"
-                path={[{ text: 'Product subscriptions' }]}
+                path={[{ text: 'Enterprise licenses' }]}
                 actions={
                     <Button to="./new" variant="primary" as={Link}>
                         <Icon aria-hidden={true} svgPath={mdiPlus} />
-                        Create product subscription
+                        Create Enterprise license
                     </Button>
                 }
                 className="mb-3"
@@ -51,8 +52,8 @@ export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<React.Pr
                     listComponent="table"
                     listClassName="table"
                     contentWrapperComponent={ListContentWrapper}
-                    noun="product subscription"
-                    pluralNoun="product subscriptions"
+                    noun="Enterprise license"
+                    pluralNoun="Enterprise licenses"
                     queryConnection={queryProductSubscriptions}
                     headComponent={SiteAdminProductSubscriptionNodeHeader}
                     nodeComponent={SiteAdminProductSubscriptionNode}

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import type { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
 import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
-import { Container, PageHeader, Link, Text } from '@sourcegraph/wildcard'
+import { Container, Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../../backend/graphql'
 import { FilteredConnection } from '../../../components/FilteredConnection'
@@ -18,9 +18,9 @@ import type {
 } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 import {
-    productSubscriptionFragment,
     ProductSubscriptionNode,
     ProductSubscriptionNodeHeader,
+    productSubscriptionFragment,
     type ProductSubscriptionNodeProps,
 } from '../../dotcom/productSubscriptions/ProductSubscriptionNode'
 
@@ -29,7 +29,8 @@ interface Props {
 }
 
 /**
- * Displays the product subscriptions associated with this account.
+ * Displays the enterprise licenses (formerly known as "product subscriptions") associated with this
+ * account.
  */
 export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
     React.PropsWithChildren<Props>
@@ -76,10 +77,10 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
 
     return (
         <div className="user-subscriptions-product-subscriptions-page">
-            <PageTitle title="Subscriptions" />
+            <PageTitle title="Enterprise licenses" />
             <PageHeader
                 headingElement="h2"
-                path={[{ text: 'Subscriptions' }]}
+                path={[{ text: 'Enterprise licenses' }]}
                 description={
                     <>
                         Search your private code with{' '}
@@ -98,8 +99,8 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
                 <FilteredConnection<ProductSubscriptionFields, ProductSubscriptionNodeProps>
                     listComponent="table"
                     listClassName="table mb-0"
-                    noun="subscription"
-                    pluralNoun="subscriptions"
+                    noun="Enterprise license"
+                    pluralNoun="Enterprise licenses"
                     queryConnection={queryLicenses}
                     headComponent={ProductSubscriptionNodeHeader}
                     nodeComponent={ProductSubscriptionNode}
@@ -107,7 +108,7 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
                     noSummaryIfAllNodesVisible={true}
                     emptyElement={
                         <Text alignment="center" className="w-100 mb-0 text-muted">
-                            You have no subscriptions.
+                            You have no Enterprise licenses.
                         </Text>
                     }
                 />

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -230,12 +230,12 @@ const businessGroup: SiteAdminSideBarGroup = {
     header: { label: 'Business', icon: BriefcaseIcon },
     items: [
         {
-            label: 'Customers',
+            label: 'Enterprise customers',
             to: '/site-admin/dotcom/customers',
             condition: () => SHOW_BUSINESS_FEATURES,
         },
         {
-            label: 'Subscriptions',
+            label: 'Enterprise licenses',
             to: '/site-admin/dotcom/product/subscriptions',
             condition: () => SHOW_BUSINESS_FEATURES,
         },

--- a/client/web/src/user/settings/sidebaritems.ts
+++ b/client/web/src/user/settings/sidebaritems.ts
@@ -15,11 +15,6 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = [
         exact: true,
     },
     {
-        label: 'Subscriptions',
-        to: '/subscriptions',
-        condition: ({ user }) => SHOW_BUSINESS_FEATURES && user.viewerCanAdminister,
-    },
-    {
         to: '/batch-changes',
         label: 'Batch Changes',
         condition: ({ batchChangesEnabled, user: { viewerCanAdminister }, authenticatedUser }) =>
@@ -45,6 +40,11 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = [
         label: 'Account security',
         to: '/security',
         exact: true,
+    },
+    {
+        label: 'Enterprise licenses',
+        to: '/subscriptions',
+        condition: ({ user }) => SHOW_BUSINESS_FEATURES && user.viewerCanAdminister,
     },
     {
         label: 'Quotas',


### PR DESCRIPTION
Some users have gotten Sourcegraph Enterprise license keys confused with Cody Pro subscriptions because the former was also called "Subscriptions" in the user settings area ([example](https://discord.com/channels/969688426372825169/1212987159791800351/1213121019397546024)). This renames "Subscriptions" to "Enterprise licenses" in the UI. The API and URLs remain unchanged for compatibility.

Docs PR: https://github.com/sourcegraph/docs/pull/125


## Test plan

Run `sg start dotcom` and confirm that the sidebar labels and page titles are updated.