### PR TITLE
Fix link feature flag check within code intel card

### DIFF
--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -4,7 +4,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject, type RefObject } from 'react'
 
-import {useApolloClient} from '@apollo/client'
+import { useApolloClient } from '@apollo/client'
 import { openSearchPanel } from '@codemirror/search'
 import { EditorState, type Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -4,6 +4,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject, type RefObject } from 'react'
 
+import {useApolloClient} from '@apollo/client'
 import { openSearchPanel } from '@codemirror/search'
 import { EditorState, type Extension } from '@codemirror/state'
 import { EditorView } from '@codemirror/view'
@@ -570,6 +571,7 @@ function useCodeIntelExtension(
 ): Extension {
     const navigate = useNavigate()
     const location = useLocation()
+    const apolloClient = useApolloClient()
     const locationRef = useRef(location)
     const [api, setApi] = useState<CodeIntelAPI | null>(null)
 
@@ -598,7 +600,7 @@ function useCodeIntelExtension(
                           api,
                           documentInfo: { repoName, filePath, commitID, revision, languages },
                           createTooltipView: ({ view, token, hovercardData }) =>
-                              new HovercardView(view, token, hovercardData),
+                              new HovercardView(view, token, hovercardData, apolloClient),
                           openImplementations(_view, documentInfo, occurrence) {
                               navigate(
                                   toPrettyBlobURL({

--- a/client/web/src/repo/blob/CodeMirrorBlob.tsx
+++ b/client/web/src/repo/blob/CodeMirrorBlob.tsx
@@ -716,7 +716,7 @@ function useCodeIntelExtension(
                   })
                 : [],
         ],
-        [repoName, filePath, commitID, revision, mode, api, navigate, locationRef, languages]
+        [repoName, filePath, commitID, revision, mode, api, navigate, locationRef, languages, apolloClient]
     )
 }
 

--- a/client/web/src/repo/blob/codemirror/tooltips/HovercardView.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/HovercardView.tsx
@@ -1,3 +1,4 @@
+import {ApolloClient, ApolloProvider} from '@apollo/client'
 import { type EditorView, repositionTooltips, type TooltipView, type ViewUpdate } from '@codemirror/view'
 import classNames from 'classnames'
 import { createRoot, type Root } from 'react-dom/client'
@@ -39,7 +40,8 @@ export class HovercardView implements TooltipView {
     constructor(
         private readonly view: EditorView,
         private readonly tokenRange: TooltipViewOptions['token'],
-        hovercardData: TooltipViewOptions['hovercardData']
+        hovercardData: TooltipViewOptions['hovercardData'],
+        private readonly client: ApolloClient<any>
     ) {
         this.dom = document.createElement('div')
         this.dom.className = 'sg-code-intel-hovercard'
@@ -106,44 +108,46 @@ export class HovercardView implements TooltipView {
         }
 
         root.render(
-            <CodeMirrorContainer navigate={props.navigate} onRender={() => repositionTooltips(this.view)}>
-                <div
-                    className={classNames({
-                        'cm-code-intel-hovercard': true,
-                        'cm-code-intel-hovercard-pinned': pinned,
-                    })}
-                >
-                    <WebHoverOverlay
-                        // Blob props
-                        location={props.location}
-                        onHoverShown={props.onHoverShown}
-                        platformContext={props.platformContext}
-                        settingsCascade={props.settingsCascade}
-                        telemetryService={props.telemetryService}
-                        extensionsController={props.extensionsController}
-                        // Hover props
-                        actionsOrError={actionsOrError}
-                        hoverOrError={hoverOrError}
-                        // CodeMirror handles the positioning but a
-                        // non-nullable value must be passed for the
-                        // hovercard to render
-                        overlayPosition={dummyOverlayPosition}
-                        hoveredToken={hoveredToken}
-                        pinOptions={{
-                            showCloseButton: pinned,
-                            onCloseButtonClick: () => {
-                                const { line, character } = hoveredToken
-                                this.view.state.facet(pinConfig).onUnpin?.({ line, character })
-                            },
-                            onCopyLinkButtonClick: () => {
-                                const { line, character } = hoveredToken
-                                this.view.state.facet(pinConfig).onPin?.({ line, character })
-                            },
-                        }}
-                        hoverOverlayContainerClassName="position-relative"
-                    />
-                </div>
-            </CodeMirrorContainer>
+            <ApolloProvider client={this.client}>
+                <CodeMirrorContainer navigate={props.navigate} onRender={() => repositionTooltips(this.view)}>
+                    <div
+                        className={classNames({
+                            'cm-code-intel-hovercard': true,
+                            'cm-code-intel-hovercard-pinned': pinned,
+                        })}
+                    >
+                        <WebHoverOverlay
+                            // Blob props
+                            location={props.location}
+                            onHoverShown={props.onHoverShown}
+                            platformContext={props.platformContext}
+                            settingsCascade={props.settingsCascade}
+                            telemetryService={props.telemetryService}
+                            extensionsController={props.extensionsController}
+                            // Hover props
+                            actionsOrError={actionsOrError}
+                            hoverOrError={hoverOrError}
+                            // CodeMirror handles the positioning but a
+                            // non-nullable value must be passed for the
+                            // hovercard to render
+                            overlayPosition={dummyOverlayPosition}
+                            hoveredToken={hoveredToken}
+                            pinOptions={{
+                                showCloseButton: pinned,
+                                onCloseButtonClick: () => {
+                                    const {line, character} = hoveredToken
+                                    this.view.state.facet(pinConfig).onUnpin?.({line, character})
+                                },
+                                onCopyLinkButtonClick: () => {
+                                    const {line, character} = hoveredToken
+                                    this.view.state.facet(pinConfig).onPin?.({line, character})
+                                },
+                            }}
+                            hoverOverlayContainerClassName="position-relative"
+                        />
+                    </div>
+                </CodeMirrorContainer>
+            </ApolloProvider>
         )
     }
 }

--- a/client/web/src/repo/blob/codemirror/tooltips/HovercardView.tsx
+++ b/client/web/src/repo/blob/codemirror/tooltips/HovercardView.tsx
@@ -1,4 +1,4 @@
-import {ApolloClient, ApolloProvider} from '@apollo/client'
+import { ApolloClient, ApolloProvider } from '@apollo/client'
 import { type EditorView, repositionTooltips, type TooltipView, type ViewUpdate } from '@codemirror/view'
 import classNames from 'classnames'
 import { createRoot, type Root } from 'react-dom/client'
@@ -135,12 +135,12 @@ export class HovercardView implements TooltipView {
                             pinOptions={{
                                 showCloseButton: pinned,
                                 onCloseButtonClick: () => {
-                                    const {line, character} = hoveredToken
-                                    this.view.state.facet(pinConfig).onUnpin?.({line, character})
+                                    const { line, character } = hoveredToken
+                                    this.view.state.facet(pinConfig).onUnpin?.({ line, character })
                                 },
                                 onCopyLinkButtonClick: () => {
-                                    const {line, character} = hoveredToken
-                                    this.view.state.facet(pinConfig).onPin?.({line, character})
+                                    const { line, character } = hoveredToken
+                                    this.view.state.facet(pinConfig).onPin?.({ line, character })
                                 },
                             }}
                             hoverOverlayContainerClassName="position-relative"


### PR DESCRIPTION
Original problem [thread](https://sourcegraph.slack.com/archives/C022SPMNR0W/p1709913968661159) 

The problem was simple, since we started checking feature flags within the link component and in the case of hovercard we render links outside of the main react call tree, the feature flag check within the link component didn't have access to the Apollo context. This PR just adds the client providers manually in the hover card.

## Test plan
- Go to the blob UI view and check that you can see code intel hover tooltip over symbols

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
