### PR TITLE
Chore: remove Own from global navbar

### DIFF
--- a/client/web/src/LegacyLayout.tsx
+++ b/client/web/src/LegacyLayout.tsx
@@ -230,7 +230,6 @@ export const LegacyLayout: FC<LegacyLayoutProps> = props => {
                             showSearchBox={showNavigationSearchBox}
                             authenticatedUser={props.authenticatedUser}
                             isSourcegraphDotCom={props.isSourcegraphDotCom}
-                            ownEnabled={props.ownEnabled}
                             notebooksEnabled={props.notebooksEnabled}
                             searchContextsEnabled={props.searchContextsEnabled}
                             codeMonitoringEnabled={props.codeMonitoringEnabled}

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -147,7 +147,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
     const showSearchContext = searchContextsEnabled && !isSourcegraphDotCom && !disableCodeSearchFeatures
     const showCodeMonitoring = codeMonitoringEnabled && !isSourcegraphDotCom && !disableCodeSearchFeatures
     const showSearchNotebook = notebooksEnabled && !isSourcegraphDotCom && !disableCodeSearchFeatures
-    const showOwn = ownEnabled && !disableCodeSearchFeatures
     const showSearchJobs = isSearchJobsEnabled() && !disableCodeSearchFeatures
     const showBatchChanges =
         props.batchChangesEnabled && isLicensed && !isSourcegraphDotCom && !disableCodeSearchFeatures
@@ -190,7 +189,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
                 <InlineNavigationPanel
                     authenticatedUser={props.authenticatedUser}
                     showSearchContext={showSearchContext}
-                    showOwn={showOwn}
                     showCodySearch={codySearchEnabled}
                     showSearchJobs={showSearchJobs}
                     showSearchNotebook={showSearchNotebook}
@@ -278,7 +276,6 @@ export const GlobalNavbar: React.FunctionComponent<React.PropsWithChildren<Globa
 
 export interface InlineNavigationPanelProps {
     showSearchContext: boolean
-    showOwn: boolean
     showCodySearch: boolean
     showSearchJobs: boolean
     showSearchNotebook: boolean
@@ -296,7 +293,6 @@ export interface InlineNavigationPanelProps {
 export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
     const {
         showSearchContext,
-        showOwn,
         showCodySearch,
         showSearchJobs,
         showSearchNotebook,
@@ -320,7 +316,6 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
             // We hardcode the code monitoring path here because PageRoutes.CodeMonitoring is a catch-all
             // path for all code monitoring sub links.
             showCodeMonitoring && { path: '/code-monitoring', content: 'Monitoring' },
-            showOwn && { path: PageRoutes.Own, content: 'Code ownership' },
             showCodySearch && {
                 path: PageRoutes.CodySearch,
                 content: (
@@ -339,7 +334,7 @@ export const InlineNavigationPanel: FC<InlineNavigationPanelProps> = props => {
             },
         ]
         return items.filter<NavDropdownItem>((item): item is NavDropdownItem => !!item)
-    }, [showOwn, showSearchContext, showCodySearch, showSearchJobs, showCodeMonitoring, showSearchNotebook])
+    }, [showSearchContext, showCodySearch, showSearchJobs, showCodeMonitoring, showSearchNotebook])
 
     const searchNavigation =
         searchNavBarItems.length > 0 ? (

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.story.tsx
@@ -26,7 +26,6 @@ export const NewGlobalNavigationBarDemo: StoryFn = () => (
     <NewGlobalNavigationBar
         routes={[]}
         isSourcegraphDotCom={true}
-        ownEnabled={true}
         notebooksEnabled={true}
         searchContextsEnabled={true}
         codeMonitoringEnabled={true}

--- a/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
+++ b/client/web/src/nav/new-global-navigation/NewGlobalNavigationBar.tsx
@@ -33,7 +33,6 @@ import styles from './NewGlobalNavigationBar.module.scss'
 interface NewGlobalNavigationBar extends TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean
-    ownEnabled: boolean
     notebooksEnabled: boolean
     searchContextsEnabled: boolean
     codeMonitoringEnabled: boolean
@@ -52,7 +51,6 @@ interface NewGlobalNavigationBar extends TelemetryProps {
 export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
     const {
         isSourcegraphDotCom,
-        ownEnabled,
         notebooksEnabled,
         searchContextsEnabled,
         codeMonitoringEnabled,
@@ -72,7 +70,6 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
 
     // Features enablement flags and conditions
     const isLicensed = !!window.context?.licenseInfo
-    const showOwn = ownEnabled
     const showSearchContext = searchContextsEnabled && !isSourcegraphDotCom
     const [showCodySearch] = useFeatureFlag('cody-web-search')
     const showSearchJobs = isSearchJobsEnabled()
@@ -112,7 +109,6 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
                 ) : (
                     <InlineNavigationPanel
                         showSearchContext={showSearchContext}
-                        showOwn={showOwn}
                         showCodySearch={showCodySearch}
                         authenticatedUser={authenticatedUser}
                         showSearchJobs={showSearchJobs}
@@ -143,7 +139,6 @@ export const NewGlobalNavigationBar: FC<NewGlobalNavigationBar> = props => {
             {isSideMenuOpen && (
                 <SidebarNavigation
                     showSearchContext={showSearchContext}
-                    showOwn={showOwn}
                     showCodySearch={showCodySearch}
                     showSearchJobs={showSearchJobs}
                     showSearchNotebook={showSearchNotebook}
@@ -291,7 +286,6 @@ const SignInUpButtons: FC<SignInUpButtonsProps> = props => {
 interface SidebarNavigationProps {
     isSourcegraphDotCom: boolean
     showSearchContext: boolean
-    showOwn: boolean
     showCodySearch: boolean
     showSearchJobs: boolean
     showSearchNotebook: boolean
@@ -305,7 +299,6 @@ interface SidebarNavigationProps {
 const SidebarNavigation: FC<SidebarNavigationProps> = props => {
     const {
         showSearchContext,
-        showOwn,
         showCodySearch,
         showSearchJobs,
         showSearchNotebook,
@@ -354,13 +347,11 @@ const SidebarNavigation: FC<SidebarNavigationProps> = props => {
                                     Context
                                 </NavItemLink>
                             )}
-                            {showOwn && <NavItemLink url={PageRoutes.Own}>Code ownership</NavItemLink>}
                             {showSearchNotebook && (
                                 <NavItemLink url={PageRoutes.Notebooks} onClick={handleNavigationClick}>
                                     Notebooks
                                 </NavItemLink>
                             )}
-
                             {showCodeMonitoring && (
                                 <NavItemLink url="/code-monitoring" onClick={handleNavigationClick}>
                                     Code Monitoring


### PR DESCRIPTION
We've removed "Own" as a named product, and have moved towards incorporating its features into the Code Search feature set. As such, we no longer need a link in the global nav bar to a landing page that doesn't exist.

## Test plan

Ran it locally, "Code ownership" no longer exists in the dropdown.