### PR TITLE
Removed unused bazel macro arg

### DIFF
--- a/client/build-config/BUILD.bazel
+++ b/client/build-config/BUILD.bazel
@@ -55,5 +55,4 @@ npm_package(
         "package.json",
         ":build-config_lib",
     ],
-    type = "commonjs",
 )

--- a/dev/defs.bzl
+++ b/dev/defs.bzl
@@ -90,7 +90,6 @@ def npm_package(name, srcs = [], **kwargs):
         **kwargs: Additional arguments to pass to npm_package
     """
     replace_prefixes = kwargs.pop("replace_prefixes", {})
-    package_type = kwargs.pop("type", "commonjs")
 
     # Modifications to package.json
     # TODO(bazel): remove when package.json can be updated in source

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -987,6 +987,8 @@ commands:
 bazelCommands:
   blobstore:
     target: //cmd/blobstore
+    env:
+      BLOBSTORE_DATA_DIR: $HOME/.sourcegraph-dev/data/blobstore-go
   cody-gateway:
     target: //cmd/cody-gateway
     env:


### PR DESCRIPTION
The `npm_package` macro had an unused argument that it was silently dropping before passing on, making any call site that used very misleading. Also fixed a small bug with running blobstore through bazel.

## Test plan
Ran `bazel test //...`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
