### PR TITLE
Include traceID in blocked responses

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -149,7 +149,7 @@ func (a *AnthropicHandlerMethods) validateRequest(ctx context.Context, logger lo
 			logger.Warn("failed to record flagged prompt", log.Error(err))
 		}
 		if a.config.RequestBlockingEnabled && result.shouldBlock {
-			return http.StatusBadRequest, result, errors.Errorf("request blocked - if you think this is a mistake, please contact support@sourcegraph.com")
+			return http.StatusBadRequest, result, requestBlockedError(ctx)
 		}
 		return 0, result, nil
 	}

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
@@ -179,7 +179,7 @@ func (a *AnthropicMessagesHandlerMethods) validateRequest(ctx context.Context, l
 			logger.Warn("failed to record flagged prompt", log.Error(err))
 		}
 		if a.config.RequestBlockingEnabled && result.shouldBlock {
-			return http.StatusBadRequest, result, errors.Errorf("request blocked - if you think this is a mistake, please contact support@sourcegraph.com")
+			return http.StatusBadRequest, result, requestBlockedError(ctx)
 		}
 		return 0, result, nil
 	}

--- a/cmd/cody-gateway/internal/httpapi/completions/flagging.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/flagging.go
@@ -1,9 +1,11 @@
 package completions
 
 import (
+	"context"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/tokenizer"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
@@ -98,4 +100,10 @@ func containsAny(prompt string, patterns []string) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+// requestBlockedError returns an error indicating that the request was blocked, including the trace ID.
+func requestBlockedError(ctx context.Context) error {
+	traceID := trace.FromContext(ctx).SpanContext().TraceID().String()
+	return errors.Errorf("request blocked - if you think this is a mistake, please contact support@sourcegraph.com and reference this ID: %s", traceID)
 }


### PR DESCRIPTION
Include traceID in blocked responses to simplify debugging - [Slack](https://sourcegraph.slack.com/archives/C1JH2BEHZ/p1710175075643709).

## Test plan

- tested locally
- e2e tests