### PR TITLE
Svelte: fix jumpy filters panel

### DIFF
--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -183,6 +183,7 @@
             }
             a {
                 margin-left: auto;
+                line-height: 1;
                 kbd {
                     // TODO: use this style globally
                     font-family: var(--font-family-base);


### PR DESCRIPTION
Tiny issue I noticed: when activating a filter, the appearance of the "Reset all" button causes everything in the filters panel to shift slightly.

## Test plan

Before:

https://github.com/sourcegraph/sourcegraph/assets/12631702/8c54dff6-1112-4501-b78e-edcbeb7f4acf

After:

https://github.com/sourcegraph/sourcegraph/assets/12631702/c32b21df-ca76-4706-a563-ad1ebb8dd811
