### PR TITLE
bazel: include //dev:go_mockgen in //dev:write_all_generated

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -152,13 +152,6 @@ http_archive(
     url = "https://github.com/aspect-build/aspect-cli/archive/5.8.20.tar.gz",
 )
 
-http_archive(
-    name = "rules_multirun",
-    sha256 = "9cd384e42b2da00104f0e18f25e66285aa21f64b573c667638a7a213206885ab",
-    strip_prefix = "rules_multirun-0.6.1",
-    url = "https://github.com/keith/rules_multirun/archive/refs/tags/0.6.1.tar.gz",
-)
-
 # hermetic_cc_toolchain setup ================================
 HERMETIC_CC_TOOLCHAIN_VERSION = "v2.2.1"
 

--- a/dev/BUILD.bazel
+++ b/dev/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_multirun//:defs.bzl", "multirun")
 load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
 
 exports_files(srcs = [
@@ -30,12 +29,13 @@ write_source_files(
         "//migrations/codeintel:write_squashed",
         "//migrations/frontend:write_squashed",
         "//schema:write_generated_schema",
+        ":go_mockgen",
     ],
 )
 
-multirun(
+write_source_files(
     name = "go_mockgen",
-    commands = [
+    additional_update_targets = [
         "//cmd/cody-gateway/internal/auth:generate_mocks",
         "//cmd/cody-gateway/internal/dotcom:generate_mocks",
         "//cmd/executor/internal/worker/cmdlogger:generate_mocks",
@@ -111,6 +111,5 @@ multirun(
         "//internal/workerutil/dbworker/store/mocks:generate_mocks",
         "//internal/workerutil:generate_mocks",
         "//lib/background:generate_mocks",
-    ],  # TODO: this list doesn't get smaller, why
-    jobs = 1,
+    ],
 )

--- a/dev/go-mockgen-gazelle/go-mockgen.go
+++ b/dev/go-mockgen-gazelle/go-mockgen.go
@@ -88,10 +88,10 @@ func (*gomockgen) Kinds() map[string]rule.KindInfo {
 				"manifests": true,
 			},
 		},
-		"multirun": {
+		"write_source_files": {
 			MatchAttrs: []string{"name"},
 			MergeableAttrs: map[string]bool{
-				"commands": true,
+				"additional_update_targets": true,
 			},
 		},
 	}
@@ -111,8 +111,8 @@ func (*gomockgen) ApparentLoads(moduleToApparentName func(string) string) []rule
 			Symbols: []string{"go_mockgen"},
 		},
 		{
-			Name:    "@rules_multirun//:defs.bzl",
-			Symbols: []string{"multirun"},
+			Name:    "@aspect_bazel_lib//lib:write_source_files.bzl",
+			Symbols: []string{"write_source_files"},
 		},
 	}
 }
@@ -123,7 +123,7 @@ func (g *gomockgen) GenerateRules(args language.GenerateArgs) language.GenerateR
 		log.Fatalf("failed to load go-mockgen config: %v", err)
 	}
 
-	// if we're in the ./dev folder, we want to generate an "all" multirun.
+	// if we're in the ./dev folder, we want to generate an "all" target.
 	if args.Rel == "dev" {
 		var targets []string
 		for _, mock := range yamlPayload.Mocks {
@@ -133,12 +133,11 @@ func (g *gomockgen) GenerateRules(args language.GenerateArgs) language.GenerateR
 		slices.Sort(targets)
 		targets = slices.Compact(targets)
 
-		multirunRule := rule.NewRule("multirun", "go_mockgen")
-		multirunRule.SetAttr("commands", targets)
-		multirunRule.SetAttr("jobs", 1)
+		catchallRule := rule.NewRule("write_source_files", "go_mockgen")
+		catchallRule.SetAttr("additional_update_targets", targets)
 
 		return language.GenerateResult{
-			Gen:     []*rule.Rule{multirunRule},
+			Gen:     []*rule.Rule{catchallRule},
 			Imports: []interface{}{nil},
 		}
 	}


### PR DESCRIPTION
`//dev:go_mockgen` had `suggested_update_target` set to `//dev:write_all_generated` without it actually being part of that list. Theres two options here: updated `suggested_update_target` to `//dev:go_mockgen` for go_mockgen targets, or add the former to the latter. We're going with the latter here (we could also do both, but want to direct people towards write_all_generated even though it does more work in the worst case)

## Test plan

CI and `bazel run //dev:write_all_generated`
