### PR TITLE
executor: Fix global secrets across namespaces colliding

### DIFF
--- a/internal/database/executor_secrets.go
+++ b/internal/database/executor_secrets.go
@@ -401,7 +401,7 @@ var executorSecretsColumns = []*sqlf.Query{
 	sqlf.Sprintf("key"),
 	sqlf.Sprintf("value"),
 	sqlf.Sprintf("encryption_key_id"),
-	sqlf.Sprintf("COALESCE((SELECT o.id FROM executor_secrets o WHERE o.key = executor_secrets.key AND o.namespace_user_id IS NULL AND o.namespace_org_id IS NULL AND o.id != executor_secrets.id)::boolean, false) AS overwrites_global"),
+	sqlf.Sprintf("COALESCE((SELECT o.id FROM executor_secrets o WHERE o.key = executor_secrets.key AND o.scope = executor_secrets.scope AND o.namespace_user_id IS NULL AND o.namespace_org_id IS NULL AND o.id != executor_secrets.id)::boolean, false) AS overwrites_global"),
 	sqlf.Sprintf("namespace_user_id"),
 	sqlf.Sprintf("namespace_org_id"),
 	sqlf.Sprintf("creator_id"),

--- a/internal/database/executor_secrets_test.go
+++ b/internal/database/executor_secrets_test.go
@@ -432,6 +432,12 @@ func TestExecutorSecrets_GetListCount(t *testing.T) {
 		if err := store.Create(internalCtx, database.ExecutorSecretScopeBatches, secret, secretVal); err != nil {
 			t.Fatal(err)
 		}
+		otherSecret := *secret
+		// We generate a second version of the secret in a separate scope (namespace)
+		// to test that they're properly isolated.
+		if err := store.Create(internalCtx, database.ExecutorSecretScopeCodeIntel, &otherSecret, secretVal); err != nil {
+			t.Fatal(err)
+		}
 		return secret
 	}
 	globalGHToken := createSecret(&database.ExecutorSecret{Key: "GH_TOKEN"})


### PR DESCRIPTION
Found this while debugging another issue:
When there are two executor secrets for both global scopes we currently support that have the same name, they will appear as both Global Secret, and Overwrites Global Secret in the UI.

So far so confusing, so let's fix that (because they're not actually overwriting anything, scopes are separate namespaces).

Turns out this also breaks detection for uniqueness of secret values in user namespaces, so when two global DOCKER_AUTH_CONFIG secrets exist (one for each scope), users cannot overwrite this secret value anymore, getting an error message like below.

![image](https://github.com/sourcegraph/sourcegraph/assets/19534377/00cba027-7f5c-402c-a495-f783e13d4c46)


## Test plan

Manually verified that things work correctly now and adjusted a test.
