### PR TITLE
wolfi: fix keys dir for building wolfi packages

### DIFF
--- a/dev/ci/scripts/wolfi/build-package.sh
+++ b/dev/ci/scripts/wolfi/build-package.sh
@@ -4,6 +4,7 @@ set -euf -o pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
 
+KEYS_DIR="/etc/sourcegraph/keys/"
 MAIN_BRANCH="main"
 BRANCH="${BUILDKITE_BRANCH:-'default-branch'}"
 IS_MAIN=$([ "$BRANCH" = "$MAIN_BRANCH" ] && echo "true" || echo "false")
@@ -67,9 +68,9 @@ echo " * Building melange package '$name'"
 
 # Sign index, using separate keys from GCS for staging and prod repos
 if [[ "$IS_MAIN" == "true" ]]; then
-  key_path="/keys/sourcegraph-melange-prod.rsa"
+  key_path="$KEYS_DIR/sourcegraph-melange-prod.rsa"
 else
-  key_path="/keys/sourcegraph-melange-dev.rsa"
+  key_path="$KEYS_DIR/sourcegraph-melange-dev.rsa"
 fi
 
 # Build package


### PR DESCRIPTION
The script for building wolfi packages was missing a change to find the melange keys, which the script for building the package index contained https://github.com/sourcegraph/sourcegraph/pull/60860/files#diff-33ae81b3302c56080854c8f451cdd920f5f92660f6a37a4ae06b8da5ffd23d40

## Test plan

Testing in https://buildkite.com/sourcegraph/sourcegraph/builds/264254 from https://github.com/sourcegraph/sourcegraph/pull/60784
