### PR TITLE
Updates vitest macro

### DIFF
--- a/client/web-sveltekit/BUILD.bazel
+++ b/client/web-sveltekit/BUILD.bazel
@@ -2,6 +2,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//client/web-sveltekit:vite/package_json.bzl", vite_bin = "bin")
 load("@npm//client/web-sveltekit:vitest/package_json.bzl", vitest_bin = "bin")
+load("//dev:defs.bzl", "vitest_test")
 
 # gazelle:ignore
 
@@ -141,16 +142,10 @@ TEST_BUILD_DEPS = [
     ":node_modules/@testing-library/user-event",
 ]
 
-vitest_bin.vitest_test(
+vitest_test(
     name = "unit_tests",
-    args = [
-        "run",
-        "--reporter=default",
-        "--color",
-        "--update=false",
-    ],
+    bin = vitest_bin,
     chdir = package_name(),
     data = SRCS + BUILD_DEPS + CONFIGS + TESTS + TEST_BUILD_DEPS,
-    env = {"BAZEL": "1", "CI": "1"},
-    patch_node_fs = True,
+    with_vitest_config = False,
 )

--- a/dev/defs.bzl
+++ b/dev/defs.bzl
@@ -1,13 +1,13 @@
 "Bazel rules"
 
-load("@aspect_rules_swc//swc:defs.bzl", "swc")
-load("@bazel_skylib//lib:partial.bzl", "partial")
-load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library")
 load("@aspect_rules_js//npm:defs.bzl", _npm_package = "npm_package")
+load("@aspect_rules_swc//swc:defs.bzl", "swc")
 load("@aspect_rules_ts//ts:defs.bzl", _ts_project = "ts_project")
-load("//dev:eslint.bzl", "eslint_test_with_types", "get_client_package_path")
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@npm//:vitest/package_json.bzl", vitest_bin = "bin")
+load("//dev:eslint.bzl", "eslint_test_with_types", "get_client_package_path")
 load(":sass.bzl", _sass = "sass")
 
 sass = _sass
@@ -91,8 +91,6 @@ def npm_package(name, srcs = [], **kwargs):
     """
     replace_prefixes = kwargs.pop("replace_prefixes", {})
 
-    package_type = kwargs.pop("type", "commonjs")
-
     # Modifications to package.json
     # TODO(bazel): remove when package.json can be updated in source
     srcs_no_pkg = [s for s in srcs if s != "package.json"]
@@ -126,28 +124,42 @@ def npm_package(name, srcs = [], **kwargs):
         **kwargs
     )
 
-def vitest_test(name, data = [], **kwargs):
+def vitest_test(name, data = [], with_vitest_config = True, bin = vitest_bin, **kwargs):
+    """Triggers a vitest test with the given name and some sensible defaults.
+
+    Args:
+        name: A unique name for this target
+
+        data: A list of sources available to the test
+
+        with_vitest_config: Whether to include a vitest.config.ts file in the test data or default to the vite config
+
+        bin: The vitest binary to use
+
+        **kwargs: Additional arguments to pass to npm_package
+    """
     vitest_config = "%s_vitest_config" % name
+    if with_vitest_config:
+        js_library(
+            name = vitest_config,
+            testonly = True,
+            srcs = ["vitest.config.ts"],
+            deps = ["//:vitest_config", "//:node_modules/vitest"],
+            data = data,
+        )
 
-    js_library(
-        name = vitest_config,
-        testonly = True,
-        srcs = ["vitest.config.ts"],
-        deps = ["//:vitest_config", "//:node_modules/vitest"],
-        data = data,
-    )
+        data.append(":%s" % vitest_config)
 
-    vitest_bin.vitest_test(
+    bin.vitest_test(
         name = name,
         args = [
             "run",
             "--reporter=default",
             "--color",
             "--update=false",
-            "--config=$(location :%s)" % vitest_config,
+            "--config=$(location :%s)" % vitest_config if with_vitest_config else "",
         ],
         data = data + native.glob(["**/__fixtures__/**/*"]) + [
-            ":%s" % vitest_config,
             "//:node_modules/happy-dom",
             "//:node_modules/jsdom",
         ],

--- a/dev/defs.bzl
+++ b/dev/defs.bzl
@@ -90,6 +90,7 @@ def npm_package(name, srcs = [], **kwargs):
         **kwargs: Additional arguments to pass to npm_package
     """
     replace_prefixes = kwargs.pop("replace_prefixes", {})
+    package_type = kwargs.pop("type", "commonjs")
 
     # Modifications to package.json
     # TODO(bazel): remove when package.json can be updated in source


### PR DESCRIPTION
Makes the vitest macro more generic to support web-svelte use cases
## Test plan
Ran target locally and it is included in CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
