### PR TITLE
auth: do not fail single identity per provider check if it's the same identity

### DIFF
--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -327,6 +327,20 @@ func TestGetAndSaveUser(t *testing.T) {
 				expNewUserCreated:                false,
 				expSavedExtAccts:                 map[int32][]extsvc.AccountSpec{},
 			},
+			{
+				description: "single identity per user mode accepts the same external identity from same provider",
+				op: GetAndSaveUserOp{
+					ExternalAccount:       ext("st1", "s1", "c1", "s1/u1"),
+					UserProps:             userProps("u1", "u1@example.com"), // This user exists in the DB already and has an external account for st1, s1, c1
+					SingleIdentityPerUser: true,
+				},
+				createIfNotExistIrrelevant: true,
+				expUserID:                  1,
+				expSavedExtAccts: map[int32][]extsvc.AccountSpec{
+					1: {ext("st1", "s1", "c1", "s1/u1")},
+				},
+				expNewUserCreated: false,
+			},
 		},
 	}
 	errorCases := []outerCase{


### PR DESCRIPTION
When the user is:

1. Already authenticated
2. Completed an auth flow using an already linked external identity/account

We should not fail the single-identity-per-provider check because that is not a new identity.

This addresses the issue in the following scnerio:

1. Sign in VSCode and dotcom using GitHub
1. Sign out VSCode but stay sign-in on sourcegraph.com
2. Try to sign in VSCode again using the exact same GitHub account
3. White auth error screen on sourcegraph.com.

## Test plan

CI and tested e2e locally