### PR TITLE
client: Quote language name in code nav search queries

### DIFF
--- a/client/web/src/enterprise/codeintel/searchBased.ts
+++ b/client/web/src/enterprise/codeintel/searchBased.ts
@@ -62,7 +62,7 @@ export function referencesQuery({
 
 function languageFilter(languages: string[], path: string): string[] {
     if (languages.length > 0) {
-        return ['(', languages.map(language => `lang:${language}`).join(' OR '), ')']
+        return ['(', languages.map(language => `lang:"${language}"`).join(' OR '), ')']
     }
     const extension = extname(path).slice(1)
     if (extension === '') {


### PR DESCRIPTION
Language names can contain spaces, and because we don't have a typed API,
I made the mistake of directly concatenating the language name string to `lang:`,
which caused an incorrect search query to be sent for code nav for `Protocol Buffers`,
resulting in 0 code nav results.

Fixes https://github.com/sourcegraph/customer/issues/2882

## Test plan

Manually confirmed that quoting fixes the issue.

![CleanShot 2024-03-11 at 14 44 35@2x](https://github.com/sourcegraph/sourcegraph/assets/93103176/ec6fc9c4-825f-4215-b285-668e7b56f3aa)
