### PR TITLE
Add Haiku to Cody Gateway and PLG

### DIFF
--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -150,6 +150,7 @@ func (c *Config) Load() {
 			"claude-instant-1.2-cyan",
 			"claude-3-opus-20240229",
 			"claude-3-sonnet-20240229",
+			"claude-3-haiku-20240307",
 		}, ","),
 		"Anthropic models that can be used."))
 	if c.Anthropic.AccessToken != "" && len(c.Anthropic.AllowedModels) == 0 {

--- a/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
+++ b/cmd/frontend/internal/dotcom/productsubscription/codygateway_dotcom_user.go
@@ -348,6 +348,7 @@ func allowedModels(scope types.CompletionsFeature, isProUser bool) []string {
 
 		if !isProUser {
 			return []string{
+				"anthropic/claude-3-haiku-20240307",
 				// Remove after the Claude 3 rollout is complete
 				"anthropic/claude-2.0",
 				"anthropic/claude-instant-v1",
@@ -359,6 +360,7 @@ func allowedModels(scope types.CompletionsFeature, isProUser bool) []string {
 		return []string{
 			"anthropic/claude-3-sonnet-20240229",
 			"anthropic/claude-3-opus-20240229",
+			"anthropic/claude-3-haiku-20240307",
 			"fireworks/" + fireworks.Mixtral8x7bInstruct,
 			"openai/gpt-3.5-turbo",
 			"openai/gpt-4-1106-preview",
@@ -374,6 +376,7 @@ func allowedModels(scope types.CompletionsFeature, isProUser bool) []string {
 		}
 	case types.CompletionsFeatureCode:
 		return []string{
+			"anthropic/claude-3-haiku-20240307",
 			"anthropic/claude-instant-v1",
 			"anthropic/claude-instant-1",
 			"anthropic/claude-instant-1.2-cyan",


### PR DESCRIPTION
https://www.anthropic.com/news/claude-3-haiku

This one is going to be enabled for free users as well as we want to experiment with it for both fast-completion (symf symbol expansion) as well as autocomplete.

## Rollout

As usual:

- [ ] Roll out CG change on dev and prod
- [ ] Add new model to the dev-private license key
- [ ] Roll out dotcom change

## Test plan

Not tested yet because my local env won't start up anymore but this just adds a string to some other strings.

```
curl -vS -X POST http://localhost:9992/v1/completions/anthropic-messages -H 'Authorization: bearer <TOKEN>' -d '{"stream":true,"max_tokens":50, "model": "anthropic/claude-3-haiku-20240307", "stop_sequences": [], "messages":[{"role":"system","content":[{"type": "text", "text": "You are Cody, an AI chat bot created by Sourcegraph."}]},{"role":"user","content":[{"type": "text", "text": "Who are you?"}]}]}' -H 'X-sourcegraph-feature: chat_completions'
```