### PR TITLE
Add basic focus ring styles to svelte button, links, input elements

### DIFF
--- a/client/web-sveltekit/src/routes/MainNavigationEntry.svelte
+++ b/client/web-sveltekit/src/routes/MainNavigationEntry.svelte
@@ -78,6 +78,13 @@
         display: flex;
         align-items: center;
         cursor: pointer;
+
+        // Since this button is part navigation links blocks
+        // we should override focus ring with inset to avoid
+        // visual cropping with parent border.
+        &:focus-visible {
+            box-shadow: 0 0 0 2px var(--primary-2) inset;
+        }
     }
 
     [role='menu'] {

--- a/client/web-sveltekit/src/routes/styles.scss
+++ b/client/web-sveltekit/src/routes/styles.scss
@@ -21,3 +21,25 @@ a[data-sveltekit-reload='true'] {
         background-repeat: no-repeat;
     }
 }
+
+// Global focus ring styles.
+//
+// NOTE: Since in svelte we use plain HTML tags for elements like
+// links, buttons, inputs, etc. We have to have some common "global"
+// styles for them (like focus ring).
+
+a:focus-visible {
+    // Inset is required here since we have a lot of links
+    // that don't have any spacing between their border and
+    // overflowed parent visible border (so any outside shadow
+    // is visually cut/cropped)
+    box-shadow: 0 0 0 2px var(--primary-2) inset;
+}
+
+button:focus-visible {
+    box-shadow: 0 0 0 2px var(--primary-2);
+}
+
+input:focus-visible {
+    box-shadow: 0 0 0 2px var(--primary-2);
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/60995

This PR adds some global focus ring styles to common focusable elements. This adds focus ring to most elements however during testing I found that Menu navigation dropdown doesn't work properly with keyboard navigation (Something that I will fix in later PR), this is only about styles.  

I'm not a fan of global styles even for focus-ring styles since there will be cases when global styles won't fit (some custom styles on chips button in combobox, etc) but this is the best that we can do at the moment I think.

https://github.com/sourcegraph/sourcegraph/assets/18492575/95b9171e-9012-4e2a-9823-4ee8614f1387


## Test plan
- Check that links, buttons and input elements (including checkboxes and radio buttons) have focus ring styles with no visual collisions 

