### PR TITLE
search jobs: fail validation for select: queries

### DIFF
--- a/internal/search/job/jobutil/exhaustive_job.go
+++ b/internal/search/job/jobutil/exhaustive_job.go
@@ -41,6 +41,10 @@ func NewExhaustive(inputs *search.Inputs) (Exhaustive, error) {
 
 	b := inputs.Plan[0]
 
+	if v, _ := b.ToParseTree().StringValue(query.FieldSelect); v != "" {
+		return Exhaustive{}, errors.Errorf("select: is not supported in Search Jobs")
+	}
+
 	// We don't support file predicates, such as file:has.content(), because the
 	// search breaks in unexpected ways. For example, for interactive search
 	// file:has.content() is translated to an AND query which we don't support in

--- a/internal/search/job/jobutil/exhaustive_job_test.go
+++ b/internal/search/job/jobutil/exhaustive_job_test.go
@@ -327,6 +327,7 @@ func TestNewExhaustive_negative(t *testing.T) {
 		// unsupported types
 		{query: `index:no type:repo`},
 		{query: `index:no type:symbol`},
+		{query: `index:no foo select:file.owners`},
 	}
 
 	for _, c := range tc {


### PR DESCRIPTION
It is currently possible to create search jobs based on `select:` queries although we don't support them. This adds a check to fail validation.

## Test plan
- updated unit test