### PR TITLE
Ingesting syntactic indexes via upload

### DIFF
--- a/internal/codeintel/codenav/request_state.go
+++ b/internal/codeintel/codenav/request_state.go
@@ -121,6 +121,8 @@ func (l *UploadsDataLoader) SetUploadInCacheMap(uploads []shared.CompletedUpload
 	l.cacheMutex.Lock()
 	defer l.cacheMutex.Unlock()
 
+	// Sus, compare with AddUpload, where we're also appending the new uploads to l.uploads
+	// There seem to be invariants broken here, or not written down elsewhere
 	for i := range uploads {
 		l.uploadsByID[uploads[i].ID] = uploads[i]
 	}

--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -8882,6 +8882,9 @@ type MockLSIFStore struct {
 	// NewSCIPWriterFunc is an instance of a mock function object
 	// controlling the behavior of the method NewSCIPWriter.
 	NewSCIPWriterFunc *LSIFStoreNewSCIPWriterFunc
+	// NewSyntacticSCIPWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewSyntacticSCIPWriter.
+	NewSyntacticSCIPWriterFunc *LSIFStoreNewSyntacticSCIPWriterFunc
 	// ReconcileCandidatesFunc is an instance of a mock function object
 	// controlling the behavior of the method ReconcileCandidates.
 	ReconcileCandidatesFunc *LSIFStoreReconcileCandidatesFunc
@@ -8924,6 +8927,11 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
+				return
+			},
+		},
+		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
@@ -8980,6 +8988,11 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 				panic("unexpected invocation of MockLSIFStore.NewSCIPWriter")
 			},
 		},
+		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
+				panic("unexpected invocation of MockLSIFStore.NewSyntacticSCIPWriter")
+			},
+		},
 		ReconcileCandidatesFunc: &LSIFStoreReconcileCandidatesFunc{
 			defaultHook: func(context.Context, int) ([]int, error) {
 				panic("unexpected invocation of MockLSIFStore.ReconcileCandidates")
@@ -9019,6 +9032,9 @@ func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
 			defaultHook: i.NewSCIPWriter,
+		},
+		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
+			defaultHook: i.NewSyntacticSCIPWriter,
 		},
 		ReconcileCandidatesFunc: &LSIFStoreReconcileCandidatesFunc{
 			defaultHook: i.ReconcileCandidates,
@@ -9699,6 +9715,117 @@ func (c LSIFStoreNewSCIPWriterFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LSIFStoreNewSCIPWriterFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LSIFStoreNewSyntacticSCIPWriterFunc describes the behavior when the
+// NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreNewSyntacticSCIPWriterFunc struct {
+	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
+	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
+	history     []LSIFStoreNewSyntacticSCIPWriterFuncCall
+	mutex       sync.Mutex
+}
+
+// NewSyntacticSCIPWriter delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) NewSyntacticSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
+	r0, r1 := m.NewSyntacticSCIPWriterFunc.nextHook()(v0, v1)
+	m.NewSyntacticSCIPWriterFunc.appendCall(LSIFStoreNewSyntacticSCIPWriterFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
+// invoked and the hook queue is empty.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// NewSyntacticSCIPWriter method of the parent MockLSIFStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+		return r0, r1
+	})
+}
+
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) appendCall(r0 LSIFStoreNewSyntacticSCIPWriterFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreNewSyntacticSCIPWriterFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) History() []LSIFStoreNewSyntacticSCIPWriterFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreNewSyntacticSCIPWriterFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreNewSyntacticSCIPWriterFuncCall is an object that describes an
+// invocation of method NewSyntacticSCIPWriter on an instance of
+// MockLSIFStore.
+type LSIFStoreNewSyntacticSCIPWriterFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 lsifstore.SCIPWriter
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFStoreNewSyntacticSCIPWriterFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFStoreNewSyntacticSCIPWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -8985,7 +8985,7 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
-				panic("unexpected invocation of MockLSIFStore.NewSCIPWriter")
+				panic("unexpected invocation of MockLSIFStore.NewPreciseSCIPWriter")
 			},
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
@@ -9031,7 +9031,7 @@ func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
 			defaultHook: i.InsertMetadata,
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
-			defaultHook: i.NewSCIPWriter,
+			defaultHook: i.NewPreciseSCIPWriter,
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
 			defaultHook: i.NewSyntacticSCIPWriter,
@@ -9610,7 +9610,7 @@ func (c LSIFStoreInsertMetadataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewSCIPWriter
+// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewPreciseSCIPWriter
 // method of the parent MockLSIFStore instance is invoked.
 type LSIFStoreNewSCIPWriterFunc struct {
 	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
@@ -9621,13 +9621,13 @@ type LSIFStoreNewSCIPWriterFunc struct {
 
 // NewSCIPWriter delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockLSIFStore) NewSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
+func (m *MockLSIFStore) NewPreciseSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
 	r0, r1 := m.NewSCIPWriterFunc.nextHook()(v0, v1)
 	m.NewSCIPWriterFunc.appendCall(LSIFStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the NewSCIPWriter method
+// SetDefaultHook sets function that is called when the NewPreciseSCIPWriter method
 // of the parent MockLSIFStore instance is invoked and the hook queue is
 // empty.
 func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
@@ -9635,7 +9635,7 @@ func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, i
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// NewSCIPWriter method of the parent MockLSIFStore instance invokes the
+// NewPreciseSCIPWriter method of the parent MockLSIFStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
 func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
@@ -9690,7 +9690,7 @@ func (f *LSIFStoreNewSCIPWriterFunc) History() []LSIFStoreNewSCIPWriterFuncCall 
 }
 
 // LSIFStoreNewSCIPWriterFuncCall is an object that describes an invocation
-// of method NewSCIPWriter on an instance of MockLSIFStore.
+// of method NewPreciseSCIPWriter on an instance of MockLSIFStore.
 type LSIFStoreNewSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.

--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -8879,9 +8879,9 @@ type MockLSIFStore struct {
 	// InsertMetadataFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertMetadata.
 	InsertMetadataFunc *LSIFStoreInsertMetadataFunc
-	// NewSCIPWriterFunc is an instance of a mock function object
-	// controlling the behavior of the method NewSCIPWriter.
-	NewSCIPWriterFunc *LSIFStoreNewSCIPWriterFunc
+	// NewPreciseSCIPWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewPreciseSCIPWriter.
+	NewPreciseSCIPWriterFunc *LSIFStoreNewPreciseSCIPWriterFunc
 	// NewSyntacticSCIPWriterFunc is an instance of a mock function object
 	// controlling the behavior of the method NewSyntacticSCIPWriter.
 	NewSyntacticSCIPWriterFunc *LSIFStoreNewSyntacticSCIPWriterFunc
@@ -8926,7 +8926,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 				return
 			},
 		},
-		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+		NewPreciseSCIPWriterFunc: &LSIFStoreNewPreciseSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
@@ -8983,7 +8983,7 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 				panic("unexpected invocation of MockLSIFStore.InsertMetadata")
 			},
 		},
