### PR TITLE
sg msp: improve cloudsqlproxy installation UX

### DIFF
--- a/dev/sg/cloudsqlproxy/binary.go
+++ b/dev/sg/cloudsqlproxy/binary.go
@@ -35,7 +35,7 @@ func Init(download bool) error {
 	if err != nil && os.IsNotExist(err) {
 		std.Out.WriteWarningf("cloud-sql-proxy binary not found at %q", cloudSQLProxyPath)
 
-		std.Out.Promptf("Would you like me to install cloud-sql-proxy for you?")
+		std.Out.Promptf("Would you like me to install cloud-sql-proxy for you? [y/N]")
 		var input string
 		if _, err := fmt.Scan(&input); err != nil {
 			return err

--- a/dev/sg/cloudsqlproxy/binary.go
+++ b/dev/sg/cloudsqlproxy/binary.go
@@ -21,10 +21,10 @@ const CloudSQLProxyVersion = "2.8.1"
 // optionally downloading if requested
 func Init(download bool) error {
 	if download {
-		err := Download()
-		if err != nil {
+		if err := Download(); err != nil {
 			return err
 		}
+		// If download succeeded, still continue and run the binary check
 	}
 
 	cloudSQLProxyPath, err := Path()
@@ -33,9 +33,21 @@ func Init(download bool) error {
 	}
 	_, err = os.Stat(cloudSQLProxyPath)
 	if err != nil && os.IsNotExist(err) {
-		std.Out.WriteWarningf("cloud-sql-proxy binary not found at %q. try running again with '-download' flag",
-			cloudSQLProxyPath)
-		return errors.Wrapf(err, "failed to find binary")
+		std.Out.WriteWarningf("cloud-sql-proxy binary not found at %q", cloudSQLProxyPath)
+
+		std.Out.Promptf("Would you like me to install cloud-sql-proxy for you?")
+		var input string
+		if _, err := fmt.Scan(&input); err != nil {
+			return err
+		}
+		if input != "y" {
+			// We should NOT install it, throw the error back at the user
+			return errors.Wrap(err, "failed to find cloud-sql-proxy")
+		}
+
+		// Call self again, but this time, set download=true. If it fails again
+		// hopefully the user doesn't say yes
+		return Init(true)
 	} else if err != nil {
 		return errors.Wrapf(err, "failed to read %s binary", cloudSQLProxyPath)
 	}

--- a/dev/sg/msp/repo/root.go
+++ b/dev/sg/msp/repo/root.go
@@ -13,7 +13,7 @@ var once sync.Once
 var repositoryRootValue string
 var repositoryRootError error
 
-var ErrNotInsideManagedServices = errors.New("not running inside sourcegraph/managed-services")
+var ErrNotInsideManagedServices = errors.New("this command must be run in the github.com/sourcegraph/managed-services repository")
 
 // RepositoryRoot caches and returns the value of findRoot.
 func repositoryRoot(cwd string) (string, error) {


### PR DESCRIPTION
Previously, we'd ask users to run the command again with the `-download` flag. This is kind of annoying especially because of flag positioning quirks. Instead, let's just ask the user if they'd actually like us to install it for them, in case we don't find the binary in the cache.

## Test plan

```sh
$ sg msp pg connect sams dev  
⚠️ cloud-sql-proxy binary not found at "/Users/robert@sourcegraph.com/Library/Caches/sourcegraph/bin/cloud-sql-proxy/2.8.1/cloud-sql-proxy"
👉 Would you like me to install cloud-sql-proxy for you? n
❌ failed to find cloud-sql-proxy: stat /Users/robert@sourcegraph.com/Library/Caches/sourcegraph/bin/cloud-sql-proxy/2.8.1/cloud-sql-proxy: no such file or directory

$ sg msp pg connect sams dev
⚠️ cloud-sql-proxy binary not found at "/Users/robert@sourcegraph.com/Library/Caches/sourcegraph/bin/cloud-sql-proxy/2.8.1/cloud-sql-proxy"
👉 Would you like me to install cloud-sql-proxy for you? y
✅ cloud-sql-proxy binary saved to "/Users/robert@sourcegraph.com/Library/Caches/sourcegraph/bin/cloud-sql-proxy/2.8.1/cloud-sql-proxy"
💡 Preparing a connection with read-only access - for write access, use the '-write-access' flag.
👉 Use this command to connect to database "accounts":
                                                                                                                   
psql -U operatoraccess-a55c85@sams-dev-bfec.iam -d accounts -h 127.0.0.1 -p 5433                                   

👉 Use this command to connect to database "cody_management":
                                                                                                                   
psql -U operatoraccess-a55c85@sams-dev-bfec.iam -d cody_management -h 127.0.0.1 -p 5433                            

⚠️ The current session will terminate in 300 seconds. Use '-session.timeout' to increase the session duration.
  [cloud-sql-proxy] 2024/03/11 03:35:04 Impersonating service account with Application Default Credentials
  [cloud-sql-proxy] 2024/03/11 03:35:05 [sams-dev-bfec:us-central1:postgresql-26ca] Listening on 127.0.0.1:5433
  [cloud-sql-proxy] 2024/03/11 03:35:05 The proxy has started successfully and is ready for new connections!
^C  [cloud-sql-proxy] 2024/03/11 03:35:06 SIGINT signal received. Shutting down...
```