### PR TITLE
Expose API to fetch cody subscription associated with SAMS identity

### DIFF
--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -2,15 +2,20 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
+	"github.com/sourcegraph/sourcegraph/internal/cody"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/gqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/ssc"
+	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 type externalAccountResolver struct {
@@ -51,6 +56,29 @@ func (r *externalAccountResolver) ServiceType() string { return r.account.Servic
 func (r *externalAccountResolver) ServiceID() string   { return r.account.ServiceID }
 func (r *externalAccountResolver) ClientID() string    { return r.account.ClientID }
 func (r *externalAccountResolver) AccountID() string   { return r.account.AccountID }
+
+func (r *externalAccountResolver) CodySubscription(ctx context.Context) (*CodySubscriptionResolver, error) {
+	if !dotcom.SourcegraphDotComMode() {
+		return nil, errors.New("this feature is only available on sourcegraph.com")
+	}
+
+	if r.account.ServiceType == "openidconnect" && r.account.ServiceID == fmt.Sprintf("https://%s", ssc.GetSAMSHostName()) {
+		return nil, nil
+	}
+
+	userResolver, err := r.User(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	subscription, err := cody.SubscriptionForSAMSAccountID(ctx, r.db, *userResolver.user, r.account.AccountID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CodySubscriptionResolver{subscription: subscription}, nil
+}
+
 func (r *externalAccountResolver) CreatedAt() gqlutil.DateTime {
 	return gqlutil.DateTime{Time: r.account.CreatedAt}
 }

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -57,6 +57,7 @@ func (r *externalAccountResolver) ServiceID() string   { return r.account.Servic
 func (r *externalAccountResolver) ClientID() string    { return r.account.ClientID }
 func (r *externalAccountResolver) AccountID() string   { return r.account.AccountID }
 
+// TEMPORARY: This resolver is temporary to help us debug the #inc-284-plg-users-paying-for-and-being-billed-for-pro-without-being-upgrade.
 func (r *externalAccountResolver) CodySubscription(ctx context.Context) (*CodySubscriptionResolver, error) {
 	if !dotcom.SourcegraphDotComMode() {
 		return nil, errors.New("this feature is only available on sourcegraph.com")

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6845,6 +6845,7 @@ type ExternalAccount implements Node {
     """
     publicAccountData: PublicExternalAccountData
     """
+    TEMPORARY: to debug #inc-284-plg-users-paying-for-and-being-billed-for-pro-without-being-upgrade.
     Cody Subscription associated with the external account.
     """
     codySubscription: CodySubscription

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6844,6 +6844,10 @@ type ExternalAccount implements Node {
     may query this field.
     """
     publicAccountData: PublicExternalAccountData
+    """
+    Cody Subscription associated with the external account.
+    """
+    codySubscription: CodySubscription
 }
 
 """

--- a/internal/cody/subscription.go
+++ b/internal/cody/subscription.go
@@ -175,6 +175,26 @@ func SubscriptionForUser(ctx context.Context, db database.DB, user types.User) (
 	return consolidateSubscriptionDetails(ctx, user, subscription)
 }
 
+// SubscriptionForSAMSAccountID returns the user's Cody subscription details associated with the given SAMS account ID.
+func SubscriptionForSAMSAccountID(ctx context.Context, db database.DB, user types.User, samsAccountID string) (*UserSubscription, error) {
+	if samsAccountID == "" {
+		return consolidateSubscriptionDetails(ctx, user, nil)
+	}
+
+	var subscription *ssc.Subscription
+	sscClient, err := getSSCClient()
+	if err != nil {
+		return nil, err
+	}
+
+	subscription, err = sscClient.FetchSubscriptionBySAMSAccountID(ctx, samsAccountID)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching subscription from SSC")
+	}
+
+	return consolidateSubscriptionDetails(ctx, user, subscription)
+}
+
 // getSSCClient returns a self-service Cody API client. We only do this once so that the stateless client
 // can persist in memory longer, so we can benefit from the underlying HTTP client only needing to reissue
 // SAMS access tokens when needed, rather than minting a new token for every request.


### PR DESCRIPTION
As part of [#inc-284-plg-users-paying-for-and-being-billed-for-pro-without-being-upgrade](https://sourcegraph.slack.com/archives/C06N8ELPKNH/p1709796118502059) it is noted that users have multiple SAMS accounts associated with their dot-com account which is unexpected.

This PR exposes graphql API to allow us to fetch cody subscription associated with the SAMS external account identity.

Comparing `user.codySubscription` with `user.externalAccounts.nodes.codySubscription` will allow us to debug the mismatch between the SAMS identity using which the user paid for cody pro vs the one they are signed in on dotcom or cody clients.

## Test plan

Run query:
```graphql
{
  user(username: "hereisnaman") {
    codySubscription {
      plan
      status
      currentPeriodStartAt
      currentPeriodEndAt
    }
    externalAccounts {
      nodes {
        serviceID
        serviceType
        accountID
        codySubscription {
          plan
          status
          currentPeriodStartAt
          currentPeriodEndAt
        }
      }
    }
  }
}
```