-		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+		NewPreciseSCIPWriterFunc: &LSIFStoreNewPreciseSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
 				panic("unexpected invocation of MockLSIFStore.NewPreciseSCIPWriter")
 			},
@@ -9030,7 +9030,7 @@ func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
 		InsertMetadataFunc: &LSIFStoreInsertMetadataFunc{
 			defaultHook: i.InsertMetadata,
 		},
-		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+		NewPreciseSCIPWriterFunc: &LSIFStoreNewPreciseSCIPWriterFunc{
 			defaultHook: i.NewPreciseSCIPWriter,
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
@@ -9610,35 +9610,36 @@ func (c LSIFStoreInsertMetadataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewPreciseSCIPWriter
-// method of the parent MockLSIFStore instance is invoked.
-type LSIFStoreNewSCIPWriterFunc struct {
+// LSIFStoreNewPreciseSCIPWriterFunc describes the behavior when the
+// NewPreciseSCIPWriter method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreNewPreciseSCIPWriterFunc struct {
 	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
 	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
-	history     []LSIFStoreNewSCIPWriterFuncCall
+	history     []LSIFStoreNewPreciseSCIPWriterFuncCall
 	mutex       sync.Mutex
 }
 
-// NewSCIPWriter delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
+// NewPreciseSCIPWriter delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
 func (m *MockLSIFStore) NewPreciseSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
-	r0, r1 := m.NewSCIPWriterFunc.nextHook()(v0, v1)
-	m.NewSCIPWriterFunc.appendCall(LSIFStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
+	r0, r1 := m.NewPreciseSCIPWriterFunc.nextHook()(v0, v1)
+	m.NewPreciseSCIPWriterFunc.appendCall(LSIFStoreNewPreciseSCIPWriterFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the NewPreciseSCIPWriter method
-// of the parent MockLSIFStore instance is invoked and the hook queue is
-// empty.
-func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+// SetDefaultHook sets function that is called when the NewPreciseSCIPWriter
+// method of the parent MockLSIFStore instance is invoked and the hook queue
+// is empty.
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// NewPreciseSCIPWriter method of the parent MockLSIFStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+// NewPreciseSCIPWriter method of the parent MockLSIFStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9646,20 +9647,20 @@ func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (l
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
 	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LSIFStoreNewSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
 	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
-func (f *LSIFStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9672,26 +9673,27 @@ func (f *LSIFStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsif
 	return hook
 }
 
-func (f *LSIFStoreNewSCIPWriterFunc) appendCall(r0 LSIFStoreNewSCIPWriterFuncCall) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) appendCall(r0 LSIFStoreNewPreciseSCIPWriterFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LSIFStoreNewSCIPWriterFuncCall objects
-// describing the invocations of this function.
-func (f *LSIFStoreNewSCIPWriterFunc) History() []LSIFStoreNewSCIPWriterFuncCall {
+// History returns a sequence of LSIFStoreNewPreciseSCIPWriterFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) History() []LSIFStoreNewPreciseSCIPWriterFuncCall {
 	f.mutex.Lock()
-	history := make([]LSIFStoreNewSCIPWriterFuncCall, len(f.history))
+	history := make([]LSIFStoreNewPreciseSCIPWriterFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LSIFStoreNewSCIPWriterFuncCall is an object that describes an invocation
-// of method NewPreciseSCIPWriter on an instance of MockLSIFStore.
-type LSIFStoreNewSCIPWriterFuncCall struct {
+// LSIFStoreNewPreciseSCIPWriterFuncCall is an object that describes an
+// invocation of method NewPreciseSCIPWriter on an instance of
+// MockLSIFStore.
+type LSIFStoreNewPreciseSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -9708,13 +9710,13 @@ type LSIFStoreNewSCIPWriterFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreNewSCIPWriterFuncCall) Args() []interface{} {
+func (c LSIFStoreNewPreciseSCIPWriterFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreNewSCIPWriterFuncCall) Results() []interface{} {
+func (c LSIFStoreNewPreciseSCIPWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/internal/background/processor/job_worker_handler_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/job_worker_handler_test.go
@@ -60,7 +60,7 @@ func TestHandle(t *testing.T) {
 
 	// Track writes to symbols table
 	scipWriter := NewMockLSIFSCIPWriter()
-	mockLSIFStore.NewSCIPWriterFunc.SetDefaultReturn(scipWriter, nil)
+	mockLSIFStore.NewPreciseSCIPWriterFunc.SetDefaultReturn(scipWriter, nil)
 
 	scipWriter.InsertDocumentFunc.SetDefaultHook(func(_ context.Context, _ string, _ *scip.Document) error {
 		return nil
@@ -297,7 +297,7 @@ func TestHandleError(t *testing.T) {
 
 	// Track writes to symbols table
 	scipWriter := NewMockLSIFSCIPWriter()
-	mockLSIFStore.NewSCIPWriterFunc.SetDefaultReturn(scipWriter, nil)
+	mockLSIFStore.NewPreciseSCIPWriterFunc.SetDefaultReturn(scipWriter, nil)
 
 	// Give correlation package a valid input dump
 	mockUploadStore.GetFunc.SetDefaultHook(copyTestDumpScip)

--- a/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -8799,7 +8799,7 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
-				panic("unexpected invocation of MockLSIFStore.NewSCIPWriter")
+				panic("unexpected invocation of MockLSIFStore.NewPreciseSCIPWriter")
 			},
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
@@ -8845,7 +8845,7 @@ func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
 			defaultHook: i.InsertMetadata,
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
-			defaultHook: i.NewSCIPWriter,
+			defaultHook: i.NewPreciseSCIPWriter,
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
 			defaultHook: i.NewSyntacticSCIPWriter,
@@ -9424,7 +9424,7 @@ func (c LSIFStoreInsertMetadataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewSCIPWriter
+// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewPreciseSCIPWriter
 // method of the parent MockLSIFStore instance is invoked.
 type LSIFStoreNewSCIPWriterFunc struct {
 	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
@@ -9435,13 +9435,13 @@ type LSIFStoreNewSCIPWriterFunc struct {
 
 // NewSCIPWriter delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockLSIFStore) NewSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
+func (m *MockLSIFStore) NewPreciseSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
 	r0, r1 := m.NewSCIPWriterFunc.nextHook()(v0, v1)
 	m.NewSCIPWriterFunc.appendCall(LSIFStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the NewSCIPWriter method
+// SetDefaultHook sets function that is called when the NewPreciseSCIPWriter method
 // of the parent MockLSIFStore instance is invoked and the hook queue is
 // empty.
 func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
@@ -9449,7 +9449,7 @@ func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, i
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// NewSCIPWriter method of the parent MockLSIFStore instance invokes the
+// NewPreciseSCIPWriter method of the parent MockLSIFStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
 func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
@@ -9504,7 +9504,7 @@ func (f *LSIFStoreNewSCIPWriterFunc) History() []LSIFStoreNewSCIPWriterFuncCall 
 }
 
 // LSIFStoreNewSCIPWriterFuncCall is an object that describes an invocation
-// of method NewSCIPWriter on an instance of MockLSIFStore.
+// of method NewPreciseSCIPWriter on an instance of MockLSIFStore.
 type LSIFStoreNewSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.

--- a/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -8696,6 +8696,9 @@ type MockLSIFStore struct {
 	// NewSCIPWriterFunc is an instance of a mock function object
 	// controlling the behavior of the method NewSCIPWriter.
 	NewSCIPWriterFunc *LSIFStoreNewSCIPWriterFunc
+	// NewSyntacticSCIPWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewSyntacticSCIPWriter.
+	NewSyntacticSCIPWriterFunc *LSIFStoreNewSyntacticSCIPWriterFunc
 	// ReconcileCandidatesFunc is an instance of a mock function object
 	// controlling the behavior of the method ReconcileCandidates.
 	ReconcileCandidatesFunc *LSIFStoreReconcileCandidatesFunc
@@ -8738,6 +8741,11 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
+				return
+			},
+		},
+		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
@@ -8794,6 +8802,11 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 				panic("unexpected invocation of MockLSIFStore.NewSCIPWriter")
 			},
 		},
+		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
+				panic("unexpected invocation of MockLSIFStore.NewSyntacticSCIPWriter")
+			},
+		},
 		ReconcileCandidatesFunc: &LSIFStoreReconcileCandidatesFunc{
 			defaultHook: func(context.Context, int) ([]int, error) {
 				panic("unexpected invocation of MockLSIFStore.ReconcileCandidates")
@@ -8833,6 +8846,9 @@ func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
 			defaultHook: i.NewSCIPWriter,
+		},
+		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
+			defaultHook: i.NewSyntacticSCIPWriter,
 		},
 		ReconcileCandidatesFunc: &LSIFStoreReconcileCandidatesFunc{
 			defaultHook: i.ReconcileCandidates,
@@ -9513,6 +9529,117 @@ func (c LSIFStoreNewSCIPWriterFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LSIFStoreNewSCIPWriterFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LSIFStoreNewSyntacticSCIPWriterFunc describes the behavior when the
+// NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreNewSyntacticSCIPWriterFunc struct {
+	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
+	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
+	history     []LSIFStoreNewSyntacticSCIPWriterFuncCall
+	mutex       sync.Mutex
+}
+
+// NewSyntacticSCIPWriter delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) NewSyntacticSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
+	r0, r1 := m.NewSyntacticSCIPWriterFunc.nextHook()(v0, v1)
+	m.NewSyntacticSCIPWriterFunc.appendCall(LSIFStoreNewSyntacticSCIPWriterFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
+// invoked and the hook queue is empty.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// NewSyntacticSCIPWriter method of the parent MockLSIFStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+		return r0, r1
+	})
+}
+
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) appendCall(r0 LSIFStoreNewSyntacticSCIPWriterFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreNewSyntacticSCIPWriterFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) History() []LSIFStoreNewSyntacticSCIPWriterFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreNewSyntacticSCIPWriterFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreNewSyntacticSCIPWriterFuncCall is an object that describes an
+// invocation of method NewSyntacticSCIPWriter on an instance of
+// MockLSIFStore.
+type LSIFStoreNewSyntacticSCIPWriterFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 lsifstore.SCIPWriter
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFStoreNewSyntacticSCIPWriterFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFStoreNewSyntacticSCIPWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -8693,9 +8693,9 @@ type MockLSIFStore struct {
 	// InsertMetadataFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertMetadata.
 	InsertMetadataFunc *LSIFStoreInsertMetadataFunc
-	// NewSCIPWriterFunc is an instance of a mock function object
-	// controlling the behavior of the method NewSCIPWriter.
-	NewSCIPWriterFunc *LSIFStoreNewSCIPWriterFunc
+	// NewPreciseSCIPWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewPreciseSCIPWriter.
+	NewPreciseSCIPWriterFunc *LSIFStoreNewPreciseSCIPWriterFunc
 	// NewSyntacticSCIPWriterFunc is an instance of a mock function object
 	// controlling the behavior of the method NewSyntacticSCIPWriter.
 	NewSyntacticSCIPWriterFunc *LSIFStoreNewSyntacticSCIPWriterFunc
@@ -8740,7 +8740,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 				return
 			},
 		},
-		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+		NewPreciseSCIPWriterFunc: &LSIFStoreNewPreciseSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
@@ -8797,7 +8797,7 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 				panic("unexpected invocation of MockLSIFStore.InsertMetadata")
 			},
 		},
-		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+		NewPreciseSCIPWriterFunc: &LSIFStoreNewPreciseSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
 				panic("unexpected invocation of MockLSIFStore.NewPreciseSCIPWriter")
 			},
@@ -8844,7 +8844,7 @@ func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
 		InsertMetadataFunc: &LSIFStoreInsertMetadataFunc{
 			defaultHook: i.InsertMetadata,
 		},
-		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+		NewPreciseSCIPWriterFunc: &LSIFStoreNewPreciseSCIPWriterFunc{
 			defaultHook: i.NewPreciseSCIPWriter,
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
@@ -9424,35 +9424,36 @@ func (c LSIFStoreInsertMetadataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewPreciseSCIPWriter
-// method of the parent MockLSIFStore instance is invoked.
-type LSIFStoreNewSCIPWriterFunc struct {
+// LSIFStoreNewPreciseSCIPWriterFunc describes the behavior when the
+// NewPreciseSCIPWriter method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreNewPreciseSCIPWriterFunc struct {
 	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
 	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
-	history     []LSIFStoreNewSCIPWriterFuncCall
+	history     []LSIFStoreNewPreciseSCIPWriterFuncCall
 	mutex       sync.Mutex
 }
 
-// NewSCIPWriter delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
+// NewPreciseSCIPWriter delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
 func (m *MockLSIFStore) NewPreciseSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
-	r0, r1 := m.NewSCIPWriterFunc.nextHook()(v0, v1)
-	m.NewSCIPWriterFunc.appendCall(LSIFStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
+	r0, r1 := m.NewPreciseSCIPWriterFunc.nextHook()(v0, v1)
+	m.NewPreciseSCIPWriterFunc.appendCall(LSIFStoreNewPreciseSCIPWriterFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the NewPreciseSCIPWriter method
-// of the parent MockLSIFStore instance is invoked and the hook queue is
-// empty.
-func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+// SetDefaultHook sets function that is called when the NewPreciseSCIPWriter
+// method of the parent MockLSIFStore instance is invoked and the hook queue
+// is empty.
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// NewPreciseSCIPWriter method of the parent MockLSIFStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+// NewPreciseSCIPWriter method of the parent MockLSIFStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9460,20 +9461,20 @@ func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (l
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
 	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LSIFStoreNewSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
 	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
-func (f *LSIFStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9486,26 +9487,27 @@ func (f *LSIFStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsif
 	return hook
 }
 
-func (f *LSIFStoreNewSCIPWriterFunc) appendCall(r0 LSIFStoreNewSCIPWriterFuncCall) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) appendCall(r0 LSIFStoreNewPreciseSCIPWriterFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LSIFStoreNewSCIPWriterFuncCall objects
-// describing the invocations of this function.
-func (f *LSIFStoreNewSCIPWriterFunc) History() []LSIFStoreNewSCIPWriterFuncCall {
+// History returns a sequence of LSIFStoreNewPreciseSCIPWriterFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) History() []LSIFStoreNewPreciseSCIPWriterFuncCall {
 	f.mutex.Lock()
-	history := make([]LSIFStoreNewSCIPWriterFuncCall, len(f.history))
+	history := make([]LSIFStoreNewPreciseSCIPWriterFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LSIFStoreNewSCIPWriterFuncCall is an object that describes an invocation
-// of method NewPreciseSCIPWriter on an instance of MockLSIFStore.
-type LSIFStoreNewSCIPWriterFuncCall struct {
+// LSIFStoreNewPreciseSCIPWriterFuncCall is an object that describes an
+// invocation of method NewPreciseSCIPWriter on an instance of
+// MockLSIFStore.
+type LSIFStoreNewPreciseSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -9522,13 +9524,13 @@ type LSIFStoreNewSCIPWriterFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreNewSCIPWriterFuncCall) Args() []interface{} {
+func (c LSIFStoreNewPreciseSCIPWriterFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreNewSCIPWriterFuncCall) Results() []interface{} {
+func (c LSIFStoreNewPreciseSCIPWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/internal/background/processor/scip.go
+++ b/internal/codeintel/uploads/internal/background/processor/scip.go
@@ -369,14 +369,11 @@ func writeSCIPDocuments(
 
 		if upload.Indexer == shared.SyntacticIndexer {
 			scipWriter, err = tx.NewSyntacticSCIPWriter(ctx, upload.ID)
-			if err != nil {
-				return err
-			}
 		} else {
 			scipWriter, err = tx.NewPreciseSCIPWriter(ctx, upload.ID)
-			if err != nil {
-				return err
-			}
+		}
+		if err != nil {
+			return err
 		}
 
 		var numDocuments uint32

--- a/internal/codeintel/uploads/internal/background/processor/scip.go
+++ b/internal/codeintel/uploads/internal/background/processor/scip.go
@@ -373,7 +373,7 @@ func writeSCIPDocuments(
 				return err
 			}
 		} else {
-			scipWriter, err = tx.NewSCIPWriter(ctx, upload.ID)
+			scipWriter, err = tx.NewPreciseSCIPWriter(ctx, upload.ID)
 			if err != nil {
 				return err
 			}

--- a/internal/codeintel/uploads/internal/background/processor/scip.go
+++ b/internal/codeintel/uploads/internal/background/processor/scip.go
@@ -367,7 +367,7 @@ func writeSCIPDocuments(
 
 		var scipWriter lsifstore.SCIPWriter
 
-		if upload.Indexer == shared.SYNTACTIC_INDEXER {
+		if upload.Indexer == shared.SyntacticIndexer {
 			scipWriter, err = tx.NewSyntacticSCIPWriter(ctx, upload.ID)
 			if err != nil {
 				return err

--- a/internal/codeintel/uploads/internal/background/processor/scip.go
+++ b/internal/codeintel/uploads/internal/background/processor/scip.go
@@ -365,9 +365,18 @@ func writeSCIPDocuments(
 			return err
 		}
 
-		scipWriter, err := tx.NewSCIPWriter(ctx, upload.ID)
-		if err != nil {
-			return err
+		var scipWriter lsifstore.SCIPWriter
+
+		if upload.Indexer == shared.SYNTACTIC_INDEXER {
+			scipWriter, err = tx.NewSyntacticSCIPWriter(ctx, upload.ID)
+			if err != nil {
+				return err
+			}
+		} else {
+			scipWriter, err = tx.NewSCIPWriter(ctx, upload.ID)
+			if err != nil {
+				return err
+			}
 		}
 
 		var numDocuments uint32

--- a/internal/codeintel/uploads/internal/lsifstore/insert.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert.go
@@ -112,7 +112,7 @@ func (s *store) NewSyntacticSCIPWriter(ctx context.Context, uploadID int) (SCIPW
 	return scipWriter, nil
 }
 
-func (s *store) NewSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error) {
+func (s *store) NewPreciseSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error) {
 	if !s.db.InTransaction() {
 		return nil, errors.New("WriteSCIPSymbols must be called in a transaction")
 	}

--- a/internal/codeintel/uploads/internal/lsifstore/insert.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert.go
@@ -316,16 +316,15 @@ func (s *scipWriter) flush(ctx context.Context) error {
 		return errors.New("unexpected number of document lookup records inserted")
 	}
 
-	return s.writeSymbols(ctx, documentLookupIDs)
+	return s.writeSymbols(ctx, documents, documentLookupIDs)
 
 }
 
-func (s *scipWriter) writeSymbols(ctx context.Context, documentLookupIDs []int) error {
+func (s *scipWriter) writeSymbols(ctx context.Context, documents []bufferedDocument, documentLookupIDs []int) error {
 	// NOTE(Christoph): We don't write symbols for syntactic indices
 	if s.isSyntactic {
 		return nil
 	}
-	documents := s.batch
 	symbolNameMap := map[string]struct{}{}
 	invertedRangeIndexes := make([][]shared.InvertedRangeIndex, 0, len(documents))
 	for _, document := range documents {

--- a/internal/codeintel/uploads/internal/lsifstore/insert.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert.go
@@ -428,23 +428,24 @@ func (s *scipWriter) Flush(ctx context.Context) (uint32, error) {
 	}
 
 	// We don't need to flush symbols for syntactic indexes, as we don't write any for them
-	if !s.isSyntactic {
-		// Flush all symbols data into temp tables
-		if err := s.symbolNameInserter.Flush(ctx); err != nil {
-			return 0, err
-		}
-		if err := s.symbolInserter.Flush(ctx); err != nil {
-			return 0, err
-		}
+	if s.isSyntactic {
+		return s.insertedSymbolsCount, nil
+	}
 
-		// Move all symbols data from temp tables into target tables
-		if err := s.db.Exec(ctx, sqlf.Sprintf(scipWriterFlushSymbolNamesQuery, s.uploadID)); err != nil {
-			return 0, err
-		}
-		if err := s.db.Exec(ctx, sqlf.Sprintf(scipWriterFlushSymbolsQuery, s.uploadID, 1)); err != nil {
-			return 0, err
-		}
+	// Flush all symbols data into temp tables
+	if err := s.symbolNameInserter.Flush(ctx); err != nil {
+		return 0, err
+	}
+	if err := s.symbolInserter.Flush(ctx); err != nil {
+		return 0, err
+	}
 
+	// Move all symbols data from temp tables into target tables
+	if err := s.db.Exec(ctx, sqlf.Sprintf(scipWriterFlushSymbolNamesQuery, s.uploadID)); err != nil {
+		return 0, err
+	}
+	if err := s.db.Exec(ctx, sqlf.Sprintf(scipWriterFlushSymbolsQuery, s.uploadID, 1)); err != nil {
+		return 0, err
 	}
 	return s.insertedSymbolsCount, nil
 }

--- a/internal/codeintel/uploads/internal/lsifstore/insert.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert.go
@@ -101,14 +101,12 @@ VALUES (%s, %s, %s, %s, %s, %s)
 `
 
 func (s *store) NewSyntacticSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error) {
-
 	scipWriter := &scipWriter{
 		uploadID:             uploadID,
 		db:                   s.db,
 		insertedSymbolsCount: 0,
 		isSyntactic:          true,
 	}
-
 	return scipWriter, nil
 }
 

--- a/internal/codeintel/uploads/internal/lsifstore/insert.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert.go
@@ -321,7 +321,6 @@ func (s *scipWriter) flush(ctx context.Context) error {
 }
 
 func (s *scipWriter) writeSymbols(ctx context.Context, documents []bufferedDocument, documentLookupIDs []int) error {
-	// NOTE(Christoph): We don't write symbols for syntactic indices
 	if s.isSyntactic {
 		return nil
 	}
@@ -426,9 +425,8 @@ func (s *scipWriter) Flush(ctx context.Context) (uint32, error) {
 		return 0, err
 	}
 
-	// NOTE(Christoph): Only flush symbols for non-syntactic indices
 	if !s.isSyntactic {
-		// Flush all data into temp tables
+		// Flush all symbols data into temp tables
 		if err := s.symbolNameInserter.Flush(ctx); err != nil {
 			return 0, err
 		}
@@ -436,7 +434,7 @@ func (s *scipWriter) Flush(ctx context.Context) (uint32, error) {
 			return 0, err
 		}
 
-		// Move all data from temp tables into target tables
+		// Move all symbols data from temp tables into target tables
 		if err := s.db.Exec(ctx, sqlf.Sprintf(scipWriterFlushSymbolNamesQuery, s.uploadID)); err != nil {
 			return 0, err
 		}

--- a/internal/codeintel/uploads/internal/lsifstore/insert.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert.go
@@ -321,6 +321,8 @@ func (s *scipWriter) flush(ctx context.Context) error {
 }
 
 func (s *scipWriter) writeSymbols(ctx context.Context, documents []bufferedDocument, documentLookupIDs []int) error {
+	// We don't write symbols for syntactic indexes, because we can't perform
+	// fuzzy matching against the trie datastructure we build for symbols in the database
 	if s.isSyntactic {
 		return nil
 	}
@@ -425,6 +427,7 @@ func (s *scipWriter) Flush(ctx context.Context) (uint32, error) {
 		return 0, err
 	}
 
+	// We don't need to flush symbols for syntactic indexes, as we don't write any for them
 	if !s.isSyntactic {
 		// Flush all symbols data into temp tables
 		if err := s.symbolNameInserter.Flush(ctx); err != nil {

--- a/internal/codeintel/uploads/internal/lsifstore/insert_test.go
+++ b/internal/codeintel/uploads/internal/lsifstore/insert_test.go
@@ -40,7 +40,7 @@ func TestInsertSharedDocumentsConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to start transaction: %s", err)
 	}
-	scipWriter24, err := tx1.NewSCIPWriter(ctx, 24)
+	scipWriter24, err := tx1.NewPreciseSCIPWriter(ctx, 24)
 	if err != nil {
 		t.Fatalf("failed to create SCIP writer: %s", err)
 	}
@@ -66,7 +66,7 @@ func TestInsertSharedDocumentsConcurrently(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to start transaction: %s", err)
 	}
-	scipWriter25, err := tx2.NewSCIPWriter(ctx, 25)
+	scipWriter25, err := tx2.NewPreciseSCIPWriter(ctx, 25)
 	if err != nil {
 		t.Fatalf("failed to create SCIP writer: %s", err)
 	}
@@ -115,7 +115,7 @@ func TestInsertDocumentWithSymbols(t *testing.T) {
 
 	var n uint32
 	if err := store.WithTransaction(ctx, func(tx Store) error {
-		scipWriter24, err := tx.NewSCIPWriter(ctx, 24)
+		scipWriter24, err := tx.NewPreciseSCIPWriter(ctx, 24)
 		if err != nil {
 			t.Fatalf("failed to write SCIP symbols: %s", err)
 		}

--- a/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -9,7 +9,6 @@ import (
 
 type operations struct {
 	insertMetadata              *observation.Operation
-	newSCIPWriter               *observation.Operation
 	idsWithMeta                 *observation.Operation
 	reconcileCandidates         *observation.Operation
 	deleteLsifDataByUploadIds   *observation.Operation
@@ -38,7 +37,6 @@ func newOperations(observationCtx *observation.Context) *operations {
 
 	return &operations{
 		insertMetadata:              op("InsertMetadata"),
-		newSCIPWriter:               op("NewPreciseSCIPWriter"),
 		idsWithMeta:                 op("IDsWithMeta"),
 		reconcileCandidates:         op("ReconcileCandidates"),
 		deleteLsifDataByUploadIds:   op("DeleteLsifDataByUploadIds"),

--- a/internal/codeintel/uploads/internal/lsifstore/observability.go
+++ b/internal/codeintel/uploads/internal/lsifstore/observability.go
@@ -38,7 +38,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 
 	return &operations{
 		insertMetadata:              op("InsertMetadata"),
-		newSCIPWriter:               op("NewSCIPWriter"),
+		newSCIPWriter:               op("NewPreciseSCIPWriter"),
 		idsWithMeta:                 op("IDsWithMeta"),
 		reconcileCandidates:         op("ReconcileCandidates"),
 		deleteLsifDataByUploadIds:   op("DeleteLsifDataByUploadIds"),

--- a/internal/codeintel/uploads/internal/lsifstore/store.go
+++ b/internal/codeintel/uploads/internal/lsifstore/store.go
@@ -16,7 +16,7 @@ type Store interface {
 
 	// Insert
 	InsertMetadata(ctx context.Context, uploadID int, meta ProcessedMetadata) error
-	NewSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error)
+	NewPreciseSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error)
 	NewSyntacticSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error)
 
 	// Reconciliation and cleanup

--- a/internal/codeintel/uploads/internal/lsifstore/store.go
+++ b/internal/codeintel/uploads/internal/lsifstore/store.go
@@ -17,6 +17,7 @@ type Store interface {
 	// Insert
 	InsertMetadata(ctx context.Context, uploadID int, meta ProcessedMetadata) error
 	NewSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error)
+	NewSyntacticSCIPWriter(ctx context.Context, uploadID int) (SCIPWriter, error)
 
 	// Reconciliation and cleanup
 	IDsWithMeta(ctx context.Context, ids []int) ([]int, error)

--- a/internal/codeintel/uploads/internal/store/commitgraph.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph.go
@@ -1098,7 +1098,7 @@ func makeFindClosestProcessUploadsConditions(path string, rootMustEnclosePath bo
 		conds = append(conds, sqlf.Sprintf("indexer = %s", indexer))
 	} else {
 		// NOTE(Christoph): We want to ignore syntactic indices unless we're explicitly requesting them
-		conds = append(conds, sqlf.Sprintf("indexer <> %s", shared.SYNTACTIC_INDEXER))
+		conds = append(conds, sqlf.Sprintf("indexer <> %s", shared.SyntacticIndexer))
 	}
 
 	return conds

--- a/internal/codeintel/uploads/internal/store/commitgraph.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph.go
@@ -276,6 +276,7 @@ LIMIT %s
 // FindClosestCompletedUploads returns the set of uploads that can most accurately answer queries for the given repository, commit, path, and
 // optional indexer. If rootMustEnclosePath is true, then only dumps with a root which is a prefix of path are returned. Otherwise,
 // any dump with a root intersecting the given path is returned.
+// Syntactic indexes are not returned unless the requested indexer is shared.SyntacticIndexer
 //
 // This method should be used when the commit is known to exist in the lsif_nearest_uploads table. If it doesn't, then this method
 // will return no dumps (as the input commit is not reachable from anything with an upload). The nearest uploads table must be

--- a/internal/codeintel/uploads/internal/store/commitgraph.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph.go
@@ -1096,6 +1096,9 @@ func makeFindClosestProcessUploadsConditions(path string, rootMustEnclosePath bo
 	}
 	if indexer != "" {
 		conds = append(conds, sqlf.Sprintf("indexer = %s", indexer))
+	} else {
+		// NOTE(Christoph): We want to ignore syntactic indices unless we're explicitly requesting them
+		conds = append(conds, sqlf.Sprintf("indexer <> %s", shared.SYNTACTIC_INDEXER))
 	}
 
 	return conds

--- a/internal/codeintel/uploads/internal/store/commitgraph.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph.go
@@ -1098,7 +1098,9 @@ func makeFindClosestProcessUploadsConditions(path string, rootMustEnclosePath bo
 	if indexer != "" {
 		conds = append(conds, sqlf.Sprintf("indexer = %s", indexer))
 	} else {
-		// NOTE(Christoph): We want to ignore syntactic indices unless we're explicitly requesting them
+		// NOTE(id: explicit-syntactic-index): Ignore syntactic indices unless they're
+		// explicitly requested to maintain backwards compatibility with older APIs
+		// where clients only expect precise results when an indexer is not specified.
 		conds = append(conds, sqlf.Sprintf("indexer <> %s", shared.SyntacticIndexer))
 	}
 

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -1010,6 +1010,7 @@ func TestFindClosestCompletedUploadsIndexerName(t *testing.T) {
 		{ID: 6, Commit: makeCommit(2), Root: "root2/", Indexer: "idx2"},
 		{ID: 7, Commit: makeCommit(3), Root: "root3/", Indexer: "idx2"},
 		{ID: 8, Commit: makeCommit(4), Root: "root4/", Indexer: "idx2"},
+		{ID: 9, Commit: makeCommit(4), Root: "root4/", Indexer: shared.SyntacticIndexer},
 	}
 	insertUploads(t, db, uploads...)
 
@@ -1051,6 +1052,7 @@ func TestFindClosestCompletedUploadsIndexerName(t *testing.T) {
 			{UploadID: 6, Distance: 2},
 			{UploadID: 7, Distance: 1},
 			{UploadID: 8, Distance: 0},
+			{UploadID: 9, Distance: 0},
 		},
 	}
 	if diff := cmp.Diff(expectedVisibleUploads, normalizeVisibleUploads(visibleUploads)); diff != "" {
@@ -1078,6 +1080,8 @@ func TestFindClosestCompletedUploadsIndexerName(t *testing.T) {
 		{commit: makeCommit(5), file: "root2/file.ts", indexer: "idx2", graph: graph, allOfIDs: []int{6}},
 		{commit: makeCommit(5), file: "root3/file.ts", indexer: "idx2", graph: graph, allOfIDs: []int{7}},
 		{commit: makeCommit(5), file: "root4/file.ts", indexer: "idx2", graph: graph, allOfIDs: []int{8}},
+		{commit: makeCommit(5), file: "root4/file.ts", indexer: "", graph: graph, allOfIDs: []int{4, 8}},
+		{commit: makeCommit(5), file: "root4/file.ts", indexer: shared.SyntacticIndexer, graph: graph, allOfIDs: []int{9}},
 	})
 }
 

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -1080,6 +1080,7 @@ func TestFindClosestCompletedUploadsIndexerName(t *testing.T) {
 		{commit: makeCommit(5), file: "root2/file.ts", indexer: "idx2", graph: graph, allOfIDs: []int{6}},
 		{commit: makeCommit(5), file: "root3/file.ts", indexer: "idx2", graph: graph, allOfIDs: []int{7}},
 		{commit: makeCommit(5), file: "root4/file.ts", indexer: "idx2", graph: graph, allOfIDs: []int{8}},
+		// Searching for visible uploads with indexer == "" yields all non-syntactic indexes
 		{commit: makeCommit(5), file: "root4/file.ts", indexer: "", graph: graph, allOfIDs: []int{4, 8}},
 		{commit: makeCommit(5), file: "root4/file.ts", indexer: shared.SyntacticIndexer, graph: graph, allOfIDs: []int{9}},
 	})

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -8524,7 +8524,7 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
-				panic("unexpected invocation of MockLSIFStore.NewSCIPWriter")
+				panic("unexpected invocation of MockLSIFStore.NewPreciseSCIPWriter")
 			},
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
@@ -8570,7 +8570,7 @@ func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
 			defaultHook: i.InsertMetadata,
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
-			defaultHook: i.NewSCIPWriter,
+			defaultHook: i.NewPreciseSCIPWriter,
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
 			defaultHook: i.NewSyntacticSCIPWriter,
@@ -9149,7 +9149,7 @@ func (c LSIFStoreInsertMetadataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewSCIPWriter
+// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewPreciseSCIPWriter
 // method of the parent MockLSIFStore instance is invoked.
 type LSIFStoreNewSCIPWriterFunc struct {
 	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
@@ -9160,13 +9160,13 @@ type LSIFStoreNewSCIPWriterFunc struct {
 
 // NewSCIPWriter delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockLSIFStore) NewSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
+func (m *MockLSIFStore) NewPreciseSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
 	r0, r1 := m.NewSCIPWriterFunc.nextHook()(v0, v1)
 	m.NewSCIPWriterFunc.appendCall(LSIFStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the NewSCIPWriter method
+// SetDefaultHook sets function that is called when the NewPreciseSCIPWriter method
 // of the parent MockLSIFStore instance is invoked and the hook queue is
 // empty.
 func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
@@ -9174,7 +9174,7 @@ func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, i
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// NewSCIPWriter method of the parent MockLSIFStore instance invokes the
+// NewPreciseSCIPWriter method of the parent MockLSIFStore instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
 func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
@@ -9229,7 +9229,7 @@ func (f *LSIFStoreNewSCIPWriterFunc) History() []LSIFStoreNewSCIPWriterFuncCall 
 }
 
 // LSIFStoreNewSCIPWriterFuncCall is an object that describes an invocation
-// of method NewSCIPWriter on an instance of MockLSIFStore.
+// of method NewPreciseSCIPWriter on an instance of MockLSIFStore.
 type LSIFStoreNewSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -8418,9 +8418,9 @@ type MockLSIFStore struct {
 	// InsertMetadataFunc is an instance of a mock function object
 	// controlling the behavior of the method InsertMetadata.
 	InsertMetadataFunc *LSIFStoreInsertMetadataFunc
-	// NewSCIPWriterFunc is an instance of a mock function object
-	// controlling the behavior of the method NewSCIPWriter.
-	NewSCIPWriterFunc *LSIFStoreNewSCIPWriterFunc
+	// NewPreciseSCIPWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewPreciseSCIPWriter.
+	NewPreciseSCIPWriterFunc *LSIFStoreNewPreciseSCIPWriterFunc
 	// NewSyntacticSCIPWriterFunc is an instance of a mock function object
 	// controlling the behavior of the method NewSyntacticSCIPWriter.
 	NewSyntacticSCIPWriterFunc *LSIFStoreNewSyntacticSCIPWriterFunc
@@ -8465,7 +8465,7 @@ func NewMockLSIFStore() *MockLSIFStore {
 				return
 			},
 		},
-		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+		NewPreciseSCIPWriterFunc: &LSIFStoreNewPreciseSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
@@ -8522,7 +8522,7 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 				panic("unexpected invocation of MockLSIFStore.InsertMetadata")
 			},
 		},
-		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+		NewPreciseSCIPWriterFunc: &LSIFStoreNewPreciseSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
 				panic("unexpected invocation of MockLSIFStore.NewPreciseSCIPWriter")
 			},
@@ -8569,7 +8569,7 @@ func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
 		InsertMetadataFunc: &LSIFStoreInsertMetadataFunc{
 			defaultHook: i.InsertMetadata,
 		},
-		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+		NewPreciseSCIPWriterFunc: &LSIFStoreNewPreciseSCIPWriterFunc{
 			defaultHook: i.NewPreciseSCIPWriter,
 		},
 		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
@@ -9149,35 +9149,36 @@ func (c LSIFStoreInsertMetadataFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
-// LSIFStoreNewSCIPWriterFunc describes the behavior when the NewPreciseSCIPWriter
-// method of the parent MockLSIFStore instance is invoked.
-type LSIFStoreNewSCIPWriterFunc struct {
+// LSIFStoreNewPreciseSCIPWriterFunc describes the behavior when the
+// NewPreciseSCIPWriter method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreNewPreciseSCIPWriterFunc struct {
 	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
 	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
-	history     []LSIFStoreNewSCIPWriterFuncCall
+	history     []LSIFStoreNewPreciseSCIPWriterFuncCall
 	mutex       sync.Mutex
 }
 
-// NewSCIPWriter delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
+// NewPreciseSCIPWriter delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
 func (m *MockLSIFStore) NewPreciseSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
-	r0, r1 := m.NewSCIPWriterFunc.nextHook()(v0, v1)
-	m.NewSCIPWriterFunc.appendCall(LSIFStoreNewSCIPWriterFuncCall{v0, v1, r0, r1})
+	r0, r1 := m.NewPreciseSCIPWriterFunc.nextHook()(v0, v1)
+	m.NewPreciseSCIPWriterFunc.appendCall(LSIFStoreNewPreciseSCIPWriterFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the NewPreciseSCIPWriter method
-// of the parent MockLSIFStore instance is invoked and the hook queue is
-// empty.
-func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+// SetDefaultHook sets function that is called when the NewPreciseSCIPWriter
+// method of the parent MockLSIFStore instance is invoked and the hook queue
+// is empty.
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// NewPreciseSCIPWriter method of the parent MockLSIFStore instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+// NewPreciseSCIPWriter method of the parent MockLSIFStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -9185,20 +9186,20 @@ func (f *LSIFStoreNewSCIPWriterFunc) PushHook(hook func(context.Context, int) (l
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *LSIFStoreNewSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
 	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *LSIFStoreNewSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
 	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
 		return r0, r1
 	})
 }
 
-func (f *LSIFStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -9211,26 +9212,27 @@ func (f *LSIFStoreNewSCIPWriterFunc) nextHook() func(context.Context, int) (lsif
 	return hook
 }
 
-func (f *LSIFStoreNewSCIPWriterFunc) appendCall(r0 LSIFStoreNewSCIPWriterFuncCall) {
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) appendCall(r0 LSIFStoreNewPreciseSCIPWriterFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of LSIFStoreNewSCIPWriterFuncCall objects
-// describing the invocations of this function.
-func (f *LSIFStoreNewSCIPWriterFunc) History() []LSIFStoreNewSCIPWriterFuncCall {
+// History returns a sequence of LSIFStoreNewPreciseSCIPWriterFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreNewPreciseSCIPWriterFunc) History() []LSIFStoreNewPreciseSCIPWriterFuncCall {
 	f.mutex.Lock()
-	history := make([]LSIFStoreNewSCIPWriterFuncCall, len(f.history))
+	history := make([]LSIFStoreNewPreciseSCIPWriterFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// LSIFStoreNewSCIPWriterFuncCall is an object that describes an invocation
-// of method NewPreciseSCIPWriter on an instance of MockLSIFStore.
-type LSIFStoreNewSCIPWriterFuncCall struct {
+// LSIFStoreNewPreciseSCIPWriterFuncCall is an object that describes an
+// invocation of method NewPreciseSCIPWriter on an instance of
+// MockLSIFStore.
+type LSIFStoreNewPreciseSCIPWriterFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -9247,13 +9249,13 @@ type LSIFStoreNewSCIPWriterFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreNewSCIPWriterFuncCall) Args() []interface{} {
+func (c LSIFStoreNewPreciseSCIPWriterFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreNewSCIPWriterFuncCall) Results() []interface{} {
+func (c LSIFStoreNewPreciseSCIPWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -8421,6 +8421,9 @@ type MockLSIFStore struct {
 	// NewSCIPWriterFunc is an instance of a mock function object
 	// controlling the behavior of the method NewSCIPWriter.
 	NewSCIPWriterFunc *LSIFStoreNewSCIPWriterFunc
+	// NewSyntacticSCIPWriterFunc is an instance of a mock function object
+	// controlling the behavior of the method NewSyntacticSCIPWriter.
+	NewSyntacticSCIPWriterFunc *LSIFStoreNewSyntacticSCIPWriterFunc
 	// ReconcileCandidatesFunc is an instance of a mock function object
 	// controlling the behavior of the method ReconcileCandidates.
 	ReconcileCandidatesFunc *LSIFStoreReconcileCandidatesFunc
@@ -8463,6 +8466,11 @@ func NewMockLSIFStore() *MockLSIFStore {
 			},
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
+				return
+			},
+		},
+		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
 			defaultHook: func(context.Context, int) (r0 lsifstore.SCIPWriter, r1 error) {
 				return
 			},
@@ -8519,6 +8527,11 @@ func NewStrictMockLSIFStore() *MockLSIFStore {
 				panic("unexpected invocation of MockLSIFStore.NewSCIPWriter")
 			},
 		},
+		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
+			defaultHook: func(context.Context, int) (lsifstore.SCIPWriter, error) {
+				panic("unexpected invocation of MockLSIFStore.NewSyntacticSCIPWriter")
+			},
+		},
 		ReconcileCandidatesFunc: &LSIFStoreReconcileCandidatesFunc{
 			defaultHook: func(context.Context, int) ([]int, error) {
 				panic("unexpected invocation of MockLSIFStore.ReconcileCandidates")
@@ -8558,6 +8571,9 @@ func NewMockLSIFStoreFrom(i lsifstore.Store) *MockLSIFStore {
 		},
 		NewSCIPWriterFunc: &LSIFStoreNewSCIPWriterFunc{
 			defaultHook: i.NewSCIPWriter,
+		},
+		NewSyntacticSCIPWriterFunc: &LSIFStoreNewSyntacticSCIPWriterFunc{
+			defaultHook: i.NewSyntacticSCIPWriter,
 		},
 		ReconcileCandidatesFunc: &LSIFStoreReconcileCandidatesFunc{
 			defaultHook: i.ReconcileCandidates,
@@ -9238,6 +9254,117 @@ func (c LSIFStoreNewSCIPWriterFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c LSIFStoreNewSCIPWriterFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// LSIFStoreNewSyntacticSCIPWriterFunc describes the behavior when the
+// NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
+// invoked.
+type LSIFStoreNewSyntacticSCIPWriterFunc struct {
+	defaultHook func(context.Context, int) (lsifstore.SCIPWriter, error)
+	hooks       []func(context.Context, int) (lsifstore.SCIPWriter, error)
+	history     []LSIFStoreNewSyntacticSCIPWriterFuncCall
+	mutex       sync.Mutex
+}
+
+// NewSyntacticSCIPWriter delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockLSIFStore) NewSyntacticSCIPWriter(v0 context.Context, v1 int) (lsifstore.SCIPWriter, error) {
+	r0, r1 := m.NewSyntacticSCIPWriterFunc.nextHook()(v0, v1)
+	m.NewSyntacticSCIPWriterFunc.appendCall(LSIFStoreNewSyntacticSCIPWriterFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// NewSyntacticSCIPWriter method of the parent MockLSIFStore instance is
+// invoked and the hook queue is empty.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// NewSyntacticSCIPWriter method of the parent MockLSIFStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushHook(hook func(context.Context, int) (lsifstore.SCIPWriter, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) SetDefaultReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) PushReturn(r0 lsifstore.SCIPWriter, r1 error) {
+	f.PushHook(func(context.Context, int) (lsifstore.SCIPWriter, error) {
+		return r0, r1
+	})
+}
+
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) nextHook() func(context.Context, int) (lsifstore.SCIPWriter, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) appendCall(r0 LSIFStoreNewSyntacticSCIPWriterFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of LSIFStoreNewSyntacticSCIPWriterFuncCall
+// objects describing the invocations of this function.
+func (f *LSIFStoreNewSyntacticSCIPWriterFunc) History() []LSIFStoreNewSyntacticSCIPWriterFuncCall {
+	f.mutex.Lock()
+	history := make([]LSIFStoreNewSyntacticSCIPWriterFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// LSIFStoreNewSyntacticSCIPWriterFuncCall is an object that describes an
+// invocation of method NewSyntacticSCIPWriter on an instance of
+// MockLSIFStore.
+type LSIFStoreNewSyntacticSCIPWriterFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 lsifstore.SCIPWriter
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c LSIFStoreNewSyntacticSCIPWriterFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c LSIFStoreNewSyntacticSCIPWriterFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/shared/indexers2.go
+++ b/internal/codeintel/uploads/shared/indexers2.go
@@ -12,7 +12,7 @@ type CodeIntelIndexer struct {
 	DockerImages []string
 }
 
-const SYNTACTIC_INDEXER = "scip-syntax"
+const SyntacticIndexer = "scip-syntax"
 
 // allIndexers is a list of all detectable/suggested indexers known to Sourcegraph.
 // Two indexers with the same language key will be preferred according to the given order.

--- a/internal/codeintel/uploads/shared/indexers2.go
+++ b/internal/codeintel/uploads/shared/indexers2.go
@@ -12,6 +12,8 @@ type CodeIntelIndexer struct {
 	DockerImages []string
 }
 
+const SYNTACTIC_INDEXER = "scip-syntax"
+
 // allIndexers is a list of all detectable/suggested indexers known to Sourcegraph.
 // Two indexers with the same language key will be preferred according to the given order.
 var allIndexers = []CodeIntelIndexer{


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/61422

When uploading syntacic indices we want to treat them as regular updates as much as possible to be able to reuse the logic in commitgraph.

The two important differences from precise uploads are:
- We don't write symbols for syntactic indices
- We don't return syntactic indexes from the annotated commit graph unless we're explictly requesting them

## Test plan

Added unit tests for index retrieval