### PR TITLE
fix/sg: doc usage of sg release commands

### DIFF
--- a/dev/sg/internal/release/release.go
+++ b/dev/sg/internal/release/release.go
@@ -31,9 +31,9 @@ var releaseRunFlags = []cli.Flag{
 		Usage: "Preview all the commands that would be performed",
 	},
 	&cli.StringFlag{
-		Name:  "version",
-		Value: "v6.6.666",
-		Usage: "Force version",
+		Name:     "version",
+		Usage:    "Force version",
+		Required: true,
 	},
 	&cli.StringFlag{
 		Name:  "inputs",
@@ -81,11 +81,11 @@ var Command = &cli.Command{
 				},
 				{
 					Name:  "internal",
-					Usage: "todo",
+					Usage: "Run manifest defined steps (internal releases)",
 					Subcommands: []*cli.Command{
 						{
 							Name:  "finalize",
-							Usage: "Run internal release finalize steps",
+							Usage: "Run manifest defined finalize step for internal releases",
 							Flags: releaseRunFlags,
 							Action: func(cctx *cli.Context) error {
 								r, err := newReleaseRunnerFromCliContext(cctx)
@@ -99,11 +99,11 @@ var Command = &cli.Command{
 				},
 				{
 					Name:  "promote-to-public",
-					Usage: "TODO",
+					Usage: "Run manifest defined steps (public releases)",
 					Subcommands: []*cli.Command{
 						{
 							Name:  "finalize",
-							Usage: "Run internal release finalize steps",
+							Usage: "Run manifest defined finalize step for public releases",
 							Flags: releaseRunFlags,
 							Action: func(cctx *cli.Context) error {
 								r, err := newReleaseRunnerFromCliContext(cctx)
@@ -118,11 +118,12 @@ var Command = &cli.Command{
 			},
 		},
 		{
-			Name:      "create",
-			Usage:     "Create a release for a given product",
-			UsageText: "sg release create --workdir [path] --type patch",
-			Category:  category.Util,
-			Flags:     releaseRunFlags,
+			Name:        "create",
+			Usage:       "Create a release for a given product",
+			Description: "See https://go/releases",
+			UsageText:   "sg release create --workdir [path-to-folder-with-manifest] --version vX.Y.Z",
+			Category:    category.Util,
+			Flags:       releaseRunFlags,
 			Action: func(cctx *cli.Context) error {
 				r, err := newReleaseRunnerFromCliContext(cctx)
 				if err != nil {
@@ -133,8 +134,8 @@ var Command = &cli.Command{
 		},
 		{
 			Name:      "promote-to-public",
-			Usage:     "Promete an existing release to the public",
-			UsageText: "sg release promote-to-public --workdir [path] --type patch",
+			Usage:     "Promote an internal release to the public",
+			UsageText: "sg release promote-to-public --workdir [path-to-folder-with-manifest] --version vX.Y.Z",
 			Category:  category.Util,
 			Flags:     releaseRunFlags,
 			Action: func(cctx *cli.Context) error {


### PR DESCRIPTION
Prior to this PR, a bunch of TODO were left in there. 

## Test plan

Locally tested, ran `go run ./dev/sg release [stuff] --help` to ensure it looks correct. 

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
