### PR TITLE
v2t: add v2t to src/enterprise/searchContexts and src/enterprise/site-admin

### DIFF
--- a/client/shared/src/testing/searchTestHelpers.ts
+++ b/client/shared/src/testing/searchTestHelpers.ts
@@ -9,6 +9,7 @@ import type { Controller } from '../extensions/controller'
 import type { PlatformContext } from '../platform/context'
 import type { AggregateStreamingSearchResults, ContentMatch, RepositoryMatch } from '../search/stream'
 import type { SettingsCascade } from '../settings/settings'
+import { noOpTelemetryRecorder } from '../telemetry'
 
 export const CHUNK_MATCH_RESULT: ContentMatch = {
     type: 'content',
@@ -643,10 +644,11 @@ export const extensionsController: Controller = {
 
 export const NOOP_PLATFORM_CONTEXT: Pick<
     PlatformContext,
-    'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings'
+    'sourcegraphURL' | 'requestGraphQL' | 'urlToFile' | 'settings' | 'telemetryRecorder'
 > = {
     requestGraphQL: () => EMPTY,
     urlToFile: () => '',
     settings: of(NOOP_SETTINGS_CASCADE),
     sourcegraphURL: '',
+    telemetryRecorder: noOpTelemetryRecorder,
 }

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -55,7 +55,11 @@ export const CodeIntelConfigurationPage: FunctionComponent<CodeIntelConfiguratio
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelConfiguration')
-        telemetryRecorder.recordEvent('codeIntel.configuration', 'view')
+        if (!!repo) {
+            telemetryRecorder.recordEvent('repo.codeIntel.configuration', 'view')
+        } else {
+            telemetryRecorder.recordEvent('admin.codeIntel.configuration', 'view')
+        }
     }, [telemetryService, telemetryRecorder])
 
     const navigate = useNavigate()

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPage.tsx
@@ -55,12 +55,12 @@ export const CodeIntelConfigurationPage: FunctionComponent<CodeIntelConfiguratio
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelConfiguration')
-        if (!!repo) {
+        if (repo) {
             telemetryRecorder.recordEvent('repo.codeIntel.configuration', 'view')
         } else {
             telemetryRecorder.recordEvent('admin.codeIntel.configuration', 'view')
         }
-    }, [telemetryService, telemetryRecorder])
+    }, [telemetryService, telemetryRecorder, repo])
 
     const navigate = useNavigate()
     const location = useLocation()

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -86,19 +86,17 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<CodeIntelConfig
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelConfigurationPolicy')
         if (domain === 'scip') {
-            if (!!repo) {
+            if (repo) {
                 telemetryRecorder.recordEvent('repo.codeIntel.configurationPolicy', 'view')
             } else {
                 telemetryRecorder.recordEvent('admin.codeIntel.configurationPolicy', 'view')
             }
+        } else if (repo) {
+            telemetryRecorder.recordEvent('repo.cody.configurationPolicy', 'view')
         } else {
-            if (!!repo) {
-                telemetryRecorder.recordEvent('repo.cody.configurationPolicy', 'view')
-            } else {
-                telemetryRecorder.recordEvent('admin.cody.configurationPolicy', 'view')
-            }
+            telemetryRecorder.recordEvent('admin.cody.configurationPolicy', 'view')
         }
-    }, [telemetryService, telemetryRecorder])
+    }, [telemetryService, telemetryRecorder, domain, repo])
 
     // Handle local policy state
     const [policy, setPolicy] = useState<CodeIntelligenceConfigurationPolicyFields | undefined>()

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -986,7 +986,7 @@ function comparePatterns(a: string[] | null, b: string[] | null): boolean {
     return a.length === b.length && a.every((pattern, index) => b[index] === pattern)
 }
 
-function getViewEventFeatureName(domain: string, hasRepo: boolean) {
+function getViewEventFeatureName(domain: string, hasRepo: boolean): string {
     if (domain === 'scip') {
         return hasRepo ? 'repo.codeIntel.configurationPolicy' : 'admin.codeIntel.configurationPolicy'
     }

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -85,17 +85,7 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<CodeIntelConfig
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelConfigurationPolicy')
-        if (domain === 'scip') {
-            if (repo) {
-                telemetryRecorder.recordEvent('repo.codeIntel.configurationPolicy', 'view')
-            } else {
-                telemetryRecorder.recordEvent('admin.codeIntel.configurationPolicy', 'view')
-            }
-        } else if (repo) {
-            telemetryRecorder.recordEvent('repo.cody.configurationPolicy', 'view')
-        } else {
-            telemetryRecorder.recordEvent('admin.cody.configurationPolicy', 'view')
-        }
+        telemetryRecorder.recordEvent(getViewEventFeatureName(domain, !!repo), 'view')
     }, [telemetryService, telemetryRecorder, domain, repo])
 
     // Handle local policy state
@@ -994,4 +984,12 @@ function comparePatterns(a: string[] | null, b: string[] | null): boolean {
 
     // Both supplied and their contents match
     return a.length === b.length && a.every((pattern, index) => b[index] === pattern)
+}
+
+function getViewEventFeatureName(domain: string, hasRepo: boolean) {
+    if (domain === 'scip') {
+        return hasRepo ? 'repo.codeIntel.configurationPolicy' : 'admin.codeIntel.configurationPolicy'
+    }
+
+    return hasRepo ? 'repo.cody.configurationPolicy' : 'admin.cody.configurationPolicy'
 }

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -986,7 +986,13 @@ function comparePatterns(a: string[] | null, b: string[] | null): boolean {
     return a.length === b.length && a.every((pattern, index) => b[index] === pattern)
 }
 
