### PR TITLE
msp/operationdocs: link to msp repo setup

### DIFF
--- a/dev/managedservicesplatform/operationdocs/operationdocs.go
+++ b/dev/managedservicesplatform/operationdocs/operationdocs.go
@@ -66,6 +66,9 @@ This service is operated on the %s.`,
 		s.Service.GetName(),
 		markdown.Link("Managed Services Platform (MSP)", mspURL))
 
+	md.Admonitionf(markdown.AdmonitionImportant, "If this is your first time here, you should follow the %s as well to set up the prerequisite tooling.",
+		markdown.Link("sourcegraph/managed-services README", "https://github.com/sourcegraph/managed-services/blob/main/README.md"))
+
 	md.Paragraphf("If you need assistance with MSP infrastructure, reach out to the %s team in #discuss-core-services.",
 		markdown.Link("Core Services", coreServicesURL))
 

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/basic.golden
@@ -7,6 +7,9 @@ Generated from: unknown revision of https://github.com/sourcegraph/managed-servi
 This document describes operational guidance for msp-testbed infrastructure.
 This service is operated on the [Managed Services Platform (MSP)](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform/).
 
+> [!IMPORTANT]
+> If this is your first time here, you should follow the [sourcegraph/managed-services README](https://github.com/sourcegraph/managed-services/blob/main/README.md) as well to set up the prerequisite tooling.
+
 If you need assistance with MSP infrastructure, reach out to the [Core Services](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/) team in #discuss-core-services.
 
 ## Service overview

--- a/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
+++ b/dev/managedservicesplatform/operationdocs/testdata/TestRender/resources.golden
@@ -7,6 +7,9 @@ Generated from: unknown revision of https://github.com/sourcegraph/managed-servi
 This document describes operational guidance for msp-testbed infrastructure.
 This service is operated on the [Managed Services Platform (MSP)](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/managed-services/platform/).
 
+> [!IMPORTANT]
+> If this is your first time here, you should follow the [sourcegraph/managed-services README](https://github.com/sourcegraph/managed-services/blob/main/README.md) as well to set up the prerequisite tooling.
+
 If you need assistance with MSP infrastructure, reach out to the [Core Services](https://handbook.sourcegraph.com/departments/engineering/teams/core-services/) team in #discuss-core-services.
 
 ## Service overview


### PR DESCRIPTION
Link to more explicit setup docs in https://github.com/sourcegraph/managed-services/pull/745 for first-time users so that subsequent steps make sense

## Test plan

https://github.com/sourcegraph/handbook/pull/8693