### PR TITLE
search: remove unused parameters in phrase boost

### DIFF
--- a/internal/search/client/client.go
+++ b/internal/search/client/client.go
@@ -124,7 +124,7 @@ func (s *searchClient) Plan(
 	}
 
 	if searchType == query.SearchTypeKeyword {
-		plan = query.MapPlan(plan, query.ExperimentalPhraseBoost(s.runtimeClients.Logger, searchQuery))
+		plan = query.MapPlan(plan, query.ExperimentalPhraseBoost)
 		tr.AddEvent("applied phrase boost")
 	}
 

--- a/internal/search/query/BUILD.bazel
+++ b/internal/search/query/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
         "@com_github_go_enry_go_enry_v2//data",
         "@com_github_grafana_regexp//:regexp",
         "@com_github_grafana_regexp//syntax",
-        "@com_github_sourcegraph_log//:log",
         "@com_github_tj_go_naturaldate//:go-naturaldate",
     ],
 )
@@ -63,7 +62,6 @@ go_test(
         "@com_github_grafana_regexp//:regexp",
         "@com_github_grafana_regexp//syntax",
         "@com_github_hexops_autogold_v2//:autogold",
-        "@com_github_sourcegraph_log//:log",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/grafana/regexp"
-	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
@@ -668,51 +667,48 @@ func ToBasicQuery(nodes []Node) (Basic, error) {
 	return Basic{Parameters: parameters, Pattern: pattern}, nil
 }
 
-// ExperimentalPhraseBoost returns a transformation on basic queries that
-// appends a phrase query to the original query but only if the original query
-// consists of a single top-level AND expression. The purpose is to improve
-// ranking of exact matches by adding a phrase query for the entire query
-// string.
+// ExperimentalPhraseBoost is transformation on basic queries that appends a
+// phrase query to the original query but only if the original query consists of
+// a single top-level AND expression. The purpose is to improve ranking of exact
+// matches by adding a phrase query for the entire query string.
 //
 // Example:
 //
 //	foo bar bas -> (or (and foo bar bas) ("foo bar bas"))
-func ExperimentalPhraseBoost(logger sglog.Logger, originalQuery string) BasicPass {
-	return func(basic Basic) Basic {
-		if basic.Pattern == nil {
+func ExperimentalPhraseBoost(basic Basic) Basic {
+	if basic.Pattern == nil {
+		return basic
+	}
+
+	if n, ok := basic.Pattern.(Operator); ok && n.Kind == And {
+		// Gate on the number of operands. We don't want to add a phrase query for very
+		// short queries.
+		if len(n.Operands) < 3 {
 			return basic
 		}
 
-		if n, ok := basic.Pattern.(Operator); ok && n.Kind == And {
-			// Gate on the number of operands. We don't want to add a phrase query for very
-			// short queries.
-			if len(n.Operands) < 3 {
+		phrase := ""
+		for _, child := range n.Operands {
+			c, isPattern := child.(Pattern)
+			if !isPattern || c.Negated || c.Annotation.Labels.IsSet(Regexp) {
 				return basic
 			}
 
-			phrase := ""
-			for _, child := range n.Operands {
-				c, isPattern := child.(Pattern)
-				if !isPattern || c.Negated || c.Annotation.Labels.IsSet(Regexp) {
-					return basic
-				}
-
-				phrase += c.Value + " "
-			}
-			phrase = strings.TrimSpace(phrase)
-
-			basic.Pattern = Operator{
-				Kind: Or,
-				Operands: []Node{
-					Pattern{
-						Value:      phrase,
-						Annotation: Annotation{Labels: Boost | Literal | QuotesAsLiterals | Standard},
-					},
-					n,
-				},
-			}
+			phrase += c.Value + " "
 		}
+		phrase = strings.TrimSpace(phrase)
 
-		return basic
+		basic.Pattern = Operator{
+			Kind: Or,
+			Operands: []Node{
+				Pattern{
+					Value:      phrase,
+					Annotation: Annotation{Labels: Boost | Literal | QuotesAsLiterals | Standard},
+				},
+				n,
+			},
+		}
 	}
+
+	return basic
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hexops/autogold/v2"
-	sglog "github.com/sourcegraph/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +15,7 @@ func TestExperimentalPhraseBoost(t *testing.T) {
 			Init(input, SearchTypeKeyword))
 		require.NoError(t, err)
 
-		plan = MapPlan(plan, ExperimentalPhraseBoost(sglog.NoOp(), input))
+		plan = MapPlan(plan, ExperimentalPhraseBoost)
 
 		return plan.ToQ().String()
 	}


### PR DESCRIPTION
I came across this while debugging another issue. I guess the parameters become obsolete in a recent refactor.

The the size of the diff is misleading. I am just removing the parameters from `ExperimentalPhraseBoost(logger sglog.Logger, originalQuery string)` which means we don't need the closure anymore.

Test plan:
CI
