### PR TITLE
svelte: Fix repo playwright test

### DIFF
--- a/client/web-sveltekit/src/routes/[...repo=reporev]/layout.spec.ts
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/layout.spec.ts
@@ -33,7 +33,7 @@ test.describe('cloned repository', () => {
     })
 
     test('has search button', async ({ page }) => {
-        await page.getByRole('button', { name: 'Search' }).click()
+        await page.getByRole('button', { name: 'Search', exact: true }).click()
         await expect(page.getByRole('textbox')).toHaveText(String.raw`repo:^github\.com/sourcegraph/sourcegraph$ `)
     })
 })


### PR DESCRIPTION
A recent change to the top navigation caused two buttons containing the word "search" to be present on the page. This change narrows down the selection to the desired button.


## Test plan

```
cd client/web-sveltekit
pnpm test
```

(playwright tests don't run in CI yet)
