### PR TITLE
gomod: update zoekt to fix symbol .* perf regression

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -5294,8 +5294,8 @@ def go_dependencies():
         name = "com_github_sourcegraph_zoekt",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/sourcegraph/zoekt",
-        sum = "h1:4AXJ4a6gIldUhw2j7dS27gczTwm6YLGaImVqKVWuWuk=",
-        version = "v0.0.0-20240304160820-371a303692de",
+        sum = "h1:aD4CM/TsPP91VTUL49ffUVLFmQu0AesOOrpWVebjwTY=",
+        version = "v0.0.0-20240313063445-cc5e093366ea",
     )
     go_repository(
         name = "com_github_spaolacci_murmur3",

--- a/go.mod
+++ b/go.mod
@@ -586,7 +586,7 @@ require (
 	github.com/scim2/filter-parser/v2 v2.2.0
 	github.com/sourcegraph/conc v0.3.1-0.20240108182409-4afefce20f9b
 	github.com/sourcegraph/mountinfo v0.0.0-20240201124957-b314c0befab1
-	github.com/sourcegraph/zoekt v0.0.0-20240304160820-371a303692de
+	github.com/sourcegraph/zoekt v0.0.0-20240313063445-cc5e093366ea
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1690,8 +1690,8 @@ github.com/sourcegraph/scip v0.3.3 h1:3EOkChYOntwHl0pPSAju7rj0oRuujh8owC4vjGDEr0
 github.com/sourcegraph/scip v0.3.3/go.mod h1:Q67VaoTpftINIy/CLrkYQOMwlsx67h8ys+ligmdUcqM=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6QW95pzcAR/72Z5TWDyDnSo0EOcyij9o=
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
-github.com/sourcegraph/zoekt v0.0.0-20240304160820-371a303692de h1:4AXJ4a6gIldUhw2j7dS27gczTwm6YLGaImVqKVWuWuk=
-github.com/sourcegraph/zoekt v0.0.0-20240304160820-371a303692de/go.mod h1:g/r6pHsEvSDyXmH3KFAwhu1bwj164duel36kUjH1vIM=
+github.com/sourcegraph/zoekt v0.0.0-20240313063445-cc5e093366ea h1:aD4CM/TsPP91VTUL49ffUVLFmQu0AesOOrpWVebjwTY=
+github.com/sourcegraph/zoekt v0.0.0-20240313063445-cc5e093366ea/go.mod h1:1q5GDMv8B5ywNhmp+befvwOZdf7b3qm+b/as0d4PDt8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=


### PR DESCRIPTION
We had a code path which was gated by the string representation of the parsed regex ".*". This string changed in go 1.22 which means we stopped using it. This update includes a fix which is robust to the version of go.

https://github.com/sourcegraph/zoekt/compare/371a303692de...cc5e093366ea

- https://github.com/sourcegraph/zoekt/commit/72423e1762 nix: use go1.22
- https://github.com/sourcegraph/zoekt/commit/acce0526a2 nix: use go1.22.1
- https://github.com/sourcegraph/zoekt/commit/755d68b13a bump versions on github actions
- https://github.com/sourcegraph/zoekt/commit/52a28e3f9e go.mod: update to go 1.22.1
- https://github.com/sourcegraph/zoekt/commit/cc5e093366 matchtree: do not depend on String for symbol all optimization

Test Plan: CI
