### PR TITLE
bazel: refactor percy mocha tests to js_test instead of js_run_binary + build_test

### DIFF
--- a/.aspect/bazelrc/ci.sourcegraph.bazelrc
+++ b/.aspect/bazelrc/ci.sourcegraph.bazelrc
@@ -31,11 +31,11 @@ common --test_env=BUILDKITE
 # Needed for mocha tests
 # We have to use the `--action_env` flag here instead of `--test_env` because
 # the mocha tests target is the build target and it's tested with `build_test`.
-common --action_env=HEADLESS=false
+common --test_env=HEADLESS=false
 # if we set this to localhost, chrome will refuse to conenct since local host is in its HTTP Strict Transport Security
 # by setting the loopback address we get passed that
-common --action_env=SOURCEGRAPH_BASE_URL="http://127.0.0.1:7080"
-common --action_env=DISPLAY=:99
+common --test_env=SOURCEGRAPH_BASE_URL="http://127.0.0.1:7080"
+common --test_env=DISPLAY=:99
 
 # Provides git commit, branch information to build targets like Percy via status file.
 # https://bazel.build/docs/user-manual#workspace-status

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,9 +46,9 @@ http_archive(
 
 http_archive(
     name = "aspect_rules_ts",
-    sha256 = "bd3e7b17e677d2b8ba1bac3862f0f238ab16edb3e43fb0f0b9308649ea58a2ad",
-    strip_prefix = "rules_ts-2.1.0",
-    url = "https://github.com/aspect-build/rules_ts/releases/download/v2.1.0/rules_ts-v2.1.0.tar.gz",
+    sha256 = "c77f0dfa78c407893806491223c1264c289074feefbf706721743a3556fa7cea",
+    strip_prefix = "rules_ts-2.2.0",
+    url = "https://github.com/aspect-build/rules_ts/releases/download/v2.2.0/rules_ts-v2.2.0.tar.gz",
 )
 
 http_archive(

--- a/client/shared/dev/BUILD.bazel
+++ b/client/shared/dev/BUILD.bazel
@@ -53,8 +53,9 @@ ts_binary(
     visibility = ["//client:__subpackages__"],
 )
 
-js_binary(
+js_library(
     name = "run_mocha_tests_with_percy",
+    srcs = ["runMochaTestsWithPercy.js"],
     data = [
         "//:node_modules/@percy/cli",
         "//:node_modules/@percy/puppeteer",
@@ -62,7 +63,6 @@ js_binary(
         "//:node_modules/puppeteer",
         "//:node_modules/resolve-bin",
     ],
-    entry_point = "runMochaTestsWithPercy.js",
     visibility = ["//client:__subpackages__"],
 )
 

--- a/client/shared/dev/runMochaTestsWithPercy.js
+++ b/client/shared/dev/runMochaTestsWithPercy.js
@@ -12,11 +12,11 @@ const resolveBin = require('resolve-bin')
 // to the Puppeteer browser executable downloaded in the postinstall script.
 /** @returns {Record<string, string>} env vars */
 function getEnvVars() {
-  // JS_BINARY__EXECROOT – Set by Bazel `js_run_binary` rule.
-  // BAZEL_BINDIR – Set by Bazel `js_run_binary` rule.
-  const { JS_BINARY__EXECROOT, BAZEL_BINDIR } = process.env
+  // JS_BINARY__EXECROOT – Set by Bazel `js_test` rule.
+  // JS_BINARY__BINDIR – Set by Bazel `js_test` rule.
+  const { JS_BINARY__EXECROOT, JS_BINARY__BINDIR } = process.env
 
-  if (!JS_BINARY__EXECROOT || !BAZEL_BINDIR) {
+  if (!JS_BINARY__EXECROOT || !JS_BINARY__BINDIR) {
     throw new Error('Missing required environment variables')
   }
 
@@ -26,7 +26,7 @@ function getEnvVars() {
   // https://github.com/percy/cli/blob/059ec21653a07105e223aa5a3ec1f815a7123ad7/packages/env/src/environment.js#L138-L139
   // https://bazel.build/docs/user-manual#workspace-status
   //
-  // NB: we derive the volatile-status.txt file path from the BAZEL_BINDIR since we are
+  // NB: we derive the volatile-status.txt file path from the JS_BINARY__BINDIR since we are
   // intentionally pulling volatile data without defining the volatile status as an input so we
   // don't bust the cache with its contents of volatile-status.txt
   // (https://github.com/bazelbuild/bazel/issues/16231). This can be improved in the future by using
@@ -34,7 +34,7 @@ function getEnvVars() {
   // volatile-status.txt file from the action inputs
   // (https://github.com/bazelbuild/bazel/pull/16240)
   const statusFilePath = path.join(
-    path.dirname(path.dirname(path.join(JS_BINARY__EXECROOT, BAZEL_BINDIR))),
+    path.dirname(path.dirname(path.join(JS_BINARY__EXECROOT, JS_BINARY__BINDIR))),
     'volatile-status.txt'
   )
   const volatileEnvVariables = Object.fromEntries(

--- a/dev/mocha.bzl
+++ b/dev/mocha.bzl
@@ -1,7 +1,6 @@
 load("@npm//:mocha/package_json.bzl", mocha_bin = "bin")
 load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
-load("@aspect_rules_js//js:defs.bzl", "js_run_binary")
-load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@aspect_rules_js//js:defs.bzl", "js_test")
 
 NON_BUNDLED = [
     # Dependencies loaded by mocha itself before the tests.
@@ -95,39 +94,26 @@ def mocha_test(name, tests, deps = [], args = [], data = [], env = {}, is_percy_
     })
 
     if is_percy_enabled:
-        # Extract test specific arguments.
-        flaky = kwargs.pop("flaky")
-        timeout = kwargs.pop("timeout")
-
-        binary_name = "%s_binary" % name
-
-        # `js_run_binary` is used here in the combination with `build_test` instead of
-        # `js_test` because only `js_run_binary` currntly supports the `stamp` attribute.
-        # otherwise we could use js_binary with bazel test.
-        # https://docs.aspect.build/rules/aspect_rules_js/docs/js_run_binary#stamp
-        js_run_binary(
-            name = binary_name,
+        js_test(
+            name = name,
             args = args,
             env = dict(env, **{
                 "PERCY_ON": "true",
             }),
-            use_default_shell_env = True,
-            srcs = data,
-            out_dirs = ["out"],
-            silent_on_success = True,
+            data = data + [
+                "//:node_modules/@percy/cli",
+                "//:node_modules/@percy/puppeteer",
+                "//:node_modules/mocha",
+                "//:node_modules/resolve-bin",
+                "//client/shared/dev:run_mocha_tests_with_percy",
+            ],
             # Executed mocha tests with Percy enabled via `percy exec -- mocha ...`
             # Prepends volatile env variables to the command to make Percy aware of the
             # current git branch and commit.
-            tool = "//client/shared/dev:run_mocha_tests_with_percy",
-            testonly = True,
+            entry_point = "//client/shared/dev:run_mocha_tests_with_percy",
+            flaky = kwargs.pop("flaky"),
+            timeout = kwargs.pop("timeout"),
             **kwargs
-        )
-
-        build_test(
-            name = name,
-            targets = [binary_name],
-            timeout = timeout,
-            flaky = flaky,
         )
     else:
         mocha_bin.mocha_test(

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1855,13 +1855,13 @@ tests:
       export SOURCEGRAPH_LICENSE_KEY=$(gcloud secrets versions access latest --secret=SOURCEGRAPH_LICENSE_KEY --quiet --project=sourcegraph-ci)
       export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(gcloud secrets versions access latest --secret=SOURCEGRAPH_LICENSE_GENERATION_KEY --quiet --project=sourcegraph-ci)
 
-      bazel test //testing:e2e_test --action_env=HEADLESS=false --action_env=SOURCEGRAPH_BASE_URL="http://localhost:7080" --action_env=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --action_env=GH_TOKEN=$GH_TOKEN --action_env=DISPLAY=$DISPLAY
+      bazel test //testing:e2e_test --test_env=HEADLESS=false --test_env=SOURCEGRAPH_BASE_URL="http://localhost:7080" --test_env=GHE_GITHUB_TOKEN=$GHE_GITHUB_TOKEN --test_env=GH_TOKEN=$GH_TOKEN --test_env=DISPLAY=$DISPLAY
 
   bazel-web-integration:
     cmd: |
       export GH_TOKEN=$(gcloud secrets versions access latest --secret=GITHUB_TOKEN --quiet --project=sourcegraph-ci)
       export PERCY_TOKEN=$(gcloud secrets versions access latest --secret=PERCY_TOKEN --quiet --project=sourcegraph-ci)
-      bazel test //client/web/src/integration:integration-tests --action_env=HEADLESS=false --action_env=SOURCEGRAPH_BASE_URL="http://localhost:7080" --action_env=GH_TOKEN=$GH_TOKEN --action_env=DISPLAY=$DISPLAY --action_env=PERCY_TOKEN=$PERCY_TOKEN
+      bazel test //client/web/src/integration:integration-tests --test_env=HEADLESS=false --test_env=SOURCEGRAPH_BASE_URL="http://localhost:7080" --test_env=GH_TOKEN=$GH_TOKEN --test_env=DISPLAY=$DISPLAY --test_env=PERCY_TOKEN=$PERCY_TOKEN
 
   backend-integration:
     cmd: cd dev/gqltest && go test -long -base-url $BASE_URL -email $EMAIL -username $USERNAME -password $PASSWORD ./gqltest


### PR DESCRIPTION
`bazel build` on percy mocha targets (such as //client/web/src/integration:integration-tests) no longer result in actually running the test!

Originally, we used `js_run_binary` with `build_test` as `js_test` doesnt support stamping, and we need to be able to read volatile variables for percy. 
Then, we worked around https://github.com/bazelbuild/bazel/issues/16231 in https://github.com/sourcegraph/sourcegraph/pull/58505 by not explicitly depending on the stamp variables, but exploiting a bit of a hack to read them anyways (will this work with RBE?)
Now, given that we're not explicitly stamping and still using the hack, we can use `js_test` instead, to avoid having the tests run as part of `bazel build`, instead only when we run `bazel test` (as is good :relieved:)

It is apparently possible to work around https://github.com/bazelbuild/bazel/issues/16231 when using disk/remote caches, but only for local builds (so no remote builds) according to [the following comment](https://github.com/bazelbuild/bazel/issues/16231#issuecomment-1772835555), but we would still need: 
1. `js_test` to support stamping and
2. this workaround to also apply to remote execution (as we're considering that once its supported in Aspect Workflows)

todo: update doc/dev/background-information/bazel/web_overview.md in new docs repo

## Test plan

CI :tada: 
