### PR TITLE
Svelte: add hover to separator and remove size change

### DIFF
--- a/client/web-sveltekit/src/lib/Separator.svelte
+++ b/client/web-sveltekit/src/lib/Separator.svelte
@@ -93,8 +93,14 @@
         }
 
         &.dragging {
+            z-index: 1;
+            outline: 1px solid var(--oc-blue-3);
             background-color: var(--oc-blue-3);
-            width: 3px;
+        }
+
+        &:hover:not(.dragging) {
+            z-index: 1;
+            outline: 1px solid var(--border-color);
         }
     }
 </style>


### PR DESCRIPTION
Just a small thing I extracted from a larger PR. This:
1) Adds a hover interaction to the separator bar (like the React app, but symmetrical)
2) Uses an outline rather than a changing width so that the page doesn't re-flow on click

## Test plan

Before:

https://github.com/sourcegraph/sourcegraph/assets/12631702/9ea7d35c-8fbb-48cd-b578-e73fa84702f9



After:


https://github.com/sourcegraph/sourcegraph/assets/12631702/0b535a34-0b3e-46c9-984b-c288b093ee4b


