### PR TITLE
msp/runtime: add -help handling for config options

### DIFF
--- a/lib/managedservicesplatform/runtime/env.go
+++ b/lib/managedservicesplatform/runtime/env.go
@@ -9,9 +9,19 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
+type requestedEnvVar struct {
+	name         string
+	defaultValue string
+	description  string
+}
+
 type Env struct {
 	errs []error
 	env  map[string]string
+
+	// requestedEnvVars are only available after ConfigLoader is used on this
+	// Env instance.
+	requestedEnvVars []requestedEnvVar
 }
 
 func newEnv() (*Env, error) {
@@ -30,8 +40,13 @@ func newEnv() (*Env, error) {
 	}, nil
 }
 
-// TODO: Try to use third param description to generate docs.
-func (e *Env) get(name, defaultValue, _ string) string {
+func (e *Env) get(name, defaultValue, description string) string {
+	e.requestedEnvVars = append(e.requestedEnvVars, requestedEnvVar{
+		name:         name,
+		defaultValue: defaultValue,
+		description:  description,
+	})
+
 	v, ok := e.env[name]
 	if !ok {
 		return defaultValue


### PR DESCRIPTION
Dump service info and configuration options when executing a MSP runtime binary with the `-help` flag.

## Test plan

```none
$ go build -o .bin/telemetry-gateway github.com/sourcegraph/sourcegraph/cmd/telemetry-gateway
$ .bin/telemetry-gateway -help                                                                                   
SERVICE: telemetry-gateway
VERSION: 0.0.0+dev
CONFIGURATION OPTIONS:
- 'TELEMETRY_GATEWAY_EVENTS_PUBSUB_ENABLED': If false, logs Pub/Sub messages instead of actually sending them (default: "true")
- 'TELEMETRY_GATEWAY_EVENTS_STREAM_PUBLISH_CONCURRENCY': Per-stream concurrent publishing limit. (default: "250")
- 'MSP': indicates if we are running in a MSP environment (default: "false")
- 'ENVIRONMENT_ID': MSP Service Environment ID (default: "unknown")
- 'PORT': service port (required)
- 'OTEL_SDK_DISABLED': disable OpenTelemetry SDK (default: "false")
```