### PR TITLE
ci: bazel do - skip adding of aspect workflows

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,7 @@ steps:
   - group: ":aspect: Aspect Workflows "
     steps:
       - key: aspect-workflows-upload
+        if: build.env("DISABLE_ASPECT_WORKFLOWS") != "true"
         label: ":aspect: Setup Aspect Workflows"
         commands:
           - "rosetta steps | buildkite-agent pipeline upload"

--- a/dev/sg/ci/subcommands.go
+++ b/dev/sg/ci/subcommands.go
@@ -145,6 +145,10 @@ var bazelCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
+		commit, err := run.TrimResult(run.GitCmd("rev-parse", "HEAD"))
+		if err != nil {
+			return err
+		}
 
 		if cmd.Bool("staged") {
 			// restore the changes we've commited so theyre back in the staging area
@@ -170,7 +174,7 @@ var bazelCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		build, err := client.GetMostRecentBuild(cmd.Context, "sourcegraph", branch)
+		build, err := client.TriggerBuild(cmd.Context, "sourcegraph", branch, commit, bk.WithEnvVar("DISABLE_ASPECT_WORKFLOWS", "true"))
 		if err != nil {
 			return err
 		}

--- a/dev/sg/internal/bk/BUILD.bazel
+++ b/dev/sg/internal/bk/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "bk",
     srcs = [
         "bk.go",
+        "create_build_opts.go",
         "logs.go",
     ],
     importpath = "github.com/sourcegraph/sourcegraph/dev/sg/internal/bk",

--- a/dev/sg/internal/bk/create_build_opts.go
+++ b/dev/sg/internal/bk/create_build_opts.go
@@ -1,0 +1,21 @@
+package bk
+
+import "github.com/buildkite/go-buildkite/v3/buildkite"
+
+type CreateBuildOpt func(*buildkite.CreateBuild)
+
+func WithEnvVar(key, value string) CreateBuildOpt {
+	return func(b *buildkite.CreateBuild) {
+		if b.Env == nil {
+			b.Env = map[string]string{}
+		}
+
+		b.Env[key] = value
+	}
+}
+
+func WithEnv(env map[string]string) CreateBuildOpt {
+	return func(b *buildkite.CreateBuild) {
+		b.Env = env
+	}
+}


### PR DESCRIPTION
- Skip uploading of aspect steps if the env contains `DISABLE_ASPECT_WORKFLOWS`
- When `bazel-do` triggers a build, it ensures `DISABLE_ASPECT-WORKFLOWS` is set
## Test plan
- https://buildkite.com/sourcegraph/sourcegraph/builds/264767#_
- Tested locally and CI

