### PR TITLE
Limit empty/zero data in json output from aggregate Cody ping data

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1013,18 +1013,18 @@ type CodyUsageStatistics struct {
 // BigQuery, which requires the input match its schema exactly.
 type CodyUsagePeriod struct {
 	StartTime                  time.Time
-	TotalCodyUsers             *CodyCountStatistics
-	TotalProductUsers          *CodyCountStatistics
-	TotalVSCodeProductUsers    *CodyCountStatistics
-	TotalJetBrainsProductUsers *CodyCountStatistics
-	TotalNeovimProductUsers    *CodyCountStatistics
-	TotalEmacsProductUsers     *CodyCountStatistics
-	TotalWebProductUsers       *CodyCountStatistics
+	TotalCodyUsers             *CodyCountStatistics `json:"TotalCodyUsers,omitempty"`
+	TotalProductUsers          *CodyCountStatistics `json:"TotalProductUsers,omitempty"`
+	TotalVSCodeProductUsers    *CodyCountStatistics `json:"TotalVSCodeProductUsers,omitempty"`
+	TotalJetBrainsProductUsers *CodyCountStatistics `json:"TotalJetBrainsProductUsers,omitempty"`
+	TotalNeovimProductUsers    *CodyCountStatistics `json:"TotalNeovimProductUsers,omitempty"`
+	TotalEmacsProductUsers     *CodyCountStatistics `json:"TotalEmacsProductUsers,omitempty"`
+	TotalWebProductUsers       *CodyCountStatistics `json:"TotalWebProductUsers,omitempty"`
 }
 
 type CodyCountStatistics struct {
-	UserCount   *int32
-	EventsCount *int32
+	UserCount   *int32 `json:"UserCount,omitempty"`
+	EventsCount *int32 `json:"EventsCount,omitempty"`
 }
 
 // CodyAggregatedUsage represents the total Cody-related event count and

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1003,8 +1003,8 @@ type UserDates struct {
 // to the updatecheck handler. This struct is marshalled and sent to
 // BigQuery, which requires the input match its schema exactly.
 type CodyUsageStatistics struct {
-	Daily   *CodyUsagePeriod
-	Weekly  *CodyUsagePeriod
+	Daily   *CodyUsagePeriodLimited
+	Weekly  *CodyUsagePeriodLimited
 	Monthly *CodyUsagePeriod
 }
 
@@ -1020,6 +1020,12 @@ type CodyUsagePeriod struct {
 	TotalNeovimProductUsers    *CodyCountStatistics `json:"TotalNeovimProductUsers,omitempty"`
 	TotalEmacsProductUsers     *CodyCountStatistics `json:"TotalEmacsProductUsers,omitempty"`
 	TotalWebProductUsers       *CodyCountStatistics `json:"TotalWebProductUsers,omitempty"`
+}
+
+type CodyUsagePeriodLimited struct {
+	StartTime         time.Time
+	TotalCodyUsers    *CodyCountStatistics `json:"TotalCodyUsers,omitempty"`
+	TotalProductUsers *CodyCountStatistics `json:"TotalProductUsers,omitempty"`
 }
 
 type CodyCountStatistics struct {

--- a/internal/usagestats/aggregated_cody.go
+++ b/internal/usagestats/aggregated_cody.go
@@ -17,8 +17,8 @@ func GetAggregatedCodyStats(ctx context.Context, db database.DB) (*types.CodyUsa
 	}
 
 	stats := &types.CodyUsageStatistics{
-		Daily:   newCodyEventPeriod(),
-		Weekly:  newCodyEventPeriod(),
+		Daily:   newCodyEventPeriodLimited(),
+		Weekly:  newCodyEventPeriodLimited(),
 		Monthly: newCodyEventPeriod(),
 	}
 
@@ -60,6 +60,14 @@ func newCodyEventPeriod() *types.CodyUsagePeriod {
 		TotalNeovimProductUsers:    newCodyCountStatistics(),
 		TotalEmacsProductUsers:     newCodyCountStatistics(),
 		TotalWebProductUsers:       newCodyCountStatistics(),
+	}
+}
+
+func newCodyEventPeriodLimited() *types.CodyUsagePeriodLimited {
+	return &types.CodyUsagePeriodLimited{
+		StartTime:         time.Now().UTC(),
+		TotalCodyUsers:    newCodyCountStatistics(),
+		TotalProductUsers: newCodyCountStatistics(),
 	}
 }
 


### PR DESCRIPTION
Avoid sending a bunch of empty/zero fields to data warehouse. Fixes https://sourcegraph.slack.com/archives/C01PQEVJ5A9/p1709742734184889?thread_ts=1705069745.537519&cid=C01PQEVJ5A9

## Test plan

CI. Also tested output locally. 

Original json value (from local testing):

```
{
    "Daily": {
        "StartTime": "2024-03-07T00:00:00Z",
        "TotalCodyUsers": {
            "UserCount": 1,
            "EventsCount": 2
        },
        "TotalProductUsers": {
            "UserCount": 0,
            "EventsCount": null
        },
        "TotalVSCodeProductUsers": {
            "UserCount": null,
            "EventsCount": null
        },
        "TotalJetBrainsProductUsers": {
            "UserCount": null,
            "EventsCount": null
        },
        "TotalNeovimProductUsers": {
            "UserCount": null,
            "EventsCount": null
        },
        "TotalEmacsProductUsers": {
            "UserCount": null,
            "EventsCount": null
        },
        "TotalWebProductUsers": {
            "UserCount": null,
            "EventsCount": null
        }
    },
    "Weekly": {
        "StartTime": "2024-03-03T00:00:00Z",
        "TotalCodyUsers": {
            "UserCount": 1,
            "EventsCount": 109
        },
        "TotalProductUsers": {
            "UserCount": 1,
            "EventsCount": null
        },
        "TotalVSCodeProductUsers": {
            "UserCount": null,
            "EventsCount": null
        },
        "TotalJetBrainsProductUsers": {
            "UserCount": null,
            "EventsCount": null
        },
        "TotalNeovimProductUsers": {
            "UserCount": null,
            "EventsCount": null
        },
        "TotalEmacsProductUsers": {
            "UserCount": null,
            "EventsCount": null
        },
        "TotalWebProductUsers": {
            "UserCount": null,
            "EventsCount": null
        }
    },
    "Monthly": {
        "StartTime": "2024-03-01T00:00:00Z",
        "TotalCodyUsers": {
            "UserCount": 1,
            "EventsCount": 109
        },
        "TotalProductUsers": {
            "UserCount": 1,
            "EventsCount": null
        },
        "TotalVSCodeProductUsers": {
            "UserCount": 0,
            "EventsCount": null
        },
        "TotalJetBrainsProductUsers": {
            "UserCount": 0,
            "EventsCount": null
        },
        "TotalNeovimProductUsers": {
            "UserCount": 0,
            "EventsCount": null
        },
        "TotalEmacsProductUsers": {
            "UserCount": 0,
            "EventsCount": null
        },
        "TotalWebProductUsers": {
            "UserCount": 0,
            "EventsCount": null
        }
    }
}
```

The new json value:

```
{
    "Daily": {
        "StartTime": "2024-03-07T00:00:00Z",
        "TotalCodyUsers": {
            "UserCount": 1,
            "EventsCount": 2
        },
        "TotalProductUsers": {
            "UserCount": 0
        }
    },
    "Weekly": {
        "StartTime": "2024-03-03T00:00:00Z",
        "TotalCodyUsers": {
            "UserCount": 1,
            "EventsCount": 109
        },
        "TotalProductUsers": {
            "UserCount": 1
        }
    },
    "Monthly": {
        "StartTime": "2024-03-01T00:00:00Z",
        "TotalCodyUsers": {
            "UserCount": 1,
            "EventsCount": 109
        },
        "TotalProductUsers": {
            "UserCount": 1
        },
        "TotalVSCodeProductUsers": {
            "UserCount": 0
        },
        "TotalJetBrainsProductUsers": {
            "UserCount": 0
        },
        "TotalNeovimProductUsers": {
            "UserCount": 0
        },
        "TotalEmacsProductUsers": {
            "UserCount": 0
        },
        "TotalWebProductUsers": {
            "UserCount": 0
        }
    }
}
```