### PR TITLE
Cleanup Cody Gateway HTTP endpoint registration code

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/handler.go
@@ -76,7 +76,9 @@ func NewHandler(
 	// V1 service routes
 	v1router := r.PathPrefix("/v1").Subrouter()
 
-	if config.Anthropic.AccessToken != "" {
+	if config.Anthropic.AccessToken == "" {
+		logger.Error("Anthropic access token not set. Not registering Anthropic-related endpoints.")
+	} else {
 		anthropicHandler, err := completions.NewAnthropicHandler(
 			logger,
 			eventLogger,
@@ -138,10 +140,11 @@ func NewHandler(
 					otelhttp.WithPublicEndpoint(),
 				),
 			))
-	} else {
-		logger.Error("Anthropic access token not set")
 	}
-	if config.OpenAI.AccessToken != "" {
+
+	if config.OpenAI.AccessToken == "" {
+		logger.Error("OpenAI access token not set. Not registering OpenAI-related endpoints.")
+	} else {
 		v1router.Path("/completions/openai").Methods(http.MethodPost).Handler(
 			overhead.HTTPMiddleware(latencyHistogram,
 				instrumentation.HTTPMiddleware("v1.completions.openai",
@@ -209,10 +212,11 @@ func NewHandler(
 					otelhttp.WithPublicEndpoint(),
 				),
 			))
-	} else {
-		logger.Error("OpenAI access token not set")
 	}
-	if config.Fireworks.AccessToken != "" {
+
+	if config.Fireworks.AccessToken == "" {
+		logger.Error("Fireworks access token not set. Not registering Fireworks-related endpoints.")
+	} else {
 		v1router.Path("/completions/fireworks").Methods(http.MethodPost).Handler(
 			overhead.HTTPMiddleware(latencyHistogram,
 				instrumentation.HTTPMiddleware("v1.completions.fireworks",
@@ -237,8 +241,6 @@ func NewHandler(
 					otelhttp.WithPublicEndpoint(),
 				),
 			))
-	} else {
-		logger.Error("Fireworks access token not set")
 	}
 
 	// Register a route where actors can retrieve their current rate limit state.

--- a/cmd/cody-gateway/internal/httpapi/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/handler.go
@@ -75,6 +75,29 @@ func NewHandler(
 
 	// V1 service routes
 	v1router := r.PathPrefix("/v1").Subrouter()
+	// registerStandardEndpoint registers an HTTP endpoint with all of the expected middleware
+	// for authentication, latency, instrumentationm, etc.
+	registerStandardEndpoint := func(name, route string, attributes attribute.Set, handler http.Handler) {
+		// Create an HTTP handler that will update the "concurrent_upstream_requests" metric.
+		gaugedHandler := gaugeHandler(
+			counter,
+			attributes,
+			authr.Middleware(
+				requestlogger.Middleware(
+					logger,
+					handler,
+				),
+			))
+		// Wrap that in our instrumentation middleware, adding more logging.
+		instrumentedHandler := instrumentation.HTTPMiddleware(
+			name,
+			gaugedHandler,
+			otelhttp.WithPublicEndpoint())
+		// Finally wrap that again in our overall middleware.
+		overheadMiddleware := overhead.HTTPMiddleware(latencyHistogram, instrumentedHandler)
+
+		v1router.Path(route).Methods(http.MethodPost).Handler(overheadMiddleware)
+	}
 
 	if config.Anthropic.AccessToken == "" {
 		logger.Error("Anthropic access token not set. Not registering Anthropic-related endpoints.")
@@ -87,28 +110,15 @@ func NewHandler(
 			httpClient,
 			config.Anthropic,
 			promptRecorder,
-			config.AutoFlushStreamingResponses,
-		)
+			config.AutoFlushStreamingResponses)
 		if err != nil {
 			return nil, errors.Wrap(err, "init Anthropic handler")
 		}
-
-		v1router.Path("/completions/anthropic").Methods(http.MethodPost).Handler(
-			overhead.HTTPMiddleware(latencyHistogram,
-				instrumentation.HTTPMiddleware("v1.completions.anthropic",
-					gaugeHandler(
-						counter,
-						attributesAnthropicCompletions,
-						authr.Middleware(
-							requestlogger.Middleware(
-								logger,
-								anthropicHandler,
-							),
-						),
-					),
-					otelhttp.WithPublicEndpoint(),
-				),
-			))
+		registerStandardEndpoint(
+			"v1.completions.anthropic",
+			"/completions/anthropic",
+			attributesAnthropicCompletions,
+			anthropicHandler)
 
 		anthropicMessagesHandler, err := completions.NewAnthropicMessagesHandler(
 			logger,
@@ -118,57 +128,33 @@ func NewHandler(
 			httpClient,
 			config.Anthropic,
 			promptRecorder,
-			config.AutoFlushStreamingResponses,
-		)
+			config.AutoFlushStreamingResponses)
 		if err != nil {
 			return nil, errors.Wrap(err, "init anthropicMessages handler")
 		}
-
-		v1router.Path("/completions/anthropic-messages").Methods(http.MethodPost).Handler(
-			overhead.HTTPMiddleware(latencyHistogram,
-				instrumentation.HTTPMiddleware("v1.completions.anthropicmessages",
-					gaugeHandler(
-						counter,
-						attributesAnthropicCompletions,
-						authr.Middleware(
-							requestlogger.Middleware(
-								logger,
-								anthropicMessagesHandler,
-							),
-						),
-					),
-					otelhttp.WithPublicEndpoint(),
-				),
-			))
+		registerStandardEndpoint(
+			"v1.completions.anthropicmessages",
+			"/completions/anthropic-messages",
+			attributesAnthropicCompletions,
+			anthropicMessagesHandler)
 	}
 
 	if config.OpenAI.AccessToken == "" {
 		logger.Error("OpenAI access token not set. Not registering OpenAI-related endpoints.")
 	} else {
-		v1router.Path("/completions/openai").Methods(http.MethodPost).Handler(
-			overhead.HTTPMiddleware(latencyHistogram,
-				instrumentation.HTTPMiddleware("v1.completions.openai",
-					gaugeHandler(
-						counter,
-						attributesOpenAICompletions,
-						authr.Middleware(
-							requestlogger.Middleware(
-								logger,
-								completions.NewOpenAIHandler(
-									logger,
-									eventLogger,
-									rs,
-									config.RateLimitNotifier,
-									httpClient,
-									config.OpenAI,
-									config.AutoFlushStreamingResponses,
-								),
-							),
-						),
-					),
-					otelhttp.WithPublicEndpoint(),
-				),
-			))
+		openAIHandler := completions.NewOpenAIHandler(
+			logger,
+			eventLogger,
+			rs,
+			config.RateLimitNotifier,
+			httpClient,
+			config.OpenAI,
+			config.AutoFlushStreamingResponses)
+		registerStandardEndpoint(
+			"v1.completions.openai",
+			"/completions/openai",
+			attributesOpenAICompletions,
+			openAIHandler)
 
 		v1router.Path("/embeddings/models").Methods(http.MethodGet).Handler(
 			instrumentation.HTTPMiddleware("v1.embeddings.models",
@@ -182,65 +168,43 @@ func NewHandler(
 			),
 		)
 
-		v1router.Path("/embeddings").Methods(http.MethodPost).Handler(
-			overhead.HTTPMiddleware(latencyHistogram,
-				instrumentation.HTTPMiddleware("v1.embeddings",
-					gaugeHandler(
-						counter,
-						// TODO - if embeddings.ModelFactoryMap includes more than
-						// just OpenAI we might need to move how we count concurrent
-						// requests into the handler, instead of assuming we are
-						// counting OpenAI requests
-						attributesOpenAIEmbeddings,
-						authr.Middleware(
-							requestlogger.Middleware(
-								logger,
-								embeddings.NewHandler(
-									logger,
-									eventLogger,
-									rs,
-									config.RateLimitNotifier,
-									embeddings.ModelFactoryMap{
-										embeddings.ModelNameOpenAIAda:         embeddings.NewOpenAIClient(httpClient, config.OpenAI.AccessToken),
-										embeddings.ModelNameSourcegraphTriton: embeddings.NewSourcegraphClient(httpClient, config.Sourcegraph.TritonURL),
-									},
-									config.EmbeddingsAllowedModels,
-								),
-							),
-						),
-					),
-					otelhttp.WithPublicEndpoint(),
-				),
-			))
+		embeddingsHandler := embeddings.NewHandler(
+			logger,
+			eventLogger,
+			rs,
+			config.RateLimitNotifier,
+			embeddings.ModelFactoryMap{
+				embeddings.ModelNameOpenAIAda:         embeddings.NewOpenAIClient(httpClient, config.OpenAI.AccessToken),
+				embeddings.ModelNameSourcegraphTriton: embeddings.NewSourcegraphClient(httpClient, config.Sourcegraph.TritonURL),
+			},
+			config.EmbeddingsAllowedModels)
+		// TODO: If embeddings.ModelFactoryMap includes more than just OpenAI, we might want to
+		// revisit how we count concurrent requests into the handler. (Instead of assuming they are
+		// all OpenAI-related requests. (i.e. maybe we should use something other than
+		// attributesOpenAIEmbeddings here.)
+		registerStandardEndpoint(
+			"v1.embeddings",
+			"/embeddings",
+			attributesOpenAIEmbeddings,
+			embeddingsHandler)
 	}
 
 	if config.Fireworks.AccessToken == "" {
 		logger.Error("Fireworks access token not set. Not registering Fireworks-related endpoints.")
 	} else {
-		v1router.Path("/completions/fireworks").Methods(http.MethodPost).Handler(
-			overhead.HTTPMiddleware(latencyHistogram,
-				instrumentation.HTTPMiddleware("v1.completions.fireworks",
-					gaugeHandler(
-						counter,
-						attributesFireworksCompletions,
-						authr.Middleware(
-							requestlogger.Middleware(
-								logger,
-								completions.NewFireworksHandler(
-									logger,
-									eventLogger,
-									rs,
-									config.RateLimitNotifier,
-									httpClient,
-									config.Fireworks,
-									config.AutoFlushStreamingResponses,
-								),
-							),
-						),
-					),
-					otelhttp.WithPublicEndpoint(),
-				),
-			))
+		fireworksHandler := completions.NewFireworksHandler(
+			logger,
+			eventLogger,
+			rs,
+			config.RateLimitNotifier,
+			httpClient,
+			config.Fireworks,
+			config.AutoFlushStreamingResponses)
+		registerStandardEndpoint(
+			"v1.completions.fireworks",
+			"/completions/fireworks",
+			attributesFireworksCompletions,
+			fireworksHandler)
 	}
 
 	// Register a route where actors can retrieve their current rate limit state.


### PR DESCRIPTION
> ⚠️ This PR is partly a conversation starter, and so feel free to suggest even better ways to clean up this part of the code. Or, if you believe things are fine as-is, I can drop it entirely. This is just in service of making it easier to land "background request sampling" discussed later.

It appears that over time we've added several common layers of HTTP middleware, but in a way that is increasingly difficult to maintain. This PR makes a few minor changes that lead to a net reduction in overall lines of code.

For reviewing, it may make more sense to look at the PR commit-by-commit.

**Minimize the use between `if` and `else` keywords.**

Something that stuck with me from _Code Complete_, was that if you use an `if/else` construct, and one of the code blocks is really short, you should make that one come "first". So that when you read the code, you can at a glance see the "if X, then Y. Otherwise long-winded-Z".

The code in `handler.go` is a good example of this. Where sometimes you would go more than a "page" of code, before seeing `} else { logger.Error("Anthropic access token not set") }`.

So simply inverting the `if`-predicate and putting the "or log an error" code first, IMHO, makes things easier to read.

**Introducing `registerStandardEndpoint` and `registerSimpleGETEndpoint`**

The next change was to wrap the boilerplate for registering HTTP endpoints (and the various layers of instrumentation, authorization, and performance counters) into a single method.

It's one thing to have duplicate code when you are doing the same thing several times. But I'd argue that the way we register our HTTP endpoints involve _a lot_ of moving parts. (e.g. configuration passed to the various layers of middleware.) So having a "standard" registration method will not only cut down on the boilerplate, but also provide us with a way to make it easier to add more logic/customization.

e.g. maybe we can reconcile `registerStandardEndpoint` and `registerSimpleGETEndpoint` by making the `attribute.Set` parameter optional and adding the HTTP method as a new parameter?

## Do we need this PR?

The main reason why I'm sending this out for review, is to make it easier to add the _next_ PR. Which I am thinking would come as yet another HTTP middleware layer.

As part of doing a better job of identifying and rejecting abusive traffic, I would like to add a new hook for our LLM-based endpoints that will periodically trigger an async "LLM API moderation check". e.g. sample N% of our traffic, sending it to a moderation endpoint async.

My thinking is that we'd call this "moderation check middleware" for all of our LLMs, as well as make the design pluggable so we could use some other 3rd party API for moderating LLM requests. Or even rely on our own classifier if desired.

We would then use the moderation endpoint results to track some sort of confidence interval for the non-abuse of our request traffic. (e.g. by sampling X of the past Y requests, over various timeframes, we have Z% confidence that...) And, if it does identify an abuse LLM request, we would then use that to trigger our existing anti-abuse mechanisms.

## Test plan

CI. The code (should 😅) be functionally equivalent. Existing testing (should 😅) be sufficient.
