### PR TITLE
Clean-up Dotcom specific checks

### DIFF
--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -9,9 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/auth"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/featureflag"
-	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
 func (r *schemaResolver) Organizations(args *struct {
@@ -32,11 +30,6 @@ type orgConnectionResolver struct {
 }
 
 func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, error) {
-	// 🚨 SECURITY: Not allowed on Cloud.
-	if dotcom.SourcegraphDotComMode() {
-		return nil, errors.New("listing organizations is not allowed")
-	}
-
 	// 🚨 SECURITY: Only site admins can list organisations.
 	if err := auth.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/orgs_test.go
+++ b/cmd/frontend/graphqlbackend/orgs_test.go
@@ -3,8 +3,6 @@ package graphqlbackend
 import (
 	"testing"
 
-	"github.com/graph-gophers/graphql-go/errors"
-
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -52,7 +50,7 @@ func TestOrgs(t *testing.T) {
 	})
 }
 
-func TestListOrgsForCloud(t *testing.T) {
+func TestListOrgsForDotcom(t *testing.T) {
 	orig := dotcom.SourcegraphDotComMode()
 	dotcom.MockSourcegraphDotComMode(true)
 	defer dotcom.MockSourcegraphDotComMode(orig)
@@ -78,13 +76,14 @@ func TestListOrgsForCloud(t *testing.T) {
 					}
 				}
 			`,
-			ExpectedResult: "null",
-			ExpectedErrors: []*errors.QueryError{
-				{
-					Message: "listing organizations is not allowed",
-					Path:    []any{"organizations", "nodes"},
-				},
-			},
+			ExpectedResult: `
+			{
+				"organizations": {
+					"nodes": [],
+					"totalCount": 42
+				}
+			}
+		`,
 		},
 		{
 			Schema: mustParseGraphQLSchema(t, db),

--- a/cmd/frontend/graphqlbackend/orgs_test.go
+++ b/cmd/frontend/graphqlbackend/orgs_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -43,61 +42,6 @@ func TestOrgs(t *testing.T) {
 							}
 						],
 						"totalCount": 2
-					}
-				}
-			`,
-		},
-	})
-}
-
-func TestListOrgsForDotcom(t *testing.T) {
-	orig := dotcom.SourcegraphDotComMode()
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(orig)
-
-	users := dbmocks.NewMockUserStore()
-	users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{SiteAdmin: true}, nil)
-
-	orgs := dbmocks.NewMockOrgStore()
-	orgs.CountFunc.SetDefaultReturn(42, nil)
-
-	db := dbmocks.NewMockDB()
-	db.UsersFunc.SetDefaultReturn(users)
-	db.OrgsFunc.SetDefaultReturn(orgs)
-
-	RunTests(t, []*Test{
-		{
-			Schema: mustParseGraphQLSchema(t, db),
-			Query: `
-				{
-					organizations {
-						nodes { name },
-						totalCount
-					}
-				}
-			`,
-			ExpectedResult: `
-			{
-				"organizations": {
-					"nodes": [],
-					"totalCount": 42
-				}
-			}
-		`,
-		},
-		{
-			Schema: mustParseGraphQLSchema(t, db),
-			Query: `
-				{
-					organizations {
-						totalCount
-					}
-				}
-			`,
-			ExpectedResult: `
-				{
-					"organizations": {
-						"totalCount": 42
 					}
 				}
 			`,

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -375,18 +375,10 @@ func (r *UserResolver) settingsSubject() api.SettingsSubject {
 }
 
 func (r *UserResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
-	// 🚨 SECURITY: Only the authenticated user can view their settings on
-	// Sourcegraph.com.
-	if dotcom.SourcegraphDotComMode() {
-		if err := auth.CheckSameUserFromActor(r.actor, r.user.ID); err != nil {
-			return nil, err
-		}
-	} else {
-		// 🚨 SECURITY: Only the user and admins are allowed to access the user's
-		// settings, because they may contain secrets or other sensitive data.
-		if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {
-			return nil, err
-		}
+	// 🚨 SECURITY: Only the user and admins are allowed to access the user's
+	// settings, because they may contain secrets or other sensitive data.
+	if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {
+		return nil, err
 	}
 
 	settings, err := r.db.Settings().GetLatest(ctx, r.settingsSubject())
@@ -440,18 +432,9 @@ func (r *schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (
 	if err != nil {
 		return nil, err
 	}
-
-	// 🚨 SECURITY: Only the authenticated user can update their properties on
-	// Sourcegraph.com.
-	if dotcom.SourcegraphDotComMode() {
-		if err := auth.CheckSameUser(ctx, userID); err != nil {
-			return nil, err
-		}
-	} else {
-		// 🚨 SECURITY: Only the user and site admins are allowed to update the user.
-		if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, userID); err != nil {
-			return nil, err
-		}
+	// 🚨 SECURITY: Only the user and site admins are allowed to update the user.
+	if err := auth.CheckSiteAdminOrSameUser(ctx, r.db, userID); err != nil {
+		return nil, err
 	}
 
 	if args.Username != nil {
@@ -598,14 +581,8 @@ func (r *UserResolver) ViewerCanAdminister() (bool, error) {
 }
 
 func (r *UserResolver) viewerCanAdministerSettings() (bool, error) {
-	// 🚨 SECURITY: Only the authenticated user can administrate settings themselves on
-	// Sourcegraph.com.
-	var err error
-	if dotcom.SourcegraphDotComMode() {
-		err = auth.CheckSameUserFromActor(r.actor, r.user.ID)
-	} else {
-		err = auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID)
-	}
+	err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID)
+
 	if errcode.IsUnauthorized(err) {
 		return false, nil
 	} else if err != nil {


### PR DESCRIPTION
This PR cleans up some Dotcom specific checks. It removes a check on:

- Listing organizations: allows site-admins on Dotcom to list organizations. People can make organizations still, so it makes sense we should be able to list them so we can remove them.
- User settings adminstration by a site-admin: on Dotcom we no longer have private code, so there shouldn't be any secrets related to codehosts in user settings.


## Test plan
CI tests.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
