### PR TITLE
exclude pnpm-lock.yaml from precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: check-yaml
+        exclude: 'pnpm-lock.yaml'
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/keith/pre-commit-buildifier


### PR DESCRIPTION
File is generated by pnpm so if `precommit` does find an issue its likely a false positive
## Test plan
On a branch where I ran `pnpm dedupe` precommit said there was an issue with `pnpm-lock.yaml`