### PR TITLE
sg: update `ci preview` to account for Aspect steps

### DIFF
--- a/dev/ci/gen-pipeline.go
+++ b/dev/ci/gen-pipeline.go
@@ -79,6 +79,15 @@ func main() {
 	}
 }
 
+func isAspectWorkflowsEnabled() bool {
+	value, ok := os.LookupEnv("DISABLE_ASPECT_WORKFLOWS")
+	if ok && value == "true" {
+		return false
+	}
+
+	return true
+}
+
 func previewPipeline(w io.Writer, c ci.Config, pipeline *buildkite.Pipeline) {
 	fmt.Fprintf(w, "- **Detected run type:** %s\n", c.RunType.String())
 	fmt.Fprintf(w, "- **Detected diffs:** %s\n", c.Diff.String())
@@ -86,7 +95,7 @@ func previewPipeline(w io.Writer, c ci.Config, pipeline *buildkite.Pipeline) {
 	fmt.Fprintf(w, "  - VERSION=%s\n", c.Version)
 	fmt.Fprintf(w, "- **Computed build steps:**\n")
 
-	if c.RunType != runtype.BazelDo {
+	if c.RunType != runtype.BazelDo && isAspectWorkflowsEnabled() {
 		// The reason we hard code the Aspect steps here is because we have no control over the Aspect steps
 		// that get generated, so we rather just specify that there will be Aspect Workflow steps instead of
 		// running the risk of hardcoding all the steps and the rendered steps getting out of sync with what

--- a/dev/ci/gen-pipeline.go
+++ b/dev/ci/gen-pipeline.go
@@ -91,8 +91,9 @@ func previewPipeline(w io.Writer, c ci.Config, pipeline *buildkite.Pipeline) {
 		// that get generated, so we rather just specify that there will be Aspect Workflow steps instead of
 		// running the risk of hardcoding all the steps and the rendered steps getting out of sync with what
 		// is ACTUALLY running on the agent.
-		steps := []any{&buildkite.Step{
-			Label: "Aspect Workflows specific steps",
+		steps := []any{&buildkite.Pipeline{
+			Group: buildkite.Group{Group: "Aspect Workflow specific steps"},
+			Steps: []any{&buildkite.Step{Label: "🤖 Generated steps that include Buildifier, Gazelle, Test and Integration/E2E tests"}},
 		}}
 		// Flipping the order so that the Aspect steps appear first
 		pipeline.Steps = append(steps, pipeline.Steps...)

--- a/dev/ci/gen-pipeline.go
+++ b/dev/ci/gen-pipeline.go
@@ -85,6 +85,18 @@ func previewPipeline(w io.Writer, c ci.Config, pipeline *buildkite.Pipeline) {
 	fmt.Fprintf(w, "- **Computed variables:**\n")
 	fmt.Fprintf(w, "  - VERSION=%s\n", c.Version)
 	fmt.Fprintf(w, "- **Computed build steps:**\n")
+
+	if c.RunType != runtype.BazelDo {
+		// The reason we hard code the Aspect steps here is because we have no control over the Aspect steps
+		// that get generated, so we rather just specify that there will be Aspect Workflow steps instead of
+		// running the risk of hardcoding all the steps and the rendered steps getting out of sync with what
+		// is ACTUALLY running on the agent.
+		steps := []any{&buildkite.Step{
+			Label: "Aspect Workflows specific steps",
+		}}
+		// Flipping the order so that the Aspect steps appear first
+		pipeline.Steps = append(steps, pipeline.Steps...)
+	}
 	printPipeline(w, "", pipeline)
 }
 


### PR DESCRIPTION
As per the comment - we don't add the steps that aspect generates in there - as we have no control over what steps get generated ( to a degree).

Closes https://github.com/sourcegraph/sourcegraph/issues/60244

## Test plan
Tested locally

With `DISABLED_ASPECT_WORKFLOWS=true`
```
DISABLE_ASPECT_WORKFLOWS=true go run ./dev/sg ci preview
If the current branch were to be pushed, the following pipeline would be run:

  Parsed diff: git command: [git diff --name-only origin/main...] changed files: [dev/ci/gen-pipeline.go] diff changes: "Go" The generated build
  pipeline will now follow, see you next time!- Detected run type: Pull request

  • Detected diffs: Go
  • Computed variables:
    • VERSION=wbjsm-sg-ci-preview_00000_2024-03-13_5.3-123456789012
  • Computed build steps:
    • :bazel: Bazel prechecks & build  sg
    • :bazel:⏳ BackCompat Tests
    • :bazel:🧹 Go mod tidy
    • Linters and static analysis
      • 🍍:lint-roller: Run sg lint → depends on bazel-prechecks
    • Security Scanning
      • Semgrep SAST Scan
```

Normal
```
If the current branch were to be pushed, the following pipeline would be run:

  Parsed diff: git command: [git diff --name-only origin/main...] changed files: [dev/ci/gen-pipeline.go] diff changes: "Go" The generated build
  pipeline will now follow, see you next time!- Detected run type: Pull request

  • Detected diffs: Go
  • Computed variables:
    • VERSION=wbjsm-sg-ci-preview_00000_2024-03-13_5.3-123456789012
  • Computed build steps:
    • Aspect Workflow specific steps
      • 🤖 Generated steps that include Buildifier, Gazelle, Test and Integration/E2E tests
    • :bazel: Bazel prechecks & build  sg
    • :bazel:⏳ BackCompat Tests
    • :bazel:🧹 Go mod tidy
    • Linters and static analysis
      • 🍍:lint-roller: Run sg lint → depends on bazel-prechecks
    • Security Scanning
      • Semgrep SAST Scan

```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
