### PR TITLE
Remove limit while fetching sams account ids

### DIFF
--- a/internal/cody/subscription.go
+++ b/internal/cody/subscription.go
@@ -96,9 +96,6 @@ func getSAMSAccountIDsForUser(ctx context.Context, db database.DB, dotcomUserID 
 		UserID:      dotcomUserID,
 		ServiceType: "openidconnect",
 		ServiceID:   fmt.Sprintf("https://%s", ssc.GetSAMSHostName()),
-		LimitOffset: &database.LimitOffset{
-			Limit: 1,
-		},
 	})
 	if err != nil {
 		return []string{}, errors.Wrap(err, "listing external accounts")


### PR DESCRIPTION
My previous [PR](https://github.com/sourcegraph/sourcegraph/pull/60913/files) made changes to merge cody subscription details from multiple SAMS accounts associated with a single user. 

Bug reported by @bobheadxi [here](https://github.com/sourcegraph/sourcegraph/pull/60913/files#r1520705295).

By mistake I forgot to remove the limit = 1. This PR removes that.

## Test plan
Unit tests present.