### PR TITLE
v2t: add v2t to src/enterprise/user

### DIFF
--- a/client/web/src/enterprise/user/productSubscriptions/UserProductSubscriptionStatus.test.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserProductSubscriptionStatus.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
 import { UserProductSubscriptionStatus } from './UserProductSubscriptionStatus'
@@ -19,6 +20,7 @@ describe('UserProductSubscriptionStatus', () => {
                 userCount={123}
                 expiresAt={23456}
                 licenseKey="lk"
+                telemetryRecorder={noOpTelemetryRecorder}
             />
         )
         expect(asFragment()).toMatchSnapshot('license key hidden')

--- a/client/web/src/enterprise/user/productSubscriptions/UserProductSubscriptionStatus.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserProductSubscriptionStatus.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react'
 
 import { mdiKey, mdiInformation } from '@mdi/js'
 
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Button, CardFooter, Link, Icon, Code, H3 } from '@sourcegraph/wildcard'
 
 import { CopyableText } from '../../../components/CopyableText'
@@ -10,7 +11,7 @@ import { ExpirationDate } from '../../productSubscription/ExpirationDate'
 import { LicenseGenerationKeyWarning } from '../../productSubscription/LicenseGenerationKeyWarning'
 import { ProductCertificate } from '../../productSubscription/ProductCertificate'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     subscriptionName: string
     productNameWithBrand: string
     userCount: number
@@ -29,10 +30,14 @@ export const UserProductSubscriptionStatus: React.FunctionComponent<React.PropsW
     expiresAt,
     licenseKey,
     className,
+    telemetryRecorder,
 }) => {
     const [showLicenseKey, setShowLicenseKey] = useState(false)
 
-    const toggleShowLicenseKey = useCallback((): void => setShowLicenseKey(!showLicenseKey), [showLicenseKey])
+    const toggleShowLicenseKey = useCallback((): void => {
+        telemetryRecorder.recordEvent('settings.userSubscription.licenseKey', showLicenseKey ? 'hide' : 'reveal')
+        setShowLicenseKey(!showLicenseKey)
+    }, [telemetryRecorder, showLicenseKey])
 
     return (
         <ProductCertificate

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import { getDocumentNode } from '@sourcegraph/http-client'
+import { noOpTelemetryRecorder } from '@sourcegraph/shared/src/telemetry'
 import { MockedTestProvider, waitForNextApolloResponse } from '@sourcegraph/shared/src/testing/apollo'
 import { renderWithBrandedContext } from '@sourcegraph/wildcard/src/testing'
 
@@ -28,7 +29,10 @@ describe('UserSubscriptionsProductSubscriptionPage', () => {
                     },
                 ]}
             >
-                <UserSubscriptionsProductSubscriptionPage user={{ settingsURL: '/u' }} />
+                <UserSubscriptionsProductSubscriptionPage
+                    user={{ settingsURL: '/u' }}
+                    telemetryRecorder={noOpTelemetryRecorder}
+                />
             </MockedTestProvider>,
             { path: '/:subscriptionUUID', route: `/${uuid}` }
         )

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom'
 import { validate as validateUUID } from 'uuid'
 
 import { useQuery } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { LoadingSpinner, H4, Text, Link, ErrorAlert, PageHeader, Container } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../../components/PageTitle'
@@ -14,14 +15,13 @@ import type {
     UserProductSubscriptionVariables,
 } from '../../../graphql-operations'
 import { SiteAdminAlert } from '../../../site-admin/SiteAdminAlert'
-import { eventLogger } from '../../../tracking/eventLogger'
 import { CodyServicesSection } from '../../site-admin/dotcom/productSubscriptions/CodyServicesSection'
 import { accessTokenPath, errorForPath } from '../../site-admin/dotcom/productSubscriptions/utils'
 
 import { USER_PRODUCT_SUBSCRIPTION } from './backend'
 import { UserProductSubscriptionStatus } from './UserProductSubscriptionStatus'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     user: Pick<UserAreaUserFields, 'settingsURL'>
 }
 
