### PR TITLE
chg/ci: don't push insiders tag on internal rels

### DIFF
--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -100,37 +100,29 @@ CANDIDATE_ONLY=${CANDIDATE_ONLY:-""}
 
 push_prod=false
 
-if [[ "$BUILDKITE_BRANCH" =~ ^main$ ]] || [[ "$BUILDKITE_BRANCH" =~ ^docker-images-candidates-notest/.* ]]; then
-  dev_tags+=("insiders")
-  prod_tags+=("insiders")
-  push_prod=true
-fi
-
-# We only push on internal registries on a main-dry-run.
-if [[ "$BUILDKITE_BRANCH" =~ ^main-dry-run/.*  ]]; then
-  dev_tags+=("insiders")
-  prod_tags+=("insiders")
-  push_prod=false
-fi
-
 # If we're doing an internal release, we need to push to the prod registry too.
 # TODO(rfc795) this should be more granular than this, we're abit abusing the idea of the prod registry here.
 if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
   push_prod=true
-fi
-
-# All release branch builds must be published to prod tags to support
-# format introduced by https://github.com/sourcegraph/sourcegraph/pull/48050
-# by release branch deployments.
-if [[ "$BUILDKITE_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
+elif [[ "$BUILDKITE_BRANCH" =~ ^main$ ]] || [[ "$BUILDKITE_BRANCH" =~ ^docker-images-candidates-notest/.* ]]; then
+  dev_tags+=("insiders")
+  prod_tags+=("insiders")
   push_prod=true
-fi
-
-# ok: v5.1.0
-# ok: v5.1.0-rc.5
-# no: v5.1.0-beta.1
-# no: v5.1.0-rc5
-if [[ "$BUILDKITE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\-rc\.[0-9]+)?$ ]]; then
+elif [[ "$BUILDKITE_BRANCH" =~ ^main-dry-run/.*  ]]; then
+  # We only push on internal registries on a main-dry-run.
+  dev_tags+=("insiders")
+  prod_tags+=("insiders")
+  push_prod=false
+elif [[ "$BUILDKITE_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  # All release branch builds must be published to prod tags to support
+  # format introduced by https://github.com/sourcegraph/sourcegraph/pull/48050
+  # by release branch deployments.
+  push_prod=true
+elif [[ "$BUILDKITE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\-rc\.[0-9]+)?$ ]]; then
+  # ok: v5.1.0
+  # ok: v5.1.0-rc.5
+  # no: v5.1.0-beta.1
+  # no: v5.1.0-rc5
   dev_tags+=("${BUILDKITE_TAG:1}")
   prod_tags+=("${BUILDKITE_TAG:1}")
   push_prod=true


### PR DESCRIPTION
The previous code was a bit convoluted and hard to follow the moment we started adding cases where it doesn't just look at the branch name. 

This is not great, but at least it's better and it won't push the `insiders` tag on internal releases. 

## Test plan

CI 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