-function getViewEventFeatureName(domain: string, hasRepo: boolean): string {
+type viewEventFeatureName =
+    | 'repo.codeIntel.configurationPolicy'
+    | 'admin.codeIntel.configurationPolicy'
+    | 'repo.cody.configurationPolicy'
+    | 'admin.cody.configurationPolicy'
+
+function getViewEventFeatureName(domain: string, hasRepo: boolean): viewEventFeatureName {
     if (domain === 'scip') {
         return hasRepo ? 'repo.codeIntel.configurationPolicy' : 'admin.codeIntel.configurationPolicy'
     }

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelConfigurationPolicyPage.tsx
@@ -85,7 +85,19 @@ export const CodeIntelConfigurationPolicyPage: FunctionComponent<CodeIntelConfig
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelConfigurationPolicy')
-        telemetryRecorder.recordEvent('codeIntel.configurationPolicy', 'view')
+        if (domain === 'scip') {
+            if (!!repo) {
+                telemetryRecorder.recordEvent('repo.codeIntel.configurationPolicy', 'view')
+            } else {
+                telemetryRecorder.recordEvent('admin.codeIntel.configurationPolicy', 'view')
+            }
+        } else {
+            if (!!repo) {
+                telemetryRecorder.recordEvent('repo.cody.configurationPolicy', 'view')
+            } else {
+                telemetryRecorder.recordEvent('admin.cody.configurationPolicy', 'view')
+            }
+        }
     }, [telemetryService, telemetryRecorder])
 
     // Handle local policy state

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelInferenceConfigurationPage.tsx
@@ -25,7 +25,7 @@ export const CodeIntelInferenceConfigurationPage: FunctionComponent<CodeIntelInf
     const inferencePreview = previewScript !== null ? previewScript : inferenceScript
 
     useEffect(() => {
-        props.telemetryRecorder.recordEvent('codeIntel.inferenceConfiguration', 'view')
+        props.telemetryRecorder.recordEvent('admin.codeIntel.inferenceConfiguration', 'view')
     }, [props.telemetryRecorder])
 
     return (

--- a/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/pages/CodeIntelRepositoryIndexConfigurationPage.tsx
@@ -22,7 +22,7 @@ export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
 > = ({ repo, authenticatedUser, telemetryService, telemetryRecorder, ...props }) => {
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelRepositoryIndexConfiguration')
-        telemetryRecorder.recordEvent('codeIntel.repoIndexConfig', 'view')
+        telemetryRecorder.recordEvent('repo.codeIntel.indexConfig', 'view')
     }, [telemetryService, telemetryRecorder])
     const location = useLocation()
 
@@ -32,10 +32,10 @@ export const CodeIntelRepositoryIndexConfigurationPage: FunctionComponent<
         const tab = new URLSearchParams(location.search).get('tab')
         if (tab === 'form') {
             setActiveTabIndex(0)
-            telemetryRecorder.recordEvent('codeIntel.repoIndexConfig.tab', 'click', { metadata: { tab: 0 } })
+            telemetryRecorder.recordEvent('repo.codeIntel.indexConfig.tab', 'click', { metadata: { tab: 0 } })
         } else if (tab === 'raw') {
             setActiveTabIndex(1)
-            telemetryRecorder.recordEvent('codeIntel.repoIndexConfig.tab', 'click', { metadata: { tab: 1 } })
+            telemetryRecorder.recordEvent('repo.codeIntel.indexConfig.tab', 'click', { metadata: { tab: 1 } })
         }
     }, [location.search, telemetryRecorder])
 

