### PR TITLE
Simplify goroutine params

### DIFF
--- a/cmd/executor/internal/worker/cmdlogger/logger.go
+++ b/cmd/executor/internal/worker/cmdlogger/logger.go
@@ -110,11 +110,10 @@ func (l *logger) writeEntries() {
 		)
 
 		wg.Add(1)
-		go func(handle *entryHandle, entryID int, initialLogEntry internalexecutor.ExecutionLogEntry) {
+		go func() {
 			defer wg.Done()
-
 			l.syncLogEntry(handle, entryID, initialLogEntry)
-		}(handle, entryID, initialLogEntry)
+		}()
 	}
 
 	wg.Wait()

--- a/cmd/frontend/graphqlbackend/observability.go
+++ b/cmd/frontend/graphqlbackend/observability.go
@@ -43,10 +43,10 @@ func (r *schemaResolver) TriggerObservabilityTestAlert(ctx context.Context, args
 	metric.With(nil).Set(1)
 
 	// reset the metric after some amount of time
-	go func(m *prometheus.GaugeVec) {
+	go func() {
 		time.Sleep(1 * time.Minute)
-		m.With(nil).Set(0)
-	}(metric)
+		metric.With(nil).Set(0)
+	}()
 
 	return &EmptyResponse{}, nil
 }

--- a/cmd/frontend/internal/auth/openidconnect/config.go
+++ b/cmd/frontend/internal/auth/openidconnect/config.go
@@ -85,11 +85,11 @@ func Init() {
 			}
 
 			for _, p := range ps {
-				go func(p providers.Provider) {
+				go func() {
 					if err := p.Refresh(context.Background()); err != nil {
 						logger.Error("Error prefetching OpenID Connect service provider metadata.", log.Error(err))
 					}
-				}(p)
+				}()
 			}
 			providers.Update(pkgName, ps)
 		})

--- a/cmd/frontend/internal/auth/saml/config.go
+++ b/cmd/frontend/internal/auth/saml/config.go
@@ -85,11 +85,11 @@ func Init() {
 			}
 
 			for _, p := range ps {
-				go func(p providers.Provider) {
+				go func() {
 					if err := p.Refresh(context.Background()); err != nil {
 						logger.Error("Error prefetching SAML service provider metadata.", log.Error(err))
 					}
-				}(p)
+				}()
 			}
 			providers.Update(pkgName, ps)
 		})

--- a/cmd/gitserver/internal/server.go
+++ b/cmd/gitserver/internal/server.go
@@ -394,7 +394,7 @@ func (p *clonePipelineRoutine) cloneJobConsumer(ctx context.Context, tasks <-cha
 			continue
 		}
 
-		go func(task *cloneTask) {
+		go func() {
 			defer cancel()
 
 			err := p.s.doClone(ctx, task.repo, task.dir, task.syncer, task.lock, task.remoteURL, task.options)
@@ -404,7 +404,7 @@ func (p *clonePipelineRoutine) cloneJobConsumer(ctx context.Context, tasks <-cha
 			// Use a different context in case we failed because the original context failed.
 			p.s.setLastErrorNonFatal(p.s.ctx, task.repo, err)
 			_ = task.done()
-		}(task)
+		}()
 	}
 }
 

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -61,13 +61,13 @@ func run(logger log.Logger) error {
 	for {
 		for _, v := range searchQueries {
 			<-ticker.C
-			go func(v GQLSearchVars) {
+			go func() {
 				if count, err := search(v); err != nil {
 					logger.Error("Error issuing search query", log.String("query", v.Query), log.Error(err))
 				} else {
 					logger.Info("Search results", log.String("query", v.Query), log.Int("matchCount", count))
 				}
-			}(v)
+			}()
 		}
 	}
 }

--- a/cmd/repo-updater/internal/scheduler/scheduler.go
+++ b/cmd/repo-updater/internal/scheduler/scheduler.go
@@ -171,7 +171,7 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 
 			subLogger := s.logger.Scoped("RunUpdateLoop")
 
-			go func(ctx context.Context, repo configuredRepo, cancel context.CancelFunc) {
+			go func() {
 				defer cancel()
 				defer s.updateQueue.remove(repo, true)
 
@@ -209,7 +209,7 @@ func (s *UpdateScheduler) runUpdateLoop(ctx context.Context) {
 					interval := resp.LastFetched.Sub(*resp.LastChanged) / 2
 					s.schedule.updateInterval(repo, interval)
 				}
-			}(ctx, repo, cancel)
+			}()
 		}
 	}
 }

--- a/cmd/server/internal/goreman/proc.go
+++ b/cmd/server/internal/goreman/proc.go
@@ -135,10 +135,10 @@ func stopProcs(kill bool) {
 	var wg sync.WaitGroup
 	for _, proc := range names() {
 		wg.Add(1)
-		go func(proc string) {
+		go func() {
 			defer wg.Done()
 			_ = stopProc(proc, kill)
-		}(proc)
+		}()
 	}
 	wg.Wait()
 }

