### PR TITLE
dotcom: MockSourcegraphDotComMode requires a T for cleanup

### DIFF
--- a/cmd/frontend/backend/user_emails_test.go
+++ b/cmd/frontend/backend/user_emails_test.go
@@ -39,8 +39,7 @@ func TestCheckEmailAbuse(t *testing.T) {
 		conf.Mock(cfg)
 	}()
 
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	now := time.Now()
 

--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -360,9 +360,9 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		db := dbmocks.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		
+		dotcom.MockSourcegraphDotComMode(t, true)
+		
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		_, err := newSchemaResolver(db, gitserver.NewTestClient(t)).CreateAccessToken(ctx,
@@ -383,9 +383,9 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		conf.Get().AuthAccessTokens = &schema.AuthAccessTokens{Allow: string(conf.AccessTokensAdmin)}
 		defer func() { conf.Get().AuthAccessTokens = nil }()
 
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		
+		dotcom.MockSourcegraphDotComMode(t, true)
+		
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		_, err := newSchemaResolver(db, gitserver.NewTestClient(t)).CreateAccessToken(ctx,

--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -360,9 +360,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		db := dbmocks.NewMockDB()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		
 		dotcom.MockSourcegraphDotComMode(t, true)
-		
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		_, err := newSchemaResolver(db, gitserver.NewTestClient(t)).CreateAccessToken(ctx,
@@ -383,9 +381,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		conf.Get().AuthAccessTokens = &schema.AuthAccessTokens{Allow: string(conf.AccessTokensAdmin)}
 		defer func() { conf.Get().AuthAccessTokens = nil }()
 
-		
 		dotcom.MockSourcegraphDotComMode(t, true)
-		
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		_, err := newSchemaResolver(db, gitserver.NewTestClient(t)).CreateAccessToken(ctx,

--- a/cmd/frontend/graphqlbackend/event_logs_test.go
+++ b/cmd/frontend/graphqlbackend/event_logs_test.go
@@ -19,9 +19,7 @@ func TestUser_EventLogs(t *testing.T) {
 		users := dbmocks.NewMockUserStore()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig) // reset
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		tests := []struct {
 			name       string

--- a/cmd/frontend/graphqlbackend/org_test.go
+++ b/cmd/frontend/graphqlbackend/org_test.go
@@ -67,9 +67,7 @@ func TestOrganization(t *testing.T) {
 	})
 
 	t.Run("users not invited or not a member cannot access on Sourcegraph.com", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		RunTests(t, []*Test{
 			{
@@ -97,9 +95,7 @@ func TestOrganization(t *testing.T) {
 	})
 
 	t.Run("org members can access on Sourcegraph.com", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 
@@ -136,9 +132,7 @@ func TestOrganization(t *testing.T) {
 	})
 
 	t.Run("invited users can access on Sourcegraph.com", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 
@@ -180,9 +174,7 @@ func TestOrganization(t *testing.T) {
 	})
 
 	t.Run("invited users can access org by ID on Sourcegraph.com", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 
@@ -274,8 +266,7 @@ func TestCreateOrganization(t *testing.T) {
 	})
 
 	t.Run("Creates organization and sets statistics", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(false)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		id, err := uuid.NewV4()
 		if err != nil {
@@ -312,8 +303,7 @@ func TestCreateOrganization(t *testing.T) {
 	})
 
 	t.Run("Fails for unauthenticated user", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(false)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		RunTest(t, &Test{
 			Schema:  mustParseGraphQLSchema(t, db),
@@ -338,8 +328,7 @@ func TestCreateOrganization(t *testing.T) {
 	})
 
 	t.Run("Fails for suspicious organization name", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(false)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		RunTest(t, &Test{
 			Schema:  mustParseGraphQLSchema(t, db),
@@ -421,8 +410,7 @@ func TestAddOrganizationMember(t *testing.T) {
 	})
 
 	t.Run("Does not work for site admin on Cloud", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(false)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		RunTest(t, &Test{
 			Schema:  mustParseGraphQLSchema(t, db),
@@ -447,7 +435,7 @@ func TestAddOrganizationMember(t *testing.T) {
 	})
 
 	t.Run("Works on Cloud if site admin is org member", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
+		dotcom.MockSourcegraphDotComMode(t, true)
 		orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultHook(func(ctx context.Context, orgID int32, userID int32) (*types.OrgMembership, error) {
 			if userID == 1 {
 				return &types.OrgMembership{OrgID: orgID, UserID: 1}, nil
@@ -459,7 +447,6 @@ func TestAddOrganizationMember(t *testing.T) {
 		})
 
 		defer func() {
-			dotcom.MockSourcegraphDotComMode(false)
 			orgMembers.GetByOrgIDAndUserIDFunc.SetDefaultReturn(nil, &database.ErrOrgMemberNotFound{})
 		}()
 

--- a/cmd/frontend/graphqlbackend/roles_test.go
+++ b/cmd/frontend/graphqlbackend/roles_test.go
@@ -164,9 +164,7 @@ func TestUserRoleListing(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("on sourcegraph.com", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		t.Run("non-admin", func(t *testing.T) {
 			userAPIID := string(MarshalUserID(userID))

--- a/cmd/frontend/graphqlbackend/settings_mutation_test.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation_test.go
@@ -119,9 +119,7 @@ func TestSettingsMutation(t *testing.T) {
 		users := dbmocks.NewMockUserStore()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig) // reset
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		tests := []struct {
 			name  string

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -56,10 +56,7 @@ func TestUser(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 
 		t.Run("allowed on Sourcegraph.com", func(t *testing.T) {
-			orig := dotcom.SourcegraphDotComMode()
-			dotcom.MockSourcegraphDotComMode(true)
-			defer dotcom.MockSourcegraphDotComMode(orig)
-
+			dotcom.MockSourcegraphDotComMode(t, true)
 			checkUserByUsername(t)
 		})
 
@@ -101,9 +98,7 @@ func TestUser(t *testing.T) {
 				})
 			}
 
-			orig := dotcom.SourcegraphDotComMode()
-			dotcom.MockSourcegraphDotComMode(true)
-			defer dotcom.MockSourcegraphDotComMode(orig)
+			dotcom.MockSourcegraphDotComMode(t, true)
 
 			t.Run("for anonymous viewer", func(t *testing.T) {
 				users.GetByCurrentAuthUserFunc.SetDefaultReturn(nil, database.ErrNoCurrentUser)
@@ -182,9 +177,7 @@ func TestUser_LatestSettings(t *testing.T) {
 		db.UsersFunc.SetDefaultReturn(users)
 		db.SettingsFunc.SetDefaultReturn(dbmocks.NewMockSettingsStore())
 
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		tests := []struct {
 			name       string
@@ -247,11 +240,7 @@ func TestUser_ViewerCanAdminister(t *testing.T) {
 		users := dbmocks.NewMockUserStore()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		t.Cleanup(func() {
-			dotcom.MockSourcegraphDotComMode(orig)
-		})
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		tests := []struct {
 			name string
@@ -366,9 +355,8 @@ func TestUpdateUser(t *testing.T) {
 	})
 
 	t.Run("disallow suspicious names", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		users := dbmocks.NewMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{ID: 1}, nil)
@@ -466,9 +454,7 @@ func TestUpdateUser(t *testing.T) {
 		users := dbmocks.NewMockUserStore()
 		db.UsersFunc.SetDefaultReturn(users)
 
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		tests := []struct {
 			name       string
@@ -747,9 +733,8 @@ func TestUser_Organizations(t *testing.T) {
 	}
 
 	t.Run("on Sourcegraph.com", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		t.Cleanup(func() { dotcom.MockSourcegraphDotComMode(orig) })
+
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		t.Run("same user", func(t *testing.T) {
 			expectOrgSuccess(t, 1)

--- a/cmd/frontend/graphqlbackend/users_randomize_password_test.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password_test.go
@@ -57,9 +57,7 @@ func TestRandomizeUserPassword(t *testing.T) {
 
 	t.Run("DotCom mode", func(t *testing.T) {
 		// Test dotcom mode
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		t.Run("Errors on DotCom when sending emails is not enabled", func(t *testing.T) {
 			conf.Mock(smtpDisabledConf)

--- a/cmd/frontend/graphqlbackend/users_test.go
+++ b/cmd/frontend/graphqlbackend/users_test.go
@@ -262,14 +262,7 @@ type usersQueryTest struct {
 
 func runUsersQuery(t *testing.T, schema *graphql.Schema, want usersQueryTest) {
 	t.Helper()
-
-	if want.dotcom {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		t.Cleanup(func() {
-			dotcom.MockSourcegraphDotComMode(orig)
-		})
-	}
+	dotcom.MockSourcegraphDotComMode(t, want.dotcom)
 
 	type node struct {
 		Username string `json:"username"`

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -74,27 +74,24 @@ func TestRedirects(t *testing.T) {
 	}
 
 	t.Run("on Sourcegraph.com", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig) // reset
+		dotcom.MockSourcegraphDotComMode(t, true)
+
 		t.Run("root", func(t *testing.T) {
 			check(t, "/", http.StatusTemporaryRedirect, "/search", "Mozilla/5.0")
 		})
 	})
 
 	t.Run("on Sourcegraph.com from Cookiebot", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig) // reset
+		dotcom.MockSourcegraphDotComMode(t, true)
+
 		t.Run("root", func(t *testing.T) {
 			check(t, "/", http.StatusTemporaryRedirect, "/search", "Mozilla/5.0 Cookiebot")
 		})
 	})
 
 	t.Run("non-Sourcegraph.com", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(false)
-		defer dotcom.MockSourcegraphDotComMode(orig) // reset
+		dotcom.MockSourcegraphDotComMode(t, false)
+
 		t.Run("root", func(t *testing.T) {
 			check(t, "/", http.StatusTemporaryRedirect, "/search", "Mozilla/5.0")
 		})

--- a/cmd/frontend/internal/app/ui/help_test.go
+++ b/cmd/frontend/internal/app/ui/help_test.go
@@ -12,11 +12,8 @@ import (
 
 func TestServeHelp(t *testing.T) {
 	t.Run("unreleased dev version", func(t *testing.T) {
-		{
-			orig := dotcom.SourcegraphDotComMode()
-			dotcom.MockSourcegraphDotComMode(false)
-			defer dotcom.MockSourcegraphDotComMode(orig) // reset
-		}
+		dotcom.MockSourcegraphDotComMode(t, false)
+
 		{
 			orig := version.Version()
 			version.Mock("0.0.0+dev")
@@ -37,11 +34,8 @@ func TestServeHelp(t *testing.T) {
 	})
 
 	t.Run("released version", func(t *testing.T) {
-		{
-			orig := dotcom.SourcegraphDotComMode()
-			dotcom.MockSourcegraphDotComMode(false)
-			defer dotcom.MockSourcegraphDotComMode(orig) // reset
-		}
+		dotcom.MockSourcegraphDotComMode(t, false)
+
 		{
 			orig := version.Version()
 			version.Mock("3.39.1")
@@ -61,9 +55,7 @@ func TestServeHelp(t *testing.T) {
 	})
 
 	t.Run("Sourcegraph.com", func(t *testing.T) {
-		orig := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(orig) // reset
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		rw := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/help/foo/bar", nil)

--- a/cmd/frontend/internal/app/ui/router_test.go
+++ b/cmd/frontend/internal/app/ui/router_test.go
@@ -22,8 +22,12 @@ import (
 
 func init() {
 	// Enable SourcegraphDotComMode for all tests in this package.
-	dotcom.MockSourcegraphDotComMode(true)
+	dotcom.MockSourcegraphDotComMode(fakeTB{}, true)
 }
+
+type fakeTB struct{}
+
+func (fakeTB) Cleanup(func()) {}
 
 func TestRouter(t *testing.T) {
 	InitRouter(dbmocks.NewMockDB())

--- a/cmd/frontend/internal/auth/bitbucketcloudoauth/BUILD.bazel
+++ b/cmd/frontend/internal/auth/bitbucketcloudoauth/BUILD.bazel
@@ -62,7 +62,6 @@ go_test(
         "//internal/database",
         "//internal/database/dbmocks",
         "//internal/database/dbtest",
-        "//internal/dotcom",
         "//internal/extsvc",
         "//internal/extsvc/bitbucketcloud",
         "//internal/httpcli",

--- a/cmd/frontend/internal/auth/bitbucketcloudoauth/provider_test.go
+++ b/cmd/frontend/internal/auth/bitbucketcloudoauth/provider_test.go
@@ -6,13 +6,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/sourcegraph/sourcegraph/internal/dotcom"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestRequestedScopes(t *testing.T) {
-	defer dotcom.MockSourcegraphDotComMode(false)
-
 	tests := []struct {
 		schema    *schema.BitbucketCloudAuthProvider
 		expScopes []string

--- a/cmd/frontend/internal/auth/githuboauth/provider_test.go
+++ b/cmd/frontend/internal/auth/githuboauth/provider_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRequestedScopes(t *testing.T) {
-	defer dotcom.MockSourcegraphDotComMode(false)
+	
 
 	tests := []struct {
 		dotComMode bool
@@ -56,7 +56,7 @@ func TestRequestedScopes(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			dotcom.MockSourcegraphDotComMode(test.dotComMode)
+			dotcom.MockSourcegraphDotComMode(t, test.dotComMode)
 			scopes := requestedScopes(test.schema)
 			sort.Strings(scopes)
 			if diff := cmp.Diff(test.expScopes, scopes); diff != "" {

--- a/cmd/frontend/internal/auth/githuboauth/provider_test.go
+++ b/cmd/frontend/internal/auth/githuboauth/provider_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestRequestedScopes(t *testing.T) {
-	
-
 	tests := []struct {
 		dotComMode bool
 		schema     *schema.GitHubAuthProvider

--- a/cmd/frontend/internal/auth/gitlaboauth/config_test.go
+++ b/cmd/frontend/internal/auth/gitlaboauth/config_test.go
@@ -331,11 +331,7 @@ func TestParseConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			old := dotcom.SourcegraphDotComMode()
-			dotcom.MockSourcegraphDotComMode(tt.dotcom)
-			t.Cleanup(func() {
-				dotcom.MockSourcegraphDotComMode(old)
-			})
+			dotcom.MockSourcegraphDotComMode(t, tt.dotcom)
 
 			gotProviders, gotProblems := parseConfig(logtest.Scoped(t), tt.args.cfg, db)
 			gotConfigs := make([]oauth2.Config, len(gotProviders))

--- a/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -486,7 +486,7 @@ func TestResolver_SetRepositoryPermissionsForBitbucketProject(t *testing.T) {
 	t.Cleanup(licensing.TestingSkipFeatureChecks())
 
 	t.Run("disabled on dotcom", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		users := dbmocks.NewStrictMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
@@ -506,9 +506,6 @@ func TestResolver_SetRepositoryPermissionsForBitbucketProject(t *testing.T) {
 		if result != nil {
 			t.Errorf("result: want nil but got %v", result)
 		}
-
-		// Reset the env var for other tests.
-		dotcom.MockSourcegraphDotComMode(false)
 	})
 
 	t.Run("authenticated as non-admin", func(t *testing.T) {
@@ -1825,7 +1822,7 @@ func TestResolver_SetSubRepositoryPermissionsForUsers(t *testing.T) {
 
 func TestResolver_BitbucketProjectPermissionJobs(t *testing.T) {
 	t.Run("disabled on dotcom", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		users := dbmocks.NewStrictMockUserStore()
 		users.GetByCurrentAuthUserFunc.SetDefaultReturn(&types.User{}, nil)
@@ -1840,9 +1837,6 @@ func TestResolver_BitbucketProjectPermissionJobs(t *testing.T) {
 
 		require.ErrorIs(t, err, errDisabledSourcegraphDotCom)
 		require.Nil(t, result)
-
-		// Reset the env var for other tests.
-		dotcom.MockSourcegraphDotComMode(false)
 	})
 
 	t.Run("authenticated as non-admin", func(t *testing.T) {

--- a/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/repo_embedding_jobs_test.go
@@ -40,8 +40,8 @@ func TestDBPaginationWithRepoFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Enable embeddings, so that resolvers work:
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
+
 	conf.Mock(&conf.Unified{
 		SiteConfiguration: schema.SiteConfiguration{
 			CodyEnabled: pointers.Ptr(true),

--- a/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/embeddings/resolvers/resolvers_test.go
@@ -32,8 +32,8 @@ import (
 
 func TestEmbeddingSearchResolver(t *testing.T) {
 	logger := logtest.Scoped(t)
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
+
 	oldMock := licensing.MockCheckFeature
 	licensing.MockCheckFeature = func(feature licensing.Feature) error {
 		return nil

--- a/cmd/frontend/internal/guardrails/resolvers/resolver_test.go
+++ b/cmd/frontend/internal/guardrails/resolvers/resolver_test.go
@@ -116,8 +116,8 @@ func TestSuccessfulAttribution(t *testing.T) {
 	})
 
 	t.Run("search bounds are zero on dotcom", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
-		t.Cleanup(func() { dotcom.MockSourcegraphDotComMode(false) })
+		dotcom.MockSourcegraphDotComMode(t, true)
+
 		// even if there would have been search results for short snippet.
 		attributionService.searchResult = []string{"repo1", "repo2"}
 		graphqlbackend.RunTest(t, &graphqlbackend.Test{

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -79,11 +79,7 @@ func TestAccessTokenAuthMiddleware(t *testing.T) {
 	}
 
 	t.Run("license check bypasses handler in dotcom mode", func(t *testing.T) {
-		currMode := dotcom.SourcegraphDotComMode()
-		dotcom.MockSourcegraphDotComMode(true)
-		t.Cleanup(func() {
-			dotcom.MockSourcegraphDotComMode(currMode)
-		})
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		req, _ := http.NewRequest("GET", "/.api/license/check", nil)
 		req.Header.Set("Authorization", "Bearer sometoken")

--- a/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -142,11 +142,7 @@ func TestEnforcement_AfterCreateUser(t *testing.T) {
 		{
 			name: "dotcom mode should always do nothing",
 			setup: func(t *testing.T) {
-				orig := dotcom.SourcegraphDotComMode()
-				dotcom.MockSourcegraphDotComMode(true)
-				t.Cleanup(func() {
-					dotcom.MockSourcegraphDotComMode(orig)
-				})
+				dotcom.MockSourcegraphDotComMode(t, true)
 			},
 			setSiteAdmin: false,
 		},

--- a/cmd/frontend/internal/own/resolvers/codeowners_resolvers_test.go
+++ b/cmd/frontend/internal/own/resolvers/codeowners_resolvers_test.go
@@ -74,11 +74,7 @@ func TestCodeownersIngestionGuarding(t *testing.T) {
 	}
 	for path, query := range pathToQueries {
 		t.Run("dotcom guarding is respected for "+path, func(t *testing.T) {
-			orig := dotcom.SourcegraphDotComMode()
-			dotcom.MockSourcegraphDotComMode(true)
-			t.Cleanup(func() {
-				dotcom.MockSourcegraphDotComMode(orig)
-			})
+			dotcom.MockSourcegraphDotComMode(t, true)
 			graphqlbackend.RunTest(t, &graphqlbackend.Test{
 				Schema:         schema,
 				Context:        ctx,
@@ -90,10 +86,7 @@ func TestCodeownersIngestionGuarding(t *testing.T) {
 			})
 		})
 		t.Run("site admin guarding is respected for "+path, func(t *testing.T) {
-			ctx = userCtx(adminUser)
-			t.Cleanup(func() {
-				ctx = context.TODO()
-			})
+			ctx := userCtx(adminUser)
 			graphqlbackend.RunTest(t, &graphqlbackend.Test{
 				Schema:         schema,
 				Context:        ctx,

--- a/cmd/frontend/internal/registry/http_api_test.go
+++ b/cmd/frontend/internal/registry/http_api_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestHandleRegistry(t *testing.T) {
-	defer dotcom.MockSourcegraphDotComMode(dotcom.SourcegraphDotComMode())
-	dotcom.MockSourcegraphDotComMode(true)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	t.Run("list", func(t *testing.T) {
 		rr := httptest.NewRecorder()

--- a/cmd/frontend/internal/searchcontexts/resolvers/resolvers_test.go
+++ b/cmd/frontend/internal/searchcontexts/resolvers/resolvers_test.go
@@ -82,17 +82,14 @@ func TestSearchContexts(t *testing.T) {
 }
 
 func TestSearchContextsStarDefaultPermissions(t *testing.T) {
-	t.Parallel()
+	// Note: this test can't do t.Parallel since it mutates global state (MockSourcegraphDotComMode)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	userID := int32(1)
 	graphqlUserID := graphqlbackend.MarshalUserID(userID)
 	username := "alice"
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: userID})
-
-	orig := dotcom.SourcegraphDotComMode()
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(orig) // reset
 
 	users := dbmocks.NewMockUserStore()
 	users.GetByIDFunc.SetDefaultReturn(&types.User{Username: username}, nil)

--- a/dev/internal/cmd/search-plan/search-plan.go
+++ b/dev/internal/cmd/search-plan/search-plan.go
@@ -43,7 +43,7 @@ func run(w io.Writer, args []string) error {
 
 	// Sourcegraph infra we need
 	conf.Mock(&conf.Unified{})
-	dotcom.MockSourcegraphDotComMode(*dotCom)
+	dotcom.MockSourcegraphDotComMode(fakeTB{}, *dotCom)
 	logger := log.Scoped("search-plan")
 
 	cli := client.Mocked(job.RuntimeClients{Logger: logger})
@@ -72,6 +72,10 @@ func run(w io.Writer, args []string) error {
 
 	return nil
 }
+
+type fakeTB struct{}
+
+func (fakeTB) Cleanup(func()) {}
 
 func main() {
 	liblog := log.Init(log.Resource{Name: "search-plan"})

--- a/internal/authz/header_test.go
+++ b/internal/authz/header_test.go
@@ -48,8 +48,7 @@ func TestParseAuthorizationHeader(t *testing.T) {
 	}
 
 	t.Run("disable sudo token for dotcom", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(false)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		_, _, err := ParseAuthorizationHeader(`token-sudo token="tok==", user="alice"`)
 		got := fmt.Sprintf("%v", err)
@@ -60,8 +59,7 @@ func TestParseAuthorizationHeader(t *testing.T) {
 	})
 
 	t.Run("empty token does not raise sudo error on dotcom", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
-		defer dotcom.MockSourcegraphDotComMode(false)
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		_, _, err := ParseAuthorizationHeader(`token`)
 		got := fmt.Sprintf("%v", err)

--- a/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_indexing_scheduler_test.go
+++ b/internal/codeintel/autoindexing/internal/background/dependencies/job_dependency_indexing_scheduler_test.go
@@ -60,7 +60,7 @@ func TestDependencyIndexingSchedulerHandler(t *testing.T) {
 
 	indexEnqueuer := NewMockIndexEnqueuer()
 
-	dotcom.MockSourcegraphDotComMode(true)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	handler := &dependencyIndexingSchedulerHandler{
 		uploadsSvc:         mockUploadsSvc,
@@ -161,7 +161,7 @@ func TestDependencyIndexingSchedulerHandlerCustomer(t *testing.T) {
 
 	indexEnqueuer := NewMockIndexEnqueuer()
 
-	dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, false)
 
 	handler := &dependencyIndexingSchedulerHandler{
 		uploadsSvc:         mockUploadsSvc,
@@ -255,7 +255,7 @@ func TestDependencyIndexingSchedulerHandlerRequeueNotCloned(t *testing.T) {
 
 	indexEnqueuer := NewMockIndexEnqueuer()
 
-	dotcom.MockSourcegraphDotComMode(true)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	handler := &dependencyIndexingSchedulerHandler{
 		uploadsSvc:         mockUploadsSvc,
@@ -317,7 +317,7 @@ func TestDependencyIndexingSchedulerHandlerSkipNonExistant(t *testing.T) {
 
 	indexEnqueuer := NewMockIndexEnqueuer()
 
-	dotcom.MockSourcegraphDotComMode(true)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	handler := &dependencyIndexingSchedulerHandler{
 		uploadsSvc:         mockUploadsSvc,
@@ -364,7 +364,7 @@ func TestDependencyIndexingSchedulerHandlerShouldSkipRepository(t *testing.T) {
 
 	indexEnqueuer := NewMockIndexEnqueuer()
 
-	dotcom.MockSourcegraphDotComMode(true)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	handler := &dependencyIndexingSchedulerHandler{
 		uploadsSvc:         mockUploadsSvc,
@@ -412,7 +412,7 @@ func TestDependencyIndexingSchedulerHandlerNoExtsvc(t *testing.T) {
 
 	indexEnqueuer := NewMockIndexEnqueuer()
 
-	dotcom.MockSourcegraphDotComMode(true)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	handler := &dependencyIndexingSchedulerHandler{
 		uploadsSvc:         mockUploadsSvc,

--- a/internal/cody/utils_test.go
+++ b/internal/cody/utils_test.go
@@ -16,11 +16,7 @@ import (
 func TestFreeUserCurrentPeriodDateRange(t *testing.T) {
 	db := dbmocks.NewMockDB()
 
-	orig := dotcom.SourcegraphDotComMode()
-	dotcom.MockSourcegraphDotComMode(true)
-	t.Cleanup(func() {
-		dotcom.MockSourcegraphDotComMode(orig)
-	})
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	users := dbmocks.NewMockUserStore()
 	db.UsersFunc.SetDefaultReturn(users)

--- a/internal/conf/auth_test.go
+++ b/internal/conf/auth_test.go
@@ -8,11 +8,8 @@ import (
 )
 
 func TestAuthPublic(t *testing.T) {
-	orig := dotcom.SourcegraphDotComMode()
-	dotcom.MockSourcegraphDotComMode(false)
-	defer dotcom.MockSourcegraphDotComMode(orig) // reset
-
 	t.Run("Default, self-hosted instance non-public auth", func(t *testing.T) {
+		dotcom.MockSourcegraphDotComMode(t, false)
 		got := AuthPublic()
 		want := false
 		if !reflect.DeepEqual(got, want) {
@@ -20,9 +17,8 @@ func TestAuthPublic(t *testing.T) {
 		}
 	})
 
-	dotcom.MockSourcegraphDotComMode(true)
-
 	t.Run("Sourcegraph.com public auth", func(t *testing.T) {
+		dotcom.MockSourcegraphDotComMode(t, true)
 		got := AuthPublic()
 		want := true
 		if !reflect.DeepEqual(got, want) {

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -1135,12 +1135,11 @@ func TestGetEmbeddingsConfig(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			defaultDeploy := deploy.Type()
-			dotcom.MockSourcegraphDotComMode(tc.dotcom)
+			dotcom.MockSourcegraphDotComMode(t, tc.dotcom)
 			if tc.deployType != "" {
 				deploy.Mock(tc.deployType)
 			}
 			t.Cleanup(func() {
-				dotcom.MockSourcegraphDotComMode(false)
 				deploy.Mock(defaultDeploy)
 			})
 			conf := GetEmbeddingsConfig(tc.siteConfig)

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -128,8 +128,7 @@ func TestExternalServicesStore_Create(t *testing.T) {
 	db := NewDB(logger, dbtest.NewDB(t))
 	ctx := actor.WithInternalActor(context.Background())
 
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	confGet := func() *conf.Unified { return &conf.Unified{} }
 
@@ -289,8 +288,7 @@ func TestExternalServicesStore_Update(t *testing.T) {
 	now := timeutil.Now()
 	codeHostURL := "https://github.com/"
 
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	// Create a new external service
 	confGet := func() *conf.Unified {
@@ -670,8 +668,7 @@ func TestExternalServicesStore_DisablePermsSyncingForExternalService(t *testing.
 		t.Fatal(err)
 	}
 
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}
@@ -2620,9 +2617,7 @@ func Test_validateOtherExternalServiceConnection(t *testing.T) {
 	require.Error(t, err)
 
 	// On DotCom, no error should be returned
-	orig := dotcom.SourcegraphDotComMode()
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(orig)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	err = validateOtherExternalServiceConnection(conn)
 	require.NoError(t, err)

--- a/internal/dotcom/dotcom.go
+++ b/internal/dotcom/dotcom.go
@@ -15,7 +15,13 @@ func SourcegraphDotComMode() bool {
 	return sourcegraphDotComMode
 }
 
+type TB interface {
+	Cleanup(func())
+}
+
 // MockSourcegraphDotComMode is used by tests to mock the result of SourcegraphDotComMode.
-func MockSourcegraphDotComMode(value bool) {
+func MockSourcegraphDotComMode(t TB, value bool) {
+	orig := sourcegraphDotComMode
 	sourcegraphDotComMode = value
+	t.Cleanup(func() { sourcegraphDotComMode = orig })
 }

--- a/internal/embeddings/background/repo/store_test.go
+++ b/internal/embeddings/background/repo/store_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 func TestRepoEmbeddingJobsStore(t *testing.T) {
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
@@ -240,8 +239,7 @@ func TestCancelRepoEmbeddingJob(t *testing.T) {
 }
 
 func TestGetEmbeddableRepos(t *testing.T) {
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	logger := logtest.Scoped(t)
 	db := database.NewDB(logger, dbtest.NewDB(t))
@@ -392,8 +390,8 @@ func TestGetEmbeddableReposLimit(t *testing.T) {
 }
 
 func TestGetEmbeddableRepoOpts(t *testing.T) {
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
+
 	conf.Mock(&conf.Unified{})
 	defer conf.Mock(nil)
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{

--- a/internal/embeddings/db/conf_test.go
+++ b/internal/embeddings/db/conf_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestNewDBFromConfFunc(t *testing.T) {
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(false)
+	dotcom.MockSourcegraphDotComMode(t, true)
+
 	t.Run("default nil", func(t *testing.T) {
 		conf.Mock(&conf.Unified{
 			ServiceConnectionConfig: conftypes.ServiceConnections{

--- a/internal/rbac/permissions_test.go
+++ b/internal/rbac/permissions_test.go
@@ -24,7 +24,7 @@ func TestComparePermissions(t *testing.T) {
 	}
 
 	t.Run("no changes to permissions", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(false)
+		dotcom.MockSourcegraphDotComMode(t, false)
 
 		schemaPerms := Schema{
 			Namespaces: []Namespace{
@@ -130,8 +130,7 @@ func TestComparePermissions(t *testing.T) {
 	})
 
 	t.Run("dotcom permission added", func(t *testing.T) {
-		dotcom.MockSourcegraphDotComMode(true)
-		t.Cleanup(func() { dotcom.MockSourcegraphDotComMode(false) })
+		dotcom.MockSourcegraphDotComMode(t, true)
 
 		schemaPerms := Schema{
 			Namespaces: []Namespace{

--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -202,9 +202,8 @@ func TestOther_DotComConfig(t *testing.T) {
 	require.True(t, repo.Private)
 
 	// Enable Dotcom mode. Then repo should be public.
-	orig := dotcom.SourcegraphDotComMode()
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(orig)
+	dotcom.MockSourcegraphDotComMode(t, true)
+
 	source = makeSource(t)
 
 	repo, err = source.otherRepoFromCloneURL("other:source", cloneURL)

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -1348,15 +1348,10 @@ func TestCloudDefaultExternalServicesDontSync(t *testing.T) {
 }
 
 func TestDotComPrivateReposDontSync(t *testing.T) {
-	orig := dotcom.SourcegraphDotComMode()
-	dotcom.MockSourcegraphDotComMode(true)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	ctx, cancel := context.WithCancel(context.Background())
-
-	t.Cleanup(func() {
-		dotcom.MockSourcegraphDotComMode(orig)
-		cancel()
-	})
+	defer cancel()
 
 	store := getTestRepoStore(t)
 

--- a/internal/search/searchcontexts/search_contexts_test.go
+++ b/internal/search/searchcontexts/search_contexts_test.go
@@ -108,9 +108,7 @@ func TestResolvingInvalidSearchContextSpecs(t *testing.T) {
 }
 
 func TestResolvingInvalidSearchContextSpecs_Cloud(t *testing.T) {
-	orig := dotcom.SourcegraphDotComMode()
-	dotcom.MockSourcegraphDotComMode(true)
-	defer dotcom.MockSourcegraphDotComMode(orig)
+	dotcom.MockSourcegraphDotComMode(t, true)
 
 	tests := []struct {
 		name              string


### PR DESCRIPTION
I had a suspicion another test was failing due to racing with reading dotcom.SourcegraphDotComMode and another test didn't unset it. It turned out this wasn't the case, but I ended improving the API to avoid this issue. Most call sites should be easier to read.

Test Plan: go test