### PR TITLE
ci: annotate with pushed images 

### DIFF
--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -101,7 +101,15 @@ func bazelPushImagesCmd(version string, isCandidate bool, opts ...bk.StepOpt) fu
 				bk.Env("PUSH_VERSION", version),
 				bk.Env("CANDIDATE_ONLY", candidate),
 				bk.Cmd(bazelStampedCmd(`build $$(bazel query 'kind("oci_push rule", //...)')`)),
-				bk.Cmd("./dev/ci/push_all.sh"),
+				bk.AnnotatedCmd(
+					"./dev/ci/push_all.sh",
+					bk.AnnotatedCmdOpts{
+						Annotations: &bk.AnnotationOpts{
+							Type:         bk.AnnotationTypeInfo,
+							IncludeNames: false,
+						},
+					},
+				),
 			)...,
 		)
 	}

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -41,6 +41,10 @@ function create_push_command() {
     --workspace_status_command=./dev/bazel_stamp_vars.sh"
 
   echo "$cmd -- $tags_args $repositories_args"
+
+  for registry in "${registries[@]}"; do
+    echo -e "| ${repository} | \`${registry}\` | \`${tags_args}\` |" >>./annotations/pushed_images.md
+  done
 }
 
 dev_registries=(
@@ -105,6 +109,9 @@ if [ -n "$CANDIDATE_ONLY" ]; then
   push_prod=false
 fi
 
+
+echo -e "## Pushed images" > ./annotations/image_promotions.md
+echo -e "\n| Name | Registry | Tags |\n|---|---|---|" >> ./annotations/image_promotions.md
 preview_tags "${dev_registries[*]}" "${dev_tags[*]}"
 if $push_prod; then
   preview_tags "${prod_registries[*]}" "${prod_tags[*]}"


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/devx-support/issues/630

Basically, when we are pushing container images, the output is very verbose, which in for a few containers for msp is a quite annoying to deal with. 

We now have an annotation, which sums it up nicely: 

![CleanShot 2024-03-11 at 16 22 11@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/79e6010c-c1f7-41bb-8c2d-5b1c605c124c)


## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