@@ -30,10 +30,11 @@ interface Props {
  */
 export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
     user,
+    telemetryRecorder,
 }) => {
     const { subscriptionUUID = '' } = useParams<{ subscriptionUUID: string }>()
 
-    useEffect(() => eventLogger.logViewEvent('UserSubscriptionsProductSubscription'), [])
+    useEffect(() => telemetryRecorder.recordEvent('settings.userSubscription', 'view'), [telemetryRecorder])
 
     const isValidUUID = validateUUID(subscriptionUUID)
     const validationError = !isValidUUID && new Error('Subscription ID is not a valid UUID')
@@ -94,6 +95,7 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<R
                     expiresAt={parseISO(productSubscription.activeLicense.info.expiresAt)}
                     licenseKey={productSubscription.activeLicense?.licenseKey ?? null}
                     className="mb-3"
+                    telemetryRecorder={telemetryRecorder}
                 />
             )}
 

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators'
 
 import { createAggregateError } from '@sourcegraph/common'
 import { gql } from '@sourcegraph/http-client'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Container, Link, PageHeader, Text } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../../backend/graphql'
@@ -24,7 +25,7 @@ import {
     type ProductSubscriptionNodeProps,
 } from '../../dotcom/productSubscriptions/ProductSubscriptionNode'
 
