### PR TITLE
Pin third-party actions

### DIFF
--- a/.github/workflows/buf-breaking-check.yml
+++ b/.github/workflows/buf-breaking-check.yml
@@ -11,8 +11,8 @@ jobs:
       # Run `git checkout`
       - uses: actions/checkout@v2
       # Install the `buf` CLI
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@517ee23296d5caf38df31c21945e6a54bbc8a89f # SECURITY: pin third-party action hashes
       # Run breaking change detection against the `main` branch
-      - uses: bufbuild/buf-breaking-action@v1
+      - uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # SECURITY: pin third-party action hashes
         with:
           against: 'https://github.com/sourcegraph/sourcegraph.git#branch=main'

--- a/.github/workflows/licenses-check.yml
+++ b/.github/workflows/licenses-check.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-node@v2
         with: { node-version: "${{ steps.node-setup.outputs.NODE_VERSION }}" }
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
         id: pnpm-install
         with:
           version: 8.9.2
@@ -29,7 +29,7 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # SECURITY: pin third-party action hashes
         with:
           ruby-version: "3.2.2" # Not needed with a .ruby-version file   - uses: actions/setup-ruby@v1
       - uses: actions/setup-go@v2

--- a/.github/workflows/licenses-update.yml
+++ b/.github/workflows/licenses-update.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # SECURITY: pin third-party action hashes
       with:
         ruby-version: '3.1.3' # Not needed with a .ruby-version file   - uses: actions/setup-ruby@v1
     - name: Install asdf plugins
@@ -28,7 +28,7 @@ jobs:
       run: git --no-pager diff
 
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v4 # https://github.com/peter-evans/create-pull-request
+      uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # SECURITY: pin third-party action hashes https://github.com/peter-evans/create-pull-request
       id: cpr
       with:
         labels: automerge
@@ -52,7 +52,7 @@ jobs:
 
     - name: Enable pull request automerge
       if: steps.cpr.outputs.pull-request-operation == 'created'
-      uses: peter-evans/enable-pull-request-automerge@v1
+      uses: peter-evans/enable-pull-request-automerge@21d45e1c52f5d111d2019b5d33f953ed2e735c46 # SECURITY: pin third-party action hashes
       with:
         token: ${{ secrets.GH_REPO_TOKEN }}
         pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,7 @@ jobs:
   update_pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: tzkhan/pr-update-action@v2
+      - uses: tzkhan/pr-update-action@bbd4c9395df8a9c4ef075b8b7fe29f2ca76cdca9 # SECURITY: pin third-party action hashes
         with:
           base-branch-regex: '[a-z\d-_.\\/]+'
           head-branch-regex: '[a-z\d-_.\\/]+'

--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
         id: pnpm-install
         with:
           version: 8.9.2

--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -6,6 +6,6 @@ jobs:
   team-labeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: JulienKode/team-labeler-action@v0.1.0
+    - uses: buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # SECURITY: pin third-party action hashes
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -6,6 +6,6 @@ jobs:
   team-labeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # SECURITY: pin third-party action hashes
+    - uses: JulienKode/team-labeler-action@a205b2457cc66b356257560e3c7bb853a9e8199e # SECURITY: pin third-party action hashes
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/universal-ctags.yml
+++ b/.github/workflows/universal-ctags.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v8
+      - uses: DeterminateSystems/nix-installer-action@07b8bcba1b22d847db7ee507180c33e115499665 # SECURITY: pin third-party action hashes # SECURITY: pin third-party action hashes
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: '🔓 Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v1'
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-latest-xlarge
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v8
+      - uses: DeterminateSystems/nix-installer-action@07b8bcba1b22d847db7ee507180c33e115499665 # SECURITY: pin third-party action hashes # SECURITY: pin third-party action hashes
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: '🔓 Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v1'
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v8
+      - uses: DeterminateSystems/nix-installer-action@07b8bcba1b22d847db7ee507180c33e115499665 # SECURITY: pin third-party action hashes # SECURITY: pin third-party action hashes
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: '🔓 Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v1'

--- a/.github/workflows/update-embeddings-list.yml
+++ b/.github/workflows/update-embeddings-list.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.17.1
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
         with:
           version: latest
       - name: Get current date
@@ -35,7 +35,7 @@ jobs:
       - name: check list in doc folder
         run: head -n 10 doc/cody/embedded-repos.md
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # SECURITY: pin third-party action hashes
         with:
           title: "Cody: Update list of embedded repos"
           commit-message: update list - ${{ steps.date.outputs.date }}


### PR DESCRIPTION
This pins the versions of the third-party actions, as recommended by GitHub. See https://github.com/sourcegraph/security-issues/issues/377 for more information.

## Test plan
Check if CI tests still operate.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
