### PR TITLE
Expose Rate Limit Status from Cody Gateway

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -6638,6 +6638,11 @@ type User implements Node & SettingsSubject & Namespace {
     """
     codySubscription: CodySubscription
     """
+    The rate limit status for the user stored in Cody Gateway.
+    On dotcom only the user and site admins can access this field.
+    """
+    codyGatewayRateLimitStatus: [CodyGatewayRateLimitStatus!]
+    """
     DEPRECATED
     Whether the user has enrolled for Cody Pro.
     """

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -233,6 +233,32 @@ func (r *UserResolver) CodySubscription(ctx context.Context) (*CodySubscriptionR
 	return &CodySubscriptionResolver{subscription: subscription}, nil
 }
 
+func (r *UserResolver) CodyGatewayRateLimitStatus(ctx context.Context) (*[]RateLimitStatus, error) {
+	if !dotcom.SourcegraphDotComMode() {
+		return nil, errors.New("this feature is only available on sourcegraph.com")
+	}
+
+	// 🚨 SECURITY: Only the user and admins are allowed to access the user's
+	// settings, because they may contain secrets or other sensitive data.
+	if err := auth.CheckSiteAdminOrSameUserFromActor(r.actor, r.db, r.user.ID); err != nil {
+		return nil, err
+	}
+
+	limits, err := cody.GetGatewayRateLimits(ctx, r.user.ID, r.db)
+	if err != nil {
+		return nil, err
+	}
+
+	rateLimits := make([]RateLimitStatus, 0, len(limits))
+	for _, limit := range limits {
+		rateLimits = append(rateLimits, &codyRateLimit{
+			rl: limit,
+		})
+	}
+
+	return &rateLimits, nil
+}
+
 func (r *UserResolver) CreatedAt() gqlutil.DateTime {
 	return gqlutil.DateTime{Time: r.user.CreatedAt}
 }

--- a/internal/cody/BUILD.bazel
+++ b/internal/cody/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//internal/accesstoken",
         "//internal/actor",
         "//internal/auth",
+        "//internal/codygateway",
         "//internal/conf",
         "//internal/conf/conftypes",
         "//internal/database",

--- a/internal/cody/rate_limits.go
+++ b/internal/cody/rate_limits.go
@@ -3,10 +3,16 @@ package cody
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"sort"
+
+	"github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/sourcegraph/internal/accesstoken"
+	"github.com/sourcegraph/sourcegraph/internal/codygateway"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -17,33 +23,90 @@ import (
 
 // RefreshGatewayRateLimits refreshes the rate limits for the user on Cody Gateway.
 func RefreshGatewayRateLimits(ctx context.Context, userID int32, db database.DB) (error, int) {
+	logger := log.Scoped("RefreshGatewayRateLimits")
+	resp, err := newGatewayRequestForUser(ctx, userID, db, http.MethodPost, "/v1/limits/refresh", nil)
+	if err != nil {
+		logger.Error("failed request to Cody Gateway to refresh rate limits", log.Error(err))
+		return err, http.StatusInternalServerError
+	}
+	if resp == nil {
+		return nil, http.StatusOK
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logger.Error(fmt.Sprintf("non-200 response refreshing Gateway rate limits: %d", resp.StatusCode))
+		return errors.Errorf("non-200 response refreshing Gateway rate limits: %d", resp.StatusCode), resp.StatusCode
+	}
+
+	return nil, http.StatusOK
+}
+
+// GetGatewayRateLimits fetches rate limits values for the user from Cody Gateway.
+func GetGatewayRateLimits(ctx context.Context, userID int32, db database.DB) ([]codygateway.LimitStatus, error) {
+	logger := log.Scoped("GetGatewayRateLimits")
+
+	resp, err := newGatewayRequestForUser(ctx, userID, db, http.MethodGet, "/v1/limits", nil)
+	if err != nil {
+		logger.Error("failed request to Cody Gateway to fetch rate limits", log.Error(err))
+		return []codygateway.LimitStatus{}, err
+	}
+
+	if resp == nil {
+		return []codygateway.LimitStatus{}, nil
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		logger.Error(fmt.Sprintf("non-200 response fetching rate limits from Gateway: %d", resp.StatusCode))
+		return []codygateway.LimitStatus{}, errors.Errorf("non-200 response fetching rate limits from Gateway: %d", resp.StatusCode)
+	}
+
+	var featureLimits map[string]codygateway.LimitStatus
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&featureLimits); err != nil {
+		return nil, err
+	}
+
+	rateLimits := make([]codygateway.LimitStatus, 0, len(featureLimits))
+	for f, limit := range featureLimits {
+		feat := codygateway.Feature(f)
+		// Check if this is a limit for a feature we know about.
+		if feat.IsValid() {
+			limit.Feature = feat
+			rateLimits = append(rateLimits, limit)
+		}
+	}
+
+	// Make sure the limits are always returned in the same order, since the map
+	// above doesn't have deterministic ordering.
+	sort.Slice(rateLimits, func(i, j int) bool {
+		return rateLimits[i].Feature < rateLimits[j].Feature
+	})
+
+	return rateLimits, nil
+}
+
+func newGatewayRequestForUser(ctx context.Context, userID int32, db database.DB, method string, pathname string, body io.Reader) (*http.Response, error) {
 	completionsConfig := conf.GetCompletionsConfig(conf.Get().SiteConfig())
 	// We don't need to do anything if the target is not Cody Gateway, but it's not an error either.
 	if completionsConfig.Provider != conftypes.CompletionsProviderNameSourcegraph {
-		return nil, http.StatusOK
+		return nil, nil
 	}
 
 	apiTokenSha256, err := db.AccessTokens().GetOrCreateInternalToken(ctx, userID, []string{"user:all"})
 	if err != nil {
-		return errors.Wrap(err, "getting internal access token"), http.StatusInternalServerError
+		return nil, errors.Wrap(err, "getting internal access token")
 	}
 	gatewayToken := accesstoken.DotcomUserGatewayAccessTokenPrefix + hex.EncodeToString(hashutil.ToSHA256Bytes(apiTokenSha256))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, completionsConfig.Endpoint+"/v1/limits/refresh", nil)
+	req, err := http.NewRequestWithContext(ctx, method, completionsConfig.Endpoint+pathname, body)
 	if err != nil {
-		return err, http.StatusInternalServerError
+		return nil, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", gatewayToken))
 
-	resp, err := httpcli.UncachedExternalDoer.Do(req)
-	defer func() { _ = resp.Body.Close() }()
-	if err != nil {
-		return err, http.StatusInternalServerError
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("non-200 response refreshing Gateway limits: %d", resp.StatusCode), resp.StatusCode
-	}
-
-	return nil, http.StatusOK
+	return httpcli.UncachedExternalDoer.Do(req)
 }


### PR DESCRIPTION
closes: https://github.com/sourcegraph/sourcegraph/issues/61055

This PR exposes a dotcom-only API for debugging purposes to easily surface the value of per feature rate limits config & usage for a user from the cody gateway redis storage. This API will only be used for debugging purposes. 

![CleanShot 2024-03-19 at 12 49 27@2x](https://github.com/sourcegraph/sourcegraph/assets/22571395/73d159bc-f715-49bc-8a06-d670eaf2e77a)


## Test plan
- Visit `/.api/console`
- Perform the following query:
``` graphql
query {
  currentUser {
    id
    codyGatewayRateLimitStatus {
      feature 
      interval
      limit
      nextLimitReset
      usage
    }
  }
}
```
- It should respond with the details as shown in screenshot above.
- If it returns in 401 error, make sure `CODY_GATEWAY_DOTCOM_ACCESS_TOKEN` is configured correctly. 