### PR TITLE
Svelte: implement preview panel

### DIFF
--- a/client/web-sveltekit/src/lib/repo/blob.ts
+++ b/client/web-sveltekit/src/lib/repo/blob.ts
@@ -157,7 +157,7 @@ interface BlobDataHandler extends Readable<CombinedBlobData> {
 
 /**
  * This store synchronizes the state of the blob data and the highlights. While new blob data is
- * loading, the old blob and highlighs data is still available. Once the blob data is loaded, the
+ * loading, the old blob and highlights data is still available. Once the blob data is loaded, the
  * highlights are updated.
  */
 export function createBlobDataHandler(): BlobDataHandler {

--- a/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
+++ b/client/web-sveltekit/src/lib/search/input/SearchInput.svelte
@@ -3,22 +3,12 @@
     //  - History more
     //  - Default context support
     //  - Global keyboard shortcut
-    import { mdiCodeBrackets, mdiFormatLetterCase, mdiRegex } from '@mdi/js'
-
-    import { goto, invalidate } from '$app/navigation'
-    import { SearchPatternType } from '$lib/graphql-operations'
-    import Icon from '$lib/Icon.svelte'
-    import Tooltip from '$lib/Tooltip.svelte'
-
-    import { type QueryStateStore, getQueryURL, QueryState } from '../state'
-    import BaseCodeMirrorQueryInput from '$lib/search/BaseQueryInput.svelte'
-    import { createSuggestionsSource } from '$lib/web'
-    import { query, type DocumentInput } from '$lib/graphql'
-    import Suggestions from './Suggestions.svelte'
-    import { user } from '$lib/stores'
 
     import { EditorSelection, EditorState, Prec, type Extension } from '@codemirror/state'
     import { EditorView } from '@codemirror/view'
+    import { mdiCodeBrackets, mdiFormatLetterCase, mdiRegex } from '@mdi/js'
+
+    import { goto, invalidate } from '$app/navigation'
     import {
         type Option,
         type Action,
@@ -35,7 +25,18 @@
         onModeChange,
         setMode,
     } from '$lib/branded'
+    import { query, type DocumentInput } from '$lib/graphql'
+    import { SearchPatternType } from '$lib/graphql-operations'
+    import Icon from '$lib/Icon.svelte'
+    import BaseCodeMirrorQueryInput from '$lib/search/BaseQueryInput.svelte'
+    import { user } from '$lib/stores'
+    import Tooltip from '$lib/Tooltip.svelte'
+    import { createSuggestionsSource } from '$lib/web'
+
+    import { type QueryStateStore, getQueryURL, QueryState } from '../state'
+
     import { createRecentSearchesStore } from './recentSearches'
+    import Suggestions from './Suggestions.svelte'
 
     const placeholderText = 'Search for code or files...'
 
@@ -370,10 +371,6 @@
         border: 0;
         background-color: transparent;
         cursor: pointer;
-    }
-
-    button.mode {
-        clear: all;
     }
 
     .mode-switcher {

--- a/client/web-sveltekit/src/lib/search/state.ts
+++ b/client/web-sveltekit/src/lib/search/state.ts
@@ -1,6 +1,5 @@
 import { writable, type Readable } from 'svelte/store'
 
-import { goto } from '$app/navigation'
 import { SearchPatternType } from '$lib/graphql-operations'
 import { buildSearchURLQuery, type Settings } from '$lib/shared'
 import { defaultSearchModeFromSettings, defaultPatternTypeFromSettings } from '$lib/web'

--- a/client/web-sveltekit/src/lib/shared.ts
+++ b/client/web-sveltekit/src/lib/shared.ts
@@ -48,6 +48,7 @@ export {
     type Progress,
     type Range,
     type Filter,
+    type SearchEvent,
 } from '@sourcegraph/shared/src/search/stream'
 export {
     type MatchItem,

--- a/client/web-sveltekit/src/lib/utils/promises.ts
+++ b/client/web-sveltekit/src/lib/utils/promises.ts
@@ -81,3 +81,19 @@ export function createPromiseStore<D, E = Error>(): PromiseStore<D, E> {
         },
     }
 }
+
+/**
+ * Returns a store that publishes updates when the promise is resolved or rejected.
+ */
+export function toReadable<D, E = Error>(promise: Promise<D>): Readable<Result<D, E>> {
+    const resultStore = writable<Result<D, E>>({ value: null, error: null, pending: true })
+    promise.then(
+        result => {
+            resultStore.set({ value: result, error: null, pending: false })
+        },
+        error => {
+            resultStore.set({ value: null, error: error, pending: false })
+        }
+    )
+    return resultStore
+}

--- a/client/web-sveltekit/src/lib/utils/promises.ts
+++ b/client/web-sveltekit/src/lib/utils/promises.ts
@@ -85,7 +85,7 @@ export function createPromiseStore<D, E = Error>(): PromiseStore<D, E> {
 /**
  * Returns a store that publishes updates when the promise is resolved or rejected.
  */
-export function toReadable<D, E = Error>(promise: Promise<D>): Readable<Result<D, E>> {
+export function toReadable<D, E = Error>(promise: PromiseLike<D>): Readable<Result<D, E>> {
     const resultStore = writable<Result<D, E>>({ value: null, error: null, pending: true })
     promise.then(
         result => {

--- a/client/web-sveltekit/src/lib/wildcard/menu/Menu.svelte
+++ b/client/web-sveltekit/src/lib/wildcard/menu/Menu.svelte
@@ -34,7 +34,7 @@
     } = createDropdownMenu({
         open,
     })
-    setContext({ item, trigger, separator, builders, open })
+    setContext({ item, trigger, separator, builders, $open })
 </script>
 
 <button {...$trigger} use:trigger class={triggerButtonClass} {...$$restProps}>

--- a/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
+++ b/client/web-sveltekit/src/routes/[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/+page.svelte
@@ -2,26 +2,25 @@
 
 <script lang="ts">
     import { mdiCodeBracesBox, mdiFileCodeOutline, mdiMapSearch } from '@mdi/js'
+    import { from } from 'rxjs'
 
+    import { goto } from '$app/navigation'
     import { page } from '$app/stores'
     import CodeMirrorBlob from '$lib/CodeMirrorBlob.svelte'
+    import { isErrorLike, type LineOrPositionOrRange } from '$lib/common'
+    import { toGraphQLResult } from '$lib/graphql'
     import Icon from '$lib/Icon.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
+    import { updateSearchParamsWithLineInformation, createBlobDataHandler } from '$lib/repo/blob'
+    import FileDiff from '$lib/repo/FileDiff.svelte'
     import FileHeader from '$lib/repo/FileHeader.svelte'
     import Permalink from '$lib/repo/Permalink.svelte'
-
-    import FileDiff from '$lib/repo/FileDiff.svelte'
+    import { createCodeIntelAPI, parseQueryAndHash } from '$lib/shared'
+    import { Alert } from '$lib/wildcard'
 
     import type { PageData } from './$types'
     import FormatAction from './FormatAction.svelte'
     import WrapLinesAction, { lineWrap } from './WrapLinesAction.svelte'
-    import { createCodeIntelAPI, parseQueryAndHash } from '$lib/shared'
-    import { goto } from '$app/navigation'
-    import { updateSearchParamsWithLineInformation, createBlobDataHandler } from '$lib/repo/blob'
-    import { isErrorLike, type LineOrPositionOrRange } from '$lib/common'
-    import { from } from 'rxjs'
-    import { toGraphQLResult } from '$lib/graphql'
-    import { Alert } from '$lib/wildcard'
 
     export let data: PageData
 

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -25,6 +25,7 @@
     import { settings } from '$lib/stores'
 
     import FileSearchResultHeader from './FileSearchResultHeader.svelte'
+    import PreviewButton from './PreviewButton.svelte'
     import RepoStars from './RepoStars.svelte'
     import SearchResult from './SearchResult.svelte'
     import { getSearchResultsContext } from './searchResultsContext'
@@ -97,6 +98,7 @@
         {#if result.repoStars}
             <RepoStars repoStars={result.repoStars} />
         {/if}
+        <PreviewButton {result} />
     </svelte:fragment>
 
     <div bind:this={root} use:observeIntersection on:intersecting={event => (visible = event.detail)} class="matches">

--- a/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FilePathSearchResult.svelte
@@ -5,6 +5,7 @@
     import type { PathMatch } from '$lib/shared'
 
     import FileSearchResultHeader from './FileSearchResultHeader.svelte'
+    import PreviewButton from './PreviewButton.svelte'
     import RepoStars from './RepoStars.svelte'
     import SearchResult from './SearchResult.svelte'
 
@@ -18,5 +19,6 @@
         {#if result.repoStars}
             <RepoStars repoStars={result.repoStars} />
         {/if}
+        <PreviewButton {result} />
     </svelte:fragment>
 </SearchResult>

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -10,8 +10,6 @@
         type SymbolMatch,
     } from '$lib/shared'
 
-    import { getSearchResultsContext } from './searchResultsContext'
-
     export let result: ContentMatch | PathMatch | SymbolMatch
 
     $: repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
@@ -23,11 +21,6 @@
         result.type !== 'symbol' && result.pathMatches
             ? result.pathMatches.map((match): [number, number] => [match.start.column, match.end.column])
             : []
-
-    const searchResultContext = getSearchResultsContext()
-    function handlePreview() {
-        searchResultContext.setPreview(result)
-    }
 </script>
 
 <a href={repoAtRevisionURL}>{repoName}</a>
@@ -38,4 +31,3 @@
         {#if fileBase}{fileBase}/{/if}<strong>{fileName}</strong>
     </a>
 {/key}
-<button on:click={handlePreview}>Preview</button>

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -10,6 +10,8 @@
         type SymbolMatch,
     } from '$lib/shared'
 
+    import { getSearchResultsContext } from './searchResultsContext'
+
     export let result: ContentMatch | PathMatch | SymbolMatch
 
     $: repoAtRevisionURL = getRepositoryUrl(result.repository, result.branches)
@@ -21,6 +23,16 @@
         result.type !== 'symbol' && result.pathMatches
             ? result.pathMatches.map((match): [number, number] => [match.start.column, match.end.column])
             : []
+
+    const searchResultContext = getSearchResultsContext()
+    function handlePreview() {
+        searchResultContext.setPreview({
+            repoName: result.repository,
+            commitID: result.commit,
+            fileName: result.path,
+            matchedRanges: [], // TODO
+        })
+    }
 </script>
 
 <a href={repoAtRevisionURL}>{repoName}</a>
@@ -31,3 +43,4 @@
         {#if fileBase}{fileBase}/{/if}<strong>{fileName}</strong>
     </a>
 {/key}
+<button on:click={handlePreview}>Preview</button>

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -26,12 +26,7 @@
 
     const searchResultContext = getSearchResultsContext()
     function handlePreview() {
-        searchResultContext.setPreview({
-            repoName: result.repository,
-            commitID: result.commit,
-            filePath: result.path,
-            matchedRanges: [], // TODO
-        })
+        searchResultContext.setPreview(result)
     }
 </script>
 

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -29,7 +29,7 @@
         searchResultContext.setPreview({
             repoName: result.repository,
             commitID: result.commit,
-            fileName: result.path,
+            filePath: result.path,
             matchedRanges: [], // TODO
         })
     }

--- a/client/web-sveltekit/src/routes/search/PreviewButton.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type { ContentMatch, PathMatch, SymbolMatch } from '$lib/shared'
+    import { Button } from '$lib/wildcard'
 
     import { getSearchResultsContext } from './searchResultsContext'
 
@@ -8,16 +9,13 @@
     const searchResultContext = getSearchResultsContext()
 </script>
 
-<button on:click={() => searchResultContext.setPreview(result)}>Preview</button>
+<div class="preview-button">
+    <Button variant="link" on:click={() => searchResultContext.setPreview(result)}>Preview</Button>
+</div>
 
 <style lang="scss">
-    button {
-        border: none;
-        background-color: transparent;
-        font-weight: 500;
-        color: var(--link-color);
-        &:hover {
-            text-decoration: underline;
-        }
+    // Override the padding of the button so it doesn't grow the header.
+    .preview-button :global(button) {
+        padding: 0;
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/PreviewButton.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewButton.svelte
@@ -9,3 +9,15 @@
 </script>
 
 <button on:click={() => searchResultContext.setPreview(result)}>Preview</button>
+
+<style lang="scss">
+    button {
+        border: none;
+        background-color: transparent;
+        font-weight: 500;
+        color: var(--link-color);
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+</style>

--- a/client/web-sveltekit/src/routes/search/PreviewButton.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewButton.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    import type { ContentMatch, PathMatch, SymbolMatch } from '$lib/shared'
+
+    import { getSearchResultsContext } from './searchResultsContext'
+
+    export let result: ContentMatch | SymbolMatch | PathMatch
+
+    const searchResultContext = getSearchResultsContext()
+</script>
+
+<button on:click={() => searchResultContext.setPreview(result)}>Preview</button>

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -71,7 +71,7 @@
 <div class="header">
     <h3>File Preview</h3>
     <button on:click={() => searchResultContext.setPreview(null)}>
-        <Icon svgPath={mdiClose} class="close-icon" />
+        <Icon svgPath={mdiClose} class="close-icon" size={16} inline />
     </button>
 </div>
 <div class="file-link">
@@ -127,6 +127,14 @@
             margin: 0;
             margin-right: auto;
             height: fit-content;
+        }
+        button {
+            background-color: transparent;
+            color: var(--text-muted);
+            border: none;
+            &:hover {
+                color: var(--body-color);
+            }
         }
     }
 

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -70,7 +70,7 @@
 
 <div class="header">
     <h3>File Preview</h3>
-    <button on:click={() => searchResultContext.setPreview(null)}>
+    <button data-testid="preview-close" on:click={() => searchResultContext.setPreview(null)}>
         <Icon svgPath={mdiClose} class="close-icon" size={16} inline />
     </button>
 </div>

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -42,7 +42,7 @@
             revspec: commitID,
             path: filePath,
         })
-        .then(mapOrThrow(result => result.data?.repository?.commit?.blob?.content ?? null))
+        .then(mapOrThrow(result => result.data?.repository?.commit?.blob ?? null))
     // const highlights = client.query(BlobSyntaxHighlightQuery, {
     //     repoName,
     //     revspec: commitID,
@@ -53,23 +53,27 @@
 
 {#await blob}
     <LoadingSpinner />
-{:then content}
-    <CodeMirrorBlob
-        blobInfo={{
-            repoName,
-            commitID,
-            revision: '',
-            filePath,
-            content: content ?? '',
-            languages: ['TODO'],
-        }}
-        highlights=""
-        {codeIntelAPI}
-    />
+{:then blob}
+    {@debug blob}
+    <!-- <CodeMirrorBlob -->
+    <!--     blobInfo={{ -->
+    <!--         repoName, -->
+    <!--         commitID, -->
+    <!--         revision: '', -->
+    <!--         filePath, -->
+    <!--         content: blob?.content ?? '', -->
+    <!--         languages: blob?.languages ?? [], -->
+    <!--     }} -->
+    <!--     highlights={''} -->
+    <!--     {codeIntelAPI} -->
+    <!-- /> -->
     <!-- TODO {highlights} -->
     <!-- selectedLines={selectedPosition?.line ? selectedPosition : null} -->
     <!-- on:selectline={event => { -->
     <!--     goto('?' + updateSearchParamsWithLineInformation($page.url.searchParams, event.detail)) -->
     <!-- }} -->
     <!-- {codeIntelAPI} -->
+{:catch error}
+    <!-- {@debug error} -->
+    <p>{error}</p>
 {/await}

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -74,7 +74,7 @@
     )
 </script>
 
-<div class="container">
+<div class="preview-container">
     <div class="header">
         <h3>File Preview</h3>
         <button data-testid="preview-close" on:click={() => searchResultContext.setPreview(null)}>
@@ -93,7 +93,7 @@
             <Alert variant="danger">
                 Unable to load file data: {$blobStore.error}
             </Alert>
-        {:else}
+        {:else if $blobStore.value}
             <CodeMirrorBlob
                 blobInfo={{
                     repoName: result.repository,
@@ -111,11 +111,10 @@
 </div>
 
 <style lang="scss">
-    .container {
+    .preview-container {
         display: flex;
         flex-direction: column;
         height: 100%;
-        padding: 0;
     }
 
     .header {

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -72,49 +72,62 @@
     )
 </script>
 
-<div class="header">
-    <h3>File Preview</h3>
-    <button data-testid="preview-close" on:click={() => searchResultContext.setPreview(null)}>
-        <Icon svgPath={mdiClose} class="close-icon" size={16} inline />
-    </button>
-</div>
-<div class="file-link">
-    <small>
-        <a href={getFileMatchUrl(result)}>{result.path}</a>
-    </small>
-</div>
-<div class="content">
-    {#if $blob}
-        <CodeMirrorBlob
-            blobInfo={{
-                repoName: result.repository,
-                commitID: result.commit ?? '',
-                revision: '',
-                filePath: result.path,
-                content: $blob.content ?? '',
-                languages: $blob.languages ?? [],
-            }}
-            highlights={$highlights}
-            {codeIntelAPI}
-        />
-    {:else}
-        <LoadingSpinner />
-    {/if}
+<div class="container">
+    <div class="header">
+        <h3>File Preview</h3>
+        <button data-testid="preview-close" on:click={() => searchResultContext.setPreview(null)}>
+            <Icon svgPath={mdiClose} class="close-icon" size={16} inline />
+        </button>
+    </div>
+    <div class="file-link">
+        <small>
+            <a href={getFileMatchUrl(result)}>{result.path}</a>
+        </small>
+    </div>
+    <div class="content">
+        {#if $blob}
+            <CodeMirrorBlob
+                blobInfo={{
+                    repoName: result.repository,
+                    commitID: result.commit ?? '',
+                    revision: '',
+                    filePath: result.path,
+                    content: $blob.content ?? '',
+                    languages: $blob.languages ?? [],
+                }}
+                highlights={$highlights}
+                {codeIntelAPI}
+            />
+        {:else}
+            <LoadingSpinner />
+        {/if}
+    </div>
 </div>
 
 <style lang="scss">
+    .container {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        padding: 0;
+    }
+
     .header {
         // Keep in sync with the action bar
         height: 3rem;
-        border-bottom: 1px solid var(--border-color);
+        flex: none;
+
         display: flex;
         align-items: center;
         padding: 0 0.5rem;
+        border-bottom: 1px solid var(--border-color);
+
         h3 {
             margin: 0;
             margin-right: auto;
             height: fit-content;
         }
+
         button {
             background-color: transparent;
             color: var(--text-muted);
@@ -131,10 +144,6 @@
     }
 
     .content {
-        display: flex;
-        flex-direction: column;
-        overflow-x: auto;
-        height: 100%;
-        flex: 1;
+        overflow: auto;
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -16,9 +16,11 @@
     import { from } from 'rxjs'
 
     import CodeMirrorBlob from '$lib/CodeMirrorBlob.svelte'
+    import { isErrorLike } from '$lib/common'
     import { getGraphQLClient, mapOrThrow, toGraphQLResult } from '$lib/graphql'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import { createCodeIntelAPI } from '$lib/shared'
+    import { settings } from '$lib/stores'
 
     // TODO: should I be importing this from a page? Seems funky.
     import { BlobPageQuery } from '../[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql'
@@ -30,7 +32,7 @@
 
     const client = getGraphQLClient()
     $: codeIntelAPI = createCodeIntelAPI({
-        settings: () => undefined, // TODO: add settings
+        settings: setting => (isErrorLike($settings?.final) ? undefined : $settings?.final?.[setting]),
         requestGraphQL(options) {
             return from(client.query(options.request, options.variables).then(toGraphQLResult))
         },
@@ -54,25 +56,23 @@
 {#await blob}
     <LoadingSpinner />
 {:then blob}
-    {@debug blob}
-    <!-- <CodeMirrorBlob -->
-    <!--     blobInfo={{ -->
-    <!--         repoName, -->
-    <!--         commitID, -->
-    <!--         revision: '', -->
-    <!--         filePath, -->
-    <!--         content: blob?.content ?? '', -->
-    <!--         languages: blob?.languages ?? [], -->
-    <!--     }} -->
-    <!--     highlights={''} -->
-    <!--     {codeIntelAPI} -->
-    <!-- /> -->
+    <CodeMirrorBlob
+        blobInfo={{
+            repoName,
+            commitID,
+            revision: '',
+            filePath,
+            content: blob?.content ?? '',
+            languages: blob?.languages ?? [],
+        }}
+        highlights={''}
+        {codeIntelAPI}
+    />
     <!-- TODO {highlights} -->
     <!-- selectedLines={selectedPosition?.line ? selectedPosition : null} -->
     <!-- on:selectline={event => { -->
     <!--     goto('?' + updateSearchParamsWithLineInformation($page.url.searchParams, event.detail)) -->
     <!-- }} -->
-    <!-- {codeIntelAPI} -->
 {:catch error}
     <!-- {@debug error} -->
     <p>{error}</p>

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -13,11 +13,13 @@
 </script>
 
 <script lang="ts">
+    import { mdiClose } from '@mdi/js'
     import { from } from 'rxjs'
 
     import CodeMirrorBlob from '$lib/CodeMirrorBlob.svelte'
     import { isErrorLike } from '$lib/common'
     import { getGraphQLClient, mapOrThrow, toGraphQLResult } from '$lib/graphql'
+    import Icon from '$lib/Icon.svelte'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import {
         getFileMatchUrl,
@@ -34,7 +36,11 @@
         BlobSyntaxHighlightQuery,
     } from '../[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql'
 
+    import { getSearchResultsContext } from './searchResultsContext'
+
     export let result: ContentMatch | SymbolMatch | PathMatch
+
+    const searchResultContext = getSearchResultsContext()
 
     const client = getGraphQLClient()
     $: codeIntelAPI = createCodeIntelAPI({
@@ -64,6 +70,9 @@
 
 <div class="header">
     <h3>File Preview</h3>
+    <button on:click={() => searchResultContext.setPreview(null)}>
+        <Icon svgPath={mdiClose} class="close-icon" />
+    </button>
 </div>
 <div class="file-link">
     <small>
@@ -116,6 +125,7 @@
         padding: 0 0.5rem;
         h3 {
             margin: 0;
+            margin-right: auto;
             height: fit-content;
         }
     }

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -1,0 +1,75 @@
+<script lang="ts" context="module">
+    export interface Range {
+        start: Location
+        end: Location
+    }
+
+    export interface Location {
+        // A zero-based line number
+        line: number
+        // A zero-based column number
+        column: number
+    }
+</script>
+
+<script lang="ts">
+    import { from } from 'rxjs'
+
+    import CodeMirrorBlob from '$lib/CodeMirrorBlob.svelte'
+    import { getGraphQLClient, mapOrThrow, toGraphQLResult } from '$lib/graphql'
+    import LoadingSpinner from '$lib/LoadingSpinner.svelte'
+    import { createCodeIntelAPI } from '$lib/shared'
+
+    // TODO: should I be importing this from a page? Seems funky.
+    import { BlobPageQuery } from '../[...repo=reporev]/(validrev)/(code)/-/blob/[...path]/page.gql'
+
+    export let repoName: string
+    export let commitID: string
+    export let filePath: string
+    export let matchedRanges: Range[]
+
+    const client = getGraphQLClient()
+    $: codeIntelAPI = createCodeIntelAPI({
+        settings: () => undefined, // TODO: add settings
+        requestGraphQL(options) {
+            return from(client.query(options.request, options.variables).then(toGraphQLResult))
+        },
+    })
+
+    const blob = client
+        .query(BlobPageQuery, {
+            repoName,
+            revspec: commitID,
+            path: filePath,
+        })
+        .then(mapOrThrow(result => result.data?.repository?.commit?.blob?.content ?? null))
+    // const highlights = client.query(BlobSyntaxHighlightQuery, {
+    //     repoName,
+    //     revspec: commitID,
+    //     path: filePath,
+    //     disableTimeout: false,
+    // }).then(mapOrThrow(result => result.data?.repository?.commit?.blob?.highlight.lsif ?? '')),
+</script>
+
+{#await blob}
+    <LoadingSpinner />
+{:then content}
+    <CodeMirrorBlob
+        blobInfo={{
+            repoName,
+            commitID,
+            revision: '',
+            filePath,
+            content: content ?? '',
+            languages: ['TODO'],
+        }}
+        highlights=""
+        {codeIntelAPI}
+    />
+    <!-- TODO {highlights} -->
+    <!-- selectedLines={selectedPosition?.line ? selectedPosition : null} -->
+    <!-- on:selectline={event => { -->
+    <!--     goto('?' + updateSearchParamsWithLineInformation($page.url.searchParams, event.detail)) -->
+    <!-- }} -->
+    <!-- {codeIntelAPI} -->
+{/await}

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -32,7 +32,9 @@
     import { toReadable } from '$lib/utils/promises'
     import { Alert } from '$lib/wildcard'
 
-    // TODO: should I be importing this from a page? Seems funky.
+    // We are reusing the queries from the blob page to ensure we take advantage of
+    // the cache. It may make sense to pass loaders into this function
+    // rather than adding a dependency on the blob page.
     import {
         BlobPageQuery,
         BlobSyntaxHighlightQuery,
@@ -52,21 +54,21 @@
         },
     })
 
-    const blobStore = toReadable(
+    $: blobStore = toReadable(
         client
             .query(BlobPageQuery, {
                 repoName: result.repository,
-                revspec: result.commit ?? '', // TODO: default value?
+                revspec: result.commit ?? '',
                 path: result.path,
             })
             .then(mapOrThrow(result => result.data?.repository?.commit?.blob ?? null))
     )
 
-    const highlightStore = toReadable(
+    $: highlightStore = toReadable(
         client
             .query(BlobSyntaxHighlightQuery, {
                 repoName: result.repository,
-                revspec: result.commit ?? '', // TODO: default value?
+                revspec: result.commit ?? '',
                 path: result.path,
                 disableTimeout: false,
             })

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -31,6 +31,8 @@
     }
 
     .icon {
+        display: flex;
+        align-items: center;
         flex-shrink: 0;
         --color: var(--text-muted);
     }
@@ -51,6 +53,8 @@
         flex-wrap: wrap;
         color: var(--text-muted);
         flex-shrink: 0;
+        gap: 0.5rem;
+        align-items: center;
     }
 
     .body {

--- a/client/web-sveltekit/src/routes/search/SearchResults.stories.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.stories.svelte
@@ -12,12 +12,12 @@
     import {
         createCommitMatch,
         createContentMatch,
-        createHighlightedFileResult,
         createPathMatch,
         createPersonMatch,
         createSymbolMatch,
         createTeamMatch,
-    } from '$testing/testdata'
+    } from '$testing/search-testdata'
+    import { createHighlightedFileResult } from '$testing/testdata'
 
     import CommitSearchResult from './CommitSearchResult.svelte'
     import FileContentSearchResult from './FileContentSearchResult.svelte'

--- a/client/web-sveltekit/src/routes/search/SearchResults.stories.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.stories.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
     import { Story } from '@storybook/addon-svelte-csf'
-    import SearchResults from './SearchResults.svelte'
+    import { graphql } from 'msw'
+    import { SvelteComponent, setContext } from 'svelte'
+    import { readable } from 'svelte/store'
+
+    import type { HighlightedFileResult, HighlightedFileVariables } from '$lib/graphql-operations'
+    import { queryStateStore } from '$lib/search/state'
+    import type { ContentMatch, PathMatch, SearchMatch, SymbolMatch } from '$lib/shared'
+    import { KEY, type SourcegraphContext } from '$lib/stores'
+    import { createTemporarySettingsStorage } from '$lib/temporarySettings'
     import {
         createCommitMatch,
         createContentMatch,
@@ -10,21 +18,15 @@
         createSymbolMatch,
         createTeamMatch,
     } from '$testing/testdata'
-    import FileContentSearchResult from './FileContentSearchResult.svelte'
-    import { SvelteComponent, setContext } from 'svelte'
-    import { KEY, type SourcegraphContext } from '$lib/stores'
-    import { readable } from 'svelte/store'
+
     import CommitSearchResult from './CommitSearchResult.svelte'
-    import PersonSearchResult from './PersonSearchResult.svelte'
-    import TeamSearchResult from './TeamSearchResult.svelte'
-    import { queryStateStore } from '$lib/search/state'
-    import { graphql } from 'msw'
-    import type { HighlightedFileResult, HighlightedFileVariables } from '$lib/graphql-operations'
-    import type { SearchMatch } from '$lib/shared'
+    import FileContentSearchResult from './FileContentSearchResult.svelte'
     import FilePathSearchResult from './FilePathSearchResult.svelte'
-    import SymbolSearchResult from './SymbolSearchResult.svelte'
-    import { createTemporarySettingsStorage } from '$lib/temporarySettings'
+    import PersonSearchResult from './PersonSearchResult.svelte'
+    import SearchResults from './SearchResults.svelte'
     import { setSearchResultsContext } from './searchResultsContext'
+    import SymbolSearchResult from './SymbolSearchResult.svelte'
+    import TeamSearchResult from './TeamSearchResult.svelte'
 
     export const meta = {
         title: 'search/SearchResults',
@@ -54,6 +56,7 @@
         },
         setExpanded(_match, _expanded) {},
         queryState: queryStateStore(undefined, {}),
+        setPreview(_props: PathMatch | ContentMatch | SymbolMatch | null): void {},
     })
     // TS complains about up MockSuitFunctions which is not relevant here
     // @ts-ignore

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -81,7 +81,7 @@
     $: resultsToShow = results.slice(0, count)
     $: expandedSet = cacheEntry?.expanded || new Set<SearchMatch>()
 
-    $: previewResult = writable<ContentMatch | SymbolMatch | PathMatch | null>(cacheEntry?.preview ?? null)
+    $: previewResult = writable(cacheEntry?.preview ?? null)
 
     setSearchResultsContext({
         isExpanded(match: SearchMatch): boolean {

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -19,9 +19,8 @@
     import { tick } from 'svelte'
     import { writable } from 'svelte/store'
 
-    import { limitHit } from '@sourcegraph/branded'
-
     import { beforeNavigate, goto } from '$app/navigation'
+    import { limitHit } from '$lib/branded'
     import Icon from '$lib/Icon.svelte'
     import { observeIntersection } from '$lib/intersection-observer'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -15,7 +15,7 @@
 <script lang="ts">
     import { mdiCloseOctagonOutline } from '@mdi/js'
     import type { Observable } from 'rxjs'
-    import { tick } from 'svelte'
+    import { tick, type ComponentProps } from 'svelte'
 
     import { beforeNavigate, goto } from '$app/navigation'
     import Icon from '$lib/Icon.svelte'
@@ -28,6 +28,7 @@
     import Separator, { getSeparatorPosition } from '$lib/Separator.svelte'
     import { type AggregateStreamingSearchResults, type SearchMatch } from '$lib/shared'
 
+    import PreviewPanel from './PreviewPanel.svelte'
     import { getSearchResultComponent } from './searchResultFactory'
     import { setSearchResultsContext } from './searchResultsContext'
     import StreamingProgress from './StreamingProgress.svelte'
@@ -72,6 +73,8 @@
     $: resultsToShow = results.slice(0, count)
     $: expandedSet = cacheEntry?.expanded || new Set<SearchMatch>()
 
+    let previewData: ComponentProps<PreviewPanel> | undefined = undefined
+
     setSearchResultsContext({
         isExpanded(match: SearchMatch): boolean {
             return expandedSet.has(match)
@@ -83,11 +86,19 @@
                 expandedSet.delete(match)
             }
         },
+        setPreview(data: ComponentProps<PreviewPanel>): void {
+            console.log({ data })
+            previewData = data
+        },
         queryState,
     })
     beforeNavigate(() => {
         cache.set(queryFromURL, { count, expanded: expandedSet })
     })
+
+    $: {
+        console.log({ previewData })
+    }
 
     function loadMore(event: { detail: boolean }) {
         if (event.detail) {
@@ -152,6 +163,9 @@
             {/if}
         </div>
     </div>
+    {#if previewData}
+        <PreviewPanel {...previewData} />
+    {/if}
 </div>
 
 <style lang="scss">

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -81,7 +81,7 @@
     $: resultsToShow = results.slice(0, count)
     $: expandedSet = cacheEntry?.expanded || new Set<SearchMatch>()
 
-    let previewResult = writable<ContentMatch | SymbolMatch | PathMatch | undefined>(undefined)
+    let previewResult = writable<ContentMatch | SymbolMatch | PathMatch | null>(null)
 
     setSearchResultsContext({
         isExpanded(match: SearchMatch): boolean {
@@ -94,8 +94,7 @@
                 expandedSet.delete(match)
             }
         },
-        setPreview(result: ContentMatch | SymbolMatch | PathMatch | undefined): void {
-            console.log({ result })
+        setPreview(result: ContentMatch | SymbolMatch | PathMatch | null): void {
             previewResult.set(result)
         },
         queryState,

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -170,9 +170,7 @@
     {#if $previewResult}
         <Separator currentPosition={previewSidebarPosition} />
         <div style:width={`clamp(10rem, ${100 - $previewSidebarPosition * 100}%, 50%)`}>
-            {#key $previewResult}
-                <PreviewPanel result={$previewResult} />
-            {/key}
+            <PreviewPanel result={$previewResult} />
         </div>
     {/if}
 </div>

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -15,7 +15,7 @@
 <script lang="ts">
     import { mdiCloseOctagonOutline } from '@mdi/js'
     import type { Observable } from 'rxjs'
-    import { tick, type ComponentProps } from 'svelte'
+    import { tick } from 'svelte'
     import { writable } from 'svelte/store'
 
     import { limitHit } from '@sourcegraph/branded'
@@ -30,7 +30,13 @@
     import SearchInput from '$lib/search/input/SearchInput.svelte'
     import { getQueryURL, type QueryStateStore } from '$lib/search/state'
     import Separator, { getSeparatorPosition } from '$lib/Separator.svelte'
-    import { type AggregateStreamingSearchResults, type SearchMatch } from '$lib/shared'
+    import {
+        type AggregateStreamingSearchResults,
+        type PathMatch,
+        type SearchMatch,
+        type SymbolMatch,
+        type ContentMatch,
+    } from '$lib/shared'
 
     import PreviewPanel from './PreviewPanel.svelte'
     import { getSearchResultComponent } from './searchResultFactory'
@@ -75,7 +81,7 @@
     $: resultsToShow = results.slice(0, count)
     $: expandedSet = cacheEntry?.expanded || new Set<SearchMatch>()
 
-    let previewData = writable<ComponentProps<PreviewPanel> | undefined>(undefined)
+    let previewResult = writable<ContentMatch | SymbolMatch | PathMatch | undefined>(undefined)
 
     setSearchResultsContext({
         isExpanded(match: SearchMatch): boolean {
@@ -88,9 +94,9 @@
                 expandedSet.delete(match)
             }
         },
-        setPreview(data: ComponentProps<PreviewPanel>): void {
-            console.log({ data })
-            previewData.set(data)
+        setPreview(result: ContentMatch | SymbolMatch | PathMatch | undefined): void {
+            console.log({ result })
+            previewResult.set(result)
         },
         queryState,
     })
@@ -161,11 +167,11 @@
             {/if}
         </div>
     </div>
-    {#if $previewData}
+    {#if $previewResult}
         <Separator currentPosition={previewSidebarPosition} />
         <div style:width={`clamp(10rem, ${100 - $previewSidebarPosition * 100}%, 50%)`}>
-            {#key $previewData}
-                <PreviewPanel {...$previewData} />
+            {#key $previewResult}
+                <PreviewPanel result={$previewResult} />
             {/key}
         </div>
     {/if}

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -17,12 +17,15 @@
     import type { Observable } from 'rxjs'
     import { tick, type ComponentProps } from 'svelte'
 
+    import { limitHit } from '@sourcegraph/branded'
+
     import { beforeNavigate, goto } from '$app/navigation'
     import Icon from '$lib/Icon.svelte'
     import { observeIntersection } from '$lib/intersection-observer'
     import LoadingSpinner from '$lib/LoadingSpinner.svelte'
     import type { URLQueryFilter } from '$lib/search/dynamicFilters'
     import DynamicFiltersSidebar from '$lib/search/dynamicFilters/Sidebar.svelte'
+    import { createRecentSearchesStore } from '$lib/search/input/recentSearches'
     import SearchInput from '$lib/search/input/SearchInput.svelte'
     import { getQueryURL, type QueryStateStore } from '$lib/search/state'
     import Separator, { getSeparatorPosition } from '$lib/Separator.svelte'
@@ -32,8 +35,6 @@
     import { getSearchResultComponent } from './searchResultFactory'
     import { setSearchResultsContext } from './searchResultsContext'
     import StreamingProgress from './StreamingProgress.svelte'
-    import { createRecentSearchesStore } from '$lib/search/input/recentSearches'
-    import { limitHit } from '@sourcegraph/branded'
 
     export let stream: Observable<AggregateStreamingSearchResults>
     export let queryFromURL: string
@@ -53,8 +54,8 @@
     let resultContainer: HTMLElement | null = null
 
     const recentSearches = createRecentSearchesStore()
-    const sidebarSize = getSeparatorPosition('search-results-sidebar', 0.2)
-    $: sidebarWidth = `clamp(14rem, ${$sidebarSize * 100}%, 50%)`
+    const filtersSidebarPosition = getSeparatorPosition('search-results-sidebar', 0.2)
+    const previewSidebarPosition = getSeparatorPosition('preview-sidebar', 0.2)
 
     $: loading = $stream.state === 'loading'
     $: results = $stream.results
@@ -128,10 +129,10 @@
 </div>
 
 <div class="search-results">
-    <div style:width={sidebarWidth}>
+    <div style:width={`clamp(14rem, ${$filtersSidebarPosition * 100}%, 50%)`}>
         <DynamicFiltersSidebar {selectedFilters} streamFilters={$stream.filters} searchQuery={queryFromURL} {loading} />
     </div>
-    <Separator currentPosition={sidebarSize} />
+    <Separator currentPosition={filtersSidebarPosition} />
     <div class="results">
         <aside class="actions">
             {#if loading}
@@ -163,7 +164,8 @@
         </div>
     </div>
     {#if previewData}
-        <div class="preview">
+        <Separator currentPosition={previewSidebarPosition} />
+        <div style:width={`clamp(10rem, ${100 - $previewSidebarPosition * 100}%, 50%)`}>
             <PreviewPanel {...previewData} />
         </div>
     {/if}
@@ -220,9 +222,5 @@
             margin: auto;
             color: var(--text-muted);
         }
-    }
-
-    .preview {
-        width: 100px;
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -133,7 +133,7 @@
 </div>
 
 <div class="search-results">
-    <div style:width={`clamp(14rem, ${$filtersSidebarPosition * 100}%, 50%)`}>
+    <div style:width={`clamp(14rem, ${$filtersSidebarPosition * 100}%, 35%)`}>
         <DynamicFiltersSidebar {selectedFilters} streamFilters={$stream.filters} searchQuery={queryFromURL} {loading} />
     </div>
     <Separator currentPosition={filtersSidebarPosition} />

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -87,7 +87,6 @@
             }
         },
         setPreview(data: ComponentProps<PreviewPanel>): void {
-            console.log({ data })
             previewData = data
         },
         queryState,
@@ -164,7 +163,9 @@
         </div>
     </div>
     {#if previewData}
-        <PreviewPanel {...previewData} />
+        <div class="preview">
+            <PreviewPanel {...previewData} />
+        </div>
     {/if}
 </div>
 
@@ -219,5 +220,9 @@
             margin: auto;
             color: var(--text-muted);
         }
+    }
+
+    .preview {
+        width: 100px;
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -5,6 +5,7 @@
     interface ResultStateCache {
         count: number
         expanded: Set<SearchMatch>
+        preview: ContentMatch | SymbolMatch | PathMatch | null
     }
     const cache = new Map<string, ResultStateCache>()
 
@@ -81,7 +82,7 @@
     $: resultsToShow = results.slice(0, count)
     $: expandedSet = cacheEntry?.expanded || new Set<SearchMatch>()
 
-    let previewResult = writable<ContentMatch | SymbolMatch | PathMatch | null>(null)
+    $: previewResult = writable<ContentMatch | SymbolMatch | PathMatch | null>(cacheEntry?.preview ?? null)
 
     setSearchResultsContext({
         isExpanded(match: SearchMatch): boolean {
@@ -100,7 +101,7 @@
         queryState,
     })
     beforeNavigate(() => {
-        cache.set(queryFromURL, { count, expanded: expandedSet })
+        cache.set(queryFromURL, { count, expanded: expandedSet, preview: $previewResult })
     })
 
     function loadMore(event: { detail: boolean }) {

--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -16,6 +16,7 @@
     import { mdiCloseOctagonOutline } from '@mdi/js'
     import type { Observable } from 'rxjs'
     import { tick, type ComponentProps } from 'svelte'
+    import { writable } from 'svelte/store'
 
     import { limitHit } from '@sourcegraph/branded'
 
@@ -74,7 +75,7 @@
     $: resultsToShow = results.slice(0, count)
     $: expandedSet = cacheEntry?.expanded || new Set<SearchMatch>()
 
-    let previewData: ComponentProps<PreviewPanel> | undefined = undefined
+    let previewData = writable<ComponentProps<PreviewPanel> | undefined>(undefined)
 
     setSearchResultsContext({
         isExpanded(match: SearchMatch): boolean {
@@ -88,17 +89,14 @@
             }
         },
         setPreview(data: ComponentProps<PreviewPanel>): void {
-            previewData = data
+            console.log({ data })
+            previewData.set(data)
         },
         queryState,
     })
     beforeNavigate(() => {
         cache.set(queryFromURL, { count, expanded: expandedSet })
     })
-
-    $: {
-        console.log({ previewData })
-    }
 
     function loadMore(event: { detail: boolean }) {
         if (event.detail) {
@@ -163,10 +161,12 @@
             {/if}
         </div>
     </div>
-    {#if previewData}
+    {#if $previewData}
         <Separator currentPosition={previewSidebarPosition} />
         <div style:width={`clamp(10rem, ${100 - $previewSidebarPosition * 100}%, 50%)`}>
-            <PreviewPanel {...previewData} />
+            {#key $previewData}
+                <PreviewPanel {...$previewData} />
+            {/key}
         </div>
     {/if}
 </div>

--- a/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
@@ -9,6 +9,7 @@
     import type { SymbolMatch } from '$lib/shared'
 
     import FileSearchResultHeader from './FileSearchResultHeader.svelte'
+    import PreviewButton from './PreviewButton.svelte'
     import RepoStars from './RepoStars.svelte'
     import SearchResult from './SearchResult.svelte'
 
@@ -35,6 +36,7 @@
         {#if result.repoStars}
             <RepoStars repoStars={result.repoStars} />
         {/if}
+        <PreviewButton {result} />
     </svelte:fragment>
     <svelte:fragment slot="body">
         <div use:observeIntersection on:intersecting={event => (visible = event.detail)}>

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '../../testing/integration'
-import { createDoneEvent, createProgressEvent } from '../../testing/search-testdata'
+import {
+    createDoneEvent,
+    createProgressEvent,
+    createCommitMatch,
+    createContentMatch,
+    createPathMatch,
+} from '../../testing/search-testdata'
 
 test('search input is autofocused', async ({ page }) => {
     await page.goto('/search')
@@ -70,4 +76,43 @@ test('main navbar menus are visible above search input', async ({ page, sg }) =>
     await page.getByRole('button', { name: 'Code Search' }).click()
     await page.getByRole('link', { name: 'Search Home' }).click()
     await expect(page).toHaveURL(/\/search$/)
+})
+
+test('preview can be opened and closed', async ({ page, sg }) => {
+    const stream = sg.mockSearchStream()
+    await page.goto('/search?q=test')
+    await page.getByRole('heading', { name: 'Filter results' }).waitFor()
+    await stream.publish([
+        {
+            type: 'matches',
+            data: [createContentMatch(), createCommitMatch(), createPathMatch()],
+        },
+        createProgressEvent(),
+        createDoneEvent(),
+    ])
+    await stream.close()
+
+    // 2 preview buttons: one for content match and one for path match
+    const previewButtons = await page.getByRole('button', { name: 'Preview' }).all()
+    expect(previewButtons).toHaveLength(2)
+
+    sg.mockOperations({
+        BlobPageQuery: () => ({
+            repository: {
+                commit: {
+                    blob: {
+                        content: 'lorem\nipsum\ndolor\n',
+                    },
+                },
+            },
+        }),
+    })
+
+    // Open preview panel
+    await previewButtons[0].click()
+    await expect(page.getByRole('heading', { name: 'File Preview' })).toBeVisible()
+
+    // Close preview panel
+    await page.getByTestId('preview-close').click()
+    await expect(page.getByRole('heading', { name: 'File Preview' })).toBeHidden()
 })

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../testing/integration'
+import { createDoneEvent, createProgressEvent } from '../../testing/search-testdata'
 
 test('search input is autofocused', async ({ page }) => {
     await page.goto('/search')
@@ -62,9 +63,10 @@ test('fills search query from URL', async ({ page }) => {
 })
 
 test('main navbar menus are visible above search input', async ({ page, sg }) => {
-    const dispatch = sg.mockSearchResults()
+    const stream = sg.mockSearchStream()
     await page.goto('/search?q=test')
-    await dispatch()
+    await stream.publish([createProgressEvent(), createDoneEvent()])
+    await stream.close()
     await page.getByRole('button', { name: 'Code Search' }).click()
     await page.getByRole('link', { name: 'Search Home' }).click()
     await expect(page).toHaveURL(/\/search$/)

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -71,7 +71,7 @@ test('fills search query from URL', async ({ page }) => {
 test('main navbar menus are visible above search input', async ({ page, sg }) => {
     const stream = sg.mockSearchStream()
     await page.goto('/search?q=test')
-    await stream.publish([createProgressEvent(), createDoneEvent()])
+    await stream.publish(createProgressEvent(), createDoneEvent())
     await stream.close()
     await page.getByRole('button', { name: 'Code Search' }).click()
     await page.getByRole('link', { name: 'Search Home' }).click()
@@ -82,14 +82,14 @@ test('preview can be opened and closed', async ({ page, sg }) => {
     const stream = sg.mockSearchStream()
     await page.goto('/search?q=test')
     await page.getByRole('heading', { name: 'Filter results' }).waitFor()
-    await stream.publish([
+    await stream.publish(
         {
             type: 'matches',
             data: [createContentMatch(), createCommitMatch(), createPathMatch()],
         },
         createProgressEvent(),
-        createDoneEvent(),
-    ])
+        createDoneEvent()
+    )
     await stream.close()
 
     // 2 preview buttons: one for content match and one for path match

--- a/client/web-sveltekit/src/routes/search/searchResultsContext.ts
+++ b/client/web-sveltekit/src/routes/search/searchResultsContext.ts
@@ -6,7 +6,7 @@ import type { ContentMatch, PathMatch, SearchMatch, SymbolMatch } from '$lib/sha
 interface SearchResultsContext {
     isExpanded(match: SearchMatch): boolean
     setExpanded(match: SearchMatch, expanded: boolean): void
-    setPreview(props: PathMatch | ContentMatch | SymbolMatch | null): void
+    setPreview(result: PathMatch | ContentMatch | SymbolMatch | null): void
     queryState: QueryStateStore
 }
 

--- a/client/web-sveltekit/src/routes/search/searchResultsContext.ts
+++ b/client/web-sveltekit/src/routes/search/searchResultsContext.ts
@@ -6,7 +6,7 @@ import type { ContentMatch, PathMatch, SearchMatch, SymbolMatch } from '$lib/sha
 interface SearchResultsContext {
     isExpanded(match: SearchMatch): boolean
     setExpanded(match: SearchMatch, expanded: boolean): void
-    setPreview(props: PathMatch | ContentMatch | SymbolMatch | undefined): void
+    setPreview(props: PathMatch | ContentMatch | SymbolMatch | null): void
     queryState: QueryStateStore
 }
 

--- a/client/web-sveltekit/src/routes/search/searchResultsContext.ts
+++ b/client/web-sveltekit/src/routes/search/searchResultsContext.ts
@@ -1,11 +1,14 @@
-import { getContext, setContext } from 'svelte'
+import { getContext, setContext, type ComponentProps } from 'svelte'
 
 import type { QueryStateStore } from '$lib/search/state'
 import type { SearchMatch } from '$lib/shared'
 
+import PreviewPanel from './PreviewPanel.svelte'
+
 interface SearchResultsContext {
     isExpanded(match: SearchMatch): boolean
     setExpanded(match: SearchMatch, expanded: boolean): void
+    setPreview(props: ComponentProps<PreviewPanel> | undefined): void
     queryState: QueryStateStore
 }
 

--- a/client/web-sveltekit/src/routes/search/searchResultsContext.ts
+++ b/client/web-sveltekit/src/routes/search/searchResultsContext.ts
@@ -1,14 +1,12 @@
-import { getContext, setContext, type ComponentProps } from 'svelte'
+import { getContext, setContext } from 'svelte'
 
 import type { QueryStateStore } from '$lib/search/state'
-import type { SearchMatch } from '$lib/shared'
-
-import PreviewPanel from './PreviewPanel.svelte'
+import type { ContentMatch, PathMatch, SearchMatch, SymbolMatch } from '$lib/shared'
 
 interface SearchResultsContext {
     isExpanded(match: SearchMatch): boolean
     setExpanded(match: SearchMatch, expanded: boolean): void
-    setPreview(props: ComponentProps<PreviewPanel> | undefined): void
+    setPreview(props: PathMatch | ContentMatch | SymbolMatch | undefined): void
     queryState: QueryStateStore
 }
 

--- a/client/web-sveltekit/src/testing/integration.ts
+++ b/client/web-sveltekit/src/testing/integration.ts
@@ -68,7 +68,7 @@ const defaultMocks: TypeMocks = {
 }
 
 interface MockSearchStream {
-    publish(events: SearchEvent | SearchEvent[]): Promise<void>
+    publish(...events: SearchEvent[]): Promise<void>
     close(): Promise<void>
 }
 
@@ -82,7 +82,7 @@ const typeDefs = glob
 
 class Sourcegraph {
     private debugMode = false
-    constructor(private readonly page: Page, private readonly graphqlMock: GraphQLMockServer) {}
+    constructor(private readonly page: Page, private readonly graphqlMock: GraphQLMockServer) { }
 
     async setup(): Promise<void> {
         await this.page.route(/\.api\/graphql/, route => {
@@ -93,9 +93,9 @@ class Sourcegraph {
                 operationName,
                 this.debugMode
                     ? {
-                          logGraphQLErrors: true,
-                          warnOnMissingOperationMocks: true,
-                      }
+                        logGraphQLErrors: true,
+                        warnOnMissingOperationMocks: true,
+                    }
                     : undefined
             )
             route.fulfill({ json: result })
@@ -120,7 +120,7 @@ class Sourcegraph {
      * page to be "ready" by waiting for the "Filter results" heading to be visible.
      */
     public mockSearchStream(): MockSearchStream {
-        this.page.addInitScript(function () {
+        this.page.addInitScript(function() {
             window.$$sources = []
             window.EventSource = class MockEventSource {
                 static readonly CONNECTING = 0
@@ -169,10 +169,7 @@ class Sourcegraph {
         })
 
         return {
-            publish: async (events: SearchEvent | SearchEvent[]): Promise<void> => {
-                if (!(events instanceof Array)) {
-                    events = [events]
-                }
+            publish: async (...events: SearchEvent[]): Promise<void> => {
                 return this.page.evaluate(
                     ([events]) => {
                         for (const event of events) {
@@ -250,7 +247,7 @@ export const test = base.extend<{ sg: Sourcegraph; utils: Utils }, { graphqlMock
         { auto: true },
     ],
     graphqlMock: [
-        async ({}, use) => {
+        async ({ }, use) => {
             const graphqlMock = new GraphQLMockServer({
                 schema: buildSchema(typeDefs),
                 mocks: defaultMocks,

--- a/client/web-sveltekit/src/testing/integration.ts
+++ b/client/web-sveltekit/src/testing/integration.ts
@@ -7,6 +7,8 @@ import { test as base, type Page, type Locator } from '@playwright/test'
 import glob from 'glob'
 import { buildSchema } from 'graphql'
 
+import { type SearchEvent } from '../lib/shared'
+
 import { GraphQLMockServer } from './graphql-mocking'
 import type { TypeMocks, ObjectMock, UserMock, OperationMocks } from './graphql-type-mocks'
 
@@ -65,6 +67,11 @@ const defaultMocks: TypeMocks = {
     JSONCString: () => '{}',
 }
 
+interface MockSearchStream {
+    publish(events: SearchEvent | SearchEvent[]): Promise<void>
+    close(): Promise<void>
+}
+
 const SCHEMA_DIR = path.resolve(
     path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../../cmd/frontend/graphqlbackend')
 )
@@ -112,23 +119,7 @@ class Sourcegraph {
      * the search results being received. The returned function will wait for the search results
      * page to be "ready" by waiting for the "Filter results" heading to be visible.
      */
-    public mockSearchResults(): () => Promise<void> {
-        // TODO: Allow customizing the events
-        const events = [
-            {
-                event: 'progress',
-                data: {
-                    done: true,
-                    matchCount: 0,
-                    skipped: [],
-                    durationMs: 100,
-                },
-            },
-            {
-                event: 'done',
-                data: {},
-            },
-        ]
+    public mockSearchStream(): MockSearchStream {
         this.page.addInitScript(function () {
             window.$$sources = []
             window.EventSource = class MockEventSource {
@@ -177,19 +168,27 @@ class Sourcegraph {
             }
         })
 
-        return async () => {
-            // Wait for the search results page to be "ready"
-            await this.page.getByRole('heading', { name: 'Filter results' }).waitFor()
-            return this.page.evaluate(
-                ([events]) => {
-                    for (const event of events) {
-                        for (const source of window.$$sources) {
-                            source.dispatchEvent(new MessageEvent(event.event, { data: JSON.stringify(event.data) }))
+        return {
+            publish: async (events: SearchEvent | SearchEvent[]): Promise<void> => {
+                if (!(events instanceof Array)) {
+                    events = [events]
+                }
+                return this.page.evaluate(
+                    ([events]) => {
+                        for (const event of events) {
+                            for (const source of this.page.window.$$sources) {
+                                source.dispatchEvent(new MessageEvent(event.type, { data: JSON.stringify(event.data) }))
+                            }
                         }
-                    }
-                },
-                [events]
-            )
+                    },
+                    [events]
+                )
+            },
+            close: async (): Promise<void> => {
+                for (const source of this.page.window.$$sources) {
+                    source.close()
+                }
+            },
         }
     }
 

--- a/client/web-sveltekit/src/testing/integration.ts
+++ b/client/web-sveltekit/src/testing/integration.ts
@@ -176,7 +176,7 @@ class Sourcegraph {
                 return this.page.evaluate(
                     ([events]) => {
                         for (const event of events) {
-                            for (const source of this.page.window.$$sources) {
+                            for (const source of window.$$sources) {
                                 source.dispatchEvent(new MessageEvent(event.type, { data: JSON.stringify(event.data) }))
                             }
                         }
@@ -185,9 +185,11 @@ class Sourcegraph {
                 )
             },
             close: async (): Promise<void> => {
-                for (const source of this.page.window.$$sources) {
-                    source.close()
-                }
+                return this.page.evaluate(() => {
+                    for (const source of window.$$sources) {
+                        source.close()
+                    }
+                })
             },
         }
     }

--- a/client/web-sveltekit/src/testing/integration.ts
+++ b/client/web-sveltekit/src/testing/integration.ts
@@ -82,7 +82,7 @@ const typeDefs = glob
 
 class Sourcegraph {
     private debugMode = false
-    constructor(private readonly page: Page, private readonly graphqlMock: GraphQLMockServer) { }
+    constructor(private readonly page: Page, private readonly graphqlMock: GraphQLMockServer) {}
 
     async setup(): Promise<void> {
         await this.page.route(/\.api\/graphql/, route => {
@@ -93,9 +93,9 @@ class Sourcegraph {
                 operationName,
                 this.debugMode
                     ? {
-                        logGraphQLErrors: true,
-                        warnOnMissingOperationMocks: true,
-                    }
+                          logGraphQLErrors: true,
+                          warnOnMissingOperationMocks: true,
+                      }
                     : undefined
             )
             route.fulfill({ json: result })
@@ -120,7 +120,7 @@ class Sourcegraph {
      * page to be "ready" by waiting for the "Filter results" heading to be visible.
      */
     public mockSearchStream(): MockSearchStream {
-        this.page.addInitScript(function() {
+        this.page.addInitScript(function () {
             window.$$sources = []
             window.EventSource = class MockEventSource {
                 static readonly CONNECTING = 0
@@ -247,7 +247,7 @@ export const test = base.extend<{ sg: Sourcegraph; utils: Utils }, { graphqlMock
         { auto: true },
     ],
     graphqlMock: [
-        async ({ }, use) => {
+        async ({}, use) => {
             const graphqlMock = new GraphQLMockServer({
                 schema: buildSchema(typeDefs),
                 mocks: defaultMocks,

--- a/client/web-sveltekit/src/testing/search-testdata.ts
+++ b/client/web-sveltekit/src/testing/search-testdata.ts
@@ -1,0 +1,245 @@
+import { faker } from '@faker-js/faker'
+import pkg from 'lodash'
+
+import type {
+    CommitMatch,
+    ContentMatch,
+    PathMatch,
+    PersonMatch,
+    SymbolMatch,
+    TeamMatch,
+    SearchEvent,
+} from '$lib/shared'
+
+import { SymbolKind } from '../lib/graphql-types'
+
+const { range } = pkg
+
+/**
+ * Converts the input string to lower case and replaces all non-word characters with -
+ */
+function clean(str: string): string {
+    return str.replaceAll(/\W+/g, '-').toLowerCase()
+}
+
+function createRepoStars(): number | undefined {
+    return faker.helpers.maybe(() => faker.number.int({ max: 1000000 }))
+}
+
+function createRepoName(): string {
+    return `github.com/${clean(faker.company.name())}/${clean(faker.company.buzzNoun())}`
+}
+
+function createCommitURL(repoName: string, commitOID: string): string {
+    return `${repoName}/-/commit/${commitOID}`
+}
+
+function createGitCommitMessage(): string {
+    return faker.git.commitMessage() + '\n\n' + faker.lorem.paragraphs({ min: 0, max: 3 })
+}
+
+export function createCommitMatch(
+    type: 'diff' | 'commit' = faker.helpers.arrayElement(['diff', 'commit'])
+): CommitMatch {
+    const diff = type === 'diff'
+    const repository = createRepoName()
+    const oid = faker.git.commitSha()
+    const message = createGitCommitMessage()
+    const content = diff ? createUnifiedDiff() : message
+    return {
+        type: 'commit',
+        oid,
+        url: createCommitURL(repository, oid),
+        ranges: (() => {
+            const lines = content.split('\n')
+            return faker.helpers
+                .uniqueArray(
+                    range(0, lines.length).filter(line => lines[line].length > 3),
+                    3
+                )
+                .map(line => {
+                    const start = faker.number.int({ max: lines[line].length - 3 })
+                    const length = faker.number.int({
+                        min: 3,
+                        max: Math.min(MAX_HIGHLIGHT_LENGTH, lines[line].length - start),
+                    })
+                    return [line + 1, start, length]
+                })
+        })(),
+        content: ['```', diff ? 'DIFF' : 'COMMIT', '\n', content, '\n```'].join(''),
+        message,
+        authorDate: faker.date.recent().toISOString(),
+        authorName: faker.person.fullName(),
+        repository,
+        repoStars: createRepoStars(),
+        committerDate: faker.date.recent().toISOString(),
+        committerName: faker.person.fullName(),
+    }
+}
+
+const MAX_HIGHLIGHT_LENGTH = 10
+const MAX_LINE_LENGTH = 100
+
+function createUnifiedDiff(): string {
+    const file = faker.system.filePath()
+    return [
+        `${file} ${file}`,
+        ...faker.helpers.multiple(
+            () => {
+                const lineNew = faker.number.int({ min: 0, max: 1000 })
+                const lineOld = faker.number.int({ min: lineNew, max: lineNew + 10 })
+
+                return [
+                    `@@ -${lineNew} +${lineOld} @@`,
+                    ...faker.helpers.multiple(
+                        () => `${faker.helpers.arrayElement([' ', '-', '+'])} ${loremLine(MAX_LINE_LENGTH)}`,
+                        { count: { min: 3, max: 8 } }
+                    ),
+                ].join('\n')
+            },
+            { count: { min: 1, max: 3 } }
+        ),
+    ].join('\n')
+}
+
+export function createContentMatch(): ContentMatch {
+    const repository = createRepoName()
+    const path = faker.system.filePath()
+
+    return {
+        type: 'content',
+        path,
+        repository,
+        repoStars: createRepoStars(),
+        chunkMatches: faker.helpers.uniqueArray(range(1000, 20), faker.number.int({ min: 1, max: 10 })).map(line => {
+            const content = faker.lorem.lines(5)
+            const ranges = faker.helpers
+                .uniqueArray(range(line, line + 3), faker.number.int({ min: 1, max: 5 }))
+                .map(line => createRange(line))
+                .sort((a, b) => a.start.line - b.start.line)
+            return {
+                content,
+                ranges,
+                contentStart: {
+                    line,
+                    column: 1,
+                    offset: 1,
+                },
+            }
+        }),
+        pathMatches: faker.helpers.maybe(() =>
+            faker.helpers.multiple(() => createRange(0, path.length), { count: { min: 0, max: 3 } })
+        ),
+    }
+}
+
+export function createPersonMatch(): PersonMatch {
+    const username = faker.internet.userName()
+    return {
+        type: 'person',
+        handle: faker.helpers.maybe(() => username),
+        user: faker.helpers.maybe(() => ({
+            username,
+            avatarURL: faker.helpers.maybe(() => faker.internet.avatar()),
+            displayName: faker.helpers.maybe(() =>
+                faker.helpers.arrayElement([faker.person.fullName(), faker.internet.displayName()])
+            ),
+        })),
+        email: faker.helpers.maybe(() => faker.internet.email()),
+    }
+}
+
+export function createTeamMatch(): TeamMatch {
+    const handle = faker.company.buzzNoun()
+    return {
+        type: 'team',
+        name: handle + ' team',
+        handle: faker.helpers.maybe(() => handle),
+        email: faker.helpers.maybe(() => faker.internet.email()),
+    }
+}
+
+export function createPathMatch(): PathMatch {
+    const path = faker.system.filePath()
+    return {
+        type: 'path',
+        repository: createRepoName(),
+        path,
+        repoStars: createRepoStars(),
+        pathMatches: faker.helpers.maybe(() =>
+            faker.helpers.multiple(() => createRange(0, path.length), { count: { min: 0, max: 3 } })
+        ),
+    }
+}
+export function createSymbolMatch(): SymbolMatch {
+    const path = faker.system.filePath()
+    return {
+        type: 'symbol',
+        repository: createRepoName(),
+        path,
+        repoStars: createRepoStars(),
+        symbols: faker.helpers.multiple(
+            () => ({
+                line: faker.number.int({ min: 1, max: 1000 }),
+                url: faker.internet.url(),
+                kind: faker.helpers.enumValue(SymbolKind),
+                name: faker.lorem.word(),
+                containerName: faker.lorem.word(),
+            }),
+            { count: { min: 1, max: 5 } }
+        ),
+    }
+}
+
+function createRange(
+    line: number,
+    maxLength: number = MAX_LINE_LENGTH
+): {
+    start: { line: number; column: number; offset: number }
+    end: { line: number; column: number; offset: number }
+} {
+    const startColumn = faker.number.int({ max: maxLength - 1 })
+
+    const start = {
+        line,
+        column: startColumn,
+        offset: faker.number.int({ min: startColumn, max: maxLength - 1 }),
+    }
+    const end = {
+        line,
+        column: faker.number.int({ min: start.column + 1, max: maxLength }),
+        offset: faker.number.int({ min: start.offset + 1, max: maxLength }),
+    }
+
+    return {
+        start,
+        end,
+    }
+}
+
+function loremLine(minLength: number): string {
+    let content = ''
+    do {
+        content += faker.lorem.sentence() + ' '
+    } while (content.length < minLength)
+
+    return content
+}
+
+export function createProgressEvent(): SearchEvent {
+    return {
+        type: 'progress',
+        data: {
+            matchCount: faker.number.int({ min: 0, max: 20000 }),
+            skipped: [],
+            durationMs: faker.number.int(30000),
+        },
+    }
+}
+
+export function createDoneEvent(): SearchEvent {
+    return {
+        type: 'done',
+        data: {},
+    }
+}

--- a/client/web-sveltekit/src/testing/testdata.ts
+++ b/client/web-sveltekit/src/testing/testdata.ts
@@ -2,9 +2,8 @@ import { faker } from '@faker-js/faker'
 import { range } from 'lodash'
 
 import type { Commit } from '$lib/Commit.gql'
-import { type HighlightedFileVariables, type HighlightedFileResult, SymbolKind } from '$lib/graphql-operations'
+import { type HighlightedFileVariables, type HighlightedFileResult } from '$lib/graphql-operations'
 import type { HistoryPanel_HistoryConnection } from '$lib/repo/HistoryPanel.gql'
-import type { CommitMatch, ContentMatch, PersonMatch, TeamMatch, PathMatch, SymbolMatch } from '$lib/shared'
 
 /**
  * Initializes faker's randomness generator with a fixed seed, for
@@ -61,216 +60,7 @@ export function createHistoryResults(count: number, pageSize: number): HistoryPa
     }))
 }
 
-/**
- * Converts the input string to lower case and replaces all non-word characters with -
- */
-function clean(str: string): string {
-    return str.replaceAll(/\W+/g, '-').toLowerCase()
-}
-
-function createRepoName(): string {
-    return `github.com/${clean(faker.company.name())}/${clean(faker.company.buzzNoun())}`
-}
-
-function createCommitURL(repoName: string, commitOID: string): string {
-    return `${repoName}/-/commit/${commitOID}`
-}
-
-function createGitCommitMessage(): string {
-    return faker.git.commitMessage() + '\n\n' + faker.lorem.paragraphs({ min: 0, max: 3 })
-}
-
-function createRepoStars(): number | undefined {
-    return faker.helpers.maybe(() => faker.number.int({ max: 1000000 }))
-}
-
-function createUnifiedDiff(): string {
-    const file = faker.system.filePath()
-    return [
-        `${file} ${file}`,
-        ...faker.helpers.multiple(
-            () => {
-                const lineNew = faker.number.int({ min: 0, max: 1000 })
-                const lineOld = faker.number.int({ min: lineNew, max: lineNew + 10 })
-
-                return [
-                    `@@ -${lineNew} +${lineOld} @@`,
-                    ...faker.helpers.multiple(
-                        () => `${faker.helpers.arrayElement([' ', '-', '+'])} ${loremLine(MAX_LINE_LENGTH)}`,
-                        { count: { min: 3, max: 8 } }
-                    ),
-                ].join('\n')
-            },
-            { count: { min: 1, max: 3 } }
-        ),
-    ].join('\n')
-}
-
-export function createCommitMatch(
-    type: 'diff' | 'commit' = faker.helpers.arrayElement(['diff', 'commit'])
-): CommitMatch {
-    const diff = type === 'diff'
-    const repository = createRepoName()
-    const oid = faker.git.commitSha()
-    const message = createGitCommitMessage()
-    const content = diff ? createUnifiedDiff() : message
-    return {
-        type: 'commit',
-        oid,
-        url: createCommitURL(repository, oid),
-        ranges: (() => {
-            const lines = content.split('\n')
-            return faker.helpers
-                .uniqueArray(
-                    range(0, lines.length).filter(line => lines[line].length > 3),
-                    3
-                )
-                .map(line => {
-                    const start = faker.number.int({ max: lines[line].length - 3 })
-                    const length = faker.number.int({
-                        min: 3,
-                        max: Math.min(MAX_HIGHLIGHT_LENGTH, lines[line].length - start),
-                    })
-                    return [line + 1, start, length]
-                })
-        })(),
-        content: ['```', diff ? 'DIFF' : 'COMMIT', '\n', content, '\n```'].join(''),
-        message,
-        authorDate: faker.date.recent().toISOString(),
-        authorName: faker.person.fullName(),
-        repository,
-        repoStars: createRepoStars(),
-        committerDate: faker.date.recent().toISOString(),
-        committerName: faker.person.fullName(),
-    }
-}
-
 const MAX_LINE_LENGTH = 100
-const MAX_HIGHLIGHT_LENGTH = 10
-
-function createRange(
-    line: number,
-    maxLength: number = MAX_LINE_LENGTH
-): {
-    start: { line: number; column: number; offset: number }
-    end: { line: number; column: number; offset: number }
-} {
-    const startColumn = faker.number.int({ max: maxLength - 1 })
-
-    const start = {
-        line,
-        column: startColumn,
-        offset: faker.number.int({ min: startColumn, max: maxLength - 1 }),
-    }
-    const end = {
-        line,
-        column: faker.number.int({ min: start.column + 1, max: maxLength }),
-        offset: faker.number.int({ min: start.offset + 1, max: maxLength }),
-    }
-
-    return {
-        start,
-        end,
-    }
-}
-
-export function createContentMatch(): ContentMatch {
-    const repository = createRepoName()
-    const path = faker.system.filePath()
-
-    return {
-        type: 'content',
-        path,
-        repository,
-        repoStars: createRepoStars(),
-        chunkMatches: faker.helpers.uniqueArray(range(1000, 20), faker.number.int({ min: 1, max: 10 })).map(line => {
-            const content = faker.lorem.lines(5)
-            const ranges = faker.helpers
-                .uniqueArray(range(line, line + 3), faker.number.int({ min: 1, max: 5 }))
-                .map(line => createRange(line))
-                .sort((a, b) => a.start.line - b.start.line)
-            return {
-                content,
-                ranges,
-                contentStart: {
-                    line,
-                    column: 1,
-                    offset: 1,
-                },
-            }
-        }),
-        pathMatches: faker.helpers.maybe(() =>
-            faker.helpers.multiple(() => createRange(0, path.length), { count: { min: 0, max: 3 } })
-        ),
-    }
-}
-
-export function createPersonMatch(): PersonMatch {
-    const username = faker.internet.userName()
-    return {
-        type: 'person',
-        handle: faker.helpers.maybe(() => username),
-        user: faker.helpers.maybe(() => ({
-            username,
-            avatarURL: faker.helpers.maybe(() => faker.internet.avatar()),
-            displayName: faker.helpers.maybe(() =>
-                faker.helpers.arrayElement([faker.person.fullName(), faker.internet.displayName()])
-            ),
-        })),
-        email: faker.helpers.maybe(() => faker.internet.email()),
-    }
-}
-
-export function createTeamMatch(): TeamMatch {
-    const handle = faker.company.buzzNoun()
-    return {
-        type: 'team',
-        name: handle + ' team',
-        handle: faker.helpers.maybe(() => handle),
-        email: faker.helpers.maybe(() => faker.internet.email()),
-    }
-}
-
-export function createPathMatch(): PathMatch {
-    const path = faker.system.filePath()
-    return {
-        type: 'path',
-        repository: createRepoName(),
-        path,
-        repoStars: createRepoStars(),
-        pathMatches: faker.helpers.maybe(() =>
-            faker.helpers.multiple(() => createRange(0, path.length), { count: { min: 0, max: 3 } })
-        ),
-    }
-}
-export function createSymbolMatch(): SymbolMatch {
-    const path = faker.system.filePath()
-    return {
-        type: 'symbol',
-        repository: createRepoName(),
-        path,
-        repoStars: createRepoStars(),
-        symbols: faker.helpers.multiple(
-            () => ({
-                line: faker.number.int({ min: 1, max: 1000 }),
-                url: faker.internet.url(),
-                kind: faker.helpers.enumValue(SymbolKind),
-                name: faker.lorem.word(),
-                containerName: faker.lorem.word(),
-            }),
-            { count: { min: 1, max: 5 } }
-        ),
-    }
-}
-
-function loremLine(minLength: number): string {
-    let content = ''
-    do {
-        content += faker.lorem.sentence() + ' '
-    } while (content.length < minLength)
-
-    return content
-}
 
 function colorize(line: string): string {
     return line
@@ -303,4 +93,13 @@ export function createHighlightedFileResult(ranges: HighlightedFileVariables['ra
             },
         },
     }
+}
+
+function loremLine(minLength: number): string {
+    let content = ''
+    do {
+        content += faker.lorem.sentence() + ' '
+    } while (content.length < minLength)
+
+    return content
 }


### PR DESCRIPTION
This implements the basics of the preview panel.

Followup tasks:
- Implement the codemirror extension that lets you cycle through matches within a file
- Add preloading on hover
- Make a more general "resizeable split" component

## Test plan

Loom walkthrough with manual testing and added a playwright test (yay!)

https://www.loom.com/share/c5e88700be014a52a6b8e794032a8894
