### PR TITLE
oidc: Add option to allow only a single identity per provider

### DIFF
--- a/cmd/frontend/internal/auth/openidconnect/user.go
+++ b/cmd/frontend/internal/auth/openidconnect/user.go
@@ -99,6 +99,7 @@ func getOrCreateUser(ctx context.Context, db database.DB, p *Provider, token *oa
 		},
 		ExternalAccountData: data,
 		CreateIfNotExist:    p.config.AllowSignup == nil || *p.config.AllowSignup,
+		SingleProvider:      p.config.SingleIdentityProvider,
 	})
 	if err != nil {
 		return false, nil, safeErrMsg, err

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1904,7 +1904,9 @@ type OpenIDConnectAuthProvider struct {
 	Order  int    `json:"order,omitempty"`
 	// RequireEmailDomain description: Only allow users to authenticate if their email domain is equal to this value (example: mycompany.com). Do not include a leading "@". If not set, all users on this OpenID Connect provider can authenticate to Sourcegraph.
 	RequireEmailDomain string `json:"requireEmailDomain,omitempty"`
-	Type               string `json:"type"`
+	// SingleIdentityProvider description: When true, any user can connect exactly one identity from the identity provider.
+	SingleIdentityProvider bool   `json:"singleIdentityProvider,omitempty"`
+	Type                   string `json:"type"`
 }
 
 // OpenTelemetry description: Configuration for the client OpenTelemetry exporter

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3113,6 +3113,11 @@
           "!go": {
             "pointer": true
           }
+        },
+        "singleIdentityProvider": {
+          "description": "When true, any user can connect exactly one identity from the identity provider.",
+          "type": "boolean",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
When using an external identity provider, Sourcegraph by default doesn't care how many external identities you're adding to your account. In some cases, this can be undesirable though, for example when trying to map a Sourcegraph user to a single identity in the outside world.

Since we cannot change the behavior here silently as people might rely on it, I decided to add a new option for this.

When enabled, the following scenario will no longer be allowed:

- I sign in to Sourcegraph for the first time using an Okta account called supererik@sourcegraph.com.
- I then go to the auth provider flow a second time (accounts tab, or through a redirect) and this time I choose my Okta account erik@sourcegraph.com
- Since I am already authenticated to Sourcegraph and it appears to Sourcegraph as if I wanted to add a new new external identity, I would have gotten a second link to an Okta identity.

Now, with this new behavior, linking a second entity for the same {ClientID, ServiceType, ServiceID} tuple but with a different externalID will be forbidden.

## Test plan

Verified locally using an Okta integration and trying to link two different accounts to the same user and see it fail. Also added a new test to cover this behavior.
