### PR TITLE
sg: add a cody-gateway-bazel commandset

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1188,9 +1188,10 @@ commandsets:
       - zoekt-web-0
       - zoekt-web-1
       - blobstore
-      - cody-gateway
       - embeddings
       - telemetry-gateway
+    bazelCommands:
+      - cody-gateway
     env:
       SOURCEGRAPHDOTCOM_MODE: true
 

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -987,6 +987,18 @@ commands:
 bazelCommands:
   blobstore:
     target: //cmd/blobstore
+  cody-gateway:
+    target: //cmd/cody-gateway
+    env:
+      CODY_GATEWAY_ANTHROPIC_ACCESS_TOKEN: foobar
+      # Set in override if you want to test local Cody Gateway: https://sourcegraph.com/docs/dev/how-to/cody_gateway
+      CODY_GATEWAY_DOTCOM_ACCESS_TOKEN: ''
+      CODY_GATEWAY_DOTCOM_API_URL: https://sourcegraph.test:3443/.api/graphql
+      CODY_GATEWAY_ALLOW_ANONYMOUS: true
+      CODY_GATEWAY_DIAGNOSTICS_SECRET: sekret
+      SRC_LOG_LEVEL: info
+      # Enables metrics in dev via debugserver
+      SRC_PROF_HTTP: '127.0.0.1:6098'
   docsite:
     runTarget: //doc:serve
   searcher:
@@ -1545,6 +1557,12 @@ commandsets:
     checks:
       - redis
     commands:
+      - cody-gateway
+
+  cody-gateway-bazel:
+    checks:
+      - redis
+    bazelCommands:
       - cody-gateway
 
   qdrant:


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/693

It seems we may have broken the mecanism that restart a command if the compilation failed when we rewrote in #60687. Rather than fixing old code, I added a `cody-gateway-bazel` command set until we fully switch to `bazel` as the default for everyone. 

I tested it and I can mess up the compilation, then fix it and it correctly picks it up without having to restart `sg`. 

## Test plan

Tested locally. 

![CleanShot 2024-03-08 at 15 32 31@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/0cd30a5a-0643-4ca8-8a7c-d48e9d94fd20)


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
