### PR TITLE
bazel: buildifier 6.4.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,9 +141,9 @@ http_archive(
 
 http_archive(
     name = "buildifier_prebuilt",
-    sha256 = "e46c16180bc49487bfd0f1ffa7345364718c57334fa0b5b67cb5f27eba10f309",
-    strip_prefix = "buildifier-prebuilt-6.1.0",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/6.1.0.tar.gz"],
+    sha256 = "8ada9d88e51ebf5a1fdff37d75ed41d51f5e677cdbeafb0a22dda54747d6e07e",
+    strip_prefix = "buildifier-prebuilt-6.4.0",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/6.4.0.tar.gz"],
 )
 
 http_archive(


### PR DESCRIPTION
Use the latest buildifier. No mention of the crashing bazel fix in the changelogs

## Test plan
CI