### PR TITLE
Fix external_account.cody_subscription logic

### DIFF
--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -63,7 +63,7 @@ func (r *externalAccountResolver) CodySubscription(ctx context.Context) (*CodySu
 		return nil, errors.New("this feature is only available on sourcegraph.com")
 	}
 
-	if r.account.ServiceType == "openidconnect" && r.account.ServiceID == fmt.Sprintf("https://%s", ssc.GetSAMSHostName()) {
+	if r.account.ServiceType != "openidconnect" || r.account.ServiceID != fmt.Sprintf("https://%s", ssc.GetSAMSHostName()) {
 		return nil, nil
 	}
 


### PR DESCRIPTION

Fix for the [PR](https://github.com/sourcegraph/sourcegraph/pull/60914). We should fetch subscription info only for openidconnect sams external account. But it was implemented otherwise. 

## Test plan

```
{
  user(username: "hereisnaman") {
    codySubscription {
      plan
      status
      currentPeriodStartAt
      currentPeriodEndAt
    }
    externalAccounts {
      nodes {
        serviceID
        serviceType
        accountID
        codySubscription {
          plan
          status
          currentPeriodStartAt
          currentPeriodEndAt
        }
      }
    }
  }
}
```