### PR TITLE
svelte/ci: Add vitest target for client/web-sveltekit

### DIFF
--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//:vite/package_json.bzl", vite_bin = "bin")
+load("@npm//client/web-sveltekit:vite/package_json.bzl", vite_bin = "bin")
+load("@npm//client/web-sveltekit:vitest/package_json.bzl", vitest_bin = "bin")
 
 # gazelle:ignore
 
@@ -33,6 +34,8 @@ SRCS = [
         "src/lib/graphql-type-mocks.ts",
         "src/**/*.gql.ts",
         "src/**/*.gql.d.ts",
+        "src/**/*.test.ts",
+        "src/**/*.spec.ts",
     ],
 ) + glob([
     "dev/**/*.cjs",
@@ -109,7 +112,6 @@ vite_bin.vite(
     srcs = SRCS + BUILD_DEPS + CONFIGS,
     args = [
         "build",
-        "--force",
         "-c vite.config.ts",
     ],
     chdir = package_name(),
@@ -125,4 +127,30 @@ vite_bin.vite(
 build_test(
     name = "vite_build_test",
     targets = [":web-sveltekit"],
+)
+
+TESTS = glob([
+    "src/**/*.test.ts",
+    "src/**/*.snap",
+])
+
+TEST_BUILD_DEPS = [
+    ":node_modules/vitest",
+    ":node_modules/signale",
+    ":node_modules/@testing-library/svelte",
+    ":node_modules/@testing-library/user-event",
+]
+
+vitest_bin.vitest_test(
+    name = "unit_tests",
+    args = [
+        "run",
+        "--reporter=default",
+        "--color",
+        "--update=false",
+    ],
+    chdir = package_name(),
+    data = SRCS + BUILD_DEPS + CONFIGS + TESTS + TEST_BUILD_DEPS,
+    env = {"BAZEL": "1", "CI": "1"},
+    patch_node_fs = True,
 )

--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -2,6 +2,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//client/web-sveltekit:vite/package_json.bzl", vite_bin = "bin")
 load("@npm//client/web-sveltekit:vitest/package_json.bzl", vitest_bin = "bin")
+load("//dev:defs.bzl", "vitest_test")
 
 # gazelle:ignore
 
@@ -141,16 +142,10 @@ TEST_BUILD_DEPS = [
     ":node_modules/@testing-library/user-event",
 ]
 
-vitest_bin.vitest_test(
+vitest_test(
     name = "unit_tests",
-    args = [
-        "run",
-        "--reporter=default",
-        "--color",
-        "--update=false",
-    ],
+    bin = vitest_bin,
     chdir = package_name(),
     data = SRCS + BUILD_DEPS + CONFIGS + TESTS + TEST_BUILD_DEPS,
-    env = {"BAZEL": "1", "CI": "1"},
-    patch_node_fs = True,
+    with_vitest_config = False,
 )

--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -59,9 +59,9 @@
     "svelte": "^4.1.1",
     "svelte-check": "^3.4.6",
     "tslib": "2.1.0",
-    "vite": "~5.0.0",
+    "vite": "~5.1.5",
     "vite-plugin-inspect": "^0.7.35",
-    "vitest": "^1.0.0"
+    "vitest": "^1.3.1"
   },
   "type": "module",
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,7 +541,7 @@ importers:
         version: 3.0.3
       '@sourcegraph/stylelint-config':
         specifier: ^1.4.0
-        version: 1.4.0(postcss@8.4.33)(stylelint@14.3.0)
+        version: 1.4.0(postcss@8.4.35)(stylelint@14.3.0)
       '@sourcegraph/stylelint-plugin-sourcegraph':
         specifier: ^1.0.1
         version: 1.0.1(stylelint@14.3.0)
@@ -580,7 +580,7 @@ importers:
         version: 7.4.6(react-dom@18.1.0)(react@18.1.0)
       '@storybook/builder-vite':
         specifier: ^7.4.6
-        version: 7.4.6(typescript@5.2.2)(vite@4.4.7)
+        version: 7.4.6(typescript@5.2.2)(vite@4.5.2)
       '@storybook/cli':
         specifier: ^7.4.6
         version: 7.4.6
@@ -601,7 +601,7 @@ importers:
         version: 7.4.6(react-dom@18.1.0)(react@18.1.0)(typescript@5.2.2)
       '@storybook/react-vite':
         specifier: ^7.4.6
-        version: 7.4.6(react-dom@18.1.0)(react@18.1.0)(typescript@5.2.2)(vite@4.4.7)
+        version: 7.4.6(react-dom@18.1.0)(react@18.1.0)(typescript@5.2.2)(vite@4.5.2)
       '@storybook/theming':
         specifier: ^7.4.6
         version: 7.4.6(react-dom@18.1.0)(react@18.1.0)
@@ -799,13 +799,13 @@ importers:
         version: 2.10.0
       '@vitejs/plugin-react':
         specifier: ^3.1.0
-        version: 3.1.0(vite@4.4.7)
+        version: 3.1.0(vite@4.5.2)
       abort-controller:
         specifier: ^3.0.0
         version: 3.0.0
       autoprefixer:
         specifier: ^10.2.1
-        version: 10.2.1(postcss@8.4.33)
+        version: 10.2.1(postcss@8.4.35)
       axe-core:
         specifier: ^4.4.1
         version: 4.4.2
@@ -961,10 +961,10 @@ importers:
         version: 4.1.0
       postcss-cli:
         specifier: ^10.1.0
-        version: 10.1.0(postcss@8.4.33)(ts-node@10.9.1)
+        version: 10.1.0(postcss@8.4.35)(ts-node@10.9.1)
       postcss-custom-media:
         specifier: ^8.0.0
-        version: 8.0.0(postcss@8.4.33)
+        version: 8.0.0(postcss@8.4.35)
       postcss-focus-visible:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1045,7 +1045,7 @@ importers:
         version: 2.0.2
       vite:
         specifier: ^4.1.4
-        version: 4.4.7(@types/node@20.8.0)(sass@1.32.4)
+        version: 4.5.2(@types/node@20.8.0)(sass@1.32.4)
       vite-plugin-turbosnap:
         specifier: ^1.0.3
         version: 1.0.3
@@ -1468,7 +1468,7 @@ importers:
         version: 7.4.6(react-dom@18.1.0)(react@18.1.0)
       '@storybook/addon-svelte-csf':
         specifier: ^4.1.0
-        version: 4.1.0(@storybook/svelte@7.2.0)(@storybook/theming@7.4.6)(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12)
+        version: 4.1.0(@storybook/svelte@7.2.0)(@storybook/theming@7.4.6)(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.5)
       '@storybook/blocks':
         specifier: ^7.2.0
         version: 7.4.6(@types/react-dom@18.0.2)(@types/react@18.0.8)(react-dom@18.1.0)(react@18.1.0)
@@ -1477,7 +1477,7 @@ importers:
         version: 7.2.0(svelte@4.1.1)
       '@storybook/sveltekit':
         specifier: ^7.2.0
-        version: 7.2.0(svelte@4.1.1)(typescript@5.2.2)(vite@5.0.12)
+        version: 7.2.0(svelte@4.1.1)(typescript@5.2.2)(vite@5.1.5)
       '@storybook/testing-library':
         specifier: 0.2.0
         version: 0.2.0
@@ -1489,10 +1489,10 @@ importers:
         version: 3.0.1(@sveltejs/kit@2.4.2)
       '@sveltejs/kit':
         specifier: ^2.0.0
-        version: 2.4.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12)
+        version: 2.4.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.5)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.0.1(svelte@4.1.1)(vite@5.0.12)
+        version: 3.0.1(svelte@4.1.1)(vite@5.1.5)
       '@testing-library/svelte':
         specifier: ^4.0.3
         version: 4.0.3(svelte@4.1.1)
@@ -1546,19 +1546,19 @@ importers:
         version: 4.1.1
       svelte-check:
         specifier: ^3.4.6
-        version: 3.4.6(@babel/core@7.23.0)(postcss@8.4.33)(sass@1.32.4)(svelte@4.1.1)
+        version: 3.4.6(@babel/core@7.23.0)(postcss@8.4.35)(sass@1.32.4)(svelte@4.1.1)
       tslib:
         specifier: 2.1.0
         version: 2.1.0
       vite:
-        specifier: ~5.0.0
-        version: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+        specifier: ~5.1.5
+        version: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
       vite-plugin-inspect:
         specifier: ^0.7.35
-        version: 0.7.35(vite@5.0.12)
+        version: 0.7.35(vite@5.1.5)
       vitest:
-        specifier: ^1.0.0
-        version: 1.2.1(@types/node@20.8.0)(happy-dom@12.10.1)(jsdom@22.1.0)(sass@1.32.4)
+        specifier: ^1.3.1
+        version: 1.3.1(@types/node@20.8.0)(happy-dom@12.10.1)(jsdom@22.1.0)(sass@1.32.4)
 
   client/wildcard:
     dependencies:
@@ -5437,7 +5437,7 @@ packages:
       '@types/yargs': 17.0.23
       chalk: 4.1.2
 
-  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.2.2)(vite@4.4.7):
+  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.2.2)(vite@4.5.2):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -5451,7 +5451,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.2.2)
       typescript: 5.2.2
