### PR TITLE
backport: update schema descriptions for 5.3.2

### DIFF
--- a/tools/release/schema_deps.bzl
+++ b/tools/release/schema_deps.bzl
@@ -8,6 +8,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 def schema_deps():
     http_file(
         name = "schemas_archive",
-        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.3.0.tar.gz"],
-        sha256 = "6c1c855b7636fc60e2f08f0961e05c019df7ef431a766f485855f871c7c1122f",
+        urls = ["https://storage.googleapis.com/schemas-migrations/dist/schemas-v5.3.2.tar.gz"],
+        sha256 = "f3d23671f8d4aff572ff930c856f644c3fc5c507883dd5f11db95ee205712384",
     )


### PR DESCRIPTION
```
git co 5.3
git pull
bazel run //tools/release:upload_current_schemas -- v5.3.2
bazel run //tools/release:generate_schemas_archive -- v5.3.2 fetch-current-schemas $(pwd)/
```

## Test plan

CI + 

```
INFO: Running command line: bazel-bin/tools/release/generate_schemas_archive v5.3.2 fetch-current-schemas /Users/tech/work/other/
Generating an archive of all released database schemas for v5.3
--- Downloading all schemas from gs://schemas-migrations/schemas
/var/folders/pc/p4c29gw17jz3vqdkgrfnnvdr0000gn/T/tmp.5c7gV2icdT /private/var/tmp/_bazel_tech/0812c8e6e121162f0d18a505d289a8d2/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/tools/release/generate_schemas_archive.runfiles/__main__
--- Filtering out migrations after 5.3
/private/var/tmp/_bazel_tech/0812c8e6e121162f0d18a505d289a8d2/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/tools/release/generate_schemas_archive.runfiles/__main__
--- Skipping current schema
✅ Found /var/folders/pc/p4c29gw17jz3vqdkgrfnnvdr0000gn/T/tmp.5c7gV2icdT/v5.3.2-internal_database_schema.json database schema for v5.3.2
✅ Found /var/folders/pc/p4c29gw17jz3vqdkgrfnnvdr0000gn/T/tmp.5c7gV2icdT/v5.3.2-internal_database_schema.codeintel.json database schema for v5.3.2
✅ Found /var/folders/pc/p4c29gw17jz3vqdkgrfnnvdr0000gn/T/tmp.5c7gV2icdT/v5.3.2-internal_database_schema.codeinsights.json database schema for v5.3.2
--- Creating tarball '/private/var/tmp/_bazel_tech/0812c8e6e121162f0d18a505d289a8d2/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/tools/release/generate_schemas_archive.runfiles/__main__/schemas-v5.3.2.tar.gz'
/var/folders/pc/p4c29gw17jz3vqdkgrfnnvdr0000gn/T/tmp.5c7gV2icdT /private/var/tmp/_bazel_tech/0812c8e6e121162f0d18a505d289a8d2/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/tools/release/generate_schemas_archive.runfiles/__main__
⚠️  BSDTar detected, using gtar to produce idempotent tarball.
/private/var/tmp/_bazel_tech/0812c8e6e121162f0d18a505d289a8d2/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/tools/release/generate_schemas_archive.runfiles/__main__
Checksum: f3d23671f8d4aff572ff930c856f644c3fc5c507883dd5f11db95ee205712384
--- Uploading tarball to gs://schemas-migrations/dist
CommandException: One or more URLs matched no objects.
--- Updating buildfiles
--- Summary
-rw-r--r--  0 0      0      263237 Jan  1  1970 ./v3.20.0-internal_database_schema.json
-rw-r--r--  0 0      0      263237 Jan  1  1970 ./v3.20.1-internal_database_schema.json
-rw-r--r--  0 0      0       13398 Jan  1  1970 ./v3.21.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      266162 Jan  1  1970 ./v3.21.0-internal_database_schema.json
-rw-r--r--  0 0      0       13398 Jan  1  1970 ./v3.21.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      266162 Jan  1  1970 ./v3.21.1-internal_database_schema.json
-rw-r--r--  0 0      0       13398 Jan  1  1970 ./v3.21.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      266162 Jan  1  1970 ./v3.21.2-internal_database_schema.json
-rw-r--r--  0 0      0       13398 Jan  1  1970 ./v3.22.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      291644 Jan  1  1970 ./v3.22.0-internal_database_schema.json
-rw-r--r--  0 0      0       13398 Jan  1  1970 ./v3.22.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      291644 Jan  1  1970 ./v3.22.1-internal_database_schema.json
-rw-r--r--  0 0      0       13424 Jan  1  1970 ./v3.23.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      289435 Jan  1  1970 ./v3.23.0-internal_database_schema.json
-rw-r--r--  0 0      0       15560 Jan  1  1970 ./v3.24.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      293605 Jan  1  1970 ./v3.24.0-internal_database_schema.json
-rw-r--r--  0 0      0       15560 Jan  1  1970 ./v3.24.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      293605 Jan  1  1970 ./v3.24.1-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.25.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       16433 Jan  1  1970 ./v3.25.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      311914 Jan  1  1970 ./v3.25.0-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.25.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       16433 Jan  1  1970 ./v3.25.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      311914 Jan  1  1970 ./v3.25.1-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.25.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       16433 Jan  1  1970 ./v3.25.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      311914 Jan  1  1970 ./v3.25.2-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.26.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       16433 Jan  1  1970 ./v3.26.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      321002 Jan  1  1970 ./v3.26.0-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.26.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       16433 Jan  1  1970 ./v3.26.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      329481 Jan  1  1970 ./v3.26.1-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.26.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       16433 Jan  1  1970 ./v3.26.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      329481 Jan  1  1970 ./v3.26.2-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.26.3-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       16433 Jan  1  1970 ./v3.26.3-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      329481 Jan  1  1970 ./v3.26.3-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.27.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       34002 Jan  1  1970 ./v3.27.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      341565 Jan  1  1970 ./v3.27.0-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.27.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       34002 Jan  1  1970 ./v3.27.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      342360 Jan  1  1970 ./v3.27.1-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.27.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       34002 Jan  1  1970 ./v3.27.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      342360 Jan  1  1970 ./v3.27.2-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.27.3-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       34002 Jan  1  1970 ./v3.27.3-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      342360 Jan  1  1970 ./v3.27.3-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.27.4-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       34002 Jan  1  1970 ./v3.27.4-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      342360 Jan  1  1970 ./v3.27.4-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.27.5-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       34002 Jan  1  1970 ./v3.27.5-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      342360 Jan  1  1970 ./v3.27.5-internal_database_schema.json
-rw-r--r--  0 0      0       17512 Jan  1  1970 ./v3.28.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       36092 Jan  1  1970 ./v3.28.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      346897 Jan  1  1970 ./v3.28.0-internal_database_schema.json
-rw-r--r--  0 0      0       21371 Jan  1  1970 ./v3.29.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       36092 Jan  1  1970 ./v3.29.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      374405 Jan  1  1970 ./v3.29.0-internal_database_schema.json
-rw-r--r--  0 0      0       21371 Jan  1  1970 ./v3.29.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       36092 Jan  1  1970 ./v3.29.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      374405 Jan  1  1970 ./v3.29.1-internal_database_schema.json
-rw-r--r--  0 0      0       33916 Jan  1  1970 ./v3.30.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       40772 Jan  1  1970 ./v3.30.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      396651 Jan  1  1970 ./v3.30.0-internal_database_schema.json
-rw-r--r--  0 0      0       33916 Jan  1  1970 ./v3.30.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       41304 Jan  1  1970 ./v3.30.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      396651 Jan  1  1970 ./v3.30.1-internal_database_schema.json
-rw-r--r--  0 0      0       33916 Jan  1  1970 ./v3.30.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       41304 Jan  1  1970 ./v3.30.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      396651 Jan  1  1970 ./v3.30.2-internal_database_schema.json
-rw-r--r--  0 0      0       33916 Jan  1  1970 ./v3.30.3-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       41304 Jan  1  1970 ./v3.30.3-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      396651 Jan  1  1970 ./v3.30.3-internal_database_schema.json
-rw-r--r--  0 0      0       33916 Jan  1  1970 ./v3.30.4-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       41304 Jan  1  1970 ./v3.30.4-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      396651 Jan  1  1970 ./v3.30.4-internal_database_schema.json
-rw-r--r--  0 0      0       38601 Jan  1  1970 ./v3.31.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       41304 Jan  1  1970 ./v3.31.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      412494 Jan  1  1970 ./v3.31.0-internal_database_schema.json
-rw-r--r--  0 0      0       38601 Jan  1  1970 ./v3.31.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       41304 Jan  1  1970 ./v3.31.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      412494 Jan  1  1970 ./v3.31.1-internal_database_schema.json
-rw-r--r--  0 0      0       38601 Jan  1  1970 ./v3.31.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       41304 Jan  1  1970 ./v3.31.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      412494 Jan  1  1970 ./v3.31.2-internal_database_schema.json
-rw-r--r--  0 0      0       50003 Jan  1  1970 ./v3.32.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       41304 Jan  1  1970 ./v3.32.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      447085 Jan  1  1970 ./v3.32.0-internal_database_schema.json
-rw-r--r--  0 0      0       50003 Jan  1  1970 ./v3.32.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       41304 Jan  1  1970 ./v3.32.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      447085 Jan  1  1970 ./v3.32.1-internal_database_schema.json
-rw-r--r--  0 0      0       62311 Jan  1  1970 ./v3.33.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       96062 Jan  1  1970 ./v3.33.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      443268 Jan  1  1970 ./v3.33.0-internal_database_schema.json
-rw-r--r--  0 0      0       62311 Jan  1  1970 ./v3.33.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       96062 Jan  1  1970 ./v3.33.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      443268 Jan  1  1970 ./v3.33.1-internal_database_schema.json
-rw-r--r--  0 0      0       62311 Jan  1  1970 ./v3.33.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       96062 Jan  1  1970 ./v3.33.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      443268 Jan  1  1970 ./v3.33.2-internal_database_schema.json
-rw-r--r--  0 0      0       64970 Jan  1  1970 ./v3.34.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.34.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      480020 Jan  1  1970 ./v3.34.0-internal_database_schema.json
-rw-r--r--  0 0      0       64970 Jan  1  1970 ./v3.34.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.34.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      480020 Jan  1  1970 ./v3.34.1-internal_database_schema.json
-rw-r--r--  0 0      0       64970 Jan  1  1970 ./v3.34.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.34.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      480887 Jan  1  1970 ./v3.34.2-internal_database_schema.json
-rw-r--r--  0 0      0       66349 Jan  1  1970 ./v3.35.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.35.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      494464 Jan  1  1970 ./v3.35.0-internal_database_schema.json
-rw-r--r--  0 0      0       66349 Jan  1  1970 ./v3.35.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.35.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      489934 Jan  1  1970 ./v3.35.1-internal_database_schema.json
-rw-r--r--  0 0      0       66349 Jan  1  1970 ./v3.35.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.35.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      489934 Jan  1  1970 ./v3.35.2-internal_database_schema.json
-rw-r--r--  0 0      0       67067 Jan  1  1970 ./v3.36.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.36.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      498656 Jan  1  1970 ./v3.36.0-internal_database_schema.json
-rw-r--r--  0 0      0       67067 Jan  1  1970 ./v3.36.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.36.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      498656 Jan  1  1970 ./v3.36.1-internal_database_schema.json
-rw-r--r--  0 0      0       67067 Jan  1  1970 ./v3.36.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.36.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      498656 Jan  1  1970 ./v3.36.2-internal_database_schema.json
-rw-r--r--  0 0      0       67067 Jan  1  1970 ./v3.36.3-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.36.3-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      498656 Jan  1  1970 ./v3.36.3-internal_database_schema.json
-rw-r--r--  0 0      0       66810 Jan  1  1970 ./v3.37.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      114304 Jan  1  1970 ./v3.37.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      505343 Jan  1  1970 ./v3.37.0-internal_database_schema.json
-rw-r--r--  0 0      0       67179 Jan  1  1970 ./v3.38.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.38.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      514336 Jan  1  1970 ./v3.38.0-internal_database_schema.json
-rw-r--r--  0 0      0       67179 Jan  1  1970 ./v3.38.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.38.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      514336 Jan  1  1970 ./v3.38.1-internal_database_schema.json
-rw-r--r--  0 0      0       67937 Jan  1  1970 ./v3.39.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.39.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      527422 Jan  1  1970 ./v3.39.0-internal_database_schema.json
-rw-r--r--  0 0      0       67937 Jan  1  1970 ./v3.39.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.39.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      527422 Jan  1  1970 ./v3.39.1-internal_database_schema.json
-rw-r--r--  0 0      0       67937 Jan  1  1970 ./v3.40.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.40.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      551825 Jan  1  1970 ./v3.40.0-internal_database_schema.json
-rw-r--r--  0 0      0       67937 Jan  1  1970 ./v3.40.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.40.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      551825 Jan  1  1970 ./v3.40.1-internal_database_schema.json
-rw-r--r--  0 0      0       67937 Jan  1  1970 ./v3.40.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.40.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      551825 Jan  1  1970 ./v3.40.2-internal_database_schema.json
-rw-r--r--  0 0      0       69350 Jan  1  1970 ./v3.41.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.41.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      571986 Jan  1  1970 ./v3.41.0-internal_database_schema.json
-rw-r--r--  0 0      0       69350 Jan  1  1970 ./v3.41.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.41.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      571986 Jan  1  1970 ./v3.41.1-internal_database_schema.json
-rw-r--r--  0 0      0       69714 Jan  1  1970 ./v3.42.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      125788 Jan  1  1970 ./v3.42.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      585761 Jan  1  1970 ./v3.42.0-internal_database_schema.json
-rw-r--r--  0 0      0       69714 Jan  1  1970 ./v3.42.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      125788 Jan  1  1970 ./v3.42.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      585761 Jan  1  1970 ./v3.42.1-internal_database_schema.json
-rw-r--r--  0 0      0       70085 Jan  1  1970 ./v3.42.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      125788 Jan  1  1970 ./v3.42.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      585761 Jan  1  1970 ./v3.42.2-internal_database_schema.json
-rw-r--r--  0 0      0       70457 Jan  1  1970 ./v3.43.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.43.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      613304 Jan  1  1970 ./v3.43.0-internal_database_schema.json
-rw-r--r--  0 0      0       70457 Jan  1  1970 ./v3.43.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.43.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      613304 Jan  1  1970 ./v3.43.1-internal_database_schema.json
-rw-r--r--  0 0      0       70457 Jan  1  1970 ./v3.43.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v3.43.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      613304 Jan  1  1970 ./v3.43.2-internal_database_schema.json
-rw-r--r--  0 0      0       70457 Jan  1  1970 ./v4.0.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v4.0.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      636007 Jan  1  1970 ./v4.0.0-internal_database_schema.json
-rw-r--r--  0 0      0       70457 Jan  1  1970 ./v4.0.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0      126160 Jan  1  1970 ./v4.0.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      636007 Jan  1  1970 ./v4.0.1-internal_database_schema.json
-rw-r--r--  0 0      0       90136 Jan  1  1970 ./v4.1.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       53644 Jan  1  1970 ./v4.1.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      657543 Jan  1  1970 ./v4.1.0-internal_database_schema.json
-rw-r--r--  0 0      0       90136 Jan  1  1970 ./v4.1.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       53644 Jan  1  1970 ./v4.1.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      657543 Jan  1  1970 ./v4.1.1-internal_database_schema.json
-rw-r--r--  0 0      0       90136 Jan  1  1970 ./v4.1.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       53644 Jan  1  1970 ./v4.1.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      657543 Jan  1  1970 ./v4.1.2-internal_database_schema.json
-rw-r--r--  0 0      0       90136 Jan  1  1970 ./v4.1.3-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       53644 Jan  1  1970 ./v4.1.3-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      657543 Jan  1  1970 ./v4.1.3-internal_database_schema.json
-rw-r--r--  0 0      0       96302 Jan  1  1970 ./v4.2.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       55539 Jan  1  1970 ./v4.2.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      688439 Jan  1  1970 ./v4.2.0-internal_database_schema.json
-rw-r--r--  0 0      0       96302 Jan  1  1970 ./v4.2.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       55539 Jan  1  1970 ./v4.2.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      688439 Jan  1  1970 ./v4.2.1-internal_database_schema.json
-rw-r--r--  0 0      0       96302 Jan  1  1970 ./v4.3.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       88232 Jan  1  1970 ./v4.3.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      707820 Jan  1  1970 ./v4.3.0-internal_database_schema.json
-rw-r--r--  0 0      0       96302 Jan  1  1970 ./v4.3.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       88232 Jan  1  1970 ./v4.3.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      707820 Jan  1  1970 ./v4.3.1-internal_database_schema.json
-rw-r--r--  0 0      0      108845 Jan  1  1970 ./v4.4.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       89554 Jan  1  1970 ./v4.4.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      727566 Jan  1  1970 ./v4.4.0-internal_database_schema.json
-rw-r--r--  0 0      0      108845 Jan  1  1970 ./v4.4.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       89554 Jan  1  1970 ./v4.4.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      727566 Jan  1  1970 ./v4.4.1-internal_database_schema.json
-rw-r--r--  0 0      0      108845 Jan  1  1970 ./v4.4.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       89554 Jan  1  1970 ./v4.4.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      727566 Jan  1  1970 ./v4.4.2-internal_database_schema.json
-rw-r--r--  0 0      0      105066 Jan  1  1970 ./v4.5.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       89554 Jan  1  1970 ./v4.5.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      767348 Jan  1  1970 ./v4.5.0-internal_database_schema.json
-rw-r--r--  0 0      0      105066 Jan  1  1970 ./v4.5.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       89554 Jan  1  1970 ./v4.5.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      767348 Jan  1  1970 ./v4.5.1-internal_database_schema.json
-rw-r--r--  0 0      0      105066 Jan  1  1970 ./v5.0.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       52821 Jan  1  1970 ./v5.0.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      830859 Jan  1  1970 ./v5.0.0-internal_database_schema.json
-rw-r--r--  0 0      0      105066 Jan  1  1970 ./v5.0.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       52821 Jan  1  1970 ./v5.0.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      830859 Jan  1  1970 ./v5.0.1-internal_database_schema.json
-rw-r--r--  0 0      0      105066 Jan  1  1970 ./v5.0.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       52821 Jan  1  1970 ./v5.0.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      830859 Jan  1  1970 ./v5.0.2-internal_database_schema.json
-rw-r--r--  0 0      0      105066 Jan  1  1970 ./v5.0.3-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       52821 Jan  1  1970 ./v5.0.3-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      830859 Jan  1  1970 ./v5.0.3-internal_database_schema.json
-rw-r--r--  0 0      0      105066 Jan  1  1970 ./v5.0.4-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       52821 Jan  1  1970 ./v5.0.4-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      831610 Jan  1  1970 ./v5.0.4-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      932040 Jan  1  1970 ./v5.1.0-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      932040 Jan  1  1970 ./v5.1.1-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      932040 Jan  1  1970 ./v5.1.2-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.3-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.3-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      932040 Jan  1  1970 ./v5.1.3-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.4-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.4-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      932018 Jan  1  1970 ./v5.1.4-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.5-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.5-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      932018 Jan  1  1970 ./v5.1.5-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.6-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.6-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      936315 Jan  1  1970 ./v5.1.6-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.7-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.7-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      932774 Jan  1  1970 ./v5.1.7-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.8-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.8-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      932774 Jan  1  1970 ./v5.1.8-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.1.9-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.1.9-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      932774 Jan  1  1970 ./v5.1.9-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.2.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.2.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      967757 Jan  1  1970 ./v5.2.0-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.2.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.2.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      967757 Jan  1  1970 ./v5.2.1-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.2.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.2.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      967757 Jan  1  1970 ./v5.2.2-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.2.3-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.2.3-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      967757 Jan  1  1970 ./v5.2.3-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.2.4-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.2.4-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      968145 Jan  1  1970 ./v5.2.4-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.2.5-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.2.5-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      968145 Jan  1  1970 ./v5.2.5-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.2.6-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.2.6-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      968145 Jan  1  1970 ./v5.2.6-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.2.7-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.2.7-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      968145 Jan  1  1970 ./v5.2.7-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.3.0-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.3.0-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      970016 Jan  1  1970 ./v5.3.0-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.3.1-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.3.1-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      970016 Jan  1  1970 ./v5.3.1-internal_database_schema.json
-rw-r--r--  0 0      0      100442 Jan  1  1970 ./v5.3.2-internal_database_schema.codeinsights.json
-rw-r--r--  0 0      0       50342 Jan  1  1970 ./v5.3.2-internal_database_schema.codeintel.json
-rw-r--r--  0 0      0      970016 Jan  1  1970 ./v5.3.2-internal_database_schema.json
Uploaded gs://schemas-migrations/dist/schemas-v5.3.2.tar.gz sha256:f3d23671f8d4aff572ff930c856f644c3fc5c507883dd5f11db95ee205712384
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
