### PR TITLE
cleanup: Remove 'Dump' terminology from backend

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.autoindexing.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.autoindexing.graphql
@@ -406,7 +406,7 @@ type IndexSteps {
     index: IndexStep!
 
     """
-    Execution log entry related to uploading the dump produced by the indexing step.
+    Execution log entry related to uploading the index produced by the indexing step.
     This field be missing if the upload step had not been executed.
     """
     upload: ExecutionLogEntry

--- a/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_indexing_scheduler_test.go
+++ b/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_indexing_scheduler_test.go
@@ -36,13 +36,13 @@ func TestDependencyIndexingSchedulerHandler(t *testing.T) {
 	mockUploadsSvc.GetUploadByIDFunc.SetDefaultReturn(shared.Upload{ID: 42, RepositoryID: 50, Indexer: "lsif-go"}, true, nil)
 	mockUploadsSvc.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v2.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v3.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v3.2.2"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v2.2.1"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v4.2.3"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v1.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/banana/world", Version: "v0.0.1"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v2.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v3.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v3.2.2"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v2.2.1"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v4.2.3"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v1.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/banana/world", Version: "v0.0.1"}}, true, nil)
 	mockScanner.NextFunc.SetDefaultReturn(shared.PackageReference{}, false, nil)
 
 	mockGitserverReposStore := NewMockGitserverRepoStore()
@@ -135,13 +135,13 @@ func TestDependencyIndexingSchedulerHandlerCustomer(t *testing.T) {
 	mockUploadsSvc.GetUploadByIDFunc.SetDefaultReturn(shared.Upload{ID: 42, RepositoryID: 50, Indexer: "lsif-go"}, true, nil)
 	mockUploadsSvc.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v2.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v3.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v3.2.2"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v2.2.1"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v4.2.3"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v1.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/banana/world", Version: "v1.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v2.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v3.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v3.2.2"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v2.2.1"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v4.2.3"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v1.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/banana/world", Version: "v1.2.0"}}, true, nil)
 	mockScanner.NextFunc.SetDefaultReturn(shared.PackageReference{}, false, nil)
 
 	// simulate github.com/banana/world not being known to the instance
@@ -239,8 +239,8 @@ func TestDependencyIndexingSchedulerHandlerRequeueNotCloned(t *testing.T) {
 	mockUploadsSvc.GetUploadByIDFunc.SetDefaultReturn(shared.Upload{ID: 42, RepositoryID: 50, Indexer: "lsif-go"}, true, nil)
 	mockUploadsSvc.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v3.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v4.2.3"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v3.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v4.2.3"}}, true, nil)
 	mockScanner.NextFunc.SetDefaultReturn(shared.PackageReference{}, false, nil)
 
 	mockGitserverReposStore := NewMockGitserverRepoStore()
@@ -301,8 +301,8 @@ func TestDependencyIndexingSchedulerHandlerSkipNonExistant(t *testing.T) {
 	mockUploadsSvc.GetUploadByIDFunc.SetDefaultReturn(shared.Upload{ID: 42, RepositoryID: 50, Indexer: "lsif-go"}, true, nil)
 	mockUploadsSvc.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v3.2.0"}}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v4.2.3"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/sample/text", Version: "v3.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "https://github.com/cheese/burger", Version: "v4.2.3"}}, true, nil)
 	mockScanner.NextFunc.SetDefaultReturn(shared.PackageReference{}, false, nil)
 
 	mockGitserverReposStore := NewMockGitserverRepoStore()
@@ -400,10 +400,10 @@ func TestDependencyIndexingSchedulerHandlerNoExtsvc(t *testing.T) {
 	mockUploadsSvc.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 	mockScanner.NextFunc.PushReturn(shared.PackageReference{
 		Package: shared.Package{
-			DumpID:  42,
-			Scheme:  dependencies.JVMPackagesScheme,
-			Name:    "banana",
-			Version: "v1.2.3",
+			UploadID: 42,
+			Scheme:   dependencies.JVMPackagesScheme,
+			Name:     "banana",
+			Version:  "v1.2.3",
 		},
 	}, true, nil)
 	mockGitserverReposStore.GetByNamesFunc.PushReturn(map[api.RepoName]*types.GitserverRepo{

--- a/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_sync_scheduler.go
+++ b/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_sync_scheduler.go
@@ -125,7 +125,7 @@ func (h *dependencySyncSchedulerHandler) Handle(ctx context.Context, logger log.
 				log.Error(err),
 				log.String("name", packageReference.Name),
 				log.String("version", packageReference.Version),
-				log.Int("dumpId", packageReference.DumpID))
+				log.Int("uploadID", packageReference.UploadID))
 			continue
 		}
 		pkg := *pkgRef

--- a/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_sync_scheduler_test.go
+++ b/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_sync_scheduler_test.go
@@ -27,7 +27,7 @@ func TestDependencySyncSchedulerJVM(t *testing.T) {
 	mockScanner := NewMockPackageReferenceScanner()
 	mockUploadsSvc.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 	mockUploadsSvc.GetUploadByIDFunc.SetDefaultReturn(shared.Upload{ID: 42, RepositoryID: 50, Indexer: "scip-java"}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: dependencies.JVMPackagesScheme, Name: "name1", Version: "v2.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: dependencies.JVMPackagesScheme, Name: "name1", Version: "v2.2.0"}}, true, nil)
 
 	handler := dependencySyncSchedulerHandler{
 		uploadsSvc:  mockUploadsSvc,
@@ -78,7 +78,7 @@ func TestDependencySyncSchedulerGomod(t *testing.T) {
 	mockScanner := NewMockPackageReferenceScanner()
 	mockUploadsSvc.ReferencesForUploadFunc.SetDefaultReturn(mockScanner, nil)
 	mockUploadsSvc.GetUploadByIDFunc.SetDefaultReturn(shared.Upload{ID: 42, RepositoryID: 50, Indexer: "lsif-go"}, true, nil)
-	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{DumpID: 42, Scheme: "gomod", Name: "name1", Version: "v2.2.0"}}, true, nil)
+	mockScanner.NextFunc.PushReturn(shared.PackageReference{Package: shared.Package{UploadID: 42, Scheme: "gomod", Name: "name1", Version: "v2.2.0"}}, true, nil)
 
 	handler := dependencySyncSchedulerHandler{
 		uploadsSvc:  mockUploadsSvc,

--- a/internal/codeintel/codenav/iface.go
+++ b/internal/codeintel/codenav/iface.go
@@ -8,8 +8,8 @@ import (
 )
 
 type UploadService interface {
-	GetDumpsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []shared.Dump, err error)
+	GetProcessedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []shared.ProcessedUpload, err error)
 	GetUploadIDsWithReferences(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, ignoreIDs []int, repositoryID int, commit string, limit int, offset int) (ids []int, recordsScanned int, totalCount int, err error)
-	GetDumpsByIDs(ctx context.Context, ids []int) (_ []shared.Dump, err error)
-	InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.Dump, err error)
+	GetProcessedUploadsByIDs(ctx context.Context, ids []int) (_ []shared.ProcessedUpload, err error)
+	InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.ProcessedUpload, err error)
 }

--- a/internal/codeintel/codenav/iface.go
+++ b/internal/codeintel/codenav/iface.go
@@ -8,8 +8,8 @@ import (
 )
 
 type UploadService interface {
-	GetProcessedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []shared.ProcessedUpload, err error)
+	GetCompletedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []shared.CompletedUpload, err error)
 	GetUploadIDsWithReferences(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, ignoreIDs []int, repositoryID int, commit string, limit int, offset int) (ids []int, recordsScanned int, totalCount int, err error)
-	GetProcessedUploadsByIDs(ctx context.Context, ids []int) (_ []shared.ProcessedUpload, err error)
-	InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.ProcessedUpload, err error)
+	GetCompletedUploadsByIDs(ctx context.Context, ids []int) (_ []shared.CompletedUpload, err error)
+	InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.CompletedUpload, err error)
 }

--- a/internal/codeintel/codenav/internal/lsifstore/document_metadata.go
+++ b/internal/codeintel/codenav/internal/lsifstore/document_metadata.go
@@ -131,13 +131,13 @@ WHERE
 LIMIT 1
 `
 
-func convertSCIPRangesToLocations(ranges []*scip.Range, dumpID int, path string) []shared.Location {
+func convertSCIPRangesToLocations(ranges []*scip.Range, uploadID int, path string) []shared.Location {
 	locations := make([]shared.Location, 0, len(ranges))
 	for _, r := range ranges {
 		locations = append(locations, shared.Location{
-			DumpID: dumpID,
-			Path:   path,
-			Range:  translateRange(r),
+			UploadID: uploadID,
+			Path:     path,
+			Range:    translateRange(r),
 		})
 	}
 

--- a/internal/codeintel/codenav/internal/lsifstore/document_metadata_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/document_metadata_test.go
@@ -156,22 +156,22 @@ func TestGetRanges(t *testing.T) {
 	)
 
 	var (
-		nonEmptyDefinitionLocations = []shared.Location{{DumpID: testSCIPUploadID, Path: path, Range: newRange(15, 16, 15, 24)}}
-		tDefinitionLocations        = []shared.Location{{DumpID: testSCIPUploadID, Path: path, Range: newRange(15, 25, 15, 26)}}
-		valueDefinitionLocations    = []shared.Location{{DumpID: testSCIPUploadID, Path: path, Range: newRange(15, 28, 15, 33)}}
+		nonEmptyDefinitionLocations = []shared.Location{{UploadID: testSCIPUploadID, Path: path, Range: newRange(15, 16, 15, 24)}}
+		tDefinitionLocations        = []shared.Location{{UploadID: testSCIPUploadID, Path: path, Range: newRange(15, 25, 15, 26)}}
+		valueDefinitionLocations    = []shared.Location{{UploadID: testSCIPUploadID, Path: path, Range: newRange(15, 28, 15, 33)}}
 
 		nonEmptyReferenceLocations = []shared.Location{}
 		tReferenceLocations        = []shared.Location{
-			{DumpID: testSCIPUploadID, Path: path, Range: newRange(15, 35, 15, 36)},
-			{DumpID: testSCIPUploadID, Path: path, Range: newRange(15, 39, 15, 40)},
-			{DumpID: testSCIPUploadID, Path: path, Range: newRange(15, 73, 15, 74)},
-			{DumpID: testSCIPUploadID, Path: path, Range: newRange(15, 77, 15, 78)},
+			{UploadID: testSCIPUploadID, Path: path, Range: newRange(15, 35, 15, 36)},
+			{UploadID: testSCIPUploadID, Path: path, Range: newRange(15, 39, 15, 40)},
+			{UploadID: testSCIPUploadID, Path: path, Range: newRange(15, 73, 15, 74)},
+			{UploadID: testSCIPUploadID, Path: path, Range: newRange(15, 77, 15, 78)},
 		}
 		valueReferenceLocations = []shared.Location{
-			{DumpID: testSCIPUploadID, Path: path, Range: newRange(15, 64, 15, 69)},
-			{DumpID: testSCIPUploadID, Path: path, Range: newRange(16, 13, 16, 18)},
-			{DumpID: testSCIPUploadID, Path: path, Range: newRange(16, 38, 16, 43)},
-			{DumpID: testSCIPUploadID, Path: path, Range: newRange(16, 48, 16, 53)},
+			{UploadID: testSCIPUploadID, Path: path, Range: newRange(15, 64, 15, 69)},
+			{UploadID: testSCIPUploadID, Path: path, Range: newRange(16, 13, 16, 18)},
+			{UploadID: testSCIPUploadID, Path: path, Range: newRange(16, 38, 16, 43)},
+			{UploadID: testSCIPUploadID, Path: path, Range: newRange(16, 48, 16, 53)},
 		}
 
 		nonEmptyImplementationLocations = []shared.Location(nil)

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position.go
@@ -76,7 +76,7 @@ func (s *store) GetBulkMonikerLocations(ctx context.Context, tableName string, u
 		totalCount += len(monikerLocations.Locations)
 	}
 	trace.AddEvent("TODO Domain Owner",
-		attribute.Int("numDumps", len(locationData)),
+		attribute.Int("numUploads", len(locationData)),
 		attribute.Int("totalCount", totalCount))
 
 	max := totalCount
@@ -94,9 +94,9 @@ outer:
 			}
 
 			locations = append(locations, shared.Location{
-				DumpID: monikerLocations.DumpID,
-				Path:   row.URI,
-				Range:  newRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
+				UploadID: monikerLocations.UploadID,
+				Path:     row.URI,
+				Range:    newRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
 			})
 
 			if len(locations) >= limit {
@@ -176,9 +176,9 @@ func (s *store) getLocations(
 			for _, monikerLocation := range monikerLocations {
 				for _, row := range monikerLocation.Locations {
 					locations = append(locations, shared.Location{
-						DumpID: monikerLocation.DumpID,
-						Path:   row.URI,
-						Range:  newRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
+						UploadID: monikerLocation.UploadID,
+						Path:     row.URI,
+						Range:    newRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
 					})
 				}
 			}
@@ -492,7 +492,7 @@ func deduplicateLocations(locations []shared.Location) []shared.Location {
 
 func locationKey(l shared.Location) string {
 	return fmt.Sprintf("%d:%s:%d:%d:%d:%d",
-		l.DumpID,
+		l.UploadID,
 		l.Path,
 		l.Range.Start.Line,
 		l.Range.Start.Character,
@@ -555,7 +555,7 @@ func (s *store) GetMinimalBulkMonikerLocations(ctx context.Context, tableName st
 		totalCount += len(monikerLocations.Locations)
 	}
 	trace.AddEvent("TODO Domain Owner",
-		attribute.Int("numDumps", len(locationData)),
+		attribute.Int("numUploads", len(locationData)),
 		attribute.Int("totalCount", totalCount))
 
 	max := totalCount
@@ -573,9 +573,9 @@ outer:
 			}
 
 			locations = append(locations, shared.Location{
-				DumpID: monikerLocations.DumpID,
-				Path:   row.URI,
-				Range:  newRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
+				UploadID: monikerLocations.UploadID,
+				Path:     row.URI,
+				Range:    newRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
 			})
 
 			if len(locations) >= limit {

--- a/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
+++ b/internal/codeintel/codenav/internal/lsifstore/locations_by_position_test.go
@@ -37,9 +37,9 @@ func TestExtractDefinitionLocationsFromPosition(t *testing.T) {
 
 	scipDefinitionLocations := []shared.Location{
 		{
-			DumpID: testSCIPUploadID,
-			Path:   "template/src/lsif/util.ts",
-			Range:  newRange(7, 10, 7, 13),
+			UploadID: testSCIPUploadID,
+			Path:     "template/src/lsif/util.ts",
+			Range:    newRange(7, 10, 7, 13),
 		},
 	}
 
@@ -84,9 +84,9 @@ func TestExtractReferenceLocationsFromPosition(t *testing.T) {
 	//         ^^^
 
 	scipExpected := []shared.Location{
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(10, 12, 10, 15)},
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(12, 19, 12, 22)},
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(15, 8, 15, 11)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(10, 12, 10, 15)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(12, 19, 12, 22)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(15, 8, 15, 11)},
 	}
 
 	testCases := []struct {
@@ -141,15 +141,15 @@ func TestGetMinimalBulkMonikerLocations(t *testing.T) {
 
 	expectedLocations := []shared.Location{
 		// SCIP results
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(10, 9, 10, 16)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(186, 43, 186, 50)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(296, 34, 296, 41)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(324, 38, 324, 45)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(384, 30, 384, 37)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(415, 8, 415, 15)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(420, 27, 420, 34)},
-		{DumpID: testSCIPUploadID, Path: "template/src/search/providers.ts", Range: newRange(9, 9, 9, 16)},
-		{DumpID: testSCIPUploadID, Path: "template/src/search/providers.ts", Range: newRange(225, 20, 225, 27)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(10, 9, 10, 16)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(186, 43, 186, 50)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(296, 34, 296, 41)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(324, 38, 324, 45)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(384, 30, 384, 37)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(415, 8, 415, 15)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(420, 27, 420, 34)},
+		{UploadID: testSCIPUploadID, Path: "template/src/search/providers.ts", Range: newRange(9, 9, 9, 16)},
+		{UploadID: testSCIPUploadID, Path: "template/src/search/providers.ts", Range: newRange(225, 20, 225, 27)},
 	}
 	if diff := cmp.Diff(expectedLocations, locations); diff != "" {
 		t.Errorf("unexpected locations (-want +got):\n%s", diff)
@@ -170,9 +170,9 @@ func TestDatabaseDefinitions(t *testing.T) {
 
 	scipDefinitionLocations := []shared.Location{
 		{
-			DumpID: testSCIPUploadID,
-			Path:   "template/src/lsif/util.ts",
-			Range:  newRange(7, 10, 7, 13),
+			UploadID: testSCIPUploadID,
+			Path:     "template/src/lsif/util.ts",
+			Range:    newRange(7, 10, 7, 13),
 		},
 	}
 
@@ -183,9 +183,9 @@ func TestDatabaseDefinitions(t *testing.T) {
 
 	scipNonLocalDefinitionLocations := []shared.Location{
 		{
-			DumpID: testSCIPUploadID,
-			Path:   "template/src/lsif/definition-hover.ts",
-			Range:  newRange(21, 17, 21, 29),
+			UploadID: testSCIPUploadID,
+			Path:     "template/src/lsif/definition-hover.ts",
+			Range:    newRange(21, 17, 21, 29),
 		},
 	}
 
@@ -249,9 +249,9 @@ func TestDatabaseReferences(t *testing.T) {
 	//         ^^^
 
 	scipExpected := []shared.Location{
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(10, 12, 10, 15)},
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(12, 19, 12, 22)},
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(15, 8, 15, 11)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(10, 12, 10, 15)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(12, 19, 12, 22)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/util.ts", Range: newRange(15, 8, 15, 11)},
 	}
 
 	// Symbol name search for
@@ -260,11 +260,11 @@ func TestDatabaseReferences(t *testing.T) {
 	//                   ^^^^^^^^^^^^
 
 	scipNonLocalExpected := []shared.Location{
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/ranges.ts", Range: newRange(6, 9, 6, 21)},
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/ranges.ts", Range: newRange(38, 12, 38, 24)},
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/ranges.ts", Range: newRange(385, 12, 385, 24)},
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/definition-hover.ts", Range: newRange(18, 12, 18, 24)},
-		{DumpID: testSCIPUploadID, Path: "template/src/lsif/definition-hover.ts", Range: newRange(123, 45, 123, 57)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/ranges.ts", Range: newRange(6, 9, 6, 21)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/ranges.ts", Range: newRange(38, 12, 38, 24)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/ranges.ts", Range: newRange(385, 12, 385, 24)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/definition-hover.ts", Range: newRange(18, 12, 18, 24)},
+		{UploadID: testSCIPUploadID, Path: "template/src/lsif/definition-hover.ts", Range: newRange(123, 45, 123, 57)},
 	}
 
 	testCases := []struct {
@@ -700,15 +700,15 @@ func TestGetBulkMonikerLocations(t *testing.T) {
 
 	expectedLocations := []shared.Location{
 		// SCIP results
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(10, 9, 10, 16)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(186, 43, 186, 50)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(296, 34, 296, 41)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(324, 38, 324, 45)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(384, 30, 384, 37)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(415, 8, 415, 15)},
-		{DumpID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(420, 27, 420, 34)},
-		{DumpID: testSCIPUploadID, Path: "template/src/search/providers.ts", Range: newRange(9, 9, 9, 16)},
-		{DumpID: testSCIPUploadID, Path: "template/src/search/providers.ts", Range: newRange(225, 20, 225, 27)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(10, 9, 10, 16)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(186, 43, 186, 50)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(296, 34, 296, 41)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(324, 38, 324, 45)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(384, 30, 384, 37)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(415, 8, 415, 15)},
+		{UploadID: testSCIPUploadID, Path: "template/src/providers.ts", Range: newRange(420, 27, 420, 34)},
+		{UploadID: testSCIPUploadID, Path: "template/src/search/providers.ts", Range: newRange(9, 9, 9, 16)},
+		{UploadID: testSCIPUploadID, Path: "template/src/search/providers.ts", Range: newRange(225, 20, 225, 27)},
 	}
 	if diff := cmp.Diff(expectedLocations, locations); diff != "" {
 		t.Errorf("unexpected locations (-want +got):\n%s", diff)

--- a/internal/codeintel/codenav/internal/lsifstore/metadata_by_position.go
+++ b/internal/codeintel/codenav/internal/lsifstore/metadata_by_position.go
@@ -234,8 +234,8 @@ func (s *store) GetDiagnostics(ctx context.Context, bundleID int, prefix string,
 
 				if offset < 0 && len(diagnostics) < limit {
 					diagnostics = append(diagnostics, shared.Diagnostic{
-						DumpID: bundleID,
-						Path:   documentData.Path,
+						UploadID: bundleID,
+						Path:     documentData.Path,
 						DiagnosticData: precise.DiagnosticData{
 							Severity:       int(diagnostic.Severity),
 							Code:           diagnostic.Code,

--- a/internal/codeintel/codenav/internal/lsifstore/scan.go
+++ b/internal/codeintel/codenav/internal/lsifstore/scan.go
@@ -86,7 +86,7 @@ func (s *store) scanSingleDocumentDataObject(rows *sql.Rows) (qualifiedDocumentD
 }
 
 type qualifiedMonikerLocations struct {
-	DumpID int
+	UploadID int
 	precise.MonikerLocations
 }
 
@@ -114,7 +114,7 @@ func (s *store) scanSingleQualifiedMonikerLocationsObject(rows *sql.Rows) (quali
 	var scipPayload []byte
 	var record qualifiedMonikerLocations
 
-	if err := rows.Scan(&record.DumpID, &record.Scheme, &record.Identifier, &scipPayload, &uri); err != nil {
+	if err := rows.Scan(&record.UploadID, &record.Scheme, &record.Identifier, &scipPayload, &uri); err != nil {
 		return qualifiedMonikerLocations{}, err
 	}
 
@@ -154,7 +154,7 @@ func (s *store) scanDeduplicatedQualifiedMonikerLocations(rows *sql.Rows, queryE
 			return nil, err
 		}
 
-		if n := len(values) - 1; n >= 0 && values[n].DumpID == record.DumpID {
+		if n := len(values) - 1; n >= 0 && values[n].UploadID == record.UploadID {
 			values[n].Locations = append(values[n].Locations, record.Locations...)
 		} else {
 			values = append(values, record)
@@ -172,7 +172,7 @@ func (s *store) scanSingleMinimalQualifiedMonikerLocationsObject(rows *sql.Rows)
 	var scipPayload []byte
 	var record qualifiedMonikerLocations
 
-	if err := rows.Scan(&record.DumpID, &scipPayload, &uri); err != nil {
+	if err := rows.Scan(&record.UploadID, &scipPayload, &uri); err != nil {
 		return qualifiedMonikerLocations{}, err
 	}
 

--- a/internal/codeintel/codenav/mocks_test.go
+++ b/internal/codeintel/codenav/mocks_test.go
@@ -2965,13 +2965,13 @@ func (c GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFuncCall) Results() 
 // github.com/sourcegraph/sourcegraph/internal/codeintel/codenav) used for
 // unit testing.
 type MockUploadService struct {
-	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetProcessedUploadsByIDs.
-	GetProcessedUploadsByIDsFunc *UploadServiceGetProcessedUploadsByIDsFunc
-	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletedUploadsByIDs.
+	GetCompletedUploadsByIDsFunc *UploadServiceGetCompletedUploadsByIDsFunc
+	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
 	// mock function object controlling the behavior of the method
-	// GetProcessedUploadsWithDefinitionsForMonikers.
-	GetProcessedUploadsWithDefinitionsForMonikersFunc *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc
+	// GetCompletedUploadsWithDefinitionsForMonikers.
+	GetCompletedUploadsWithDefinitionsForMonikersFunc *UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetUploadIDsWithReferencesFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// GetUploadIDsWithReferences.
@@ -2985,13 +2985,13 @@ type MockUploadService struct {
 // All methods return zero values for all results, unless overwritten.
 func NewMockUploadService() *MockUploadService {
 	return &MockUploadService{
-		GetProcessedUploadsByIDsFunc: &UploadServiceGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared1.ProcessedUpload, r1 error) {
+		GetCompletedUploadsByIDsFunc: &UploadServiceGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.ProcessedUpload, r1 error) {
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -3001,7 +3001,7 @@ func NewMockUploadService() *MockUploadService {
 			},
 		},
 		InferClosestUploadsFunc: &UploadServiceInferClosestUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.ProcessedUpload, r1 error) {
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -3012,14 +3012,14 @@ func NewMockUploadService() *MockUploadService {
 // interface. All methods panic on invocation, unless overwritten.
 func NewStrictMockUploadService() *MockUploadService {
 	return &MockUploadService{
-		GetProcessedUploadsByIDsFunc: &UploadServiceGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
-				panic("unexpected invocation of MockUploadService.GetProcessedUploadsByIDs")
+		GetCompletedUploadsByIDsFunc: &UploadServiceGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared1.CompletedUpload, error) {
+				panic("unexpected invocation of MockUploadService.GetCompletedUploadsByIDs")
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
-				panic("unexpected invocation of MockUploadService.GetProcessedUploadsWithDefinitionsForMonikers")
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
+				panic("unexpected invocation of MockUploadService.GetCompletedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetUploadIDsWithReferencesFunc: &UploadServiceGetUploadIDsWithReferencesFunc{
@@ -3028,7 +3028,7 @@ func NewStrictMockUploadService() *MockUploadService {
 			},
 		},
 		InferClosestUploadsFunc: &UploadServiceInferClosestUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
 				panic("unexpected invocation of MockUploadService.InferClosestUploads")
 			},
 		},
@@ -3040,11 +3040,11 @@ func NewStrictMockUploadService() *MockUploadService {
 // overwritten.
 func NewMockUploadServiceFrom(i UploadService) *MockUploadService {
 	return &MockUploadService{
-		GetProcessedUploadsByIDsFunc: &UploadServiceGetProcessedUploadsByIDsFunc{
-			defaultHook: i.GetProcessedUploadsByIDs,
+		GetCompletedUploadsByIDsFunc: &UploadServiceGetCompletedUploadsByIDsFunc{
+			defaultHook: i.GetCompletedUploadsByIDs,
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
 		},
 		GetUploadIDsWithReferencesFunc: &UploadServiceGetUploadIDsWithReferencesFunc{
 			defaultHook: i.GetUploadIDsWithReferences,
@@ -3055,37 +3055,37 @@ func NewMockUploadServiceFrom(i UploadService) *MockUploadService {
 	}
 }
 
-// UploadServiceGetProcessedUploadsByIDsFunc describes the behavior when the
-// GetProcessedUploadsByIDs method of the parent MockUploadService instance
+// UploadServiceGetCompletedUploadsByIDsFunc describes the behavior when the
+// GetCompletedUploadsByIDs method of the parent MockUploadService instance
 // is invoked.
-type UploadServiceGetProcessedUploadsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared1.ProcessedUpload, error)
-	hooks       []func(context.Context, []int) ([]shared1.ProcessedUpload, error)
-	history     []UploadServiceGetProcessedUploadsByIDsFuncCall
+type UploadServiceGetCompletedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared1.CompletedUpload, error)
+	history     []UploadServiceGetCompletedUploadsByIDsFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// GetCompletedUploadsByIDs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockUploadService) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared1.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsByIDsFunc.appendCall(UploadServiceGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
+func (m *MockUploadService) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsByIDsFunc.appendCall(UploadServiceGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsByIDs method of the parent MockUploadService instance
+// GetCompletedUploadsByIDs method of the parent MockUploadService instance
 // is invoked and the hook queue is empty.
-func (f *UploadServiceGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.ProcessedUpload, error)) {
+func (f *UploadServiceGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsByIDs method of the parent MockUploadService instance
+// GetCompletedUploadsByIDs method of the parent MockUploadService instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *UploadServiceGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.ProcessedUpload, error)) {
+func (f *UploadServiceGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3093,20 +3093,20 @@ func (f *UploadServiceGetProcessedUploadsByIDsFunc) PushHook(hook func(context.C
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UploadServiceGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+func (f *UploadServiceGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UploadServiceGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+func (f *UploadServiceGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *UploadServiceGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+func (f *UploadServiceGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3119,28 +3119,28 @@ func (f *UploadServiceGetProcessedUploadsByIDsFunc) nextHook() func(context.Cont
 	return hook
 }
 
-func (f *UploadServiceGetProcessedUploadsByIDsFunc) appendCall(r0 UploadServiceGetProcessedUploadsByIDsFuncCall) {
+func (f *UploadServiceGetCompletedUploadsByIDsFunc) appendCall(r0 UploadServiceGetCompletedUploadsByIDsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// UploadServiceGetProcessedUploadsByIDsFuncCall objects describing the
+// UploadServiceGetCompletedUploadsByIDsFuncCall objects describing the
 // invocations of this function.
-func (f *UploadServiceGetProcessedUploadsByIDsFunc) History() []UploadServiceGetProcessedUploadsByIDsFuncCall {
+func (f *UploadServiceGetCompletedUploadsByIDsFunc) History() []UploadServiceGetCompletedUploadsByIDsFuncCall {
 	f.mutex.Lock()
-	history := make([]UploadServiceGetProcessedUploadsByIDsFuncCall, len(f.history))
+	history := make([]UploadServiceGetCompletedUploadsByIDsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// UploadServiceGetProcessedUploadsByIDsFuncCall is an object that describes
-// an invocation of method GetProcessedUploadsByIDs on an instance of
+// UploadServiceGetCompletedUploadsByIDsFuncCall is an object that describes
+// an invocation of method GetCompletedUploadsByIDs on an instance of
 // MockUploadService.
-type UploadServiceGetProcessedUploadsByIDsFuncCall struct {
+type UploadServiceGetCompletedUploadsByIDsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3149,7 +3149,7 @@ type UploadServiceGetProcessedUploadsByIDsFuncCall struct {
 	Arg1 []int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.ProcessedUpload
+	Result0 []shared1.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3157,48 +3157,48 @@ type UploadServiceGetProcessedUploadsByIDsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c UploadServiceGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
+func (c UploadServiceGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c UploadServiceGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
+func (c UploadServiceGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc describes
-// the behavior when the GetProcessedUploadsWithDefinitionsForMonikers
+// UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc describes
+// the behavior when the GetCompletedUploadsWithDefinitionsForMonikers
 // method of the parent MockUploadService instance is invoked.
-type UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)
-	history     []UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+type UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)
+	history     []UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockUploadService) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+func (m *MockUploadService) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockUploadService instance is invoked and the hook queue is empty.
-func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)) {
+func (f *UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockUploadService instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)) {
+func (f *UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3206,20 +3206,20 @@ func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHoo
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+func (f *UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+func (f *UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+func (f *UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3232,29 +3232,29 @@ func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHoo
 	return hook
 }
 
-func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
+func (f *UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+// UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall
 // objects describing the invocations of this function.
-func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
+func (f *UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
 	f.mutex.Lock()
-	history := make([]UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	history := make([]UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an
+// UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an
 // object that describes an invocation of method
-// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
 // MockUploadService.
-type UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
+type UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3263,7 +3263,7 @@ type UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 	Arg1 []precise.QualifiedMonikerData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.ProcessedUpload
+	Result0 []shared1.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3271,13 +3271,13 @@ type UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+func (c UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+func (c UploadServiceGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3418,15 +3418,15 @@ func (c UploadServiceGetUploadIDsWithReferencesFuncCall) Results() []interface{}
 // InferClosestUploads method of the parent MockUploadService instance is
 // invoked.
 type UploadServiceInferClosestUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)
 	history     []UploadServiceInferClosestUploadsFuncCall
 	mutex       sync.Mutex
 }
 
 // InferClosestUploads delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockUploadService) InferClosestUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.ProcessedUpload, error) {
+func (m *MockUploadService) InferClosestUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.CompletedUpload, error) {
 	r0, r1 := m.InferClosestUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
 	m.InferClosestUploadsFunc.appendCall(UploadServiceInferClosestUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
@@ -3435,7 +3435,7 @@ func (m *MockUploadService) InferClosestUploads(v0 context.Context, v1 int, v2 s
 // SetDefaultHook sets function that is called when the InferClosestUploads
 // method of the parent MockUploadService instance is invoked and the hook
 // queue is empty.
-func (f *UploadServiceInferClosestUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)) {
+func (f *UploadServiceInferClosestUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -3444,7 +3444,7 @@ func (f *UploadServiceInferClosestUploadsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *UploadServiceInferClosestUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)) {
+func (f *UploadServiceInferClosestUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3452,20 +3452,20 @@ func (f *UploadServiceInferClosestUploadsFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UploadServiceInferClosestUploadsFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
+func (f *UploadServiceInferClosestUploadsFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UploadServiceInferClosestUploadsFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
+func (f *UploadServiceInferClosestUploadsFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *UploadServiceInferClosestUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
+func (f *UploadServiceInferClosestUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3519,7 +3519,7 @@ type UploadServiceInferClosestUploadsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.ProcessedUpload
+	Result0 []shared1.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/codeintel/codenav/mocks_test.go
+++ b/internal/codeintel/codenav/mocks_test.go
@@ -2965,13 +2965,13 @@ func (c GitTreeTranslatorGetTargetCommitRangeFromSourceRangeFuncCall) Results() 
 // github.com/sourcegraph/sourcegraph/internal/codeintel/codenav) used for
 // unit testing.
 type MockUploadService struct {
-	// GetDumpsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetDumpsByIDs.
-	GetDumpsByIDsFunc *UploadServiceGetDumpsByIDsFunc
-	// GetDumpsWithDefinitionsForMonikersFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// GetDumpsWithDefinitionsForMonikers.
-	GetDumpsWithDefinitionsForMonikersFunc *UploadServiceGetDumpsWithDefinitionsForMonikersFunc
+	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetProcessedUploadsByIDs.
+	GetProcessedUploadsByIDsFunc *UploadServiceGetProcessedUploadsByIDsFunc
+	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// GetProcessedUploadsWithDefinitionsForMonikers.
+	GetProcessedUploadsWithDefinitionsForMonikersFunc *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc
 	// GetUploadIDsWithReferencesFunc is an instance of a mock function
 	// object controlling the behavior of the method
 	// GetUploadIDsWithReferences.
@@ -2985,13 +2985,13 @@ type MockUploadService struct {
 // All methods return zero values for all results, unless overwritten.
 func NewMockUploadService() *MockUploadService {
 	return &MockUploadService{
-		GetDumpsByIDsFunc: &UploadServiceGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared1.Dump, r1 error) {
+		GetProcessedUploadsByIDsFunc: &UploadServiceGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared1.ProcessedUpload, r1 error) {
 				return
 			},
 		},
-		GetDumpsWithDefinitionsForMonikersFunc: &UploadServiceGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.Dump, r1 error) {
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -3001,7 +3001,7 @@ func NewMockUploadService() *MockUploadService {
 			},
 		},
 		InferClosestUploadsFunc: &UploadServiceInferClosestUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.Dump, r1 error) {
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -3012,14 +3012,14 @@ func NewMockUploadService() *MockUploadService {
 // interface. All methods panic on invocation, unless overwritten.
 func NewStrictMockUploadService() *MockUploadService {
 	return &MockUploadService{
-		GetDumpsByIDsFunc: &UploadServiceGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared1.Dump, error) {
-				panic("unexpected invocation of MockUploadService.GetDumpsByIDs")
+		GetProcessedUploadsByIDsFunc: &UploadServiceGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+				panic("unexpected invocation of MockUploadService.GetProcessedUploadsByIDs")
 			},
 		},
-		GetDumpsWithDefinitionsForMonikersFunc: &UploadServiceGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
-				panic("unexpected invocation of MockUploadService.GetDumpsWithDefinitionsForMonikers")
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+				panic("unexpected invocation of MockUploadService.GetProcessedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetUploadIDsWithReferencesFunc: &UploadServiceGetUploadIDsWithReferencesFunc{
@@ -3028,7 +3028,7 @@ func NewStrictMockUploadService() *MockUploadService {
 			},
 		},
 		InferClosestUploadsFunc: &UploadServiceInferClosestUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error) {
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
 				panic("unexpected invocation of MockUploadService.InferClosestUploads")
 			},
 		},
@@ -3040,11 +3040,11 @@ func NewStrictMockUploadService() *MockUploadService {
 // overwritten.
 func NewMockUploadServiceFrom(i UploadService) *MockUploadService {
 	return &MockUploadService{
-		GetDumpsByIDsFunc: &UploadServiceGetDumpsByIDsFunc{
-			defaultHook: i.GetDumpsByIDs,
+		GetProcessedUploadsByIDsFunc: &UploadServiceGetProcessedUploadsByIDsFunc{
+			defaultHook: i.GetProcessedUploadsByIDs,
 		},
-		GetDumpsWithDefinitionsForMonikersFunc: &UploadServiceGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetDumpsWithDefinitionsForMonikers,
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
 		},
 		GetUploadIDsWithReferencesFunc: &UploadServiceGetUploadIDsWithReferencesFunc{
 			defaultHook: i.GetUploadIDsWithReferences,
@@ -3055,35 +3055,37 @@ func NewMockUploadServiceFrom(i UploadService) *MockUploadService {
 	}
 }
 
-// UploadServiceGetDumpsByIDsFunc describes the behavior when the
-// GetDumpsByIDs method of the parent MockUploadService instance is invoked.
-type UploadServiceGetDumpsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared1.Dump, error)
-	hooks       []func(context.Context, []int) ([]shared1.Dump, error)
-	history     []UploadServiceGetDumpsByIDsFuncCall
+// UploadServiceGetProcessedUploadsByIDsFunc describes the behavior when the
+// GetProcessedUploadsByIDs method of the parent MockUploadService instance
+// is invoked.
+type UploadServiceGetProcessedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared1.ProcessedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared1.ProcessedUpload, error)
+	history     []UploadServiceGetProcessedUploadsByIDsFuncCall
 	mutex       sync.Mutex
 }
 
-// GetDumpsByIDs delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockUploadService) GetDumpsByIDs(v0 context.Context, v1 []int) ([]shared1.Dump, error) {
-	r0, r1 := m.GetDumpsByIDsFunc.nextHook()(v0, v1)
-	m.GetDumpsByIDsFunc.appendCall(UploadServiceGetDumpsByIDsFuncCall{v0, v1, r0, r1})
+// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockUploadService) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared1.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsByIDsFunc.appendCall(UploadServiceGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the GetDumpsByIDs method
-// of the parent MockUploadService instance is invoked and the hook queue is
-// empty.
-func (f *UploadServiceGetDumpsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.Dump, error)) {
+// SetDefaultHook sets function that is called when the
+// GetProcessedUploadsByIDs method of the parent MockUploadService instance
+// is invoked and the hook queue is empty.
+func (f *UploadServiceGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsByIDs method of the parent MockUploadService instance invokes the
-// hook at the front of the queue and discards it. After the queue is empty,
-// the default hook function is invoked for any future action.
-func (f *UploadServiceGetDumpsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.Dump, error)) {
+// GetProcessedUploadsByIDs method of the parent MockUploadService instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *UploadServiceGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3091,20 +3093,20 @@ func (f *UploadServiceGetDumpsByIDsFunc) PushHook(hook func(context.Context, []i
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UploadServiceGetDumpsByIDsFunc) SetDefaultReturn(r0 []shared1.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared1.Dump, error) {
+func (f *UploadServiceGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UploadServiceGetDumpsByIDsFunc) PushReturn(r0 []shared1.Dump, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared1.Dump, error) {
+func (f *UploadServiceGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *UploadServiceGetDumpsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.Dump, error) {
+func (f *UploadServiceGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3117,26 +3119,28 @@ func (f *UploadServiceGetDumpsByIDsFunc) nextHook() func(context.Context, []int)
 	return hook
 }
 
-func (f *UploadServiceGetDumpsByIDsFunc) appendCall(r0 UploadServiceGetDumpsByIDsFuncCall) {
+func (f *UploadServiceGetProcessedUploadsByIDsFunc) appendCall(r0 UploadServiceGetProcessedUploadsByIDsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of UploadServiceGetDumpsByIDsFuncCall objects
-// describing the invocations of this function.
-func (f *UploadServiceGetDumpsByIDsFunc) History() []UploadServiceGetDumpsByIDsFuncCall {
+// History returns a sequence of
+// UploadServiceGetProcessedUploadsByIDsFuncCall objects describing the
+// invocations of this function.
+func (f *UploadServiceGetProcessedUploadsByIDsFunc) History() []UploadServiceGetProcessedUploadsByIDsFuncCall {
 	f.mutex.Lock()
-	history := make([]UploadServiceGetDumpsByIDsFuncCall, len(f.history))
+	history := make([]UploadServiceGetProcessedUploadsByIDsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// UploadServiceGetDumpsByIDsFuncCall is an object that describes an
-// invocation of method GetDumpsByIDs on an instance of MockUploadService.
-type UploadServiceGetDumpsByIDsFuncCall struct {
+// UploadServiceGetProcessedUploadsByIDsFuncCall is an object that describes
+// an invocation of method GetProcessedUploadsByIDs on an instance of
+// MockUploadService.
+type UploadServiceGetProcessedUploadsByIDsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3145,7 +3149,7 @@ type UploadServiceGetDumpsByIDsFuncCall struct {
 	Arg1 []int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.Dump
+	Result0 []shared1.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3153,47 +3157,48 @@ type UploadServiceGetDumpsByIDsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c UploadServiceGetDumpsByIDsFuncCall) Args() []interface{} {
+func (c UploadServiceGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c UploadServiceGetDumpsByIDsFuncCall) Results() []interface{} {
+func (c UploadServiceGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// UploadServiceGetDumpsWithDefinitionsForMonikersFunc describes the
-// behavior when the GetDumpsWithDefinitionsForMonikers method of the parent
-// MockUploadService instance is invoked.
-type UploadServiceGetDumpsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error)
-	history     []UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall
+// UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc describes
+// the behavior when the GetProcessedUploadsWithDefinitionsForMonikers
+// method of the parent MockUploadService instance is invoked.
+type UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)
+	history     []UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall
 	mutex       sync.Mutex
 }
 
-// GetDumpsWithDefinitionsForMonikers delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockUploadService) GetDumpsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
-	r0, r1 := m.GetDumpsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetDumpsWithDefinitionsForMonikersFunc.appendCall(UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockUploadService) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockUploadService
-// instance is invoked and the hook queue is empty.
-func (f *UploadServiceGetDumpsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error)) {
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockUploadService instance is invoked and the hook queue is empty.
+func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockUploadService
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *UploadServiceGetDumpsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error)) {
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockUploadService instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3201,20 +3206,20 @@ func (f *UploadServiceGetDumpsWithDefinitionsForMonikersFunc) PushHook(hook func
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UploadServiceGetDumpsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
+func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UploadServiceGetDumpsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.Dump, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
+func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *UploadServiceGetDumpsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
+func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3227,28 +3232,29 @@ func (f *UploadServiceGetDumpsWithDefinitionsForMonikersFunc) nextHook() func(co
 	return hook
 }
 
-func (f *UploadServiceGetDumpsWithDefinitionsForMonikersFunc) appendCall(r0 UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall) {
+func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall objects
-// describing the invocations of this function.
-func (f *UploadServiceGetDumpsWithDefinitionsForMonikersFunc) History() []UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall {
+// UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+// objects describing the invocations of this function.
+func (f *UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
 	f.mutex.Lock()
-	history := make([]UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall, len(f.history))
+	history := make([]UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall is an object that
-// describes an invocation of method GetDumpsWithDefinitionsForMonikers on
-// an instance of MockUploadService.
-type UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall struct {
+// UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an
+// object that describes an invocation of method
+// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// MockUploadService.
+type UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3257,7 +3263,7 @@ type UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall struct {
 	Arg1 []precise.QualifiedMonikerData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.Dump
+	Result0 []shared1.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3265,13 +3271,13 @@ type UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+func (c UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c UploadServiceGetDumpsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+func (c UploadServiceGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3412,15 +3418,15 @@ func (c UploadServiceGetUploadIDsWithReferencesFuncCall) Results() []interface{}
 // InferClosestUploads method of the parent MockUploadService instance is
 // invoked.
 type UploadServiceInferClosestUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error)
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)
 	history     []UploadServiceInferClosestUploadsFuncCall
 	mutex       sync.Mutex
 }
 
 // InferClosestUploads delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockUploadService) InferClosestUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.Dump, error) {
+func (m *MockUploadService) InferClosestUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.ProcessedUpload, error) {
 	r0, r1 := m.InferClosestUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
 	m.InferClosestUploadsFunc.appendCall(UploadServiceInferClosestUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
@@ -3429,7 +3435,7 @@ func (m *MockUploadService) InferClosestUploads(v0 context.Context, v1 int, v2 s
 // SetDefaultHook sets function that is called when the InferClosestUploads
 // method of the parent MockUploadService instance is invoked and the hook
 // queue is empty.
-func (f *UploadServiceInferClosestUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error)) {
+func (f *UploadServiceInferClosestUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -3438,7 +3444,7 @@ func (f *UploadServiceInferClosestUploadsFunc) SetDefaultHook(hook func(context.
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *UploadServiceInferClosestUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error)) {
+func (f *UploadServiceInferClosestUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3446,20 +3452,20 @@ func (f *UploadServiceInferClosestUploadsFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *UploadServiceInferClosestUploadsFunc) SetDefaultReturn(r0 []shared1.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error) {
+func (f *UploadServiceInferClosestUploadsFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *UploadServiceInferClosestUploadsFunc) PushReturn(r0 []shared1.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error) {
+func (f *UploadServiceInferClosestUploadsFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *UploadServiceInferClosestUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error) {
+func (f *UploadServiceInferClosestUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3513,7 +3519,7 @@ type UploadServiceInferClosestUploadsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.Dump
+	Result0 []shared1.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/codeintel/codenav/observability.go
+++ b/internal/codeintel/codenav/observability.go
@@ -12,17 +12,17 @@ import (
 )
 
 type operations struct {
-	getReferences          *observation.Operation
-	getImplementations     *observation.Operation
-	getPrototypes          *observation.Operation
-	getDiagnostics         *observation.Operation
-	getHover               *observation.Operation
-	getDefinitions         *observation.Operation
-	getRanges              *observation.Operation
-	getStencil             *observation.Operation
-	getClosestDumpsForBlob *observation.Operation
-	snapshotForDocument    *observation.Operation
-	visibleUploadsForPath  *observation.Operation
+	getReferences                     *observation.Operation
+	getImplementations                *observation.Operation
+	getPrototypes                     *observation.Operation
+	getDiagnostics                    *observation.Operation
+	getHover                          *observation.Operation
+	getDefinitions                    *observation.Operation
+	getRanges                         *observation.Operation
+	getStencil                        *observation.Operation
+	getClosestProcessedUploadsForBlob *observation.Operation
+	snapshotForDocument               *observation.Operation
+	visibleUploadsForPath             *observation.Operation
 }
 
 var m = new(metrics.SingletonREDMetrics)
@@ -46,17 +46,17 @@ func newOperations(observationCtx *observation.Context) *operations {
 	}
 
 	return &operations{
-		getReferences:          op("getReferences"),
-		getImplementations:     op("getImplementations"),
-		getPrototypes:          op("getPrototypes"),
-		getDiagnostics:         op("getDiagnostics"),
-		getHover:               op("getHover"),
-		getDefinitions:         op("getDefinitions"),
-		getRanges:              op("getRanges"),
-		getStencil:             op("getStencil"),
-		getClosestDumpsForBlob: op("GetClosestDumpsForBlob"),
-		snapshotForDocument:    op("SnapshotForDocument"),
-		visibleUploadsForPath:  op("VisibleUploadsForPath"),
+		getReferences:                     op("getReferences"),
+		getImplementations:                op("getImplementations"),
+		getPrototypes:                     op("getPrototypes"),
+		getDiagnostics:                    op("getDiagnostics"),
+		getHover:                          op("getHover"),
+		getDefinitions:                    op("getDefinitions"),
+		getRanges:                         op("getRanges"),
+		getStencil:                        op("getStencil"),
+		getClosestProcessedUploadsForBlob: op("GetClosestProcessedUploadsForBlob"),
+		snapshotForDocument:               op("SnapshotForDocument"),
+		visibleUploadsForPath:             op("VisibleUploadsForPath"),
 	}
 }
 

--- a/internal/codeintel/codenav/observability.go
+++ b/internal/codeintel/codenav/observability.go
@@ -20,7 +20,7 @@ type operations struct {
 	getDefinitions                    *observation.Operation
 	getRanges                         *observation.Operation
 	getStencil                        *observation.Operation
-	getClosestProcessedUploadsForBlob *observation.Operation
+	getClosestCompletedUploadsForBlob *observation.Operation
 	snapshotForDocument               *observation.Operation
 	visibleUploadsForPath             *observation.Operation
 }
@@ -54,7 +54,7 @@ func newOperations(observationCtx *observation.Context) *operations {
 		getDefinitions:                    op("getDefinitions"),
 		getRanges:                         op("getRanges"),
 		getStencil:                        op("getStencil"),
-		getClosestProcessedUploadsForBlob: op("GetClosestProcessedUploadsForBlob"),
+		getClosestCompletedUploadsForBlob: op("GetClosestCompletedUploadsForBlob"),
 		snapshotForDocument:               op("SnapshotForDocument"),
 		visibleUploadsForPath:             op("VisibleUploadsForPath"),
 	}

--- a/internal/codeintel/codenav/request_state.go
+++ b/internal/codeintel/codenav/request_state.go
@@ -31,7 +31,7 @@ type RequestState struct {
 }
 
 func NewRequestState(
-	uploads []shared.ProcessedUpload,
+	uploads []shared.CompletedUpload,
 	repoStore database.RepoStore,
 	authChecker authz.SubRepoPermissionChecker,
 	gitserverClient gitserver.Client,
@@ -56,13 +56,13 @@ func NewRequestState(
 	return *r
 }
 
-func (r RequestState) GetCacheUploads() []shared.ProcessedUpload {
+func (r RequestState) GetCacheUploads() []shared.CompletedUpload {
 	return r.dataLoader.uploads
 }
 
-func (r RequestState) GetCacheUploadsAtIndex(index int) shared.ProcessedUpload {
+func (r RequestState) GetCacheUploadsAtIndex(index int) shared.CompletedUpload {
 	if index < 0 || index >= len(r.dataLoader.uploads) {
-		return shared.ProcessedUpload{}
+		return shared.CompletedUpload{}
 	}
 
 	return r.dataLoader.uploads[index]
@@ -72,7 +72,7 @@ func (r *RequestState) SetAuthChecker(authChecker authz.SubRepoPermissionChecker
 	r.authChecker = authChecker
 }
 
-func (r *RequestState) SetUploadsDataLoader(uploads []shared.ProcessedUpload) {
+func (r *RequestState) SetUploadsDataLoader(uploads []shared.CompletedUpload) {
 	r.dataLoader = NewUploadsDataLoader()
 	for _, upload := range uploads {
 		r.dataLoader.AddUpload(upload)
@@ -98,18 +98,18 @@ func (r *RequestState) SetMaximumIndexesPerMonikerSearch(maxNumber int) {
 }
 
 type UploadsDataLoader struct {
-	uploads     []shared.ProcessedUpload
-	uploadsByID map[int]shared.ProcessedUpload
+	uploads     []shared.CompletedUpload
+	uploadsByID map[int]shared.CompletedUpload
 	cacheMutex  sync.RWMutex
 }
 
 func NewUploadsDataLoader() *UploadsDataLoader {
 	return &UploadsDataLoader{
-		uploadsByID: make(map[int]shared.ProcessedUpload),
+		uploadsByID: make(map[int]shared.CompletedUpload),
 	}
 }
 
-func (l *UploadsDataLoader) GetUploadFromCacheMap(id int) (shared.ProcessedUpload, bool) {
+func (l *UploadsDataLoader) GetUploadFromCacheMap(id int) (shared.CompletedUpload, bool) {
 	l.cacheMutex.RLock()
 	defer l.cacheMutex.RUnlock()
 
@@ -117,7 +117,7 @@ func (l *UploadsDataLoader) GetUploadFromCacheMap(id int) (shared.ProcessedUploa
 	return upload, ok
 }
 
-func (l *UploadsDataLoader) SetUploadInCacheMap(uploads []shared.ProcessedUpload) {
+func (l *UploadsDataLoader) SetUploadInCacheMap(uploads []shared.CompletedUpload) {
 	l.cacheMutex.Lock()
 	defer l.cacheMutex.Unlock()
 
@@ -126,7 +126,7 @@ func (l *UploadsDataLoader) SetUploadInCacheMap(uploads []shared.ProcessedUpload
 	}
 }
 
-func (l *UploadsDataLoader) AddUpload(dump shared.ProcessedUpload) {
+func (l *UploadsDataLoader) AddUpload(dump shared.CompletedUpload) {
 	l.cacheMutex.Lock()
 	defer l.cacheMutex.Unlock()
 

--- a/internal/codeintel/codenav/request_state.go
+++ b/internal/codeintel/codenav/request_state.go
@@ -31,7 +31,7 @@ type RequestState struct {
 }
 
 func NewRequestState(
-	uploads []shared.Dump,
+	uploads []shared.ProcessedUpload,
 	repoStore database.RepoStore,
 	authChecker authz.SubRepoPermissionChecker,
 	gitserverClient gitserver.Client,
@@ -56,13 +56,13 @@ func NewRequestState(
 	return *r
 }
 
-func (r RequestState) GetCacheUploads() []shared.Dump {
+func (r RequestState) GetCacheUploads() []shared.ProcessedUpload {
 	return r.dataLoader.uploads
 }
 
-func (r RequestState) GetCacheUploadsAtIndex(index int) shared.Dump {
+func (r RequestState) GetCacheUploadsAtIndex(index int) shared.ProcessedUpload {
 	if index < 0 || index >= len(r.dataLoader.uploads) {
-		return shared.Dump{}
+		return shared.ProcessedUpload{}
 	}
 
 	return r.dataLoader.uploads[index]
@@ -72,7 +72,7 @@ func (r *RequestState) SetAuthChecker(authChecker authz.SubRepoPermissionChecker
 	r.authChecker = authChecker
 }
 
-func (r *RequestState) SetUploadsDataLoader(uploads []shared.Dump) {
+func (r *RequestState) SetUploadsDataLoader(uploads []shared.ProcessedUpload) {
 	r.dataLoader = NewUploadsDataLoader()
 	for _, upload := range uploads {
 		r.dataLoader.AddUpload(upload)
@@ -98,18 +98,18 @@ func (r *RequestState) SetMaximumIndexesPerMonikerSearch(maxNumber int) {
 }
 
 type UploadsDataLoader struct {
-	uploads     []shared.Dump
-	uploadsByID map[int]shared.Dump
+	uploads     []shared.ProcessedUpload
+	uploadsByID map[int]shared.ProcessedUpload
 	cacheMutex  sync.RWMutex
 }
 
 func NewUploadsDataLoader() *UploadsDataLoader {
 	return &UploadsDataLoader{
-		uploadsByID: make(map[int]shared.Dump),
+		uploadsByID: make(map[int]shared.ProcessedUpload),
 	}
 }
 
-func (l *UploadsDataLoader) GetUploadFromCacheMap(id int) (shared.Dump, bool) {
+func (l *UploadsDataLoader) GetUploadFromCacheMap(id int) (shared.ProcessedUpload, bool) {
 	l.cacheMutex.RLock()
 	defer l.cacheMutex.RUnlock()
 
@@ -117,7 +117,7 @@ func (l *UploadsDataLoader) GetUploadFromCacheMap(id int) (shared.Dump, bool) {
 	return upload, ok
 }
 
-func (l *UploadsDataLoader) SetUploadInCacheMap(uploads []shared.Dump) {
+func (l *UploadsDataLoader) SetUploadInCacheMap(uploads []shared.ProcessedUpload) {
 	l.cacheMutex.Lock()
 	defer l.cacheMutex.Unlock()
 
@@ -126,7 +126,7 @@ func (l *UploadsDataLoader) SetUploadInCacheMap(uploads []shared.Dump) {
 	}
 }
 
-func (l *UploadsDataLoader) AddUpload(dump shared.Dump) {
+func (l *UploadsDataLoader) AddUpload(dump shared.ProcessedUpload) {
 	l.cacheMutex.Lock()
 	defer l.cacheMutex.Unlock()
 

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -272,7 +272,7 @@ func (s *Service) getUploadLocations(ctx context.Context, args RequestArgs, requ
 		if !checkerEnabled {
 			uploadLocations = append(uploadLocations, adjustedLocation)
 		} else {
-			repo := api.RepoName(adjustedLocation.Dump.RepositoryName)
+			repo := api.RepoName(adjustedLocation.Upload.RepositoryName)
 			if include, err := authz.FilterActorPath(ctx, requestState.authChecker, a, repo, adjustedLocation.Path); err != nil {
 				return nil, err
 			} else if include {
@@ -287,15 +287,15 @@ func (s *Service) getUploadLocations(ctx context.Context, args RequestArgs, requ
 // getUploadLocation translates a location (relative to the indexed commit) into an equivalent location in
 // the requested commit. If the translation fails, then the original commit and range are used as the
 // commit and range of the adjusted location and a false flag is returned.
-func (s *Service) getUploadLocation(ctx context.Context, args RequestArgs, requestState RequestState, dump uploadsshared.CompletedUpload, location shared.Location) (shared.UploadLocation, bool, error) {
-	adjustedCommit, adjustedRange, ok, err := s.getSourceRange(ctx, args, requestState, dump.RepositoryID, dump.Commit, dump.Root+location.Path, location.Range)
+func (s *Service) getUploadLocation(ctx context.Context, args RequestArgs, requestState RequestState, upload uploadsshared.CompletedUpload, location shared.Location) (shared.UploadLocation, bool, error) {
+	adjustedCommit, adjustedRange, ok, err := s.getSourceRange(ctx, args, requestState, upload.RepositoryID, upload.Commit, upload.Root+location.Path, location.Range)
 	if err != nil {
 		return shared.UploadLocation{}, ok, err
 	}
 
 	return shared.UploadLocation{
-		Dump:         dump,
-		Path:         dump.Root + location.Path,
+		Upload:       upload,
+		Path:         upload.Root + location.Path,
 		TargetCommit: adjustedCommit,
 		TargetRange:  adjustedRange,
 	}, ok, nil

--- a/internal/codeintel/codenav/service.go
+++ b/internal/codeintel/codenav/service.go
@@ -158,7 +158,7 @@ func (s *Service) GetHover(ctx context.Context, args PositionalRequestArgs, requ
 		// Fetch hover text attached to a definition in the defining index
 		text, _, exists, err := s.lsifstore.GetHover(
 			ctx,
-			locations[i].DumpID,
+			locations[i].UploadID,
 			locations[i].Path,
 			locations[i].Range.Start.Line,
 			locations[i].Range.Start.Character,
@@ -178,16 +178,16 @@ func (s *Service) GetHover(ctx context.Context, args PositionalRequestArgs, requ
 
 // getUploadsWithDefinitionsForMonikers returns the set of uploads that provide any of the given monikers.
 // This method will not return uploads for commits which are unknown to gitserver.
-func (s *Service) getUploadsWithDefinitionsForMonikers(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, requestState RequestState) ([]uploadsshared.Dump, error) {
-	dumps, err := s.uploadSvc.GetDumpsWithDefinitionsForMonikers(ctx, orderedMonikers)
+func (s *Service) getUploadsWithDefinitionsForMonikers(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, requestState RequestState) ([]uploadsshared.ProcessedUpload, error) {
+	uploads, err := s.uploadSvc.GetProcessedUploadsWithDefinitionsForMonikers(ctx, orderedMonikers)
 	if err != nil {
 		return nil, errors.Wrap(err, "dbstore.DefinitionDumps")
 	}
 
-	uploads := copyDumps(dumps)
-	requestState.dataLoader.SetUploadInCacheMap(uploads)
+	uploadsCopy := copyUploads(uploads)
+	requestState.dataLoader.SetUploadInCacheMap(uploadsCopy)
 
-	uploadsWithResolvableCommits, err := s.removeUploadsWithUnknownCommits(ctx, uploads, requestState)
+	uploadsWithResolvableCommits, err := s.removeUploadsWithUnknownCommits(ctx, uploadsCopy, requestState)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ func (s *Service) getUploadLocations(ctx context.Context, args RequestArgs, requ
 		a = actor.FromContext(ctx)
 	}
 	for _, location := range locations {
-		upload, ok := requestState.dataLoader.GetUploadFromCacheMap(location.DumpID)
+		upload, ok := requestState.dataLoader.GetUploadFromCacheMap(location.UploadID)
 		if !ok {
 			continue
 		}
@@ -287,7 +287,7 @@ func (s *Service) getUploadLocations(ctx context.Context, args RequestArgs, requ
 // getUploadLocation translates a location (relative to the indexed commit) into an equivalent location in
 // the requested commit. If the translation fails, then the original commit and range are used as the
 // commit and range of the adjusted location and a false flag is returned.
-func (s *Service) getUploadLocation(ctx context.Context, args RequestArgs, requestState RequestState, dump uploadsshared.Dump, location shared.Location) (shared.UploadLocation, bool, error) {
+func (s *Service) getUploadLocation(ctx context.Context, args RequestArgs, requestState RequestState, dump uploadsshared.ProcessedUpload, location shared.Location) (shared.UploadLocation, bool, error) {
 	adjustedCommit, adjustedRange, ok, err := s.getSourceRange(ctx, args, requestState, dump.RepositoryID, dump.Commit, dump.Root+location.Path, location.Range)
 	if err != nil {
 		return shared.UploadLocation{}, ok, err
@@ -322,9 +322,9 @@ func (s *Service) getSourceRange(ctx context.Context, args RequestArgs, requestS
 // getUploadsByIDs returns a slice of uploads with the given identifiers. This method will not return a
 // new upload record for a commit which is unknown to gitserver. The given upload map is used as a
 // caching mechanism - uploads present in the map are not fetched again from the database.
-func (s *Service) getUploadsByIDs(ctx context.Context, ids []int, requestState RequestState) ([]uploadsshared.Dump, error) {
+func (s *Service) getUploadsByIDs(ctx context.Context, ids []int, requestState RequestState) ([]uploadsshared.ProcessedUpload, error) {
 	missingIDs := make([]int, 0, len(ids))
-	existingUploads := make([]uploadsshared.Dump, 0, len(ids))
+	existingUploads := make([]uploadsshared.ProcessedUpload, 0, len(ids))
 
 	for _, id := range ids {
 		if upload, ok := requestState.dataLoader.GetUploadFromCacheMap(id); ok {
@@ -334,9 +334,9 @@ func (s *Service) getUploadsByIDs(ctx context.Context, ids []int, requestState R
 		}
 	}
 
-	uploads, err := s.uploadSvc.GetDumpsByIDs(ctx, missingIDs)
+	uploads, err := s.uploadSvc.GetProcessedUploadsByIDs(ctx, missingIDs)
 	if err != nil {
-		return nil, errors.Wrap(err, "service.GetDumpsByIDs")
+		return nil, errors.Wrap(err, "service.GetProcessedUploadsByIDs")
 	}
 
 	uploadsWithResolvableCommits, err := s.removeUploadsWithUnknownCommits(ctx, uploads, requestState)
@@ -352,7 +352,7 @@ func (s *Service) getUploadsByIDs(ctx context.Context, ids []int, requestState R
 
 // removeUploadsWithUnknownCommits removes uploads for commits which are unknown to gitserver from the given
 // slice. The slice is filtered in-place and returned (to update the slice length).
-func (s *Service) removeUploadsWithUnknownCommits(ctx context.Context, uploads []uploadsshared.Dump, requestState RequestState) ([]uploadsshared.Dump, error) {
+func (s *Service) removeUploadsWithUnknownCommits(ctx context.Context, uploads []uploadsshared.ProcessedUpload, requestState RequestState) ([]uploadsshared.ProcessedUpload, error) {
 	rcs := make([]RepositoryCommit, 0, len(uploads))
 	for _, upload := range uploads {
 		rcs = append(rcs, RepositoryCommit{
@@ -378,7 +378,7 @@ func (s *Service) removeUploadsWithUnknownCommits(ctx context.Context, uploads [
 
 // getBulkMonikerLocations returns the set of locations (within the given uploads) with an attached moniker
 // whose scheme+identifier matches any of the given monikers.
-func (s *Service) getBulkMonikerLocations(ctx context.Context, uploads []uploadsshared.Dump, orderedMonikers []precise.QualifiedMonikerData, tableName string, limit, offset int) ([]shared.Location, int, error) {
+func (s *Service) getBulkMonikerLocations(ctx context.Context, uploads []uploadsshared.ProcessedUpload, orderedMonikers []precise.QualifiedMonikerData, tableName string, limit, offset int) ([]shared.Location, int, error) {
 	ids := make([]int, 0, len(uploads))
 	for i := range uploads {
 		ids = append(ids, uploads[i].ID)
@@ -449,7 +449,7 @@ func (s *Service) GetDiagnostics(ctx context.Context, args PositionalRequestArgs
 			}
 
 			// sub-repo checker is enabled, proceeding with check
-			if include, err := authz.FilterActorPath(ctx, requestState.authChecker, a, api.RepoName(adjustedDiagnostic.Dump.RepositoryName), adjustedDiagnostic.Path); err != nil {
+			if include, err := authz.FilterActorPath(ctx, requestState.authChecker, a, api.RepoName(adjustedDiagnostic.Upload.RepositoryName), adjustedDiagnostic.Path); err != nil {
 				return nil, 0, err
 			} else if include {
 				diagnosticsAtUploads = append(diagnosticsAtUploads, adjustedDiagnostic)
@@ -502,13 +502,13 @@ func (s *Service) getRequestedCommitDiagnostic(ctx context.Context, args Request
 
 	return DiagnosticAtUpload{
 		Diagnostic:     diagnostic,
-		Dump:           adjustedUpload.Upload,
+		Upload:         adjustedUpload.Upload,
 		AdjustedCommit: adjustedCommit,
 		AdjustedRange:  adjustedRange,
 	}, nil
 }
 
-func (s *Service) VisibleUploadsForPath(ctx context.Context, requestState RequestState) (dumps []uploadsshared.Dump, err error) {
+func (s *Service) VisibleUploadsForPath(ctx context.Context, requestState RequestState) (uploads []uploadsshared.ProcessedUpload, err error) {
 	ctx, _, endObservation := s.operations.visibleUploadsForPath.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.String("path", requestState.Path),
 		attribute.String("commit", requestState.Commit),
@@ -516,7 +516,7 @@ func (s *Service) VisibleUploadsForPath(ctx context.Context, requestState Reques
 	}})
 	defer func() {
 		endObservation(1, observation.Args{Attrs: []attribute.KeyValue{
-			attribute.Int("numUploads", len(dumps)),
+			attribute.Int("numUploads", len(uploads)),
 		}})
 	}()
 
@@ -526,7 +526,7 @@ func (s *Service) VisibleUploadsForPath(ctx context.Context, requestState Reques
 	}
 
 	for _, upload := range visibleUploads {
-		dumps = append(dumps, upload.Upload)
+		uploads = append(uploads, upload.Upload)
 	}
 
 	return
@@ -666,7 +666,7 @@ func (s *Service) GetStencil(ctx context.Context, args PositionalRequestArgs, re
 		}
 
 		for i, rn := range ranges {
-			// FIXME: change this at it expects an empty uploadsshared.Dump{}
+			// FIXME: change this at it expects an empty uploadsshared.ProcessedUpload{}
 			cu := requestState.GetCacheUploadsAtIndex(i)
 			// Adjust the highlighted range back to the appropriate range in the target commit
 			_, adjustedRange, _, err := s.getSourceRange(ctx, args.RequestArgs, requestState, cu.RepositoryID, cu.Commit, args.Path, rn)
@@ -684,12 +684,12 @@ func (s *Service) GetStencil(ctx context.Context, args PositionalRequestArgs, re
 }
 
 // TODO(#48681) - do not proxy this
-func (s *Service) GetDumpsByIDs(ctx context.Context, ids []int) ([]uploadsshared.Dump, error) {
-	return s.uploadSvc.GetDumpsByIDs(ctx, ids)
+func (s *Service) GetProcessedUploadsByIDs(ctx context.Context, ids []int) ([]uploadsshared.ProcessedUpload, error) {
+	return s.uploadSvc.GetProcessedUploadsByIDs(ctx, ids)
 }
 
-func (s *Service) GetClosestDumpsForBlob(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []uploadsshared.Dump, err error) {
-	ctx, trace, endObservation := s.operations.getClosestDumpsForBlob.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+func (s *Service) GetClosestProcessedUploadsForBlob(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []uploadsshared.ProcessedUpload, err error) {
+	ctx, trace, endObservation := s.operations.getClosestProcessedUploadsForBlob.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repositoryID", repositoryID),
 		attribute.String("commit", commit),
 		attribute.String("path", path),
@@ -703,7 +703,7 @@ func (s *Service) GetClosestDumpsForBlob(ctx context.Context, repositoryID int, 
 		return nil, err
 	}
 
-	uploadCandidates := copyDumps(candidates)
+	uploadCandidates := copyUploads(candidates)
 	trace.AddEvent("TODO Domain Owner",
 		attribute.Int("numCandidates", len(candidates)),
 		attribute.String("candidates", uploadIDsToString(uploadCandidates)))
@@ -747,7 +747,7 @@ func (s *Service) GetClosestDumpsForBlob(ctx context.Context, repositoryID int, 
 
 // filterUploadsWithCommits removes the uploads for commits which are unknown to gitserver from the given
 // slice. The slice is filtered in-place and returned (to update the slice length).
-func filterUploadsWithCommits(ctx context.Context, commitCache CommitCache, uploads []uploadsshared.Dump) ([]uploadsshared.Dump, error) {
+func filterUploadsWithCommits(ctx context.Context, commitCache CommitCache, uploads []uploadsshared.ProcessedUpload) ([]uploadsshared.ProcessedUpload, error) {
 	rcs := make([]RepositoryCommit, 0, len(uploads))
 	for _, upload := range uploads {
 		rcs = append(rcs, RepositoryCommit{
@@ -770,9 +770,9 @@ func filterUploadsWithCommits(ctx context.Context, commitCache CommitCache, uplo
 	return filtered, nil
 }
 
-func copyDumps(uploadDumps []uploadsshared.Dump) []uploadsshared.Dump {
-	ud := make([]uploadsshared.Dump, len(uploadDumps))
-	copy(ud, uploadDumps)
+func copyUploads(uploads []uploadsshared.ProcessedUpload) []uploadsshared.ProcessedUpload {
+	ud := make([]uploadsshared.ProcessedUpload, len(uploads))
+	copy(ud, uploads)
 	return ud
 }
 
@@ -800,7 +800,7 @@ func (s *Service) getVisibleUploads(ctx context.Context, line, character int, r 
 
 // getVisibleUpload returns the current target path and the given position for the given upload. If
 // the upload cannot be adjusted, a false-valued flag is returned.
-func (s *Service) getVisibleUpload(ctx context.Context, line, character int, upload uploadsshared.Dump, r RequestState) (visibleUpload, bool, error) {
+func (s *Service) getVisibleUpload(ctx context.Context, line, character int, upload uploadsshared.ProcessedUpload, r RequestState) (visibleUpload, bool, error) {
 	position := shared.Position{
 		Line:      line,
 		Character: character,
@@ -832,16 +832,16 @@ func (s *Service) SnapshotForDocument(ctx context.Context, repositoryID int, com
 		}})
 	}()
 
-	dumps, err := s.GetDumpsByIDs(ctx, []int{uploadID})
+	uploads, err := s.GetProcessedUploadsByIDs(ctx, []int{uploadID})
 	if err != nil {
 		return nil, err
 	}
 
-	if len(dumps) == 0 {
+	if len(uploads) == 0 {
 		return nil, nil
 	}
 
-	dump := dumps[0]
+	dump := uploads[0]
 
 	document, err := s.lsifstore.SCIPDocument(ctx, dump.ID, strings.TrimPrefix(path, dump.Root))
 	if err != nil || document == nil {

--- a/internal/codeintel/codenav/service_diagnostics_test.go
+++ b/internal/codeintel/codenav/service_diagnostics_test.go
@@ -31,7 +31,7 @@ func TestDiagnostics(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.ProcessedUpload{
+	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -104,7 +104,7 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.ProcessedUpload{
+	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},

--- a/internal/codeintel/codenav/service_diagnostics_test.go
+++ b/internal/codeintel/codenav/service_diagnostics_test.go
@@ -31,7 +31,7 @@ func TestDiagnostics(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.Dump{
+	uploads := []uploadsshared.ProcessedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -70,11 +70,11 @@ func TestDiagnostics(t *testing.T) {
 	}
 
 	expectedDiagnostics := []DiagnosticAtUpload{
-		{Dump: uploads[0], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub1/", DiagnosticData: precise.DiagnosticData{Code: "c1"}}},
-		{Dump: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c2"}}},
-		{Dump: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c3"}}},
-		{Dump: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c4"}}},
-		{Dump: uploads[2], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub3/", DiagnosticData: precise.DiagnosticData{Code: "c5"}}},
+		{Upload: uploads[0], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub1/", DiagnosticData: precise.DiagnosticData{Code: "c1"}}},
+		{Upload: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c2"}}},
+		{Upload: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c3"}}},
+		{Upload: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c4"}}},
+		{Upload: uploads[2], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub3/", DiagnosticData: precise.DiagnosticData{Code: "c5"}}},
 	}
 	if diff := cmp.Diff(expectedDiagnostics, adjustedDiagnostics); diff != "" {
 		t.Errorf("unexpected diagnostics (-want +got):\n%s", diff)
@@ -104,7 +104,7 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.Dump{
+	uploads := []uploadsshared.ProcessedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -157,9 +157,9 @@ func TestDiagnosticsWithSubRepoPermissions(t *testing.T) {
 	}
 
 	expectedDiagnostics := []DiagnosticAtUpload{
-		{Dump: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c2"}}},
-		{Dump: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c3"}}},
-		{Dump: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c4"}}},
+		{Upload: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c2"}}},
+		{Upload: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c3"}}},
+		{Upload: uploads[1], AdjustedCommit: "deadbeef", Diagnostic: shared.Diagnostic{Path: "sub2/", DiagnosticData: precise.DiagnosticData{Code: "c4"}}},
 	}
 	if diff := cmp.Diff(expectedDiagnostics, adjustedDiagnostics); diff != "" {
 		t.Errorf("unexpected diagnostics (-want +got):\n%s", diff)

--- a/internal/codeintel/codenav/service_hover_test.go
+++ b/internal/codeintel/codenav/service_hover_test.go
@@ -31,7 +31,7 @@ func TestHover(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.ProcessedUpload{
+	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -87,7 +87,7 @@ func TestHoverRemote(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.ProcessedUpload{
+	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef"},
 	}
 	mockRequestState.SetUploadsDataLoader(uploads)
@@ -104,13 +104,13 @@ func TestHoverRemote(t *testing.T) {
 	}
 	mockLsifStore.GetHoverFunc.PushReturn("doctext", remoteRange, true, nil)
 
-	uploadsWithDefinitions := []uploadsshared.ProcessedUpload{
+	uploadsWithDefinitions := []uploadsshared.CompletedUpload{
 		{ID: 150, Commit: "deadbeef1", Root: "sub1/"},
 		{ID: 151, Commit: "deadbeef2", Root: "sub2/"},
 		{ID: 152, Commit: "deadbeef3", Root: "sub3/"},
 		{ID: 153, Commit: "deadbeef4", Root: "sub4/"},
 	}
-	mockUploadSvc.GetProcessedUploadsWithDefinitionsForMonikersFunc.PushReturn(uploadsWithDefinitions, nil)
+	mockUploadSvc.GetCompletedUploadsWithDefinitionsForMonikersFunc.PushReturn(uploadsWithDefinitions, nil)
 
 	monikers := []precise.MonikerData{
 		{Kind: "import", Scheme: "tsc", Identifier: "padLeft", PackageInformationID: "51"},

--- a/internal/codeintel/codenav/service_hover_test.go
+++ b/internal/codeintel/codenav/service_hover_test.go
@@ -31,7 +31,7 @@ func TestHover(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.Dump{
+	uploads := []uploadsshared.ProcessedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -87,7 +87,7 @@ func TestHoverRemote(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.Dump{
+	uploads := []uploadsshared.ProcessedUpload{
 		{ID: 50, Commit: "deadbeef"},
 	}
 	mockRequestState.SetUploadsDataLoader(uploads)
@@ -104,13 +104,13 @@ func TestHoverRemote(t *testing.T) {
 	}
 	mockLsifStore.GetHoverFunc.PushReturn("doctext", remoteRange, true, nil)
 
-	uploadsWithDefinitions := []uploadsshared.Dump{
+	uploadsWithDefinitions := []uploadsshared.ProcessedUpload{
 		{ID: 150, Commit: "deadbeef1", Root: "sub1/"},
 		{ID: 151, Commit: "deadbeef2", Root: "sub2/"},
 		{ID: 152, Commit: "deadbeef3", Root: "sub3/"},
 		{ID: 153, Commit: "deadbeef4", Root: "sub4/"},
 	}
-	mockUploadSvc.GetDumpsWithDefinitionsForMonikersFunc.PushReturn(uploadsWithDefinitions, nil)
+	mockUploadSvc.GetProcessedUploadsWithDefinitionsForMonikersFunc.PushReturn(uploadsWithDefinitions, nil)
 
 	monikers := []precise.MonikerData{
 		{Kind: "import", Scheme: "tsc", Identifier: "padLeft", PackageInformationID: "51"},
@@ -129,11 +129,11 @@ func TestHoverRemote(t *testing.T) {
 	mockLsifStore.GetPackageInformationFunc.PushReturn(packageInformation2, true, nil)
 
 	locations := []shared.Location{
-		{DumpID: 151, Path: "a.go", Range: testRange1},
-		{DumpID: 151, Path: "b.go", Range: testRange2},
-		{DumpID: 151, Path: "a.go", Range: testRange3},
-		{DumpID: 151, Path: "b.go", Range: testRange4},
-		{DumpID: 151, Path: "c.go", Range: testRange5},
+		{UploadID: 151, Path: "a.go", Range: testRange1},
+		{UploadID: 151, Path: "b.go", Range: testRange2},
+		{UploadID: 151, Path: "a.go", Range: testRange3},
+		{UploadID: 151, Path: "b.go", Range: testRange4},
+		{UploadID: 151, Path: "c.go", Range: testRange5},
 	}
 	mockLsifStore.GetBulkMonikerLocationsFunc.PushReturn(locations, 0, nil)
 	mockLsifStore.GetBulkMonikerLocationsFunc.PushReturn(locations, len(locations), nil)

--- a/internal/codeintel/codenav/service_new.go
+++ b/internal/codeintel/codenav/service_new.go
@@ -284,7 +284,7 @@ func (s *Service) getVisibleUploadsFromCursor(
 	if cursor.VisibleUploads != nil {
 		visibleUploads := make([]visibleUpload, 0, len(cursor.VisibleUploads))
 		for _, u := range cursor.VisibleUploads {
-			upload, ok := requestState.dataLoader.GetUploadFromCacheMap(u.DumpID)
+			upload, ok := requestState.dataLoader.GetUploadFromCacheMap(u.UploadID)
 			if !ok {
 				return nil, Cursor{}, ErrConcurrentModification
 			}
@@ -308,7 +308,7 @@ func (s *Service) getVisibleUploadsFromCursor(
 	cursorVisibleUpload := make([]CursorVisibleUpload, 0, len(visibleUploads))
 	for i := range visibleUploads {
 		cursorVisibleUpload = append(cursorVisibleUpload, CursorVisibleUpload{
-			DumpID:                visibleUploads[i].Upload.ID,
+			UploadID:              visibleUploads[i].Upload.ID,
 			TargetPath:            visibleUploads[i].TargetPath,
 			TargetPosition:        visibleUploads[i].TargetPosition,
 			TargetPathWithoutRoot: visibleUploads[i].TargetPathWithoutRoot,
@@ -580,7 +580,7 @@ func (s *Service) prepareCandidateUploads(
 		}
 		idMap := make(map[int]struct{}, len(uploads)+len(cursor.VisibleUploads))
 		for _, upload := range cursor.VisibleUploads {
-			idMap[upload.DumpID] = struct{}{}
+			idMap[upload.UploadID] = struct{}{}
 		}
 		for _, upload := range uploads {
 			idMap[upload.ID] = struct{}{}

--- a/internal/codeintel/codenav/service_new_test.go
+++ b/internal/codeintel/codenav/service_new_test.go
@@ -33,7 +33,7 @@ func TestGetDefinitions(t *testing.T) {
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 
 		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-		uploads := []uploadsshared.ProcessedUpload{
+		uploads := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: mockCommit, Root: "sub1/"},
 			{ID: 51, Commit: mockCommit, Root: "sub2/"},
 			{ID: 52, Commit: mockCommit, Root: "sub3/"},
@@ -93,7 +93,7 @@ func TestGetDefinitions(t *testing.T) {
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{ID: 42}, mockCommit, mockPath, hunkCache)
 		mockRequestState.GitTreeTranslator = mockedGitTreeTranslator()
-		uploads1 := []uploadsshared.ProcessedUpload{
+		uploads1 := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 			{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 			{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -101,13 +101,13 @@ func TestGetDefinitions(t *testing.T) {
 		}
 		mockRequestState.SetUploadsDataLoader(uploads1)
 
-		uploads2 := []uploadsshared.ProcessedUpload{
+		uploads2 := []uploadsshared.CompletedUpload{
 			{ID: 150, Commit: "deadbeef1", Root: "sub1/"},
 			{ID: 151, Commit: "deadbeef2", Root: "sub2/"},
 			{ID: 152, Commit: "deadbeef3", Root: "sub3/"},
 			{ID: 153, Commit: "deadbeef4", Root: "sub4/"},
 		}
-		mockUploadSvc.GetProcessedUploadsWithDefinitionsForMonikersFunc.PushReturn(uploads2, nil)
+		mockUploadSvc.GetCompletedUploadsWithDefinitionsForMonikersFunc.PushReturn(uploads2, nil)
 
 		// upload #150's commit no longer exists; all others do
 		mockGitserverClient.GetCommitFunc.SetDefaultHook(func(ctx context.Context, rn api.RepoName, ci api.CommitID) (*gitdomain.Commit, error) {
@@ -162,7 +162,7 @@ func TestGetDefinitions(t *testing.T) {
 			t.Errorf("unexpected locations (-want +got):\n%s", diff)
 		}
 
-		if history := mockUploadSvc.GetProcessedUploadsWithDefinitionsForMonikersFunc.History(); len(history) != 1 {
+		if history := mockUploadSvc.GetCompletedUploadsWithDefinitionsForMonikersFunc.History(); len(history) != 1 {
 			t.Fatalf("unexpected call count for dbstore.DefinitionDump. want=%d have=%d", 1, len(history))
 		} else {
 			expectedMonikers := []precise.QualifiedMonikerData{
@@ -214,7 +214,7 @@ func TestGetReferences(t *testing.T) {
 		mockRequestState := RequestState{}
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-		uploads := []uploadsshared.ProcessedUpload{
+		uploads := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 			{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 			{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -279,7 +279,7 @@ func TestGetReferences(t *testing.T) {
 		mockRequestState := RequestState{}
 		mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 		mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-		uploads := []uploadsshared.ProcessedUpload{
+		uploads := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 			{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 			{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -287,23 +287,23 @@ func TestGetReferences(t *testing.T) {
 		}
 		mockRequestState.SetUploadsDataLoader(uploads)
 
-		definitionUploads := []uploadsshared.ProcessedUpload{
+		definitionUploads := []uploadsshared.CompletedUpload{
 			{ID: 150, Commit: "deadbeef1", Root: "sub1/"},
 			{ID: 151, Commit: "deadbeef2", Root: "sub2/"},
 			{ID: 152, Commit: "deadbeef3", Root: "sub3/"},
 			{ID: 153, Commit: "deadbeef4", Root: "sub4/"},
 		}
-		mockUploadSvc.GetProcessedUploadsWithDefinitionsForMonikersFunc.PushReturn(definitionUploads, nil)
+		mockUploadSvc.GetCompletedUploadsWithDefinitionsForMonikersFunc.PushReturn(definitionUploads, nil)
 
-		referenceUploads := []uploadsshared.ProcessedUpload{
+		referenceUploads := []uploadsshared.CompletedUpload{
 			{ID: 250, Commit: "deadbeef1", Root: "sub1/"},
 			{ID: 251, Commit: "deadbeef2", Root: "sub2/"},
 			{ID: 252, Commit: "deadbeef3", Root: "sub3/"},
 			{ID: 253, Commit: "deadbeef4", Root: "sub4/"},
 		}
-		mockUploadSvc.GetProcessedUploadsByIDsFunc.PushReturn(nil, nil) // empty
-		mockUploadSvc.GetProcessedUploadsByIDsFunc.PushReturn(referenceUploads[:2], nil)
-		mockUploadSvc.GetProcessedUploadsByIDsFunc.PushReturn(referenceUploads[2:], nil)
+		mockUploadSvc.GetCompletedUploadsByIDsFunc.PushReturn(nil, nil) // empty
+		mockUploadSvc.GetCompletedUploadsByIDsFunc.PushReturn(referenceUploads[:2], nil)
+		mockUploadSvc.GetCompletedUploadsByIDsFunc.PushReturn(referenceUploads[2:], nil)
 
 		mockUploadSvc.GetUploadIDsWithReferencesFunc.PushReturn([]int{250, 251}, 0, 4, nil)
 		mockUploadSvc.GetUploadIDsWithReferencesFunc.PushReturn([]int{252, 253}, 0, 2, nil)
@@ -358,7 +358,7 @@ func TestGetReferences(t *testing.T) {
 		mockLsifStore.GetMinimalBulkMonikerLocationsFunc.PushReturn(monikerLocations[1:2], 1, nil) // refs batch 1
 		mockLsifStore.GetMinimalBulkMonikerLocationsFunc.PushReturn(monikerLocations[2:], 3, nil)  // refs batch 2
 
-		// uploads := []dbstore.ProcessedUpload{
+		// uploads := []dbstore.CompletedUpload{
 		// 	{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		// 	{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		// 	{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -398,7 +398,7 @@ func TestGetReferences(t *testing.T) {
 			t.Errorf("unexpected locations (-want +got):\n%s", diff)
 		}
 
-		if history := mockUploadSvc.GetProcessedUploadsWithDefinitionsForMonikersFunc.History(); len(history) != 1 {
+		if history := mockUploadSvc.GetCompletedUploadsWithDefinitionsForMonikersFunc.History(); len(history) != 1 {
 			t.Fatalf("unexpected call count for dbstore.DefinitionDump. want=%d have=%d", 1, len(history))
 		} else {
 			expectedMonikers := []precise.QualifiedMonikerData{
@@ -473,7 +473,7 @@ func TestGetImplementations(t *testing.T) {
 		}
 		mockLsifStore.ExtractImplementationLocationsFromPositionFunc.PushReturn(locations, nil, nil)
 
-		uploads := []uploadsshared.ProcessedUpload{
+		uploads := []uploadsshared.CompletedUpload{
 			{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 			{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 			{ID: 52, Commit: "deadbeef", Root: "sub3/"},

--- a/internal/codeintel/codenav/service_new_test.go
+++ b/internal/codeintel/codenav/service_new_test.go
@@ -65,11 +65,11 @@ func TestGetDefinitions(t *testing.T) {
 			t.Fatalf("unexpected error querying definitions: %s", err)
 		}
 		expectedLocations := []shared.UploadLocation{
-			{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: mockCommit, TargetRange: testRange1},
-			{Dump: uploads[1], Path: "sub2/b.go", TargetCommit: mockCommit, TargetRange: testRange2},
-			{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: mockCommit, TargetRange: testRange3},
-			{Dump: uploads[1], Path: "sub2/b.go", TargetCommit: mockCommit, TargetRange: testRange4},
-			{Dump: uploads[1], Path: "sub2/c.go", TargetCommit: mockCommit, TargetRange: testRange5},
+			{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: mockCommit, TargetRange: testRange1},
+			{Upload: uploads[1], Path: "sub2/b.go", TargetCommit: mockCommit, TargetRange: testRange2},
+			{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: mockCommit, TargetRange: testRange3},
+			{Upload: uploads[1], Path: "sub2/b.go", TargetCommit: mockCommit, TargetRange: testRange4},
+			{Upload: uploads[1], Path: "sub2/c.go", TargetCommit: mockCommit, TargetRange: testRange5},
 		}
 
 		if diff := cmp.Diff(expectedLocations, adjustedLocations); diff != "" {
@@ -151,11 +151,11 @@ func TestGetDefinitions(t *testing.T) {
 		}
 
 		xLocations := []shared.UploadLocation{
-			{Dump: remoteUploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef2", TargetRange: testRange1},
-			{Dump: remoteUploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef2", TargetRange: testRange2},
-			{Dump: remoteUploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef2", TargetRange: testRange3},
-			{Dump: remoteUploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef2", TargetRange: testRange4},
-			{Dump: remoteUploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef2", TargetRange: testRange5},
+			{Upload: remoteUploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef2", TargetRange: testRange1},
+			{Upload: remoteUploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef2", TargetRange: testRange2},
+			{Upload: remoteUploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef2", TargetRange: testRange3},
+			{Upload: remoteUploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef2", TargetRange: testRange4},
+			{Upload: remoteUploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef2", TargetRange: testRange5},
 		}
 
 		if diff := cmp.Diff(xLocations, adjustedLocations); diff != "" {
@@ -253,11 +253,11 @@ func TestGetReferences(t *testing.T) {
 		}
 
 		expectedLocations := []shared.UploadLocation{
-			{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange1},
-			{Dump: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange2},
-			{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange3},
-			{Dump: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange4},
-			{Dump: uploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef", TargetRange: testRange5},
+			{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange1},
+			{Upload: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange2},
+			{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange3},
+			{Upload: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange4},
+			{Upload: uploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef", TargetRange: testRange5},
 		}
 		if diff := cmp.Diff(expectedLocations, adjustedLocations); diff != "" {
 			t.Errorf("unexpected locations (-want +got):\n%s", diff)
@@ -383,16 +383,16 @@ func TestGetReferences(t *testing.T) {
 		}
 
 		expectedLocations := []shared.UploadLocation{
-			{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange1},
-			{Dump: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange2},
-			{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange3},
-			{Dump: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange4},
-			{Dump: uploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef", TargetRange: testRange5},
-			{Dump: uploads[3], Path: "sub4/a.go", TargetCommit: "deadbeef", TargetRange: testRange1},
-			{Dump: uploads[3], Path: "sub4/b.go", TargetCommit: "deadbeef", TargetRange: testRange2},
-			{Dump: uploads[3], Path: "sub4/a.go", TargetCommit: "deadbeef", TargetRange: testRange3},
-			{Dump: uploads[3], Path: "sub4/b.go", TargetCommit: "deadbeef", TargetRange: testRange4},
-			{Dump: uploads[3], Path: "sub4/c.go", TargetCommit: "deadbeef", TargetRange: testRange5},
+			{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange1},
+			{Upload: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange2},
+			{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange3},
+			{Upload: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange4},
+			{Upload: uploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef", TargetRange: testRange5},
+			{Upload: uploads[3], Path: "sub4/a.go", TargetCommit: "deadbeef", TargetRange: testRange1},
+			{Upload: uploads[3], Path: "sub4/b.go", TargetCommit: "deadbeef", TargetRange: testRange2},
+			{Upload: uploads[3], Path: "sub4/a.go", TargetCommit: "deadbeef", TargetRange: testRange3},
+			{Upload: uploads[3], Path: "sub4/b.go", TargetCommit: "deadbeef", TargetRange: testRange4},
+			{Upload: uploads[3], Path: "sub4/c.go", TargetCommit: "deadbeef", TargetRange: testRange5},
 		}
 		if diff := cmp.Diff(expectedLocations, adjustedLocations); diff != "" {
 			t.Errorf("unexpected locations (-want +got):\n%s", diff)
@@ -497,11 +497,11 @@ func TestGetImplementations(t *testing.T) {
 		}
 
 		expectedLocations := []shared.UploadLocation{
-			{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange1},
-			{Dump: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange2},
-			{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange3},
-			{Dump: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange4},
-			{Dump: uploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef", TargetRange: testRange5},
+			{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange1},
+			{Upload: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange2},
+			{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange3},
+			{Upload: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange4},
+			{Upload: uploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef", TargetRange: testRange5},
 		}
 		if diff := cmp.Diff(expectedLocations, adjustedLocations); diff != "" {
 			t.Errorf("unexpected locations (-want +got):\n%s", diff)

--- a/internal/codeintel/codenav/service_ranges_test.go
+++ b/internal/codeintel/codenav/service_ranges_test.go
@@ -57,7 +57,7 @@ func TestRanges(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.Dump{
+	uploads := []uploadsshared.ProcessedUpload{
 		{ID: 50, Commit: "deadbeef1", Root: "sub1/", RepositoryID: 42},
 		{ID: 51, Commit: "deadbeef1", Root: "sub2/", RepositoryID: 42},
 		{ID: 52, Commit: "deadbeef2", Root: "sub3/", RepositoryID: 42},
@@ -65,15 +65,15 @@ func TestRanges(t *testing.T) {
 	}
 	mockRequestState.SetUploadsDataLoader(uploads)
 
-	testLocation1 := shared.Location{DumpID: 50, Path: "a.go", Range: testRange1}
-	testLocation2 := shared.Location{DumpID: 51, Path: "b.go", Range: testRange2}
-	testLocation3 := shared.Location{DumpID: 51, Path: "c.go", Range: testRange1}
-	testLocation4 := shared.Location{DumpID: 51, Path: "d.go", Range: testRange2}
-	testLocation5 := shared.Location{DumpID: 51, Path: "e.go", Range: testRange1}
-	testLocation6 := shared.Location{DumpID: 51, Path: "a.go", Range: testRange2}
-	testLocation7 := shared.Location{DumpID: 51, Path: "a.go", Range: testRange3}
-	testLocation8 := shared.Location{DumpID: 52, Path: "a.go", Range: testRange4}
-	testLocation9 := shared.Location{DumpID: 52, Path: "changed.go", Range: testRange6}
+	testLocation1 := shared.Location{UploadID: 50, Path: "a.go", Range: testRange1}
+	testLocation2 := shared.Location{UploadID: 51, Path: "b.go", Range: testRange2}
+	testLocation3 := shared.Location{UploadID: 51, Path: "c.go", Range: testRange1}
+	testLocation4 := shared.Location{UploadID: 51, Path: "d.go", Range: testRange2}
+	testLocation5 := shared.Location{UploadID: 51, Path: "e.go", Range: testRange1}
+	testLocation6 := shared.Location{UploadID: 51, Path: "a.go", Range: testRange2}
+	testLocation7 := shared.Location{UploadID: 51, Path: "a.go", Range: testRange3}
+	testLocation8 := shared.Location{UploadID: 52, Path: "a.go", Range: testRange4}
+	testLocation9 := shared.Location{UploadID: 52, Path: "changed.go", Range: testRange6}
 
 	ranges := []shared.CodeIntelligenceRange{
 		{Range: testRange1, HoverText: "text1", Definitions: nil, References: []shared.Location{testLocation1}, Implementations: []shared.Location{}},

--- a/internal/codeintel/codenav/service_ranges_test.go
+++ b/internal/codeintel/codenav/service_ranges_test.go
@@ -57,7 +57,7 @@ func TestRanges(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.ProcessedUpload{
+	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef1", Root: "sub1/", RepositoryID: 42},
 		{ID: 51, Commit: "deadbeef1", Root: "sub2/", RepositoryID: 42},
 		{ID: 52, Commit: "deadbeef2", Root: "sub3/", RepositoryID: 42},

--- a/internal/codeintel/codenav/service_ranges_test.go
+++ b/internal/codeintel/codenav/service_ranges_test.go
@@ -103,14 +103,14 @@ func TestRanges(t *testing.T) {
 		t.Fatalf("unexpected error querying ranges: %s", err)
 	}
 
-	adjustedLocation1 := shared.UploadLocation{Dump: uploads[0], Path: "sub1/a.go", TargetCommit: "deadbeef", TargetRange: testRange1}
-	adjustedLocation2 := shared.UploadLocation{Dump: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange2}
-	adjustedLocation3 := shared.UploadLocation{Dump: uploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef", TargetRange: testRange1}
-	adjustedLocation4 := shared.UploadLocation{Dump: uploads[1], Path: "sub2/d.go", TargetCommit: "deadbeef", TargetRange: testRange2}
-	adjustedLocation5 := shared.UploadLocation{Dump: uploads[1], Path: "sub2/e.go", TargetCommit: "deadbeef", TargetRange: testRange1}
-	adjustedLocation6 := shared.UploadLocation{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange2}
-	adjustedLocation7 := shared.UploadLocation{Dump: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange3}
-	adjustedLocation8 := shared.UploadLocation{Dump: uploads[2], Path: "sub3/a.go", TargetCommit: "deadbeef", TargetRange: testRange4}
+	adjustedLocation1 := shared.UploadLocation{Upload: uploads[0], Path: "sub1/a.go", TargetCommit: "deadbeef", TargetRange: testRange1}
+	adjustedLocation2 := shared.UploadLocation{Upload: uploads[1], Path: "sub2/b.go", TargetCommit: "deadbeef", TargetRange: testRange2}
+	adjustedLocation3 := shared.UploadLocation{Upload: uploads[1], Path: "sub2/c.go", TargetCommit: "deadbeef", TargetRange: testRange1}
+	adjustedLocation4 := shared.UploadLocation{Upload: uploads[1], Path: "sub2/d.go", TargetCommit: "deadbeef", TargetRange: testRange2}
+	adjustedLocation5 := shared.UploadLocation{Upload: uploads[1], Path: "sub2/e.go", TargetCommit: "deadbeef", TargetRange: testRange1}
+	adjustedLocation6 := shared.UploadLocation{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange2}
+	adjustedLocation7 := shared.UploadLocation{Upload: uploads[1], Path: "sub2/a.go", TargetCommit: "deadbeef", TargetRange: testRange3}
+	adjustedLocation8 := shared.UploadLocation{Upload: uploads[2], Path: "sub3/a.go", TargetCommit: "deadbeef", TargetRange: testRange4}
 
 	expectedRanges := []AdjustedCodeIntelligenceRange{
 		{Range: testRange1, HoverText: "text1", Definitions: []shared.UploadLocation{}, References: []shared.UploadLocation{adjustedLocation1}, Implementations: []shared.UploadLocation{}},

--- a/internal/codeintel/codenav/service_snapshot_test.go
+++ b/internal/codeintel/codenav/service_snapshot_test.go
@@ -28,7 +28,7 @@ func TestSnapshotForDocument(t *testing.T) {
 	// Init service
 	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
-	mockUploadSvc.GetDumpsByIDsFunc.SetDefaultReturn([]shared.Dump{{}}, nil)
+	mockUploadSvc.GetProcessedUploadsByIDsFunc.SetDefaultReturn([]shared.ProcessedUpload{{}}, nil)
 	mockRepoStore.GetFunc.SetDefaultReturn(&types.Repo{}, nil)
 	mockGitserverClient.NewFileReaderFunc.SetDefaultReturn(io.NopCloser(bytes.NewReader([]byte(sampleFile1))), nil)
 	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{

--- a/internal/codeintel/codenav/service_snapshot_test.go
+++ b/internal/codeintel/codenav/service_snapshot_test.go
@@ -28,7 +28,7 @@ func TestSnapshotForDocument(t *testing.T) {
 	// Init service
 	svc := newService(&observation.TestContext, mockRepoStore, mockLsifStore, mockUploadSvc, mockGitserverClient)
 
-	mockUploadSvc.GetProcessedUploadsByIDsFunc.SetDefaultReturn([]shared.ProcessedUpload{{}}, nil)
+	mockUploadSvc.GetCompletedUploadsByIDsFunc.SetDefaultReturn([]shared.CompletedUpload{{}}, nil)
 	mockRepoStore.GetFunc.SetDefaultReturn(&types.Repo{}, nil)
 	mockGitserverClient.NewFileReaderFunc.SetDefaultReturn(io.NopCloser(bytes.NewReader([]byte(sampleFile1))), nil)
 	mockLsifStore.SCIPDocumentFunc.SetDefaultReturn(&scip.Document{

--- a/internal/codeintel/codenav/service_stencil_test.go
+++ b/internal/codeintel/codenav/service_stencil_test.go
@@ -28,7 +28,7 @@ func TestStencil(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.Dump{
+	uploads := []uploadsshared.ProcessedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -86,7 +86,7 @@ func TestStencilWithDuplicateRanges(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.Dump{
+	uploads := []uploadsshared.ProcessedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},

--- a/internal/codeintel/codenav/service_stencil_test.go
+++ b/internal/codeintel/codenav/service_stencil_test.go
@@ -28,7 +28,7 @@ func TestStencil(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.ProcessedUpload{
+	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},
@@ -86,7 +86,7 @@ func TestStencilWithDuplicateRanges(t *testing.T) {
 	mockRequestState := RequestState{}
 	mockRequestState.SetLocalCommitCache(mockRepoStore, mockGitserverClient)
 	mockRequestState.SetLocalGitTreeTranslator(mockGitserverClient, &sgtypes.Repo{}, mockCommit, mockPath, hunkCache)
-	uploads := []uploadsshared.ProcessedUpload{
+	uploads := []uploadsshared.CompletedUpload{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
 		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
 		{ID: 52, Commit: "deadbeef", Root: "sub3/"},

--- a/internal/codeintel/codenav/shared/types.go
+++ b/internal/codeintel/codenav/shared/types.go
@@ -7,16 +7,16 @@ import (
 
 // Location is an LSP-like location scoped to a dump.
 type Location struct {
-	DumpID int
-	Path   string
-	Range  Range
+	UploadID int
+	Path     string
+	Range    Range
 }
 
 // Diagnostic describes diagnostic information attached to a location within a
 // particular dump.
 type Diagnostic struct {
-	DumpID int
-	Path   string
+	UploadID int
+	Path     string
 	precise.DiagnosticData
 }
 
@@ -32,7 +32,7 @@ type CodeIntelligenceRange struct {
 // UploadLocation is a path and range pair from within a particular upload. The target commit
 // denotes the target commit for which the location was set (the originally requested commit).
 type UploadLocation struct {
-	Dump         shared.Dump
+	Dump         shared.ProcessedUpload
 	Path         string
 	TargetCommit string
 	TargetRange  Range

--- a/internal/codeintel/codenav/shared/types.go
+++ b/internal/codeintel/codenav/shared/types.go
@@ -32,7 +32,7 @@ type CodeIntelligenceRange struct {
 // UploadLocation is a path and range pair from within a particular upload. The target commit
 // denotes the target commit for which the location was set (the originally requested commit).
 type UploadLocation struct {
-	Dump         shared.ProcessedUpload
+	Dump         shared.CompletedUpload
 	Path         string
 	TargetCommit string
 	TargetRange  Range

--- a/internal/codeintel/codenav/shared/types.go
+++ b/internal/codeintel/codenav/shared/types.go
@@ -32,7 +32,7 @@ type CodeIntelligenceRange struct {
 // UploadLocation is a path and range pair from within a particular upload. The target commit
 // denotes the target commit for which the location was set (the originally requested commit).
 type UploadLocation struct {
-	Dump         shared.CompletedUpload
+	Upload       shared.CompletedUpload
 	Path         string
 	TargetCommit string
 	TargetRange  Range

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -17,8 +17,8 @@ type CodeNavService interface {
 	GetDiagnostics(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState) (diagnosticsAtUploads []codenav.DiagnosticAtUpload, _ int, err error)
 	GetRanges(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState, startLine, endLine int) (adjustedRanges []codenav.AdjustedCodeIntelligenceRange, err error)
 	GetStencil(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState) (adjustedRanges []shared.Range, err error)
-	GetClosestProcessedUploadsForBlob(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []uploadsshared.ProcessedUpload, err error)
-	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.ProcessedUpload, error)
+	GetClosestCompletedUploadsForBlob(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []uploadsshared.CompletedUpload, err error)
+	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.CompletedUpload, error)
 	SnapshotForDocument(ctx context.Context, repositoryID int, commit, path string, uploadID int) (data []shared.SnapshotData, err error)
 }
 

--- a/internal/codeintel/codenav/transport/graphql/iface.go
+++ b/internal/codeintel/codenav/transport/graphql/iface.go
@@ -17,8 +17,8 @@ type CodeNavService interface {
 	GetDiagnostics(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState) (diagnosticsAtUploads []codenav.DiagnosticAtUpload, _ int, err error)
 	GetRanges(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState, startLine, endLine int) (adjustedRanges []codenav.AdjustedCodeIntelligenceRange, err error)
 	GetStencil(ctx context.Context, args codenav.PositionalRequestArgs, requestState codenav.RequestState) (adjustedRanges []shared.Range, err error)
-	GetClosestDumpsForBlob(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []uploadsshared.Dump, err error)
-	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.Dump, error)
+	GetClosestProcessedUploadsForBlob(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []uploadsshared.ProcessedUpload, err error)
+	VisibleUploadsForPath(ctx context.Context, requestState codenav.RequestState) ([]uploadsshared.ProcessedUpload, error)
 	SnapshotForDocument(ctx context.Context, repositoryID int, commit, path string, uploadID int) (data []shared.SnapshotData, err error)
 }
 

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -178,9 +178,10 @@ func (c AutoIndexingServiceQueueRepoRevFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/transport/graphql)
 // used for unit testing.
 type MockCodeNavService struct {
-	// GetClosestDumpsForBlobFunc is an instance of a mock function object
-	// controlling the behavior of the method GetClosestDumpsForBlob.
-	GetClosestDumpsForBlobFunc *CodeNavServiceGetClosestDumpsForBlobFunc
+	// GetClosestProcessedUploadsForBlobFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// GetClosestProcessedUploadsForBlob.
+	GetClosestProcessedUploadsForBlobFunc *CodeNavServiceGetClosestProcessedUploadsForBlobFunc
 	// GetDefinitionsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDefinitions.
 	GetDefinitionsFunc *CodeNavServiceGetDefinitionsFunc
@@ -217,8 +218,8 @@ type MockCodeNavService struct {
 // All methods return zero values for all results, unless overwritten.
 func NewMockCodeNavService() *MockCodeNavService {
 	return &MockCodeNavService{
-		GetClosestDumpsForBlobFunc: &CodeNavServiceGetClosestDumpsForBlobFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.Dump, r1 error) {
+		GetClosestProcessedUploadsForBlobFunc: &CodeNavServiceGetClosestProcessedUploadsForBlobFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -268,7 +269,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		VisibleUploadsForPathFunc: &CodeNavServiceVisibleUploadsForPathFunc{
-			defaultHook: func(context.Context, codenav.RequestState) (r0 []shared.Dump, r1 error) {
+			defaultHook: func(context.Context, codenav.RequestState) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -279,9 +280,9 @@ func NewMockCodeNavService() *MockCodeNavService {
 // interface. All methods panic on invocation, unless overwritten.
 func NewStrictMockCodeNavService() *MockCodeNavService {
 	return &MockCodeNavService{
-		GetClosestDumpsForBlobFunc: &CodeNavServiceGetClosestDumpsForBlobFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockCodeNavService.GetClosestDumpsForBlob")
+		GetClosestProcessedUploadsForBlobFunc: &CodeNavServiceGetClosestProcessedUploadsForBlobFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockCodeNavService.GetClosestProcessedUploadsForBlob")
 			},
 		},
 		GetDefinitionsFunc: &CodeNavServiceGetDefinitionsFunc{
@@ -330,7 +331,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		VisibleUploadsForPathFunc: &CodeNavServiceVisibleUploadsForPathFunc{
-			defaultHook: func(context.Context, codenav.RequestState) ([]shared.Dump, error) {
+			defaultHook: func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error) {
 				panic("unexpected invocation of MockCodeNavService.VisibleUploadsForPath")
 			},
 		},
@@ -342,8 +343,8 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 // overwritten.
 func NewMockCodeNavServiceFrom(i CodeNavService) *MockCodeNavService {
 	return &MockCodeNavService{
-		GetClosestDumpsForBlobFunc: &CodeNavServiceGetClosestDumpsForBlobFunc{
-			defaultHook: i.GetClosestDumpsForBlob,
+		GetClosestProcessedUploadsForBlobFunc: &CodeNavServiceGetClosestProcessedUploadsForBlobFunc{
+			defaultHook: i.GetClosestProcessedUploadsForBlob,
 		},
 		GetDefinitionsFunc: &CodeNavServiceGetDefinitionsFunc{
 			defaultHook: i.GetDefinitions,
@@ -378,37 +379,37 @@ func NewMockCodeNavServiceFrom(i CodeNavService) *MockCodeNavService {
 	}
 }
 
-// CodeNavServiceGetClosestDumpsForBlobFunc describes the behavior when the
-// GetClosestDumpsForBlob method of the parent MockCodeNavService instance
-// is invoked.
-type CodeNavServiceGetClosestDumpsForBlobFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)
-	history     []CodeNavServiceGetClosestDumpsForBlobFuncCall
+// CodeNavServiceGetClosestProcessedUploadsForBlobFunc describes the
+// behavior when the GetClosestProcessedUploadsForBlob method of the parent
+// MockCodeNavService instance is invoked.
+type CodeNavServiceGetClosestProcessedUploadsForBlobFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
+	history     []CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall
 	mutex       sync.Mutex
 }
 
-// GetClosestDumpsForBlob delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) GetClosestDumpsForBlob(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.Dump, error) {
-	r0, r1 := m.GetClosestDumpsForBlobFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.GetClosestDumpsForBlobFunc.appendCall(CodeNavServiceGetClosestDumpsForBlobFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+// GetClosestProcessedUploadsForBlob delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockCodeNavService) GetClosestProcessedUploadsForBlob(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.GetClosestProcessedUploadsForBlobFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.GetClosestProcessedUploadsForBlobFunc.appendCall(CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetClosestDumpsForBlob method of the parent MockCodeNavService instance
-// is invoked and the hook queue is empty.
-func (f *CodeNavServiceGetClosestDumpsForBlobFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)) {
+// GetClosestProcessedUploadsForBlob method of the parent MockCodeNavService
+// instance is invoked and the hook queue is empty.
+func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetClosestDumpsForBlob method of the parent MockCodeNavService instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *CodeNavServiceGetClosestDumpsForBlobFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)) {
+// GetClosestProcessedUploadsForBlob method of the parent MockCodeNavService
+// instance invokes the hook at the front of the queue and discards it.
+// After the queue is empty, the default hook function is invoked for any
+// future action.
+func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -416,20 +417,20 @@ func (f *CodeNavServiceGetClosestDumpsForBlobFunc) PushHook(hook func(context.Co
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceGetClosestDumpsForBlobFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceGetClosestDumpsForBlobFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceGetClosestDumpsForBlobFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -442,28 +443,28 @@ func (f *CodeNavServiceGetClosestDumpsForBlobFunc) nextHook() func(context.Conte
 	return hook
 }
 
-func (f *CodeNavServiceGetClosestDumpsForBlobFunc) appendCall(r0 CodeNavServiceGetClosestDumpsForBlobFuncCall) {
+func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) appendCall(r0 CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// CodeNavServiceGetClosestDumpsForBlobFuncCall objects describing the
-// invocations of this function.
-func (f *CodeNavServiceGetClosestDumpsForBlobFunc) History() []CodeNavServiceGetClosestDumpsForBlobFuncCall {
+// CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall objects
+// describing the invocations of this function.
+func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) History() []CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeNavServiceGetClosestDumpsForBlobFuncCall, len(f.history))
+	history := make([]CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeNavServiceGetClosestDumpsForBlobFuncCall is an object that describes
-// an invocation of method GetClosestDumpsForBlob on an instance of
-// MockCodeNavService.
-type CodeNavServiceGetClosestDumpsForBlobFuncCall struct {
+// CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall is an object that
+// describes an invocation of method GetClosestProcessedUploadsForBlob on an
+// instance of MockCodeNavService.
+type CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -484,7 +485,7 @@ type CodeNavServiceGetClosestDumpsForBlobFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.Dump
+	Result0 []shared.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -492,13 +493,13 @@ type CodeNavServiceGetClosestDumpsForBlobFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeNavServiceGetClosestDumpsForBlobFuncCall) Args() []interface{} {
+func (c CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeNavServiceGetClosestDumpsForBlobFuncCall) Results() []interface{} {
+func (c CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -1554,15 +1555,15 @@ func (c CodeNavServiceSnapshotForDocumentFuncCall) Results() []interface{} {
 // VisibleUploadsForPath method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceVisibleUploadsForPathFunc struct {
-	defaultHook func(context.Context, codenav.RequestState) ([]shared.Dump, error)
-	hooks       []func(context.Context, codenav.RequestState) ([]shared.Dump, error)
+	defaultHook func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error)
 	history     []CodeNavServiceVisibleUploadsForPathFuncCall
 	mutex       sync.Mutex
 }
 
 // VisibleUploadsForPath delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) VisibleUploadsForPath(v0 context.Context, v1 codenav.RequestState) ([]shared.Dump, error) {
+func (m *MockCodeNavService) VisibleUploadsForPath(v0 context.Context, v1 codenav.RequestState) ([]shared.ProcessedUpload, error) {
 	r0, r1 := m.VisibleUploadsForPathFunc.nextHook()(v0, v1)
 	m.VisibleUploadsForPathFunc.appendCall(CodeNavServiceVisibleUploadsForPathFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -1571,7 +1572,7 @@ func (m *MockCodeNavService) VisibleUploadsForPath(v0 context.Context, v1 codena
 // SetDefaultHook sets function that is called when the
 // VisibleUploadsForPath method of the parent MockCodeNavService instance is
 // invoked and the hook queue is empty.
-func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultHook(hook func(context.Context, codenav.RequestState) ([]shared.Dump, error)) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultHook(hook func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -1580,7 +1581,7 @@ func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultHook(hook func(conte
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeNavServiceVisibleUploadsForPathFunc) PushHook(hook func(context.Context, codenav.RequestState) ([]shared.Dump, error)) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) PushHook(hook func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1588,20 +1589,20 @@ func (f *CodeNavServiceVisibleUploadsForPathFunc) PushHook(hook func(context.Con
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, codenav.RequestState) ([]shared.Dump, error) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceVisibleUploadsForPathFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, codenav.RequestState) ([]shared.Dump, error) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceVisibleUploadsForPathFunc) nextHook() func(context.Context, codenav.RequestState) ([]shared.Dump, error) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) nextHook() func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1643,7 +1644,7 @@ type CodeNavServiceVisibleUploadsForPathFuncCall struct {
 	Arg1 codenav.RequestState
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.Dump
+	Result0 []shared.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/codeintel/codenav/transport/graphql/mocks_test.go
+++ b/internal/codeintel/codenav/transport/graphql/mocks_test.go
@@ -178,10 +178,10 @@ func (c AutoIndexingServiceQueueRepoRevFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/internal/codeintel/codenav/transport/graphql)
 // used for unit testing.
 type MockCodeNavService struct {
-	// GetClosestProcessedUploadsForBlobFunc is an instance of a mock
+	// GetClosestCompletedUploadsForBlobFunc is an instance of a mock
 	// function object controlling the behavior of the method
-	// GetClosestProcessedUploadsForBlob.
-	GetClosestProcessedUploadsForBlobFunc *CodeNavServiceGetClosestProcessedUploadsForBlobFunc
+	// GetClosestCompletedUploadsForBlob.
+	GetClosestCompletedUploadsForBlobFunc *CodeNavServiceGetClosestCompletedUploadsForBlobFunc
 	// GetDefinitionsFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDefinitions.
 	GetDefinitionsFunc *CodeNavServiceGetDefinitionsFunc
@@ -218,8 +218,8 @@ type MockCodeNavService struct {
 // All methods return zero values for all results, unless overwritten.
 func NewMockCodeNavService() *MockCodeNavService {
 	return &MockCodeNavService{
-		GetClosestProcessedUploadsForBlobFunc: &CodeNavServiceGetClosestProcessedUploadsForBlobFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.ProcessedUpload, r1 error) {
+		GetClosestCompletedUploadsForBlobFunc: &CodeNavServiceGetClosestCompletedUploadsForBlobFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -269,7 +269,7 @@ func NewMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		VisibleUploadsForPathFunc: &CodeNavServiceVisibleUploadsForPathFunc{
-			defaultHook: func(context.Context, codenav.RequestState) (r0 []shared.ProcessedUpload, r1 error) {
+			defaultHook: func(context.Context, codenav.RequestState) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -280,9 +280,9 @@ func NewMockCodeNavService() *MockCodeNavService {
 // interface. All methods panic on invocation, unless overwritten.
 func NewStrictMockCodeNavService() *MockCodeNavService {
 	return &MockCodeNavService{
-		GetClosestProcessedUploadsForBlobFunc: &CodeNavServiceGetClosestProcessedUploadsForBlobFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockCodeNavService.GetClosestProcessedUploadsForBlob")
+		GetClosestCompletedUploadsForBlobFunc: &CodeNavServiceGetClosestCompletedUploadsForBlobFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockCodeNavService.GetClosestCompletedUploadsForBlob")
 			},
 		},
 		GetDefinitionsFunc: &CodeNavServiceGetDefinitionsFunc{
@@ -331,7 +331,7 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 			},
 		},
 		VisibleUploadsForPathFunc: &CodeNavServiceVisibleUploadsForPathFunc{
-			defaultHook: func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error) {
+			defaultHook: func(context.Context, codenav.RequestState) ([]shared.CompletedUpload, error) {
 				panic("unexpected invocation of MockCodeNavService.VisibleUploadsForPath")
 			},
 		},
@@ -343,8 +343,8 @@ func NewStrictMockCodeNavService() *MockCodeNavService {
 // overwritten.
 func NewMockCodeNavServiceFrom(i CodeNavService) *MockCodeNavService {
 	return &MockCodeNavService{
-		GetClosestProcessedUploadsForBlobFunc: &CodeNavServiceGetClosestProcessedUploadsForBlobFunc{
-			defaultHook: i.GetClosestProcessedUploadsForBlob,
+		GetClosestCompletedUploadsForBlobFunc: &CodeNavServiceGetClosestCompletedUploadsForBlobFunc{
+			defaultHook: i.GetClosestCompletedUploadsForBlob,
 		},
 		GetDefinitionsFunc: &CodeNavServiceGetDefinitionsFunc{
 			defaultHook: i.GetDefinitions,
@@ -379,37 +379,37 @@ func NewMockCodeNavServiceFrom(i CodeNavService) *MockCodeNavService {
 	}
 }
 
-// CodeNavServiceGetClosestProcessedUploadsForBlobFunc describes the
-// behavior when the GetClosestProcessedUploadsForBlob method of the parent
+// CodeNavServiceGetClosestCompletedUploadsForBlobFunc describes the
+// behavior when the GetClosestCompletedUploadsForBlob method of the parent
 // MockCodeNavService instance is invoked.
-type CodeNavServiceGetClosestProcessedUploadsForBlobFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
-	history     []CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall
+type CodeNavServiceGetClosestCompletedUploadsForBlobFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	history     []CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall
 	mutex       sync.Mutex
 }
 
-// GetClosestProcessedUploadsForBlob delegates to the next hook function in
+// GetClosestCompletedUploadsForBlob delegates to the next hook function in
 // the queue and stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) GetClosestProcessedUploadsForBlob(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.GetClosestProcessedUploadsForBlobFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.GetClosestProcessedUploadsForBlobFunc.appendCall(CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockCodeNavService) GetClosestCompletedUploadsForBlob(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetClosestCompletedUploadsForBlobFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.GetClosestCompletedUploadsForBlobFunc.appendCall(CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetClosestProcessedUploadsForBlob method of the parent MockCodeNavService
+// GetClosestCompletedUploadsForBlob method of the parent MockCodeNavService
 // instance is invoked and the hook queue is empty.
-func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetClosestProcessedUploadsForBlob method of the parent MockCodeNavService
+// GetClosestCompletedUploadsForBlob method of the parent MockCodeNavService
 // instance invokes the hook at the front of the queue and discards it.
 // After the queue is empty, the default hook function is invoked for any
 // future action.
-func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -417,20 +417,20 @@ func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) PushHook(hook func
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -443,28 +443,28 @@ func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) nextHook() func(co
 	return hook
 }
 
-func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) appendCall(r0 CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall) {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) appendCall(r0 CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall objects
+// CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall objects
 // describing the invocations of this function.
-func (f *CodeNavServiceGetClosestProcessedUploadsForBlobFunc) History() []CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall {
+func (f *CodeNavServiceGetClosestCompletedUploadsForBlobFunc) History() []CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall {
 	f.mutex.Lock()
-	history := make([]CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall, len(f.history))
+	history := make([]CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall is an object that
-// describes an invocation of method GetClosestProcessedUploadsForBlob on an
+// CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall is an object that
+// describes an invocation of method GetClosestCompletedUploadsForBlob on an
 // instance of MockCodeNavService.
-type CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall struct {
+type CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -485,7 +485,7 @@ type CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -493,13 +493,13 @@ type CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall) Args() []interface{} {
+func (c CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CodeNavServiceGetClosestProcessedUploadsForBlobFuncCall) Results() []interface{} {
+func (c CodeNavServiceGetClosestCompletedUploadsForBlobFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -1555,15 +1555,15 @@ func (c CodeNavServiceSnapshotForDocumentFuncCall) Results() []interface{} {
 // VisibleUploadsForPath method of the parent MockCodeNavService instance is
 // invoked.
 type CodeNavServiceVisibleUploadsForPathFunc struct {
-	defaultHook func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error)
+	defaultHook func(context.Context, codenav.RequestState) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, codenav.RequestState) ([]shared.CompletedUpload, error)
 	history     []CodeNavServiceVisibleUploadsForPathFuncCall
 	mutex       sync.Mutex
 }
 
 // VisibleUploadsForPath delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockCodeNavService) VisibleUploadsForPath(v0 context.Context, v1 codenav.RequestState) ([]shared.ProcessedUpload, error) {
+func (m *MockCodeNavService) VisibleUploadsForPath(v0 context.Context, v1 codenav.RequestState) ([]shared.CompletedUpload, error) {
 	r0, r1 := m.VisibleUploadsForPathFunc.nextHook()(v0, v1)
 	m.VisibleUploadsForPathFunc.appendCall(CodeNavServiceVisibleUploadsForPathFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -1572,7 +1572,7 @@ func (m *MockCodeNavService) VisibleUploadsForPath(v0 context.Context, v1 codena
 // SetDefaultHook sets function that is called when the
 // VisibleUploadsForPath method of the parent MockCodeNavService instance is
 // invoked and the hook queue is empty.
-func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultHook(hook func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error)) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultHook(hook func(context.Context, codenav.RequestState) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
@@ -1581,7 +1581,7 @@ func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultHook(hook func(conte
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *CodeNavServiceVisibleUploadsForPathFunc) PushHook(hook func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error)) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) PushHook(hook func(context.Context, codenav.RequestState) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1589,20 +1589,20 @@ func (f *CodeNavServiceVisibleUploadsForPathFunc) PushHook(hook func(context.Con
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, codenav.RequestState) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *CodeNavServiceVisibleUploadsForPathFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, codenav.RequestState) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *CodeNavServiceVisibleUploadsForPathFunc) nextHook() func(context.Context, codenav.RequestState) ([]shared.ProcessedUpload, error) {
+func (f *CodeNavServiceVisibleUploadsForPathFunc) nextHook() func(context.Context, codenav.RequestState) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1644,7 +1644,7 @@ type CodeNavServiceVisibleUploadsForPathFuncCall struct {
 	Arg1 codenav.RequestState
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -80,7 +80,7 @@ func (r *rootResolver) GitBlobLSIFData(ctx context.Context, args *resolverstubs.
 	}})
 	endObservation.OnCancel(ctx, 1, observation.Args{})
 
-	uploads, err := r.svc.GetClosestProcessedUploadsForBlob(ctx, int(args.Repo.ID), string(args.Commit), args.Path, args.ExactPath, args.ToolName)
+	uploads, err := r.svc.GetClosestCompletedUploadsForBlob(ctx, int(args.Repo.ID), string(args.Commit), args.Path, args.ExactPath, args.ToolName)
 	if err != nil || len(uploads) == 0 {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func (r *gitBlobLSIFDataResolver) VisibleIndexes(ctx context.Context) (_ *[]reso
 	return &resolvers, nil
 }
 
-func dumpToUpload(expected uploadsshared.ProcessedUpload) *uploadsshared.Upload {
+func dumpToUpload(expected uploadsshared.CompletedUpload) *uploadsshared.Upload {
 	return &uploadsshared.Upload{
 		ID:                expected.ID,
 		Commit:            expected.Commit,

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -80,7 +80,7 @@ func (r *rootResolver) GitBlobLSIFData(ctx context.Context, args *resolverstubs.
 	}})
 	endObservation.OnCancel(ctx, 1, observation.Args{})
 
-	uploads, err := r.svc.GetClosestDumpsForBlob(ctx, int(args.Repo.ID), string(args.Commit), args.Path, args.ExactPath, args.ToolName)
+	uploads, err := r.svc.GetClosestProcessedUploadsForBlob(ctx, int(args.Repo.ID), string(args.Commit), args.Path, args.ExactPath, args.ToolName)
 	if err != nil || len(uploads) == 0 {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func (r *gitBlobLSIFDataResolver) VisibleIndexes(ctx context.Context) (_ *[]reso
 	return &resolvers, nil
 }
 
-func dumpToUpload(expected uploadsshared.Dump) *uploadsshared.Upload {
+func dumpToUpload(expected uploadsshared.ProcessedUpload) *uploadsshared.Upload {
 	return &uploadsshared.Upload{
 		ID:                expected.ID,
 		Commit:            expected.Commit,

--- a/internal/codeintel/codenav/transport/graphql/root_resolver.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver.go
@@ -11,7 +11,6 @@ import (
 	resolverstubs "github.com/sourcegraph/sourcegraph/internal/codeintel/resolvers"
 	sharedresolvers "github.com/sourcegraph/sourcegraph/internal/codeintel/shared/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel/shared/resolvers/gitresolvers"
-	uploadsshared "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/shared"
 	uploadsgraphql "github.com/sourcegraph/sourcegraph/internal/codeintel/uploads/transport/graphql"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/dotcom"
@@ -177,13 +176,14 @@ func (r *gitBlobLSIFDataResolver) VisibleIndexes(ctx context.Context) (_ *[]reso
 
 	resolvers := make([]resolverstubs.PreciseIndexResolver, 0, len(visibleUploads))
 	for _, u := range visibleUploads {
+		upload := u.ConvertToUpload()
 		resolver, err := r.indexResolverFactory.Create(
 			ctx,
 			r.uploadLoader,
 			r.indexLoader,
 			r.locationResolver,
 			traceErrs,
-			dumpToUpload(u),
+			&upload,
 			nil,
 		)
 		if err != nil {
@@ -193,25 +193,4 @@ func (r *gitBlobLSIFDataResolver) VisibleIndexes(ctx context.Context) (_ *[]reso
 	}
 
 	return &resolvers, nil
-}
-
-func dumpToUpload(expected uploadsshared.CompletedUpload) *uploadsshared.Upload {
-	return &uploadsshared.Upload{
-		ID:                expected.ID,
-		Commit:            expected.Commit,
-		Root:              expected.Root,
-		UploadedAt:        expected.UploadedAt,
-		State:             expected.State,
-		FailureMessage:    expected.FailureMessage,
-		StartedAt:         expected.StartedAt,
-		FinishedAt:        expected.FinishedAt,
-		ProcessAfter:      expected.ProcessAfter,
-		NumResets:         expected.NumResets,
-		NumFailures:       expected.NumFailures,
-		RepositoryID:      expected.RepositoryID,
-		RepositoryName:    expected.RepositoryName,
-		Indexer:           expected.Indexer,
-		IndexerVersion:    expected.IndexerVersion,
-		AssociatedIndexID: expected.AssociatedIndexID,
-	}
 }

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_diagnostics.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_diagnostics.go
@@ -79,7 +79,7 @@ func (r *diagnosticResolver) Location(ctx context.Context) (resolverstubs.Locati
 		ctx,
 		r.locationResolver,
 		shared.UploadLocation{
-			Dump:         r.diagnostic.Dump,
+			Dump:         r.diagnostic.Upload,
 			Path:         r.diagnostic.Path,
 			TargetCommit: r.diagnostic.AdjustedCommit,
 			TargetRange:  r.diagnostic.AdjustedRange,

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_diagnostics.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_diagnostics.go
@@ -79,7 +79,7 @@ func (r *diagnosticResolver) Location(ctx context.Context) (resolverstubs.Locati
 		ctx,
 		r.locationResolver,
 		shared.UploadLocation{
-			Dump:         r.diagnostic.Upload,
+			Upload:       r.diagnostic.Upload,
 			Path:         r.diagnostic.Path,
 			TargetCommit: r.diagnostic.AdjustedCommit,
 			TargetRange:  r.diagnostic.AdjustedRange,

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
@@ -374,10 +374,10 @@ func TestResolveLocations(t *testing.T) {
 	r4 := shared.Range{Start: shared.Position{Line: 41, Character: 42}, End: shared.Position{Line: 43, Character: 44}}
 
 	locations, err := resolveLocations(context.Background(), locationResolver, []shared.UploadLocation{
-		{Dump: uploadsshared.CompletedUpload{RepositoryID: 50}, TargetCommit: "deadbeef1", TargetRange: r1, Path: "p1"},
-		{Dump: uploadsshared.CompletedUpload{RepositoryID: 51}, TargetCommit: "deadbeef2", TargetRange: r2, Path: "p2"},
-		{Dump: uploadsshared.CompletedUpload{RepositoryID: 52}, TargetCommit: "deadbeef3", TargetRange: r3, Path: "p3"},
-		{Dump: uploadsshared.CompletedUpload{RepositoryID: 53}, TargetCommit: "deadbeef4", TargetRange: r4, Path: "p4"},
+		{Upload: uploadsshared.CompletedUpload{RepositoryID: 50}, TargetCommit: "deadbeef1", TargetRange: r1, Path: "p1"},
+		{Upload: uploadsshared.CompletedUpload{RepositoryID: 51}, TargetCommit: "deadbeef2", TargetRange: r2, Path: "p2"},
+		{Upload: uploadsshared.CompletedUpload{RepositoryID: 52}, TargetCommit: "deadbeef3", TargetRange: r3, Path: "p3"},
+		{Upload: uploadsshared.CompletedUpload{RepositoryID: 53}, TargetCommit: "deadbeef4", TargetRange: r4, Path: "p4"},
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
@@ -374,10 +374,10 @@ func TestResolveLocations(t *testing.T) {
 	r4 := shared.Range{Start: shared.Position{Line: 41, Character: 42}, End: shared.Position{Line: 43, Character: 44}}
 
 	locations, err := resolveLocations(context.Background(), locationResolver, []shared.UploadLocation{
-		{Dump: uploadsshared.ProcessedUpload{RepositoryID: 50}, TargetCommit: "deadbeef1", TargetRange: r1, Path: "p1"},
-		{Dump: uploadsshared.ProcessedUpload{RepositoryID: 51}, TargetCommit: "deadbeef2", TargetRange: r2, Path: "p2"},
-		{Dump: uploadsshared.ProcessedUpload{RepositoryID: 52}, TargetCommit: "deadbeef3", TargetRange: r3, Path: "p3"},
-		{Dump: uploadsshared.ProcessedUpload{RepositoryID: 53}, TargetCommit: "deadbeef4", TargetRange: r4, Path: "p4"},
+		{Dump: uploadsshared.CompletedUpload{RepositoryID: 50}, TargetCommit: "deadbeef1", TargetRange: r1, Path: "p1"},
+		{Dump: uploadsshared.CompletedUpload{RepositoryID: 51}, TargetCommit: "deadbeef2", TargetRange: r2, Path: "p2"},
+		{Dump: uploadsshared.CompletedUpload{RepositoryID: 52}, TargetCommit: "deadbeef3", TargetRange: r3, Path: "p3"},
+		{Dump: uploadsshared.CompletedUpload{RepositoryID: 53}, TargetCommit: "deadbeef4", TargetRange: r4, Path: "p4"},
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)

--- a/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
+++ b/internal/codeintel/codenav/transport/graphql/root_resolver_test.go
@@ -374,10 +374,10 @@ func TestResolveLocations(t *testing.T) {
 	r4 := shared.Range{Start: shared.Position{Line: 41, Character: 42}, End: shared.Position{Line: 43, Character: 44}}
 
 	locations, err := resolveLocations(context.Background(), locationResolver, []shared.UploadLocation{
-		{Dump: uploadsshared.Dump{RepositoryID: 50}, TargetCommit: "deadbeef1", TargetRange: r1, Path: "p1"},
-		{Dump: uploadsshared.Dump{RepositoryID: 51}, TargetCommit: "deadbeef2", TargetRange: r2, Path: "p2"},
-		{Dump: uploadsshared.Dump{RepositoryID: 52}, TargetCommit: "deadbeef3", TargetRange: r3, Path: "p3"},
-		{Dump: uploadsshared.Dump{RepositoryID: 53}, TargetCommit: "deadbeef4", TargetRange: r4, Path: "p4"},
+		{Dump: uploadsshared.ProcessedUpload{RepositoryID: 50}, TargetCommit: "deadbeef1", TargetRange: r1, Path: "p1"},
+		{Dump: uploadsshared.ProcessedUpload{RepositoryID: 51}, TargetCommit: "deadbeef2", TargetRange: r2, Path: "p2"},
+		{Dump: uploadsshared.ProcessedUpload{RepositoryID: 52}, TargetCommit: "deadbeef3", TargetRange: r3, Path: "p3"},
+		{Dump: uploadsshared.ProcessedUpload{RepositoryID: 53}, TargetCommit: "deadbeef4", TargetRange: r4, Path: "p4"},
 	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)

--- a/internal/codeintel/codenav/transport/graphql/util_locations.go
+++ b/internal/codeintel/codenav/transport/graphql/util_locations.go
@@ -42,7 +42,7 @@ func resolveLocations(ctx context.Context, locationResolver *gitresolvers.Cached
 // resolveLocation creates a LocationResolver for the given adjusted location. This function may return a
 // nil resolver if the location's commit is not known by gitserver.
 func resolveLocation(ctx context.Context, locationResolver *gitresolvers.CachedLocationResolver, location shared.UploadLocation) (resolverstubs.LocationResolver, error) {
-	treeResolver, err := locationResolver.Path(ctx, api.RepoID(location.Dump.RepositoryID), location.TargetCommit, location.Path, false)
+	treeResolver, err := locationResolver.Path(ctx, api.RepoID(location.Upload.RepositoryID), location.TargetCommit, location.Path, false)
 	if err != nil || treeResolver == nil {
 		return nil, err
 	}

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -11,7 +11,7 @@ import (
 // visibleUpload pairs an upload visible from the current target commit with the
 // current target path and position matched to the data within the underlying index.
 type visibleUpload struct {
-	Upload                uploadsshared.Dump
+	Upload                uploadsshared.ProcessedUpload
 	TargetPath            string
 	TargetPosition        shared.Position
 	TargetPathWithoutRoot string
@@ -65,7 +65,7 @@ type PositionalRequestArgs struct {
 // the target commit for which the location was adjusted (the originally requested commit).
 type DiagnosticAtUpload struct {
 	shared.Diagnostic
-	Dump           uploadsshared.Dump
+	Upload         uploadsshared.ProcessedUpload
 	AdjustedCommit string
 	AdjustedRange  shared.Range
 }
@@ -111,7 +111,7 @@ type Cursor struct {
 }
 
 type CursorVisibleUpload struct {
-	DumpID                int             `json:"id"`
+	UploadID              int             `json:"id"`
 	TargetPath            string          `json:"path"`
 	TargetPathWithoutRoot string          `json:"path_no_root"` // TODO - can store these differently?
 	TargetPosition        shared.Position `json:"pos"`          // TODO - inline
@@ -179,7 +179,7 @@ type ImplementationsCursor struct {
 
 // cursorAdjustedUpload
 type CursorToVisibleUpload struct {
-	DumpID                int             `json:"dumpID"`
+	UploadID              int             `json:"uploadID"`
 	TargetPath            string          `json:"adjustedPath"`
 	TargetPosition        shared.Position `json:"adjustedPosition"`
 	TargetPathWithoutRoot string          `json:"adjustedPathInBundle"`

--- a/internal/codeintel/codenav/types.go
+++ b/internal/codeintel/codenav/types.go
@@ -11,7 +11,7 @@ import (
 // visibleUpload pairs an upload visible from the current target commit with the
 // current target path and position matched to the data within the underlying index.
 type visibleUpload struct {
-	Upload                uploadsshared.ProcessedUpload
+	Upload                uploadsshared.CompletedUpload
 	TargetPath            string
 	TargetPosition        shared.Position
 	TargetPathWithoutRoot string
@@ -65,7 +65,7 @@ type PositionalRequestArgs struct {
 // the target commit for which the location was adjusted (the originally requested commit).
 type DiagnosticAtUpload struct {
 	shared.Diagnostic
-	Upload         uploadsshared.ProcessedUpload
+	Upload         uploadsshared.CompletedUpload
 	AdjustedCommit string
 	AdjustedRange  shared.Range
 }

--- a/internal/codeintel/codenav/utils.go
+++ b/internal/codeintel/codenav/utils.go
@@ -29,7 +29,7 @@ func sliceContains(slice []string, str string) bool {
 	return false
 }
 
-func uploadIDsToString(vs []uploadsshared.Dump) string {
+func uploadIDsToString(vs []uploadsshared.ProcessedUpload) string {
 	ids := make([]string, 0, len(vs))
 	for _, v := range vs {
 		ids = append(ids, strconv.Itoa(v.ID))

--- a/internal/codeintel/codenav/utils.go
+++ b/internal/codeintel/codenav/utils.go
@@ -29,7 +29,7 @@ func sliceContains(slice []string, str string) bool {
 	return false
 }
 
-func uploadIDsToString(vs []uploadsshared.ProcessedUpload) string {
+func uploadIDsToString(vs []uploadsshared.CompletedUpload) string {
 	ids := make([]string, 0, len(vs))
 	for _, v := range vs {
 		ids = append(ids, strconv.Itoa(v.ID))

--- a/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
@@ -80,6 +80,13 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// GetCommitsVisibleToUpload.
 	GetCommitsVisibleToUploadFunc *StoreGetCommitsVisibleToUploadFunc
+	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletedUploadsByIDs.
+	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
+	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// GetCompletedUploadsWithDefinitionsForMonikers.
+	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetDirtyRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDirtyRepositories.
 	GetDirtyRepositoriesFunc *StoreGetDirtyRepositoriesFunc
@@ -102,13 +109,6 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
-	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetCompletedUploadsByIDs.
-	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
-	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
-	// mock function object controlling the behavior of the method
-	// GetCompletedUploadsWithDefinitionsForMonikers.
-	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -323,6 +323,16 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared.CompletedUpload, r1 error) {
+				return
+			},
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.CompletedUpload, r1 error) {
+				return
+			},
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) (r0 []shared.DirtyRepository, r1 error) {
 				return
@@ -355,16 +365,6 @@ func NewMockStore() *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (r0 time.Time, r1 bool, r2 error) {
-				return
-			},
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared.CompletedUpload, r1 error) {
-				return
-			},
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -650,6 +650,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetCommitsVisibleToUpload")
 			},
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
+			},
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
+			},
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) ([]shared.DirtyRepository, error) {
 				panic("unexpected invocation of MockStore.GetDirtyRepositories")
@@ -683,16 +693,6 @@ func NewStrictMockStore() *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (time.Time, bool, error) {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
-			},
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared.CompletedUpload, error) {
-				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
-			},
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -945,6 +945,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetCommitsVisibleToUploadFunc: &StoreGetCommitsVisibleToUploadFunc{
 			defaultHook: i.GetCommitsVisibleToUpload,
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: i.GetCompletedUploadsByIDs,
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: i.GetDirtyRepositories,
 		},
@@ -965,12 +971,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: i.GetCompletedUploadsByIDs,
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -2904,6 +2904,230 @@ func (c StoreGetCommitsVisibleToUploadFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
+// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
+// invoked.
+type StoreGetCompletedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCompletedUploadsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.CompletedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetCompletedUploadsByIDs on an instance of
+// MockStore.
+type StoreGetCompletedUploadsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.CompletedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
+// the parent MockStore instance is invoked.
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
+// describing the invocations of this function.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
+// that describes an invocation of method
+// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
+// MockStore.
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []precise.QualifiedMonikerData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.CompletedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // StoreGetDirtyRepositoriesFunc describes the behavior when the
 // GetDirtyRepositories method of the parent MockStore instance is invoked.
 type StoreGetDirtyRepositoriesFunc struct {
@@ -3673,230 +3897,6 @@ func (c StoreGetOldestCommitDateFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
-// GetCompletedUploadsByIDs method of the parent MockStore instance is
-// invoked.
-type StoreGetCompletedUploadsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, []int) ([]shared.CompletedUpload, error)
-	history     []StoreGetCompletedUploadsByIDsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetCompletedUploadsByIDs delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
-	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetCompletedUploadsByIDs method of the parent MockStore instance is
-// invoked and the hook queue is empty.
-func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.CompletedUpload, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
-// objects describing the invocations of this function.
-func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
-// invocation of method GetCompletedUploadsByIDs on an instance of
-// MockStore.
-type StoreGetCompletedUploadsByIDsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.CompletedUpload
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
-// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
-// the parent MockStore instance is invoked.
-type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
-	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
-	mutex       sync.Mutex
-}
-
-// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
-// function in the queue and stores the parameter and result values of this
-// invocation.
-func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
-// MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
-// MockStore instance invokes the hook at the front of the queue and
-// discards it. After the queue is empty, the default hook function is
-// invoked for any future action.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
-// describing the invocations of this function.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
-// that describes an invocation of method
-// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
-// MockStore.
-type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []precise.QualifiedMonikerData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.CompletedUpload
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetRecentIndexesSummaryFunc describes the behavior when the

--- a/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
@@ -41,10 +41,10 @@ type MockStore struct {
 	// DeleteOldAuditLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteOldAuditLogs.
 	DeleteOldAuditLogsFunc *StoreDeleteOldAuditLogsFunc
-	// DeleteOverlappingProcessedUploadsFunc is an instance of a mock
+	// DeleteOverlappingCompletedUploadsFunc is an instance of a mock
 	// function object controlling the behavior of the method
-	// DeleteOverlappingProcessedUploads.
-	DeleteOverlappingProcessedUploadsFunc *StoreDeleteOverlappingProcessedUploadsFunc
+	// DeleteOverlappingCompletedUploads.
+	DeleteOverlappingCompletedUploadsFunc *StoreDeleteOverlappingCompletedUploadsFunc
 	// DeleteUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteUploadByID.
 	DeleteUploadByIDFunc *StoreDeleteUploadByIDFunc
@@ -62,14 +62,14 @@ type MockStore struct {
 	// ExpireFailedRecordsFunc is an instance of a mock function object
 	// controlling the behavior of the method ExpireFailedRecords.
 	ExpireFailedRecordsFunc *StoreExpireFailedRecordsFunc
-	// FindClosestProcessedUploadsFunc is an instance of a mock function
+	// FindClosestCompletedUploadsFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// FindClosestProcessedUploads.
-	FindClosestProcessedUploadsFunc *StoreFindClosestProcessedUploadsFunc
-	// FindClosestProcessedUploadsFromGraphFragmentFunc is an instance of a
+	// FindClosestCompletedUploads.
+	FindClosestCompletedUploadsFunc *StoreFindClosestCompletedUploadsFunc
+	// FindClosestCompletedUploadsFromGraphFragmentFunc is an instance of a
 	// mock function object controlling the behavior of the method
-	// FindClosestProcessedUploadsFromGraphFragment.
-	FindClosestProcessedUploadsFromGraphFragmentFunc *StoreFindClosestProcessedUploadsFromGraphFragmentFunc
+	// FindClosestCompletedUploadsFromGraphFragment.
+	FindClosestCompletedUploadsFromGraphFragmentFunc *StoreFindClosestCompletedUploadsFromGraphFragmentFunc
 	// GetAuditLogsForUploadFunc is an instance of a mock function object
 	// controlling the behavior of the method GetAuditLogsForUpload.
 	GetAuditLogsForUploadFunc *StoreGetAuditLogsForUploadFunc
@@ -102,13 +102,13 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
-	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetProcessedUploadsByIDs.
-	GetProcessedUploadsByIDsFunc *StoreGetProcessedUploadsByIDsFunc
-	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletedUploadsByIDs.
+	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
+	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
 	// mock function object controlling the behavior of the method
-	// GetProcessedUploadsWithDefinitionsForMonikers.
-	GetProcessedUploadsWithDefinitionsForMonikersFunc *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc
+	// GetCompletedUploadsWithDefinitionsForMonikers.
+	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -268,7 +268,7 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) (r0 error) {
 				return
 			},
@@ -298,13 +298,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.ProcessedUpload, r1 error) {
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.ProcessedUpload, r1 error) {
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -358,13 +358,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared.ProcessedUpload, r1 error) {
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.ProcessedUpload, r1 error) {
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -595,9 +595,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteOldAuditLogs")
 			},
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) error {
-				panic("unexpected invocation of MockStore.DeleteOverlappingProcessedUploads")
+				panic("unexpected invocation of MockStore.DeleteOverlappingCompletedUploads")
 			},
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
@@ -625,14 +625,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ExpireFailedRecords")
 			},
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.FindClosestProcessedUploads")
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestCompletedUploads")
 			},
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.FindClosestProcessedUploadsFromGraphFragment")
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestCompletedUploadsFromGraphFragment")
 			},
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
@@ -685,14 +685,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
 			},
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.GetProcessedUploadsByIDs")
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.GetProcessedUploadsWithDefinitionsForMonikers")
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -912,8 +912,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		DeleteOldAuditLogsFunc: &StoreDeleteOldAuditLogsFunc{
 			defaultHook: i.DeleteOldAuditLogs,
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
-			defaultHook: i.DeleteOverlappingProcessedUploads,
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
+			defaultHook: i.DeleteOverlappingCompletedUploads,
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
 			defaultHook: i.DeleteUploadByID,
@@ -930,11 +930,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
 			defaultHook: i.ExpireFailedRecords,
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: i.FindClosestProcessedUploads,
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: i.FindClosestCompletedUploads,
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: i.FindClosestProcessedUploadsFromGraphFragment,
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: i.FindClosestCompletedUploadsFromGraphFragment,
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
 			defaultHook: i.GetAuditLogsForUpload,
@@ -966,11 +966,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: i.GetProcessedUploadsByIDs,
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: i.GetCompletedUploadsByIDs,
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -1639,37 +1639,37 @@ func (c StoreDeleteOldAuditLogsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreDeleteOverlappingProcessedUploadsFunc describes the behavior when
-// the DeleteOverlappingProcessedUploads method of the parent MockStore
+// StoreDeleteOverlappingCompletedUploadsFunc describes the behavior when
+// the DeleteOverlappingCompletedUploads method of the parent MockStore
 // instance is invoked.
-type StoreDeleteOverlappingProcessedUploadsFunc struct {
+type StoreDeleteOverlappingCompletedUploadsFunc struct {
 	defaultHook func(context.Context, int, string, string, string) error
 	hooks       []func(context.Context, int, string, string, string) error
-	history     []StoreDeleteOverlappingProcessedUploadsFuncCall
+	history     []StoreDeleteOverlappingCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteOverlappingProcessedUploads delegates to the next hook function in
+// DeleteOverlappingCompletedUploads delegates to the next hook function in
 // the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) DeleteOverlappingProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
-	r0 := m.DeleteOverlappingProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.DeleteOverlappingProcessedUploadsFunc.appendCall(StoreDeleteOverlappingProcessedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
+func (m *MockStore) DeleteOverlappingCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
+	r0 := m.DeleteOverlappingCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DeleteOverlappingCompletedUploadsFunc.appendCall(StoreDeleteOverlappingCompletedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// DeleteOverlappingCompletedUploads method of the parent MockStore instance
 // is invoked and the hook queue is empty.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// DeleteOverlappingCompletedUploads method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1677,20 +1677,20 @@ func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultReturn(r0 error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushReturn(r0 error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1703,28 +1703,28 @@ func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Con
 	return hook
 }
 
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) appendCall(r0 StoreDeleteOverlappingProcessedUploadsFuncCall) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) appendCall(r0 StoreDeleteOverlappingCompletedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreDeleteOverlappingProcessedUploadsFuncCall objects describing the
+// StoreDeleteOverlappingCompletedUploadsFuncCall objects describing the
 // invocations of this function.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) History() []StoreDeleteOverlappingProcessedUploadsFuncCall {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) History() []StoreDeleteOverlappingCompletedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreDeleteOverlappingProcessedUploadsFuncCall, len(f.history))
+	history := make([]StoreDeleteOverlappingCompletedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreDeleteOverlappingProcessedUploadsFuncCall is an object that
-// describes an invocation of method DeleteOverlappingProcessedUploads on an
+// StoreDeleteOverlappingCompletedUploadsFuncCall is an object that
+// describes an invocation of method DeleteOverlappingCompletedUploads on an
 // instance of MockStore.
-type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
+type StoreDeleteOverlappingCompletedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1747,13 +1747,13 @@ type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Args() []interface{} {
+func (c StoreDeleteOverlappingCompletedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Results() []interface{} {
+func (c StoreDeleteOverlappingCompletedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2314,37 +2314,37 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreFindClosestProcessedUploadsFunc describes the behavior when the
-// FindClosestProcessedUploads method of the parent MockStore instance is
+// StoreFindClosestCompletedUploadsFunc describes the behavior when the
+// FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked.
-type StoreFindClosestProcessedUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
-	history     []StoreFindClosestProcessedUploadsFuncCall
+type StoreFindClosestCompletedUploadsFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	history     []StoreFindClosestCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestProcessedUploads delegates to the next hook function in the
+// FindClosestCompletedUploads delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.FindClosestProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestProcessedUploadsFunc.appendCall(StoreFindClosestProcessedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestProcessedUploads method of the parent MockStore instance is
+// FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestProcessedUploads method of the parent MockStore instance
+// FindClosestCompletedUploads method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2352,20 +2352,20 @@ func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestProcessedUploadsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2378,27 +2378,27 @@ func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, 
 	return hook
 }
 
-func (f *StoreFindClosestProcessedUploadsFunc) appendCall(r0 StoreFindClosestProcessedUploadsFuncCall) {
+func (f *StoreFindClosestCompletedUploadsFunc) appendCall(r0 StoreFindClosestCompletedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreFindClosestProcessedUploadsFuncCall
+// History returns a sequence of StoreFindClosestCompletedUploadsFuncCall
 // objects describing the invocations of this function.
-func (f *StoreFindClosestProcessedUploadsFunc) History() []StoreFindClosestProcessedUploadsFuncCall {
+func (f *StoreFindClosestCompletedUploadsFunc) History() []StoreFindClosestCompletedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestProcessedUploadsFuncCall, len(f.history))
+	history := make([]StoreFindClosestCompletedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestProcessedUploadsFuncCall is an object that describes an
-// invocation of method FindClosestProcessedUploads on an instance of
+// StoreFindClosestCompletedUploadsFuncCall is an object that describes an
+// invocation of method FindClosestCompletedUploads on an instance of
 // MockStore.
-type StoreFindClosestProcessedUploadsFuncCall struct {
+type StoreFindClosestCompletedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2419,7 +2419,7 @@ type StoreFindClosestProcessedUploadsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2427,48 +2427,48 @@ type StoreFindClosestProcessedUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFuncCall) Args() []interface{} {
+func (c StoreFindClosestCompletedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFuncCall) Results() []interface{} {
+func (c StoreFindClosestCompletedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreFindClosestProcessedUploadsFromGraphFragmentFunc describes the
-// behavior when the FindClosestProcessedUploadsFromGraphFragment method of
+// StoreFindClosestCompletedUploadsFromGraphFragmentFunc describes the
+// behavior when the FindClosestCompletedUploadsFromGraphFragment method of
 // the parent MockStore instance is invoked.
-type StoreFindClosestProcessedUploadsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
-	history     []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall
+type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	history     []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestProcessedUploadsFromGraphFragment delegates to the next hook
+// FindClosestCompletedUploadsFromGraphFragment delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) FindClosestProcessedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.FindClosestProcessedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestProcessedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2476,20 +2476,20 @@ func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook fu
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2502,28 +2502,28 @@ func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(
 	return hook
 }
 
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall objects
+// StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall objects
 // describing the invocations of this function.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) History() []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) History() []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall, len(f.history))
+	history := make([]StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall is an object
+// StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall is an object
 // that describes an invocation of method
-// FindClosestProcessedUploadsFromGraphFragment on an instance of MockStore.
-type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
+// FindClosestCompletedUploadsFromGraphFragment on an instance of MockStore.
+type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2547,7 +2547,7 @@ type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 	Arg6 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2555,13 +2555,13 @@ type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
+func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
+func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3675,36 +3675,36 @@ func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreGetProcessedUploadsByIDsFunc describes the behavior when the
-// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
 // invoked.
-type StoreGetProcessedUploadsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, []int) ([]shared.ProcessedUpload, error)
-	history     []StoreGetProcessedUploadsByIDsFuncCall
+type StoreGetCompletedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsByIDsFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// GetCompletedUploadsByIDs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockStore) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsByIDsFunc.appendCall(StoreGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
+func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsByIDs method of the parent MockStore instance invokes
+// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3712,20 +3712,20 @@ func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3738,27 +3738,27 @@ func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []i
 	return hook
 }
 
-func (f *StoreGetProcessedUploadsByIDsFunc) appendCall(r0 StoreGetProcessedUploadsByIDsFuncCall) {
+func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreGetProcessedUploadsByIDsFuncCall
+// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
 // objects describing the invocations of this function.
-func (f *StoreGetProcessedUploadsByIDsFunc) History() []StoreGetProcessedUploadsByIDsFuncCall {
+func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreGetProcessedUploadsByIDsFuncCall, len(f.history))
+	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreGetProcessedUploadsByIDsFuncCall is an object that describes an
-// invocation of method GetProcessedUploadsByIDs on an instance of
+// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetCompletedUploadsByIDs on an instance of
 // MockStore.
-type StoreGetProcessedUploadsByIDsFuncCall struct {
+type StoreGetCompletedUploadsByIDsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3767,7 +3767,7 @@ type StoreGetProcessedUploadsByIDsFuncCall struct {
 	Arg1 []int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3775,48 +3775,48 @@ type StoreGetProcessedUploadsByIDsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
+func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
+func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFunc describes the
-// behavior when the GetProcessedUploadsWithDefinitionsForMonikers method of
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
 // the parent MockStore instance is invoked.
-type StoreGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
-	history     []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3824,20 +3824,20 @@ func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook f
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3850,29 +3850,29 @@ func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func
 	return hook
 }
 
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall objects
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
 // describing the invocations of this function.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an object
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
 // that describes an invocation of method
-// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
 // MockStore.
-type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3881,7 +3881,7 @@ type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 	Arg1 []precise.QualifiedMonikerData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3889,13 +3889,13 @@ type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/backfiller/mocks_test.go
@@ -41,9 +41,10 @@ type MockStore struct {
 	// DeleteOldAuditLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteOldAuditLogs.
 	DeleteOldAuditLogsFunc *StoreDeleteOldAuditLogsFunc
-	// DeleteOverlappingDumpsFunc is an instance of a mock function object
-	// controlling the behavior of the method DeleteOverlappingDumps.
-	DeleteOverlappingDumpsFunc *StoreDeleteOverlappingDumpsFunc
+	// DeleteOverlappingProcessedUploadsFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// DeleteOverlappingProcessedUploads.
+	DeleteOverlappingProcessedUploadsFunc *StoreDeleteOverlappingProcessedUploadsFunc
 	// DeleteUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteUploadByID.
 	DeleteUploadByIDFunc *StoreDeleteUploadByIDFunc
@@ -61,13 +62,14 @@ type MockStore struct {
 	// ExpireFailedRecordsFunc is an instance of a mock function object
 	// controlling the behavior of the method ExpireFailedRecords.
 	ExpireFailedRecordsFunc *StoreExpireFailedRecordsFunc
-	// FindClosestDumpsFunc is an instance of a mock function object
-	// controlling the behavior of the method FindClosestDumps.
-	FindClosestDumpsFunc *StoreFindClosestDumpsFunc
-	// FindClosestDumpsFromGraphFragmentFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// FindClosestDumpsFromGraphFragment.
-	FindClosestDumpsFromGraphFragmentFunc *StoreFindClosestDumpsFromGraphFragmentFunc
+	// FindClosestProcessedUploadsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// FindClosestProcessedUploads.
+	FindClosestProcessedUploadsFunc *StoreFindClosestProcessedUploadsFunc
+	// FindClosestProcessedUploadsFromGraphFragmentFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// FindClosestProcessedUploadsFromGraphFragment.
+	FindClosestProcessedUploadsFromGraphFragmentFunc *StoreFindClosestProcessedUploadsFromGraphFragmentFunc
 	// GetAuditLogsForUploadFunc is an instance of a mock function object
 	// controlling the behavior of the method GetAuditLogsForUpload.
 	GetAuditLogsForUploadFunc *StoreGetAuditLogsForUploadFunc
@@ -81,13 +83,6 @@ type MockStore struct {
 	// GetDirtyRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDirtyRepositories.
 	GetDirtyRepositoriesFunc *StoreGetDirtyRepositoriesFunc
-	// GetDumpsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetDumpsByIDs.
-	GetDumpsByIDsFunc *StoreGetDumpsByIDsFunc
-	// GetDumpsWithDefinitionsForMonikersFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// GetDumpsWithDefinitionsForMonikers.
-	GetDumpsWithDefinitionsForMonikersFunc *StoreGetDumpsWithDefinitionsForMonikersFunc
 	// GetIndexByIDFunc is an instance of a mock function object controlling
 	// the behavior of the method GetIndexByID.
 	GetIndexByIDFunc *StoreGetIndexByIDFunc
@@ -107,6 +102,13 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
+	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetProcessedUploadsByIDs.
+	GetProcessedUploadsByIDsFunc *StoreGetProcessedUploadsByIDsFunc
+	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// GetProcessedUploadsWithDefinitionsForMonikers.
+	GetProcessedUploadsWithDefinitionsForMonikersFunc *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -266,7 +268,7 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) (r0 error) {
 				return
 			},
@@ -296,13 +298,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.Dump, r1 error) {
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.Dump, r1 error) {
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -323,16 +325,6 @@ func NewMockStore() *MockStore {
 		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) (r0 []shared.DirtyRepository, r1 error) {
-				return
-			},
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared.Dump, r1 error) {
-				return
-			},
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.Dump, r1 error) {
 				return
 			},
 		},
@@ -363,6 +355,16 @@ func NewMockStore() *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (r0 time.Time, r1 bool, r2 error) {
+				return
+			},
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared.ProcessedUpload, r1 error) {
+				return
+			},
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -593,9 +595,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteOldAuditLogs")
 			},
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) error {
-				panic("unexpected invocation of MockStore.DeleteOverlappingDumps")
+				panic("unexpected invocation of MockStore.DeleteOverlappingProcessedUploads")
 			},
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
@@ -623,14 +625,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ExpireFailedRecords")
 			},
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.FindClosestDumps")
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestProcessedUploads")
 			},
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.FindClosestDumpsFromGraphFragment")
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestProcessedUploadsFromGraphFragment")
 			},
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
@@ -651,16 +653,6 @@ func NewStrictMockStore() *MockStore {
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) ([]shared.DirtyRepository, error) {
 				panic("unexpected invocation of MockStore.GetDirtyRepositories")
-			},
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.GetDumpsByIDs")
-			},
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.GetDumpsWithDefinitionsForMonikers")
 			},
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
@@ -691,6 +683,16 @@ func NewStrictMockStore() *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (time.Time, bool, error) {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
+			},
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.GetProcessedUploadsByIDs")
+			},
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.GetProcessedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -910,8 +912,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		DeleteOldAuditLogsFunc: &StoreDeleteOldAuditLogsFunc{
 			defaultHook: i.DeleteOldAuditLogs,
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
-			defaultHook: i.DeleteOverlappingDumps,
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+			defaultHook: i.DeleteOverlappingProcessedUploads,
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
 			defaultHook: i.DeleteUploadByID,
@@ -928,11 +930,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
 			defaultHook: i.ExpireFailedRecords,
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: i.FindClosestDumps,
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: i.FindClosestProcessedUploads,
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: i.FindClosestDumpsFromGraphFragment,
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: i.FindClosestProcessedUploadsFromGraphFragment,
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
 			defaultHook: i.GetAuditLogsForUpload,
@@ -945,12 +947,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: i.GetDirtyRepositories,
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: i.GetDumpsByIDs,
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetDumpsWithDefinitionsForMonikers,
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
 			defaultHook: i.GetIndexByID,
@@ -969,6 +965,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: i.GetProcessedUploadsByIDs,
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -1637,36 +1639,37 @@ func (c StoreDeleteOldAuditLogsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreDeleteOverlappingDumpsFunc describes the behavior when the
-// DeleteOverlappingDumps method of the parent MockStore instance is
-// invoked.
-type StoreDeleteOverlappingDumpsFunc struct {
+// StoreDeleteOverlappingProcessedUploadsFunc describes the behavior when
+// the DeleteOverlappingProcessedUploads method of the parent MockStore
+// instance is invoked.
+type StoreDeleteOverlappingProcessedUploadsFunc struct {
 	defaultHook func(context.Context, int, string, string, string) error
 	hooks       []func(context.Context, int, string, string, string) error
-	history     []StoreDeleteOverlappingDumpsFuncCall
+	history     []StoreDeleteOverlappingProcessedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteOverlappingDumps delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockStore) DeleteOverlappingDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
-	r0 := m.DeleteOverlappingDumpsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.DeleteOverlappingDumpsFunc.appendCall(StoreDeleteOverlappingDumpsFuncCall{v0, v1, v2, v3, v4, r0})
+// DeleteOverlappingProcessedUploads delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockStore) DeleteOverlappingProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
+	r0 := m.DeleteOverlappingProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DeleteOverlappingProcessedUploadsFunc.appendCall(StoreDeleteOverlappingProcessedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteOverlappingDumps method of the parent MockStore instance is invoked
-// and the hook queue is empty.
-func (f *StoreDeleteOverlappingDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
+// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// is invoked and the hook queue is empty.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteOverlappingDumps method of the parent MockStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *StoreDeleteOverlappingDumpsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
+// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1674,20 +1677,20 @@ func (f *StoreDeleteOverlappingDumpsFunc) PushHook(hook func(context.Context, in
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreDeleteOverlappingDumpsFunc) SetDefaultReturn(r0 error) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDeleteOverlappingDumpsFunc) PushReturn(r0 error) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
-func (f *StoreDeleteOverlappingDumpsFunc) nextHook() func(context.Context, int, string, string, string) error {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1700,26 +1703,28 @@ func (f *StoreDeleteOverlappingDumpsFunc) nextHook() func(context.Context, int, 
 	return hook
 }
 
-func (f *StoreDeleteOverlappingDumpsFunc) appendCall(r0 StoreDeleteOverlappingDumpsFuncCall) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) appendCall(r0 StoreDeleteOverlappingProcessedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreDeleteOverlappingDumpsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreDeleteOverlappingDumpsFunc) History() []StoreDeleteOverlappingDumpsFuncCall {
+// History returns a sequence of
+// StoreDeleteOverlappingProcessedUploadsFuncCall objects describing the
+// invocations of this function.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) History() []StoreDeleteOverlappingProcessedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreDeleteOverlappingDumpsFuncCall, len(f.history))
+	history := make([]StoreDeleteOverlappingProcessedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreDeleteOverlappingDumpsFuncCall is an object that describes an
-// invocation of method DeleteOverlappingDumps on an instance of MockStore.
-type StoreDeleteOverlappingDumpsFuncCall struct {
+// StoreDeleteOverlappingProcessedUploadsFuncCall is an object that
+// describes an invocation of method DeleteOverlappingProcessedUploads on an
+// instance of MockStore.
+type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1742,13 +1747,13 @@ type StoreDeleteOverlappingDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDeleteOverlappingDumpsFuncCall) Args() []interface{} {
+func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDeleteOverlappingDumpsFuncCall) Results() []interface{} {
+func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2309,35 +2314,37 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreFindClosestDumpsFunc describes the behavior when the
-// FindClosestDumps method of the parent MockStore instance is invoked.
-type StoreFindClosestDumpsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)
-	history     []StoreFindClosestDumpsFuncCall
+// StoreFindClosestProcessedUploadsFunc describes the behavior when the
+// FindClosestProcessedUploads method of the parent MockStore instance is
+// invoked.
+type StoreFindClosestProcessedUploadsFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
+	history     []StoreFindClosestProcessedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestDumps delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestDumpsFunc.appendCall(StoreFindClosestDumpsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+// FindClosestProcessedUploads delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockStore) FindClosestProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.FindClosestProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.FindClosestProcessedUploadsFunc.appendCall(StoreFindClosestProcessedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the FindClosestDumps
-// method of the parent MockStore instance is invoked and the hook queue is
-// empty.
-func (f *StoreFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)) {
+// SetDefaultHook sets function that is called when the
+// FindClosestProcessedUploads method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestDumps method of the parent MockStore instance invokes the hook
-// at the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)) {
+// FindClosestProcessedUploads method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2345,20 +2352,20 @@ func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, str
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestDumpsFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestDumpsFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2371,26 +2378,27 @@ func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string
 	return hook
 }
 
-func (f *StoreFindClosestDumpsFunc) appendCall(r0 StoreFindClosestDumpsFuncCall) {
+func (f *StoreFindClosestProcessedUploadsFunc) appendCall(r0 StoreFindClosestProcessedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreFindClosestDumpsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreFindClosestDumpsFunc) History() []StoreFindClosestDumpsFuncCall {
+// History returns a sequence of StoreFindClosestProcessedUploadsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreFindClosestProcessedUploadsFunc) History() []StoreFindClosestProcessedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestDumpsFuncCall, len(f.history))
+	history := make([]StoreFindClosestProcessedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestDumpsFuncCall is an object that describes an invocation
-// of method FindClosestDumps on an instance of MockStore.
-type StoreFindClosestDumpsFuncCall struct {
+// StoreFindClosestProcessedUploadsFuncCall is an object that describes an
+// invocation of method FindClosestProcessedUploads on an instance of
+// MockStore.
+type StoreFindClosestProcessedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2411,7 +2419,7 @@ type StoreFindClosestDumpsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.Dump
+	Result0 []shared.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2419,47 +2427,48 @@ type StoreFindClosestDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestDumpsFuncCall) Args() []interface{} {
+func (c StoreFindClosestProcessedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestDumpsFuncCall) Results() []interface{} {
+func (c StoreFindClosestProcessedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreFindClosestDumpsFromGraphFragmentFunc describes the behavior when
-// the FindClosestDumpsFromGraphFragment method of the parent MockStore
-// instance is invoked.
-type StoreFindClosestDumpsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)
-	history     []StoreFindClosestDumpsFromGraphFragmentFuncCall
+// StoreFindClosestProcessedUploadsFromGraphFragmentFunc describes the
+// behavior when the FindClosestProcessedUploadsFromGraphFragment method of
+// the parent MockStore instance is invoked.
+type StoreFindClosestProcessedUploadsFromGraphFragmentFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
+	history     []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestDumpsFromGraphFragment delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestDumpsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestDumpsFromGraphFragmentFunc.appendCall(StoreFindClosestDumpsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+// FindClosestProcessedUploadsFromGraphFragment delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) FindClosestProcessedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.FindClosestProcessedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.FindClosestProcessedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestDumpsFromGraphFragment method of the parent MockStore instance
-// is invoked and the hook queue is empty.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)) {
+// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestDumpsFromGraphFragment method of the parent MockStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)) {
+// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2467,20 +2476,20 @@ func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushHook(hook func(context.
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2493,28 +2502,28 @@ func (f *StoreFindClosestDumpsFromGraphFragmentFunc) nextHook() func(context.Con
 	return hook
 }
 
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestDumpsFromGraphFragmentFuncCall) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreFindClosestDumpsFromGraphFragmentFuncCall objects describing the
-// invocations of this function.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) History() []StoreFindClosestDumpsFromGraphFragmentFuncCall {
+// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall objects
+// describing the invocations of this function.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) History() []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestDumpsFromGraphFragmentFuncCall, len(f.history))
+	history := make([]StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestDumpsFromGraphFragmentFuncCall is an object that
-// describes an invocation of method FindClosestDumpsFromGraphFragment on an
-// instance of MockStore.
-type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
+// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall is an object
+// that describes an invocation of method
+// FindClosestProcessedUploadsFromGraphFragment on an instance of MockStore.
+type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2538,7 +2547,7 @@ type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
 	Arg6 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.Dump
+	Result0 []shared.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2546,13 +2555,13 @@ type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestDumpsFromGraphFragmentFuncCall) Args() []interface{} {
+func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestDumpsFromGraphFragmentFuncCall) Results() []interface{} {
+func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -2997,225 +3006,6 @@ func (c StoreGetDirtyRepositoriesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreGetDirtyRepositoriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetDumpsByIDsFunc describes the behavior when the GetDumpsByIDs
-// method of the parent MockStore instance is invoked.
-type StoreGetDumpsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared.Dump, error)
-	hooks       []func(context.Context, []int) ([]shared.Dump, error)
-	history     []StoreGetDumpsByIDsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetDumpsByIDs delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockStore) GetDumpsByIDs(v0 context.Context, v1 []int) ([]shared.Dump, error) {
-	r0, r1 := m.GetDumpsByIDsFunc.nextHook()(v0, v1)
-	m.GetDumpsByIDsFunc.appendCall(StoreGetDumpsByIDsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the GetDumpsByIDs method
-// of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetDumpsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.Dump, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsByIDs method of the parent MockStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreGetDumpsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.Dump, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetDumpsByIDsFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetDumpsByIDsFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetDumpsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.Dump, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetDumpsByIDsFunc) appendCall(r0 StoreGetDumpsByIDsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetDumpsByIDsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreGetDumpsByIDsFunc) History() []StoreGetDumpsByIDsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetDumpsByIDsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetDumpsByIDsFuncCall is an object that describes an invocation of
-// method GetDumpsByIDs on an instance of MockStore.
-type StoreGetDumpsByIDsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.Dump
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetDumpsByIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetDumpsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetDumpsWithDefinitionsForMonikersFunc describes the behavior when
-// the GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance is invoked.
-type StoreGetDumpsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)
-	history     []StoreGetDumpsWithDefinitionsForMonikersFuncCall
-	mutex       sync.Mutex
-}
-
-// GetDumpsWithDefinitionsForMonikers delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) GetDumpsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-	r0, r1 := m.GetDumpsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetDumpsWithDefinitionsForMonikersFunc.appendCall(StoreGetDumpsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance is invoked and the hook queue is empty.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetDumpsWithDefinitionsForMonikersFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreGetDumpsWithDefinitionsForMonikersFuncCall objects describing the
-// invocations of this function.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) History() []StoreGetDumpsWithDefinitionsForMonikersFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetDumpsWithDefinitionsForMonikersFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetDumpsWithDefinitionsForMonikersFuncCall is an object that
-// describes an invocation of method GetDumpsWithDefinitionsForMonikers on
-// an instance of MockStore.
-type StoreGetDumpsWithDefinitionsForMonikersFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []precise.QualifiedMonikerData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.Dump
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetDumpsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetDumpsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3883,6 +3673,230 @@ func (c StoreGetOldestCommitDateFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreGetProcessedUploadsByIDsFunc describes the behavior when the
+// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// invoked.
+type StoreGetProcessedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared.ProcessedUpload, error)
+	history     []StoreGetProcessedUploadsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsByIDsFunc.appendCall(StoreGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetProcessedUploadsByIDs method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetProcessedUploadsByIDsFunc) appendCall(r0 StoreGetProcessedUploadsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetProcessedUploadsByIDsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetProcessedUploadsByIDsFunc) History() []StoreGetProcessedUploadsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetProcessedUploadsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetProcessedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetProcessedUploadsByIDs on an instance of
+// MockStore.
+type StoreGetProcessedUploadsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.ProcessedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetProcessedUploadsWithDefinitionsForMonikers method of
+// the parent MockStore instance is invoked.
+type StoreGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
+	history     []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+	mutex       sync.Mutex
+}
+
+// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall objects
+// describing the invocations of this function.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an object
+// that describes an invocation of method
+// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// MockStore.
+type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []precise.QualifiedMonikerData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.ProcessedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetRecentIndexesSummaryFunc describes the behavior when the

--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -385,9 +385,10 @@ type MockStore struct {
 	// DeleteOldAuditLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteOldAuditLogs.
 	DeleteOldAuditLogsFunc *StoreDeleteOldAuditLogsFunc
-	// DeleteOverlappingDumpsFunc is an instance of a mock function object
-	// controlling the behavior of the method DeleteOverlappingDumps.
-	DeleteOverlappingDumpsFunc *StoreDeleteOverlappingDumpsFunc
+	// DeleteOverlappingProcessedUploadsFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// DeleteOverlappingProcessedUploads.
+	DeleteOverlappingProcessedUploadsFunc *StoreDeleteOverlappingProcessedUploadsFunc
 	// DeleteUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteUploadByID.
 	DeleteUploadByIDFunc *StoreDeleteUploadByIDFunc
@@ -405,13 +406,14 @@ type MockStore struct {
 	// ExpireFailedRecordsFunc is an instance of a mock function object
 	// controlling the behavior of the method ExpireFailedRecords.
 	ExpireFailedRecordsFunc *StoreExpireFailedRecordsFunc
-	// FindClosestDumpsFunc is an instance of a mock function object
-	// controlling the behavior of the method FindClosestDumps.
-	FindClosestDumpsFunc *StoreFindClosestDumpsFunc
-	// FindClosestDumpsFromGraphFragmentFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// FindClosestDumpsFromGraphFragment.
-	FindClosestDumpsFromGraphFragmentFunc *StoreFindClosestDumpsFromGraphFragmentFunc
+	// FindClosestProcessedUploadsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// FindClosestProcessedUploads.
+	FindClosestProcessedUploadsFunc *StoreFindClosestProcessedUploadsFunc
+	// FindClosestProcessedUploadsFromGraphFragmentFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// FindClosestProcessedUploadsFromGraphFragment.
+	FindClosestProcessedUploadsFromGraphFragmentFunc *StoreFindClosestProcessedUploadsFromGraphFragmentFunc
 	// GetAuditLogsForUploadFunc is an instance of a mock function object
 	// controlling the behavior of the method GetAuditLogsForUpload.
 	GetAuditLogsForUploadFunc *StoreGetAuditLogsForUploadFunc
@@ -425,13 +427,6 @@ type MockStore struct {
 	// GetDirtyRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDirtyRepositories.
 	GetDirtyRepositoriesFunc *StoreGetDirtyRepositoriesFunc
-	// GetDumpsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetDumpsByIDs.
-	GetDumpsByIDsFunc *StoreGetDumpsByIDsFunc
-	// GetDumpsWithDefinitionsForMonikersFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// GetDumpsWithDefinitionsForMonikers.
-	GetDumpsWithDefinitionsForMonikersFunc *StoreGetDumpsWithDefinitionsForMonikersFunc
 	// GetIndexByIDFunc is an instance of a mock function object controlling
 	// the behavior of the method GetIndexByID.
 	GetIndexByIDFunc *StoreGetIndexByIDFunc
@@ -451,6 +446,13 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
+	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetProcessedUploadsByIDs.
+	GetProcessedUploadsByIDsFunc *StoreGetProcessedUploadsByIDsFunc
+	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// GetProcessedUploadsWithDefinitionsForMonikers.
+	GetProcessedUploadsWithDefinitionsForMonikersFunc *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -610,7 +612,7 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) (r0 error) {
 				return
 			},
@@ -640,13 +642,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.Dump, r1 error) {
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.ProcessedUpload, r1 error) {
 				return
 			},
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared1.Dump, r1 error) {
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared1.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -667,16 +669,6 @@ func NewMockStore() *MockStore {
 		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) (r0 []shared1.DirtyRepository, r1 error) {
-				return
-			},
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared1.Dump, r1 error) {
-				return
-			},
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.Dump, r1 error) {
 				return
 			},
 		},
@@ -707,6 +699,16 @@ func NewMockStore() *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (r0 time.Time, r1 bool, r2 error) {
+				return
+			},
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared1.ProcessedUpload, r1 error) {
+				return
+			},
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -937,9 +939,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteOldAuditLogs")
 			},
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) error {
-				panic("unexpected invocation of MockStore.DeleteOverlappingDumps")
+				panic("unexpected invocation of MockStore.DeleteOverlappingProcessedUploads")
 			},
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
@@ -967,14 +969,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ExpireFailedRecords")
 			},
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error) {
-				panic("unexpected invocation of MockStore.FindClosestDumps")
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestProcessedUploads")
 			},
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.Dump, error) {
-				panic("unexpected invocation of MockStore.FindClosestDumpsFromGraphFragment")
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestProcessedUploadsFromGraphFragment")
 			},
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
@@ -995,16 +997,6 @@ func NewStrictMockStore() *MockStore {
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) ([]shared1.DirtyRepository, error) {
 				panic("unexpected invocation of MockStore.GetDirtyRepositories")
-			},
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared1.Dump, error) {
-				panic("unexpected invocation of MockStore.GetDumpsByIDs")
-			},
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
-				panic("unexpected invocation of MockStore.GetDumpsWithDefinitionsForMonikers")
 			},
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
@@ -1035,6 +1027,16 @@ func NewStrictMockStore() *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (time.Time, bool, error) {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
+			},
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.GetProcessedUploadsByIDs")
+			},
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.GetProcessedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -1254,8 +1256,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		DeleteOldAuditLogsFunc: &StoreDeleteOldAuditLogsFunc{
 			defaultHook: i.DeleteOldAuditLogs,
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
-			defaultHook: i.DeleteOverlappingDumps,
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+			defaultHook: i.DeleteOverlappingProcessedUploads,
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
 			defaultHook: i.DeleteUploadByID,
@@ -1272,11 +1274,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
 			defaultHook: i.ExpireFailedRecords,
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: i.FindClosestDumps,
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: i.FindClosestProcessedUploads,
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: i.FindClosestDumpsFromGraphFragment,
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: i.FindClosestProcessedUploadsFromGraphFragment,
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
 			defaultHook: i.GetAuditLogsForUpload,
@@ -1289,12 +1291,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: i.GetDirtyRepositories,
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: i.GetDumpsByIDs,
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetDumpsWithDefinitionsForMonikers,
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
 			defaultHook: i.GetIndexByID,
@@ -1313,6 +1309,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: i.GetProcessedUploadsByIDs,
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -1981,36 +1983,37 @@ func (c StoreDeleteOldAuditLogsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreDeleteOverlappingDumpsFunc describes the behavior when the
-// DeleteOverlappingDumps method of the parent MockStore instance is
-// invoked.
-type StoreDeleteOverlappingDumpsFunc struct {
+// StoreDeleteOverlappingProcessedUploadsFunc describes the behavior when
+// the DeleteOverlappingProcessedUploads method of the parent MockStore
+// instance is invoked.
+type StoreDeleteOverlappingProcessedUploadsFunc struct {
 	defaultHook func(context.Context, int, string, string, string) error
 	hooks       []func(context.Context, int, string, string, string) error
-	history     []StoreDeleteOverlappingDumpsFuncCall
+	history     []StoreDeleteOverlappingProcessedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteOverlappingDumps delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockStore) DeleteOverlappingDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
-	r0 := m.DeleteOverlappingDumpsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.DeleteOverlappingDumpsFunc.appendCall(StoreDeleteOverlappingDumpsFuncCall{v0, v1, v2, v3, v4, r0})
+// DeleteOverlappingProcessedUploads delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockStore) DeleteOverlappingProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
+	r0 := m.DeleteOverlappingProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DeleteOverlappingProcessedUploadsFunc.appendCall(StoreDeleteOverlappingProcessedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteOverlappingDumps method of the parent MockStore instance is invoked
-// and the hook queue is empty.
-func (f *StoreDeleteOverlappingDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
+// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// is invoked and the hook queue is empty.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteOverlappingDumps method of the parent MockStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *StoreDeleteOverlappingDumpsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
+// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2018,20 +2021,20 @@ func (f *StoreDeleteOverlappingDumpsFunc) PushHook(hook func(context.Context, in
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreDeleteOverlappingDumpsFunc) SetDefaultReturn(r0 error) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDeleteOverlappingDumpsFunc) PushReturn(r0 error) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
-func (f *StoreDeleteOverlappingDumpsFunc) nextHook() func(context.Context, int, string, string, string) error {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2044,26 +2047,28 @@ func (f *StoreDeleteOverlappingDumpsFunc) nextHook() func(context.Context, int, 
 	return hook
 }
 
-func (f *StoreDeleteOverlappingDumpsFunc) appendCall(r0 StoreDeleteOverlappingDumpsFuncCall) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) appendCall(r0 StoreDeleteOverlappingProcessedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreDeleteOverlappingDumpsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreDeleteOverlappingDumpsFunc) History() []StoreDeleteOverlappingDumpsFuncCall {
+// History returns a sequence of
+// StoreDeleteOverlappingProcessedUploadsFuncCall objects describing the
+// invocations of this function.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) History() []StoreDeleteOverlappingProcessedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreDeleteOverlappingDumpsFuncCall, len(f.history))
+	history := make([]StoreDeleteOverlappingProcessedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreDeleteOverlappingDumpsFuncCall is an object that describes an
-// invocation of method DeleteOverlappingDumps on an instance of MockStore.
-type StoreDeleteOverlappingDumpsFuncCall struct {
+// StoreDeleteOverlappingProcessedUploadsFuncCall is an object that
+// describes an invocation of method DeleteOverlappingProcessedUploads on an
+// instance of MockStore.
+type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2086,13 +2091,13 @@ type StoreDeleteOverlappingDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDeleteOverlappingDumpsFuncCall) Args() []interface{} {
+func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDeleteOverlappingDumpsFuncCall) Results() []interface{} {
+func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2653,35 +2658,37 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreFindClosestDumpsFunc describes the behavior when the
-// FindClosestDumps method of the parent MockStore instance is invoked.
-type StoreFindClosestDumpsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error)
-	history     []StoreFindClosestDumpsFuncCall
+// StoreFindClosestProcessedUploadsFunc describes the behavior when the
+// FindClosestProcessedUploads method of the parent MockStore instance is
+// invoked.
+type StoreFindClosestProcessedUploadsFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)
+	history     []StoreFindClosestProcessedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestDumps delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestDumpsFunc.appendCall(StoreFindClosestDumpsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+// FindClosestProcessedUploads delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockStore) FindClosestProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.ProcessedUpload, error) {
+	r0, r1 := m.FindClosestProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.FindClosestProcessedUploadsFunc.appendCall(StoreFindClosestProcessedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the FindClosestDumps
-// method of the parent MockStore instance is invoked and the hook queue is
-// empty.
-func (f *StoreFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error)) {
+// SetDefaultHook sets function that is called when the
+// FindClosestProcessedUploads method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestDumps method of the parent MockStore instance invokes the hook
-// at the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error)) {
+// FindClosestProcessedUploads method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2689,20 +2696,20 @@ func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, str
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestDumpsFunc) SetDefaultReturn(r0 []shared1.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestDumpsFunc) PushReturn(r0 []shared1.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2715,26 +2722,27 @@ func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string
 	return hook
 }
 
-func (f *StoreFindClosestDumpsFunc) appendCall(r0 StoreFindClosestDumpsFuncCall) {
+func (f *StoreFindClosestProcessedUploadsFunc) appendCall(r0 StoreFindClosestProcessedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreFindClosestDumpsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreFindClosestDumpsFunc) History() []StoreFindClosestDumpsFuncCall {
+// History returns a sequence of StoreFindClosestProcessedUploadsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreFindClosestProcessedUploadsFunc) History() []StoreFindClosestProcessedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestDumpsFuncCall, len(f.history))
+	history := make([]StoreFindClosestProcessedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestDumpsFuncCall is an object that describes an invocation
-// of method FindClosestDumps on an instance of MockStore.
-type StoreFindClosestDumpsFuncCall struct {
+// StoreFindClosestProcessedUploadsFuncCall is an object that describes an
+// invocation of method FindClosestProcessedUploads on an instance of
+// MockStore.
+type StoreFindClosestProcessedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2755,7 +2763,7 @@ type StoreFindClosestDumpsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.Dump
+	Result0 []shared1.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2763,47 +2771,48 @@ type StoreFindClosestDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestDumpsFuncCall) Args() []interface{} {
+func (c StoreFindClosestProcessedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestDumpsFuncCall) Results() []interface{} {
+func (c StoreFindClosestProcessedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreFindClosestDumpsFromGraphFragmentFunc describes the behavior when
-// the FindClosestDumpsFromGraphFragment method of the parent MockStore
-// instance is invoked.
-type StoreFindClosestDumpsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.Dump, error)
-	history     []StoreFindClosestDumpsFromGraphFragmentFuncCall
+// StoreFindClosestProcessedUploadsFromGraphFragmentFunc describes the
+// behavior when the FindClosestProcessedUploadsFromGraphFragment method of
+// the parent MockStore instance is invoked.
+type StoreFindClosestProcessedUploadsFromGraphFragmentFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error)
+	history     []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestDumpsFromGraphFragment delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestDumpsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared1.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestDumpsFromGraphFragmentFunc.appendCall(StoreFindClosestDumpsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+// FindClosestProcessedUploadsFromGraphFragment delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) FindClosestProcessedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
+	r0, r1 := m.FindClosestProcessedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.FindClosestProcessedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestDumpsFromGraphFragment method of the parent MockStore instance
-// is invoked and the hook queue is empty.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.Dump, error)) {
+// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestDumpsFromGraphFragment method of the parent MockStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.Dump, error)) {
+// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2811,20 +2820,20 @@ func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushHook(hook func(context.
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared1.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushReturn(r0 []shared1.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2837,28 +2846,28 @@ func (f *StoreFindClosestDumpsFromGraphFragmentFunc) nextHook() func(context.Con
 	return hook
 }
 
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestDumpsFromGraphFragmentFuncCall) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreFindClosestDumpsFromGraphFragmentFuncCall objects describing the
-// invocations of this function.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) History() []StoreFindClosestDumpsFromGraphFragmentFuncCall {
+// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall objects
+// describing the invocations of this function.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) History() []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestDumpsFromGraphFragmentFuncCall, len(f.history))
+	history := make([]StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestDumpsFromGraphFragmentFuncCall is an object that
-// describes an invocation of method FindClosestDumpsFromGraphFragment on an
-// instance of MockStore.
-type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
+// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall is an object
+// that describes an invocation of method
+// FindClosestProcessedUploadsFromGraphFragment on an instance of MockStore.
+type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2882,7 +2891,7 @@ type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
 	Arg6 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.Dump
+	Result0 []shared1.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2890,13 +2899,13 @@ type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestDumpsFromGraphFragmentFuncCall) Args() []interface{} {
+func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestDumpsFromGraphFragmentFuncCall) Results() []interface{} {
+func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3341,225 +3350,6 @@ func (c StoreGetDirtyRepositoriesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreGetDirtyRepositoriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetDumpsByIDsFunc describes the behavior when the GetDumpsByIDs
-// method of the parent MockStore instance is invoked.
-type StoreGetDumpsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared1.Dump, error)
-	hooks       []func(context.Context, []int) ([]shared1.Dump, error)
-	history     []StoreGetDumpsByIDsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetDumpsByIDs delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockStore) GetDumpsByIDs(v0 context.Context, v1 []int) ([]shared1.Dump, error) {
-	r0, r1 := m.GetDumpsByIDsFunc.nextHook()(v0, v1)
-	m.GetDumpsByIDsFunc.appendCall(StoreGetDumpsByIDsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the GetDumpsByIDs method
-// of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetDumpsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.Dump, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsByIDs method of the parent MockStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreGetDumpsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.Dump, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetDumpsByIDsFunc) SetDefaultReturn(r0 []shared1.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared1.Dump, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetDumpsByIDsFunc) PushReturn(r0 []shared1.Dump, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared1.Dump, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetDumpsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.Dump, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetDumpsByIDsFunc) appendCall(r0 StoreGetDumpsByIDsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetDumpsByIDsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreGetDumpsByIDsFunc) History() []StoreGetDumpsByIDsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetDumpsByIDsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetDumpsByIDsFuncCall is an object that describes an invocation of
-// method GetDumpsByIDs on an instance of MockStore.
-type StoreGetDumpsByIDsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared1.Dump
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetDumpsByIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetDumpsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetDumpsWithDefinitionsForMonikersFunc describes the behavior when
-// the GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance is invoked.
-type StoreGetDumpsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error)
-	history     []StoreGetDumpsWithDefinitionsForMonikersFuncCall
-	mutex       sync.Mutex
-}
-
-// GetDumpsWithDefinitionsForMonikers delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) GetDumpsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
-	r0, r1 := m.GetDumpsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetDumpsWithDefinitionsForMonikersFunc.appendCall(StoreGetDumpsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance is invoked and the hook queue is empty.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.Dump, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.Dump, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetDumpsWithDefinitionsForMonikersFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreGetDumpsWithDefinitionsForMonikersFuncCall objects describing the
-// invocations of this function.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) History() []StoreGetDumpsWithDefinitionsForMonikersFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetDumpsWithDefinitionsForMonikersFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetDumpsWithDefinitionsForMonikersFuncCall is an object that
-// describes an invocation of method GetDumpsWithDefinitionsForMonikers on
-// an instance of MockStore.
-type StoreGetDumpsWithDefinitionsForMonikersFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []precise.QualifiedMonikerData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared1.Dump
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetDumpsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetDumpsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -4227,6 +4017,230 @@ func (c StoreGetOldestCommitDateFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreGetProcessedUploadsByIDsFunc describes the behavior when the
+// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// invoked.
+type StoreGetProcessedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared1.ProcessedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared1.ProcessedUpload, error)
+	history     []StoreGetProcessedUploadsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared1.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsByIDsFunc.appendCall(StoreGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.ProcessedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetProcessedUploadsByIDs method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.ProcessedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetProcessedUploadsByIDsFunc) appendCall(r0 StoreGetProcessedUploadsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetProcessedUploadsByIDsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetProcessedUploadsByIDsFunc) History() []StoreGetProcessedUploadsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetProcessedUploadsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetProcessedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetProcessedUploadsByIDs on an instance of
+// MockStore.
+type StoreGetProcessedUploadsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared1.ProcessedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetProcessedUploadsWithDefinitionsForMonikers method of
+// the parent MockStore instance is invoked.
+type StoreGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)
+	history     []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+	mutex       sync.Mutex
+}
+
+// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall objects
+// describing the invocations of this function.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an object
+// that describes an invocation of method
+// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// MockStore.
+type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []precise.QualifiedMonikerData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared1.ProcessedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetRecentIndexesSummaryFunc describes the behavior when the

--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -424,6 +424,13 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// GetCommitsVisibleToUpload.
 	GetCommitsVisibleToUploadFunc *StoreGetCommitsVisibleToUploadFunc
+	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletedUploadsByIDs.
+	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
+	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// GetCompletedUploadsWithDefinitionsForMonikers.
+	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetDirtyRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDirtyRepositories.
 	GetDirtyRepositoriesFunc *StoreGetDirtyRepositoriesFunc
@@ -446,13 +453,6 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
-	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetCompletedUploadsByIDs.
-	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
-	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
-	// mock function object controlling the behavior of the method
-	// GetCompletedUploadsWithDefinitionsForMonikers.
-	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -667,6 +667,16 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared1.CompletedUpload, r1 error) {
+				return
+			},
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.CompletedUpload, r1 error) {
+				return
+			},
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) (r0 []shared1.DirtyRepository, r1 error) {
 				return
@@ -699,16 +709,6 @@ func NewMockStore() *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (r0 time.Time, r1 bool, r2 error) {
-				return
-			},
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared1.CompletedUpload, r1 error) {
-				return
-			},
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -994,6 +994,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetCommitsVisibleToUpload")
 			},
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared1.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
+			},
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
+			},
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) ([]shared1.DirtyRepository, error) {
 				panic("unexpected invocation of MockStore.GetDirtyRepositories")
@@ -1027,16 +1037,6 @@ func NewStrictMockStore() *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (time.Time, bool, error) {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
-			},
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared1.CompletedUpload, error) {
-				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
-			},
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
-				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -1289,6 +1289,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetCommitsVisibleToUploadFunc: &StoreGetCommitsVisibleToUploadFunc{
 			defaultHook: i.GetCommitsVisibleToUpload,
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: i.GetCompletedUploadsByIDs,
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: i.GetDirtyRepositories,
 		},
@@ -1309,12 +1315,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: i.GetCompletedUploadsByIDs,
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -3248,6 +3248,230 @@ func (c StoreGetCommitsVisibleToUploadFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
+// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
+// invoked.
+type StoreGetCompletedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared1.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCompletedUploadsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.CompletedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.CompletedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared1.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared1.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.CompletedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetCompletedUploadsByIDs on an instance of
+// MockStore.
+type StoreGetCompletedUploadsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared1.CompletedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
+// the parent MockStore instance is invoked.
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
+// describing the invocations of this function.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
+// that describes an invocation of method
+// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
+// MockStore.
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []precise.QualifiedMonikerData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared1.CompletedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // StoreGetDirtyRepositoriesFunc describes the behavior when the
 // GetDirtyRepositories method of the parent MockStore instance is invoked.
 type StoreGetDirtyRepositoriesFunc struct {
@@ -4017,230 +4241,6 @@ func (c StoreGetOldestCommitDateFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
-// GetCompletedUploadsByIDs method of the parent MockStore instance is
-// invoked.
-type StoreGetCompletedUploadsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared1.CompletedUpload, error)
-	hooks       []func(context.Context, []int) ([]shared1.CompletedUpload, error)
-	history     []StoreGetCompletedUploadsByIDsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetCompletedUploadsByIDs delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared1.CompletedUpload, error) {
-	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
-	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetCompletedUploadsByIDs method of the parent MockStore instance is
-// invoked and the hook queue is empty.
-func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.CompletedUpload, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.CompletedUpload, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared1.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared1.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.CompletedUpload, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
-// objects describing the invocations of this function.
-func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
-// invocation of method GetCompletedUploadsByIDs on an instance of
-// MockStore.
-type StoreGetCompletedUploadsByIDsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared1.CompletedUpload
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
-// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
-// the parent MockStore instance is invoked.
-type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)
-	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
-	mutex       sync.Mutex
-}
-
-// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
-// function in the queue and stores the parameter and result values of this
-// invocation.
-func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
-	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
-// MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
-// MockStore instance invokes the hook at the front of the queue and
-// discards it. After the queue is empty, the default hook function is
-// invoked for any future action.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
-// describing the invocations of this function.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
-// that describes an invocation of method
-// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
-// MockStore.
-type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []precise.QualifiedMonikerData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared1.CompletedUpload
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetRecentIndexesSummaryFunc describes the behavior when the

--- a/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/expirer/mocks_test.go
@@ -385,10 +385,10 @@ type MockStore struct {
 	// DeleteOldAuditLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteOldAuditLogs.
 	DeleteOldAuditLogsFunc *StoreDeleteOldAuditLogsFunc
-	// DeleteOverlappingProcessedUploadsFunc is an instance of a mock
+	// DeleteOverlappingCompletedUploadsFunc is an instance of a mock
 	// function object controlling the behavior of the method
-	// DeleteOverlappingProcessedUploads.
-	DeleteOverlappingProcessedUploadsFunc *StoreDeleteOverlappingProcessedUploadsFunc
+	// DeleteOverlappingCompletedUploads.
+	DeleteOverlappingCompletedUploadsFunc *StoreDeleteOverlappingCompletedUploadsFunc
 	// DeleteUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteUploadByID.
 	DeleteUploadByIDFunc *StoreDeleteUploadByIDFunc
@@ -406,14 +406,14 @@ type MockStore struct {
 	// ExpireFailedRecordsFunc is an instance of a mock function object
 	// controlling the behavior of the method ExpireFailedRecords.
 	ExpireFailedRecordsFunc *StoreExpireFailedRecordsFunc
-	// FindClosestProcessedUploadsFunc is an instance of a mock function
+	// FindClosestCompletedUploadsFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// FindClosestProcessedUploads.
-	FindClosestProcessedUploadsFunc *StoreFindClosestProcessedUploadsFunc
-	// FindClosestProcessedUploadsFromGraphFragmentFunc is an instance of a
+	// FindClosestCompletedUploads.
+	FindClosestCompletedUploadsFunc *StoreFindClosestCompletedUploadsFunc
+	// FindClosestCompletedUploadsFromGraphFragmentFunc is an instance of a
 	// mock function object controlling the behavior of the method
-	// FindClosestProcessedUploadsFromGraphFragment.
-	FindClosestProcessedUploadsFromGraphFragmentFunc *StoreFindClosestProcessedUploadsFromGraphFragmentFunc
+	// FindClosestCompletedUploadsFromGraphFragment.
+	FindClosestCompletedUploadsFromGraphFragmentFunc *StoreFindClosestCompletedUploadsFromGraphFragmentFunc
 	// GetAuditLogsForUploadFunc is an instance of a mock function object
 	// controlling the behavior of the method GetAuditLogsForUpload.
 	GetAuditLogsForUploadFunc *StoreGetAuditLogsForUploadFunc
@@ -446,13 +446,13 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
-	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetProcessedUploadsByIDs.
-	GetProcessedUploadsByIDsFunc *StoreGetProcessedUploadsByIDsFunc
-	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletedUploadsByIDs.
+	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
+	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
 	// mock function object controlling the behavior of the method
-	// GetProcessedUploadsWithDefinitionsForMonikers.
-	GetProcessedUploadsWithDefinitionsForMonikersFunc *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc
+	// GetCompletedUploadsWithDefinitionsForMonikers.
+	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -612,7 +612,7 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) (r0 error) {
 				return
 			},
@@ -642,13 +642,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.ProcessedUpload, r1 error) {
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared1.ProcessedUpload, r1 error) {
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -702,13 +702,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared1.ProcessedUpload, r1 error) {
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.ProcessedUpload, r1 error) {
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared1.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -939,9 +939,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteOldAuditLogs")
 			},
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) error {
-				panic("unexpected invocation of MockStore.DeleteOverlappingProcessedUploads")
+				panic("unexpected invocation of MockStore.DeleteOverlappingCompletedUploads")
 			},
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
@@ -969,14 +969,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ExpireFailedRecords")
 			},
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.FindClosestProcessedUploads")
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestCompletedUploads")
 			},
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.FindClosestProcessedUploadsFromGraphFragment")
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestCompletedUploadsFromGraphFragment")
 			},
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
@@ -1029,14 +1029,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
 			},
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.GetProcessedUploadsByIDs")
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared1.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.GetProcessedUploadsWithDefinitionsForMonikers")
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -1256,8 +1256,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		DeleteOldAuditLogsFunc: &StoreDeleteOldAuditLogsFunc{
 			defaultHook: i.DeleteOldAuditLogs,
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
-			defaultHook: i.DeleteOverlappingProcessedUploads,
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
+			defaultHook: i.DeleteOverlappingCompletedUploads,
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
 			defaultHook: i.DeleteUploadByID,
@@ -1274,11 +1274,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
 			defaultHook: i.ExpireFailedRecords,
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: i.FindClosestProcessedUploads,
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: i.FindClosestCompletedUploads,
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: i.FindClosestProcessedUploadsFromGraphFragment,
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: i.FindClosestCompletedUploadsFromGraphFragment,
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
 			defaultHook: i.GetAuditLogsForUpload,
@@ -1310,11 +1310,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: i.GetProcessedUploadsByIDs,
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: i.GetCompletedUploadsByIDs,
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -1983,37 +1983,37 @@ func (c StoreDeleteOldAuditLogsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreDeleteOverlappingProcessedUploadsFunc describes the behavior when
-// the DeleteOverlappingProcessedUploads method of the parent MockStore
+// StoreDeleteOverlappingCompletedUploadsFunc describes the behavior when
+// the DeleteOverlappingCompletedUploads method of the parent MockStore
 // instance is invoked.
-type StoreDeleteOverlappingProcessedUploadsFunc struct {
+type StoreDeleteOverlappingCompletedUploadsFunc struct {
 	defaultHook func(context.Context, int, string, string, string) error
 	hooks       []func(context.Context, int, string, string, string) error
-	history     []StoreDeleteOverlappingProcessedUploadsFuncCall
+	history     []StoreDeleteOverlappingCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteOverlappingProcessedUploads delegates to the next hook function in
+// DeleteOverlappingCompletedUploads delegates to the next hook function in
 // the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) DeleteOverlappingProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
-	r0 := m.DeleteOverlappingProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.DeleteOverlappingProcessedUploadsFunc.appendCall(StoreDeleteOverlappingProcessedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
+func (m *MockStore) DeleteOverlappingCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
+	r0 := m.DeleteOverlappingCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DeleteOverlappingCompletedUploadsFunc.appendCall(StoreDeleteOverlappingCompletedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// DeleteOverlappingCompletedUploads method of the parent MockStore instance
 // is invoked and the hook queue is empty.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// DeleteOverlappingCompletedUploads method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2021,20 +2021,20 @@ func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultReturn(r0 error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushReturn(r0 error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2047,28 +2047,28 @@ func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Con
 	return hook
 }
 
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) appendCall(r0 StoreDeleteOverlappingProcessedUploadsFuncCall) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) appendCall(r0 StoreDeleteOverlappingCompletedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreDeleteOverlappingProcessedUploadsFuncCall objects describing the
+// StoreDeleteOverlappingCompletedUploadsFuncCall objects describing the
 // invocations of this function.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) History() []StoreDeleteOverlappingProcessedUploadsFuncCall {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) History() []StoreDeleteOverlappingCompletedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreDeleteOverlappingProcessedUploadsFuncCall, len(f.history))
+	history := make([]StoreDeleteOverlappingCompletedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreDeleteOverlappingProcessedUploadsFuncCall is an object that
-// describes an invocation of method DeleteOverlappingProcessedUploads on an
+// StoreDeleteOverlappingCompletedUploadsFuncCall is an object that
+// describes an invocation of method DeleteOverlappingCompletedUploads on an
 // instance of MockStore.
-type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
+type StoreDeleteOverlappingCompletedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2091,13 +2091,13 @@ type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Args() []interface{} {
+func (c StoreDeleteOverlappingCompletedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Results() []interface{} {
+func (c StoreDeleteOverlappingCompletedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2658,37 +2658,37 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreFindClosestProcessedUploadsFunc describes the behavior when the
-// FindClosestProcessedUploads method of the parent MockStore instance is
+// StoreFindClosestCompletedUploadsFunc describes the behavior when the
+// FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked.
-type StoreFindClosestProcessedUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)
-	history     []StoreFindClosestProcessedUploadsFuncCall
+type StoreFindClosestCompletedUploadsFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)
+	history     []StoreFindClosestCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestProcessedUploads delegates to the next hook function in the
+// FindClosestCompletedUploads delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.ProcessedUpload, error) {
-	r0, r1 := m.FindClosestProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestProcessedUploadsFunc.appendCall(StoreFindClosestProcessedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestProcessedUploads method of the parent MockStore instance is
+// FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestProcessedUploads method of the parent MockStore instance
+// FindClosestCompletedUploads method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2696,20 +2696,20 @@ func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestProcessedUploadsFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2722,27 +2722,27 @@ func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, 
 	return hook
 }
 
-func (f *StoreFindClosestProcessedUploadsFunc) appendCall(r0 StoreFindClosestProcessedUploadsFuncCall) {
+func (f *StoreFindClosestCompletedUploadsFunc) appendCall(r0 StoreFindClosestCompletedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreFindClosestProcessedUploadsFuncCall
+// History returns a sequence of StoreFindClosestCompletedUploadsFuncCall
 // objects describing the invocations of this function.
-func (f *StoreFindClosestProcessedUploadsFunc) History() []StoreFindClosestProcessedUploadsFuncCall {
+func (f *StoreFindClosestCompletedUploadsFunc) History() []StoreFindClosestCompletedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestProcessedUploadsFuncCall, len(f.history))
+	history := make([]StoreFindClosestCompletedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestProcessedUploadsFuncCall is an object that describes an
-// invocation of method FindClosestProcessedUploads on an instance of
+// StoreFindClosestCompletedUploadsFuncCall is an object that describes an
+// invocation of method FindClosestCompletedUploads on an instance of
 // MockStore.
-type StoreFindClosestProcessedUploadsFuncCall struct {
+type StoreFindClosestCompletedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2763,7 +2763,7 @@ type StoreFindClosestProcessedUploadsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.ProcessedUpload
+	Result0 []shared1.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2771,48 +2771,48 @@ type StoreFindClosestProcessedUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFuncCall) Args() []interface{} {
+func (c StoreFindClosestCompletedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFuncCall) Results() []interface{} {
+func (c StoreFindClosestCompletedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreFindClosestProcessedUploadsFromGraphFragmentFunc describes the
-// behavior when the FindClosestProcessedUploadsFromGraphFragment method of
+// StoreFindClosestCompletedUploadsFromGraphFragmentFunc describes the
+// behavior when the FindClosestCompletedUploadsFromGraphFragment method of
 // the parent MockStore instance is invoked.
-type StoreFindClosestProcessedUploadsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error)
-	history     []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall
+type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)
+	history     []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestProcessedUploadsFromGraphFragment delegates to the next hook
+// FindClosestCompletedUploadsFromGraphFragment delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) FindClosestProcessedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
-	r0, r1 := m.FindClosestProcessedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestProcessedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2820,20 +2820,20 @@ func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook fu
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2846,28 +2846,28 @@ func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(
 	return hook
 }
 
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall objects
+// StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall objects
 // describing the invocations of this function.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) History() []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) History() []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall, len(f.history))
+	history := make([]StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall is an object
+// StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall is an object
 // that describes an invocation of method
-// FindClosestProcessedUploadsFromGraphFragment on an instance of MockStore.
-type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
+// FindClosestCompletedUploadsFromGraphFragment on an instance of MockStore.
+type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2891,7 +2891,7 @@ type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 	Arg6 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.ProcessedUpload
+	Result0 []shared1.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2899,13 +2899,13 @@ type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
+func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
+func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -4019,36 +4019,36 @@ func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreGetProcessedUploadsByIDsFunc describes the behavior when the
-// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
 // invoked.
-type StoreGetProcessedUploadsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared1.ProcessedUpload, error)
-	hooks       []func(context.Context, []int) ([]shared1.ProcessedUpload, error)
-	history     []StoreGetProcessedUploadsByIDsFuncCall
+type StoreGetCompletedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared1.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsByIDsFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// GetCompletedUploadsByIDs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockStore) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared1.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsByIDsFunc.appendCall(StoreGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
+func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsByIDs method of the parent MockStore instance invokes
+// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4056,20 +4056,20 @@ func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4082,27 +4082,27 @@ func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []i
 	return hook
 }
 
-func (f *StoreGetProcessedUploadsByIDsFunc) appendCall(r0 StoreGetProcessedUploadsByIDsFuncCall) {
+func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreGetProcessedUploadsByIDsFuncCall
+// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
 // objects describing the invocations of this function.
-func (f *StoreGetProcessedUploadsByIDsFunc) History() []StoreGetProcessedUploadsByIDsFuncCall {
+func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreGetProcessedUploadsByIDsFuncCall, len(f.history))
+	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreGetProcessedUploadsByIDsFuncCall is an object that describes an
-// invocation of method GetProcessedUploadsByIDs on an instance of
+// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetCompletedUploadsByIDs on an instance of
 // MockStore.
-type StoreGetProcessedUploadsByIDsFuncCall struct {
+type StoreGetCompletedUploadsByIDsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -4111,7 +4111,7 @@ type StoreGetProcessedUploadsByIDsFuncCall struct {
 	Arg1 []int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.ProcessedUpload
+	Result0 []shared1.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -4119,48 +4119,48 @@ type StoreGetProcessedUploadsByIDsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
+func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
+func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFunc describes the
-// behavior when the GetProcessedUploadsWithDefinitionsForMonikers method of
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
 // the parent MockStore instance is invoked.
-type StoreGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)
-	history     []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -4168,20 +4168,20 @@ func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook f
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared1.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared1.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4194,29 +4194,29 @@ func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func
 	return hook
 }
 
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall objects
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
 // describing the invocations of this function.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an object
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
 // that describes an invocation of method
-// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
 // MockStore.
-type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -4225,7 +4225,7 @@ type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 	Arg1 []precise.QualifiedMonikerData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared1.ProcessedUpload
+	Result0 []shared1.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -4233,13 +4233,13 @@ type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
+++ b/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
@@ -290,8 +290,8 @@ func (h *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 			// Before we mark the upload as complete, we need to delete any existing completed uploads
 			// that have the same repository_id, commit, root, and indexer values. Otherwise, the transaction
 			// will fail as these values form a unique constraint.
-			if err := tx.DeleteOverlappingProcessedUploads(ctx, upload.RepositoryID, upload.Commit, upload.Root, upload.Indexer); err != nil {
-				return errors.Wrap(err, "store.DeleteOverlappingProcessedUploads")
+			if err := tx.DeleteOverlappingCompletedUploads(ctx, upload.RepositoryID, upload.Commit, upload.Root, upload.Indexer); err != nil {
+				return errors.Wrap(err, "store.DeleteOverlappingCompletedUploads")
 			}
 
 			trace.AddEvent("TODO Domain Owner", attribute.Int("packages", len(pkgData.Packages)))

--- a/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
+++ b/internal/codeintel/uploads/internal/background/processor/job_worker_handler.go
@@ -290,8 +290,8 @@ func (h *handler) HandleRawUpload(ctx context.Context, logger log.Logger, upload
 			// Before we mark the upload as complete, we need to delete any existing completed uploads
 			// that have the same repository_id, commit, root, and indexer values. Otherwise, the transaction
 			// will fail as these values form a unique constraint.
-			if err := tx.DeleteOverlappingDumps(ctx, upload.RepositoryID, upload.Commit, upload.Root, upload.Indexer); err != nil {
-				return errors.Wrap(err, "store.DeleteOverlappingDumps")
+			if err := tx.DeleteOverlappingProcessedUploads(ctx, upload.RepositoryID, upload.Commit, upload.Root, upload.Indexer); err != nil {
+				return errors.Wrap(err, "store.DeleteOverlappingProcessedUploads")
 			}
 
 			trace.AddEvent("TODO Domain Owner", attribute.Int("packages", len(pkgData.Packages)))

--- a/internal/codeintel/uploads/internal/background/processor/job_worker_handler_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/job_worker_handler_test.go
@@ -108,7 +108,7 @@ func TestHandle(t *testing.T) {
 		t.Errorf("unexpected UpdateCommitedAt commit date. want=%s have=%s", expectedCommitDate, calls[0].Arg3)
 	}
 
-	expectedPackagesDumpID := 42
+	expectedPackagesUploadID := 42
 	expectedPackages := []precise.Package{
 		{
 			Scheme:  "scip-typescript",
@@ -119,13 +119,13 @@ func TestHandle(t *testing.T) {
 	}
 	if len(mockDBStore.UpdatePackagesFunc.History()) != 1 {
 		t.Errorf("unexpected number of UpdatePackages calls. want=%d have=%d", 1, len(mockDBStore.UpdatePackagesFunc.History()))
-	} else if diff := cmp.Diff(expectedPackagesDumpID, mockDBStore.UpdatePackagesFunc.History()[0].Arg1); diff != "" {
+	} else if diff := cmp.Diff(expectedPackagesUploadID, mockDBStore.UpdatePackagesFunc.History()[0].Arg1); diff != "" {
 		t.Errorf("unexpected UpdatePackagesFunc args (-want +got):\n%s", diff)
 	} else if diff := cmp.Diff(expectedPackages, mockDBStore.UpdatePackagesFunc.History()[0].Arg2); diff != "" {
 		t.Errorf("unexpected UpdatePackagesFunc args (-want +got):\n%s", diff)
 	}
 
-	expectedPackageReferencesDumpID := 42
+	expectedPackageReferencesUploadID := 42
 	expectedPackageReferences := []precise.PackageReference{
 		{Package: precise.Package{
 			Scheme:  "scip-typescript",
@@ -178,7 +178,7 @@ func TestHandle(t *testing.T) {
 	}
 	if len(mockDBStore.UpdatePackageReferencesFunc.History()) != 1 {
 		t.Errorf("unexpected number of UpdatePackageReferences calls. want=%d have=%d", 1, len(mockDBStore.UpdatePackageReferencesFunc.History()))
-	} else if diff := cmp.Diff(expectedPackageReferencesDumpID, mockDBStore.UpdatePackageReferencesFunc.History()[0].Arg1); diff != "" {
+	} else if diff := cmp.Diff(expectedPackageReferencesUploadID, mockDBStore.UpdatePackageReferencesFunc.History()[0].Arg1); diff != "" {
 		t.Errorf("unexpected UpdatePackageReferencesFunc args (-want +got):\n%s", diff)
 	} else {
 		sort.Slice(expectedPackageReferences, func(i, j int) bool {
@@ -196,16 +196,16 @@ func TestHandle(t *testing.T) {
 		t.Errorf("unexpected value for upload id. want=%d have=%d", 42, mockDBStore.InsertDependencySyncingJobFunc.History()[0].Arg1)
 	}
 
-	if len(mockDBStore.DeleteOverlappingDumpsFunc.History()) != 1 {
-		t.Errorf("unexpected number of DeleteOverlappingDumps calls. want=%d have=%d", 1, len(mockDBStore.DeleteOverlappingDumpsFunc.History()))
-	} else if mockDBStore.DeleteOverlappingDumpsFunc.History()[0].Arg1 != 50 {
-		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDBStore.DeleteOverlappingDumpsFunc.History()[0].Arg1)
-	} else if mockDBStore.DeleteOverlappingDumpsFunc.History()[0].Arg2 != "deadbeef" {
-		t.Errorf("unexpected value for commit. want=%s have=%s", "deadbeef", mockDBStore.DeleteOverlappingDumpsFunc.History()[0].Arg2)
-	} else if mockDBStore.DeleteOverlappingDumpsFunc.History()[0].Arg3 != "" {
-		t.Errorf("unexpected value for root. want=%s have=%s", "", mockDBStore.DeleteOverlappingDumpsFunc.History()[0].Arg3)
-	} else if mockDBStore.DeleteOverlappingDumpsFunc.History()[0].Arg4 != "lsif-go" {
-		t.Errorf("unexpected value for indexer. want=%s have=%s", "lsif-go", mockDBStore.DeleteOverlappingDumpsFunc.History()[0].Arg4)
+	if len(mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()) != 1 {
+		t.Errorf("unexpected number of DeleteOverlappingProcessedUploads calls. want=%d have=%d", 1, len(mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()))
+	} else if mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg1 != 50 {
+		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg1)
+	} else if mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg2 != "deadbeef" {
+		t.Errorf("unexpected value for commit. want=%s have=%s", "deadbeef", mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg2)
+	} else if mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg3 != "" {
+		t.Errorf("unexpected value for root. want=%s have=%s", "", mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg3)
+	} else if mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg4 != "lsif-go" {
+		t.Errorf("unexpected value for indexer. want=%s have=%s", "lsif-go", mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg4)
 	}
 
 	if len(mockDBStore.SetRepositoryAsDirtyFunc.History()) != 1 {

--- a/internal/codeintel/uploads/internal/background/processor/job_worker_handler_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/job_worker_handler_test.go
@@ -196,16 +196,16 @@ func TestHandle(t *testing.T) {
 		t.Errorf("unexpected value for upload id. want=%d have=%d", 42, mockDBStore.InsertDependencySyncingJobFunc.History()[0].Arg1)
 	}
 
-	if len(mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()) != 1 {
-		t.Errorf("unexpected number of DeleteOverlappingProcessedUploads calls. want=%d have=%d", 1, len(mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()))
-	} else if mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg1 != 50 {
-		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg1)
-	} else if mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg2 != "deadbeef" {
-		t.Errorf("unexpected value for commit. want=%s have=%s", "deadbeef", mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg2)
-	} else if mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg3 != "" {
-		t.Errorf("unexpected value for root. want=%s have=%s", "", mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg3)
-	} else if mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg4 != "lsif-go" {
-		t.Errorf("unexpected value for indexer. want=%s have=%s", "lsif-go", mockDBStore.DeleteOverlappingProcessedUploadsFunc.History()[0].Arg4)
+	if len(mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()) != 1 {
+		t.Errorf("unexpected number of DeleteOverlappingCompletedUploads calls. want=%d have=%d", 1, len(mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()))
+	} else if mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()[0].Arg1 != 50 {
+		t.Errorf("unexpected value for repository id. want=%d have=%d", 50, mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()[0].Arg1)
+	} else if mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()[0].Arg2 != "deadbeef" {
+		t.Errorf("unexpected value for commit. want=%s have=%s", "deadbeef", mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()[0].Arg2)
+	} else if mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()[0].Arg3 != "" {
+		t.Errorf("unexpected value for root. want=%s have=%s", "", mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()[0].Arg3)
+	} else if mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()[0].Arg4 != "lsif-go" {
+		t.Errorf("unexpected value for indexer. want=%s have=%s", "lsif-go", mockDBStore.DeleteOverlappingCompletedUploadsFunc.History()[0].Arg4)
 	}
 
 	if len(mockDBStore.SetRepositoryAsDirtyFunc.History()) != 1 {

--- a/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -199,10 +199,10 @@ type MockStore struct {
 	// DeleteOldAuditLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteOldAuditLogs.
 	DeleteOldAuditLogsFunc *StoreDeleteOldAuditLogsFunc
-	// DeleteOverlappingProcessedUploadsFunc is an instance of a mock
+	// DeleteOverlappingCompletedUploadsFunc is an instance of a mock
 	// function object controlling the behavior of the method
-	// DeleteOverlappingProcessedUploads.
-	DeleteOverlappingProcessedUploadsFunc *StoreDeleteOverlappingProcessedUploadsFunc
+	// DeleteOverlappingCompletedUploads.
+	DeleteOverlappingCompletedUploadsFunc *StoreDeleteOverlappingCompletedUploadsFunc
 	// DeleteUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteUploadByID.
 	DeleteUploadByIDFunc *StoreDeleteUploadByIDFunc
@@ -220,14 +220,14 @@ type MockStore struct {
 	// ExpireFailedRecordsFunc is an instance of a mock function object
 	// controlling the behavior of the method ExpireFailedRecords.
 	ExpireFailedRecordsFunc *StoreExpireFailedRecordsFunc
-	// FindClosestProcessedUploadsFunc is an instance of a mock function
+	// FindClosestCompletedUploadsFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// FindClosestProcessedUploads.
-	FindClosestProcessedUploadsFunc *StoreFindClosestProcessedUploadsFunc
-	// FindClosestProcessedUploadsFromGraphFragmentFunc is an instance of a
+	// FindClosestCompletedUploads.
+	FindClosestCompletedUploadsFunc *StoreFindClosestCompletedUploadsFunc
+	// FindClosestCompletedUploadsFromGraphFragmentFunc is an instance of a
 	// mock function object controlling the behavior of the method
-	// FindClosestProcessedUploadsFromGraphFragment.
-	FindClosestProcessedUploadsFromGraphFragmentFunc *StoreFindClosestProcessedUploadsFromGraphFragmentFunc
+	// FindClosestCompletedUploadsFromGraphFragment.
+	FindClosestCompletedUploadsFromGraphFragmentFunc *StoreFindClosestCompletedUploadsFromGraphFragmentFunc
 	// GetAuditLogsForUploadFunc is an instance of a mock function object
 	// controlling the behavior of the method GetAuditLogsForUpload.
 	GetAuditLogsForUploadFunc *StoreGetAuditLogsForUploadFunc
@@ -260,13 +260,13 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
-	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetProcessedUploadsByIDs.
-	GetProcessedUploadsByIDsFunc *StoreGetProcessedUploadsByIDsFunc
-	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletedUploadsByIDs.
+	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
+	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
 	// mock function object controlling the behavior of the method
-	// GetProcessedUploadsWithDefinitionsForMonikers.
-	GetProcessedUploadsWithDefinitionsForMonikersFunc *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc
+	// GetCompletedUploadsWithDefinitionsForMonikers.
+	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -426,7 +426,7 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) (r0 error) {
 				return
 			},
@@ -456,13 +456,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.ProcessedUpload, r1 error) {
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.ProcessedUpload, r1 error) {
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -516,13 +516,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared.ProcessedUpload, r1 error) {
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.ProcessedUpload, r1 error) {
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -753,9 +753,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteOldAuditLogs")
 			},
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) error {
-				panic("unexpected invocation of MockStore.DeleteOverlappingProcessedUploads")
+				panic("unexpected invocation of MockStore.DeleteOverlappingCompletedUploads")
 			},
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
@@ -783,14 +783,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ExpireFailedRecords")
 			},
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.FindClosestProcessedUploads")
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestCompletedUploads")
 			},
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.FindClosestProcessedUploadsFromGraphFragment")
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestCompletedUploadsFromGraphFragment")
 			},
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
@@ -843,14 +843,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
 			},
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.GetProcessedUploadsByIDs")
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.GetProcessedUploadsWithDefinitionsForMonikers")
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -1070,8 +1070,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		DeleteOldAuditLogsFunc: &StoreDeleteOldAuditLogsFunc{
 			defaultHook: i.DeleteOldAuditLogs,
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
-			defaultHook: i.DeleteOverlappingProcessedUploads,
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
+			defaultHook: i.DeleteOverlappingCompletedUploads,
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
 			defaultHook: i.DeleteUploadByID,
@@ -1088,11 +1088,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
 			defaultHook: i.ExpireFailedRecords,
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: i.FindClosestProcessedUploads,
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: i.FindClosestCompletedUploads,
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: i.FindClosestProcessedUploadsFromGraphFragment,
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: i.FindClosestCompletedUploadsFromGraphFragment,
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
 			defaultHook: i.GetAuditLogsForUpload,
@@ -1124,11 +1124,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: i.GetProcessedUploadsByIDs,
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: i.GetCompletedUploadsByIDs,
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -1797,37 +1797,37 @@ func (c StoreDeleteOldAuditLogsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreDeleteOverlappingProcessedUploadsFunc describes the behavior when
-// the DeleteOverlappingProcessedUploads method of the parent MockStore
+// StoreDeleteOverlappingCompletedUploadsFunc describes the behavior when
+// the DeleteOverlappingCompletedUploads method of the parent MockStore
 // instance is invoked.
-type StoreDeleteOverlappingProcessedUploadsFunc struct {
+type StoreDeleteOverlappingCompletedUploadsFunc struct {
 	defaultHook func(context.Context, int, string, string, string) error
 	hooks       []func(context.Context, int, string, string, string) error
-	history     []StoreDeleteOverlappingProcessedUploadsFuncCall
+	history     []StoreDeleteOverlappingCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteOverlappingProcessedUploads delegates to the next hook function in
+// DeleteOverlappingCompletedUploads delegates to the next hook function in
 // the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) DeleteOverlappingProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
-	r0 := m.DeleteOverlappingProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.DeleteOverlappingProcessedUploadsFunc.appendCall(StoreDeleteOverlappingProcessedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
+func (m *MockStore) DeleteOverlappingCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
+	r0 := m.DeleteOverlappingCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DeleteOverlappingCompletedUploadsFunc.appendCall(StoreDeleteOverlappingCompletedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// DeleteOverlappingCompletedUploads method of the parent MockStore instance
 // is invoked and the hook queue is empty.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// DeleteOverlappingCompletedUploads method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1835,20 +1835,20 @@ func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultReturn(r0 error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushReturn(r0 error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1861,28 +1861,28 @@ func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Con
 	return hook
 }
 
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) appendCall(r0 StoreDeleteOverlappingProcessedUploadsFuncCall) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) appendCall(r0 StoreDeleteOverlappingCompletedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreDeleteOverlappingProcessedUploadsFuncCall objects describing the
+// StoreDeleteOverlappingCompletedUploadsFuncCall objects describing the
 // invocations of this function.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) History() []StoreDeleteOverlappingProcessedUploadsFuncCall {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) History() []StoreDeleteOverlappingCompletedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreDeleteOverlappingProcessedUploadsFuncCall, len(f.history))
+	history := make([]StoreDeleteOverlappingCompletedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreDeleteOverlappingProcessedUploadsFuncCall is an object that
-// describes an invocation of method DeleteOverlappingProcessedUploads on an
+// StoreDeleteOverlappingCompletedUploadsFuncCall is an object that
+// describes an invocation of method DeleteOverlappingCompletedUploads on an
 // instance of MockStore.
-type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
+type StoreDeleteOverlappingCompletedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1905,13 +1905,13 @@ type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Args() []interface{} {
+func (c StoreDeleteOverlappingCompletedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Results() []interface{} {
+func (c StoreDeleteOverlappingCompletedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2472,37 +2472,37 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreFindClosestProcessedUploadsFunc describes the behavior when the
-// FindClosestProcessedUploads method of the parent MockStore instance is
+// StoreFindClosestCompletedUploadsFunc describes the behavior when the
+// FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked.
-type StoreFindClosestProcessedUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
-	history     []StoreFindClosestProcessedUploadsFuncCall
+type StoreFindClosestCompletedUploadsFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	history     []StoreFindClosestCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestProcessedUploads delegates to the next hook function in the
+// FindClosestCompletedUploads delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.FindClosestProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestProcessedUploadsFunc.appendCall(StoreFindClosestProcessedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestProcessedUploads method of the parent MockStore instance is
+// FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestProcessedUploads method of the parent MockStore instance
+// FindClosestCompletedUploads method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2510,20 +2510,20 @@ func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestProcessedUploadsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2536,27 +2536,27 @@ func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, 
 	return hook
 }
 
-func (f *StoreFindClosestProcessedUploadsFunc) appendCall(r0 StoreFindClosestProcessedUploadsFuncCall) {
+func (f *StoreFindClosestCompletedUploadsFunc) appendCall(r0 StoreFindClosestCompletedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreFindClosestProcessedUploadsFuncCall
+// History returns a sequence of StoreFindClosestCompletedUploadsFuncCall
 // objects describing the invocations of this function.
-func (f *StoreFindClosestProcessedUploadsFunc) History() []StoreFindClosestProcessedUploadsFuncCall {
+func (f *StoreFindClosestCompletedUploadsFunc) History() []StoreFindClosestCompletedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestProcessedUploadsFuncCall, len(f.history))
+	history := make([]StoreFindClosestCompletedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestProcessedUploadsFuncCall is an object that describes an
-// invocation of method FindClosestProcessedUploads on an instance of
+// StoreFindClosestCompletedUploadsFuncCall is an object that describes an
+// invocation of method FindClosestCompletedUploads on an instance of
 // MockStore.
-type StoreFindClosestProcessedUploadsFuncCall struct {
+type StoreFindClosestCompletedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2577,7 +2577,7 @@ type StoreFindClosestProcessedUploadsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2585,48 +2585,48 @@ type StoreFindClosestProcessedUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFuncCall) Args() []interface{} {
+func (c StoreFindClosestCompletedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFuncCall) Results() []interface{} {
+func (c StoreFindClosestCompletedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreFindClosestProcessedUploadsFromGraphFragmentFunc describes the
-// behavior when the FindClosestProcessedUploadsFromGraphFragment method of
+// StoreFindClosestCompletedUploadsFromGraphFragmentFunc describes the
+// behavior when the FindClosestCompletedUploadsFromGraphFragment method of
 // the parent MockStore instance is invoked.
-type StoreFindClosestProcessedUploadsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
-	history     []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall
+type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	history     []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestProcessedUploadsFromGraphFragment delegates to the next hook
+// FindClosestCompletedUploadsFromGraphFragment delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) FindClosestProcessedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.FindClosestProcessedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestProcessedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2634,20 +2634,20 @@ func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook fu
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2660,28 +2660,28 @@ func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(
 	return hook
 }
 
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall objects
+// StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall objects
 // describing the invocations of this function.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) History() []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) History() []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall, len(f.history))
+	history := make([]StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall is an object
+// StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall is an object
 // that describes an invocation of method
-// FindClosestProcessedUploadsFromGraphFragment on an instance of MockStore.
-type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
+// FindClosestCompletedUploadsFromGraphFragment on an instance of MockStore.
+type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2705,7 +2705,7 @@ type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 	Arg6 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2713,13 +2713,13 @@ type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
+func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
+func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3833,36 +3833,36 @@ func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreGetProcessedUploadsByIDsFunc describes the behavior when the
-// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
 // invoked.
-type StoreGetProcessedUploadsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, []int) ([]shared.ProcessedUpload, error)
-	history     []StoreGetProcessedUploadsByIDsFuncCall
+type StoreGetCompletedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsByIDsFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// GetCompletedUploadsByIDs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockStore) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsByIDsFunc.appendCall(StoreGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
+func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsByIDs method of the parent MockStore instance invokes
+// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3870,20 +3870,20 @@ func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3896,27 +3896,27 @@ func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []i
 	return hook
 }
 
-func (f *StoreGetProcessedUploadsByIDsFunc) appendCall(r0 StoreGetProcessedUploadsByIDsFuncCall) {
+func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreGetProcessedUploadsByIDsFuncCall
+// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
 // objects describing the invocations of this function.
-func (f *StoreGetProcessedUploadsByIDsFunc) History() []StoreGetProcessedUploadsByIDsFuncCall {
+func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreGetProcessedUploadsByIDsFuncCall, len(f.history))
+	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreGetProcessedUploadsByIDsFuncCall is an object that describes an
-// invocation of method GetProcessedUploadsByIDs on an instance of
+// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetCompletedUploadsByIDs on an instance of
 // MockStore.
-type StoreGetProcessedUploadsByIDsFuncCall struct {
+type StoreGetCompletedUploadsByIDsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3925,7 +3925,7 @@ type StoreGetProcessedUploadsByIDsFuncCall struct {
 	Arg1 []int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3933,48 +3933,48 @@ type StoreGetProcessedUploadsByIDsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
+func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
+func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFunc describes the
-// behavior when the GetProcessedUploadsWithDefinitionsForMonikers method of
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
 // the parent MockStore instance is invoked.
-type StoreGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
-	history     []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3982,20 +3982,20 @@ func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook f
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -4008,29 +4008,29 @@ func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func
 	return hook
 }
 
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall objects
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
 // describing the invocations of this function.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an object
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
 // that describes an invocation of method
-// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
 // MockStore.
-type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -4039,7 +4039,7 @@ type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 	Arg1 []precise.QualifiedMonikerData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -4047,13 +4047,13 @@ type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -238,6 +238,13 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// GetCommitsVisibleToUpload.
 	GetCommitsVisibleToUploadFunc *StoreGetCommitsVisibleToUploadFunc
+	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletedUploadsByIDs.
+	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
+	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// GetCompletedUploadsWithDefinitionsForMonikers.
+	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetDirtyRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDirtyRepositories.
 	GetDirtyRepositoriesFunc *StoreGetDirtyRepositoriesFunc
@@ -260,13 +267,6 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
-	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetCompletedUploadsByIDs.
-	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
-	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
-	// mock function object controlling the behavior of the method
-	// GetCompletedUploadsWithDefinitionsForMonikers.
-	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -481,6 +481,16 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared.CompletedUpload, r1 error) {
+				return
+			},
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.CompletedUpload, r1 error) {
+				return
+			},
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) (r0 []shared.DirtyRepository, r1 error) {
 				return
@@ -513,16 +523,6 @@ func NewMockStore() *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (r0 time.Time, r1 bool, r2 error) {
-				return
-			},
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared.CompletedUpload, r1 error) {
-				return
-			},
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -808,6 +808,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetCommitsVisibleToUpload")
 			},
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
+			},
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
+			},
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) ([]shared.DirtyRepository, error) {
 				panic("unexpected invocation of MockStore.GetDirtyRepositories")
@@ -841,16 +851,6 @@ func NewStrictMockStore() *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (time.Time, bool, error) {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
-			},
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared.CompletedUpload, error) {
-				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
-			},
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -1103,6 +1103,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetCommitsVisibleToUploadFunc: &StoreGetCommitsVisibleToUploadFunc{
 			defaultHook: i.GetCommitsVisibleToUpload,
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: i.GetCompletedUploadsByIDs,
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: i.GetDirtyRepositories,
 		},
@@ -1123,12 +1129,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: i.GetCompletedUploadsByIDs,
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -3062,6 +3062,230 @@ func (c StoreGetCommitsVisibleToUploadFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
+// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
+// invoked.
+type StoreGetCompletedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCompletedUploadsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.CompletedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetCompletedUploadsByIDs on an instance of
+// MockStore.
+type StoreGetCompletedUploadsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.CompletedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
+// the parent MockStore instance is invoked.
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
+// describing the invocations of this function.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
+// that describes an invocation of method
+// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
+// MockStore.
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []precise.QualifiedMonikerData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.CompletedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // StoreGetDirtyRepositoriesFunc describes the behavior when the
 // GetDirtyRepositories method of the parent MockStore instance is invoked.
 type StoreGetDirtyRepositoriesFunc struct {
@@ -3831,230 +4055,6 @@ func (c StoreGetOldestCommitDateFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
-// GetCompletedUploadsByIDs method of the parent MockStore instance is
-// invoked.
-type StoreGetCompletedUploadsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, []int) ([]shared.CompletedUpload, error)
-	history     []StoreGetCompletedUploadsByIDsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetCompletedUploadsByIDs delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
-	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetCompletedUploadsByIDs method of the parent MockStore instance is
-// invoked and the hook queue is empty.
-func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.CompletedUpload, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
-// objects describing the invocations of this function.
-func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
-// invocation of method GetCompletedUploadsByIDs on an instance of
-// MockStore.
-type StoreGetCompletedUploadsByIDsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.CompletedUpload
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
-// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
-// the parent MockStore instance is invoked.
-type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
-	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
-	mutex       sync.Mutex
-}
-
-// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
-// function in the queue and stores the parameter and result values of this
-// invocation.
-func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
-// MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
-// MockStore instance invokes the hook at the front of the queue and
-// discards it. After the queue is empty, the default hook function is
-// invoked for any future action.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
-// describing the invocations of this function.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
-// that describes an invocation of method
-// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
-// MockStore.
-type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []precise.QualifiedMonikerData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.CompletedUpload
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetRecentIndexesSummaryFunc describes the behavior when the

--- a/internal/codeintel/uploads/internal/background/processor/mocks_test.go
+++ b/internal/codeintel/uploads/internal/background/processor/mocks_test.go
@@ -199,9 +199,10 @@ type MockStore struct {
 	// DeleteOldAuditLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteOldAuditLogs.
 	DeleteOldAuditLogsFunc *StoreDeleteOldAuditLogsFunc
-	// DeleteOverlappingDumpsFunc is an instance of a mock function object
-	// controlling the behavior of the method DeleteOverlappingDumps.
-	DeleteOverlappingDumpsFunc *StoreDeleteOverlappingDumpsFunc
+	// DeleteOverlappingProcessedUploadsFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// DeleteOverlappingProcessedUploads.
+	DeleteOverlappingProcessedUploadsFunc *StoreDeleteOverlappingProcessedUploadsFunc
 	// DeleteUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteUploadByID.
 	DeleteUploadByIDFunc *StoreDeleteUploadByIDFunc
@@ -219,13 +220,14 @@ type MockStore struct {
 	// ExpireFailedRecordsFunc is an instance of a mock function object
 	// controlling the behavior of the method ExpireFailedRecords.
 	ExpireFailedRecordsFunc *StoreExpireFailedRecordsFunc
-	// FindClosestDumpsFunc is an instance of a mock function object
-	// controlling the behavior of the method FindClosestDumps.
-	FindClosestDumpsFunc *StoreFindClosestDumpsFunc
-	// FindClosestDumpsFromGraphFragmentFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// FindClosestDumpsFromGraphFragment.
-	FindClosestDumpsFromGraphFragmentFunc *StoreFindClosestDumpsFromGraphFragmentFunc
+	// FindClosestProcessedUploadsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// FindClosestProcessedUploads.
+	FindClosestProcessedUploadsFunc *StoreFindClosestProcessedUploadsFunc
+	// FindClosestProcessedUploadsFromGraphFragmentFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// FindClosestProcessedUploadsFromGraphFragment.
+	FindClosestProcessedUploadsFromGraphFragmentFunc *StoreFindClosestProcessedUploadsFromGraphFragmentFunc
 	// GetAuditLogsForUploadFunc is an instance of a mock function object
 	// controlling the behavior of the method GetAuditLogsForUpload.
 	GetAuditLogsForUploadFunc *StoreGetAuditLogsForUploadFunc
@@ -239,13 +241,6 @@ type MockStore struct {
 	// GetDirtyRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDirtyRepositories.
 	GetDirtyRepositoriesFunc *StoreGetDirtyRepositoriesFunc
-	// GetDumpsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetDumpsByIDs.
-	GetDumpsByIDsFunc *StoreGetDumpsByIDsFunc
-	// GetDumpsWithDefinitionsForMonikersFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// GetDumpsWithDefinitionsForMonikers.
-	GetDumpsWithDefinitionsForMonikersFunc *StoreGetDumpsWithDefinitionsForMonikersFunc
 	// GetIndexByIDFunc is an instance of a mock function object controlling
 	// the behavior of the method GetIndexByID.
 	GetIndexByIDFunc *StoreGetIndexByIDFunc
@@ -265,6 +260,13 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
+	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetProcessedUploadsByIDs.
+	GetProcessedUploadsByIDsFunc *StoreGetProcessedUploadsByIDsFunc
+	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// GetProcessedUploadsWithDefinitionsForMonikers.
+	GetProcessedUploadsWithDefinitionsForMonikersFunc *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -424,7 +426,7 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) (r0 error) {
 				return
 			},
@@ -454,13 +456,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.Dump, r1 error) {
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.Dump, r1 error) {
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -481,16 +483,6 @@ func NewMockStore() *MockStore {
 		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) (r0 []shared.DirtyRepository, r1 error) {
-				return
-			},
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared.Dump, r1 error) {
-				return
-			},
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.Dump, r1 error) {
 				return
 			},
 		},
@@ -521,6 +513,16 @@ func NewMockStore() *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (r0 time.Time, r1 bool, r2 error) {
+				return
+			},
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared.ProcessedUpload, r1 error) {
+				return
+			},
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -751,9 +753,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteOldAuditLogs")
 			},
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) error {
-				panic("unexpected invocation of MockStore.DeleteOverlappingDumps")
+				panic("unexpected invocation of MockStore.DeleteOverlappingProcessedUploads")
 			},
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
@@ -781,14 +783,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ExpireFailedRecords")
 			},
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.FindClosestDumps")
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestProcessedUploads")
 			},
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.FindClosestDumpsFromGraphFragment")
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestProcessedUploadsFromGraphFragment")
 			},
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
@@ -809,16 +811,6 @@ func NewStrictMockStore() *MockStore {
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) ([]shared.DirtyRepository, error) {
 				panic("unexpected invocation of MockStore.GetDirtyRepositories")
-			},
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.GetDumpsByIDs")
-			},
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.GetDumpsWithDefinitionsForMonikers")
 			},
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
@@ -849,6 +841,16 @@ func NewStrictMockStore() *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (time.Time, bool, error) {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
+			},
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.GetProcessedUploadsByIDs")
+			},
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.GetProcessedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -1068,8 +1070,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		DeleteOldAuditLogsFunc: &StoreDeleteOldAuditLogsFunc{
 			defaultHook: i.DeleteOldAuditLogs,
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
-			defaultHook: i.DeleteOverlappingDumps,
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+			defaultHook: i.DeleteOverlappingProcessedUploads,
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
 			defaultHook: i.DeleteUploadByID,
@@ -1086,11 +1088,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
 			defaultHook: i.ExpireFailedRecords,
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: i.FindClosestDumps,
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: i.FindClosestProcessedUploads,
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: i.FindClosestDumpsFromGraphFragment,
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: i.FindClosestProcessedUploadsFromGraphFragment,
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
 			defaultHook: i.GetAuditLogsForUpload,
@@ -1103,12 +1105,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: i.GetDirtyRepositories,
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: i.GetDumpsByIDs,
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetDumpsWithDefinitionsForMonikers,
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
 			defaultHook: i.GetIndexByID,
@@ -1127,6 +1123,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: i.GetProcessedUploadsByIDs,
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -1795,36 +1797,37 @@ func (c StoreDeleteOldAuditLogsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreDeleteOverlappingDumpsFunc describes the behavior when the
-// DeleteOverlappingDumps method of the parent MockStore instance is
-// invoked.
-type StoreDeleteOverlappingDumpsFunc struct {
+// StoreDeleteOverlappingProcessedUploadsFunc describes the behavior when
+// the DeleteOverlappingProcessedUploads method of the parent MockStore
+// instance is invoked.
+type StoreDeleteOverlappingProcessedUploadsFunc struct {
 	defaultHook func(context.Context, int, string, string, string) error
 	hooks       []func(context.Context, int, string, string, string) error
-	history     []StoreDeleteOverlappingDumpsFuncCall
+	history     []StoreDeleteOverlappingProcessedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteOverlappingDumps delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockStore) DeleteOverlappingDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
-	r0 := m.DeleteOverlappingDumpsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.DeleteOverlappingDumpsFunc.appendCall(StoreDeleteOverlappingDumpsFuncCall{v0, v1, v2, v3, v4, r0})
+// DeleteOverlappingProcessedUploads delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockStore) DeleteOverlappingProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
+	r0 := m.DeleteOverlappingProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DeleteOverlappingProcessedUploadsFunc.appendCall(StoreDeleteOverlappingProcessedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteOverlappingDumps method of the parent MockStore instance is invoked
-// and the hook queue is empty.
-func (f *StoreDeleteOverlappingDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
+// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// is invoked and the hook queue is empty.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteOverlappingDumps method of the parent MockStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *StoreDeleteOverlappingDumpsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
+// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1832,20 +1835,20 @@ func (f *StoreDeleteOverlappingDumpsFunc) PushHook(hook func(context.Context, in
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreDeleteOverlappingDumpsFunc) SetDefaultReturn(r0 error) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDeleteOverlappingDumpsFunc) PushReturn(r0 error) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
-func (f *StoreDeleteOverlappingDumpsFunc) nextHook() func(context.Context, int, string, string, string) error {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1858,26 +1861,28 @@ func (f *StoreDeleteOverlappingDumpsFunc) nextHook() func(context.Context, int, 
 	return hook
 }
 
-func (f *StoreDeleteOverlappingDumpsFunc) appendCall(r0 StoreDeleteOverlappingDumpsFuncCall) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) appendCall(r0 StoreDeleteOverlappingProcessedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreDeleteOverlappingDumpsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreDeleteOverlappingDumpsFunc) History() []StoreDeleteOverlappingDumpsFuncCall {
+// History returns a sequence of
+// StoreDeleteOverlappingProcessedUploadsFuncCall objects describing the
+// invocations of this function.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) History() []StoreDeleteOverlappingProcessedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreDeleteOverlappingDumpsFuncCall, len(f.history))
+	history := make([]StoreDeleteOverlappingProcessedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreDeleteOverlappingDumpsFuncCall is an object that describes an
-// invocation of method DeleteOverlappingDumps on an instance of MockStore.
-type StoreDeleteOverlappingDumpsFuncCall struct {
+// StoreDeleteOverlappingProcessedUploadsFuncCall is an object that
+// describes an invocation of method DeleteOverlappingProcessedUploads on an
+// instance of MockStore.
+type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1900,13 +1905,13 @@ type StoreDeleteOverlappingDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDeleteOverlappingDumpsFuncCall) Args() []interface{} {
+func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDeleteOverlappingDumpsFuncCall) Results() []interface{} {
+func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2467,35 +2472,37 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreFindClosestDumpsFunc describes the behavior when the
-// FindClosestDumps method of the parent MockStore instance is invoked.
-type StoreFindClosestDumpsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)
-	history     []StoreFindClosestDumpsFuncCall
+// StoreFindClosestProcessedUploadsFunc describes the behavior when the
+// FindClosestProcessedUploads method of the parent MockStore instance is
+// invoked.
+type StoreFindClosestProcessedUploadsFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
+	history     []StoreFindClosestProcessedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestDumps delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestDumpsFunc.appendCall(StoreFindClosestDumpsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+// FindClosestProcessedUploads delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockStore) FindClosestProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.FindClosestProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.FindClosestProcessedUploadsFunc.appendCall(StoreFindClosestProcessedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the FindClosestDumps
-// method of the parent MockStore instance is invoked and the hook queue is
-// empty.
-func (f *StoreFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)) {
+// SetDefaultHook sets function that is called when the
+// FindClosestProcessedUploads method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestDumps method of the parent MockStore instance invokes the hook
-// at the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)) {
+// FindClosestProcessedUploads method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2503,20 +2510,20 @@ func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, str
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestDumpsFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestDumpsFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2529,26 +2536,27 @@ func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string
 	return hook
 }
 
-func (f *StoreFindClosestDumpsFunc) appendCall(r0 StoreFindClosestDumpsFuncCall) {
+func (f *StoreFindClosestProcessedUploadsFunc) appendCall(r0 StoreFindClosestProcessedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreFindClosestDumpsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreFindClosestDumpsFunc) History() []StoreFindClosestDumpsFuncCall {
+// History returns a sequence of StoreFindClosestProcessedUploadsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreFindClosestProcessedUploadsFunc) History() []StoreFindClosestProcessedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestDumpsFuncCall, len(f.history))
+	history := make([]StoreFindClosestProcessedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestDumpsFuncCall is an object that describes an invocation
-// of method FindClosestDumps on an instance of MockStore.
-type StoreFindClosestDumpsFuncCall struct {
+// StoreFindClosestProcessedUploadsFuncCall is an object that describes an
+// invocation of method FindClosestProcessedUploads on an instance of
+// MockStore.
+type StoreFindClosestProcessedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2569,7 +2577,7 @@ type StoreFindClosestDumpsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.Dump
+	Result0 []shared.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2577,47 +2585,48 @@ type StoreFindClosestDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestDumpsFuncCall) Args() []interface{} {
+func (c StoreFindClosestProcessedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestDumpsFuncCall) Results() []interface{} {
+func (c StoreFindClosestProcessedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreFindClosestDumpsFromGraphFragmentFunc describes the behavior when
-// the FindClosestDumpsFromGraphFragment method of the parent MockStore
-// instance is invoked.
-type StoreFindClosestDumpsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)
-	history     []StoreFindClosestDumpsFromGraphFragmentFuncCall
+// StoreFindClosestProcessedUploadsFromGraphFragmentFunc describes the
+// behavior when the FindClosestProcessedUploadsFromGraphFragment method of
+// the parent MockStore instance is invoked.
+type StoreFindClosestProcessedUploadsFromGraphFragmentFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
+	history     []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestDumpsFromGraphFragment delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestDumpsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestDumpsFromGraphFragmentFunc.appendCall(StoreFindClosestDumpsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+// FindClosestProcessedUploadsFromGraphFragment delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) FindClosestProcessedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.FindClosestProcessedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.FindClosestProcessedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestDumpsFromGraphFragment method of the parent MockStore instance
-// is invoked and the hook queue is empty.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)) {
+// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestDumpsFromGraphFragment method of the parent MockStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)) {
+// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2625,20 +2634,20 @@ func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushHook(hook func(context.
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2651,28 +2660,28 @@ func (f *StoreFindClosestDumpsFromGraphFragmentFunc) nextHook() func(context.Con
 	return hook
 }
 
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestDumpsFromGraphFragmentFuncCall) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreFindClosestDumpsFromGraphFragmentFuncCall objects describing the
-// invocations of this function.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) History() []StoreFindClosestDumpsFromGraphFragmentFuncCall {
+// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall objects
+// describing the invocations of this function.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) History() []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestDumpsFromGraphFragmentFuncCall, len(f.history))
+	history := make([]StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestDumpsFromGraphFragmentFuncCall is an object that
-// describes an invocation of method FindClosestDumpsFromGraphFragment on an
-// instance of MockStore.
-type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
+// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall is an object
+// that describes an invocation of method
+// FindClosestProcessedUploadsFromGraphFragment on an instance of MockStore.
+type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2696,7 +2705,7 @@ type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
 	Arg6 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.Dump
+	Result0 []shared.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2704,13 +2713,13 @@ type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestDumpsFromGraphFragmentFuncCall) Args() []interface{} {
+func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestDumpsFromGraphFragmentFuncCall) Results() []interface{} {
+func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3155,225 +3164,6 @@ func (c StoreGetDirtyRepositoriesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreGetDirtyRepositoriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetDumpsByIDsFunc describes the behavior when the GetDumpsByIDs
-// method of the parent MockStore instance is invoked.
-type StoreGetDumpsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared.Dump, error)
-	hooks       []func(context.Context, []int) ([]shared.Dump, error)
-	history     []StoreGetDumpsByIDsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetDumpsByIDs delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockStore) GetDumpsByIDs(v0 context.Context, v1 []int) ([]shared.Dump, error) {
-	r0, r1 := m.GetDumpsByIDsFunc.nextHook()(v0, v1)
-	m.GetDumpsByIDsFunc.appendCall(StoreGetDumpsByIDsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the GetDumpsByIDs method
-// of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetDumpsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.Dump, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsByIDs method of the parent MockStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreGetDumpsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.Dump, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetDumpsByIDsFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetDumpsByIDsFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetDumpsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.Dump, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetDumpsByIDsFunc) appendCall(r0 StoreGetDumpsByIDsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetDumpsByIDsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreGetDumpsByIDsFunc) History() []StoreGetDumpsByIDsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetDumpsByIDsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetDumpsByIDsFuncCall is an object that describes an invocation of
-// method GetDumpsByIDs on an instance of MockStore.
-type StoreGetDumpsByIDsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.Dump
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetDumpsByIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetDumpsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetDumpsWithDefinitionsForMonikersFunc describes the behavior when
-// the GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance is invoked.
-type StoreGetDumpsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)
-	history     []StoreGetDumpsWithDefinitionsForMonikersFuncCall
-	mutex       sync.Mutex
-}
-
-// GetDumpsWithDefinitionsForMonikers delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) GetDumpsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-	r0, r1 := m.GetDumpsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetDumpsWithDefinitionsForMonikersFunc.appendCall(StoreGetDumpsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance is invoked and the hook queue is empty.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetDumpsWithDefinitionsForMonikersFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreGetDumpsWithDefinitionsForMonikersFuncCall objects describing the
-// invocations of this function.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) History() []StoreGetDumpsWithDefinitionsForMonikersFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetDumpsWithDefinitionsForMonikersFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetDumpsWithDefinitionsForMonikersFuncCall is an object that
-// describes an invocation of method GetDumpsWithDefinitionsForMonikers on
-// an instance of MockStore.
-type StoreGetDumpsWithDefinitionsForMonikersFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []precise.QualifiedMonikerData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.Dump
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetDumpsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetDumpsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -4041,6 +3831,230 @@ func (c StoreGetOldestCommitDateFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreGetProcessedUploadsByIDsFunc describes the behavior when the
+// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// invoked.
+type StoreGetProcessedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared.ProcessedUpload, error)
+	history     []StoreGetProcessedUploadsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsByIDsFunc.appendCall(StoreGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetProcessedUploadsByIDs method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetProcessedUploadsByIDsFunc) appendCall(r0 StoreGetProcessedUploadsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetProcessedUploadsByIDsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetProcessedUploadsByIDsFunc) History() []StoreGetProcessedUploadsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetProcessedUploadsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetProcessedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetProcessedUploadsByIDs on an instance of
+// MockStore.
+type StoreGetProcessedUploadsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.ProcessedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetProcessedUploadsWithDefinitionsForMonikers method of
+// the parent MockStore instance is invoked.
+type StoreGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
+	history     []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+	mutex       sync.Mutex
+}
+
+// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall objects
+// describing the invocations of this function.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an object
+// that describes an invocation of method
+// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// MockStore.
+type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []precise.QualifiedMonikerData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.ProcessedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetRecentIndexesSummaryFunc describes the behavior when the

--- a/internal/codeintel/uploads/internal/lsifstore/cleanup_test.go
+++ b/internal/codeintel/uploads/internal/lsifstore/cleanup_test.go
@@ -38,12 +38,12 @@ func TestDeleteLsifDataByUploadIds(t *testing.T) {
 			t.Fatalf("unexpected error clearing bundle data: %s", err)
 		}
 
-		dumpIDs, err := basestore.ScanInts(codeIntelDB.QueryContext(context.Background(), "SELECT upload_id FROM codeintel_scip_metadata"))
+		uploadIDs, err := basestore.ScanInts(codeIntelDB.QueryContext(context.Background(), "SELECT upload_id FROM codeintel_scip_metadata"))
 		if err != nil {
 			t.Fatalf("Unexpected error querying dump identifiers: %s", err)
 		}
 
-		if diff := cmp.Diff([]int{1, 3, 5}, dumpIDs); diff != "" {
+		if diff := cmp.Diff([]int{1, 3, 5}, uploadIDs); diff != "" {
 			t.Errorf("unexpected dump identifiers (-want +got):\n%s", diff)
 		}
 	})

--- a/internal/codeintel/uploads/internal/store/commitgraph.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph.go
@@ -273,7 +273,7 @@ ORDER BY c.commit_bytea
 LIMIT %s
 `
 
-// FindClosestDumps returns the set of dumps that can most accurately answer queries for the given repository, commit, path, and
+// FindClosestProcessedUploads returns the set of uploads that can most accurately answer queries for the given repository, commit, path, and
 // optional indexer. If rootMustEnclosePath is true, then only dumps with a root which is a prefix of path are returned. Otherwise,
 // any dump with a root intersecting the given path is returned.
 //
@@ -281,12 +281,12 @@ LIMIT %s
 // will return no dumps (as the input commit is not reachable from anything with an upload). The nearest uploads table must be
 // refreshed before calling this method when the commit is unknown.
 //
-// Because refreshing the commit graph can be very expensive, we also provide FindClosestDumpsFromGraphFragment. That method should
+// Because refreshing the commit graph can be very expensive, we also provide FindClosestProcessedUploadsFromGraphFragment. That method should
 // be used instead in low-latency paths. It should be supplied a small fragment of the commit graph that contains the input commit
 // as well as a commit that is likely to exist in the lsif_nearest_uploads table. This is enough to propagate the correct upload
 // visibility data down the graph fragment.
 //
-// The graph supplied to FindClosestDumpsFromGraphFragment will also determine whether or not it is possible to produce a partial set
+// The graph supplied to FindClosestProcessedUploadsFromGraphFragment will also determine whether or not it is possible to produce a partial set
 // of visible uploads (ideally, we'd like to return the complete set of visible uploads, or fail). If the graph fragment is complete
 // by depth (e.g. if the graph contains an ancestor at depth d, then the graph also contains all other ancestors up to depth d), then
 // we get the ideal behavior. Only if we contain a partial row of ancestors will we return partial results.
@@ -294,8 +294,8 @@ LIMIT %s
 // It is possible for some dumps to overlap theoretically, e.g. if someone uploads one dump covering the repository root and then later
 // splits the repository into multiple dumps. For this reason, the returned dumps are always sorted in most-recently-finished order to
 // prevent returning data from stale dumps.
-func (s *store) FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) (_ []shared.Dump, err error) {
-	ctx, trace, endObservation := s.operations.findClosestDumps.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+func (s *store) FindClosestProcessedUploads(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) (_ []shared.ProcessedUpload, err error) {
+	ctx, trace, endObservation := s.operations.findClosestProcessedUploads.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repositoryID", repositoryID),
 		attribute.String("commit", commit),
 		attribute.String("path", path),
@@ -304,19 +304,20 @@ func (s *store) FindClosestDumps(ctx context.Context, repositoryID int, commit, 
 	}})
 	defer endObservation(1, observation.Args{})
 
-	conds := makeFindClosestDumpConditions(path, rootMustEnclosePath, indexer)
-	query := sqlf.Sprintf(findClosestDumpsQuery, makeVisibleUploadsQuery(repositoryID, commit), sqlf.Join(conds, " AND "))
+	conds := makeFindClosestProcessUploadsConditions(path, rootMustEnclosePath, indexer)
+	// TODO(id: completed-state-check) Make sure we only return uploads with state = 'completed' here
+	query := sqlf.Sprintf(findClosestProcessedUploadsQuery, makeVisibleUploadsQuery(repositoryID, commit), sqlf.Join(conds, " AND "))
 
-	dumps, err := scanDumps(s.db.Query(ctx, query))
+	uploads, err := scanProcessedUploads(s.db.Query(ctx, query))
 	if err != nil {
 		return nil, err
 	}
-	trace.AddEvent("TODO Domain Owner", attribute.Int("numDumps", len(dumps)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numUploads", len(uploads)))
 
-	return dumps, nil
+	return uploads, nil
 }
 
-const findClosestDumpsQuery = `
+const findClosestProcessedUploadsQuery = `
 WITH
 visible_uploads AS (%s)
 SELECT
@@ -343,10 +344,10 @@ WHERE %s
 ORDER BY u.finished_at DESC
 `
 
-// FindClosestDumpsFromGraphFragment returns the set of dumps that can most accurately answer queries for the given repository, commit,
-// path, and optional indexer by only considering the given fragment of the full git graph. See FindClosestDumps for additional details.
-func (s *store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) (_ []shared.Dump, err error) {
-	ctx, trace, endObservation := s.operations.findClosestDumpsFromGraphFragment.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+// FindClosestProcessedUploadsFromGraphFragment returns the set of uploads that can most accurately answer queries for the given repository, commit,
+// path, and optional indexer by only considering the given fragment of the full git graph. See FindClosestProcessedUploads for additional details.
+func (s *store) FindClosestProcessedUploadsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) (_ []shared.ProcessedUpload, err error) {
+	ctx, trace, endObservation := s.operations.findClosestProcessedUploadsFromGraphFragment.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repositoryID", repositoryID),
 		attribute.String("commit", commit),
 		attribute.String("path", path),
@@ -366,7 +367,7 @@ func (s *store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 	}
 
 	commitGraphView, err := scanCommitGraphView(s.db.Query(ctx, sqlf.Sprintf(
-		findClosestDumpsFromGraphFragmentCommitGraphQuery,
+		findClosestProcessedUploadsFromGraphFragmentCommitGraphQuery,
 		repositoryID,
 		sqlf.Join(commitQueries, ", "),
 		repositoryID,
@@ -387,19 +388,20 @@ func (s *store) FindClosestDumpsFromGraphFragment(ctx context.Context, repositor
 		return nil, nil
 	}
 
-	conds := makeFindClosestDumpConditions(path, rootMustEnclosePath, indexer)
-	query := sqlf.Sprintf(findClosestDumpsFromGraphFragmentQuery, sqlf.Join(ids, ","), sqlf.Join(conds, " AND "))
+	conds := makeFindClosestProcessUploadsConditions(path, rootMustEnclosePath, indexer)
+	// TODO(id: completed-state-check) Make sure we only return uploads with state = 'completed' here
+	query := sqlf.Sprintf(findClosestProcessedUploadsFromGraphFragmentQuery, sqlf.Join(ids, ","), sqlf.Join(conds, " AND "))
 
-	dumps, err := scanDumps(s.db.Query(ctx, query))
+	uploads, err := scanProcessedUploads(s.db.Query(ctx, query))
 	if err != nil {
 		return nil, err
 	}
-	trace.AddEvent("TODO Domain Owner", attribute.Int("numDumps", len(dumps)))
+	trace.AddEvent("TODO Domain Owner", attribute.Int("numUploads", len(uploads)))
 
-	return dumps, nil
+	return uploads, nil
 }
 
-const findClosestDumpsFromGraphFragmentCommitGraphQuery = `
+const findClosestProcessedUploadsFromGraphFragmentCommitGraphQuery = `
 WITH
 visible_uploads AS (
 	-- Select the set of uploads visible from one of the given commits. This is done by
@@ -437,7 +439,7 @@ FROM visible_uploads vu
 JOIN lsif_uploads u ON u.id = vu.upload_id
 `
 
-const findClosestDumpsFromGraphFragmentQuery = `
+const findClosestProcessedUploadsFromGraphFragmentQuery = `
 SELECT
 	u.id,
 	u.commit,
@@ -1084,7 +1086,7 @@ func (s *uploadMetaListSerializer) take() []byte {
 //
 //
 
-func makeFindClosestDumpConditions(path string, rootMustEnclosePath bool, indexer string) (conds []*sqlf.Query) {
+func makeFindClosestProcessUploadsConditions(path string, rootMustEnclosePath bool, indexer string) (conds []*sqlf.Query) {
 	if rootMustEnclosePath {
 		// Ensure that the root is a prefix of the path
 		conds = append(conds, sqlf.Sprintf(`%s LIKE (u.root || '%%%%')`, path))

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -496,7 +496,7 @@ func TestUpdateUploadsVisibleToCommitsOverlappingRoots(t *testing.T) {
 	//          |       |
 	//          +-- 4 --+
 	//
-	// With the following LSIF dumps:
+	// With the following LSIF uploads:
 	//
 	// | UploadID | Commit | Root    | Indexer |
 	// | -------- + ------ + ------- + ------- |
@@ -683,7 +683,7 @@ func TestUpdateUploadsVisibleToCommitsResetsDirtyFlag(t *testing.T) {
 	}
 }
 
-func TestFindClosestDumps(t *testing.T) {
+func TestFindClosestProcessedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -737,7 +737,7 @@ func TestFindClosestDumps(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
+	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
 		{commit: makeCommit(1), file: "file.ts", rootMustEnclosePath: true, graph: graph, anyOfIDs: []int{1}},
 		{commit: makeCommit(2), file: "file.ts", rootMustEnclosePath: true, graph: graph, anyOfIDs: []int{1}},
 		{commit: makeCommit(3), file: "file.ts", rootMustEnclosePath: true, graph: graph, anyOfIDs: []int{2}},
@@ -749,7 +749,7 @@ func TestFindClosestDumps(t *testing.T) {
 	})
 }
 
-func TestFindClosestDumpsAlternateCommitGraph(t *testing.T) {
+func TestFindClosestProcessedUploadsAlternateCommitGraph(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -798,7 +798,7 @@ func TestFindClosestDumpsAlternateCommitGraph(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
+	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
 		{commit: makeCommit(2), graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(3), graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(4), graph: graph},
@@ -809,7 +809,7 @@ func TestFindClosestDumpsAlternateCommitGraph(t *testing.T) {
 	})
 }
 
-func TestFindClosestDumpsAlternateCommitGraphWithOverwrittenVisibleUploads(t *testing.T) {
+func TestFindClosestProcessedUploadsAlternateCommitGraphWithOverwrittenVisibleUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -854,7 +854,7 @@ func TestFindClosestDumpsAlternateCommitGraphWithOverwrittenVisibleUploads(t *te
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
+	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
 		{commit: makeCommit(2), graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(3), graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(4), graph: graph, allOfIDs: []int{1}},
@@ -862,7 +862,7 @@ func TestFindClosestDumpsAlternateCommitGraphWithOverwrittenVisibleUploads(t *te
 	})
 }
 
-func TestFindClosestDumpsDistinctRoots(t *testing.T) {
+func TestFindClosestProcessedUploadsDistinctRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -903,7 +903,7 @@ func TestFindClosestDumpsDistinctRoots(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
+	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
 		{commit: makeCommit(1), file: "blah", rootMustEnclosePath: true, graph: graph},
 		{commit: makeCommit(2), file: "root1/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(1), file: "root2/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{2}},
@@ -912,7 +912,7 @@ func TestFindClosestDumpsDistinctRoots(t *testing.T) {
 	})
 }
 
-func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
+func TestFindClosestProcessedUploadsOverlappingRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -923,7 +923,7 @@ func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
 	//          |       |
 	//          +-- 4 --+
 	//
-	// With the following LSIF dumps:
+	// With the following LSIF uploads:
 	//
 	// | UploadID | Commit | Root    | Indexer |
 	// | -------- + ------ + ------- + ------- |
@@ -983,7 +983,7 @@ func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
+	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
 		{commit: makeCommit(4), file: "root1/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{7, 3}},
 		{commit: makeCommit(5), file: "root2/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{8, 7}},
 		{commit: makeCommit(3), file: "root3/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{5, 1}},
@@ -992,7 +992,7 @@ func TestFindClosestDumpsOverlappingRoots(t *testing.T) {
 	})
 }
 
-func TestFindClosestDumpsIndexerName(t *testing.T) {
+func TestFindClosestProcessedUploadsIndexerName(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -1069,7 +1069,7 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
+	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
 		{commit: makeCommit(5), file: "root1/file.ts", indexer: "idx1", graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(5), file: "root2/file.ts", indexer: "idx1", graph: graph, allOfIDs: []int{2}},
 		{commit: makeCommit(5), file: "root3/file.ts", indexer: "idx1", graph: graph, allOfIDs: []int{3}},
@@ -1081,7 +1081,7 @@ func TestFindClosestDumpsIndexerName(t *testing.T) {
 	})
 }
 
-func TestFindClosestDumpsIntersectingPath(t *testing.T) {
+func TestFindClosestProcessedUploadsIntersectingPath(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -1118,14 +1118,14 @@ func TestFindClosestDumpsIntersectingPath(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
+	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
 		{commit: makeCommit(1), file: "", rootMustEnclosePath: false, graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(1), file: "web/", rootMustEnclosePath: false, graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(1), file: "web/src/file.ts", rootMustEnclosePath: false, graph: graph, allOfIDs: []int{1}},
 	})
 }
 
-func TestFindClosestDumpsFromGraphFragment(t *testing.T) {
+func TestFindClosestProcessedUploadsFromGraphFragment(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -1182,7 +1182,7 @@ func TestFindClosestDumpsFromGraphFragment(t *testing.T) {
 		strings.Join([]string{makeCommit(3)}, " "),
 	})
 
-	testFindClosestDumps(t, store, []FindClosestDumpsTestCase{
+	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
 		// Note: Can't query anything outside of the graph fragment
 		{commit: makeCommit(3), file: "file.ts", rootMustEnclosePath: true, graph: graphFragment, anyOfIDs: []int{1}},
 		{commit: makeCommit(6), file: "file.ts", rootMustEnclosePath: true, graph: graphFragment, anyOfIDs: []int{2}},
@@ -1272,7 +1272,7 @@ func TestCommitGraphMetadata(t *testing.T) {
 //
 //
 
-type FindClosestDumpsTestCase struct {
+type FindClosestProcessedUploadsTestCase struct {
 	commit              string
 	file                string
 	rootMustEnclosePath bool
@@ -1283,7 +1283,7 @@ type FindClosestDumpsTestCase struct {
 	allOfIDs            []int
 }
 
-func testFindClosestDumps(t *testing.T, store Store, testCases []FindClosestDumpsTestCase) {
+func testFindClosestProcessedUploads(t *testing.T, store Store, testCases []FindClosestProcessedUploadsTestCase) {
 	for _, testCase := range testCases {
 		name := fmt.Sprintf(
 			"commit=%s file=%s rootMustEnclosePath=%v indexer=%s",
@@ -1293,55 +1293,55 @@ func testFindClosestDumps(t *testing.T, store Store, testCases []FindClosestDump
 			testCase.indexer,
 		)
 
-		assertDumpIDs := func(t *testing.T, dumps []shared.Dump) {
+		assertUploadIDs := func(t *testing.T, uploads []shared.ProcessedUpload) {
 			if len(testCase.anyOfIDs) > 0 {
-				testAnyOf(t, dumps, testCase.anyOfIDs)
+				testAnyOf(t, uploads, testCase.anyOfIDs)
 				return
 			}
 
 			if len(testCase.allOfIDs) > 0 {
-				testAllOf(t, dumps, testCase.allOfIDs)
+				testAllOf(t, uploads, testCase.allOfIDs)
 				return
 			}
 
-			if len(dumps) != 0 {
-				t.Errorf("unexpected nearest dump length. want=%d have=%d", 0, len(dumps))
+			if len(uploads) != 0 {
+				t.Errorf("unexpected nearest upload length. want=%d have=%d", 0, len(uploads))
 				return
 			}
 		}
 
 		if !testCase.graphFragmentOnly {
 			t.Run(name, func(t *testing.T) {
-				dumps, err := store.FindClosestDumps(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer)
+				uploads, err := store.FindClosestProcessedUploads(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer)
 				if err != nil {
-					t.Fatalf("unexpected error finding closest dumps: %s", err)
+					t.Fatalf("unexpected error finding closest uploads: %s", err)
 				}
 
-				assertDumpIDs(t, dumps)
+				assertUploadIDs(t, uploads)
 			})
 		}
 
 		if testCase.graph != nil {
 			t.Run(name+" [graph-fragment]", func(t *testing.T) {
-				dumps, err := store.FindClosestDumpsFromGraphFragment(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer, testCase.graph)
+				uploads, err := store.FindClosestProcessedUploadsFromGraphFragment(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer, testCase.graph)
 				if err != nil {
-					t.Fatalf("unexpected error finding closest dumps: %s", err)
+					t.Fatalf("unexpected error finding closest uploads: %s", err)
 				}
 
-				assertDumpIDs(t, dumps)
+				assertUploadIDs(t, uploads)
 			})
 		}
 	}
 }
 
-func testAnyOf(t *testing.T, dumps []shared.Dump, expectedIDs []int) {
-	if len(dumps) != 1 {
-		t.Errorf("unexpected nearest dump length. want=%d have=%d", 1, len(dumps))
+func testAnyOf(t *testing.T, uploads []shared.ProcessedUpload, expectedIDs []int) {
+	if len(uploads) != 1 {
+		t.Errorf("unexpected nearest upload length. want=%d have=%d", 1, len(uploads))
 		return
 	}
 
-	if !testPresence(dumps[0].ID, expectedIDs) {
-		t.Errorf("unexpected nearest dump ids. want one of %v have=%v", expectedIDs, dumps[0].ID)
+	if !testPresence(uploads[0].ID, expectedIDs) {
+		t.Errorf("unexpected nearest dump ids. want one of %v have=%v", expectedIDs, uploads[0].ID)
 	}
 }
 
@@ -1355,19 +1355,19 @@ func testPresence(needle int, haystack []int) bool {
 	return false
 }
 
-func testAllOf(t *testing.T, dumps []shared.Dump, expectedIDs []int) {
-	if len(dumps) != len(expectedIDs) {
-		t.Errorf("unexpected nearest dump length. want=%d have=%d", 1, len(dumps))
+func testAllOf(t *testing.T, uploads []shared.ProcessedUpload, expectedIDs []int) {
+	if len(uploads) != len(expectedIDs) {
+		t.Errorf("unexpected nearest upload length. want=%d have=%d", 1, len(uploads))
 	}
 
-	var dumpIDs []int
-	for _, dump := range dumps {
-		dumpIDs = append(dumpIDs, dump.ID)
+	var uploadIDs []int
+	for _, dump := range uploads {
+		uploadIDs = append(uploadIDs, dump.ID)
 	}
 
 	for _, expectedID := range expectedIDs {
-		if !testPresence(expectedID, dumpIDs) {
-			t.Errorf("unexpected nearest dump ids. want all of %v have=%v", expectedIDs, dumpIDs)
+		if !testPresence(expectedID, uploadIDs) {
+			t.Errorf("unexpected nearest dump ids. want all of %v have=%v", expectedIDs, uploadIDs)
 			return
 		}
 	}

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -1361,8 +1361,8 @@ func testAllOf(t *testing.T, uploads []shared.CompletedUpload, expectedIDs []int
 	}
 
 	var uploadIDs []int
-	for _, dump := range uploads {
-		uploadIDs = append(uploadIDs, dump.ID)
+	for _, upload := range uploads {
+		uploadIDs = append(uploadIDs, upload.ID)
 	}
 
 	for _, expectedID := range expectedIDs {

--- a/internal/codeintel/uploads/internal/store/commitgraph_test.go
+++ b/internal/codeintel/uploads/internal/store/commitgraph_test.go
@@ -683,7 +683,7 @@ func TestUpdateUploadsVisibleToCommitsResetsDirtyFlag(t *testing.T) {
 	}
 }
 
-func TestFindClosestProcessedUploads(t *testing.T) {
+func TestFindClosestCompletedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -737,7 +737,7 @@ func TestFindClosestProcessedUploads(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
+	testFindClosestCompletedUploads(t, store, []FindClosestCompletedUploadsTestCase{
 		{commit: makeCommit(1), file: "file.ts", rootMustEnclosePath: true, graph: graph, anyOfIDs: []int{1}},
 		{commit: makeCommit(2), file: "file.ts", rootMustEnclosePath: true, graph: graph, anyOfIDs: []int{1}},
 		{commit: makeCommit(3), file: "file.ts", rootMustEnclosePath: true, graph: graph, anyOfIDs: []int{2}},
@@ -749,7 +749,7 @@ func TestFindClosestProcessedUploads(t *testing.T) {
 	})
 }
 
-func TestFindClosestProcessedUploadsAlternateCommitGraph(t *testing.T) {
+func TestFindClosestCompletedUploadsAlternateCommitGraph(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -798,7 +798,7 @@ func TestFindClosestProcessedUploadsAlternateCommitGraph(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
+	testFindClosestCompletedUploads(t, store, []FindClosestCompletedUploadsTestCase{
 		{commit: makeCommit(2), graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(3), graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(4), graph: graph},
@@ -809,7 +809,7 @@ func TestFindClosestProcessedUploadsAlternateCommitGraph(t *testing.T) {
 	})
 }
 
-func TestFindClosestProcessedUploadsAlternateCommitGraphWithOverwrittenVisibleUploads(t *testing.T) {
+func TestFindClosestCompletedUploadsAlternateCommitGraphWithOverwrittenVisibleUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -854,7 +854,7 @@ func TestFindClosestProcessedUploadsAlternateCommitGraphWithOverwrittenVisibleUp
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
+	testFindClosestCompletedUploads(t, store, []FindClosestCompletedUploadsTestCase{
 		{commit: makeCommit(2), graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(3), graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(4), graph: graph, allOfIDs: []int{1}},
@@ -862,7 +862,7 @@ func TestFindClosestProcessedUploadsAlternateCommitGraphWithOverwrittenVisibleUp
 	})
 }
 
-func TestFindClosestProcessedUploadsDistinctRoots(t *testing.T) {
+func TestFindClosestCompletedUploadsDistinctRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -903,7 +903,7 @@ func TestFindClosestProcessedUploadsDistinctRoots(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
+	testFindClosestCompletedUploads(t, store, []FindClosestCompletedUploadsTestCase{
 		{commit: makeCommit(1), file: "blah", rootMustEnclosePath: true, graph: graph},
 		{commit: makeCommit(2), file: "root1/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(1), file: "root2/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{2}},
@@ -912,7 +912,7 @@ func TestFindClosestProcessedUploadsDistinctRoots(t *testing.T) {
 	})
 }
 
-func TestFindClosestProcessedUploadsOverlappingRoots(t *testing.T) {
+func TestFindClosestCompletedUploadsOverlappingRoots(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -983,7 +983,7 @@ func TestFindClosestProcessedUploadsOverlappingRoots(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
+	testFindClosestCompletedUploads(t, store, []FindClosestCompletedUploadsTestCase{
 		{commit: makeCommit(4), file: "root1/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{7, 3}},
 		{commit: makeCommit(5), file: "root2/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{8, 7}},
 		{commit: makeCommit(3), file: "root3/file.ts", rootMustEnclosePath: true, graph: graph, allOfIDs: []int{5, 1}},
@@ -992,7 +992,7 @@ func TestFindClosestProcessedUploadsOverlappingRoots(t *testing.T) {
 	})
 }
 
-func TestFindClosestProcessedUploadsIndexerName(t *testing.T) {
+func TestFindClosestCompletedUploadsIndexerName(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -1069,7 +1069,7 @@ func TestFindClosestProcessedUploadsIndexerName(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
+	testFindClosestCompletedUploads(t, store, []FindClosestCompletedUploadsTestCase{
 		{commit: makeCommit(5), file: "root1/file.ts", indexer: "idx1", graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(5), file: "root2/file.ts", indexer: "idx1", graph: graph, allOfIDs: []int{2}},
 		{commit: makeCommit(5), file: "root3/file.ts", indexer: "idx1", graph: graph, allOfIDs: []int{3}},
@@ -1081,7 +1081,7 @@ func TestFindClosestProcessedUploadsIndexerName(t *testing.T) {
 	})
 }
 
-func TestFindClosestProcessedUploadsIntersectingPath(t *testing.T) {
+func TestFindClosestCompletedUploadsIntersectingPath(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -1118,14 +1118,14 @@ func TestFindClosestProcessedUploadsIntersectingPath(t *testing.T) {
 	insertLinks(t, db, 50, links)
 
 	// Test
-	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
+	testFindClosestCompletedUploads(t, store, []FindClosestCompletedUploadsTestCase{
 		{commit: makeCommit(1), file: "", rootMustEnclosePath: false, graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(1), file: "web/", rootMustEnclosePath: false, graph: graph, allOfIDs: []int{1}},
 		{commit: makeCommit(1), file: "web/src/file.ts", rootMustEnclosePath: false, graph: graph, allOfIDs: []int{1}},
 	})
 }
 
-func TestFindClosestProcessedUploadsFromGraphFragment(t *testing.T) {
+func TestFindClosestCompletedUploadsFromGraphFragment(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
@@ -1182,7 +1182,7 @@ func TestFindClosestProcessedUploadsFromGraphFragment(t *testing.T) {
 		strings.Join([]string{makeCommit(3)}, " "),
 	})
 
-	testFindClosestProcessedUploads(t, store, []FindClosestProcessedUploadsTestCase{
+	testFindClosestCompletedUploads(t, store, []FindClosestCompletedUploadsTestCase{
 		// Note: Can't query anything outside of the graph fragment
 		{commit: makeCommit(3), file: "file.ts", rootMustEnclosePath: true, graph: graphFragment, anyOfIDs: []int{1}},
 		{commit: makeCommit(6), file: "file.ts", rootMustEnclosePath: true, graph: graphFragment, anyOfIDs: []int{2}},
@@ -1272,7 +1272,7 @@ func TestCommitGraphMetadata(t *testing.T) {
 //
 //
 
-type FindClosestProcessedUploadsTestCase struct {
+type FindClosestCompletedUploadsTestCase struct {
 	commit              string
 	file                string
 	rootMustEnclosePath bool
@@ -1283,7 +1283,7 @@ type FindClosestProcessedUploadsTestCase struct {
 	allOfIDs            []int
 }
 
-func testFindClosestProcessedUploads(t *testing.T, store Store, testCases []FindClosestProcessedUploadsTestCase) {
+func testFindClosestCompletedUploads(t *testing.T, store Store, testCases []FindClosestCompletedUploadsTestCase) {
 	for _, testCase := range testCases {
 		name := fmt.Sprintf(
 			"commit=%s file=%s rootMustEnclosePath=%v indexer=%s",
@@ -1293,7 +1293,7 @@ func testFindClosestProcessedUploads(t *testing.T, store Store, testCases []Find
 			testCase.indexer,
 		)
 
-		assertUploadIDs := func(t *testing.T, uploads []shared.ProcessedUpload) {
+		assertUploadIDs := func(t *testing.T, uploads []shared.CompletedUpload) {
 			if len(testCase.anyOfIDs) > 0 {
 				testAnyOf(t, uploads, testCase.anyOfIDs)
 				return
@@ -1312,7 +1312,7 @@ func testFindClosestProcessedUploads(t *testing.T, store Store, testCases []Find
 
 		if !testCase.graphFragmentOnly {
 			t.Run(name, func(t *testing.T) {
-				uploads, err := store.FindClosestProcessedUploads(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer)
+				uploads, err := store.FindClosestCompletedUploads(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer)
 				if err != nil {
 					t.Fatalf("unexpected error finding closest uploads: %s", err)
 				}
@@ -1323,7 +1323,7 @@ func testFindClosestProcessedUploads(t *testing.T, store Store, testCases []Find
 
 		if testCase.graph != nil {
 			t.Run(name+" [graph-fragment]", func(t *testing.T) {
-				uploads, err := store.FindClosestProcessedUploadsFromGraphFragment(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer, testCase.graph)
+				uploads, err := store.FindClosestCompletedUploadsFromGraphFragment(context.Background(), 50, testCase.commit, testCase.file, testCase.rootMustEnclosePath, testCase.indexer, testCase.graph)
 				if err != nil {
 					t.Fatalf("unexpected error finding closest uploads: %s", err)
 				}
@@ -1334,7 +1334,7 @@ func testFindClosestProcessedUploads(t *testing.T, store Store, testCases []Find
 	}
 }
 
-func testAnyOf(t *testing.T, uploads []shared.ProcessedUpload, expectedIDs []int) {
+func testAnyOf(t *testing.T, uploads []shared.CompletedUpload, expectedIDs []int) {
 	if len(uploads) != 1 {
 		t.Errorf("unexpected nearest upload length. want=%d have=%d", 1, len(uploads))
 		return
@@ -1355,7 +1355,7 @@ func testPresence(needle int, haystack []int) bool {
 	return false
 }
 
-func testAllOf(t *testing.T, uploads []shared.ProcessedUpload, expectedIDs []int) {
+func testAllOf(t *testing.T, uploads []shared.CompletedUpload, expectedIDs []int) {
 	if len(uploads) != len(expectedIDs) {
 		t.Errorf("unexpected nearest upload length. want=%d have=%d", 1, len(uploads))
 	}

--- a/internal/codeintel/uploads/internal/store/dependencies.go
+++ b/internal/codeintel/uploads/internal/store/dependencies.go
@@ -37,7 +37,7 @@ ORDER BY r.scheme, r.manager, r.name, r.version
 `
 
 // UpdatePackages upserts package data tied to the given upload.
-func (s *store) UpdatePackages(ctx context.Context, dumpID int, packages []precise.Package) (err error) {
+func (s *store) UpdatePackages(ctx context.Context, uploadID int, packages []precise.Package) (err error) {
 	ctx, _, endObservation := s.operations.updatePackages.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("numPackages", len(packages)),
 	}})
@@ -67,7 +67,7 @@ func (s *store) UpdatePackages(ctx context.Context, dumpID int, packages []preci
 
 		// Insert the values from the temporary table into the target table. We select a
 		// parameterized dump id here since it is the same for all rows in this operation.
-		return tx.db.Exec(ctx, sqlf.Sprintf(updatePackagesInsertQuery, dumpID))
+		return tx.db.Exec(ctx, sqlf.Sprintf(updatePackagesInsertQuery, uploadID))
 	})
 }
 
@@ -101,7 +101,7 @@ func loadPackagesChannel(packages []precise.Package) <-chan []any {
 }
 
 // UpdatePackageReferences inserts reference data tied to the given upload.
-func (s *store) UpdatePackageReferences(ctx context.Context, dumpID int, references []precise.PackageReference) (err error) {
+func (s *store) UpdatePackageReferences(ctx context.Context, uploadID int, references []precise.PackageReference) (err error) {
 	ctx, _, endObservation := s.operations.updatePackageReferences.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("numReferences", len(references)),
 	}})
@@ -131,7 +131,7 @@ func (s *store) UpdatePackageReferences(ctx context.Context, dumpID int, referen
 
 		// Insert the values from the temporary table into the target table. We select a
 		// parameterized dump id here since it is the same for all rows in this operation.
-		return tx.db.Exec(ctx, sqlf.Sprintf(updateReferencesInsertQuery, dumpID))
+		return tx.db.Exec(ctx, sqlf.Sprintf(updateReferencesInsertQuery, uploadID))
 	})
 }
 
@@ -185,7 +185,7 @@ func (s *rowScanner) Next() (reference shared.PackageReference, _ bool, _ error)
 	}
 
 	if err := s.rows.Scan(
-		&reference.DumpID,
+		&reference.UploadID,
 		&reference.Scheme,
 		&reference.Manager,
 		&reference.Name,

--- a/internal/codeintel/uploads/internal/store/dependencies_test.go
+++ b/internal/codeintel/uploads/internal/store/dependencies_test.go
@@ -29,11 +29,11 @@ func TestReferencesForUpload(t *testing.T) {
 	)
 
 	insertPackageReferences(t, store, []shared.PackageReference{
-		{Package: shared.Package{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "1.1.0"}},
-		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "2.1.0"}},
-		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "3.1.0"}},
-		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "4.1.0"}},
-		{Package: shared.Package{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "5.1.0"}},
+		{Package: shared.Package{UploadID: 1, Scheme: "gomod", Name: "leftpad", Version: "1.1.0"}},
+		{Package: shared.Package{UploadID: 2, Scheme: "gomod", Name: "leftpad", Version: "2.1.0"}},
+		{Package: shared.Package{UploadID: 2, Scheme: "gomod", Name: "leftpad", Version: "3.1.0"}},
+		{Package: shared.Package{UploadID: 2, Scheme: "gomod", Name: "leftpad", Version: "4.1.0"}},
+		{Package: shared.Package{UploadID: 3, Scheme: "gomod", Name: "leftpad", Version: "5.1.0"}},
 	})
 
 	scanner, err := store.ReferencesForUpload(context.Background(), 2)
@@ -47,9 +47,9 @@ func TestReferencesForUpload(t *testing.T) {
 	}
 
 	expected := []shared.PackageReference{
-		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "2.1.0"}},
-		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "3.1.0"}},
-		{Package: shared.Package{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "4.1.0"}},
+		{Package: shared.Package{UploadID: 2, Scheme: "gomod", Name: "leftpad", Version: "2.1.0"}},
+		{Package: shared.Package{UploadID: 2, Scheme: "gomod", Name: "leftpad", Version: "3.1.0"}},
+		{Package: shared.Package{UploadID: 2, Scheme: "gomod", Name: "leftpad", Version: "4.1.0"}},
 	}
 	if diff := cmp.Diff(expected, filters); diff != "" {
 		t.Errorf("unexpected filters (-want +got):\n%s", diff)

--- a/internal/codeintel/uploads/internal/store/expiration_test.go
+++ b/internal/codeintel/uploads/internal/store/expiration_test.go
@@ -29,24 +29,24 @@ func TestSoftDeleteExpiredUploads(t *testing.T) {
 		shared.Upload{ID: 56, RepositoryID: 103, State: "completed"}, // referenced by 52, 53
 	)
 	insertPackages(t, store, []shared.Package{
-		{DumpID: 53, Scheme: "test", Name: "p1", Version: "1.2.3"},
-		{DumpID: 54, Scheme: "test", Name: "p2", Version: "1.2.3"},
-		{DumpID: 55, Scheme: "test", Name: "p3", Version: "1.2.3"},
-		{DumpID: 56, Scheme: "test", Name: "p4", Version: "1.2.3"},
+		{UploadID: 53, Scheme: "test", Name: "p1", Version: "1.2.3"},
+		{UploadID: 54, Scheme: "test", Name: "p2", Version: "1.2.3"},
+		{UploadID: 55, Scheme: "test", Name: "p3", Version: "1.2.3"},
+		{UploadID: 56, Scheme: "test", Name: "p4", Version: "1.2.3"},
 	})
 	insertPackageReferences(t, store, []shared.PackageReference{
 		// References removed
-		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 51, Scheme: "test", Name: "p3", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 52, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 52, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 51, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 51, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 51, Scheme: "test", Name: "p3", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 52, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 52, Scheme: "test", Name: "p4", Version: "1.2.3"}},
 
 		// Remaining references
-		{Package: shared.Package{DumpID: 53, Scheme: "test", Name: "p4", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 55, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 56, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 53, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 54, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 55, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 56, Scheme: "test", Name: "p1", Version: "1.2.3"}},
 	})
 
 	// expire uploads 51-54
@@ -129,32 +129,32 @@ func TestSoftDeleteExpiredUploadsViaTraversal(t *testing.T) {
 		shared.Upload{ID: 108, RepositoryID: 58, State: "completed"}, // Referenced by 107
 	)
 	insertPackages(t, store, []shared.Package{
-		{DumpID: 100, Scheme: "test", Name: "p1", Version: "1.2.3"},
-		{DumpID: 101, Scheme: "test", Name: "p2", Version: "1.2.3"},
-		{DumpID: 102, Scheme: "test", Name: "p3", Version: "1.2.3"},
-		{DumpID: 103, Scheme: "test", Name: "p4", Version: "1.2.3"},
-		{DumpID: 104, Scheme: "test", Name: "p5", Version: "1.2.3"},
-		{DumpID: 105, Scheme: "test", Name: "p6", Version: "1.2.3"},
-		{DumpID: 106, Scheme: "test", Name: "p7", Version: "1.2.3"},
+		{UploadID: 100, Scheme: "test", Name: "p1", Version: "1.2.3"},
+		{UploadID: 101, Scheme: "test", Name: "p2", Version: "1.2.3"},
+		{UploadID: 102, Scheme: "test", Name: "p3", Version: "1.2.3"},
+		{UploadID: 103, Scheme: "test", Name: "p4", Version: "1.2.3"},
+		{UploadID: 104, Scheme: "test", Name: "p5", Version: "1.2.3"},
+		{UploadID: 105, Scheme: "test", Name: "p6", Version: "1.2.3"},
+		{UploadID: 106, Scheme: "test", Name: "p7", Version: "1.2.3"},
 
 		// Another component
-		{DumpID: 107, Scheme: "test", Name: "p8", Version: "1.2.3"},
-		{DumpID: 108, Scheme: "test", Name: "p9", Version: "1.2.3"},
+		{UploadID: 107, Scheme: "test", Name: "p8", Version: "1.2.3"},
+		{UploadID: 108, Scheme: "test", Name: "p9", Version: "1.2.3"},
 	})
 	insertPackageReferences(t, store, []shared.PackageReference{
-		{Package: shared.Package{DumpID: 100, Scheme: "test", Name: "p2", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 101, Scheme: "test", Name: "p3", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 102, Scheme: "test", Name: "p4", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 103, Scheme: "test", Name: "p5", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 104, Scheme: "test", Name: "p1", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 104, Scheme: "test", Name: "p2", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 105, Scheme: "test", Name: "p5", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 106, Scheme: "test", Name: "p6", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 105, Scheme: "test", Name: "p7", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 100, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 101, Scheme: "test", Name: "p3", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 102, Scheme: "test", Name: "p4", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 103, Scheme: "test", Name: "p5", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 104, Scheme: "test", Name: "p1", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 104, Scheme: "test", Name: "p2", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 105, Scheme: "test", Name: "p5", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 106, Scheme: "test", Name: "p6", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 105, Scheme: "test", Name: "p7", Version: "1.2.3"}},
 
 		// Another component
-		{Package: shared.Package{DumpID: 107, Scheme: "test", Name: "p9", Version: "1.2.3"}},
-		{Package: shared.Package{DumpID: 108, Scheme: "test", Name: "p8", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 107, Scheme: "test", Name: "p9", Version: "1.2.3"}},
+		{Package: shared.Package{UploadID: 108, Scheme: "test", Name: "p8", Version: "1.2.3"}},
 	})
 
 	// We'll first confirm that none of the uploads can be deleted by either of the soft delete mechanisms;

--- a/internal/codeintel/uploads/internal/store/observability.go
+++ b/internal/codeintel/uploads/internal/store/observability.go
@@ -62,11 +62,11 @@ type operations struct {
 	deleteUploads                        *observation.Operation
 
 	// Dumps
-	findClosestProcessedUploads                   *observation.Operation
-	findClosestProcessedUploadsFromGraphFragment  *observation.Operation
-	getProcessedUploadsWithDefinitionsForMonikers *observation.Operation
-	getProcessedUploadsByIDs                      *observation.Operation
-	deleteOverlappingProcessedUploads             *observation.Operation
+	findClosestCompletedUploads                   *observation.Operation
+	findClosestCompletedUploadsFromGraphFragment  *observation.Operation
+	getCompletedUploadsWithDefinitionsForMonikers *observation.Operation
+	getCompletedUploadsByIDs                      *observation.Operation
+	deleteOverlappingCompletedUploads             *observation.Operation
 
 	// Packages
 	updatePackages *observation.Operation
@@ -169,11 +169,11 @@ func newOperations(observationCtx *observation.Context) *operations {
 		persistUploadsVisibleAtTip: op("persistUploadsVisibleAtTip"),
 
 		// Dumps
-		findClosestProcessedUploads:                   op("FindClosestProcessedUploads"),
-		findClosestProcessedUploadsFromGraphFragment:  op("FindClosestProcessedUploadsFromGraphFragment"),
-		getProcessedUploadsWithDefinitionsForMonikers: op("GetUploadsWithDefinitionsForMonikers"),
-		getProcessedUploadsByIDs:                      op("GetProcessedUploadsByIDs"),
-		deleteOverlappingProcessedUploads:             op("DeleteOverlappingProcessedUploads"),
+		findClosestCompletedUploads:                   op("FindClosestCompletedUploads"),
+		findClosestCompletedUploadsFromGraphFragment:  op("FindClosestCompletedUploadsFromGraphFragment"),
+		getCompletedUploadsWithDefinitionsForMonikers: op("GetUploadsWithDefinitionsForMonikers"),
+		getCompletedUploadsByIDs:                      op("GetCompletedUploadsByIDs"),
+		deleteOverlappingCompletedUploads:             op("DeleteOverlappingCompletedUploads"),
 
 		// Packages
 		updatePackages: op("UpdatePackages"),

--- a/internal/codeintel/uploads/internal/store/observability.go
+++ b/internal/codeintel/uploads/internal/store/observability.go
@@ -62,11 +62,11 @@ type operations struct {
 	deleteUploads                        *observation.Operation
 
 	// Dumps
-	findClosestDumps                   *observation.Operation
-	findClosestDumpsFromGraphFragment  *observation.Operation
-	getDumpsWithDefinitionsForMonikers *observation.Operation
-	getDumpsByIDs                      *observation.Operation
-	deleteOverlappingDumps             *observation.Operation
+	findClosestProcessedUploads                   *observation.Operation
+	findClosestProcessedUploadsFromGraphFragment  *observation.Operation
+	getProcessedUploadsWithDefinitionsForMonikers *observation.Operation
+	getProcessedUploadsByIDs                      *observation.Operation
+	deleteOverlappingProcessedUploads             *observation.Operation
 
 	// Packages
 	updatePackages *observation.Operation
@@ -169,11 +169,11 @@ func newOperations(observationCtx *observation.Context) *operations {
 		persistUploadsVisibleAtTip: op("persistUploadsVisibleAtTip"),
 
 		// Dumps
-		findClosestDumps:                   op("FindClosestDumps"),
-		findClosestDumpsFromGraphFragment:  op("FindClosestDumpsFromGraphFragment"),
-		getDumpsWithDefinitionsForMonikers: op("GetUploadsWithDefinitionsForMonikers"),
-		getDumpsByIDs:                      op("GetDumpsByIDs"),
-		deleteOverlappingDumps:             op("DeleteOverlappingDumps"),
+		findClosestProcessedUploads:                   op("FindClosestProcessedUploads"),
+		findClosestProcessedUploadsFromGraphFragment:  op("FindClosestProcessedUploadsFromGraphFragment"),
+		getProcessedUploadsWithDefinitionsForMonikers: op("GetUploadsWithDefinitionsForMonikers"),
+		getProcessedUploadsByIDs:                      op("GetProcessedUploadsByIDs"),
+		deleteOverlappingProcessedUploads:             op("DeleteOverlappingProcessedUploads"),
 
 		// Packages
 		updatePackages: op("UpdatePackages"),

--- a/internal/codeintel/uploads/internal/store/processing.go
+++ b/internal/codeintel/uploads/internal/store/processing.go
@@ -125,11 +125,11 @@ WHERE
 	id = %s
 `
 
-// DeleteOverlapapingDumps deletes all completed uploads for the given repository with the same
+// DeleteOverlapapingProcessedUploads deletes all completed uploads for the given repository with the same
 // commit, root, and indexer. This is necessary to perform during conversions before changing
 // the state of a processing upload to completed as there is a unique index on these four columns.
-func (s *store) DeleteOverlappingDumps(ctx context.Context, repositoryID int, commit, root, indexer string) (err error) {
-	ctx, trace, endObservation := s.operations.deleteOverlappingDumps.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+func (s *store) DeleteOverlappingProcessedUploads(ctx context.Context, repositoryID int, commit, root, indexer string) (err error) {
+	ctx, trace, endObservation := s.operations.deleteOverlappingProcessedUploads.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repositoryID", repositoryID),
 		attribute.String("commit", commit),
 		attribute.String("root", root),
@@ -139,7 +139,7 @@ func (s *store) DeleteOverlappingDumps(ctx context.Context, repositoryID int, co
 
 	unset, _ := s.db.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "upload overlapping with a newer upload")
 	defer unset(ctx)
-	count, _, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(deleteOverlappingDumpsQuery, repositoryID, commit, root, indexer)))
+	count, _, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(deleteOverlappingProcessedUploadsQuery, repositoryID, commit, root, indexer)))
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (s *store) DeleteOverlappingDumps(ctx context.Context, repositoryID int, co
 	return nil
 }
 
-const deleteOverlappingDumpsQuery = `
+const deleteOverlappingProcessedUploadsQuery = `
 WITH
 candidates AS (
 	SELECT u.id

--- a/internal/codeintel/uploads/internal/store/processing.go
+++ b/internal/codeintel/uploads/internal/store/processing.go
@@ -125,11 +125,11 @@ WHERE
 	id = %s
 `
 
-// DeleteOverlapapingProcessedUploads deletes all completed uploads for the given repository with the same
+// DeleteOverlapapingCompletedUploads deletes all completed uploads for the given repository with the same
 // commit, root, and indexer. This is necessary to perform during conversions before changing
 // the state of a processing upload to completed as there is a unique index on these four columns.
-func (s *store) DeleteOverlappingProcessedUploads(ctx context.Context, repositoryID int, commit, root, indexer string) (err error) {
-	ctx, trace, endObservation := s.operations.deleteOverlappingProcessedUploads.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+func (s *store) DeleteOverlappingCompletedUploads(ctx context.Context, repositoryID int, commit, root, indexer string) (err error) {
+	ctx, trace, endObservation := s.operations.deleteOverlappingCompletedUploads.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repositoryID", repositoryID),
 		attribute.String("commit", commit),
 		attribute.String("root", root),
@@ -139,7 +139,7 @@ func (s *store) DeleteOverlappingProcessedUploads(ctx context.Context, repositor
 
 	unset, _ := s.db.SetLocal(ctx, "codeintel.lsif_uploads_audit.reason", "upload overlapping with a newer upload")
 	defer unset(ctx)
-	count, _, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(deleteOverlappingProcessedUploadsQuery, repositoryID, commit, root, indexer)))
+	count, _, err := basestore.ScanFirstInt(s.db.Query(ctx, sqlf.Sprintf(deleteOverlappingCompletedUploadsQuery, repositoryID, commit, root, indexer)))
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func (s *store) DeleteOverlappingProcessedUploads(ctx context.Context, repositor
 	return nil
 }
 
-const deleteOverlappingProcessedUploadsQuery = `
+const deleteOverlappingCompletedUploadsQuery = `
 WITH
 candidates AS (
 	SELECT u.id

--- a/internal/codeintel/uploads/internal/store/processing_test.go
+++ b/internal/codeintel/uploads/internal/store/processing_test.go
@@ -277,7 +277,7 @@ func TestMarkFailed(t *testing.T) {
 	}
 }
 
-func TestDeleteOverlappingDumps(t *testing.T) {
+func TestDeleteOverlappingProcessedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
@@ -290,7 +290,7 @@ func TestDeleteOverlappingDumps(t *testing.T) {
 		Indexer: "lsif-go",
 	})
 
-	err := store.DeleteOverlappingDumps(context.Background(), 50, makeCommit(1), "cmd/", "lsif-go")
+	err := store.DeleteOverlappingProcessedUploads(context.Background(), 50, makeCommit(1), "cmd/", "lsif-go")
 	if err != nil {
 		t.Fatalf("unexpected error deleting dump: %s", err)
 	}
@@ -303,7 +303,7 @@ func TestDeleteOverlappingDumps(t *testing.T) {
 	}
 }
 
-func TestDeleteOverlappingDumpsNoMatches(t *testing.T) {
+func TestDeleteOverlappingProcessedUploadsNoMatches(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
@@ -327,21 +327,21 @@ func TestDeleteOverlappingDumpsNoMatches(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := store.DeleteOverlappingDumps(context.Background(), 50, testCase.commit, testCase.root, testCase.indexer)
+		err := store.DeleteOverlappingProcessedUploads(context.Background(), 50, testCase.commit, testCase.root, testCase.indexer)
 		if err != nil {
 			t.Fatalf("unexpected error deleting dump: %s", err)
 		}
 	}
 
 	// Original dump still exists
-	if dumps, err := store.GetDumpsByIDs(context.Background(), []int{1}); err != nil {
+	if uploads, err := store.GetProcessedUploadsByIDs(context.Background(), []int{1}); err != nil {
 		t.Fatalf("unexpected error getting dump: %s", err)
-	} else if len(dumps) != 1 {
+	} else if len(uploads) != 1 {
 		t.Fatal("expected dump record to still exist")
 	}
 }
 
-func TestDeleteOverlappingDumpsIgnoresIncompleteUploads(t *testing.T) {
+func TestDeleteOverlappingProcessedUploadsIgnoresIncompleteUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
@@ -355,7 +355,7 @@ func TestDeleteOverlappingDumpsIgnoresIncompleteUploads(t *testing.T) {
 		State:   "queued",
 	})
 
-	err := store.DeleteOverlappingDumps(context.Background(), 50, makeCommit(1), "cmd/", "lsif-go")
+	err := store.DeleteOverlappingProcessedUploads(context.Background(), 50, makeCommit(1), "cmd/", "lsif-go")
 	if err != nil {
 		t.Fatalf("unexpected error deleting dump: %s", err)
 	}

--- a/internal/codeintel/uploads/internal/store/processing_test.go
+++ b/internal/codeintel/uploads/internal/store/processing_test.go
@@ -277,7 +277,7 @@ func TestMarkFailed(t *testing.T) {
 	}
 }
 
-func TestDeleteOverlappingProcessedUploads(t *testing.T) {
+func TestDeleteOverlappingCompletedUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
@@ -290,7 +290,7 @@ func TestDeleteOverlappingProcessedUploads(t *testing.T) {
 		Indexer: "lsif-go",
 	})
 
-	err := store.DeleteOverlappingProcessedUploads(context.Background(), 50, makeCommit(1), "cmd/", "lsif-go")
+	err := store.DeleteOverlappingCompletedUploads(context.Background(), 50, makeCommit(1), "cmd/", "lsif-go")
 	if err != nil {
 		t.Fatalf("unexpected error deleting dump: %s", err)
 	}
@@ -303,7 +303,7 @@ func TestDeleteOverlappingProcessedUploads(t *testing.T) {
 	}
 }
 
-func TestDeleteOverlappingProcessedUploadsNoMatches(t *testing.T) {
+func TestDeleteOverlappingCompletedUploadsNoMatches(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
@@ -327,21 +327,21 @@ func TestDeleteOverlappingProcessedUploadsNoMatches(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		err := store.DeleteOverlappingProcessedUploads(context.Background(), 50, testCase.commit, testCase.root, testCase.indexer)
+		err := store.DeleteOverlappingCompletedUploads(context.Background(), 50, testCase.commit, testCase.root, testCase.indexer)
 		if err != nil {
 			t.Fatalf("unexpected error deleting dump: %s", err)
 		}
 	}
 
 	// Original dump still exists
-	if uploads, err := store.GetProcessedUploadsByIDs(context.Background(), []int{1}); err != nil {
+	if uploads, err := store.GetCompletedUploadsByIDs(context.Background(), []int{1}); err != nil {
 		t.Fatalf("unexpected error getting dump: %s", err)
 	} else if len(uploads) != 1 {
 		t.Fatal("expected dump record to still exist")
 	}
 }
 
-func TestDeleteOverlappingProcessedUploadsIgnoresIncompleteUploads(t *testing.T) {
+func TestDeleteOverlappingCompletedUploadsIgnoresIncompleteUploads(t *testing.T) {
 	logger := logtest.Scoped(t)
 	sqlDB := dbtest.NewDB(t)
 	db := database.NewDB(logger, sqlDB)
@@ -355,7 +355,7 @@ func TestDeleteOverlappingProcessedUploadsIgnoresIncompleteUploads(t *testing.T)
 		State:   "queued",
 	})
 
-	err := store.DeleteOverlappingProcessedUploads(context.Background(), 50, makeCommit(1), "cmd/", "lsif-go")
+	err := store.DeleteOverlappingCompletedUploads(context.Background(), 50, makeCommit(1), "cmd/", "lsif-go")
 	if err != nil {
 		t.Fatalf("unexpected error deleting dump: %s", err)
 	}

--- a/internal/codeintel/uploads/internal/store/store.go
+++ b/internal/codeintel/uploads/internal/store/store.go
@@ -22,12 +22,12 @@ type Store interface {
 	// Upload records
 	GetUploads(ctx context.Context, opts shared.GetUploadsOptions) ([]shared.Upload, int, error)
 	GetUploadByID(ctx context.Context, id int) (shared.Upload, bool, error)
-	GetDumpsByIDs(ctx context.Context, ids []int) ([]shared.Dump, error)
+	GetProcessedUploadsByIDs(ctx context.Context, ids []int) ([]shared.ProcessedUpload, error)
 	GetUploadsByIDs(ctx context.Context, ids ...int) ([]shared.Upload, error)
 	GetUploadsByIDsAllowDeleted(ctx context.Context, ids ...int) ([]shared.Upload, error)
 	GetUploadIDsWithReferences(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, ignoreIDs []int, repositoryID int, commit string, limit int, offset int, trace observation.TraceLogger) ([]int, int, int, error)
 	GetVisibleUploadsMatchingMonikers(ctx context.Context, repositoryID int, commit string, orderedMonikers []precise.QualifiedMonikerData, limit, offset int) (shared.PackageReferenceScanner, int, error)
-	GetDumpsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) ([]shared.Dump, error)
+	GetProcessedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
 	GetAuditLogsForUpload(ctx context.Context, uploadID int) ([]shared.UploadLog, error)
 	DeleteUploads(ctx context.Context, opts shared.DeleteUploadsOptions) error
 	DeleteUploadByID(ctx context.Context, id int) (bool, error)
@@ -48,13 +48,13 @@ type Store interface {
 	AddUploadPart(ctx context.Context, uploadID, partIndex int) error
 	MarkQueued(ctx context.Context, id int, uploadSize *int64) error
 	MarkFailed(ctx context.Context, id int, reason string) error
-	DeleteOverlappingDumps(ctx context.Context, repositoryID int, commit, root, indexer string) error
+	DeleteOverlappingProcessedUploads(ctx context.Context, repositoryID int, commit, root, indexer string) error
 	WorkerutilStore(observationCtx *observation.Context) dbworkerstore.Store[shared.Upload]
 
 	// Dependencies
 	ReferencesForUpload(ctx context.Context, uploadID int) (shared.PackageReferenceScanner, error)
-	UpdatePackages(ctx context.Context, dumpID int, packages []precise.Package) error
-	UpdatePackageReferences(ctx context.Context, dumpID int, references []precise.PackageReference) error
+	UpdatePackages(ctx context.Context, uploadID int, packages []precise.Package) error
+	UpdatePackageReferences(ctx context.Context, uploadID int, references []precise.PackageReference) error
 
 	// Summary
 	GetIndexers(ctx context.Context, opts shared.GetIndexersOptions) ([]string, error)
@@ -68,8 +68,8 @@ type Store interface {
 	GetDirtyRepositories(ctx context.Context) ([]shared.DirtyRepository, error)
 	UpdateUploadsVisibleToCommits(ctx context.Context, repositoryID int, graph *gitdomain.CommitGraph, refDescriptions map[string][]gitdomain.RefDescription, maxAgeForNonStaleBranches, maxAgeForNonStaleTags time.Duration, dirtyToken int, now time.Time) error
 	GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) ([]string, *string, error)
-	FindClosestDumps(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) ([]shared.Dump, error)
-	FindClosestDumpsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) ([]shared.Dump, error)
+	FindClosestProcessedUploads(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) ([]shared.ProcessedUpload, error)
+	FindClosestProcessedUploadsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
 	GetRepositoriesMaxStaleAge(ctx context.Context) (time.Duration, error)
 	GetCommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, _ error)
 

--- a/internal/codeintel/uploads/internal/store/store.go
+++ b/internal/codeintel/uploads/internal/store/store.go
@@ -22,12 +22,12 @@ type Store interface {
 	// Upload records
 	GetUploads(ctx context.Context, opts shared.GetUploadsOptions) ([]shared.Upload, int, error)
 	GetUploadByID(ctx context.Context, id int) (shared.Upload, bool, error)
-	GetProcessedUploadsByIDs(ctx context.Context, ids []int) ([]shared.ProcessedUpload, error)
+	GetCompletedUploadsByIDs(ctx context.Context, ids []int) ([]shared.CompletedUpload, error)
 	GetUploadsByIDs(ctx context.Context, ids ...int) ([]shared.Upload, error)
 	GetUploadsByIDsAllowDeleted(ctx context.Context, ids ...int) ([]shared.Upload, error)
 	GetUploadIDsWithReferences(ctx context.Context, orderedMonikers []precise.QualifiedMonikerData, ignoreIDs []int, repositoryID int, commit string, limit int, offset int, trace observation.TraceLogger) ([]int, int, int, error)
 	GetVisibleUploadsMatchingMonikers(ctx context.Context, repositoryID int, commit string, orderedMonikers []precise.QualifiedMonikerData, limit, offset int) (shared.PackageReferenceScanner, int, error)
-	GetProcessedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
+	GetCompletedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
 	GetAuditLogsForUpload(ctx context.Context, uploadID int) ([]shared.UploadLog, error)
 	DeleteUploads(ctx context.Context, opts shared.DeleteUploadsOptions) error
 	DeleteUploadByID(ctx context.Context, id int) (bool, error)
@@ -48,7 +48,7 @@ type Store interface {
 	AddUploadPart(ctx context.Context, uploadID, partIndex int) error
 	MarkQueued(ctx context.Context, id int, uploadSize *int64) error
 	MarkFailed(ctx context.Context, id int, reason string) error
-	DeleteOverlappingProcessedUploads(ctx context.Context, repositoryID int, commit, root, indexer string) error
+	DeleteOverlappingCompletedUploads(ctx context.Context, repositoryID int, commit, root, indexer string) error
 	WorkerutilStore(observationCtx *observation.Context) dbworkerstore.Store[shared.Upload]
 
 	// Dependencies
@@ -68,8 +68,8 @@ type Store interface {
 	GetDirtyRepositories(ctx context.Context) ([]shared.DirtyRepository, error)
 	UpdateUploadsVisibleToCommits(ctx context.Context, repositoryID int, graph *gitdomain.CommitGraph, refDescriptions map[string][]gitdomain.RefDescription, maxAgeForNonStaleBranches, maxAgeForNonStaleTags time.Duration, dirtyToken int, now time.Time) error
 	GetCommitsVisibleToUpload(ctx context.Context, uploadID, limit int, token *string) ([]string, *string, error)
-	FindClosestProcessedUploads(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) ([]shared.ProcessedUpload, error)
-	FindClosestProcessedUploadsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
+	FindClosestCompletedUploads(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string) ([]shared.CompletedUpload, error)
+	FindClosestCompletedUploadsFromGraphFragment(ctx context.Context, repositoryID int, commit, path string, rootMustEnclosePath bool, indexer string, commitGraph *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
 	GetRepositoriesMaxStaleAge(ctx context.Context) (time.Duration, error)
 	GetCommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, _ error)
 

--- a/internal/codeintel/uploads/internal/store/store_test.go
+++ b/internal/codeintel/uploads/internal/store/store_test.go
@@ -63,7 +63,7 @@ func insertNearestUploads(t testing.TB, db database.DB, repositoryID int, upload
 // insertPackages populates the lsif_packages table with the given packages.
 func insertPackages(t testing.TB, store Store, packages []shared.Package) {
 	for _, pkg := range packages {
-		if err := store.UpdatePackages(context.Background(), pkg.DumpID, []precise.Package{
+		if err := store.UpdatePackages(context.Background(), pkg.UploadID, []precise.Package{
 			{
 				Scheme:  pkg.Scheme,
 				Manager: pkg.Manager,
@@ -79,7 +79,7 @@ func insertPackages(t testing.TB, store Store, packages []shared.Package) {
 // insertPackageReferences populates the lsif_references table with the given package references.
 func insertPackageReferences(t testing.TB, store Store, packageReferences []shared.PackageReference) {
 	for _, packageReference := range packageReferences {
-		if err := store.UpdatePackageReferences(context.Background(), packageReference.DumpID, []precise.PackageReference{
+		if err := store.UpdatePackageReferences(context.Background(), packageReference.UploadID, []precise.PackageReference{
 			{
 				Package: precise.Package{
 					Scheme:  packageReference.Scheme,

--- a/internal/codeintel/uploads/internal/store/uploads.go
+++ b/internal/codeintel/uploads/internal/store/uploads.go
@@ -218,9 +218,9 @@ JOIN repo ON repo.id = u.repository_id
 WHERE repo.deleted_at IS NULL AND u.state != 'deleted' AND u.id = %s AND %s
 `
 
-// GetProcessedUploadsByIDs returns a set of uploads by identifiers.
-func (s *store) GetProcessedUploadsByIDs(ctx context.Context, ids []int) (_ []shared.ProcessedUpload, err error) {
-	ctx, trace, endObservation := s.operations.getProcessedUploadsByIDs.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+// GetCompletedUploadsByIDs returns a set of uploads by identifiers.
+func (s *store) GetCompletedUploadsByIDs(ctx context.Context, ids []int) (_ []shared.CompletedUpload, err error) {
+	ctx, trace, endObservation := s.operations.getCompletedUploadsByIDs.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("numIDs", len(ids)),
 		attribute.IntSlice("ids", ids),
 	}})
@@ -236,7 +236,7 @@ func (s *store) GetProcessedUploadsByIDs(ctx context.Context, ids []int) (_ []sh
 	}
 
 	// TODO(id: completed-state-check) Make sure we only return uploads with state = 'completed' here
-	uploads, err := scanProcessedUploads(s.db.Query(ctx, sqlf.Sprintf(getProcessedUploadsByIDsQuery, sqlf.Join(idx, ", "))))
+	uploads, err := scanCompletedUploads(s.db.Query(ctx, sqlf.Sprintf(getCompletedUploadsByIDsQuery, sqlf.Join(idx, ", "))))
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +245,7 @@ func (s *store) GetProcessedUploadsByIDs(ctx context.Context, ids []int) (_ []sh
 	return uploads, nil
 }
 
-const getProcessedUploadsByIDsQuery = `
+const getCompletedUploadsByIDsQuery = `
 SELECT
 	u.id,
 	u.commit,
@@ -545,9 +545,9 @@ WHERE
 // definitionDumpsLimit is the maximum number of records that can be returned from DefinitionDumps.
 var definitionDumpsLimit, _ = strconv.ParseInt(env.Get("PRECISE_CODE_INTEL_DEFINITION_DUMPS_LIMIT", "100", "The maximum number of dumps that can define the same package."), 10, 64)
 
-// GetProcessedUploadsWithDefinitionsForMonikers returns the set of uploads that define at least one of the given monikers.
-func (s *store) GetProcessedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []shared.ProcessedUpload, err error) {
-	ctx, trace, endObservation := s.operations.getProcessedUploadsWithDefinitionsForMonikers.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
+// GetCompletedUploadsWithDefinitionsForMonikers returns the set of uploads that define at least one of the given monikers.
+func (s *store) GetCompletedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) (_ []shared.CompletedUpload, err error) {
+	ctx, trace, endObservation := s.operations.getCompletedUploadsWithDefinitionsForMonikers.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("numMonikers", len(monikers)),
 		attribute.String("monikers", monikersToString(monikers)),
 	}})
@@ -568,8 +568,8 @@ func (s *store) GetProcessedUploadsWithDefinitionsForMonikers(ctx context.Contex
 	}
 
 	// TODO(id: completed-state-check) Make sure we only return uploads with state = 'completed' here
-	query := sqlf.Sprintf(getProcessedUploadsWithDefinitionsForMonikersQuery, sqlf.Join(qs, ", "), authzConds, definitionDumpsLimit)
-	uploads, err := scanProcessedUploads(s.db.Query(ctx, query))
+	query := sqlf.Sprintf(getCompletedUploadsWithDefinitionsForMonikersQuery, sqlf.Join(qs, ", "), authzConds, definitionDumpsLimit)
+	uploads, err := scanCompletedUploads(s.db.Query(ctx, query))
 	if err != nil {
 		return nil, err
 	}
@@ -578,7 +578,7 @@ func (s *store) GetProcessedUploadsWithDefinitionsForMonikers(ctx context.Contex
 	return uploads, nil
 }
 
-const getProcessedUploadsWithDefinitionsForMonikersQuery = `
+const getCompletedUploadsWithDefinitionsForMonikersQuery = `
 WITH
 ranked_uploads AS (
 	SELECT
@@ -626,8 +626,8 @@ FROM lsif_dumps_with_repository_name u
 WHERE u.id IN (SELECT id FROM canonical_uploads)
 `
 
-// scanProcessedUploads scans a slice of dumps from the return value of `*Store.query`.
-func scanProcessedUpload(s dbutil.Scanner) (upload shared.ProcessedUpload, err error) {
+// scanCompletedUploads scans a slice of dumps from the return value of `*Store.query`.
+func scanCompletedUpload(s dbutil.Scanner) (upload shared.CompletedUpload, err error) {
 	err = s.Scan(
 		&upload.ID,
 		&upload.Commit,
@@ -650,7 +650,7 @@ func scanProcessedUpload(s dbutil.Scanner) (upload shared.ProcessedUpload, err e
 	return upload, err
 }
 
-var scanProcessedUploads = basestore.NewSliceScanner(scanProcessedUpload)
+var scanCompletedUploads = basestore.NewSliceScanner(scanCompletedUpload)
 
 // GetAuditLogsForUpload returns all the audit logs for the given upload ID in order of entry
 // from oldest to newest, according to the auto-incremented internal sequence field.

--- a/internal/codeintel/uploads/internal/store/uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/uploads_test.go
@@ -341,13 +341,13 @@ func TestGetUploadByIDDeleted(t *testing.T) {
 	}
 }
 
-func TestGetProcessedUploadsByIDs(t *testing.T) {
+func TestGetCompletedUploadsByIDs(t *testing.T) {
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
 	store := New(&observation.TestContext, db)
 
 	// Dumps do not exist initially
-	if uploads, err := store.GetProcessedUploadsByIDs(context.Background(), []int{1, 2}); err != nil {
+	if uploads, err := store.GetCompletedUploadsByIDs(context.Background(), []int{1, 2}); err != nil {
 		t.Fatalf("unexpected error getting dump: %s", err)
 	} else if len(uploads) > 0 {
 		t.Fatal("unexpected record")
@@ -357,7 +357,7 @@ func TestGetProcessedUploadsByIDs(t *testing.T) {
 	startedAt := uploadedAt.Add(time.Minute)
 	finishedAt := uploadedAt.Add(time.Minute * 2)
 	expectedAssociatedIndexID := 42
-	expected1 := shared.ProcessedUpload{
+	expected1 := shared.CompletedUpload{
 		ID:                1,
 		Commit:            makeCommit(1),
 		Root:              "sub/",
@@ -373,7 +373,7 @@ func TestGetProcessedUploadsByIDs(t *testing.T) {
 		IndexerVersion:    "latest",
 		AssociatedIndexID: &expectedAssociatedIndexID,
 	}
-	expected2 := shared.ProcessedUpload{
+	expected2 := shared.CompletedUpload{
 		ID:                2,
 		Commit:            makeCommit(2),
 		Root:              "other/",
@@ -393,7 +393,7 @@ func TestGetProcessedUploadsByIDs(t *testing.T) {
 	insertUploads(t, db, dumpToUpload(expected1), dumpToUpload(expected2))
 	insertVisibleAtTip(t, db, 50, 1)
 
-	if uploads, err := store.GetProcessedUploadsByIDs(context.Background(), []int{1}); err != nil {
+	if uploads, err := store.GetCompletedUploadsByIDs(context.Background(), []int{1}); err != nil {
 		t.Fatalf("unexpected error getting dump: %s", err)
 	} else if len(uploads) != 1 {
 		t.Fatal("expected one record")
@@ -401,7 +401,7 @@ func TestGetProcessedUploadsByIDs(t *testing.T) {
 		t.Errorf("unexpected dump (-want +got):\n%s", diff)
 	}
 
-	if uploads, err := store.GetProcessedUploadsByIDs(context.Background(), []int{1, 2}); err != nil {
+	if uploads, err := store.GetCompletedUploadsByIDs(context.Background(), []int{1, 2}); err != nil {
 		t.Fatalf("unexpected error getting dump: %s", err)
 	} else if len(uploads) != 2 {
 		t.Fatal("expected two records")
@@ -613,7 +613,7 @@ func TestDefinitionDumps(t *testing.T) {
 	}
 
 	// Package does not exist initially
-	if uploads, err := store.GetProcessedUploadsWithDefinitionsForMonikers(context.Background(), []precise.QualifiedMonikerData{moniker1}); err != nil {
+	if uploads, err := store.GetCompletedUploadsWithDefinitionsForMonikers(context.Background(), []precise.QualifiedMonikerData{moniker1}); err != nil {
 		t.Fatalf("unexpected error getting package: %s", err)
 	} else if len(uploads) != 0 {
 		t.Fatal("unexpected record")
@@ -622,7 +622,7 @@ func TestDefinitionDumps(t *testing.T) {
 	uploadedAt := time.Unix(1587396557, 0).UTC()
 	startedAt := uploadedAt.Add(time.Minute)
 	finishedAt := uploadedAt.Add(time.Minute * 2)
-	expected1 := shared.ProcessedUpload{
+	expected1 := shared.CompletedUpload{
 		ID:             1,
 		Commit:         makeCommit(1),
 		Root:           "sub/",
@@ -637,7 +637,7 @@ func TestDefinitionDumps(t *testing.T) {
 		Indexer:        "lsif-go",
 		IndexerVersion: "latest",
 	}
-	expected2 := shared.ProcessedUpload{
+	expected2 := shared.CompletedUpload{
 		ID:                2,
 		Commit:            makeCommit(2),
 		Root:              "other/",
@@ -653,7 +653,7 @@ func TestDefinitionDumps(t *testing.T) {
 		IndexerVersion:    "1.2.3",
 		AssociatedIndexID: nil,
 	}
-	expected3 := shared.ProcessedUpload{
+	expected3 := shared.CompletedUpload{
 		ID:             3,
 		Commit:         makeCommit(3),
 		Root:           "sub/",
@@ -691,7 +691,7 @@ func TestDefinitionDumps(t *testing.T) {
 		t.Fatalf("unexpected error updating packages: %s", err)
 	}
 
-	if uploads, err := store.GetProcessedUploadsWithDefinitionsForMonikers(context.Background(), []precise.QualifiedMonikerData{moniker1}); err != nil {
+	if uploads, err := store.GetCompletedUploadsWithDefinitionsForMonikers(context.Background(), []precise.QualifiedMonikerData{moniker1}); err != nil {
 		t.Fatalf("unexpected error getting package: %s", err)
 	} else if len(uploads) != 1 {
 		t.Fatal("expected one record")
@@ -699,7 +699,7 @@ func TestDefinitionDumps(t *testing.T) {
 		t.Errorf("unexpected dump (-want +got):\n%s", diff)
 	}
 
-	if uploads, err := store.GetProcessedUploadsWithDefinitionsForMonikers(context.Background(), []precise.QualifiedMonikerData{moniker1, moniker2}); err != nil {
+	if uploads, err := store.GetCompletedUploadsWithDefinitionsForMonikers(context.Background(), []precise.QualifiedMonikerData{moniker1, moniker2}); err != nil {
 		t.Fatalf("unexpected error getting package: %s", err)
 	} else if len(uploads) != 2 {
 		t.Fatal("expected two records")
@@ -718,7 +718,7 @@ func TestDefinitionDumps(t *testing.T) {
 		globals.SetPermissionsUserMapping(&schema.PermissionsUserMapping{Enabled: true})
 		defer globals.SetPermissionsUserMapping(before)
 
-		if uploads, err := store.GetProcessedUploadsWithDefinitionsForMonikers(context.Background(), []precise.QualifiedMonikerData{moniker1, moniker2}); err != nil {
+		if uploads, err := store.GetCompletedUploadsWithDefinitionsForMonikers(context.Background(), []precise.QualifiedMonikerData{moniker1, moniker2}); err != nil {
 			t.Fatalf("unexpected error getting package: %s", err)
 		} else if len(uploads) != 0 {
 			t.Errorf("unexpected count. want=%d have=%d", 0, len(uploads))
@@ -1023,7 +1023,7 @@ func TestReindexUploadByID(t *testing.T) {
 //
 //
 
-func dumpToUpload(expected shared.ProcessedUpload) shared.Upload {
+func dumpToUpload(expected shared.CompletedUpload) shared.Upload {
 	return shared.Upload{
 		ID:                expected.ID,
 		Commit:            expected.Commit,

--- a/internal/codeintel/uploads/internal/store/uploads_test.go
+++ b/internal/codeintel/uploads/internal/store/uploads_test.go
@@ -390,7 +390,7 @@ func TestGetCompletedUploadsByIDs(t *testing.T) {
 		AssociatedIndexID: nil,
 	}
 
-	insertUploads(t, db, dumpToUpload(expected1), dumpToUpload(expected2))
+	insertUploads(t, db, expected1.ConvertToUpload(), expected2.ConvertToUpload())
 	insertVisibleAtTip(t, db, 50, 1)
 
 	if uploads, err := store.GetCompletedUploadsByIDs(context.Background(), []int{1}); err != nil {
@@ -669,7 +669,7 @@ func TestDefinitionDumps(t *testing.T) {
 		IndexerVersion: "latest",
 	}
 
-	insertUploads(t, db, dumpToUpload(expected1), dumpToUpload(expected2), dumpToUpload(expected3))
+	insertUploads(t, db, expected1.ConvertToUpload(), expected2.ConvertToUpload(), expected3.ConvertToUpload())
 	insertVisibleAtTip(t, db, 50, 1)
 
 	if err := store.UpdatePackages(context.Background(), 1, []precise.Package{
@@ -1016,31 +1016,6 @@ func TestReindexUploadByID(t *testing.T) {
 		t.Fatal("upload missing")
 	} else if !upload.ShouldReindex {
 		t.Fatal("upload not marked for reindexing")
-	}
-}
-
-//
-//
-//
-
-func dumpToUpload(expected shared.CompletedUpload) shared.Upload {
-	return shared.Upload{
-		ID:                expected.ID,
-		Commit:            expected.Commit,
-		Root:              expected.Root,
-		UploadedAt:        expected.UploadedAt,
-		State:             expected.State,
-		FailureMessage:    expected.FailureMessage,
-		StartedAt:         expected.StartedAt,
-		FinishedAt:        expected.FinishedAt,
-		ProcessAfter:      expected.ProcessAfter,
-		NumResets:         expected.NumResets,
-		NumFailures:       expected.NumFailures,
-		RepositoryID:      expected.RepositoryID,
-		RepositoryName:    expected.RepositoryName,
-		Indexer:           expected.Indexer,
-		IndexerVersion:    expected.IndexerVersion,
-		AssociatedIndexID: expected.AssociatedIndexID,
 	}
 }
 

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -87,6 +87,13 @@ type MockStore struct {
 	// object controlling the behavior of the method
 	// GetCommitsVisibleToUpload.
 	GetCommitsVisibleToUploadFunc *StoreGetCommitsVisibleToUploadFunc
+	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletedUploadsByIDs.
+	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
+	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// GetCompletedUploadsWithDefinitionsForMonikers.
+	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetDirtyRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDirtyRepositories.
 	GetDirtyRepositoriesFunc *StoreGetDirtyRepositoriesFunc
@@ -109,13 +116,6 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
-	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetCompletedUploadsByIDs.
-	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
-	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
-	// mock function object controlling the behavior of the method
-	// GetCompletedUploadsWithDefinitionsForMonikers.
-	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -330,6 +330,16 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared.CompletedUpload, r1 error) {
+				return
+			},
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.CompletedUpload, r1 error) {
+				return
+			},
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) (r0 []shared.DirtyRepository, r1 error) {
 				return
@@ -362,16 +372,6 @@ func NewMockStore() *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (r0 time.Time, r1 bool, r2 error) {
-				return
-			},
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared.CompletedUpload, r1 error) {
-				return
-			},
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -657,6 +657,16 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetCommitsVisibleToUpload")
 			},
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
+			},
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
+			},
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) ([]shared.DirtyRepository, error) {
 				panic("unexpected invocation of MockStore.GetDirtyRepositories")
@@ -690,16 +700,6 @@ func NewStrictMockStore() *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (time.Time, bool, error) {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
-			},
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared.CompletedUpload, error) {
-				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
-			},
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -952,6 +952,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetCommitsVisibleToUploadFunc: &StoreGetCommitsVisibleToUploadFunc{
 			defaultHook: i.GetCommitsVisibleToUpload,
 		},
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: i.GetCompletedUploadsByIDs,
+		},
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
+		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: i.GetDirtyRepositories,
 		},
@@ -972,12 +978,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
-		},
-		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
-			defaultHook: i.GetCompletedUploadsByIDs,
-		},
-		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -2911,6 +2911,230 @@ func (c StoreGetCommitsVisibleToUploadFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
+// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
+// invoked.
+type StoreGetCompletedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCompletedUploadsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.CompletedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetCompletedUploadsByIDs on an instance of
+// MockStore.
+type StoreGetCompletedUploadsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.CompletedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
+// the parent MockStore instance is invoked.
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
+	mutex       sync.Mutex
+}
+
+// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
+// describing the invocations of this function.
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
+// that describes an invocation of method
+// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
+// MockStore.
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []precise.QualifiedMonikerData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.CompletedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // StoreGetDirtyRepositoriesFunc describes the behavior when the
 // GetDirtyRepositories method of the parent MockStore instance is invoked.
 type StoreGetDirtyRepositoriesFunc struct {
@@ -3680,230 +3904,6 @@ func (c StoreGetOldestCommitDateFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
-}
-
-// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
-// GetCompletedUploadsByIDs method of the parent MockStore instance is
-// invoked.
-type StoreGetCompletedUploadsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, []int) ([]shared.CompletedUpload, error)
-	history     []StoreGetCompletedUploadsByIDsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetCompletedUploadsByIDs delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
-	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetCompletedUploadsByIDs method of the parent MockStore instance is
-// invoked and the hook queue is empty.
-func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.CompletedUpload, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
-// objects describing the invocations of this function.
-func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
-// invocation of method GetCompletedUploadsByIDs on an instance of
-// MockStore.
-type StoreGetCompletedUploadsByIDsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.CompletedUpload
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
-// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
-// the parent MockStore instance is invoked.
-type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
-	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
-	mutex       sync.Mutex
-}
-
-// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
-// function in the queue and stores the parameter and result values of this
-// invocation.
-func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
-// MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
-// MockStore instance invokes the hook at the front of the queue and
-// discards it. After the queue is empty, the default hook function is
-// invoked for any future action.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
-// describing the invocations of this function.
-func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
-// that describes an invocation of method
-// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
-// MockStore.
-type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []precise.QualifiedMonikerData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.CompletedUpload
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetRecentIndexesSummaryFunc describes the behavior when the

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -48,10 +48,10 @@ type MockStore struct {
 	// DeleteOldAuditLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteOldAuditLogs.
 	DeleteOldAuditLogsFunc *StoreDeleteOldAuditLogsFunc
-	// DeleteOverlappingProcessedUploadsFunc is an instance of a mock
+	// DeleteOverlappingCompletedUploadsFunc is an instance of a mock
 	// function object controlling the behavior of the method
-	// DeleteOverlappingProcessedUploads.
-	DeleteOverlappingProcessedUploadsFunc *StoreDeleteOverlappingProcessedUploadsFunc
+	// DeleteOverlappingCompletedUploads.
+	DeleteOverlappingCompletedUploadsFunc *StoreDeleteOverlappingCompletedUploadsFunc
 	// DeleteUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteUploadByID.
 	DeleteUploadByIDFunc *StoreDeleteUploadByIDFunc
@@ -69,14 +69,14 @@ type MockStore struct {
 	// ExpireFailedRecordsFunc is an instance of a mock function object
 	// controlling the behavior of the method ExpireFailedRecords.
 	ExpireFailedRecordsFunc *StoreExpireFailedRecordsFunc
-	// FindClosestProcessedUploadsFunc is an instance of a mock function
+	// FindClosestCompletedUploadsFunc is an instance of a mock function
 	// object controlling the behavior of the method
-	// FindClosestProcessedUploads.
-	FindClosestProcessedUploadsFunc *StoreFindClosestProcessedUploadsFunc
-	// FindClosestProcessedUploadsFromGraphFragmentFunc is an instance of a
+	// FindClosestCompletedUploads.
+	FindClosestCompletedUploadsFunc *StoreFindClosestCompletedUploadsFunc
+	// FindClosestCompletedUploadsFromGraphFragmentFunc is an instance of a
 	// mock function object controlling the behavior of the method
-	// FindClosestProcessedUploadsFromGraphFragment.
-	FindClosestProcessedUploadsFromGraphFragmentFunc *StoreFindClosestProcessedUploadsFromGraphFragmentFunc
+	// FindClosestCompletedUploadsFromGraphFragment.
+	FindClosestCompletedUploadsFromGraphFragmentFunc *StoreFindClosestCompletedUploadsFromGraphFragmentFunc
 	// GetAuditLogsForUploadFunc is an instance of a mock function object
 	// controlling the behavior of the method GetAuditLogsForUpload.
 	GetAuditLogsForUploadFunc *StoreGetAuditLogsForUploadFunc
@@ -109,13 +109,13 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
-	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetProcessedUploadsByIDs.
-	GetProcessedUploadsByIDsFunc *StoreGetProcessedUploadsByIDsFunc
-	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// GetCompletedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetCompletedUploadsByIDs.
+	GetCompletedUploadsByIDsFunc *StoreGetCompletedUploadsByIDsFunc
+	// GetCompletedUploadsWithDefinitionsForMonikersFunc is an instance of a
 	// mock function object controlling the behavior of the method
-	// GetProcessedUploadsWithDefinitionsForMonikers.
-	GetProcessedUploadsWithDefinitionsForMonikersFunc *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc
+	// GetCompletedUploadsWithDefinitionsForMonikers.
+	GetCompletedUploadsWithDefinitionsForMonikersFunc *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -275,7 +275,7 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) (r0 error) {
 				return
 			},
@@ -305,13 +305,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.ProcessedUpload, r1 error) {
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.ProcessedUpload, r1 error) {
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -365,13 +365,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared.ProcessedUpload, r1 error) {
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.ProcessedUpload, r1 error) {
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.CompletedUpload, r1 error) {
 				return
 			},
 		},
@@ -602,9 +602,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteOldAuditLogs")
 			},
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) error {
-				panic("unexpected invocation of MockStore.DeleteOverlappingProcessedUploads")
+				panic("unexpected invocation of MockStore.DeleteOverlappingCompletedUploads")
 			},
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
@@ -632,14 +632,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ExpireFailedRecords")
 			},
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.FindClosestProcessedUploads")
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestCompletedUploads")
 			},
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.FindClosestProcessedUploadsFromGraphFragment")
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestCompletedUploadsFromGraphFragment")
 			},
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
@@ -692,14 +692,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
 			},
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.GetProcessedUploadsByIDs")
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsByIDs")
 			},
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
-				panic("unexpected invocation of MockStore.GetProcessedUploadsWithDefinitionsForMonikers")
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+				panic("unexpected invocation of MockStore.GetCompletedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -919,8 +919,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		DeleteOldAuditLogsFunc: &StoreDeleteOldAuditLogsFunc{
 			defaultHook: i.DeleteOldAuditLogs,
 		},
-		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
-			defaultHook: i.DeleteOverlappingProcessedUploads,
+		DeleteOverlappingCompletedUploadsFunc: &StoreDeleteOverlappingCompletedUploadsFunc{
+			defaultHook: i.DeleteOverlappingCompletedUploads,
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
 			defaultHook: i.DeleteUploadByID,
@@ -937,11 +937,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
 			defaultHook: i.ExpireFailedRecords,
 		},
-		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
-			defaultHook: i.FindClosestProcessedUploads,
+		FindClosestCompletedUploadsFunc: &StoreFindClosestCompletedUploadsFunc{
+			defaultHook: i.FindClosestCompletedUploads,
 		},
-		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
-			defaultHook: i.FindClosestProcessedUploadsFromGraphFragment,
+		FindClosestCompletedUploadsFromGraphFragmentFunc: &StoreFindClosestCompletedUploadsFromGraphFragmentFunc{
+			defaultHook: i.FindClosestCompletedUploadsFromGraphFragment,
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
 			defaultHook: i.GetAuditLogsForUpload,
@@ -973,11 +973,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
 		},
-		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
-			defaultHook: i.GetProcessedUploadsByIDs,
+		GetCompletedUploadsByIDsFunc: &StoreGetCompletedUploadsByIDsFunc{
+			defaultHook: i.GetCompletedUploadsByIDs,
 		},
-		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
+		GetCompletedUploadsWithDefinitionsForMonikersFunc: &StoreGetCompletedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetCompletedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -1646,37 +1646,37 @@ func (c StoreDeleteOldAuditLogsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreDeleteOverlappingProcessedUploadsFunc describes the behavior when
-// the DeleteOverlappingProcessedUploads method of the parent MockStore
+// StoreDeleteOverlappingCompletedUploadsFunc describes the behavior when
+// the DeleteOverlappingCompletedUploads method of the parent MockStore
 // instance is invoked.
-type StoreDeleteOverlappingProcessedUploadsFunc struct {
+type StoreDeleteOverlappingCompletedUploadsFunc struct {
 	defaultHook func(context.Context, int, string, string, string) error
 	hooks       []func(context.Context, int, string, string, string) error
-	history     []StoreDeleteOverlappingProcessedUploadsFuncCall
+	history     []StoreDeleteOverlappingCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteOverlappingProcessedUploads delegates to the next hook function in
+// DeleteOverlappingCompletedUploads delegates to the next hook function in
 // the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) DeleteOverlappingProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
-	r0 := m.DeleteOverlappingProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.DeleteOverlappingProcessedUploadsFunc.appendCall(StoreDeleteOverlappingProcessedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
+func (m *MockStore) DeleteOverlappingCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
+	r0 := m.DeleteOverlappingCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DeleteOverlappingCompletedUploadsFunc.appendCall(StoreDeleteOverlappingCompletedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// DeleteOverlappingCompletedUploads method of the parent MockStore instance
 // is invoked and the hook queue is empty.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// DeleteOverlappingCompletedUploads method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1684,20 +1684,20 @@ func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultReturn(r0 error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushReturn(r0 error) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1710,28 +1710,28 @@ func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Con
 	return hook
 }
 
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) appendCall(r0 StoreDeleteOverlappingProcessedUploadsFuncCall) {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) appendCall(r0 StoreDeleteOverlappingCompletedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreDeleteOverlappingProcessedUploadsFuncCall objects describing the
+// StoreDeleteOverlappingCompletedUploadsFuncCall objects describing the
 // invocations of this function.
-func (f *StoreDeleteOverlappingProcessedUploadsFunc) History() []StoreDeleteOverlappingProcessedUploadsFuncCall {
+func (f *StoreDeleteOverlappingCompletedUploadsFunc) History() []StoreDeleteOverlappingCompletedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreDeleteOverlappingProcessedUploadsFuncCall, len(f.history))
+	history := make([]StoreDeleteOverlappingCompletedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreDeleteOverlappingProcessedUploadsFuncCall is an object that
-// describes an invocation of method DeleteOverlappingProcessedUploads on an
+// StoreDeleteOverlappingCompletedUploadsFuncCall is an object that
+// describes an invocation of method DeleteOverlappingCompletedUploads on an
 // instance of MockStore.
-type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
+type StoreDeleteOverlappingCompletedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1754,13 +1754,13 @@ type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Args() []interface{} {
+func (c StoreDeleteOverlappingCompletedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Results() []interface{} {
+func (c StoreDeleteOverlappingCompletedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2321,37 +2321,37 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreFindClosestProcessedUploadsFunc describes the behavior when the
-// FindClosestProcessedUploads method of the parent MockStore instance is
+// StoreFindClosestCompletedUploadsFunc describes the behavior when the
+// FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked.
-type StoreFindClosestProcessedUploadsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
-	history     []StoreFindClosestProcessedUploadsFuncCall
+type StoreFindClosestCompletedUploadsFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)
+	history     []StoreFindClosestCompletedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestProcessedUploads delegates to the next hook function in the
+// FindClosestCompletedUploads delegates to the next hook function in the
 // queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.FindClosestProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestProcessedUploadsFunc.appendCall(StoreFindClosestProcessedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+func (m *MockStore) FindClosestCompletedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.FindClosestCompletedUploadsFunc.appendCall(StoreFindClosestCompletedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestProcessedUploads method of the parent MockStore instance is
+// FindClosestCompletedUploads method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestProcessedUploads method of the parent MockStore instance
+// FindClosestCompletedUploads method of the parent MockStore instance
 // invokes the hook at the front of the queue and discards it. After the
 // queue is empty, the default hook function is invoked for any future
 // action.
-func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2359,20 +2359,20 @@ func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Contex
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestProcessedUploadsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2385,27 +2385,27 @@ func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, 
 	return hook
 }
 
-func (f *StoreFindClosestProcessedUploadsFunc) appendCall(r0 StoreFindClosestProcessedUploadsFuncCall) {
+func (f *StoreFindClosestCompletedUploadsFunc) appendCall(r0 StoreFindClosestCompletedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreFindClosestProcessedUploadsFuncCall
+// History returns a sequence of StoreFindClosestCompletedUploadsFuncCall
 // objects describing the invocations of this function.
-func (f *StoreFindClosestProcessedUploadsFunc) History() []StoreFindClosestProcessedUploadsFuncCall {
+func (f *StoreFindClosestCompletedUploadsFunc) History() []StoreFindClosestCompletedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestProcessedUploadsFuncCall, len(f.history))
+	history := make([]StoreFindClosestCompletedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestProcessedUploadsFuncCall is an object that describes an
-// invocation of method FindClosestProcessedUploads on an instance of
+// StoreFindClosestCompletedUploadsFuncCall is an object that describes an
+// invocation of method FindClosestCompletedUploads on an instance of
 // MockStore.
-type StoreFindClosestProcessedUploadsFuncCall struct {
+type StoreFindClosestCompletedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2426,7 +2426,7 @@ type StoreFindClosestProcessedUploadsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2434,48 +2434,48 @@ type StoreFindClosestProcessedUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFuncCall) Args() []interface{} {
+func (c StoreFindClosestCompletedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFuncCall) Results() []interface{} {
+func (c StoreFindClosestCompletedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreFindClosestProcessedUploadsFromGraphFragmentFunc describes the
-// behavior when the FindClosestProcessedUploadsFromGraphFragment method of
+// StoreFindClosestCompletedUploadsFromGraphFragmentFunc describes the
+// behavior when the FindClosestCompletedUploadsFromGraphFragment method of
 // the parent MockStore instance is invoked.
-type StoreFindClosestProcessedUploadsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
-	history     []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall
+type StoreFindClosestCompletedUploadsFromGraphFragmentFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)
+	history     []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestProcessedUploadsFromGraphFragment delegates to the next hook
+// FindClosestCompletedUploadsFromGraphFragment delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) FindClosestProcessedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.FindClosestProcessedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestProcessedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+func (m *MockStore) FindClosestCompletedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.FindClosestCompletedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.FindClosestCompletedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// FindClosestCompletedUploadsFromGraphFragment method of the parent
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2483,20 +2483,20 @@ func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook fu
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2509,28 +2509,28 @@ func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(
 	return hook
 }
 
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall objects
+// StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall objects
 // describing the invocations of this function.
-func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) History() []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall {
+func (f *StoreFindClosestCompletedUploadsFromGraphFragmentFunc) History() []StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall, len(f.history))
+	history := make([]StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall is an object
+// StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall is an object
 // that describes an invocation of method
-// FindClosestProcessedUploadsFromGraphFragment on an instance of MockStore.
-type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
+// FindClosestCompletedUploadsFromGraphFragment on an instance of MockStore.
+type StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2554,7 +2554,7 @@ type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 	Arg6 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2562,13 +2562,13 @@ type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
+func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
+func (c StoreFindClosestCompletedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3682,36 +3682,36 @@ func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreGetProcessedUploadsByIDsFunc describes the behavior when the
-// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// StoreGetCompletedUploadsByIDsFunc describes the behavior when the
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
 // invoked.
-type StoreGetProcessedUploadsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, []int) ([]shared.ProcessedUpload, error)
-	history     []StoreGetProcessedUploadsByIDsFuncCall
+type StoreGetCompletedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsByIDsFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// GetCompletedUploadsByIDs delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockStore) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsByIDsFunc.appendCall(StoreGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
+func (m *MockStore) GetCompletedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsByIDsFunc.appendCall(StoreGetCompletedUploadsByIDsFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// GetCompletedUploadsByIDs method of the parent MockStore instance is
 // invoked and the hook queue is empty.
-func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsByIDs method of the parent MockStore instance invokes
+// GetCompletedUploadsByIDs method of the parent MockStore instance invokes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3719,20 +3719,20 @@ func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, 
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3745,27 +3745,27 @@ func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []i
 	return hook
 }
 
-func (f *StoreGetProcessedUploadsByIDsFunc) appendCall(r0 StoreGetProcessedUploadsByIDsFuncCall) {
+func (f *StoreGetCompletedUploadsByIDsFunc) appendCall(r0 StoreGetCompletedUploadsByIDsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreGetProcessedUploadsByIDsFuncCall
+// History returns a sequence of StoreGetCompletedUploadsByIDsFuncCall
 // objects describing the invocations of this function.
-func (f *StoreGetProcessedUploadsByIDsFunc) History() []StoreGetProcessedUploadsByIDsFuncCall {
+func (f *StoreGetCompletedUploadsByIDsFunc) History() []StoreGetCompletedUploadsByIDsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreGetProcessedUploadsByIDsFuncCall, len(f.history))
+	history := make([]StoreGetCompletedUploadsByIDsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreGetProcessedUploadsByIDsFuncCall is an object that describes an
-// invocation of method GetProcessedUploadsByIDs on an instance of
+// StoreGetCompletedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetCompletedUploadsByIDs on an instance of
 // MockStore.
-type StoreGetProcessedUploadsByIDsFuncCall struct {
+type StoreGetCompletedUploadsByIDsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3774,7 +3774,7 @@ type StoreGetProcessedUploadsByIDsFuncCall struct {
 	Arg1 []int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3782,48 +3782,48 @@ type StoreGetProcessedUploadsByIDsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
+func (c StoreGetCompletedUploadsByIDsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
+func (c StoreGetCompletedUploadsByIDsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFunc describes the
-// behavior when the GetProcessedUploadsWithDefinitionsForMonikers method of
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetCompletedUploadsWithDefinitionsForMonikers method of
 // the parent MockStore instance is invoked.
-type StoreGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
-	history     []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)
+	history     []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall
 	mutex       sync.Mutex
 }
 
-// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// GetCompletedUploadsWithDefinitionsForMonikers delegates to the next hook
 // function in the queue and stores the parameter and result values of this
 // invocation.
-func (m *MockStore) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
-	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+func (m *MockStore) GetCompletedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	r0, r1 := m.GetCompletedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetCompletedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// GetCompletedUploadsWithDefinitionsForMonikers method of the parent
 // MockStore instance invokes the hook at the front of the queue and
 // discards it. After the queue is empty, the default hook function is
 // invoked for any future action.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -3831,20 +3831,20 @@ func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook f
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.CompletedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -3857,29 +3857,29 @@ func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func
 	return hook
 }
 
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall objects
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall objects
 // describing the invocations of this function.
-func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
+func (f *StoreGetCompletedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	history := make([]StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an object
+// StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall is an object
 // that describes an invocation of method
-// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// GetCompletedUploadsWithDefinitionsForMonikers on an instance of
 // MockStore.
-type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
+type StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -3888,7 +3888,7 @@ type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 	Arg1 []precise.QualifiedMonikerData
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.ProcessedUpload
+	Result0 []shared.CompletedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -3896,13 +3896,13 @@ type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+func (c StoreGetCompletedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/internal/codeintel/uploads/mocks_test.go
+++ b/internal/codeintel/uploads/mocks_test.go
@@ -48,9 +48,10 @@ type MockStore struct {
 	// DeleteOldAuditLogsFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteOldAuditLogs.
 	DeleteOldAuditLogsFunc *StoreDeleteOldAuditLogsFunc
-	// DeleteOverlappingDumpsFunc is an instance of a mock function object
-	// controlling the behavior of the method DeleteOverlappingDumps.
-	DeleteOverlappingDumpsFunc *StoreDeleteOverlappingDumpsFunc
+	// DeleteOverlappingProcessedUploadsFunc is an instance of a mock
+	// function object controlling the behavior of the method
+	// DeleteOverlappingProcessedUploads.
+	DeleteOverlappingProcessedUploadsFunc *StoreDeleteOverlappingProcessedUploadsFunc
 	// DeleteUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteUploadByID.
 	DeleteUploadByIDFunc *StoreDeleteUploadByIDFunc
@@ -68,13 +69,14 @@ type MockStore struct {
 	// ExpireFailedRecordsFunc is an instance of a mock function object
 	// controlling the behavior of the method ExpireFailedRecords.
 	ExpireFailedRecordsFunc *StoreExpireFailedRecordsFunc
-	// FindClosestDumpsFunc is an instance of a mock function object
-	// controlling the behavior of the method FindClosestDumps.
-	FindClosestDumpsFunc *StoreFindClosestDumpsFunc
-	// FindClosestDumpsFromGraphFragmentFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// FindClosestDumpsFromGraphFragment.
-	FindClosestDumpsFromGraphFragmentFunc *StoreFindClosestDumpsFromGraphFragmentFunc
+	// FindClosestProcessedUploadsFunc is an instance of a mock function
+	// object controlling the behavior of the method
+	// FindClosestProcessedUploads.
+	FindClosestProcessedUploadsFunc *StoreFindClosestProcessedUploadsFunc
+	// FindClosestProcessedUploadsFromGraphFragmentFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// FindClosestProcessedUploadsFromGraphFragment.
+	FindClosestProcessedUploadsFromGraphFragmentFunc *StoreFindClosestProcessedUploadsFromGraphFragmentFunc
 	// GetAuditLogsForUploadFunc is an instance of a mock function object
 	// controlling the behavior of the method GetAuditLogsForUpload.
 	GetAuditLogsForUploadFunc *StoreGetAuditLogsForUploadFunc
@@ -88,13 +90,6 @@ type MockStore struct {
 	// GetDirtyRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method GetDirtyRepositories.
 	GetDirtyRepositoriesFunc *StoreGetDirtyRepositoriesFunc
-	// GetDumpsByIDsFunc is an instance of a mock function object
-	// controlling the behavior of the method GetDumpsByIDs.
-	GetDumpsByIDsFunc *StoreGetDumpsByIDsFunc
-	// GetDumpsWithDefinitionsForMonikersFunc is an instance of a mock
-	// function object controlling the behavior of the method
-	// GetDumpsWithDefinitionsForMonikers.
-	GetDumpsWithDefinitionsForMonikersFunc *StoreGetDumpsWithDefinitionsForMonikersFunc
 	// GetIndexByIDFunc is an instance of a mock function object controlling
 	// the behavior of the method GetIndexByID.
 	GetIndexByIDFunc *StoreGetIndexByIDFunc
@@ -114,6 +109,13 @@ type MockStore struct {
 	// GetOldestCommitDateFunc is an instance of a mock function object
 	// controlling the behavior of the method GetOldestCommitDate.
 	GetOldestCommitDateFunc *StoreGetOldestCommitDateFunc
+	// GetProcessedUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetProcessedUploadsByIDs.
+	GetProcessedUploadsByIDsFunc *StoreGetProcessedUploadsByIDsFunc
+	// GetProcessedUploadsWithDefinitionsForMonikersFunc is an instance of a
+	// mock function object controlling the behavior of the method
+	// GetProcessedUploadsWithDefinitionsForMonikers.
+	GetProcessedUploadsWithDefinitionsForMonikersFunc *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc
 	// GetRecentIndexesSummaryFunc is an instance of a mock function object
 	// controlling the behavior of the method GetRecentIndexesSummary.
 	GetRecentIndexesSummaryFunc *StoreGetRecentIndexesSummaryFunc
@@ -273,7 +275,7 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) (r0 error) {
 				return
 			},
@@ -303,13 +305,13 @@ func NewMockStore() *MockStore {
 				return
 			},
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.Dump, r1 error) {
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.Dump, r1 error) {
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -330,16 +332,6 @@ func NewMockStore() *MockStore {
 		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) (r0 []shared.DirtyRepository, r1 error) {
-				return
-			},
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) (r0 []shared.Dump, r1 error) {
-				return
-			},
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.Dump, r1 error) {
 				return
 			},
 		},
@@ -370,6 +362,16 @@ func NewMockStore() *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (r0 time.Time, r1 bool, r2 error) {
+				return
+			},
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) (r0 []shared.ProcessedUpload, r1 error) {
+				return
+			},
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) (r0 []shared.ProcessedUpload, r1 error) {
 				return
 			},
 		},
@@ -600,9 +602,9 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.DeleteOldAuditLogs")
 			},
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
 			defaultHook: func(context.Context, int, string, string, string) error {
-				panic("unexpected invocation of MockStore.DeleteOverlappingDumps")
+				panic("unexpected invocation of MockStore.DeleteOverlappingProcessedUploads")
 			},
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
@@ -630,14 +632,14 @@ func NewStrictMockStore() *MockStore {
 				panic("unexpected invocation of MockStore.ExpireFailedRecords")
 			},
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.FindClosestDumps")
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestProcessedUploads")
 			},
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.FindClosestDumpsFromGraphFragment")
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.FindClosestProcessedUploadsFromGraphFragment")
 			},
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
@@ -658,16 +660,6 @@ func NewStrictMockStore() *MockStore {
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: func(context.Context) ([]shared.DirtyRepository, error) {
 				panic("unexpected invocation of MockStore.GetDirtyRepositories")
-			},
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: func(context.Context, []int) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.GetDumpsByIDs")
-			},
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-				panic("unexpected invocation of MockStore.GetDumpsWithDefinitionsForMonikers")
 			},
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
@@ -698,6 +690,16 @@ func NewStrictMockStore() *MockStore {
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: func(context.Context, int) (time.Time, bool, error) {
 				panic("unexpected invocation of MockStore.GetOldestCommitDate")
+			},
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.GetProcessedUploadsByIDs")
+			},
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+				panic("unexpected invocation of MockStore.GetProcessedUploadsWithDefinitionsForMonikers")
 			},
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
@@ -917,8 +919,8 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		DeleteOldAuditLogsFunc: &StoreDeleteOldAuditLogsFunc{
 			defaultHook: i.DeleteOldAuditLogs,
 		},
-		DeleteOverlappingDumpsFunc: &StoreDeleteOverlappingDumpsFunc{
-			defaultHook: i.DeleteOverlappingDumps,
+		DeleteOverlappingProcessedUploadsFunc: &StoreDeleteOverlappingProcessedUploadsFunc{
+			defaultHook: i.DeleteOverlappingProcessedUploads,
 		},
 		DeleteUploadByIDFunc: &StoreDeleteUploadByIDFunc{
 			defaultHook: i.DeleteUploadByID,
@@ -935,11 +937,11 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		ExpireFailedRecordsFunc: &StoreExpireFailedRecordsFunc{
 			defaultHook: i.ExpireFailedRecords,
 		},
-		FindClosestDumpsFunc: &StoreFindClosestDumpsFunc{
-			defaultHook: i.FindClosestDumps,
+		FindClosestProcessedUploadsFunc: &StoreFindClosestProcessedUploadsFunc{
+			defaultHook: i.FindClosestProcessedUploads,
 		},
-		FindClosestDumpsFromGraphFragmentFunc: &StoreFindClosestDumpsFromGraphFragmentFunc{
-			defaultHook: i.FindClosestDumpsFromGraphFragment,
+		FindClosestProcessedUploadsFromGraphFragmentFunc: &StoreFindClosestProcessedUploadsFromGraphFragmentFunc{
+			defaultHook: i.FindClosestProcessedUploadsFromGraphFragment,
 		},
 		GetAuditLogsForUploadFunc: &StoreGetAuditLogsForUploadFunc{
 			defaultHook: i.GetAuditLogsForUpload,
@@ -952,12 +954,6 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetDirtyRepositoriesFunc: &StoreGetDirtyRepositoriesFunc{
 			defaultHook: i.GetDirtyRepositories,
-		},
-		GetDumpsByIDsFunc: &StoreGetDumpsByIDsFunc{
-			defaultHook: i.GetDumpsByIDs,
-		},
-		GetDumpsWithDefinitionsForMonikersFunc: &StoreGetDumpsWithDefinitionsForMonikersFunc{
-			defaultHook: i.GetDumpsWithDefinitionsForMonikers,
 		},
 		GetIndexByIDFunc: &StoreGetIndexByIDFunc{
 			defaultHook: i.GetIndexByID,
@@ -976,6 +972,12 @@ func NewMockStoreFrom(i store.Store) *MockStore {
 		},
 		GetOldestCommitDateFunc: &StoreGetOldestCommitDateFunc{
 			defaultHook: i.GetOldestCommitDate,
+		},
+		GetProcessedUploadsByIDsFunc: &StoreGetProcessedUploadsByIDsFunc{
+			defaultHook: i.GetProcessedUploadsByIDs,
+		},
+		GetProcessedUploadsWithDefinitionsForMonikersFunc: &StoreGetProcessedUploadsWithDefinitionsForMonikersFunc{
+			defaultHook: i.GetProcessedUploadsWithDefinitionsForMonikers,
 		},
 		GetRecentIndexesSummaryFunc: &StoreGetRecentIndexesSummaryFunc{
 			defaultHook: i.GetRecentIndexesSummary,
@@ -1644,36 +1646,37 @@ func (c StoreDeleteOldAuditLogsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreDeleteOverlappingDumpsFunc describes the behavior when the
-// DeleteOverlappingDumps method of the parent MockStore instance is
-// invoked.
-type StoreDeleteOverlappingDumpsFunc struct {
+// StoreDeleteOverlappingProcessedUploadsFunc describes the behavior when
+// the DeleteOverlappingProcessedUploads method of the parent MockStore
+// instance is invoked.
+type StoreDeleteOverlappingProcessedUploadsFunc struct {
 	defaultHook func(context.Context, int, string, string, string) error
 	hooks       []func(context.Context, int, string, string, string) error
-	history     []StoreDeleteOverlappingDumpsFuncCall
+	history     []StoreDeleteOverlappingProcessedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// DeleteOverlappingDumps delegates to the next hook function in the queue
-// and stores the parameter and result values of this invocation.
-func (m *MockStore) DeleteOverlappingDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
-	r0 := m.DeleteOverlappingDumpsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.DeleteOverlappingDumpsFunc.appendCall(StoreDeleteOverlappingDumpsFuncCall{v0, v1, v2, v3, v4, r0})
+// DeleteOverlappingProcessedUploads delegates to the next hook function in
+// the queue and stores the parameter and result values of this invocation.
+func (m *MockStore) DeleteOverlappingProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 string) error {
+	r0 := m.DeleteOverlappingProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
+	m.DeleteOverlappingProcessedUploadsFunc.appendCall(StoreDeleteOverlappingProcessedUploadsFuncCall{v0, v1, v2, v3, v4, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
-// DeleteOverlappingDumps method of the parent MockStore instance is invoked
-// and the hook queue is empty.
-func (f *StoreDeleteOverlappingDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
+// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// is invoked and the hook queue is empty.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, string) error) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// DeleteOverlappingDumps method of the parent MockStore instance invokes
-// the hook at the front of the queue and discards it. After the queue is
-// empty, the default hook function is invoked for any future action.
-func (f *StoreDeleteOverlappingDumpsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
+// DeleteOverlappingProcessedUploads method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, string) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1681,20 +1684,20 @@ func (f *StoreDeleteOverlappingDumpsFunc) PushHook(hook func(context.Context, in
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreDeleteOverlappingDumpsFunc) SetDefaultReturn(r0 error) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) SetDefaultReturn(r0 error) {
 	f.SetDefaultHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreDeleteOverlappingDumpsFunc) PushReturn(r0 error) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) PushReturn(r0 error) {
 	f.PushHook(func(context.Context, int, string, string, string) error {
 		return r0
 	})
 }
 
-func (f *StoreDeleteOverlappingDumpsFunc) nextHook() func(context.Context, int, string, string, string) error {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1707,26 +1710,28 @@ func (f *StoreDeleteOverlappingDumpsFunc) nextHook() func(context.Context, int, 
 	return hook
 }
 
-func (f *StoreDeleteOverlappingDumpsFunc) appendCall(r0 StoreDeleteOverlappingDumpsFuncCall) {
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) appendCall(r0 StoreDeleteOverlappingProcessedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreDeleteOverlappingDumpsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreDeleteOverlappingDumpsFunc) History() []StoreDeleteOverlappingDumpsFuncCall {
+// History returns a sequence of
+// StoreDeleteOverlappingProcessedUploadsFuncCall objects describing the
+// invocations of this function.
+func (f *StoreDeleteOverlappingProcessedUploadsFunc) History() []StoreDeleteOverlappingProcessedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreDeleteOverlappingDumpsFuncCall, len(f.history))
+	history := make([]StoreDeleteOverlappingProcessedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreDeleteOverlappingDumpsFuncCall is an object that describes an
-// invocation of method DeleteOverlappingDumps on an instance of MockStore.
-type StoreDeleteOverlappingDumpsFuncCall struct {
+// StoreDeleteOverlappingProcessedUploadsFuncCall is an object that
+// describes an invocation of method DeleteOverlappingProcessedUploads on an
+// instance of MockStore.
+type StoreDeleteOverlappingProcessedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -1749,13 +1754,13 @@ type StoreDeleteOverlappingDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDeleteOverlappingDumpsFuncCall) Args() []interface{} {
+func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDeleteOverlappingDumpsFuncCall) Results() []interface{} {
+func (c StoreDeleteOverlappingProcessedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0}
 }
 
@@ -2316,35 +2321,37 @@ func (c StoreExpireFailedRecordsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
-// StoreFindClosestDumpsFunc describes the behavior when the
-// FindClosestDumps method of the parent MockStore instance is invoked.
-type StoreFindClosestDumpsFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)
-	history     []StoreFindClosestDumpsFuncCall
+// StoreFindClosestProcessedUploadsFunc describes the behavior when the
+// FindClosestProcessedUploads method of the parent MockStore instance is
+// invoked.
+type StoreFindClosestProcessedUploadsFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)
+	history     []StoreFindClosestProcessedUploadsFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestDumps delegates to the next hook function in the queue and
-// stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestDumps(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
-	m.FindClosestDumpsFunc.appendCall(StoreFindClosestDumpsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
+// FindClosestProcessedUploads delegates to the next hook function in the
+// queue and stores the parameter and result values of this invocation.
+func (m *MockStore) FindClosestProcessedUploads(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.FindClosestProcessedUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.FindClosestProcessedUploadsFunc.appendCall(StoreFindClosestProcessedUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the FindClosestDumps
-// method of the parent MockStore instance is invoked and the hook queue is
-// empty.
-func (f *StoreFindClosestDumpsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)) {
+// SetDefaultHook sets function that is called when the
+// FindClosestProcessedUploads method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestDumps method of the parent MockStore instance invokes the hook
-// at the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.Dump, error)) {
+// FindClosestProcessedUploads method of the parent MockStore instance
+// invokes the hook at the front of the queue and discards it. After the
+// queue is empty, the default hook function is invoked for any future
+// action.
+func (f *StoreFindClosestProcessedUploadsFunc) PushHook(hook func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2352,20 +2359,20 @@ func (f *StoreFindClosestDumpsFunc) PushHook(hook func(context.Context, int, str
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestDumpsFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestDumpsFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFunc) nextHook() func(context.Context, int, string, string, bool, string) ([]shared.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2378,26 +2385,27 @@ func (f *StoreFindClosestDumpsFunc) nextHook() func(context.Context, int, string
 	return hook
 }
 
-func (f *StoreFindClosestDumpsFunc) appendCall(r0 StoreFindClosestDumpsFuncCall) {
+func (f *StoreFindClosestProcessedUploadsFunc) appendCall(r0 StoreFindClosestProcessedUploadsFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of StoreFindClosestDumpsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreFindClosestDumpsFunc) History() []StoreFindClosestDumpsFuncCall {
+// History returns a sequence of StoreFindClosestProcessedUploadsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreFindClosestProcessedUploadsFunc) History() []StoreFindClosestProcessedUploadsFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestDumpsFuncCall, len(f.history))
+	history := make([]StoreFindClosestProcessedUploadsFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestDumpsFuncCall is an object that describes an invocation
-// of method FindClosestDumps on an instance of MockStore.
-type StoreFindClosestDumpsFuncCall struct {
+// StoreFindClosestProcessedUploadsFuncCall is an object that describes an
+// invocation of method FindClosestProcessedUploads on an instance of
+// MockStore.
+type StoreFindClosestProcessedUploadsFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2418,7 +2426,7 @@ type StoreFindClosestDumpsFuncCall struct {
 	Arg5 string
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.Dump
+	Result0 []shared.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2426,47 +2434,48 @@ type StoreFindClosestDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestDumpsFuncCall) Args() []interface{} {
+func (c StoreFindClosestProcessedUploadsFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestDumpsFuncCall) Results() []interface{} {
+func (c StoreFindClosestProcessedUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
-// StoreFindClosestDumpsFromGraphFragmentFunc describes the behavior when
-// the FindClosestDumpsFromGraphFragment method of the parent MockStore
-// instance is invoked.
-type StoreFindClosestDumpsFromGraphFragmentFunc struct {
-	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)
-	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)
-	history     []StoreFindClosestDumpsFromGraphFragmentFuncCall
+// StoreFindClosestProcessedUploadsFromGraphFragmentFunc describes the
+// behavior when the FindClosestProcessedUploadsFromGraphFragment method of
+// the parent MockStore instance is invoked.
+type StoreFindClosestProcessedUploadsFromGraphFragmentFunc struct {
+	defaultHook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)
+	history     []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall
 	mutex       sync.Mutex
 }
 
-// FindClosestDumpsFromGraphFragment delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) FindClosestDumpsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.Dump, error) {
-	r0, r1 := m.FindClosestDumpsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
-	m.FindClosestDumpsFromGraphFragmentFunc.appendCall(StoreFindClosestDumpsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
+// FindClosestProcessedUploadsFromGraphFragment delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) FindClosestProcessedUploadsFromGraphFragment(v0 context.Context, v1 int, v2 string, v3 string, v4 bool, v5 string, v6 *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.FindClosestProcessedUploadsFromGraphFragmentFunc.nextHook()(v0, v1, v2, v3, v4, v5, v6)
+	m.FindClosestProcessedUploadsFromGraphFragmentFunc.appendCall(StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall{v0, v1, v2, v3, v4, v5, v6, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the
-// FindClosestDumpsFromGraphFragment method of the parent MockStore instance
-// is invoked and the hook queue is empty.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)) {
+// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// FindClosestDumpsFromGraphFragment method of the parent MockStore instance
-// invokes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error)) {
+// FindClosestProcessedUploadsFromGraphFragment method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushHook(hook func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -2474,20 +2483,20 @@ func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushHook(hook func(context.
 
 // SetDefaultReturn calls SetDefaultHook with a function that returns the
 // given values.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.Dump, error) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) nextHook() func(context.Context, int, string, string, bool, string, *gitdomain.CommitGraph) ([]shared.ProcessedUpload, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -2500,28 +2509,28 @@ func (f *StoreFindClosestDumpsFromGraphFragmentFunc) nextHook() func(context.Con
 	return hook
 }
 
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestDumpsFromGraphFragmentFuncCall) {
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) appendCall(r0 StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
 // History returns a sequence of
-// StoreFindClosestDumpsFromGraphFragmentFuncCall objects describing the
-// invocations of this function.
-func (f *StoreFindClosestDumpsFromGraphFragmentFunc) History() []StoreFindClosestDumpsFromGraphFragmentFuncCall {
+// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall objects
+// describing the invocations of this function.
+func (f *StoreFindClosestProcessedUploadsFromGraphFragmentFunc) History() []StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall {
 	f.mutex.Lock()
-	history := make([]StoreFindClosestDumpsFromGraphFragmentFuncCall, len(f.history))
+	history := make([]StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// StoreFindClosestDumpsFromGraphFragmentFuncCall is an object that
-// describes an invocation of method FindClosestDumpsFromGraphFragment on an
-// instance of MockStore.
-type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
+// StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall is an object
+// that describes an invocation of method
+// FindClosestProcessedUploadsFromGraphFragment on an instance of MockStore.
+type StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -2545,7 +2554,7 @@ type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
 	Arg6 *gitdomain.CommitGraph
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 []shared.Dump
+	Result0 []shared.ProcessedUpload
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error
@@ -2553,13 +2562,13 @@ type StoreFindClosestDumpsFromGraphFragmentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreFindClosestDumpsFromGraphFragmentFuncCall) Args() []interface{} {
+func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreFindClosestDumpsFromGraphFragmentFuncCall) Results() []interface{} {
+func (c StoreFindClosestProcessedUploadsFromGraphFragmentFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3004,225 +3013,6 @@ func (c StoreGetDirtyRepositoriesFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c StoreGetDirtyRepositoriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetDumpsByIDsFunc describes the behavior when the GetDumpsByIDs
-// method of the parent MockStore instance is invoked.
-type StoreGetDumpsByIDsFunc struct {
-	defaultHook func(context.Context, []int) ([]shared.Dump, error)
-	hooks       []func(context.Context, []int) ([]shared.Dump, error)
-	history     []StoreGetDumpsByIDsFuncCall
-	mutex       sync.Mutex
-}
-
-// GetDumpsByIDs delegates to the next hook function in the queue and stores
-// the parameter and result values of this invocation.
-func (m *MockStore) GetDumpsByIDs(v0 context.Context, v1 []int) ([]shared.Dump, error) {
-	r0, r1 := m.GetDumpsByIDsFunc.nextHook()(v0, v1)
-	m.GetDumpsByIDsFunc.appendCall(StoreGetDumpsByIDsFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the GetDumpsByIDs method
-// of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreGetDumpsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.Dump, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsByIDs method of the parent MockStore instance invokes the hook at
-// the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *StoreGetDumpsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.Dump, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetDumpsByIDsFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []int) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetDumpsByIDsFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, []int) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetDumpsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.Dump, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetDumpsByIDsFunc) appendCall(r0 StoreGetDumpsByIDsFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of StoreGetDumpsByIDsFuncCall objects
-// describing the invocations of this function.
-func (f *StoreGetDumpsByIDsFunc) History() []StoreGetDumpsByIDsFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetDumpsByIDsFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetDumpsByIDsFuncCall is an object that describes an invocation of
-// method GetDumpsByIDs on an instance of MockStore.
-type StoreGetDumpsByIDsFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []int
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.Dump
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetDumpsByIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetDumpsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
-}
-
-// StoreGetDumpsWithDefinitionsForMonikersFunc describes the behavior when
-// the GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance is invoked.
-type StoreGetDumpsWithDefinitionsForMonikersFunc struct {
-	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)
-	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)
-	history     []StoreGetDumpsWithDefinitionsForMonikersFuncCall
-	mutex       sync.Mutex
-}
-
-// GetDumpsWithDefinitionsForMonikers delegates to the next hook function in
-// the queue and stores the parameter and result values of this invocation.
-func (m *MockStore) GetDumpsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-	r0, r1 := m.GetDumpsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
-	m.GetDumpsWithDefinitionsForMonikersFunc.appendCall(StoreGetDumpsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
-	return r0, r1
-}
-
-// SetDefaultHook sets function that is called when the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance is invoked and the hook queue is empty.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)) {
-	f.defaultHook = hook
-}
-
-// PushHook adds a function to the end of hook queue. Each invocation of the
-// GetDumpsWithDefinitionsForMonikers method of the parent MockStore
-// instance invokes the hook at the front of the queue and discards it.
-// After the queue is empty, the default hook function is invoked for any
-// future action.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error)) {
-	f.mutex.Lock()
-	f.hooks = append(f.hooks, hook)
-	f.mutex.Unlock()
-}
-
-// SetDefaultReturn calls SetDefaultHook with a function that returns the
-// given values.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.Dump, r1 error) {
-	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-// PushReturn calls PushHook with a function that returns the given values.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.Dump, r1 error) {
-	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-		return r0, r1
-	})
-}
-
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-	f.mutex.Lock()
-	defer f.mutex.Unlock()
-
-	if len(f.hooks) == 0 {
-		return f.defaultHook
-	}
-
-	hook := f.hooks[0]
-	f.hooks = f.hooks[1:]
-	return hook
-}
-
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetDumpsWithDefinitionsForMonikersFuncCall) {
-	f.mutex.Lock()
-	f.history = append(f.history, r0)
-	f.mutex.Unlock()
-}
-
-// History returns a sequence of
-// StoreGetDumpsWithDefinitionsForMonikersFuncCall objects describing the
-// invocations of this function.
-func (f *StoreGetDumpsWithDefinitionsForMonikersFunc) History() []StoreGetDumpsWithDefinitionsForMonikersFuncCall {
-	f.mutex.Lock()
-	history := make([]StoreGetDumpsWithDefinitionsForMonikersFuncCall, len(f.history))
-	copy(history, f.history)
-	f.mutex.Unlock()
-
-	return history
-}
-
-// StoreGetDumpsWithDefinitionsForMonikersFuncCall is an object that
-// describes an invocation of method GetDumpsWithDefinitionsForMonikers on
-// an instance of MockStore.
-type StoreGetDumpsWithDefinitionsForMonikersFuncCall struct {
-	// Arg0 is the value of the 1st argument passed to this method
-	// invocation.
-	Arg0 context.Context
-	// Arg1 is the value of the 2nd argument passed to this method
-	// invocation.
-	Arg1 []precise.QualifiedMonikerData
-	// Result0 is the value of the 1st result returned from this method
-	// invocation.
-	Result0 []shared.Dump
-	// Result1 is the value of the 2nd result returned from this method
-	// invocation.
-	Result1 error
-}
-
-// Args returns an interface slice containing the arguments of this
-// invocation.
-func (c StoreGetDumpsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
-}
-
-// Results returns an interface slice containing the results of this
-// invocation.
-func (c StoreGetDumpsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 
@@ -3890,6 +3680,230 @@ func (c StoreGetOldestCommitDateFuncCall) Args() []interface{} {
 // invocation.
 func (c StoreGetOldestCommitDateFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// StoreGetProcessedUploadsByIDsFunc describes the behavior when the
+// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// invoked.
+type StoreGetProcessedUploadsByIDsFunc struct {
+	defaultHook func(context.Context, []int) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, []int) ([]shared.ProcessedUpload, error)
+	history     []StoreGetProcessedUploadsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetProcessedUploadsByIDs delegates to the next hook function in the queue
+// and stores the parameter and result values of this invocation.
+func (m *MockStore) GetProcessedUploadsByIDs(v0 context.Context, v1 []int) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsByIDsFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsByIDsFunc.appendCall(StoreGetProcessedUploadsByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetProcessedUploadsByIDs method of the parent MockStore instance is
+// invoked and the hook queue is empty.
+func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetProcessedUploadsByIDs method of the parent MockStore instance invokes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *StoreGetProcessedUploadsByIDsFunc) PushHook(hook func(context.Context, []int) ([]shared.ProcessedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetProcessedUploadsByIDsFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetProcessedUploadsByIDsFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetProcessedUploadsByIDsFunc) nextHook() func(context.Context, []int) ([]shared.ProcessedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetProcessedUploadsByIDsFunc) appendCall(r0 StoreGetProcessedUploadsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of StoreGetProcessedUploadsByIDsFuncCall
+// objects describing the invocations of this function.
+func (f *StoreGetProcessedUploadsByIDsFunc) History() []StoreGetProcessedUploadsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetProcessedUploadsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetProcessedUploadsByIDsFuncCall is an object that describes an
+// invocation of method GetProcessedUploadsByIDs on an instance of
+// MockStore.
+type StoreGetProcessedUploadsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.ProcessedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetProcessedUploadsByIDsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetProcessedUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFunc describes the
+// behavior when the GetProcessedUploadsWithDefinitionsForMonikers method of
+// the parent MockStore instance is invoked.
+type StoreGetProcessedUploadsWithDefinitionsForMonikersFunc struct {
+	defaultHook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
+	hooks       []func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)
+	history     []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall
+	mutex       sync.Mutex
+}
+
+// GetProcessedUploadsWithDefinitionsForMonikers delegates to the next hook
+// function in the queue and stores the parameter and result values of this
+// invocation.
+func (m *MockStore) GetProcessedUploadsWithDefinitionsForMonikers(v0 context.Context, v1 []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+	r0, r1 := m.GetProcessedUploadsWithDefinitionsForMonikersFunc.nextHook()(v0, v1)
+	m.GetProcessedUploadsWithDefinitionsForMonikersFunc.appendCall(StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance is invoked and the hook queue is empty.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetProcessedUploadsWithDefinitionsForMonikers method of the parent
+// MockStore instance invokes the hook at the front of the queue and
+// discards it. After the queue is empty, the default hook function is
+// invoked for any future action.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushHook(hook func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultHook with a function that returns the
+// given values.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) SetDefaultReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.SetDefaultHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushHook with a function that returns the given values.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) PushReturn(r0 []shared.ProcessedUpload, r1 error) {
+	f.PushHook(func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+		return r0, r1
+	})
+}
+
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) nextHook() func(context.Context, []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) appendCall(r0 StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall objects
+// describing the invocations of this function.
+func (f *StoreGetProcessedUploadsWithDefinitionsForMonikersFunc) History() []StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall {
+	f.mutex.Lock()
+	history := make([]StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall is an object
+// that describes an invocation of method
+// GetProcessedUploadsWithDefinitionsForMonikers on an instance of
+// MockStore.
+type StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 []precise.QualifiedMonikerData
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []shared.ProcessedUpload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c StoreGetProcessedUploadsWithDefinitionsForMonikersFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // StoreGetRecentIndexesSummaryFunc describes the behavior when the

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -104,7 +104,7 @@ const numAncestors = 100
 // the graph. This will not always produce the full set of visible commits - some responses may not contain
 // all results while a subsequent request made after the lsif_nearest_uploads has been updated to include
 // this commit will.
-func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.Dump, err error) {
+func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.ProcessedUpload, err error) {
 	ctx, _, endObservation := s.operations.inferClosestUploads.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repositoryID", repositoryID),
 		attribute.String("commit", commit),
@@ -123,10 +123,10 @@ func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, com
 	// that can answer queries for a directory (e.g. diagnostics), we want any dump that happens
 	// to intersect the target directory. If we're looking for dumps that can answer queries for
 	// a single file, then we need a dump with a root that properly encloses that file.
-	if dumps, err := s.store.FindClosestDumps(ctx, repositoryID, commit, path, exactPath, indexer); err != nil {
-		return nil, errors.Wrap(err, "store.FindClosestDumps")
-	} else if len(dumps) != 0 {
-		return dumps, nil
+	if uploads, err := s.store.FindClosestProcessedUploads(ctx, repositoryID, commit, path, exactPath, indexer); err != nil {
+		return nil, errors.Wrap(err, "store.FindClosestProcessedUploads")
+	} else if len(uploads) != 0 {
+		return uploads, nil
 	}
 
 	// Repository has no LSIF data at all
@@ -156,24 +156,24 @@ func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, com
 		return nil, errors.Wrap(err, "gitserverClient.CommitGraph")
 	}
 
-	dumps, err := s.store.FindClosestDumpsFromGraphFragment(ctx, repositoryID, commit, path, exactPath, indexer, graph)
+	uploads, err := s.store.FindClosestProcessedUploadsFromGraphFragment(ctx, repositoryID, commit, path, exactPath, indexer, graph)
 	if err != nil {
-		return nil, errors.Wrap(err, "dbstore.FindClosestDumpsFromGraphFragment")
+		return nil, errors.Wrap(err, "dbstore.FindClosestProcessedUploadsFromGraphFragment")
 	}
 
 	if err := s.store.SetRepositoryAsDirty(ctx, repositoryID); err != nil {
 		return nil, errors.Wrap(err, "dbstore.MarkRepositoryAsDirty")
 	}
 
-	return dumps, nil
+	return uploads, nil
 }
 
-func (s *Service) GetDumpsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) ([]shared.Dump, error) {
-	return s.store.GetDumpsWithDefinitionsForMonikers(ctx, monikers)
+func (s *Service) GetProcessedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
+	return s.store.GetProcessedUploadsWithDefinitionsForMonikers(ctx, monikers)
 }
 
-func (s *Service) GetDumpsByIDs(ctx context.Context, ids []int) ([]shared.Dump, error) {
-	return s.store.GetDumpsByIDs(ctx, ids)
+func (s *Service) GetProcessedUploadsByIDs(ctx context.Context, ids []int) ([]shared.ProcessedUpload, error) {
+	return s.store.GetProcessedUploadsByIDs(ctx, ids)
 }
 
 func (s *Service) ReferencesForUpload(ctx context.Context, uploadID int) (shared.PackageReferenceScanner, error) {

--- a/internal/codeintel/uploads/service.go
+++ b/internal/codeintel/uploads/service.go
@@ -104,7 +104,7 @@ const numAncestors = 100
 // the graph. This will not always produce the full set of visible commits - some responses may not contain
 // all results while a subsequent request made after the lsif_nearest_uploads has been updated to include
 // this commit will.
-func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.ProcessedUpload, err error) {
+func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, commit, path string, exactPath bool, indexer string) (_ []shared.CompletedUpload, err error) {
 	ctx, _, endObservation := s.operations.inferClosestUploads.With(ctx, &err, observation.Args{Attrs: []attribute.KeyValue{
 		attribute.Int("repositoryID", repositoryID),
 		attribute.String("commit", commit),
@@ -123,8 +123,8 @@ func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, com
 	// that can answer queries for a directory (e.g. diagnostics), we want any dump that happens
 	// to intersect the target directory. If we're looking for dumps that can answer queries for
 	// a single file, then we need a dump with a root that properly encloses that file.
-	if uploads, err := s.store.FindClosestProcessedUploads(ctx, repositoryID, commit, path, exactPath, indexer); err != nil {
-		return nil, errors.Wrap(err, "store.FindClosestProcessedUploads")
+	if uploads, err := s.store.FindClosestCompletedUploads(ctx, repositoryID, commit, path, exactPath, indexer); err != nil {
+		return nil, errors.Wrap(err, "store.FindClosestCompletedUploads")
 	} else if len(uploads) != 0 {
 		return uploads, nil
 	}
@@ -156,9 +156,9 @@ func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, com
 		return nil, errors.Wrap(err, "gitserverClient.CommitGraph")
 	}
 
-	uploads, err := s.store.FindClosestProcessedUploadsFromGraphFragment(ctx, repositoryID, commit, path, exactPath, indexer, graph)
+	uploads, err := s.store.FindClosestCompletedUploadsFromGraphFragment(ctx, repositoryID, commit, path, exactPath, indexer, graph)
 	if err != nil {
-		return nil, errors.Wrap(err, "dbstore.FindClosestProcessedUploadsFromGraphFragment")
+		return nil, errors.Wrap(err, "dbstore.FindClosestCompletedUploadsFromGraphFragment")
 	}
 
 	if err := s.store.SetRepositoryAsDirty(ctx, repositoryID); err != nil {
@@ -168,12 +168,12 @@ func (s *Service) InferClosestUploads(ctx context.Context, repositoryID int, com
 	return uploads, nil
 }
 
-func (s *Service) GetProcessedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) ([]shared.ProcessedUpload, error) {
-	return s.store.GetProcessedUploadsWithDefinitionsForMonikers(ctx, monikers)
+func (s *Service) GetCompletedUploadsWithDefinitionsForMonikers(ctx context.Context, monikers []precise.QualifiedMonikerData) ([]shared.CompletedUpload, error) {
+	return s.store.GetCompletedUploadsWithDefinitionsForMonikers(ctx, monikers)
 }
 
-func (s *Service) GetProcessedUploadsByIDs(ctx context.Context, ids []int) ([]shared.ProcessedUpload, error) {
-	return s.store.GetProcessedUploadsByIDs(ctx, ids)
+func (s *Service) GetCompletedUploadsByIDs(ctx context.Context, ids []int) ([]shared.CompletedUpload, error) {
+	return s.store.GetCompletedUploadsByIDs(ctx, ids)
 }
 
 func (s *Service) ReferencesForUpload(ctx context.Context, uploadID int) (shared.PackageReferenceScanner, error) {

--- a/internal/codeintel/uploads/shared/types.go
+++ b/internal/codeintel/uploads/shared/types.go
@@ -55,10 +55,12 @@ func (u Upload) SizeStats() UploadSizeStats {
 	return UploadSizeStats{u.ID, u.UploadSize, u.UncompressedSize}
 }
 
-// TODO - unify with Upload
-// Dump is a subset of the lsif_uploads table (queried via the lsif_dumps_with_repository_name view)
+// ProcessedUpload is a subset of the lsif_uploads table
+// (queried via the lsif_dumps_with_repository_name view)
 // and stores only processed records.
-type Dump struct {
+//
+// The State must be 'completed', see TODO(id: completed-state-check).
+type ProcessedUpload struct {
 	ID                int        `json:"id"`
 	Commit            string     `json:"commit"`
 	Root              string     `json:"root"`
@@ -202,11 +204,11 @@ type DeleteUploadsOptions struct {
 
 // Package pairs a package scheme+manager+name+version with the dump that provides it.
 type Package struct {
-	DumpID  int
-	Scheme  string
-	Manager string
-	Name    string
-	Version string
+	UploadID int
+	Scheme   string
+	Manager  string
+	Name     string
+	Version  string
 }
 
 // PackageReference is a package scheme+name+version

--- a/internal/codeintel/uploads/shared/types.go
+++ b/internal/codeintel/uploads/shared/types.go
@@ -80,6 +80,27 @@ type CompletedUpload struct {
 	AssociatedIndexID *int       `json:"associatedIndex"`
 }
 
+func (u *CompletedUpload) ConvertToUpload() Upload {
+	return Upload{
+		ID:                u.ID,
+		Commit:            u.Commit,
+		Root:              u.Root,
+		UploadedAt:        u.UploadedAt,
+		State:             u.State,
+		FailureMessage:    u.FailureMessage,
+		StartedAt:         u.StartedAt,
+		FinishedAt:        u.FinishedAt,
+		ProcessAfter:      u.ProcessAfter,
+		NumResets:         u.NumResets,
+		NumFailures:       u.NumFailures,
+		RepositoryID:      u.RepositoryID,
+		RepositoryName:    u.RepositoryName,
+		Indexer:           u.Indexer,
+		IndexerVersion:    u.IndexerVersion,
+		AssociatedIndexID: u.AssociatedIndexID,
+	}
+}
+
 type UploadLog struct {
 	LogTimestamp      time.Time
 	RecordDeletedAt   *time.Time

--- a/internal/codeintel/uploads/shared/types.go
+++ b/internal/codeintel/uploads/shared/types.go
@@ -55,12 +55,12 @@ func (u Upload) SizeStats() UploadSizeStats {
 	return UploadSizeStats{u.ID, u.UploadSize, u.UncompressedSize}
 }
 
-// ProcessedUpload is a subset of the lsif_uploads table
+// CompletedUpload is a subset of the lsif_uploads table
 // (queried via the lsif_dumps_with_repository_name view)
 // and stores only processed records.
 //
 // The State must be 'completed', see TODO(id: completed-state-check).
-type ProcessedUpload struct {
+type CompletedUpload struct {
 	ID                int        `json:"id"`
 	Commit            string     `json:"commit"`
 	Root              string     `json:"root"`

--- a/internal/oobmigration/migrations/codeintel/lsif/migrator.go
+++ b/internal/oobmigration/migrations/codeintel/lsif/migrator.go
@@ -232,7 +232,7 @@ func (m *migrator) run(ctx context.Context, sourceVersion, targetVersion int, dr
 	}
 	defer func() { err = tx.Done(err) }()
 
-	dumpID, ok, err := m.selectAndLockDump(ctx, tx, sourceVersion)
+	uploadID, ok, err := m.selectAndLockDump(ctx, tx, sourceVersion)
 	if err != nil {
 		return err
 	}
@@ -240,12 +240,12 @@ func (m *migrator) run(ctx context.Context, sourceVersion, targetVersion int, dr
 		return nil
 	}
 
-	rowValues, err := m.processRows(ctx, tx, dumpID, sourceVersion, driverFunc)
+	rowValues, err := m.processRows(ctx, tx, uploadID, sourceVersion, driverFunc)
 	if err != nil {
 		return err
 	}
 
-	if err := m.updateBatch(ctx, tx, dumpID, targetVersion, rowValues); err != nil {
+	if err := m.updateBatch(ctx, tx, uploadID, targetVersion, rowValues); err != nil {
 		return err
 	}
 
@@ -255,12 +255,12 @@ func (m *migrator) run(ctx context.Context, sourceVersion, targetVersion int, dr
 
 	rows, err := tx.Query(ctx, sqlf.Sprintf(
 		runUpdateBoundsQuery,
-		dumpID,
+		uploadID,
 		sqlf.Sprintf(m.options.tableName),
-		dumpID,
+		uploadID,
 		sqlf.Sprintf(m.options.tableName),
 		sqlf.Sprintf(m.options.tableName),
-		dumpID,
+		uploadID,
 	))
 	if err != nil {
 		return err
@@ -360,12 +360,12 @@ FOR UPDATE SKIP LOCKED
 // processRows selects a batch of rows from the target table associated with the given dump identifier
 // to  update and calls the given driver func over each row. The driver func returns the set of values
 // that should be used to update that row. These values are fed into a channel usable for batch insert.
-func (m *migrator) processRows(ctx context.Context, tx *basestore.Store, dumpID, version int, driverFunc driverFunc) (_ <-chan []any, err error) {
+func (m *migrator) processRows(ctx context.Context, tx *basestore.Store, uploadID, version int, driverFunc driverFunc) (_ <-chan []any, err error) {
 	rows, err := tx.Query(ctx, sqlf.Sprintf(
 		processRowsQuery,
 		sqlf.Join(m.selectionExpressions, ", "),
 		sqlf.Sprintf(m.options.tableName),
-		dumpID,
+		uploadID,
 		version,
 		m.options.batchSize,
 	))
@@ -401,7 +401,7 @@ var (
 // updateBatch creates a temporary table symmetric to the target table but without any of the read-only
 // fields. Then, the given row values are bulk inserted into the temporary table. Finally, the rows in
 // the temporary table are used to update the target table.
-func (m *migrator) updateBatch(ctx context.Context, tx *basestore.Store, dumpID, targetVersion int, rowValues <-chan []any) error {
+func (m *migrator) updateBatch(ctx context.Context, tx *basestore.Store, uploadID, targetVersion int, rowValues <-chan []any) error {
 	if err := tx.Exec(ctx, sqlf.Sprintf(
 		updateBatchTemporaryTableQuery,
 		temporaryTableExpression,
@@ -429,7 +429,7 @@ func (m *migrator) updateBatch(ctx context.Context, tx *basestore.Store, dumpID,
 		sqlf.Join(m.updateAssignments, ", "),
 		targetVersion,
 		temporaryTableExpression,
-		dumpID,
+		uploadID,
 		sqlf.Join(m.updateConditions, " AND "),
 	)); err != nil {
 		return err

--- a/internal/oobmigration/migrations/codeintel/lsif/migrator_test.go
+++ b/internal/oobmigration/migrations/codeintel/lsif/migrator_test.go
@@ -69,11 +69,11 @@ func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
 
 	for i := 0; i < n; i++ {
 		// 33% id=42, 33% id=43, 33% id=44
-		dumpID := 42 + i/(n/3)
+		uploadID := 42 + i/(n/3)
 
 		if err := store.Exec(context.Background(), sqlf.Sprintf(
 			"INSERT INTO t_test (dump_id, a, b, c, schema_version) VALUES (%s, %s, %s, %s, 1)",
-			dumpID,
+			uploadID,
 			i,
 			i*10,
 			i*100,
@@ -83,10 +83,10 @@ func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
 	}
 
 	// 42 is missing; 45 is extra
-	for _, dumpID := range []int{43, 44, 45} {
+	for _, uploadID := range []int{43, 44, 45} {
 		if err := store.Exec(context.Background(), sqlf.Sprintf(
 			"INSERT INTO t_test_schema_versions (dump_id, min_schema_version, max_schema_version) VALUES (%s, 1, 1)",
-			dumpID,
+			uploadID,
 		)); err != nil {
 			t.Fatalf("unexpected error inserting schema version row: %s", err)
 		}

--- a/lib/codeintel/lsif/conversion/correlate.go
+++ b/lib/codeintel/lsif/conversion/correlate.go
@@ -146,15 +146,15 @@ func correlateFromReader(ctx context.Context, r io.Reader, root string) (*State,
 
 type wrappedState struct {
 	*State
-	dumpRoot            string
+	uploadRoot          string
 	unsupportedVertices *datastructures.IDSet
 	rangeToDoc          map[int]int
 }
 
-func newWrappedState(dumpRoot string) *wrappedState {
+func newWrappedState(uploadRoot string) *wrappedState {
 	return &wrappedState{
 		State:               newState(),
-		dumpRoot:            dumpRoot,
+		uploadRoot:          uploadRoot,
 		unsupportedVertices: datastructures.NewIDSet(),
 		rangeToDoc:          map[int]int{},
 	}
@@ -252,8 +252,8 @@ func correlateMetaData(state *wrappedState, element Element) error {
 		payload.ProjectRoot += "/"
 	}
 
-	if state.dumpRoot != "" && !strings.HasSuffix(payload.ProjectRoot, "/"+state.dumpRoot) {
-		payload.ProjectRoot += state.dumpRoot
+	if state.uploadRoot != "" && !strings.HasSuffix(payload.ProjectRoot, "/"+state.uploadRoot) {
+		payload.ProjectRoot += state.uploadRoot
 	}
 
 	state.LSIFVersion = payload.Version

--- a/lib/codeintel/precise/types.go
+++ b/lib/codeintel/precise/types.go
@@ -204,7 +204,7 @@ type DocumentationMapping struct {
 type DocumentationSearchResult struct {
 	ID        int64
 	RepoID    int32
-	DumpID    int32
+	UploadID  int32
 	DumpRoot  string
 	PathID    string
 	Detail    string

--- a/lib/codeintel/tools/lsif-repl/main.go
+++ b/lib/codeintel/tools/lsif-repl/main.go
@@ -41,7 +41,7 @@ func main() {
 				fmt.Println("wrong number of args to q")
 				break
 			}
-			dumpID, err := strconv.Atoi(fields[1])
+			uploadID, err := strconv.Atoi(fields[1])
 			if err != nil {
 				fmt.Println("first arg should be an integer")
 				break
@@ -58,7 +58,7 @@ func main() {
 				break
 			}
 
-			err = queryBundle(bundles[dumpID], path, line, column)
+			err = queryBundle(bundles[uploadID], path, line, column)
 			if err != nil {
 				fmt.Printf("%s\n", helpMsg)
 				break


### PR DESCRIPTION
Reviewer request:
- Christoph - please check if my understanding of the commitgraph bits is correct
- Anton - please check that my general understanding of state of `lsif_uploads`/`lsif_dumps` is correct
- Other parts - Anyone is free to review

Background information:

- `lsif_dumps` is a view which subsets out `lsif_uploads` ([source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@e7484252eb449c27e1fb2ca22ab7fa8bd757a818/-/blob/migrations/frontend/squashed.sql?L3102-3126)). It checks that the state is either 'completed' or 'deleting'.
  - `lsif_dumps_with_repository_name` is a view which further subsets out `lsif_dumps` and checks that `deleted_at IS NULL` ([source](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@e7484252eb449c27e1fb2ca22ab7fa8bd757a818/-/blob/migrations/frontend/squashed.sql?L3137-3163)).
    - [ ] Is it guaranteed that the state is `deleting` then `deleted_at` is non null? It seems reasonable, but I need to double-check. Or can we return uploads which are currently mid-deletion (which seems non-ideal)? I briefly looked at [`SET state = 'deleting'`](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40ec02bad+SET+state+%3D+%27deleting%27&patternType=standard&sm=0) and [`SET state = 'deleted'`](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40ec02bad+SET+state+%3D+%27deleted%27&patternType=standard&sm=0), and in both places, we don't seem to be setting the `deleted_at` column. 🤔
    - There are 3 usages of this view. In all 3 cases, it seems like we really only want `state = 'completed'` uploads.
      - [`getDumpsByIDsQuery`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@e7484252eb449c27e1fb2ca22ab7fa8bd757a818/-/blob/internal/codeintel/uploads/internal/store/uploads.go?L247-267)
      - [`definitionDumpsQuery`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@e7484252eb449c27e1fb2ca22ab7fa8bd757a818/-/blob/internal/codeintel/uploads/internal/store/uploads.go?L579-625)
      - [`findClosestDumpsFromGraphFragmentQuery`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@e7484252eb449c27e1fb2ca22ab7fa8bd757a818/-/blob/internal/codeintel/uploads/internal/store/commitgraph.go?L440-461)

For now, I'm just removing the 'Dumps' terminology because it is not self-explanatory, and is sometimes used interchangeably with an entirely different term 'Uploads', making reading the code confusing. If there is agreement on the expected behavior, I can file follow-up issues so that we rename the views, and change the logic to check `state = 'completed'` rather than `deleted_at is NULL`.

Side-notes:

- `lsif_dumps` is directly used in [referenceIDsQuery](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@ec02bad50e68a07354dddb189c8c7f56bd047225/-/blob/internal/codeintel/uploads/internal/store/uploads.go?L478-516) which makes it seems like we can potentially return references inside `state = 'deleting'` uploads.
  - This seems wrong given that [this usage site of `referenceIDsQuery`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@ec02bad50e68a07354dddb189c8c7f56bd047225/-/blob/internal/codeintel/uploads/internal/store/uploads.go?L413-463) where we attempt to locate uploads which refer to package names from any of the arguments.

## Test plan

Covered by existing tests