### PR TITLE
Blob view: record copy event

### DIFF
--- a/client/branded/src/search-ui/components/FileMatchChildren.tsx
+++ b/client/branded/src/search-ui/components/FileMatchChildren.tsx
@@ -50,7 +50,7 @@ export const FileMatchChildren: React.FunctionComponent<React.PropsWithChildren<
     )
 
     const logEventOnCopy = useCallback(() => {
-        telemetryService.log(...codeCopiedEvent('file-match'))
+        telemetryService.log(...codeCopiedEvent('search-result'))
     }, [telemetryService])
 
     return (

--- a/client/branded/src/search-ui/components/SymbolSearchResult.tsx
+++ b/client/branded/src/search-ui/components/SymbolSearchResult.tsx
@@ -83,7 +83,7 @@ export const SymbolSearchResult: React.FunctionComponent<SymbolSearchResultProps
     )
 
     const logEventOnCopy = useCallback(() => {
-        telemetryService.log(...codeCopiedEvent('file-match'))
+        telemetryService.log(...codeCopiedEvent('search-result'))
     }, [telemetryService])
 
     const [hasBeenVisible, setHasBeenVisible] = useState(false)

--- a/client/shared/src/tracking/event-log-creators.ts
+++ b/client/shared/src/tracking/event-log-creators.ts
@@ -2,8 +2,6 @@
  * Returns an [EventName, argument, publicArgument] for a "code copied" to clipboard event
  *
  * @param page page or component from where copied
- *
- * TODO: this is an experiment to check how often users copy from SG, will be removed soon
  */
 export const codeCopiedEvent = (page: string): [string, { page: string }, { page: string }] => [
     'CodeCopied',

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -30,6 +30,7 @@ import type { TemporarySettingsSchema } from '@sourcegraph/shared/src/settings/t
 import { TelemetryV2Props, noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useIsLightTheme } from '@sourcegraph/shared/src/theme'
+import { codeCopiedEvent } from '@sourcegraph/shared/src/tracking/event-log-creators'
 import {
     parseQueryAndHash,
     toPrettyBlobURL,
@@ -226,6 +227,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
         searchPanelConfig,
         staticHighlightRanges,
         'data-testid': dataTestId,
+        telemetryService,
     } = props
 
     const navigate = useNavigate()
@@ -529,6 +531,10 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
         setEditorScope,
     ])
 
+    const logEventOnCopy = useCallback(() => {
+        telemetryService.log(...codeCopiedEvent('blob-view'))
+    }, [telemetryService])
+
     return (
         <>
             <div
@@ -538,6 +544,7 @@ export const CodeMirrorBlob: React.FunctionComponent<BlobProps> = props => {
                 data-testid={dataTestId}
                 className={`${className} overflow-hidden test-editor`}
                 data-editor="codemirror6"
+                onCopy={logEventOnCopy}
             />
             {overrideBrowserSearchKeybinding && useFileSearch && (
                 <Shortcut ordered={['f']} held={['Mod']} onMatch={openSearch} ignoreInput={true} />


### PR DESCRIPTION
We used to record copy events in the legacy blob view, but stopped when we
moved to CodeMirror. This restores the copy event logging.

## Test plan

Manual testing: I enabled "Enable event / telemetry debugging", copied
something from the blob view, then checked an event was logged.

```
EVENT CodeCopied {page: 'blob-view'} {page: 'blob-view'}
```
Let me know if you have tips for unit testing this! I wasn't able to find a
good example to follow.
