### PR TITLE
ci: do not fetch tags on steps that do not require it

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -14,6 +14,7 @@ function fetch_tags() {
     COUNT=10
     echo "~~~ :git: Fetching last $COUNT tags"
     git ls-remote --tags origin | sort -t '/' -k 3 -V | tail -n $COUNT | awk -F'/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq | while read -r tag; do
+    # we don't use deepen here since during testing it caused more history to be fetched than just the history for the tag which incured a ~40s cost over 5s with just fetch tag
     git fetch -v origin tag "$tag"
     done
 }

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -13,7 +13,7 @@ source "$HOME/.profile"
 COUNT=10
 echo "~~~ :git: Fetching last $COUNT tags"
 git ls-remote --tags origin | sort -t '/' -k 3 -V | tail -n $COUNT | awk -F'/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq | while read -r tag; do
-  git fetch -v origin tag "$tag"
+  git fetch --deepen=500 -v origin tag "$tag"
 done
 
 # Link command wrapper scripts so we can have more readable steps in the buildkite UI

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -3,17 +3,26 @@
 # shellcheck disable=SC1090,SC1091
 source "$HOME/.profile"
 
-# due to how the repostiory is cloned with --depth=100 (see aspect terraform docs), we need to fetch the tags manually
-# we don't want to fetch all the tags, so here:
-# 1. Get a list of tags from the remote
-# 2. Sort them
-# 3. Get the last $COUNT tags
-# 4. Parse them so that we only get the tag
-# 5. Then loop through every tag and fetch it
-COUNT=10
-echo "~~~ :git: Fetching last $COUNT tags"
-git ls-remote --tags origin | sort -t '/' -k 3 -V | tail -n $COUNT | awk -F'/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq | while read -r tag; do
-  git fetch --deepen=500 -v origin tag "$tag"
+function fetch_tags() {
+    # due to how the repostiory is cloned with --depth=100 (see aspect terraform docs), we need to fetch the tags manually
+    # we don't want to fetch all the tags, so here:
+    # 1. Get a list of tags from the remote
+    # 2. Sort them
+    # 3. Get the last $COUNT tags
+    # 4. Parse them so that we only get the tag
+    # 5. Then loop through every tag and fetch it
+    COUNT=10
+    echo "~~~ :git: Fetching last $COUNT tags"
+    git ls-remote --tags origin | sort -t '/' -k 3 -V | tail -n $COUNT | awk -F'/' '{gsub(/\^\{\}$/, "", $3); print $3}' | uniq | while read -r tag; do
+    git fetch -v origin tag "$tag"
+    done
+}
+
+steps_with_tags=(":pipeline: Generate pipeline" ":bazel: Test" ":bazel: Integration/E2E (Test)")
+for step in "${steps_with_tags[@]}"; do
+    if [[ "$BUILDKITE_LABEL" == "$step" ]]; then
+        fetch_tags
+    fi
 done
 
 # Link command wrapper scripts so we can have more readable steps in the buildkite UI


### PR DESCRIPTION
This is a small optimization. We don't need to incur the cost of fetching tags on steps that do not require it.

Also added a comment on why we do not use `--deepen` as part of the fetch. Since the original premice was that without `--deepen` git would fetch all of the history and therefore take longer and one should use `--deepen` or to limit that. In testing `--deepen` caused the command to take 50s over just 5s (warm repo) for `git fetch --tag`

## Test plan
CI