### PR TITLE
Github Acionts: update workflows to use go 1.22

### DIFF
--- a/.github/workflows/buildchecker-history.yml
+++ b/.github/workflows/buildchecker-history.yml
@@ -17,8 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
-        with: { go-version: '1.21' }
+      - uses: actions/setup-go@v4
+        with: { go-version: '1.22' }
 
       - run: ./dev/buildchecker/run-week-history.sh
         env:

--- a/.github/workflows/buildchecker.yml
+++ b/.github/workflows/buildchecker.yml
@@ -17,8 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v2
-        with: { go-version: '1.21' }
+      - uses: actions/setup-go@v4
+        with: { go-version: '1.22' }
       - run: ./dev/buildchecker/run-check.sh
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOBUILDSHERRIF_GITHUB_TOKEN }}

--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           ruby-version: "3.2.2" # Not needed with a .ruby-version file   - uses: actions/setup-ruby@v1
       - uses: actions/setup-go@v2
-        with: { go-version: "1.21" }
+        with: { go-version: "1.22" }
 
 
       - name: Install license_finder

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           repository: 'sourcegraph/pr-auditor'
       - uses: actions/setup-go@v4
-        with: { go-version: '1.21' }
+        with: { go-version: '1.22' }
 
       - run: './check-pr.sh'
         env:

--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -98,9 +98,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.21.4
+        uses: actions/setup-go@v4
+        with: { go-version: '1.22' }
 
       - name: Build and upload macOS
         if: startsWith(matrix.os, 'macos-') == true

--- a/.github/workflows/sg-setup.yml
+++ b/.github/workflows/sg-setup.yml
@@ -22,9 +22,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.21.4
+        uses: actions/setup-go@v4
+        with: { go-version: '1.22' }
 
       - name: Install asdf plugins
         uses: asdf-vm/actions/install@v1


### PR DESCRIPTION
Let Github workflows use the new go version
## Test plan
Github Actions
