### PR TITLE
Bug: remove extra GraphQL validation

### DIFF
--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -162,11 +162,6 @@ func serveGraphQL(logger log.Logger, schema *graphql.Schema, rlw graphqlbackend.
 			}
 		}
 
-		validationErrs := schema.ValidateWithVariables(params.Query, params.Variables)
-		if len(validationErrs) > 0 {
-			return errors.Wrap(err, "failed to validate the GraphQL query")
-		}
-
 		traceData.execStart = time.Now()
 		response := schema.Exec(r.Context(), params.Query, params.OperationName, params.Variables)
 		traceData.queryErrors = response.Errors


### PR DESCRIPTION
This code was breaking the GraphQL API when a client sends invalid parameters. It is also redundant because `schema.Exec` validates the parameters are part of executing a GraphQL query. The validation errors will still be returned to the client.

## Test plan

[This query](https://sourcegraph.sourcegraph.com/api/console#%7B%22query%22%3A%22query%20BlobPageQuery(%24repoName%3A%20String!%2C%20%24revspec%3A%20String!%2C%20%24path%3A%20String!)%20%7B%5Cn%20%20repository(name%3A%20%24repoName)%20%7B%5Cn%20%20%20%20id%5Cn%20%20%20%20commit(rev%3A%20%24revspec)%20%7B%5Cn%20%20%20%20%20%20id%5Cn%20%20%20%20%20%20oid%5Cn%20%20%20%20%20%20blob(path%3A%20%24path)%20%7B%5Cn%20%20%20%20%20%20%20%20...BlobPage_Blob%5Cn%20%20%20%20%20%20%20%20__typename%5Cn%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20__typename%5Cn%20%20%20%20%7D%5Cn%20%20%20%20__typename%5Cn%20%20%7D%5Cn%7D%5Cn%5Cnfragment%20BlobPage_Blob%20on%20GitBlob%20%7B%5Cn%20%20canonicalURL%5Cn%20%20content%5Cn%20%20richHTML%5Cn%20%20languages%5Cn%20%20__typename%5Cn%7D%5Cn%22%2C%22operationName%22%3A%22BlobPageQuery%22%2C%22variables%22%3A%22%7B%5Cn%20%20%5C%22repoName%5C%22%3A%20%5C%22github.com%2Fsourcegraph%2Fabout%5C%22%2C%5Cn%20%20%5C%22revspec%5C%22%3A%20%5C%22802fba0f41f4a2c16f22b79a376f1622d0f7d17c%5C%22%5Cn%7D%22%7D) now returns a proper JSON payload with the errors:

```json
{
  "errors": [
    {
      "message": "Variable \"path\" has invalid value null.\nExpected type \"String!\", found null.",
      "locations": [
        {
          "line": 1,
          "column": 60
        }
      ]
    }
  ]
}
```
