### PR TITLE
feat/rel: run tests + finalize steps

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -63,7 +63,7 @@ promoteToPublic:
               "branch": "{{git.branch}}",
               "message": "Promoting internal release {{version}} to public",
               "env": {
-                "DISABLE_ASPECT_WORKFLOWS": "true"
+                "DISABLE_ASPECT_WORKFLOWS": "true",
                 "RELEASE_PUBLIC": "true",
                 "VERSION": "{{tag}}"
               }


### PR DESCRIPTION
Fixes #61066
Fixes #61067 

The issue with the promotion of the jaeger image is unrelated to this PR, gotta check why it wasn't part of the internal release. 

## Test plan

- Internal release showing the placeholders:
  - ![CleanShot 2024-03-14 at 17 07 38@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/c672ab90-78e9-4e41-b8e2-85f117fbf2f7)
- Promoted release showing the placeholders:
  - ![CleanShot 2024-03-14 at 17 06 38@2x](https://github.com/sourcegraph/sourcegraph/assets/10151/fd79f3f1-cdce-4754-84fd-5b147d8e75b7)
  

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
