### PR TITLE
search: set Regexp annotation on patterns for FileContainsPatterns

### DIFF
--- a/internal/search/codycontext/query_transformer.go
+++ b/internal/search/codycontext/query_transformer.go
@@ -120,7 +120,9 @@ func queryStringToKeywordQuery(queryString string) (*keywordQuery, error) {
 
 	patternNodes := make([]query.Node, 0, len(transformedPatterns))
 	for _, p := range transformedPatterns {
-		patternNodes = append(patternNodes, query.Pattern{Value: p})
+		node := query.Pattern{Value: p}
+		node.Annotation.Labels.Set(query.Literal)
+		patternNodes = append(patternNodes, node)
 	}
 
 	if len(patternNodes) > 0 {

--- a/internal/search/job/jobutil/job.go
+++ b/internal/search/job/jobutil/job.go
@@ -84,7 +84,9 @@ func NewBasicJob(inputs *search.Inputs, b query.Basic) (job.Job, error) {
 	if len(fileContainsPatterns) > 0 {
 		newNodes := make([]query.Node, 0, len(fileContainsPatterns)+1)
 		for _, pat := range fileContainsPatterns {
-			newNodes = append(newNodes, query.Pattern{Value: pat})
+			node := query.Pattern{Value: pat}
+			node.Annotation.Labels.Set(query.Regexp)
+			newNodes = append(newNodes, node)
 		}
 		if b.Pattern != nil {
 			newNodes = append(newNodes, b.Pattern)

--- a/internal/search/job/jobutil/job_test.go
+++ b/internal/search/job/jobutil/job_test.go
@@ -854,6 +854,86 @@ func TestNewPlanJob(t *testing.T) {
             (repoNamePatterns . [])))))))
 `),
 		}, {
+			query:      `file:contains.content(a.*b)`,
+			protocol:   search.Streaming,
+			searchType: query.SearchTypeKeyword,
+			want: autogold.Expect(`
+(LOG
+  (ALERT
+    (features . error decoding features)
+    (protocol . Streaming)
+    (onSourcegraphDotCom . true)
+    (query . )
+    (originalQuery . )
+    (patternType . keyword)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 10000)
+        (FILECONTAINSFILTER
+          (originalPatterns . [])
+          (filterPatterns . [(?i:a.*b)])
+          (PARALLEL
+            (ZOEKTGLOBALTEXTSEARCH
+              (fileMatchLimit . 10000)
+              (select . )
+              (repoScope . [(and branch="HEAD" rawConfig:RcOnlyPublic|RcNoForks|RcNoArchived)])
+              (includePrivate . true)
+              (globalZoektQueryRegexps . [(?i)(?-s:a.*b)])
+              (query . regex:"(?-s:a.*b)")
+              (type . text))
+            REPOSCOMPUTEEXCLUDED
+            NOOP))))))
+`),
+		}, {
+			query:      `repo:foo file:contains.content(a.*b) index:no`,
+			protocol:   search.Streaming,
+			searchType: query.SearchTypeKeyword,
+			want: autogold.Expect(`
+(LOG
+  (ALERT
+    (features . error decoding features)
+    (protocol . Streaming)
+    (onSourcegraphDotCom . true)
+    (query . )
+    (originalQuery . )
+    (patternType . keyword)
+    (TIMEOUT
+      (timeout . 20s)
+      (LIMIT
+        (limit . 10000)
+        (FILECONTAINSFILTER
+          (originalPatterns . [])
+          (filterPatterns . [(?i:a.*b)])
+          (PARALLEL
+            (REPOPAGER
+              (containsRefGlobs . false)
+              (repoOpts.repoFilters . [foo])
+              (repoOpts.useIndex . no)
+              (PARTIALREPOS
+                (ZOEKTREPOSUBSETTEXTSEARCH
+                  (fileMatchLimit . 10000)
+                  (select . )
+                  (zoektQueryRegexps . [(?i)(?-s:a.*b)])
+                  (query . regex:"(?-s:a.*b)")
+                  (type . text))))
+            (REPOPAGER
+              (containsRefGlobs . false)
+              (repoOpts.repoFilters . [foo])
+              (repoOpts.useIndex . no)
+              (PARTIALREPOS
+                (SEARCHERTEXTSEARCH
+                  (useFullDeadline . true)
+                  (patternInfo . TextPatternInfo{(/a.*b/),filematchlimit:10000})
+                  (numRepos . 0)
+                  (pathRegexps . [(?i)a.*b])
+                  (indexed . false))))
+            (REPOSCOMPUTEEXCLUDED
+              (repoOpts.repoFilters . [foo])
+              (repoOpts.useIndex . no))
+            NOOP))))))
+`),
+		}, {
 			query:      `repo:contains.file(path:a content:b)`,
 			protocol:   search.Streaming,
 			searchType: query.SearchTypeRegex,


### PR DESCRIPTION
This was the root cause of a bug where searcher and zoekt treated the pattern it received inconsistently. The way file:contains.content() works is it always takes a regex.

Additionally we came across a case for cody context not setting inputs as literal. This likely fixes a bug, but I did not test further. This came up when auditing direct creations of query.Pattern.

Test Plan: added a unit test which ensures searcher uses a regex for the pattern.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/61100

Part of https://github.com/sourcegraph/sourcegraph/issues/60745