--- a/client/web/src/enterprise/codeintel/dashboard/pages/GlobalDashboardPage.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/pages/GlobalDashboardPage.tsx
@@ -90,7 +90,7 @@ export const GlobalDashboardPage: React.FunctionComponent<GlobalDashboardPagePro
 }) => {
     useEffect(() => {
         telemetryService.logPageView('CodeIntelGlobalDashboard')
-        telemetryRecorder.recordEvent('codeIntel.globalDashboard', 'view')
+        telemetryRecorder.recordEvent('admin.codeIntel.dashboard', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const { data, error, loading } = useQuery<GlobalCodeIntelStatusResult>(globalCodeIntelStatusQuery, {

--- a/client/web/src/enterprise/codeintel/dashboard/pages/RepoDashboardPage.tsx
+++ b/client/web/src/enterprise/codeintel/dashboard/pages/RepoDashboardPage.tsx
@@ -103,7 +103,7 @@ export const RepoDashboardPage: React.FunctionComponent<RepoDashboardPageProps> 
 }) => {
     useEffect(() => {
         telemetryService.logPageView('CodeIntelRepoDashboard')
-        telemetryRecorder.recordEvent('codeIntel.repoDashboard', 'view')
+        telemetryRecorder.recordEvent('repo.codeIntel.dashboard', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const location = useLocation()

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexPage.tsx
@@ -80,7 +80,7 @@ export const CodeIntelPreciseIndexPage: FunctionComponent<CodeIntelPreciseIndexP
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelPreciseIndexPage')
-        telemetryRecorder.recordEvent('codeIntel.preciseIndex', 'view')
+        telemetryRecorder.recordEvent('repo.codeIntel.preciseIndex', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const apolloClient = useApolloClient()

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
@@ -131,12 +131,12 @@ export const CodeIntelPreciseIndexesPage: FunctionComponent<CodeIntelPreciseInde
     const location = useLocation()
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelPreciseIndexesPage')
-        if (!!repo) {
+        if (repo) {
             telemetryRecorder.recordEvent('repo.codeIntel.preciseIndexes', 'view')
         } else {
             telemetryRecorder.recordEvent('admin.codeIntel.preciseIndexes', 'view')
         }
-    }, [telemetryService, telemetryRecorder])
+    }, [telemetryService, telemetryRecorder, repo])
 
     const apolloClient = useApolloClient()
     const { handleDeletePreciseIndex, deleteError } = useDeletePreciseIndex()

--- a/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
+++ b/client/web/src/enterprise/codeintel/indexes/pages/CodeIntelPreciseIndexesPage.tsx
@@ -131,7 +131,11 @@ export const CodeIntelPreciseIndexesPage: FunctionComponent<CodeIntelPreciseInde
     const location = useLocation()
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelPreciseIndexesPage')
-        telemetryRecorder.recordEvent('codeIntel.preciseIndexes', 'view')
+        if (!!repo) {
+            telemetryRecorder.recordEvent('repo.codeIntel.preciseIndexes', 'view')
+        } else {
+            telemetryRecorder.recordEvent('admin.codeIntel.preciseIndexes', 'view')
+        }
     }, [telemetryService, telemetryRecorder])
 
     const apolloClient = useApolloClient()

--- a/client/web/src/enterprise/codeintel/ranking/pages/CodeIntelRankingPage.tsx
+++ b/client/web/src/enterprise/codeintel/ranking/pages/CodeIntelRankingPage.tsx
@@ -49,7 +49,7 @@ export const CodeIntelRankingPage: FunctionComponent<CodeIntelRankingPageProps> 
 }) => {
     useEffect(() => {
         telemetryService.logViewEvent('CodeIntelRankingPage')
-        telemetryRecorder.recordEvent('codeIntel.ranking', 'view')
+        telemetryRecorder.recordEvent('admin.codeIntel.ranking', 'view')
     }, [telemetryService, telemetryRecorder])
 
     const { data, loading, error, refetch } = useRankingSummary({})

--- a/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
+++ b/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
@@ -43,7 +43,11 @@ export const CodyConfigurationPage: FC<CodyConfigurationPageProps> = ({
 }) => {
     useEffect(() => {
         telemetryService.logPageView('CodyConfigurationPage')
-        telemetryRecorder.recordEvent('cody.configuration', 'view')
+        if (!!repo) {
+            telemetryRecorder.recordEvent('repo.cody.configuration', 'view')
+        } else {
+            telemetryRecorder.recordEvent('admin.cody.configuration', 'view')
+        }
     }, [telemetryService, telemetryRecorder])
 
     const navigate = useNavigate()

--- a/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
+++ b/client/web/src/enterprise/cody/configuration/pages/CodyConfigurationPage.tsx
@@ -43,12 +43,12 @@ export const CodyConfigurationPage: FC<CodyConfigurationPageProps> = ({
 }) => {
     useEffect(() => {
         telemetryService.logPageView('CodyConfigurationPage')
-        if (!!repo) {
+        if (repo) {
             telemetryRecorder.recordEvent('repo.cody.configuration', 'view')
         } else {
             telemetryRecorder.recordEvent('admin.cody.configuration', 'view')
         }
-    }, [telemetryService, telemetryRecorder])
+    }, [telemetryService, telemetryRecorder, repo])
 
     const navigate = useNavigate()
     const location = useLocation()

--- a/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/CreateSearchContextPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 
 import { mdiMagnify } from '@mdi/js'
 import { Navigate, useLocation } from 'react-router-dom'
@@ -26,7 +26,7 @@ import { SearchContextForm } from './SearchContextForm'
 export interface CreateSearchContextPageProps
     extends TelemetryProps,
         Pick<SearchContextProps, 'createSearchContext' | 'deleteSearchContext'>,
-        PlatformContextProps<'requestGraphQL'> {
+        PlatformContextProps<'requestGraphQL' | 'telemetryRecorder'> {
     authenticatedUser: AuthenticatedUser
     isSourcegraphDotCom: boolean
 }
@@ -40,12 +40,19 @@ export const AuthenticatedCreateSearchContextPage: React.FunctionComponent<
 
     const query = parseSearchURLQuery(location.search)
 
+    useEffect(() => {
+        platformContext.telemetryRecorder.recordEvent('searchContexts.create', 'view')
+    }, [platformContext.telemetryRecorder])
+
     const onSubmit = useCallback(
         (
             id: Scalars['ID'] | undefined,
             searchContext: SearchContextInput,
             repositories: SearchContextRepositoryRevisionsInput[]
-        ): Observable<SearchContextFields> => createSearchContext({ searchContext, repositories }, platformContext),
+        ): Observable<SearchContextFields> => {
+            platformContext.telemetryRecorder.recordEvent('searchContext', 'create')
+            return createSearchContext({ searchContext, repositories }, platformContext)
+        },
         [createSearchContext, platformContext]
     )
 

--- a/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.tsx
+++ b/client/web/src/enterprise/searchContexts/DeleteSearchContextModal.tsx
@@ -14,7 +14,7 @@ import { ALLOW_NAVIGATION } from '../../components/AwayPrompt'
 
 interface DeleteSearchContextModalProps
     extends Pick<SearchContextProps, 'deleteSearchContext'>,
-        PlatformContextProps<'requestGraphQL'> {
+        PlatformContextProps<'requestGraphQL' | 'telemetryRecorder'> {
     isOpen: boolean
     searchContext: SearchContextFields
     toggleDeleteModal: () => void
@@ -34,6 +34,7 @@ export const DeleteSearchContextModal: React.FunctionComponent<
                     mergeMap(() =>
                         deleteSearchContext(searchContext.id, platformContext).pipe(
                             tap(() => {
+                                platformContext.telemetryRecorder.recordEvent('searchContext', 'delete')
                                 navigate('/contexts', { state: ALLOW_NAVIGATION })
                             }),
                             startWith(LOADING),

--- a/client/web/src/enterprise/searchContexts/EditSearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/EditSearchContextPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 
 import { mdiMagnify } from '@mdi/js'
 import { useParams } from 'react-router-dom'
@@ -27,7 +27,7 @@ import { SearchContextForm } from './SearchContextForm'
 export interface EditSearchContextPageProps
     extends TelemetryProps,
         Pick<SearchContextProps, 'updateSearchContext' | 'fetchSearchContextBySpec' | 'deleteSearchContext'>,
-        PlatformContextProps<'requestGraphQL'> {
+        PlatformContextProps<'requestGraphQL' | 'telemetryRecorder'> {
     authenticatedUser: AuthenticatedUser
     isSourcegraphDotCom: boolean
 }
@@ -41,6 +41,11 @@ export const AuthenticatedEditSearchContextPage: React.FunctionComponent<
     const spec: string = params.spec ? `${params.specOrOrg}/${params.spec}` : params.specOrOrg!
 
     const { updateSearchContext, fetchSearchContextBySpec, platformContext } = props
+
+    useEffect(() => {
+        platformContext.telemetryRecorder.recordEvent('searchContext.edit', 'view')
+    }, [platformContext.telemetryRecorder])
+
     const onSubmit = useCallback(
         (
             id: Scalars['ID'] | undefined,
@@ -50,6 +55,7 @@ export const AuthenticatedEditSearchContextPage: React.FunctionComponent<
             if (!id) {
                 return throwError(new Error('Cannot update search context with undefined ID'))
             }
+            platformContext.telemetryRecorder.recordEvent('searchContext', 'update')
             return updateSearchContext({ id, searchContext, repositories }, platformContext)
         },
         [updateSearchContext, platformContext]

--- a/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextForm.tsx
@@ -16,7 +16,6 @@ import {
 } from '@sourcegraph/shared/src/graphql-operations'
 import type { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import type { QueryState, SearchContextProps } from '@sourcegraph/shared/src/search'
-import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
 import {
@@ -112,7 +111,7 @@ const LOADING = 'loading' as const
 export interface SearchContextFormProps
     extends TelemetryProps,
         Pick<SearchContextProps, 'deleteSearchContext'>,
-        PlatformContextProps<'requestGraphQL'> {
+        PlatformContextProps<'requestGraphQL' | 'telemetryRecorder'> {
     searchContext?: SearchContextFields
     query?: string
     authenticatedUser: AuthenticatedUser
@@ -473,8 +472,7 @@ export const SearchContextForm: React.FunctionComponent<React.PropsWithChildren<
                                 onChange={onRepositoriesConfigChange}
                                 validateRepositories={validateRepositories}
                                 repositories={searchContext?.repositories}
-                                // TODO (dadlerj) replace with real telemetryRecorder
-                                telemetryRecorder={noOpTelemetryRecorder}
+                                telemetryRecorder={platformContext.telemetryRecorder}
                             />
                         </div>
                     </div>

--- a/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { mdiMagnify } from '@mdi/js'
 import classNames from 'classnames'
@@ -41,7 +41,7 @@ import styles from './SearchContextPage.module.scss'
 
 export interface SearchContextPageProps
     extends Pick<SearchContextProps, 'fetchSearchContextBySpec'>,
-        PlatformContextProps<'requestGraphQL'> {
+        PlatformContextProps<'requestGraphQL' | 'telemetryRecorder'> {
     authenticatedUser: Pick<AuthenticatedUser, 'id'> | null
 }
 
@@ -151,6 +151,10 @@ export const SearchContextPage: React.FunctionComponent<SearchContextPageProps> 
     const spec: string = params.spec ? `${params.specOrOrg}/${params.spec}` : params.specOrOrg!
 
     const LOADING = 'loading' as const
+
+    useEffect(() => {
+        platformContext.telemetryRecorder.recordEvent('searchContext', 'view')
+    }, [platformContext.telemetryRecorder])
 
     const searchContextOrError = useObservable(
         React.useMemo(

--- a/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/enterprise/searchContexts/SearchContextsListPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { mdiMagnify, mdiPlus } from '@mdi/js'
 
@@ -17,7 +17,7 @@ import styles from './SearchContextsListPage.module.scss'
 
 export interface SearchContextsListPageProps
     extends Pick<SearchContextProps, 'fetchSearchContexts' | 'getUserSearchContextNamespaces'>,
-        PlatformContextProps<'requestGraphQL'> {
+        PlatformContextProps<'requestGraphQL' | 'telemetryRecorder'> {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
 }
@@ -30,6 +30,10 @@ export const SearchContextsListPage: React.FunctionComponent<SearchContextsListP
     isSourcegraphDotCom,
 }) => {
     const [alert, setAlert] = useState<string | undefined>()
+
+    useEffect(() => {
+        platformContext.telemetryRecorder.recordEvent('searchContexts.list', 'view')
+    }, [platformContext.telemetryRecorder])
 
     return (
         <div data-testid="search-contexts-list-page" className="w-100">
@@ -60,9 +64,13 @@ export const SearchContextsListPage: React.FunctionComponent<SearchContextsListP
                                     To search across your team's private repositories,{' '}
                                     <Link
                                         to="https://sourcegraph.com"
-                                        onClick={() =>
+                                        onClick={() => {
                                             eventLogger.log('ClickedOnEnterpriseCTA', { location: 'ContextsSettings' })
-                                        }
+                                            platformContext.telemetryRecorder.recordEvent(
+                                                'searchContexts.enterpriseCTA',
+                                                'click'
+                                            )
+                                        }}
                                     >
                                         get Sourcegraph Enterprise
                                     </Link>

--- a/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
+++ b/client/web/src/enterprise/site-admin/cody/SiteAdminCodyPage.tsx
@@ -5,6 +5,7 @@ import { capitalize } from 'lodash'
 import { useLocation } from 'react-router-dom'
 
 import { RepoEmbeddingJobState } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     Button,
@@ -43,7 +44,7 @@ import { RepoEmbeddingJobNode } from './RepoEmbeddingJobNode'
 
 import styles from './SiteAdminCodyPage.module.scss'
 
-export interface SiteAdminCodyPageProps extends TelemetryProps {}
+export interface SiteAdminCodyPageProps extends TelemetryProps, TelemetryV2Props {}
 
 interface RepoEmbeddingJobsFormValues {
     repositories: string[]
@@ -72,10 +73,11 @@ const enumToFilterValues = <T extends string>(enumeration: { [key in T]: T }): F
     return values
 }
 
-export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService }) => {
+export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService, telemetryRecorder }) => {
     useEffect(() => {
         telemetryService.logPageView('SiteAdminCodyPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('admin.cody.embeddingsJobs', 'view')
+    }, [telemetryService, telemetryRecorder])
 
     const location = useLocation()
     const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search])
@@ -119,10 +121,11 @@ export const SiteAdminCodyPage: FC<SiteAdminCodyPageProps> = ({ telemetryService
 
     const onSubmit = useCallback(
         async (repoNames: string[]) => {
+            telemetryRecorder.recordEvent('admin.cody.embeddingsJobs', 'scheduleJob')
             await scheduleRepoEmbeddingJobs({ variables: { repoNames } })
             refetchFirst()
         },
-        [refetchFirst, scheduleRepoEmbeddingJobs]
+        [refetchFirst, scheduleRepoEmbeddingJobs, telemetryRecorder]
     )
 
     const form = useForm<RepoEmbeddingJobsFormValues>({

--- a/client/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomersPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/customers/SiteAdminCustomersPage.tsx
@@ -5,13 +5,13 @@ import { map } from 'rxjs/operators'
 
 import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { H2 } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../../../backend/graphql'
 import { FilteredConnection } from '../../../../components/FilteredConnection'
 import { PageTitle } from '../../../../components/PageTitle'
 import type { CustomerFields, CustomersResult, CustomersVariables } from '../../../../graphql-operations'
-import { eventLogger } from '../../../../tracking/eventLogger'
 import { userURL } from '../../../../user'
 import { AccountName } from '../../../dotcom/productSubscriptions/AccountName'
 
@@ -42,13 +42,13 @@ const SiteAdminCustomerNode: React.FunctionComponent<React.PropsWithChildren<Sit
     </li>
 )
 
-interface Props {}
+interface Props extends TelemetryV2Props {}
 
 /**
  * Displays a list of customers associated with user accounts on Sourcegraph.com.
  */
 export const SiteAdminProductCustomersPage: React.FunctionComponent<React.PropsWithChildren<Props>> = props => {
-    useEffect(() => eventLogger.logViewEvent('SiteAdminProductCustomers'), [])
+    useEffect(() => props.telemetryRecorder.recordEvent('admin.customers', 'view'), [props.telemetryRecorder])
 
     const updates = useMemo(() => new Subject<void>(), [])
     const nodeProps: Pick<SiteAdminCustomerNodeProps, Exclude<keyof SiteAdminCustomerNodeProps, 'node'>> = {}

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/CodyServicesSection.tsx
@@ -8,6 +8,7 @@ import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
 import { logger } from '@sourcegraph/common'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
 import { CodyGatewayRateLimitSource } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     H3,
     ProductStatusBadge,
@@ -54,7 +55,7 @@ import { numberFormatter, prettyInterval } from './utils'
 
 import styles from './CodyServicesSection.module.scss'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     productSubscriptionUUID: string
     productSubscriptionID: Scalars['ID']
     currentSourcegraphAccessToken: string | null
@@ -72,6 +73,7 @@ export const CodyServicesSection: React.FunctionComponent<Props> = ({
     accessTokenError,
     refetchSubscription,
     codyGatewayAccess,
+    telemetryRecorder,
 }) => {
     const [updateCodyGatewayConfig, { loading: updateCodyGatewayConfigLoading, error: updateCodyGatewayConfigError }] =
         useMutation<UpdateCodyGatewayConfigResult, UpdateCodyGatewayConfigVariables>(UPDATE_CODY_GATEWAY_CONFIG)
@@ -87,6 +89,10 @@ export const CodyServicesSection: React.FunctionComponent<Props> = ({
             return
         }
         try {
+            telemetryRecorder.recordEvent(
+                'admin.productSubscription.codyAccess',
+                codyServicesStateChange ? 'enable' : 'disable'
+            )
             await updateCodyGatewayConfig({
                 variables: {
                     productSubscriptionID,
@@ -100,7 +106,13 @@ export const CodyServicesSection: React.FunctionComponent<Props> = ({
             // Reset the intent to change state.
             setCodyServicesStateChange(undefined)
         }
-    }, [productSubscriptionID, refetchSubscription, updateCodyGatewayConfig, codyServicesStateChange])
+    }, [
+        productSubscriptionID,
+        refetchSubscription,
+        updateCodyGatewayConfig,
+        codyServicesStateChange,
+        telemetryRecorder,
+    ])
 
     return (
         <>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -7,6 +7,7 @@ import { catchError, concatMapTo, map, tap } from 'rxjs/operators'
 
 import { asError, type ErrorLike, isErrorLike } from '@sourcegraph/common'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, useEventObservable, Link, Alert, Icon, Form, Container, PageHeader } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../../../auth'
@@ -20,9 +21,8 @@ import type {
     ProductSubscriptionAccountFields,
     CreateProductSubscriptionResult,
 } from '../../../../graphql-operations'
-import { eventLogger } from '../../../../tracking/eventLogger'
 
-interface UserCreateSubscriptionNodeProps {
+interface UserCreateSubscriptionNodeProps extends TelemetryV2Props {
     /**
      * The user to display in this list item.
      */
@@ -62,7 +62,7 @@ const UserCreateSubscriptionNode: React.FunctionComponent<React.PropsWithChildre
             > =>
                 submits.pipe(
                     tap(event => event.preventDefault()),
-                    tap(() => eventLogger.log('NewProductSubscriptionCreated')),
+                    tap(() => props.telemetryRecorder.recordEvent('admin.productSubscriptions', 'create')),
                     concatMapTo(
                         merge(
                             of('saving' as const),
@@ -114,7 +114,7 @@ const UserCreateSubscriptionNode: React.FunctionComponent<React.PropsWithChildre
     )
 }
 
-interface Props {
+interface Props extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
 }
 
@@ -126,9 +126,7 @@ interface Props {
 export const SiteAdminCreateProductSubscriptionPage: React.FunctionComponent<
     React.PropsWithChildren<Props>
 > = props => {
-    useEffect(() => {
-        eventLogger.logViewEvent('SiteAdminCreateProductSubscription')
-    })
+    useEffect(() => props.telemetryRecorder.recordEvent('admin.productSubscriptions.create', 'view'))
     return (
         <div className="site-admin-create-product-subscription-page">
             <PageTitle title="Create product subscription" />

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminCreateProductSubscriptionPage.tsx
@@ -72,7 +72,7 @@ const UserCreateSubscriptionNode: React.FunctionComponent<React.PropsWithChildre
                         )
                     )
                 ),
-            [props.node.id]
+            [props.node.id, props.telemetryRecorder]
         )
     )
 

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx
@@ -1,6 +1,7 @@
 import { noop } from 'lodash'
 import { describe, expect, test } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
@@ -18,6 +19,7 @@ describe('SiteAdminGenerateProductLicenseForSubscriptionForm', () => {
                         onCancel={noop}
                         subscriptionAccount="foo"
                         onGenerate={noop}
+                        telemetryRecorder={noOpTelemetryRecorder}
                     />
                 </MockedTestProvider>
             ).baseElement

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -153,16 +153,14 @@ const getTagsFromFormData = (formData: FormData): string[] =>
         ])
     )
 
-const getTagsForTelemetry = (formData: FormData): { [key: string]: number } => {
-    return {
-        trueUp: formData.trueUp ? 1 : 0,
-        trial: formData.trial ? 1 : 0,
-        airGapped: formData.airGapped ? 1 : 0,
-        batchChanges: formData.batchChanges ? 1 : 0,
-        codeInsights: formData.codeInsights ? 1 : 0,
-        disableTelemetry: formData.disableTelemetry ? 1 : 0,
-    }
-}
+const getTagsForTelemetry = (formData: FormData): { [key: string]: number } => ({
+    trueUp: formData.trueUp ? 1 : 0,
+    trial: formData.trial ? 1 : 0,
+    airGapped: formData.airGapped ? 1 : 0,
+    batchChanges: formData.batchChanges ? 1 : 0,
+    codeInsights: formData.codeInsights ? 1 : 0,
+    disableTelemetry: formData.disableTelemetry ? 1 : 0,
+})
 
 const HANDBOOK_INFO_URL =
     'https://handbook.sourcegraph.com/ce/license_keys#how-to-create-a-license-key-for-a-new-prospect-or-new-customer'

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -8,6 +8,7 @@ import { noop } from 'lodash'
 
 import { useMutation } from '@sourcegraph/http-client'
 import type { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Alert,
     Button,
@@ -61,7 +62,7 @@ import styles from './SiteAdminGenerateProductLicenseForSubscriptionForm.module.
 interface License extends Omit<ProductLicenseFields, 'subscription' | 'info'> {
     info: Omit<ProductLicenseInfoFields, 'productNameWithBrand'> | null
 }
-interface Props {
+interface Props extends TelemetryV2Props {
     subscriptionID: Scalars['ID']
     subscriptionAccount: string
     latestLicense: License | undefined
@@ -152,6 +153,17 @@ const getTagsFromFormData = (formData: FormData): string[] =>
         ])
     )
 
+const getTagsForTelemetry = (formData: FormData): { [key: string]: number } => {
+    return {
+        trueUp: formData.trueUp ? 1 : 0,
+        trial: formData.trial ? 1 : 0,
+        airGapped: formData.airGapped ? 1 : 0,
+        batchChanges: formData.batchChanges ? 1 : 0,
+        codeInsights: formData.codeInsights ? 1 : 0,
+        disableTelemetry: formData.disableTelemetry ? 1 : 0,
+    }
+}
+
 const HANDBOOK_INFO_URL =
     'https://handbook.sourcegraph.com/ce/license_keys#how-to-create-a-license-key-for-a-new-prospect-or-new-customer'
 
@@ -162,7 +174,7 @@ const HANDBOOK_INFO_URL =
  */
 export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionComponent<
     React.PropsWithChildren<Props>
-> = ({ latestLicense, subscriptionID, subscriptionAccount, onGenerate, onCancel }) => {
+> = ({ latestLicense, subscriptionID, subscriptionAccount, onGenerate, onCancel, telemetryRecorder }) => {
     const labelId = 'generateLicense'
 
     const [hasAcknowledgedInfo, setHasAcknowledgedInfo] = useState(false)
@@ -287,10 +299,13 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
     const onSubmit = useCallback<React.FormEventHandler>(
         event => {
             event.preventDefault()
+            telemetryRecorder.recordEvent('admin.productSubscription.license', 'generate', {
+                metadata: getTagsForTelemetry(formData),
+            })
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             generateLicense()
         },
-        [generateLicense]
+        [formData, telemetryRecorder, generateLicense]
     )
 
     const tags = useDebounce<string[]>(tagsFromString(formData.tags), 300)

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminLicenseKeyLookupPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminLicenseKeyLookupPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 
 import { useSearchParams } from 'react-router-dom'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import {
@@ -15,20 +16,21 @@ import {
     ConnectionForm,
 } from '../../../../components/FilteredConnection/ui'
 import { PageTitle } from '../../../../components/PageTitle'
-import { eventLogger } from '../../../../tracking/eventLogger'
 
 import { useQueryProductLicensesConnection } from './backend'
 import { SiteAdminProductLicenseNode } from './SiteAdminProductLicenseNode'
 
-interface Props {}
+interface Props extends TelemetryV2Props {}
 
 const SEARCH_PARAM_KEY = 'query'
 
 /**
  * Displays the product licenses that have been created on Sourcegraph.com.
  */
-export const SiteAdminLicenseKeyLookupPage: React.FunctionComponent<React.PropsWithChildren<Props>> = () => {
-    useEffect(() => eventLogger.logPageView('SiteAdminLicenseKeyLookup'), [])
+export const SiteAdminLicenseKeyLookupPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    telemetryRecorder,
+}) => {
+    useEffect(() => telemetryRecorder.recordEvent('admin.licenseKeyLookup', 'view'), [telemetryRecorder])
 
     const [searchParams, setSearchParams] = useSearchParams()
 
@@ -83,6 +85,7 @@ export const SiteAdminLicenseKeyLookupPage: React.FunctionComponent<React.PropsW
                                         node={node}
                                         showSubscription={true}
                                         onRevokeCompleted={refetchAll}
+                                        telemetryRecorder={telemetryRecorder}
                                     />
                                 ))}
                             </ConnectionList>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.test.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider } from '@sourcegraph/shared/src/testing/apollo'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
@@ -43,6 +44,7 @@ describe('SiteAdminProductLicenseNode', () => {
                         onRevokeCompleted={function (): void {
                             throw new Error('Function not implemented.')
                         }}
+                        telemetryRecorder={noOpTelemetryRecorder}
                     />
                 </MockedTestProvider>
             ).asFragment()
@@ -84,6 +86,7 @@ describe('SiteAdminProductLicenseNode', () => {
                         onRevokeCompleted={function (): void {
                             throw new Error('Function not implemented.')
                         }}
+                        telemetryRecorder={noOpTelemetryRecorder}
                     />
                 </MockedTestProvider>
             ).asFragment()

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductLicenseNode.tsx
@@ -4,6 +4,7 @@ import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { useMutation } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import {
     Alert,
     Button,
@@ -31,7 +32,7 @@ import { REVOKE_LICENSE } from './backend'
 
 const getLicenseUUID = (id: string): string => atob(id).slice('ProductLicense:"'.length, -1)
 
-export interface SiteAdminProductLicenseNodeProps {
+export interface SiteAdminProductLicenseNodeProps extends TelemetryV2Props {
     node: ProductLicenseFields
     showSubscription: boolean
     defaultExpanded?: boolean
@@ -43,12 +44,13 @@ export interface SiteAdminProductLicenseNodeProps {
  */
 export const SiteAdminProductLicenseNode: React.FunctionComponent<
     React.PropsWithChildren<SiteAdminProductLicenseNodeProps>
-> = ({ node, showSubscription, onRevokeCompleted, defaultExpanded = false }) => {
+> = ({ node, showSubscription, onRevokeCompleted, defaultExpanded = false, telemetryRecorder }) => {
     const [revoke, { loading, error }] = useMutation<RevokeLicenseResult, RevokeLicenseVariables>(REVOKE_LICENSE)
 
     const onRevoke = useCallback(() => {
         const reason = window.prompt('Reason for revoking the license key:')
         if (reason) {
+            telemetryRecorder.recordEvent('admin.productSubscription.license', 'revoke')
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             revoke({
                 variables: {
@@ -62,7 +64,7 @@ export const SiteAdminProductLicenseNode: React.FunctionComponent<
                 },
             })
         }
-    }, [revoke, node, onRevokeCompleted])
+    }, [revoke, node, onRevokeCompleted, telemetryRecorder])
 
     const [open, setOpen] = useState(defaultExpanded)
     const toggleOpen = useCallback(() => {

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -6,6 +6,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { logger } from '@sourcegraph/common'
 import { useMutation, useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, LoadingSpinner, Link, Icon, ErrorAlert, PageHeader, Container, H3, Text } from '@sourcegraph/wildcard'
 
 import {
@@ -25,7 +26,6 @@ import type {
     ArchiveProductSubscriptionResult,
     ArchiveProductSubscriptionVariables,
 } from '../../../../graphql-operations'
-import { eventLogger } from '../../../../tracking/eventLogger'
 import { AccountName } from '../../../dotcom/productSubscriptions/AccountName'
 import { ProductSubscriptionLabel } from '../../../dotcom/productSubscriptions/ProductSubscriptionLabel'
 import { LicenseGenerationKeyWarning } from '../../../productSubscription/LicenseGenerationKeyWarning'
@@ -40,15 +40,17 @@ import { SiteAdminGenerateProductLicenseForSubscriptionForm } from './SiteAdminG
 import { SiteAdminProductLicenseNode } from './SiteAdminProductLicenseNode'
 import { accessTokenPath, errorForPath } from './utils'
 
-interface Props {}
+interface Props extends TelemetryV2Props {}
 
 /**
  * Displays a product subscription in the site admin area.
  */
-export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.PropsWithChildren<Props>> = () => {
+export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
+    telemetryRecorder,
+}) => {
     const navigate = useNavigate()
     const { subscriptionUUID = '' } = useParams<{ subscriptionUUID: string }>()
-    useEffect(() => eventLogger.logViewEvent('SiteAdminProductSubscription'), [])
+    useEffect(() => telemetryRecorder.recordEvent('admin.productSubscription', 'view'), [telemetryRecorder])
 
     const [showGenerate, setShowGenerate] = useState<boolean>(false)
 
@@ -77,6 +79,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
             return
         }
         try {
+            telemetryRecorder.recordEvent('admin.productSubscription', 'archive')
             await archiveProductSubscription({ variables: { id: data.dotcom.productSubscription.id } })
             navigate('/site-admin/dotcom/product/subscriptions')
         } catch (error) {
@@ -202,6 +205,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
                     productSubscriptionID={productSubscription.id}
                     productSubscriptionUUID={subscriptionUUID}
                     refetchSubscription={refetch}
+                    telemetryRecorder={telemetryRecorder}
                 />
 
                 <H3 className="d-flex align-items-start">
@@ -216,6 +220,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
                         subscriptionUUID={subscriptionUUID}
                         toggleShowGenerate={toggleShowGenerate}
                         setRefetch={setRefetchRef}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 </Container>
             </div>
@@ -227,17 +232,25 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
                     latestLicense={productSubscription.productLicenses?.nodes[0] ?? undefined}
                     onGenerate={onLicenseUpdate}
                     onCancel={() => setShowGenerate(false)}
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
         </>
     )
 }
 
-const ProductSubscriptionLicensesConnection: React.FunctionComponent<{
+interface ProductSubscriptionLicensesConnectionProps extends TelemetryV2Props {
     subscriptionUUID: string
     toggleShowGenerate: () => void
     setRefetch: (refetch: () => void) => void
-}> = ({ subscriptionUUID, setRefetch, toggleShowGenerate }) => {
+}
+
+const ProductSubscriptionLicensesConnection: React.FunctionComponent<ProductSubscriptionLicensesConnectionProps> = ({
+    subscriptionUUID,
+    setRefetch,
+    toggleShowGenerate,
+    telemetryRecorder,
+}) => {
     const { loading, hasNextPage, fetchMore, refetchAll, connection, error } = useProductSubscriptionLicensesConnection(
         subscriptionUUID,
         20
@@ -268,6 +281,7 @@ const ProductSubscriptionLicensesConnection: React.FunctionComponent<{
                         defaultExpanded={node.id === licenseIDFromLocationHash}
                         showSubscription={false}
                         onRevokeCompleted={refetchAll}
+                        telemetryRecorder={telemetryRecorder}
                     />
                 ))}
             </ConnectionList>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -85,7 +85,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
         } catch (error) {
             logger.error(error)
         }
-    }, [data, archiveProductSubscription, navigate])
+    }, [data, archiveProductSubscription, navigate, telemetryRecorder])
 
     const toggleShowGenerate = useCallback((): void => setShowGenerate(previousValue => !previousValue), [])
 

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
@@ -2,13 +2,13 @@ import React, { useEffect } from 'react'
 
 import { mdiPlus } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, Container, Icon, Link, PageHeader } from '@sourcegraph/wildcard'
 
 import type { AuthenticatedUser } from '../../../../auth'
 import { FilteredConnection } from '../../../../components/FilteredConnection'
 import { PageTitle } from '../../../../components/PageTitle'
 import type { SiteAdminProductSubscriptionFields } from '../../../../graphql-operations'
-import { eventLogger } from '../../../../tracking/eventLogger'
 
 import { queryProductSubscriptions } from './backend'
 import {
@@ -19,7 +19,7 @@ import {
 
 import styles from './SiteAdminCreateProductSubscriptionPage.module.scss'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     authenticatedUser: AuthenticatedUser
 }
 
@@ -29,8 +29,9 @@ interface Props {
  */
 export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     authenticatedUser,
+    telemetryRecorder,
 }) => {
-    useEffect(() => eventLogger.logViewEvent('SiteAdminProductSubscriptions'), [])
+    useEffect(() => telemetryRecorder.recordEvent('admin.productSubscriptions', 'view'), [telemetryRecorder])
 
     return (
         <div className="site-admin-product-subscriptions-page">

--- a/client/web/src/enterprise/site-admin/productSubscription/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/productSubscription/SiteAdminProductSubscriptionPage.tsx
@@ -1,20 +1,25 @@
 import React, { useEffect } from 'react'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
+
 import { PageTitle } from '../../../components/PageTitle'
-import { eventLogger } from '../../../tracking/eventLogger'
 
 import { ProductSubscriptionStatus } from './ProductSubscriptionStatus'
+
+interface SiteAdminProductSubscriptionPageProps extends TelemetryV2Props {}
 
 /**
  * Displays the product subscription information from the license key in site configuration.
  */
-export const SiteAdminProductSubscriptionPage: React.FunctionComponent = () => {
-    useEffect(() => eventLogger.logViewEvent('SiteAdminProductSubscription'), [])
+export const SiteAdminProductSubscriptionPage: React.FunctionComponent<SiteAdminProductSubscriptionPageProps> = ({
+    telemetryRecorder,
+}) => {
+    useEffect(() => telemetryRecorder.recordEvent('admin.productSubscription', 'view'), [telemetryRecorder])
 
     return (
         <div className="site-admin-product-subscription-page">
             <PageTitle title="Sourcegraph product subscription" />
-            <ProductSubscriptionStatus />
+            <ProductSubscriptionStatus telemetryRecorder={telemetryRecorder} />
         </div>
     )
 }

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -114,6 +114,7 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<R
                 productSubscriptionID={productSubscription.id}
                 productSubscriptionUUID={subscriptionUUID}
                 refetchSubscription={refetch}
+                telemetryRecorder={telemetryRecorder}
             />
         </div>
     )

--- a/client/web/src/site-admin/routes.tsx
+++ b/client/web/src/site-admin/routes.tsx
@@ -375,11 +375,13 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     },
     {
         path: '/license',
-        render: () => <SiteAdminProductSubscriptionPage />,
+        render: props => (
+            <SiteAdminProductSubscriptionPage telemetryRecorder={props.platformContext.telemetryRecorder} />
+        ),
     },
     {
         path: '/dotcom/customers',
-        render: () => <SiteAdminProductCustomersPage />,
+        render: props => <SiteAdminProductCustomersPage telemetryRecorder={props.platformContext.telemetryRecorder} />,
         condition: () => SHOW_BUSINESS_FEATURES,
     },
     {
@@ -394,7 +396,9 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     },
     {
         path: '/dotcom/product/subscriptions',
-        render: props => <SiteAdminProductSubscriptionsPage {...props} />,
+        render: props => (
+            <SiteAdminProductSubscriptionsPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />
+        ),
         condition: () => SHOW_BUSINESS_FEATURES,
     },
     {
@@ -496,7 +500,7 @@ export const otherSiteAdminRoutes: readonly SiteAdminAreaRoute[] = [
     {
         exact: true,
         path: '/embeddings',
-        render: props => <SiteAdminCodyPage {...props} />,
+        render: props => <SiteAdminCodyPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />,
         condition: codyIsEnabled,
     },
     {


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally