### PR TITLE
executors: Fix version detection for V2 payloads

### DIFF
--- a/cmd/frontend/internal/executorqueue/handler/handler.go
+++ b/cmd/frontend/internal/executorqueue/handler/handler.go
@@ -124,7 +124,7 @@ func (h *handler[T]) dequeue(ctx context.Context, queueName string, metadata exe
 	version2Supported := false
 	if metadata.version != "" {
 		var err error
-		version2Supported, err = api.CheckSourcegraphVersion(metadata.version, "4.3.0-0", "2022-11-24")
+		version2Supported, err = api.CheckSourcegraphVersion(metadata.version, ">= 4.3.0-0", "2022-11-24")
 		if err != nil {
 			return executortypes.Job{}, false, errors.Wrapf(err, "failed to check version %q", metadata.version)
 		}

--- a/cmd/frontend/internal/executorqueue/handler/multihandler.go
+++ b/cmd/frontend/internal/executorqueue/handler/multihandler.go
@@ -89,7 +89,7 @@ func (m *MultiHandler) dequeue(ctx context.Context, req executortypes.DequeueReq
 	version2Supported := false
 	if req.Version != "" {
 		var err error
-		version2Supported, err = api.CheckSourcegraphVersion(req.Version, "4.3.0-0", "2022-11-24")
+		version2Supported, err = api.CheckSourcegraphVersion(req.Version, ">= 4.3.0-0", "2022-11-24")
 		if err != nil {
 			return executortypes.Job{}, false, errors.Wrapf(err, "failed to check version %q", req.Version)
 		}


### PR DESCRIPTION
This is.. bad. This broke docker auth via executor secrets because the V0 payload didn't support it. This could also affect non-utf-8 encoded virtual machine file contents.

## Test plan

Verified that the new syntax works correctly.
