### PR TITLE
bazel: patch rules_oci to run tar with --no-xattrs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,6 +114,10 @@ http_archive(
 # Container rules
 http_archive(
     name = "rules_oci",
+    patch_args = ["-p1"],
+    patches = [
+        "//third_party/rules_oci:no_xattr.patch",
+    ],
     sha256 = "d41d0ba7855f029ad0e5ee35025f882cbe45b0d5d570842c52704f7a47ba8668",
     strip_prefix = "rules_oci-1.4.3",
     url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.4.3/rules_oci-v1.4.3.tar.gz",

--- a/third_party/rules_oci/BUILD.bazel
+++ b/third_party/rules_oci/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/third_party/rules_oci/no_xattr.patch
+++ b/third_party/rules_oci/no_xattr.patch
@@ -1,0 +1,10 @@
+diff --git a/oci/private/tarball.sh.tpl b/oci/private/tarball.sh.tpl
+index 2b5052f..d22fef3 100644
+--- a/oci/private/tarball.sh.tpl
++++ b/oci/private/tarball.sh.tpl
+@@ -137,4 +137,4 @@ layers="${LAYERS}" \
+         --output-format json > "${STAGING_DIR}/manifest.json"
+
+ # TODO: https://github.com/bazel-contrib/rules_oci/issues/217
+-tar -C "${STAGING_DIR}" -cf "${TARBALL_PATH}" manifest.json blobs
++tar --no-xattrs -C "${STAGING_DIR}" -cf "${TARBALL_PATH}" manifest.json blobs


### PR DESCRIPTION
Workaround for https://github.com/sourcegraph/devx-support/issues/622. This is portable between both bsdtar and gnutar. On gnutar, this is the default, so this changes nothing for CI builds. This only changes behaviour in macOS with bsdtar.

It is unclear to me where a final solution will exist:
- An issue was opened upstream in docker/moby, but the latest opinion is that this is an issue with rules_oci _technically_ emitting docker-compatible formats that are incompatible with docker (Im not 100% sure yet that docker itself cant create a tarball that would fail to `docker load`, but I dont want to subject Christoph to more experiments lol) https://github.com/moby/moby/issues/47517
- A PR exists in rules_oci to use a hermetic BSD tar instead of system tar (doesnt work on nixos though coz dynamic libraries :sadge:). It uses `mtree` format to add files, I don't know yet if that works around xattr issue without also passing `--no-xattr` (my current belief is that it does not)  https://github.com/bazel-contrib/rules_oci/pull/385

## Test plan

Had Christoph run `bazel run //cmd/batcheshelper:image_tarball`, which succeeded with this patch