-      vite: 4.4.7(@types/node@20.8.0)(sass@1.32.4)
+      vite: 4.5.2(@types/node@20.8.0)(sass@1.32.4)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -8312,11 +8312,11 @@ packages:
     resolution: {integrity: sha512-FQ1/Ued4I02R0JkrHHofDN163juVxUnPALzfxPZrDZUHv+c3jHjfZhmTHEz+Wd+g3b7MFk0fkj36nZSnvPyU8A==}
     dev: true
 
-  /@sourcegraph/stylelint-config@1.4.0(postcss@8.4.33)(stylelint@14.3.0):
+  /@sourcegraph/stylelint-config@1.4.0(postcss@8.4.35)(stylelint@14.3.0):
     resolution: {integrity: sha512-VYL0SRcS/49ttoYsS5pIX2ifVJIzLBWhHj8SvVcT/AF87AnFtuNJ5bAyEJFDL0k4xV5lyWG6R36hXF4xMGThTA==}
     dependencies:
       stylelint-config-prettier: 9.0.3(stylelint@14.3.0)
-      stylelint-config-standard-scss: 3.0.0(postcss@8.4.33)(stylelint@14.3.0)
+      stylelint-config-standard-scss: 3.0.0(postcss@8.4.35)(stylelint@14.3.0)
     transitivePeerDependencies:
       - postcss
       - stylelint