--- a/cmd/worker/internal/executorqueue/external_emitter.go
+++ b/cmd/worker/internal/executorqueue/external_emitter.go
@@ -50,10 +50,10 @@ func runParallel(fns []func()) {
 	wg.Add(len(fns))
 
 	for _, fn := range fns {
-		go func(fn func()) {
+		go func() {
 			defer wg.Done()
 			fn()
-		}(fn)
+		}()
 	}
 
 	wg.Wait()

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -343,7 +343,7 @@ func runRoutinesConcurrently(observationCtx *observation.Context, jobs map[strin
 		wg.Add(1)
 		jobLogger.Debug("Running job")
 
-		go func(name string) {
+		go func() {
 			defer wg.Done()
 
 			routines, err := jobs[name].Routines(ctx, observationCtx)
@@ -361,7 +361,7 @@ func runRoutinesConcurrently(observationCtx *observation.Context, jobs map[strin
 			} else {
 				cancel()
 			}
-		}(name)
+		}()
 	}
 
 	wg.Wait()

--- a/dev/codeintel-qa/cmd/upload/upload.go
+++ b/dev/codeintel-qa/cmd/upload/upload.go
@@ -44,7 +44,7 @@ func uploadAll(ctx context.Context, extensionAndCommitsByRepo map[string][]inter
 
 			wg.Add(1)
 
-			go func(repoName, commit, file string) {
+			go func(file string) {
 				defer wg.Done()
 
 				if err := limiter.Acquire(ctx); err != nil {
@@ -70,7 +70,7 @@ func uploadAll(ctx context.Context, extensionAndCommitsByRepo map[string][]inter
 					commit:   commit,
 					root:     cleanedRoot,
 				}
-			}(repoName, commit, fmt.Sprintf("%s.%s.%s.%s", strings.Replace(repoName, "/", ".", 1), commit, root, extension))
+			}(fmt.Sprintf("%s.%s.%s.%s", strings.Replace(repoName, "/", ".", 1), commit, root, extension))
 		}
 	}
 

--- a/dev/sg/internal/run/installer.go
+++ b/dev/sg/internal/run/installer.go
@@ -100,7 +100,7 @@ func (installer *InstallManager) start(ctx context.Context) {
 // Starts the installation process in a non-blocking process
 func (installer *InstallManager) install(ctx context.Context, cmds []Installer) {
 	for _, cmd := range cmds {
-		go func(ctx context.Context, cmd Installer) {
+		go func() {
 			// Set the log channel for the installer
 			cmd.SetInstallerOutput(installer.logs)
 
@@ -110,7 +110,7 @@ func (installer *InstallManager) install(ctx context.Context, cmds []Installer) 
 			}
 
 			installer.installed <- cmd.GetName()
-		}(ctx, cmd)
+		}()
 	}
 }
 

--- a/internal/batches/store/changesets_test.go
+++ b/internal/batches/store/changesets_test.go
@@ -2433,7 +2433,7 @@ func TestCancelQueuedBatchChangeChangesets(t *testing.T) {
 
 	// We start this goroutine to simulate the processing of these
 	// changesets to stop after 50ms
-	go func(t *testing.T) {
+	go func() {
 		time.Sleep(50 * time.Millisecond)
 
 		// c5 ends up errored, which would be retried, so it needs to be
@@ -2450,7 +2450,7 @@ func TestCancelQueuedBatchChangeChangesets(t *testing.T) {
 		if err := s.UpdateChangeset(ctx, c6); err != nil {
 			t.Errorf("update changeset failed: %s", err)
 		}
-	}(t)
+	}()
 
 	if err := s.CancelQueuedBatchChangeChangesets(ctx, batchChange.ID); err != nil {
 		t.Fatal(err)
@@ -2618,7 +2618,7 @@ func TestEnqueueChangesetsToClose(t *testing.T) {
 		// sure that we finish it, otherwise the loop in
 		// EnqueueChangesetsToClose will take 2min and then fail.
 		if c.ReconcilerState == btypes.ReconcilerStateProcessing {
-			go func(t *testing.T) {
+			go func() {
 				time.Sleep(50 * time.Millisecond)
 
 				c.ReconcilerState = btypes.ReconcilerStateCompleted
@@ -2626,7 +2626,7 @@ func TestEnqueueChangesetsToClose(t *testing.T) {
 				if err := s.UpdateChangeset(ctx, c); err != nil {
 					t.Errorf("update changeset failed: %s", err)
 				}
-			}(t)
+			}()
 		}
 	}
 

--- a/internal/codeintel/autoindexing/internal/background/scheduler/job_scheduler.go
+++ b/internal/codeintel/autoindexing/internal/background/scheduler/job_scheduler.go
@@ -132,7 +132,7 @@ func (b indexSchedulerJob) handleScheduler(
 		if err := sema.Acquire(ctx, 1); err != nil {
 			return err
 		}
-		go func(repositoryID int) {
+		go func() {
 			defer sema.Release(1)
 			if repositoryErr := b.handleRepository(ctx, repositoryID, policyBatchSize, now); repositoryErr != nil {
 				if !errors.As(err, &inference.LimitError{}) {
@@ -141,7 +141,7 @@ func (b indexSchedulerJob) handleScheduler(
 					errMu.Unlock()
 				}
 			}
-		}(repositoryID)
+		}()
 	}
 
 	if err := sema.Acquire(ctx, int64(inferenceConcurrency)); err != nil {

--- a/internal/database/migration/runner/runner.go
+++ b/internal/database/migration/runner/runner.go
@@ -117,7 +117,7 @@ func (r *Runner) forEachSchema(ctx context.Context, schemaNames []string, visito
 	for _, schemaName := range schemaNames {
 		wg.Add(1)
 
-		go func(schemaName string) {
+		go func() {
 			defer wg.Done()
 
 			errorCh <- visitor(ctx, schemaContext{
@@ -126,7 +126,7 @@ func (r *Runner) forEachSchema(ctx context.Context, schemaNames []string, visito
 				store:                storeMap[schemaName],
 				initialSchemaVersion: versionMap[schemaName],
 			})
-		}(schemaName)
+		}()
 	}
 
 	wg.Wait()

--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -169,7 +169,7 @@ func (s *store) OpenWithPath(ctx context.Context, key []string, fetcher FetcherW
 		err error
 	}
 	ch := make(chan result, 1)
-	go func(ctx context.Context) {
+	go func() {
 		var err error
 		var f *File
 		ctx, trace, endObservation := s.observe.backgroundFetch.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
@@ -184,7 +184,7 @@ func (s *store) OpenWithPath(ctx context.Context, key []string, fetcher FetcherW
 		}
 		f, err = doFetch(ctx, path, fetcher, trace)
 		ch <- result{f, err}
-	}(ctx)
+	}()
 
 	select {
 	case <-ctx.Done():

--- a/internal/grpc/defaults/cache_test.go
+++ b/internal/grpc/defaults/cache_test.go
@@ -57,7 +57,7 @@ func TestCloseGRPCConnectionCallback(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	go func(ctx context.Context) {
+	go func() {
 		for {
 			select {
 			case <-ctx.Done():
@@ -70,7 +70,7 @@ func TestCloseGRPCConnectionCallback(t *testing.T) {
 				}
 			}
 		}
-	}(ctx)
+	}()
 
 	select {
 	case <-ctx.Done():

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -279,7 +279,7 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 		}
 
 		wg.Add(1)
-		go func(q string) {
+		go func() {
 			defer wg.Done()
 
 			next := &bitbucketserver.PageToken{Limit: 1000}
@@ -293,7 +293,7 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 				ch <- batch{repos: repos}
 				next = page
 			}
-		}(q)
+		}()
 	}
 
 	for _, q := range s.config.ProjectKeys {

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -327,7 +327,7 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 
 		const perPage = 100
 		wg.Add(1)
-		go func(projectQuery string) {
+		go func() {
 			defer wg.Done()
 
 			urlStr, err := projectQueryToURL(projectQuery, perPage) // first page URL
@@ -352,7 +352,7 @@ func (s *GitLabSource) listAllProjects(ctx context.Context, results chan SourceR
 				}
 				urlStr = *nextPageURL
 			}
-		}(projectQuery)
+		}()
 	}
 
 	go func() {

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -146,10 +146,10 @@ func (s *HorizontalSearcher) List(ctx context.Context, q query.Q, opts *zoekt.Li
 	}
 	results := make(chan result, len(clients))
 	for _, c := range clients {
-		go func(c zoekt.Streamer) {
+		go func() {
 			rl, err := c.List(ctx, q, opts)
 			results <- result{rl: rl, err: err}
-		}(c)
+		}()
 	}
 
 	// PERF: We don't deduplicate Repos since the only user of List already

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -177,10 +177,10 @@ func GetIndexOptions(
 
 	for i := range repos {
 		sema <- struct{}{}
-		go func(i int) {
+		go func() {
 			defer func() { <-sema }()
 			results[i] = getIndexOptions(c, repos[i], getRepoIndexOptions, getSearchContextRevisions, getSiteConfigRevisions)
-		}(i)
+		}()
 	}
 
 	// Wait for jobs to finish (acquire full semaphore)

--- a/lib/output/output_unix.go
+++ b/lib/output/output_unix.go
@@ -53,14 +53,14 @@ func init() {
 					if err == nil {
 						mu.RLock()
 						for _, out := range chans {
-							go func(out chan capabilities, caps capabilities) {
+							go func() {
 								select {
 								case out <- caps:
 									// success
 								default:
 									// welp
 								}
-							}(out, caps)
+							}()
 						}
 						mu.RUnlock()
 					}


### PR DESCRIPTION
Now that we've updated to Go 1.22, we don't need to copy loop variables before
using them in goroutines.

I found these using the regex searches `go func\(\w+` and `\.Go(func\(\w+`. I
also simplified some non-loop vars when it made sense. 

## Test plan

Straight refactor, covered by existing tests