### PR TITLE
svelte: Improve TS types for GraphQL mocks

### DIFF
--- a/client/web-sveltekit/src/testing/integration.ts
+++ b/client/web-sveltekit/src/testing/integration.ts
@@ -194,6 +194,8 @@ class Sourcegraph {
     }
 
     public fixture(fixtures: (ObjectMock & { __typename: NonNullable<ObjectMock['__typename']> })[]): void {
+        // @ts-expect-error - Unclear how to type this correctly. ObjectMock is missing string index signature
+        // which is required by addFixtures
         this.graphqlMock.addFixtures(fixtures)
     }
 


### PR DESCRIPTION
Before this commit the "mock types" had been generated by simply applying `DeepPartial` (which is like `Partial` but applies recursively) to the existing GraphQL types.

This commit generates the TS types "from scratch". This allows us to customize how TS types for mocks are defined. Concrete differences (so far):

- Mock types for interfaces have a `__typename` field that is a union of the type names of all implementations of that interface. This should make it easier to define mocks of concreate types for fields that accept an interface.
- Fields that take an enum are now defined as string union, which allows speciying the enum value as string literal (with completion support), instead of having to import the actual enum.

Example of generated code:

```ts
export interface AggregationModeAvailabilityMock {
  __typename?: 'AggregationModeAvailability',
  /**
   * Boolean indicating if the mode is available
   */
  available?: Scalars['Boolean']['output'],
  /**
   * The SearchAggregationMode
   */
  mode?: 'AUTHOR' | 'CAPTURE_GROUP' | 'PATH' | 'REPO' | 'REPO_METADATA',
  /**
   * If the mode is unavailable the reason why
   */
  reasonUnavailable?: Scalars['String']['output'] | null,
}
```

Note that this only affect type mocks, not operation mocks. Those require more effort to process. I might do that in a future PR.



## Test plan

`pnpm build` -> to inspect graphql codegen output
`pnpm check` -> to find TypeScript issues

Manual inspection of generated files.