### PR TITLE
rename 'Enterprise licenses' to 'Enterprise subscriptions' to accurately represent enterprise accounts

### DIFF
--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminLicenseKeyLookupPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminLicenseKeyLookupPage.tsx
@@ -47,11 +47,11 @@ export const SiteAdminLicenseKeyLookupPage: React.FunctionComponent<React.PropsW
 
     return (
         <div className="site-admin-product-subscriptions-page">
-            <PageTitle title="Product subscriptions" />
+            <PageTitle title="Enterprise subscriptions" />
             <PageHeader
                 path={[{ text: 'License key lookup' }]}
                 headingElement="h2"
-                description="Find matching licenses and their associated product subscriptions"
+                description="Find matching licenses and their associated enterprise subscriptions"
                 className="mb-3"
             />
             <ConnectionContainer>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -122,11 +122,11 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<React.Pro
     return (
         <>
             <div className="site-admin-product-subscription-page">
-                <PageTitle title="Product subscription" />
+                <PageTitle title="Enterprise subscription" />
                 <PageHeader
                     headingElement="h2"
                     path={[
-                        { text: 'Product subscriptions', to: '/site-admin/dotcom/product/subscriptions' },
+                        { text: 'Enterprise subscriptions', to: '/site-admin/dotcom/product/subscriptions' },
                         { text: productSubscription.name },
                     ]}
                     description={

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionsPage.tsx
@@ -24,7 +24,7 @@ interface Props {
 }
 
 /**
- * Displays the enterprise licenses (formerly known as "product subscriptions") that have been
+ * Displays the enterprise subscriptions (formerly known as "product subscriptions") that have been
  * created on Sourcegraph.com.
  */
 export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<React.PropsWithChildren<Props>> = ({
@@ -34,14 +34,14 @@ export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<React.Pr
 
     return (
         <div className="site-admin-product-subscriptions-page">
-            <PageTitle title="Enterprise licenses" />
+            <PageTitle title="Enterprise subscriptions" />
             <PageHeader
                 headingElement="h2"
-                path={[{ text: 'Enterprise licenses' }]}
+                path={[{ text: 'Enterprise subscriptions' }]}
                 actions={
                     <Button to="./new" variant="primary" as={Link}>
                         <Icon aria-hidden={true} svgPath={mdiPlus} />
-                        Create Enterprise license
+                        Create Enterprise subscription
                     </Button>
                 }
                 className="mb-3"
@@ -52,8 +52,8 @@ export const SiteAdminProductSubscriptionsPage: React.FunctionComponent<React.Pr
                     listComponent="table"
                     listClassName="table"
                     contentWrapperComponent={ListContentWrapper}
-                    noun="Enterprise license"
-                    pluralNoun="Enterprise licenses"
+                    noun="Enterprise subscription"
+                    pluralNoun="Enterprise subscriptions"
                     queryConnection={queryProductSubscriptions}
                     headComponent={SiteAdminProductSubscriptionNodeHeader}
                     nodeComponent={SiteAdminProductSubscriptionNode}

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
@@ -29,7 +29,7 @@ interface Props {
 }
 
 /**
- * Displays the enterprise licenses (formerly known as "product subscriptions") associated with this
+ * Displays the enterprise subscriptions (formerly known as "product subscriptions") associated with this
  * account.
  */
 export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
@@ -77,10 +77,10 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
 
     return (
         <div className="user-subscriptions-product-subscriptions-page">
-            <PageTitle title="Enterprise licenses" />
+            <PageTitle title="Enterprise subscriptions" />
             <PageHeader
                 headingElement="h2"
-                path={[{ text: 'Enterprise licenses' }]}
+                path={[{ text: 'Enterprise subscriptions' }]}
                 description={
                     <>
                         Search your private code with{' '}
@@ -99,8 +99,8 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
                 <FilteredConnection<ProductSubscriptionFields, ProductSubscriptionNodeProps>
                     listComponent="table"
                     listClassName="table mb-0"
-                    noun="Enterprise license"
-                    pluralNoun="Enterprise licenses"
+                    noun="Enterprise subscription"
+                    pluralNoun="Enterprise subscriptions"
                     queryConnection={queryLicenses}
                     headComponent={ProductSubscriptionNodeHeader}
                     nodeComponent={ProductSubscriptionNode}
@@ -108,7 +108,7 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
                     noSummaryIfAllNodesVisible={true}
                     emptyElement={
                         <Text alignment="center" className="w-100 mb-0 text-muted">
-                            You have no Enterprise licenses.
+                            You have no Enterprise subscriptions.
                         </Text>
                     }
                 />

--- a/client/web/src/site-admin/sidebaritems.ts
+++ b/client/web/src/site-admin/sidebaritems.ts
@@ -235,7 +235,7 @@ const businessGroup: SiteAdminSideBarGroup = {
             condition: () => SHOW_BUSINESS_FEATURES,
         },
         {
-            label: 'Enterprise licenses',
+            label: 'Enterprise subscriptions',
             to: '/site-admin/dotcom/product/subscriptions',
             condition: () => SHOW_BUSINESS_FEATURES,
         },

--- a/client/web/src/user/settings/sidebaritems.ts
+++ b/client/web/src/user/settings/sidebaritems.ts
@@ -42,7 +42,7 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = [
         exact: true,
     },
     {
-        label: 'Enterprise licenses',
+        label: 'Enterprise subscriptions',
         to: '/subscriptions',
         condition: ({ user }) => SHOW_BUSINESS_FEATURES && user.viewerCanAdminister,
     },


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/60911 renamed "Subscriptions" to "Enterprise licenses", but the two are not equivalent, as "subscriptions" are an entity above individual licenses - for example `Create new Enterprise license` is not equivalent to the previous `Create new product subscription`. This entity is important because there are some elements of these subscriptions that are more subscription-oriented, than license-oriented - for example, Cody Gateway rate limits exist at an "Enterprise subscription" level and are not necessarily tied to individual licenses (though they can affect what is evaluated at the "subscription" level).

In [RFC 885 Sourcegraph Enterprise Portal](https://docs.google.com/document/d/1tiaW1IVKm_YSSYhH-z7Q8sv4HSO_YJ_Uu6eYDjX7uU4/edit#heading=h.tdaxc5h34u7q) outlining how Core Services plans to change this area (and also the existing use cases of a "subscription"-like entity), we've taken to referring to these as "Enterprise subscriptions" to differentiate from PLG ones. This naming more accurately reflects the model while avoiding confusion with PLG subscriptions.

See thread: https://sourcegraph.slack.com/archives/C04MEF2T33M/p1710292839852869?thread_ts=1709789262.898779&cid=C04MEF2T33M

This PR applies the new naming and also fixes a few spots missed in https://github.com/sourcegraph/sourcegraph/pull/60911

## Test plan

`sg start dotcom`

![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/249653c4-14f5-4e0c-b28c-1b0071ba35e2)
![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/1dfbe856-ae78-44bc-a452-253302d9a62b)
![image](https://github.com/sourcegraph/sourcegraph/assets/23356519/f76eb15d-571b-4b67-84be-d838d1355af7)
