### PR TITLE
revert marking a test as eternal for test

### DIFF
--- a/dev/sg/internal/images/BUILD.bazel
+++ b/dev/sg/internal/images/BUILD.bazel
@@ -35,7 +35,7 @@ go_library(
 
 go_test(
     name = "images_test",
-    timeout = "eternal",
+    timeout = "short",
     srcs = [
         "images_test.go",
         "pure_docker_test.go",


### PR DESCRIPTION
Accidentally merged without revert a test 

## Test plan
None - this is just changing the timeout on a test