### PR TITLE
oidc: Rename singleProvider property to singleIdentityPerUser

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -33,9 +33,9 @@ type GetAndSaveUserOp struct {
 	ExternalAccountData extsvc.AccountData
 	CreateIfNotExist    bool
 	LookUpByUsername    bool
-	// SingleProvider indicates that the provider should only allow to
+	// SingleIdentityPerUser indicates that the provider should only allow to
 	// connect a single external identity per user.
-	SingleProvider bool
+	SingleIdentityPerUser bool
 }
 
 // GetAndSaveUser accepts authentication information associated with a given user, validates and applies
@@ -255,12 +255,13 @@ func GetAndSaveUser(ctx context.Context, db database.DB, op GetAndSaveUserOp) (n
 		return newUserSaved, 0, safeErrMsg, err
 	}
 
-	if op.SingleProvider && !extAcctSaved {
+	if op.SingleIdentityPerUser && !extAcctSaved {
 		// If we're here, the user has already signed up before this request,
 		// but has no entry for this exact accountID in the user external accounts
 		// table yet.
-		// In single provider mode, we want to attach a new external account
-		// only if no other identity for the same user already exists.
+		// In single identity mode, we want to attach a new external account
+		// only if no other identity of the same provider for the same user already
+		// exists.
 		other, err := externalAccountsStore.List(ctx, database.ExternalAccountsListOptions{
 			UserID:      userID,
 			ServiceType: acct.ServiceType,

--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -313,11 +313,11 @@ func TestGetAndSaveUser(t *testing.T) {
 				expNewUserCreated:                false,
 			},
 			{
-				description: "single provider rejects multiple external identities from same provider",
+				description: "single identity per user mode rejects multiple external identities from same provider",
 				op: GetAndSaveUserOp{
-					ExternalAccount: ext("st1", "s1", "c1", "s1/u1-new"),
-					UserProps:       userProps("u1", "u1@example.com"), // This user exists in the DB already and has an external account for st1, s1, c1
-					SingleProvider:  true,
+					ExternalAccount:       ext("st1", "s1", "c1", "s1/u1-new"),
+					UserProps:             userProps("u1", "u1@example.com"), // This user exists in the DB already and has an external account for st1, s1, c1
+					SingleIdentityPerUser: true,
 				},
 				createIfNotExistIrrelevant:       true,
 				expSafeErr:                       "Another identity for this user from this provider already exists. Remove the link to the other identity from your account.",

--- a/cmd/frontend/internal/auth/openidconnect/user.go
+++ b/cmd/frontend/internal/auth/openidconnect/user.go
@@ -97,9 +97,9 @@ func getOrCreateUser(ctx context.Context, db database.DB, p *Provider, token *oa
 			ClientID:    pi.ClientID,
 			AccountID:   idToken.Subject,
 		},
-		ExternalAccountData: data,
-		CreateIfNotExist:    p.config.AllowSignup == nil || *p.config.AllowSignup,
-		SingleProvider:      p.config.SingleIdentityProvider,
+		ExternalAccountData:   data,
+		CreateIfNotExist:      p.config.AllowSignup == nil || *p.config.AllowSignup,
+		SingleIdentityPerUser: p.config.SingleIdentityPerUser,
 	})
 	if err != nil {
 		return false, nil, safeErrMsg, err

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1904,9 +1904,9 @@ type OpenIDConnectAuthProvider struct {
 	Order  int    `json:"order,omitempty"`
 	// RequireEmailDomain description: Only allow users to authenticate if their email domain is equal to this value (example: mycompany.com). Do not include a leading "@". If not set, all users on this OpenID Connect provider can authenticate to Sourcegraph.
 	RequireEmailDomain string `json:"requireEmailDomain,omitempty"`
-	// SingleIdentityProvider description: When true, any user can connect exactly one identity from the identity provider.
-	SingleIdentityProvider bool   `json:"singleIdentityProvider,omitempty"`
-	Type                   string `json:"type"`
+	// SingleIdentityPerUser description: When true, any user can connect exactly one identity from the identity provider.
+	SingleIdentityPerUser bool   `json:"singleIdentityPerUser,omitempty"`
+	Type                  string `json:"type"`
 }
 
 // OpenTelemetry description: Configuration for the client OpenTelemetry exporter

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -3114,7 +3114,7 @@
             "pointer": true
           }
         },
-        "singleIdentityProvider": {
+        "singleIdentityPerUser": {
           "description": "When true, any user can connect exactly one identity from the identity provider.",
           "type": "boolean",
           "default": false


### PR DESCRIPTION
This has not been used anywhere yet and I've gotten feedback that the name was confusing. So changing it here.

## Test plan

Existing test suites, code review.