@@ -8822,7 +8822,7 @@ packages:
       - '@types/react-dom'
     dev: true
 
-  /@storybook/addon-svelte-csf@4.1.0(@storybook/svelte@7.2.0)(@storybook/theming@7.4.6)(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12):
+  /@storybook/addon-svelte-csf@4.1.0(@storybook/svelte@7.2.0)(@storybook/theming@7.4.6)(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.5):
     resolution: {integrity: sha512-h6AdfweSph09M0sMrwZy5WagkZcccA2i0ioywrheVZi65QtcIgGidbTixoiY94Xi71JT/MQ1psGoD91J44KJFQ==}
     peerDependencies:
       '@storybook/svelte': ^7.0.0
@@ -8842,12 +8842,12 @@ packages:
       '@babel/runtime': 7.23.1
       '@storybook/svelte': 7.2.0(svelte@4.1.1)
       '@storybook/theming': 7.4.6(react-dom@18.1.0)(react@18.1.0)
-      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.1.1)(vite@5.1.5)
       dedent: 1.5.1
       fs-extra: 11.1.1
       magic-string: 0.30.5
       svelte: 4.1.1
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - babel-plugin-macros
     dev: true
@@ -9079,7 +9079,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.2.0(typescript@5.2.2)(vite@5.0.12):
+  /@storybook/builder-vite@7.2.0(typescript@5.2.2)(vite@5.1.5):
     resolution: {integrity: sha512-YmTtyIMxWKaFOsJaLU5rGHukvt37LjVvW6QEAEK1Clbl1f3QUNSEGJwVYLRYO7xQvhymBF4JMa8N5NSc1+xSEQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -9114,13 +9114,13 @@ packages:
       remark-slug: 6.1.0
       rollup: 3.26.3
       typescript: 5.2.2
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - encoding
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.4.6(typescript@5.2.2)(vite@4.4.7):
+  /@storybook/builder-vite@7.4.6(typescript@5.2.2)(vite@4.5.2):
     resolution: {integrity: sha512-xV9STYK+TkqWWTf2ydm6jx+7P70fjD2UPd1XTUw08uKszIjhuuxk+bG/OF5R1E25mPunAKXm6kBFh351AKejBg==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -9155,7 +9155,7 @@ packages:
       remark-slug: 6.1.0
       rollup: 3.26.3
       typescript: 5.2.2
-      vite: 4.4.7(@types/node@20.8.0)(sass@1.32.4)
+      vite: 4.5.2(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9833,7 +9833,7 @@ packages:
       react-dom: 18.1.0(react@18.1.0)
     dev: true
 
-  /@storybook/react-vite@7.4.6(react-dom@18.1.0)(react@18.1.0)(typescript@5.2.2)(vite@4.4.7):
+  /@storybook/react-vite@7.4.6(react-dom@18.1.0)(react@18.1.0)(typescript@5.2.2)(vite@4.5.2):
     resolution: {integrity: sha512-jkjnrf3FxzR5wcmebXRPflrsM4WIDjWyW/NVFJwxi5PeIOk7fE7/QAPrm4NFRUu2Q7DeuH3oLKsw8bigvUI9RA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -9841,17 +9841,17 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.2.2)(vite@4.4.7)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.2.2)(vite@4.5.2)
       '@rollup/pluginutils': 5.0.2
-      '@storybook/builder-vite': 7.4.6(typescript@5.2.2)(vite@4.4.7)
+      '@storybook/builder-vite': 7.4.6(typescript@5.2.2)(vite@4.5.2)
       '@storybook/react': 7.4.6(react-dom@18.1.0)(react@18.1.0)(typescript@5.2.2)
-      '@vitejs/plugin-react': 3.1.0(vite@4.4.7)
+      '@vitejs/plugin-react': 3.1.0(vite@4.5.2)
       ast-types: 0.14.2
       magic-string: 0.30.5
       react: 18.1.0
       react-docgen: 6.0.0-alpha.3
       react-dom: 18.1.0(react@18.1.0)
-      vite: 4.4.7(@types/node@20.8.0)(sass@1.32.4)
+      vite: 4.5.2(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -9942,22 +9942,22 @@ packages:
       react-dom: 18.1.0(react@18.1.0)
     dev: true
 
-  /@storybook/svelte-vite@7.2.0(svelte@4.1.1)(typescript@5.2.2)(vite@5.0.12):
+  /@storybook/svelte-vite@7.2.0(svelte@4.1.1)(typescript@5.2.2)(vite@5.1.5):
     resolution: {integrity: sha512-iGaaY64xWjMDzECpu+qw82Y0LtwZYD5FimCEmx1gjPLiv0TJDRVcpBvtGNzEf6ztevastRQs8HEDxv1H1xjCkQ==}
     engines: {node: ^14.18 || >=16}
     peerDependencies:
       svelte: ^3.0.0 || ^4.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@storybook/builder-vite': 7.2.0(typescript@5.2.2)(vite@5.0.12)
+      '@storybook/builder-vite': 7.2.0(typescript@5.2.2)(vite@5.1.5)
       '@storybook/node-logger': 7.2.0
       '@storybook/svelte': 7.2.0(svelte@4.1.1)
-      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@4.1.1)(vite@5.1.5)
       magic-string: 0.30.5
       svelte: 4.1.1
       sveltedoc-parser: 4.2.1
       ts-dedent: 2.2.0
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -9987,18 +9987,18 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/sveltekit@7.2.0(svelte@4.1.1)(typescript@5.2.2)(vite@5.0.12):
+  /@storybook/sveltekit@7.2.0(svelte@4.1.1)(typescript@5.2.2)(vite@5.1.5):
     resolution: {integrity: sha512-JyhRofOywpIElqgpc6NR6xMyBgop5bVSnzeDl9aJk0VTVGFvQOEco85f9FHJmlhhBpFr7g+Nal7hzsqg5vkdPg==}
     engines: {node: ^14.18 || >=16}
     peerDependencies:
       svelte: ^3.0.0 || ^4.0.0
       vite: ^4.0.0
     dependencies:
-      '@storybook/builder-vite': 7.2.0(typescript@5.2.2)(vite@5.0.12)
+      '@storybook/builder-vite': 7.2.0(typescript@5.2.2)(vite@5.1.5)
       '@storybook/svelte': 7.2.0(svelte@4.1.1)
-      '@storybook/svelte-vite': 7.2.0(svelte@4.1.1)(typescript@5.2.2)(vite@5.0.12)
+      '@storybook/svelte-vite': 7.2.0(svelte@4.1.1)(typescript@5.2.2)(vite@5.1.5)
       svelte: 4.1.1
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -10098,7 +10098,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.4.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/kit': 2.4.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.5)
       import-meta-resolve: 4.0.0
     dev: true
 
@@ -10107,10 +10107,10 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.4.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/kit': 2.4.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.5)
     dev: true
 
-  /@sveltejs/kit@2.4.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12):
+  /@sveltejs/kit@2.4.2(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.5):
     resolution: {integrity: sha512-1HgRMt9jmlaJamrq++nKQtoMP/v5oHPqIamFOlb0oHYW2XaZPJj9ri1BcR0AAA0vu68DD1UdUtj9zbvn1bR/7g==}
     engines: {node: '>=18.13'}
     hasBin: true
@@ -10120,7 +10120,7 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.3
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.1.1)(vite@5.1.5)
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 4.3.2
@@ -10134,10 +10134,10 @@ packages:
       sirv: 2.0.4
       svelte: 4.1.1
       tiny-glob: 0.2.9
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@4.1.1)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@4.1.1)(vite@5.1.5):
     resolution: {integrity: sha512-Khdl5jmmPN6SUsVuqSXatKpQTMIifoQPDanaxC84m9JxIibWvSABJyHpyys0Z+1yYrxY5TTEQm+6elh0XCMaOA==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -10145,15 +10145,15 @@ packages:
       svelte: ^3.54.0 || ^4.0.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte': 2.4.2(svelte@4.1.1)(vite@5.1.5)
       debug: 4.3.4
       svelte: 4.1.1
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.5):
     resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
