### PR TITLE
document the actual git command needed for ParseCommitGraph

### DIFF
--- a/internal/codeintel/uploads/internal/commitgraph/commit_graph_test.go
+++ b/internal/codeintel/uploads/internal/commitgraph/commit_graph_test.go
@@ -32,7 +32,7 @@ func TestCalculateVisibleUploads(t *testing.T) {
 	//                         +--- g
 	//
 	// NOTE: The input to ParseCommitGraph must match the order and format
-	// of `git log --topo-sort`.
+	// of `git log --pretty="%H %P" --topo-order`.
 	testGraph := gitdomain.ParseCommitGraph([]string{
 		"n l",
 		"m k",

--- a/internal/gitserver/gitdomain/commit_graph.go
+++ b/internal/gitserver/gitdomain/commit_graph.go
@@ -17,7 +17,7 @@ func (c *CommitGraph) Order() []string            { return c.order }
 // before children. If a commit is listed but has no ancestors then its parent
 // slice is empty, but is still present in the map and the ordering. If the
 // ordering is to be correct, the git log output must be formatted with
-// --topo-order.
+// `git log --pretty="%H %P" --topo-order`.
 func ParseCommitGraph(lines []string) *CommitGraph {
 	// Process lines backwards so that we see all parents before children. We get a
 	// topological ordering by simply scraping the keys off in this order.


### PR DESCRIPTION
I had to track this down through the code, but having it in the doc string should make it easier for the next person.

## Test plan

Just a documentation change
