### PR TITLE
Svelte: search results styling updates

### DIFF
--- a/client/web-sveltekit/src/lib/search/dynamicFilters/CountBadge.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/CountBadge.svelte
@@ -30,3 +30,10 @@
         {/if}
     </span>
 {/if}
+
+<style lang="scss">
+    span.count :global(span) {
+        background-color: var(--secondary-2);
+        color: var(--text-muted);
+    }
+</style>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Section.svelte
@@ -154,7 +154,7 @@
         }
 
         &:hover {
-            background-color: var(--secondary-4);
+            background-color: var(--secondary-2);
         }
 
         &.selected {

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -100,12 +100,7 @@
         {#if !queryHasTypeFilter(searchQuery)}
             <Section items={typeFilters} title="By type" showAll>
                 <svelte:fragment slot="label" let:label>
-                    <Icon
-                        --color="var(--icon-color)"
-                        svgPath={typeFilterIcons[label]}
-                        inline
-                        aria-hidden="true"
-                    />&nbsp;
+                    <Icon svgPath={typeFilterIcons[label]} inline aria-hidden="true" />&nbsp;
                     {label}
                 </svelte:fragment>
             </Section>
@@ -115,7 +110,7 @@
             <svelte:fragment slot="label" let:label>
                 <Tooltip tooltip={label} placement="right">
                     <span>
-                        <CodeHostIcon --color="var(--icon-color)" disableTooltip repository={label} />
+                        <CodeHostIcon disableTooltip repository={label} />
                         <span>{displayRepoName(label)}</span>
                     </span>
                 </Tooltip>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/Sidebar.svelte
@@ -100,7 +100,12 @@
         {#if !queryHasTypeFilter(searchQuery)}
             <Section items={typeFilters} title="By type" showAll>
                 <svelte:fragment slot="label" let:label>
-                    <Icon svgPath={typeFilterIcons[label]} inline aria-hidden="true" />&nbsp;
+                    <Icon
+                        --color="var(--icon-color)"
+                        svgPath={typeFilterIcons[label]}
+                        inline
+                        aria-hidden="true"
+                    />&nbsp;
                     {label}
                 </svelte:fragment>
             </Section>
@@ -110,7 +115,7 @@
             <svelte:fragment slot="label" let:label>
                 <Tooltip tooltip={label} placement="right">
                     <span>
-                        <CodeHostIcon disableTooltip repository={label} />
+                        <CodeHostIcon --color="var(--icon-color)" disableTooltip repository={label} />
                         <span>{displayRepoName(label)}</span>
                     </span>
                 </Tooltip>

--- a/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
+++ b/client/web-sveltekit/src/lib/search/dynamicFilters/index.ts
@@ -1,11 +1,4 @@
-import {
-    mdiCodeTags,
-    mdiFileCodeOutline,
-    mdiPlusMinus,
-    mdiShapeOutline,
-    mdiSourceCommit,
-    mdiSourceRepository,
-} from '@mdi/js'
+import { mdiCodeBraces, mdiFileOutline, mdiFunction, mdiPlusMinus, mdiSourceCommit, mdiSourceFork } from '@mdi/js'
 
 import type { Filter } from '@sourcegraph/shared/src/search/stream'
 
@@ -90,10 +83,10 @@ export const staticTypeFilters: URLQueryFilter[] = [
 ]
 
 export const typeFilterIcons: Record<string, string> = {
-    Code: mdiCodeTags,
-    Repositories: mdiSourceRepository,
-    Paths: mdiFileCodeOutline,
-    Symbols: mdiShapeOutline,
+    Code: mdiCodeBraces,
+    Repositories: mdiSourceFork,
+    Paths: mdiFileOutline,
+    Symbols: mdiFunction,
     Commits: mdiSourceCommit,
     Diffs: mdiPlusMinus,
 }

--- a/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/FileContentSearchResult.svelte
@@ -165,10 +165,7 @@
         }
 
         &:hover {
-            // Set the background color of the whole div to also change the color of the padding,
-            // but also make --background-color transparent to unset the background color of CodeExcerpt.
             background-color: var(--subtle-bg-2);
-            --background-color: transparent;
         }
 
         a {

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -152,5 +152,6 @@
 
     .content {
         overflow: auto;
+        background-color: var(--code-bg);
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -71,11 +71,9 @@
     {#if description}
         <!-- #key is needed here to recreate the paragraph because use:highlightRanges changes the DOM -->
         {#key description}
-            <div class="test">
-                <p class="p-2 m-0" use:highlightRanges={{ ranges: descriptionMatches }}>
-                    {limitDescription(description)}
-                </p>
-            </div>
+            <p class="p-2 m-0" use:highlightRanges={{ ranges: descriptionMatches }}>
+                {limitDescription(description)}
+            </p>
         {/key}
     {/if}<!--
         Intentional weird comment to avoid adding an empty line to the body

--- a/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/RepoSearchResult.svelte
@@ -71,12 +71,15 @@
     {#if description}
         <!-- #key is needed here to recreate the paragraph because use:highlightRanges changes the DOM -->
         {#key description}
-            <p class="p-2 m-0" use:highlightRanges={{ ranges: descriptionMatches }}>
-                {limitDescription(description)}
-            </p>
+            <div class="test">
+                <p class="p-2 m-0" use:highlightRanges={{ ranges: descriptionMatches }}>
+                    {limitDescription(description)}
+                </p>
+            </div>
         {/key}
-    {/if}
-    {#if badges.length > 0}
+    {/if}<!--
+        Intentional weird comment to avoid adding an empty line to the body
+    -->{#if badges.length > 0}
         <ul class="p-2">
             {#each badges as badge}
                 <li>

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -11,7 +11,11 @@
         </div>
     </div>
     {#if $$slots.default || $$slots.body}
-        <slot name="body"><div class="body"><slot /></div></slot>
+        <slot name="body">
+            <div class="body">
+                <slot />
+            </div>
+        </slot>
     {/if}
 </article>
 

--- a/client/web-sveltekit/src/routes/search/SearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResult.svelte
@@ -11,11 +11,7 @@
         </div>
     </div>
     {#if $$slots.default || $$slots.body}
-        <slot name="body">
-            <div class="body">
-                <slot />
-            </div>
-        </slot>
+        <slot name="body"><div class="body"><slot /></div></slot>
     {/if}
 </article>
 
@@ -57,7 +53,7 @@
         align-items: center;
     }
 
-    .body {
+    .body:not(:empty) {
         background-color: var(--code-bg);
         border-bottom: 1px solid var(--border-color);
     }

--- a/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
+++ b/client/web-sveltekit/src/routes/search/SymbolSearchResult.svelte
@@ -66,9 +66,13 @@
         display: flex;
         align-items: center;
         width: 100%;
-        background-color: var(--code-bg);
         padding: 0.5rem;
         border-bottom: 1px solid var(--border-color);
+
+        background-color: var(--code-bg);
+        &:hover {
+            background-color: var(--subtle-bg-2);
+        }
     }
 
     .symbol-kind {


### PR DESCRIPTION
This makes a handful of small styling updates to the Svelte implementation of the search results page to bring it more in line with the designs and the react app. It is not comprehensive, but it takes care of the big things.


## Test plan

Manual testing. See [Loom recording](https://www.loom.com/share/a5dd1ac1700d43be98ca483ec3c85f25)

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
