### PR TITLE
svelte: Fix main navigation dropdown hidden behind search input

### DIFF
--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -223,11 +223,9 @@
     @use '$lib/breakpoints';
 
     form {
+        isolation: isolate;
         width: 100%;
         position: relative;
-        // Necessary to ensure that the search input (especially the suggestions) are rendered above sticky headers
-        // in the search results page ("position: sticky" creates a new stacking context).
-        z-index: 1;
         padding: 0.75rem;
 
         &:focus-within {
@@ -251,6 +249,7 @@
         border: 1px solid var(--border-color-2);
         background-color: var(--input-bg);
         position: relative;
+        // This is necessary to ensure that the input is shown above the suggestions container
         z-index: 1;
 
         &:focus-within {

--- a/client/web-sveltekit/src/routes/+layout.svelte
+++ b/client/web-sveltekit/src/routes/+layout.svelte
@@ -106,6 +106,7 @@
     }
 
     main {
+        isolation: isolate;
         flex: 1;
         display: flex;
         flex-direction: column;

--- a/client/web-sveltekit/src/routes/MainNavigationEntry.svelte
+++ b/client/web-sveltekit/src/routes/MainNavigationEntry.svelte
@@ -81,7 +81,6 @@
     }
 
     [role='menu'] {
-        isolation: isolate;
         font-size: 0.875rem;
         min-width: 10rem;
         background-clip: padding-box;

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
@@ -34,7 +34,13 @@ fragment BlobPage_Blob on GitBlob {
     languages
 }
 
-query BlobSyntaxHighlightQuery($repoName: String!, $revspec: String!, $path: String!, $disableTimeout: Boolean!, $format: HighlightResponseFormat = JSON_SCIP) {
+query BlobSyntaxHighlightQuery(
+    $repoName: String!
+    $revspec: String!
+    $path: String!
+    $disableTimeout: Boolean!
+    $format: HighlightResponseFormat = JSON_SCIP
+) {
     repository(name: $repoName) {
         id
         commit(rev: $revspec) {

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -149,6 +149,8 @@
         border-bottom: 1px solid var(--border-color);
         align-self: stretch;
         padding: 0.25rem;
+        // This ensures that suggestions are rendered above sticky search result headers
+        z-index: 1;
     }
 
     .search-results {

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -47,3 +47,12 @@ test('fills search query from URL', async ({ page }) => {
     await page.goto('/search?q=test')
     await expect(page.getByRole('textbox')).toHaveText('test')
 })
+
+test('main navbar menus are visible above search input', async ({ page, sg }) => {
+    const dispatch = sg.mockSearchResults()
+    await page.goto('/search?q=test')
+    await dispatch()
+    await page.getByRole('button', { name: 'Code Search' }).click()
+    await page.getByRole('link', { name: 'Search Home' }).click()
+    await expect(page).toHaveURL(/\/search$/)
+})


### PR DESCRIPTION
Due to z-index setting, the search dropdown of the main navigation is hidden behind the search input on the search results page.

This commit solves this by introducing stacking contexts at the appropriate level:

- In the search input, the actual input needs a higher z-index to appear above the suggestion container. This only needs to work inside the search input so it should create a new stacking context.
- In the search results page, the (full) search input should appear above the search results list. Using `position: sticky` would cause the headsers to appear above the search input suggestions. Giving the search input container a higher z-index fixes that. But again, that only needs to work inside the search results itself. Because the search results page doesn't have its own container I added `isolation: isolate` to the `<main />` element in the top level layout. I think that makes sense conceptually.
- melt-ui appends the dropdown to the bottom of the page so it will now naturally render above all other elements.

I added a test to verify that this works (the test failed without the CSS changes). For that I also added a rudimentary mocking API for search results, otherwise I was getting errors.

Before:
![2024-03-08_22-14](https://github.com/sourcegraph/sourcegraph/assets/179026/240c845a-e417-4992-88cb-6d65c2d48993)


After: 
![2024-03-08_22-13](https://github.com/sourcegraph/sourcegraph/assets/179026/e590ecd6-a63c-4503-8b1b-e41534507693)



## Test plan

Manual testing and new playwright test