### PR TITLE
Svelte: scroll result list without actions

### DIFF
--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -112,7 +112,7 @@
         <DynamicFiltersSidebar {selectedFilters} streamFilters={$stream.filters} searchQuery={queryFromURL} {loading} />
     </div>
     <Separator currentPosition={sidebarSize} />
-    <div class="results" bind:this={resultContainer}>
+    <div class="results">
         <aside class="actions">
             {#if loading}
                 <div>
@@ -121,7 +121,7 @@
             {/if}
             <StreamingProgress progress={$stream.progress} on:submit={onResubmitQuery} />
         </aside>
-        <div class="result-list">
+        <div class="result-list" bind:this={resultContainer}>
             <ol>
                 {#each resultsToShow as result, i}
                     {@const component = getSearchResultComponent(result)}
@@ -159,7 +159,8 @@
 
     .results {
         flex: 1;
-        overflow: auto;
+        overflow: hidden;
+        min-height: 0;
         display: flex;
         flex-direction: column;
 

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -121,24 +121,26 @@
             {/if}
             <StreamingProgress progress={$stream.progress} on:submit={onResubmitQuery} />
         </aside>
-        <ol>
-            {#each resultsToShow as result, i}
-                {@const component = getSearchResultComponent(result)}
-                {#if i === resultsToShow.length - 1}
-                    <li use:observeIntersection on:intersecting={loadMore}>
-                        <svelte:component this={component} {result} />
-                    </li>
-                {:else}
-                    <li><svelte:component this={component} {result} /></li>
-                {/if}
-            {/each}
-        </ol>
-        {#if resultsToShow.length === 0 && !loading}
-            <div class="no-result">
-                <Icon svgPath={mdiCloseOctagonOutline} />
-                <p>No results found</p>
-            </div>
-        {/if}
+        <div class="result-list">
+            <ol>
+                {#each resultsToShow as result, i}
+                    {@const component = getSearchResultComponent(result)}
+                    {#if i === resultsToShow.length - 1}
+                        <li use:observeIntersection on:intersecting={loadMore}>
+                            <svelte:component this={component} {result} />
+                        </li>
+                    {:else}
+                        <li><svelte:component this={component} {result} /></li>
+                    {/if}
+                {/each}
+            </ol>
+            {#if resultsToShow.length === 0 && !loading}
+                <div class="no-result">
+                    <Icon svgPath={mdiCloseOctagonOutline} />
+                    <p>No results found</p>
+                </div>
+            {/if}
+        </div>
     </div>
 </div>
 
@@ -173,10 +175,14 @@
             flex-shrink: 0;
         }
 
-        ol {
-            padding: 0;
-            margin: 0;
-            list-style: none;
+        .result-list {
+            overflow: auto;
+
+            ol {
+                padding: 0;
+                margin: 0;
+                list-style: none;
+            }
         }
 
         .no-result {


### PR DESCRIPTION
This moves the action bar outside of the scrollable element in search results. We want the actions (and result count) to always be visible.

## Test plan
Before:


https://github.com/sourcegraph/sourcegraph/assets/12631702/766199b0-c396-459a-b2f5-74486457bae8



After:

https://github.com/sourcegraph/sourcegraph/assets/12631702/c19253f9-565e-4c2a-93be-0d501945dd68


