### PR TITLE
guardrails: fix TestSnippetAttributionReactsToSiteConfigChanges

### DIFF
--- a/cmd/frontend/graphqlbackend/guardrails_test.go
+++ b/cmd/frontend/graphqlbackend/guardrails_test.go
@@ -243,7 +243,7 @@ func TestSnippetAttributionReactsToSiteConfigChanges(t *testing.T) {
 	require.NoError(t, err)
 	// Same query runs in every test:
 	query := `query SnippetAttribution {
-		snippetAttribution(snippet: "sourcegraph.Location(new URL", first: 2) {
+		snippetAttribution(snippet: "sourcegraph.Location(new URL\n\n\n\n\n\n\n\n\n\n", first: 2) {
 			nodes {
 				repositoryName
 			}


### PR DESCRIPTION
This test fails for me when run via go test, but for some reason passes via bazel. I have no idea why, but the reason it fails locally for me is we don't actually try to speak to the attribution service if there are less than 10 lines in the snippet. So this is a terrible hack to fix that. It is a complete mystery to me how this test passes inside of bazel.

https://github.com/sourcegraph/sourcegraph/blob/4bca03435626b245c43cce3c6b5966e9a4ba0b7a/cmd/frontend/internal/guardrails/resolvers/resolver.go#L43-L47

Test Plan: Both of these now pass

```
go test ./cmd/frontend/graphqlbackend -run TestSnippetAttributionReactsToSiteConfigChanges
bazel test //cmd/frontend/graphqlbackend:graphqlbackend_test
```