### PR TITLE
svelte: Enable autofocus on search homepage

### DIFF
--- a/client/web-sveltekit/package.json
+++ b/client/web-sveltekit/package.json
@@ -65,7 +65,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@melt-ui/svelte": "^0.66.2",
+    "@melt-ui/svelte": "^0.76.0",
     "@popperjs/core": "^2.11.8",
     "@sourcegraph/branded": "workspace:*",
     "@sourcegraph/client-api": "workspace:*",

--- a/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
+++ b/client/web-sveltekit/src/lib/search/BaseQueryInput.svelte
@@ -54,6 +54,7 @@
     import { multiline, parseInputAsQuery, searchInputEventHandlers, toSingleLine } from '$lib/branded'
     import type { SearchPatternType } from '$lib/graphql-operations'
     import { createCompartments } from '$lib/codemirror/utils'
+    import { afterNavigate } from '$app/navigation'
 
     export let value: string
     export let patternType: SearchPatternType
@@ -127,10 +128,19 @@
             staticExtensions,
         ])
 
-        if (autoFocus) {
-            window.requestAnimationFrame(() => view!.focus())
+        // This is only run once when the view is created
+        if (view && autoFocus) {
+            view.focus()
         }
     }
+
+    afterNavigate(() => {
+        // We also set focus after navigation because SvelteKit resets the focus
+        // when navigating to a new page.
+        if (autoFocus) {
+            view?.focus()
+        }
+    })
 </script>
 
 {#if browser}

--- a/client/web-sveltekit/src/routes/+layout.ts
+++ b/client/web-sveltekit/src/routes/+layout.ts
@@ -1,4 +1,4 @@
-import { error } from '@sveltejs/kit'
+import { error, redirect } from '@sveltejs/kit'
 
 import { browser } from '$app/environment'
 import { isErrorLike, parseJSONCOrError } from '$lib/common'
@@ -26,6 +26,11 @@ if (browser) {
 export const load: LayoutLoad = async ({ fetch }) => {
     const client = getGraphQLClient()
     const result = await client.query(Init, {}, { fetch, requestPolicy: 'network-only' })
+    if (result.error?.response?.status === 401) {
+        // The server will take care of redirecting to the sign-in page, but when
+        // developing locally an proxying the API requests, we need to do it ourselves.
+        redirect(307, '/sign-in')
+    }
     if (!result.data || result.error) {
         error(500, `Failed to initialize app: ${result.error}`)
     }

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql
@@ -34,7 +34,13 @@ fragment BlobPage_Blob on GitBlob {
     languages
 }
 
-query BlobSyntaxHighlightQuery($repoName: String!, $revspec: String!, $path: String!, $disableTimeout: Boolean!, $format: HighlightResponseFormat = JSON_SCIP) {
+query BlobSyntaxHighlightQuery(
+    $repoName: String!
+    $revspec: String!
+    $path: String!
+    $disableTimeout: Boolean!
+    $format: HighlightResponseFormat = JSON_SCIP
+) {
     repository(name: $repoName) {
         id
         commit(rev: $revspec) {

--- a/client/web-sveltekit/src/routes/search/SearchHome.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchHome.svelte
@@ -20,7 +20,7 @@
     <div class="content">
         <img class="logo" src={$isLightTheme ? logoLight : logoDark} alt="Sourcegraph Logo" />
         <div class="search">
-            <SearchInput {queryState} />
+            <SearchInput {queryState} autoFocus />
         </div>
     </div>
 </section>

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -1,5 +1,18 @@
 import { test, expect } from '../../testing/integration'
 
+test('search input is autofocused', async ({ page }) => {
+    await page.goto('/search')
+    const searchInput = page.getByRole('textbox')
+    const suggestions = page.getByLabel('Narrow your search')
+    await expect(searchInput).toBeFocused()
+
+    // Doesn't show suggestions without user interaction
+    await expect(suggestions).not.toBeVisible()
+
+    await searchInput.click()
+    await expect(suggestions).toBeVisible()
+})
+
 test('shows suggestions', async ({ sg, page }) => {
     await page.goto('/search')
     const searchInput = page.getByRole('textbox')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1388,8 +1388,8 @@ importers:
   client/web-sveltekit:
     dependencies:
       '@melt-ui/svelte':
-        specifier: ^0.66.2
-        version: 0.66.2(svelte@4.1.1)
+        specifier: ^0.76.0
+        version: 0.76.0(svelte@4.1.1)
       '@popperjs/core':
         specifier: ^2.11.8
         version: 2.11.8
@@ -5591,8 +5591,8 @@ packages:
       react: 18.1.0
     dev: true
 
-  /@melt-ui/svelte@0.66.2(svelte@4.1.1):
-    resolution: {integrity: sha512-ufIhgOYP11A/G3AvW+2Qw74UGudMBJQ2wK+sETpU51VkC63/5D2sctKgXzGl0OUEJBlPHku6LRSry9rIeAVkNw==}
+  /@melt-ui/svelte@0.76.0(svelte@4.1.1):
+    resolution: {integrity: sha512-X1ktxKujjLjOBt8LBvfckHGDMrkHWceRt1jdsUTf0EH76ikNPP1ofSoiV0IhlduDoCBV+2YchJ8kXCDfDXfC9Q==}
     peerDependencies:
       svelte: '>=3 <5'
     dependencies:
@@ -5601,7 +5601,7 @@ packages:
       '@internationalized/date': 3.5.1
       dequal: 2.0.3
       focus-trap: 7.5.2
-      nanoid: 4.0.2
+      nanoid: 5.0.6
       svelte: 4.1.1
     dev: false
 
@@ -19829,9 +19829,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  /nanoid@4.0.2:
-    resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
-    engines: {node: ^14 || ^16 || >=18}
+  /nanoid@5.0.6:
+    resolution: {integrity: sha512-rRq0eMHoGZxlvaFOUdK1Ev83Bd1IgzzR+WJ3IbDJ7QOSdAxYjlurSPqFs9s4lJg29RT6nPwizFtJhQS6V5xgiA==}
+    engines: {node: ^18 || >=20}
     hasBin: true
     dev: false
 


### PR DESCRIPTION
Closes #60836 

This enables autofocus on the search homepage in a similar way as was done in the React version.

Some additional changes:

- `@melt-ui/svelte` was update to the latest version to bring in a focus bugfix. This bug caused focus to be stolen from other elements when dropdown menus were mounted. This prevent the autofocusing the search input.
- `afterNavigate` is used to focus the element, as suggested in the SvelteKit documentation. We also focus it after the input is created, in case it's used in a situation where the input is shown in response to some other user interaction.
- Some refactoring of the search input component to avoid unnecessarily recreating extensions.



## Test plan

Manual testing and new playwright test