@@ -10161,50 +10161,50 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte': 3.0.1(svelte@4.1.1)(vite@5.1.5)
       debug: 4.3.4
       svelte: 4.1.1
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.4.2(svelte@4.1.1)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte@2.4.2(svelte@4.1.1)(vite@5.1.5):
     resolution: {integrity: sha512-ePfcC48ftMKhkT0OFGdOyycYKnnkT6i/buzey+vHRTR/JpQvuPzzhf1PtKqCDQfJRgoPSN2vscXs6gLigx/zGw==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.3(@sveltejs/vite-plugin-svelte@2.4.2)(svelte@4.1.1)(vite@5.1.5)
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.5
       svelte: 4.1.1
       svelte-hmr: 0.15.3(svelte@4.1.1)
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
-      vitefu: 0.2.5(vite@5.0.12)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
+      vitefu: 0.2.5(vite@5.1.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.1.1)(vite@5.0.12):
+  /@sveltejs/vite-plugin-svelte@3.0.1(svelte@4.1.1)(vite@5.1.5):
     resolution: {integrity: sha512-CGURX6Ps+TkOovK6xV+Y2rn8JKa8ZPUHPZ/NKgCxAmgBrXReavzFl8aOSCj3kQ1xqT7yGJj53hjcV/gqwDAaWA==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.0.12)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.1)(svelte@4.1.1)(vite@5.1.5)
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.5
       svelte: 4.1.1
       svelte-hmr: 0.15.3(svelte@4.1.1)
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
-      vitefu: 0.2.5(vite@5.0.12)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
+      vitefu: 0.2.5(vite@5.1.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11664,7 +11664,7 @@ packages:
       react: 18.1.0
     dev: false
 
-  /@vitejs/plugin-react@3.1.0(vite@4.4.7):
+  /@vitejs/plugin-react@3.1.0(vite@4.5.2):
     resolution: {integrity: sha512-AfgcRL8ZBhAlc3BFdigClmTUMISmmzHn7sB2h9U1odvc5U/MjWXsAaz18b/WoppUTDBzxOJwo2VdClfUcItu9g==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -11675,7 +11675,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.23.0)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.4.7(@types/node@20.8.0)(sass@1.32.4)
+      vite: 4.5.2(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11688,11 +11688,11 @@ packages:
       chai: 4.3.10
     dev: true
 
-  /@vitest/expect@1.2.1:
-    resolution: {integrity: sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==}
+  /@vitest/expect@1.3.1:
+    resolution: {integrity: sha512-xofQFwIzfdmLLlHa6ag0dPV8YsnKOCP1KdAeVVh34vSjN2dcUiXYCD9htu/9eM7t8Xln4v03U9HLxLpPlsXdZw==}
     dependencies:
-      '@vitest/spy': 1.2.1
-      '@vitest/utils': 1.2.1
+      '@vitest/spy': 1.3.1
+      '@vitest/utils': 1.3.1
       chai: 4.3.10
     dev: true
 
@@ -11704,10 +11704,10 @@ packages:
       pathe: 1.1.2
     dev: true
 
-  /@vitest/runner@1.2.1:
-    resolution: {integrity: sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==}
+  /@vitest/runner@1.3.1:
+    resolution: {integrity: sha512-5FzF9c3jG/z5bgCnjr8j9LNq/9OxV2uEBAITOXfoe3rdZJTdO7jzThth7FXv/6b+kdY65tpRQB7WaKhNZwX+Kg==}
     dependencies:
-      '@vitest/utils': 1.2.1
+      '@vitest/utils': 1.3.1
       p-limit: 5.0.0
       pathe: 1.1.2
     dev: true
@@ -11720,8 +11720,8 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/snapshot@1.2.1:
-    resolution: {integrity: sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==}
+  /@vitest/snapshot@1.3.1:
+    resolution: {integrity: sha512-EF++BZbt6RZmOlE3SuTPu/NfwBF6q4ABS37HHXzs2LUVPBLx2QoY/K0fKpRChSo8eLiuxcbCVfqKgx/dplCDuQ==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.2
@@ -11734,8 +11734,8 @@ packages:
       tinyspy: 2.2.0
     dev: true
 
-  /@vitest/spy@1.2.1:
-    resolution: {integrity: sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==}
+  /@vitest/spy@1.3.1:
+    resolution: {integrity: sha512-xAcW+S099ylC9VLU7eZfdT9myV67Nor9w9zhf0mGCYJSO+zM2839tOeROTdikOi/8Qeusffvxb/MyBSOja1Uig==}
     dependencies:
       tinyspy: 2.2.0
     dev: true
@@ -11748,8 +11748,8 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/utils@1.2.1:
-    resolution: {integrity: sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==}
+  /@vitest/utils@1.3.1:
+    resolution: {integrity: sha512-d3Waie/299qqRyHTm2DjADeTaNdNSVsnwHPWrs20JMpjh6eiVq7ggggweO8rc4arhf6rRkWuHKwvxGvejUXZZQ==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -12475,7 +12475,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /autoprefixer@10.2.1(postcss@8.4.33):
+  /autoprefixer@10.2.1(postcss@8.4.35):
     resolution: {integrity: sha512-dwP0UjyYvROUvtU+boBx8ff5pPWami1NGTrJs9YUsS/oZVbRAcdNHOOuXSA1fc46tgKqe072cVaKD69rvCc3QQ==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
@@ -12487,7 +12487,7 @@ packages:
       colorette: 1.4.0
       fraction.js: 4.0.13
       normalize-range: 0.1.2
-      postcss: 8.4.33
+      postcss: 8.4.35
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -18175,6 +18175,10 @@ packages:
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  /js-tokens@8.0.3:
+    resolution: {integrity: sha512-UfJMcSJc+SEXEl9lH/VLHSZbThQyLpw1vLO1Lb+j4RWDvG3N2f7yj3PVQA3cmkTBNldJ9eFnM+xEXxHIXrYiJw==}
+    dev: true
+
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
@@ -20894,14 +20898,39 @@ packages:
       yargs: 17.7.2
     transitivePeerDependencies:
       - ts-node
+    dev: false
 
-  /postcss-custom-media@8.0.0(postcss@8.4.33):
+  /postcss-cli@10.1.0(postcss@8.4.35)(ts-node@10.9.1):
+    resolution: {integrity: sha512-Zu7PLORkE9YwNdvOeOVKPmWghprOtjFQU3srMUGbdz3pHJiFh7yZ4geiZFMkjMfB0mtTFR3h8RemR62rPkbOPA==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      chokidar: 3.5.3
+      dependency-graph: 0.11.0
+      fs-extra: 11.1.1
+      get-stdin: 9.0.0
+      globby: 13.1.3
+      picocolors: 1.0.0
+      postcss: 8.4.35
+      postcss-load-config: 4.0.1(postcss@8.4.35)(ts-node@10.9.1)
+      postcss-reporter: 7.0.5(postcss@8.4.35)
+      pretty-hrtime: 1.0.3
+      read-cache: 1.0.0
+      slash: 5.0.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - ts-node
+    dev: true
+
+  /postcss-custom-media@8.0.0(postcss@8.4.35):
     resolution: {integrity: sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
     dev: true
 
   /postcss-focus-visible@5.0.0:
@@ -20934,6 +20963,25 @@ packages:
       postcss: 8.4.33
       ts-node: 10.9.1(@types/node@20.8.0)(typescript@5.2.2)
       yaml: 2.3.2
+    dev: false
+
+  /postcss-load-config@4.0.1(postcss@8.4.35)(ts-node@10.9.1):
+    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.6
+      postcss: 8.4.35
+      ts-node: 10.9.1(@types/node@20.8.0)(typescript@5.2.2)
+      yaml: 2.3.2
+    dev: true
 
   /postcss-media-query-parser@0.2.3:
     resolution: {integrity: sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==}
@@ -21028,6 +21076,18 @@ packages:
       picocolors: 1.0.0
       postcss: 8.4.33
       thenby: 1.3.4
+    dev: false
+
+  /postcss-reporter@7.0.5(postcss@8.4.35):
+    resolution: {integrity: sha512-glWg7VZBilooZGOFPhN9msJ3FQs19Hie7l5a/eE6WglzYqVeH3ong3ShFcp9kDWJT1g2Y/wd59cocf9XxBtkWA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      picocolors: 1.0.0
+      postcss: 8.4.35
+      thenby: 1.3.4
+    dev: true
 
   /postcss-resolve-nested-selector@0.1.1:
     resolution: {integrity: sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==}
@@ -21042,13 +21102,13 @@ packages:
       postcss: 8.4.33
     dev: true
 
-  /postcss-scss@4.0.3(postcss@8.4.33):
+  /postcss-scss@4.0.3(postcss@8.4.35):
     resolution: {integrity: sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.3.3
     dependencies:
-      postcss: 8.4.33
+      postcss: 8.4.35
     dev: true
 
   /postcss-selector-parser@6.0.9:
@@ -21084,6 +21144,15 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
+
+  /postcss@8.4.35:
+    resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
 
   /prebuild-install@7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
@@ -22506,6 +22575,14 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /rollup@3.29.4:
+    resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /rollup@4.9.6:
     resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -23486,6 +23563,12 @@ packages:
       acorn: 8.11.3
     dev: true
 
+  /strip-literal@2.0.0:
+    resolution: {integrity: sha512-f9vHgsCWBq2ugHAkGMiiYY+AYG0D/cbloKKg0nhaaaSNsujdGIpVXCNsrJpCKr5M0f4aI31mr13UjY6GAuXCKA==}
+    dependencies:
+      js-tokens: 8.0.3
+    dev: true
+
   /strnum@1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
     dev: false
@@ -23508,12 +23591,12 @@ packages:
       stylelint: 14.3.0
     dev: true
 
-  /stylelint-config-recommended-scss@5.0.2(postcss@8.4.33)(stylelint@14.3.0):
+  /stylelint-config-recommended-scss@5.0.2(postcss@8.4.35)(stylelint@14.3.0):
     resolution: {integrity: sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==}
     peerDependencies:
       stylelint: ^14.0.0
     dependencies:
-      postcss-scss: 4.0.3(postcss@8.4.33)
+      postcss-scss: 4.0.3(postcss@8.4.35)
       stylelint: 14.3.0
       stylelint-config-recommended: 6.0.0(stylelint@14.3.0)
       stylelint-scss: 4.1.0(stylelint@14.3.0)
@@ -23529,13 +23612,13 @@ packages:
       stylelint: 14.3.0
     dev: true
 
-  /stylelint-config-standard-scss@3.0.0(postcss@8.4.33)(stylelint@14.3.0):
+  /stylelint-config-standard-scss@3.0.0(postcss@8.4.35)(stylelint@14.3.0):
     resolution: {integrity: sha512-zt3ZbzIbllN1iCmc94e4pDxqpkzeR6CJo5DDXzltshuXr+82B8ylHyMMARNnUYrZH80B7wgY7UkKTYCFM0UUyw==}
     peerDependencies:
       stylelint: ^14.0.0
     dependencies:
       stylelint: 14.3.0
-      stylelint-config-recommended-scss: 5.0.2(postcss@8.4.33)(stylelint@14.3.0)
+      stylelint-config-recommended-scss: 5.0.2(postcss@8.4.35)(stylelint@14.3.0)
       stylelint-config-standard: 24.0.0(stylelint@14.3.0)
     transitivePeerDependencies:
       - postcss
@@ -23697,7 +23780,7 @@ packages:
       react: 18.1.0
     dev: false
 
-  /svelte-check@3.4.6(@babel/core@7.23.0)(postcss@8.4.33)(sass@1.32.4)(svelte@4.1.1):
+  /svelte-check@3.4.6(@babel/core@7.23.0)(postcss@8.4.35)(sass@1.32.4)(svelte@4.1.1):
     resolution: {integrity: sha512-OBlY8866Zh1zHQTkBMPS6psPi7o2umTUyj6JWm4SacnIHXpWFm658pG32m3dKvKFL49V4ntAkfFHKo4ztH07og==}
     hasBin: true
     peerDependencies:
@@ -23710,7 +23793,7 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.1.1
-      svelte-preprocess: 5.0.4(@babel/core@7.23.0)(postcss@8.4.33)(sass@1.32.4)(svelte@4.1.1)(typescript@5.2.2)
+      svelte-preprocess: 5.0.4(@babel/core@7.23.0)(postcss@8.4.35)(sass@1.32.4)(svelte@4.1.1)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -23733,7 +23816,7 @@ packages:
       svelte: 4.1.1
     dev: true
 
-  /svelte-preprocess@5.0.4(@babel/core@7.23.0)(postcss@8.4.33)(sass@1.32.4)(svelte@4.1.1)(typescript@5.2.2):
+  /svelte-preprocess@5.0.4(@babel/core@7.23.0)(postcss@8.4.35)(sass@1.32.4)(svelte@4.1.1)(typescript@5.2.2):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -23775,7 +23858,7 @@ packages:
       '@types/pug': 2.0.6
       detect-indent: 6.1.0
       magic-string: 0.27.0
-      postcss: 8.4.33
+      postcss: 8.4.35
       sass: 1.32.4
       sorcery: 0.11.0
       strip-indent: 3.0.0
@@ -24050,8 +24133,8 @@ packages:
     resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
     dev: true
 
-  /tinypool@0.8.1:
-    resolution: {integrity: sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==}
+  /tinypool@0.8.2:
+    resolution: {integrity: sha512-SUszKYe5wgsxnNOVlBYO6IC+8VGWdVGZWAqUxp3UErNBtptZvWbwyUOyzNL59zigz2rCA92QiL3wvG+JDSdJdQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -24904,7 +24987,7 @@ packages:
       mlly: 1.5.0
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 4.5.2(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -24916,8 +24999,8 @@ packages:
       - terser
     dev: true
 
-  /vite-node@1.2.1(@types/node@20.8.0)(sass@1.32.4):
-    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
+  /vite-node@1.3.1(@types/node@20.8.0)(sass@1.32.4):
+    resolution: {integrity: sha512-azbRrqRxlWTJEVbzInZCTchx0X69M/XPTCz4H+TLvlTcR/xH/3hkRqhOakT41fMJCMzXTu4UvegkZiEoJAWvng==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -24925,7 +25008,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -24937,7 +25020,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-inspect@0.7.35(vite@5.0.12):
+  /vite-plugin-inspect@0.7.35(vite@5.1.5):
     resolution: {integrity: sha512-e5w5dJAj3vDcHTxn8hHbiH+mVqYs17gaW00f3aGuMTXiqUog+T1Lsxr9Jb4WRiip84cpuhR0KFFBT1egtXboiA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -24954,7 +25037,7 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.4
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -24964,8 +25047,8 @@ packages:
     resolution: {integrity: sha512-p4D8CFVhZS412SyQX125qxyzOgIFouwOcvjZWk6bQbNPR1wtaEzFT6jZxAjf1dejlGqa6fqHcuCvQea6EWUkUA==}
     dev: true
 
-  /vite@4.4.7(@types/node@20.8.0)(sass@1.32.4):
-    resolution: {integrity: sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==}
+  /vite@4.5.2(@types/node@20.8.0)(sass@1.32.4):
+    resolution: {integrity: sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -24994,15 +25077,15 @@ packages:
     dependencies:
       '@types/node': 20.8.0
       esbuild: 0.18.17
-      postcss: 8.4.33
-      rollup: 3.26.3
+      postcss: 8.4.35
+      rollup: 3.29.4
       sass: 1.32.4
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /vite@5.0.12(@types/node@20.8.0)(sass@1.32.4):
-    resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
+  /vite@5.1.5(@types/node@20.8.0)(sass@1.32.4):
+    resolution: {integrity: sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -25031,14 +25114,14 @@ packages:
     dependencies:
       '@types/node': 20.8.0
       esbuild: 0.19.11
-      postcss: 8.4.33
+      postcss: 8.4.35
       rollup: 4.9.6
       sass: 1.32.4
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
 
-  /vitefu@0.2.5(vite@5.0.12):
+  /vitefu@0.2.5(vite@5.1.5):
     resolution: {integrity: sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
@@ -25046,7 +25129,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
     dev: true
 
   /vitest-fetch-mock@0.2.2(vitest@1.0.0-beta.4):
@@ -25106,8 +25189,8 @@ packages:
       std-env: 3.7.0
       strip-literal: 1.3.0
       tinybench: 2.6.0
-      tinypool: 0.8.1
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
+      tinypool: 0.8.2
+      vite: 4.5.2(@types/node@20.8.0)(sass@1.32.4)
       vite-node: 1.0.0-beta.4(@types/node@20.8.0)(sass@1.32.4)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
@@ -25120,15 +25203,15 @@ packages:
       - terser
     dev: true
 
-  /vitest@1.2.1(@types/node@20.8.0)(happy-dom@12.10.1)(jsdom@22.1.0)(sass@1.32.4):
-    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
+  /vitest@1.3.1(@types/node@20.8.0)(happy-dom@12.10.1)(jsdom@22.1.0)(sass@1.32.4):
+    resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': ^1.0.0
-      '@vitest/ui': ^1.0.0
+      '@vitest/browser': 1.3.1
+      '@vitest/ui': 1.3.1
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -25146,13 +25229,12 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.8.0
-      '@vitest/expect': 1.2.1
-      '@vitest/runner': 1.2.1
-      '@vitest/snapshot': 1.2.1
-      '@vitest/spy': 1.2.1
-      '@vitest/utils': 1.2.1
+      '@vitest/expect': 1.3.1
+      '@vitest/runner': 1.3.1
+      '@vitest/snapshot': 1.3.1
+      '@vitest/spy': 1.3.1
+      '@vitest/utils': 1.3.1
       acorn-walk: 8.3.2
-      cac: 6.7.14
       chai: 4.3.10
       debug: 4.3.4
       execa: 8.0.1
@@ -25163,11 +25245,11 @@ packages:
       pathe: 1.1.2
       picocolors: 1.0.0
       std-env: 3.7.0
-      strip-literal: 1.3.0
+      strip-literal: 2.0.0
       tinybench: 2.6.0
-      tinypool: 0.8.1
-      vite: 5.0.12(@types/node@20.8.0)(sass@1.32.4)
-      vite-node: 1.2.1(@types/node@20.8.0)(sass@1.32.4)
+      tinypool: 0.8.2
+      vite: 5.1.5(@types/node@20.8.0)(sass@1.32.4)
+      vite-node: 1.3.1(@types/node@20.8.0)(sass@1.32.4)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Closes #60882 

This commit adds a new target to run the unit tests inside client/web-sveltekit with vitest.

We have an existing vitest rule (macro?) but that expects the existence of a vitest.config.ts file, which client/web-sveltekit doesn't have. The test config is defined in `vite.config.ts`. Therefore I'm using the vitest binary directly.


## Test plan

CI