-interface Props {
+interface Props extends TelemetryV2Props {
     user: UserAreaUserFields
 }
 
@@ -35,9 +36,10 @@ interface Props {
 export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
     React.PropsWithChildren<Props>
 > = props => {
-    useEffect(() => {
-        eventLogger.logViewEvent('UserSubscriptionsProductSubscriptions')
-    }, [])
+    useEffect(
+        () => props.telemetryRecorder.recordEvent('settings.userSubscriptions', 'view'),
+        [props.telemetryRecorder]
+    )
 
     const queryLicenses = useCallback(
         (args: { first?: number }): Observable<ProductSubscriptionsResult['dotcom']['productSubscriptions']> => {
@@ -86,7 +88,10 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
                         Search your private code with{' '}
                         <Link
                             to="https://sourcegraph.com"
-                            onClick={() => eventLogger.log('ClickedOnEnterpriseCTA', { location: 'Subscriptions' })}
+                            onClick={() => {
+                                eventLogger.log('ClickedOnEnterpriseCTA', { location: 'Subscriptions' })
+                                props.telemetryRecorder.recordEvent('settings.userSubscriptions.enterpriseCTA', 'click')
+                            }}
                         >
                             Sourcegraph Enterprise
                         </Link>

--- a/client/web/src/enterprise/user/settings/UserEventLogsPage.tsx
+++ b/client/web/src/enterprise/user/settings/UserEventLogsPage.tsx
@@ -6,7 +6,7 @@ import { map } from 'rxjs/operators'
 
 import { Timestamp } from '@sourcegraph/branded/src/components/Timestamp'
 import { dataOrThrowErrors, gql } from '@sourcegraph/http-client'
-import type { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { TelemetryV2Props } from '@sourcegraph/shared/src/telemetry'
 import { Container, PageHeader, Link, Code } from '@sourcegraph/wildcard'
 
 import { requestGraphQL } from '../../../backend/graphql'
@@ -57,7 +57,7 @@ export interface UserEventLogsPageProps
     extends Pick<UserSettingsAreaRouteContext, 'authenticatedUser' | 'isSourcegraphDotCom'>,
         UserEventLogsPageContentProps {}
 
-export interface UserEventLogsPageContentProps extends Pick<UserSettingsAreaRouteContext, 'user'>, TelemetryProps {}
+export interface UserEventLogsPageContentProps extends Pick<UserSettingsAreaRouteContext, 'user'>, TelemetryV2Props {}
 
 /**
  * A page displaying usage statistics for the site.
@@ -65,7 +65,7 @@ export interface UserEventLogsPageContentProps extends Pick<UserSettingsAreaRout
 export const UserEventLogsPage: React.FunctionComponent<React.PropsWithChildren<UserEventLogsPageProps>> = ({
     isSourcegraphDotCom,
     authenticatedUser,
-    telemetryService,
+    telemetryRecorder,
     user,
 }) => {
     if (isSourcegraphDotCom && authenticatedUser && user.id !== authenticatedUser.id) {
@@ -75,15 +75,15 @@ export const UserEventLogsPage: React.FunctionComponent<React.PropsWithChildren<
             </SiteAdminAlert>
         )
     }
-    return <UserEventLogsPageContent telemetryService={telemetryService} user={user} />
+    return <UserEventLogsPageContent telemetryRecorder={telemetryRecorder} user={user} />
 }
 
 export const UserEventLogsPageContent: React.FunctionComponent<
     React.PropsWithChildren<UserEventLogsPageContentProps>
-> = ({ telemetryService, user }) => {
+> = ({ telemetryRecorder, user }) => {
     useMemo(() => {
-        telemetryService.logViewEvent('UserEventLogPage')
-    }, [telemetryService])
+        telemetryRecorder.recordEvent('settings.userEventLogs', 'view')
+    }, [telemetryRecorder])
 
     const queryUserEventLogs = useCallback(
         (args: { first?: number }): Observable<UserEventLogsConnectionFields> =>

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.test.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.test.tsx
@@ -83,7 +83,6 @@ describe('UserSettingsPermissionsPage', () => {
                 <UserSettingsPermissionsPage
                     user={{ id: gqlUserID, username: 'alice' }}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
-                    // TODO (dadlerj): update to use a real telemetry recorder
                     telemetryRecorder={noOpTelemetryRecorder}
                 />
             </MockedTestProvider>,
@@ -136,7 +135,6 @@ describe('UserSettingsPermissionsPage', () => {
                 <UserSettingsPermissionsPage
                     user={{ id: gqlUserID, username: 'alice' }}
                     telemetryService={NOOP_TELEMETRY_SERVICE}
-                    // TODO (dadlerj): update to use a real telemetry recorder
                     telemetryRecorder={noOpTelemetryRecorder}
                 />
             </MockedTestProvider>,

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -33,7 +33,6 @@ import { ActionContainer } from '../../../../repo/settings/components/ActionCont
 import { ExternalRepositoryIcon } from '../../../../site-admin/components/ExternalRepositoryIcon'
 import { PermissionsSyncJobsTable } from '../../../../site-admin/permissions-center/PermissionsSyncJobsTable'
 import { Table, type IColumn } from '../../../../site-admin/UserManagement/components/Table'
-import { eventLogger } from '../../../../tracking/eventLogger'
 import { PermissionReasonBadgeProps } from '../../../settings/permissons'
 
 import { scheduleUserPermissionsSync, UserPermissionsInfoQuery } from './backend'
@@ -52,7 +51,7 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<React.PropsWit
     telemetryService,
     telemetryRecorder,
 }) => {
-    useEffect(() => eventLogger.logViewEvent('UserSettingsPermissions'), [])
+    useEffect(() => telemetryRecorder.recordEvent('settings.permissions', 'view'), [telemetryRecorder])
 
     const [{ query }, setSearchQuery] = useURLSyncedState({ query: '' })
     const debouncedQuery = useDebounce(query, 300)

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -36,21 +36,6 @@ const AboutOrganizationPage = lazyComponent(
     'AboutOrganizationPage'
 )
 
-const UserEventLogsPage = lazyComponent<UserEventLogsPageProps, 'UserEventLogsPage'>(
-    () => import('../../enterprise/user/settings/UserEventLogsPage'),
-    'UserEventLogsPage'
-)
-
-const UserSubscriptionsProductSubscriptionsPage = lazyComponent(
-    () => import('../../enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage'),
-    'UserSubscriptionsProductSubscriptionsPage'
-)
-
-const UserSubscriptionsProductSubscriptionPage = lazyComponent(
-    () => import('../../enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage'),
-    'UserSubscriptionsProductSubscriptionPage'
-)
-
 const shouldRenderBatchChangesPage = ({
     batchChangesEnabled,
     user: { viewerCanAdminister },
@@ -110,7 +95,10 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     },
     {
         path: 'event-log',
-        render: props => <UserEventLogsPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />,
+        render: lazyComponent<UserEventLogsPageProps, 'UserEventLogsPage'>(
+            () => import('../../enterprise/user/settings/UserEventLogsPage'),
+            'UserEventLogsPage'
+        ),
     },
     {
         path: 'executors/*',
@@ -133,21 +121,17 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     },
     {
         path: 'subscriptions/:subscriptionUUID',
-        render: props => (
-            <UserSubscriptionsProductSubscriptionPage
-                {...props}
-                telemetryRecorder={props.platformContext.telemetryRecorder}
-            />
+        render: lazyComponent(
+            () => import('../../enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage'),
+            'UserSubscriptionsProductSubscriptionPage'
         ),
         condition: () => SHOW_BUSINESS_FEATURES,
     },
     {
         path: 'subscriptions',
-        render: props => (
-            <UserSubscriptionsProductSubscriptionsPage
-                {...props}
-                telemetryRecorder={props.platformContext.telemetryRecorder}
-            />
+        render: lazyComponent(
+            () => import('../../enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage'),
+            'UserSubscriptionsProductSubscriptionsPage'
         ),
         condition: () => SHOW_BUSINESS_FEATURES,
     },

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -36,6 +36,21 @@ const AboutOrganizationPage = lazyComponent(
     'AboutOrganizationPage'
 )
 
+const UserEventLogsPage = lazyComponent<UserEventLogsPageProps, 'UserEventLogsPage'>(
+    () => import('../../enterprise/user/settings/UserEventLogsPage'),
+    'UserEventLogsPage'
+)
+
+const UserSubscriptionsProductSubscriptionsPage = lazyComponent(
+    () => import('../../enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage'),
+    'UserSubscriptionsProductSubscriptionsPage'
+)
+
+const UserSubscriptionsProductSubscriptionPage = lazyComponent(
+    () => import('../../enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage'),
+    'UserSubscriptionsProductSubscriptionPage'
+)
+
 const shouldRenderBatchChangesPage = ({
     batchChangesEnabled,
     user: { viewerCanAdminister },
@@ -95,10 +110,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     },
     {
         path: 'event-log',
-        render: lazyComponent<UserEventLogsPageProps, 'UserEventLogsPage'>(
-            () => import('../../enterprise/user/settings/UserEventLogsPage'),
-            'UserEventLogsPage'
-        ),
+        render: props => <UserEventLogsPage {...props} telemetryRecorder={props.platformContext.telemetryRecorder} />,
     },
     {
         path: 'executors/*',
@@ -121,17 +133,21 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     },
     {
         path: 'subscriptions/:subscriptionUUID',
-        render: lazyComponent(
-            () => import('../../enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage'),
-            'UserSubscriptionsProductSubscriptionPage'
+        render: props => (
+            <UserSubscriptionsProductSubscriptionPage
+                {...props}
+                telemetryRecorder={props.platformContext.telemetryRecorder}
+            />
         ),
         condition: () => SHOW_BUSINESS_FEATURES,
     },
     {
         path: 'subscriptions',
-        render: lazyComponent(
-            () => import('../../enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage'),
-            'UserSubscriptionsProductSubscriptionsPage'
+        render: props => (
+            <UserSubscriptionsProductSubscriptionsPage
+                {...props}
+                telemetryRecorder={props.platformContext.telemetryRecorder}
+            />
         ),
         condition: () => SHOW_BUSINESS_FEATURES,
     },


### PR DESCRIPTION
Context:

* https://github.com/sourcegraph/sourcegraph/pull/60127
* https://github.com/sourcegraph/sourcegraph/pull/60192
* https://github.com/sourcegraph/sourcegraph/pull/60219
* https://github.com/sourcegraph/sourcegraph/pull/60343
* https://github.com/sourcegraph/sourcegraph/pull/60377
* https://github.com/sourcegraph/sourcegraph/pull/60382
* https://github.com/sourcegraph/sourcegraph/pull/60764
* https://github.com/sourcegraph/sourcegraph/pull/60765
* https://github.com/sourcegraph/sourcegraph/pull/60767
* https://github.com/sourcegraph/sourcegraph/pull/60768
* https://github.com/sourcegraph/sourcegraph/pull/60788
* https://github.com/sourcegraph/sourcegraph/pull/60789
* https://github.com/sourcegraph/sourcegraph/pull/60803
* https://github.com/sourcegraph/sourcegraph/pull/60812
* https://github.com/sourcegraph/sourcegraph/pull/60850
* https://github.com/sourcegraph/sourcegraph/pull/60851
* https://github.com/sourcegraph/sourcegraph/pull/60939

## Test plan

`sg start`
visit page
check if events appear in `event_logs` table locally