### PR TITLE
Svelte: implement preview panel extension for match iteration

### DIFF
--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -44,6 +44,12 @@
             outline: 'none',
             boxShadow: 'none',
         },
+        '.cm-panels': {
+            '&-top': {
+                borderBottom: '1px solid var(--border-color)',
+            },
+            backgroundColor: 'transparent',
+        },
         '.cm-gutters': {
             'background-color': 'var(--code-bg)',
             border: 'none',

--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -35,14 +35,20 @@
             height: '100%',
             color: 'var(--color-code)',
         },
+        '&.cm-focused': {
+            outline: 'none',
+        },
         '.cm-scroller': {
             lineHeight: '1rem',
             fontFamily: 'var(--code-font-family)',
             fontSize: 'var(--code-font-size)',
         },
-        '.cm-content:focus-visible': {
-            outline: 'none',
-            boxShadow: 'none',
+        '.cm-content': {
+            backgroundColor: 'var(--code-bg)',
+            '&:focus-visible': {
+                outline: 'none',
+                boxShadow: 'none',
+            },
         },
         '.cm-panels': {
             '&-top': {

--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -114,6 +114,9 @@
     import { createEventDispatcher, onMount } from 'svelte'
 
     import { browser } from '$app/environment'
+    import { goto } from '$app/navigation'
+    import type { LineOrPositionOrRange } from '$lib/common'
+    import type { CodeIntelAPI } from '$lib/shared'
     import {
         selectableLineNumbers,
         syntaxHighlight,
@@ -125,16 +128,16 @@
         syncSelection,
         temporaryTooltip,
     } from '$lib/web'
-    import { goto } from '$app/navigation'
-    import type { CodeIntelAPI } from '$lib/shared'
+
+    import { type Range, staticHighlights } from './codemirror/static-highlights'
     import { goToDefinition, openImplementations, openReferences } from './repo/blob'
-    import type { LineOrPositionOrRange } from '$lib/common'
 
     export let blobInfo: BlobInfo
     export let highlights: string
     export let wrapLines: boolean = false
     export let selectedLines: LineOrPositionOrRange | null = null
     export let codeIntelAPI: CodeIntelAPI
+    export let staticHighlightRanges: Range[] = []
 
     const dispatch = createEventDispatcher<{ selectline: SelectedLineRange }>()
 
@@ -180,8 +183,17 @@
     })
     $: settings = configureMiscSettings({ wrapLines })
     $: sh = configureSyntaxHighlighting(blobInfo.content, highlights)
+    $: staticHighlightExtension = staticHighlights(staticHighlightRanges)
 
-    $: extensions = [sh, settings, lineNumbers, temporaryTooltip, codeIntelExtension, staticExtensions]
+    $: extensions = [
+        sh,
+        settings,
+        lineNumbers,
+        temporaryTooltip,
+        codeIntelExtension,
+        staticExtensions,
+        staticHighlightExtension,
+    ]
 
     function update(blobInfo: BlobInfo, extensions: Extension, range: LineOrPositionOrRange | null) {
         if (editor) {

--- a/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
+++ b/client/web-sveltekit/src/lib/CodeMirrorBlob.svelte
@@ -32,10 +32,8 @@
 
     const defaultTheme = EditorView.theme({
         '&': {
-            width: '100%',
-            'min-height': 0,
+            height: '100%',
             color: 'var(--color-code)',
-            flex: 1,
         },
         '.cm-scroller': {
             lineHeight: '1rem',
@@ -241,7 +239,6 @@
 <style lang="scss">
     .root {
         display: contents;
-        overflow: hidden;
     }
     pre {
         margin: 0;

--- a/client/web-sveltekit/src/lib/codemirror/StaticHighlightsPanel.svelte
+++ b/client/web-sveltekit/src/lib/codemirror/StaticHighlightsPanel.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+    import { mdiChevronLeft, mdiChevronRight } from '@mdi/js'
+
+    import { pluralize } from '$lib/common'
+    import Icon from '$lib/Icon.svelte'
+    import { Button } from '$lib/wildcard'
+
+    import type { HighlightedRange } from './static-highlights'
+
+    export let ranges: HighlightedRange[]
+    export let handlePrevious: () => void
+    export let handleNext: () => void
+
+    const totalMatches = ranges.length
+    const selectedIdx = ranges.findIndex(range => range.selected)
+</script>
+
+<div class="root">
+    {#if totalMatches > 1}
+        <div>
+            <Button
+                size="sm"
+                outline
+                variant="secondary"
+                on:click={handlePrevious}
+                data-testid="blob-view-static-previous"
+                aria-label="previous result"
+            >
+                <Icon svgPath={mdiChevronLeft} aria-hidden={true} />
+            </Button>
+
+            <Button
+                size="sm"
+                outline
+                variant="secondary"
+                on:click={handleNext}
+                data-testid="blob-view-static-next"
+                aria-label="next result"
+            >
+                <Icon svgPath={mdiChevronRight} aria-hidden={true} />
+            </Button>
+        </div>
+    {/if}
+    <text>
+        {selectedIdx === -1 ? '' : `${selectedIdx + 1} of `}
+        {totalMatches}
+        {pluralize('result', totalMatches)}
+    </text>
+</div>

--- a/client/web-sveltekit/src/lib/codemirror/StaticHighlightsPanel.svelte
+++ b/client/web-sveltekit/src/lib/codemirror/StaticHighlightsPanel.svelte
@@ -11,39 +11,69 @@
     export let handlePrevious: () => void
     export let handleNext: () => void
 
-    const totalMatches = ranges.length
-    const selectedIdx = ranges.findIndex(range => range.selected)
+    $: totalMatches = ranges.length
+    $: selectedIdx = ranges.findIndex(range => range.selected)
 </script>
 
 <div class="root">
     {#if totalMatches > 1}
-        <div>
-            <Button
-                size="sm"
-                outline
-                variant="secondary"
-                on:click={handlePrevious}
-                data-testid="blob-view-static-previous"
-                aria-label="previous result"
-            >
-                <Icon svgPath={mdiChevronLeft} aria-hidden={true} />
-            </Button>
-
-            <Button
-                size="sm"
-                outline
-                variant="secondary"
-                on:click={handleNext}
-                data-testid="blob-view-static-next"
-                aria-label="next result"
-            >
-                <Icon svgPath={mdiChevronRight} aria-hidden={true} />
-            </Button>
+        <div class="buttons">
+            <div class="left">
+                <Button
+                    size="sm"
+                    outline
+                    variant="secondary"
+                    on:click={handlePrevious}
+                    data-testid="blob-view-static-previous"
+                    aria-label="previous result"
+                >
+                    <Icon inline svgPath={mdiChevronLeft} aria-hidden={true} />
+                </Button>
+            </div>
+            <div class="right">
+                <Button
+                    size="sm"
+                    outline
+                    variant="secondary"
+                    on:click={handleNext}
+                    data-testid="blob-view-static-next"
+                    aria-label="next result"
+                >
+                    <Icon inline svgPath={mdiChevronRight} aria-hidden={true} />
+                </Button>
+            </div>
         </div>
     {/if}
-    <text>
+    <div>
         {selectedIdx === -1 ? '' : `${selectedIdx + 1} of `}
         {totalMatches}
         {pluralize('result', totalMatches)}
-    </text>
+    </div>
 </div>
+
+<style lang="scss">
+    .root {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.5rem;
+        color: var(--text-muted);
+
+        background-color: var(--color-bg);
+
+        .buttons {
+            display: flex;
+            .left :global(button) {
+                padding: 0.25rem;
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0;
+            }
+            .right :global(button) {
+                padding: 0.25rem;
+                border-top-left-radius: 0;
+                border-bottom-left-radius: 0;
+                border-left: none;
+            }
+        }
+    }
+</style>

--- a/client/web-sveltekit/src/lib/codemirror/static-highlights.ts
+++ b/client/web-sveltekit/src/lib/codemirror/static-highlights.ts
@@ -1,0 +1,202 @@
+/**
+ * This provides CodeMirror extension for highlighting a static set of ranges.
+ */
+
+import { type Extension, EditorState, StateField, Facet } from '@codemirror/state'
+import { Decoration, EditorView, showPanel, type Panel, ViewUpdate } from '@codemirror/view'
+import { sortedIndexBy } from 'lodash'
+
+import StaticHighlightsPanelComponent from './StaticHighlightsPanel.svelte'
+
+export interface Range {
+    start: Location
+    end: Location
+}
+
+export interface Location {
+    // A zero-based line number
+    line: number
+    // A zero-based column number
+    column: number
+}
+
+/**
+ * staticHighlights is an extension that highlights a static set of ranges
+ * and opens a panel that allows navigation between these highlights.
+ */
+export function staticHighlights(ranges: Range[]): Extension {
+    if (ranges.length === 0) {
+        return []
+    }
+    const facet = Facet.define<Range[], Range[]>({
+        combine: ranges => ranges.flat(),
+        enables: () => [
+            staticHighlightTheme,
+            staticHighlightState.init(state => {
+                const codeMirrorRanges = ranges.map(range => ({
+                    selected: false,
+                    from: toCodeMirrorLocation(state, range.start),
+                    to: toCodeMirrorLocation(state, range.end),
+                }))
+                return codeMirrorRanges.sort((a, b) => a.from - b.from)
+            }),
+            showPanel.of(view => new StaticHighlightsPanel(view)),
+            scrollToFirstRange(),
+        ],
+    })
+    return facet.of(ranges)
+}
+
+/**
+ * scrollToFirstRange is a small utility extension that just scrolls to
+ * the selected range on startup.
+ */
+function scrollToFirstRange(): Extension {
+    let scrolled = false
+    return EditorView.updateListener.of((update: ViewUpdate) => {
+        if (scrolled) {
+            return
+        }
+        const ranges = update.view.state.field(staticHighlightState)
+        scrolled = true
+        update.view.dispatch({
+            selection: { anchor: ranges[0].from, head: ranges[0].to },
+            effects: EditorView.scrollIntoView(ranges[0].from, {
+                y: 'nearest',
+                x: 'center',
+                yMargin: update.view.dom.getBoundingClientRect().height / 3,
+            }),
+        })
+    })
+}
+
+const staticHighlightDecoration = Decoration.mark({ class: 'cm-sg-static-highlight' })
+const staticHighlightSelectedDecoration = Decoration.mark({ class: 'cm-sg-static-highlight-selected' })
+
+interface HighlightedRange {
+    from: number
+    to: number
+    selected: boolean
+}
+
+const staticHighlightState = StateField.define<HighlightedRange[]>({
+    create: () => [],
+    update: (ranges, tr) => {
+        // When the selection changes, update the selection
+        const selectedRange = tr.selection?.main
+        if (selectedRange === undefined) {
+            return ranges
+        }
+        return ranges.map(range => ({
+            from: range.from,
+            to: range.to,
+            selected: range.from === selectedRange.from && range.to === selectedRange.to,
+        }))
+    },
+    provide: f =>
+        EditorView.decorations.from(f, ranges =>
+            Decoration.set(
+                ranges.map(({ selected, from, to }) =>
+                    selected
+                        ? staticHighlightSelectedDecoration.range(from, to)
+                        : staticHighlightDecoration.range(from, to)
+                ),
+                true
+            )
+        ),
+})
+
+const staticHighlightTheme = EditorView.theme({
+    '.cm-sg-static-highlight': {
+        backgroundColor: 'var(--mark-bg)',
+    },
+    '.cm-sg-static-highlight-selected': {
+        backgroundColor: 'var(--oc-orange-3)',
+    },
+})
+
+function toCodeMirrorLocation(state: EditorState, location: Location): number {
+    // Codemirror expects 1-based line numbers
+    return state.doc.line(location.line + 1).from + location.column
+}
+
+function findSelectedIdx(ranges: HighlightedRange[]): number | undefined {
+    const selectedIdx = ranges.findIndex(range => range.selected)
+    return selectedIdx === -1 ? undefined : selectedIdx
+}
+
+class StaticHighlightsPanel implements Panel {
+    public dom: HTMLElement
+    public top = true
+
+    private root: StaticHighlightsPanelComponent
+
+    constructor(private view: EditorView) {
+        this.dom = document.createElement('div')
+        this.root = new StaticHighlightsPanelComponent({
+            target: this.dom,
+            props: {
+                ranges: this.ranges,
+                handlePrevious: this.navigatePrevious.bind(this),
+                handleNext: this.navigateNext.bind(this),
+            },
+        })
+    }
+
+    private get ranges(): HighlightedRange[] {
+        return this.view.state.field(staticHighlightState)
+    }
+
+    public update(viewUpdate: ViewUpdate): void {
+        const oldSelectedIdx = findSelectedIdx(viewUpdate.startState.field(staticHighlightState))
+        const newSelectedIdx = findSelectedIdx(viewUpdate.state.field(staticHighlightState))
+        if (newSelectedIdx !== oldSelectedIdx) {
+            this.root.$set({
+                ranges: this.ranges,
+                handlePrevious: this.navigatePrevious.bind(this),
+                handleNext: this.navigateNext.bind(this),
+            })
+        }
+    }
+
+    public destroy(): void {
+        this.root.$destroy()
+    }
+
+    private navigateTo(target: { from: number; to: number }): void {
+        this.view.dispatch({
+            selection: { anchor: target.from, head: target.to },
+            effects: [
+                EditorView.scrollIntoView(target.from, {
+                    y: 'nearest',
+                    x: 'center',
+                    yMargin: this.view.dom.getBoundingClientRect().height / 3,
+                }),
+            ],
+        })
+    }
+
+    private navigatePrevious(): void {
+        const currentSelection = this.view.state.selection.main
+        // Find the index of the first element before or equal to the selection
+        const idx = sortedIndexBy(
+            this.ranges,
+            { from: currentSelection.from, to: 0, selected: false },
+            range => range.from
+        )
+        const previousRange = this.ranges[(this.ranges.length + idx - 1) % this.ranges.length]
+        this.navigateTo(previousRange)
+    }
+
+    private navigateNext(): void {
+        const currentSelection = this.view.state.selection.main
+        // Find the index of the first element after the selection
+        const idx = sortedIndexBy(
+            this.ranges,
+            { from: currentSelection.from + 1, to: 0, selected: false },
+            range => range.from
+        )
+        const nextRange = this.ranges[idx % this.ranges.length]
+        this.navigateTo(nextRange)
+    }
+}

--- a/client/web-sveltekit/src/lib/codemirror/static-highlights.ts
+++ b/client/web-sveltekit/src/lib/codemirror/static-highlights.ts
@@ -73,7 +73,7 @@ function scrollToFirstRange(): Extension {
 const staticHighlightDecoration = Decoration.mark({ class: 'cm-sg-static-highlight' })
 const staticHighlightSelectedDecoration = Decoration.mark({ class: 'cm-sg-static-highlight-selected' })
 
-interface HighlightedRange {
+export interface HighlightedRange {
     from: number
     to: number
     selected: boolean

--- a/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
+++ b/client/web-sveltekit/src/routes/search/FileSearchResultHeader.svelte
@@ -1,4 +1,4 @@
-f<script lang="ts">
+<script lang="ts">
     import { highlightRanges } from '$lib/dom'
     import {
         displayRepoName,

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -1,14 +1,11 @@
 <script lang="ts" context="module">
-    export interface Range {
-        start: Location
-        end: Location
-    }
+    import type { Range } from '$lib/codemirror/static-highlights'
 
-    export interface Location {
-        // A zero-based line number
-        line: number
-        // A zero-based column number
-        column: number
+    function extractHighlightedRanges(result: ContentMatch | SymbolMatch | PathMatch): Range[] {
+        if (result.type !== 'content') {
+            return []
+        }
+        return result.chunkMatches?.flatMap(chunkMatch => chunkMatch.ranges) || []
     }
 </script>
 
@@ -107,6 +104,7 @@
                 }}
                 highlights={$highlightStore.value ?? ''}
                 {codeIntelAPI}
+                staticHighlightRanges={extractHighlightedRanges(result)}
             />
         {/if}
     </div>

--- a/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
+++ b/client/web-sveltekit/src/routes/search/PreviewPanel.svelte
@@ -146,10 +146,11 @@
     .file-link {
         padding: 0.25rem 0.5rem;
         border-bottom: 1px solid var(--border-color);
+        flex: none;
     }
 
     .content {
-        overflow: auto;
-        background-color: var(--code-bg);
+        flex: 1;
+        min-height: 0;
     }
 </style>

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -109,41 +109,123 @@ test('copy path button appears and copies path', async ({ page, sg }) => {
     }
 })
 
-test('preview can be opened and closed', async ({ page, sg }) => {
-    const stream = sg.mockSearchStream()
-    await page.goto('/search?q=test')
-    await page.getByRole('heading', { name: 'Filter results' }).waitFor()
-    await stream.publish(
-        {
-            type: 'matches',
-            data: [createContentMatch(), createCommitMatch(), createPathMatch()],
-        },
-        createProgressEvent(),
-        createDoneEvent()
-    )
-    await stream.close()
+test.describe('preview panel', async () => {
+    test('can be opened and closed', async ({ page, sg }) => {
+        const stream = sg.mockSearchStream()
+        await page.goto('/search?q=test')
+        await page.getByRole('heading', { name: 'Filter results' }).waitFor()
+        await stream.publish(
+            {
+                type: 'matches',
+                data: [createContentMatch(), createCommitMatch(), createPathMatch()],
+            },
+            createProgressEvent(),
+            createDoneEvent()
+        )
+        await stream.close()
 
-    // 2 preview buttons: one for content match and one for path match
-    const previewButtons = await page.getByRole('button', { name: 'Preview' }).all()
-    expect(previewButtons).toHaveLength(2)
+        // 2 preview buttons: one for content match and one for path match
+        const previewButtons = await page.getByRole('button', { name: 'Preview' }).all()
+        expect(previewButtons).toHaveLength(2)
 
-    sg.mockOperations({
-        BlobPageQuery: () => ({
-            repository: {
-                commit: {
-                    blob: {
-                        content: 'lorem\nipsum\ndolor\n',
+        sg.mockOperations({
+            BlobPageQuery: () => ({
+                repository: {
+                    commit: {
+                        blob: {
+                            content: 'lorem\nipsum\ndolor\n',
+                        },
                     },
                 },
-            },
-        }),
+            }),
+        })
+
+        // Open preview panel
+        await previewButtons[0].click()
+        await expect(page.getByRole('heading', { name: 'File Preview' })).toBeVisible()
+
+        // Close preview panel
+        await page.getByTestId('preview-close').click()
+        await expect(page.getByRole('heading', { name: 'File Preview' })).toBeHidden()
     })
 
-    // Open preview panel
-    await previewButtons[0].click()
-    await expect(page.getByRole('heading', { name: 'File Preview' })).toBeVisible()
+    test('can iterate over matches', async ({ page, sg }) => {
+        const stream = sg.mockSearchStream()
+        await page.goto('/search?q=test')
+        await page.getByRole('heading', { name: 'Filter results' }).waitFor()
+        await stream.publish(
+            {
+                type: 'matches',
+                data: [
+                    {
+                        type: 'content',
+                        path: 'README.md',
+                        pathMatches: [],
+                        repository: 'github.com/sourcegraph/conc',
+                        repoStars: 9001,
+                        commit: 'abcde12345',
+                        chunkMatches: [
+                            {
+                                content: 'lorem ipsum\ndolor sit\namet',
+                                contentStart: {
+                                    offset: 0,
+                                    line: 1,
+                                    column: 1,
+                                },
+                                ranges: [
+                                    {
+                                        // "lorem"
+                                        start: { offset: 0, line: 0, column: 0 },
+                                        end: { offset: 5, line: 0, column: 5 },
+                                    },
+                                    {
+                                        // "sit"
+                                        start: { offset: 18, line: 1, column: 6 },
+                                        end: { offset: 21, line: 1, column: 9 },
+                                    },
+                                ],
+                            },
+                        ],
+                        language: 'text',
+                    },
+                ],
+            },
+            createProgressEvent(),
+            createDoneEvent()
+        )
+        await stream.close()
 
-    // Close preview panel
-    await page.getByTestId('preview-close').click()
-    await expect(page.getByRole('heading', { name: 'File Preview' })).toBeHidden()
+        sg.mockOperations({
+            BlobPageQuery: () => ({
+                repository: {
+                    commit: {
+                        blob: {
+                            content: 'lorem ipsum\ndolor sit\namet\n',
+                        },
+                    },
+                },
+            }),
+        })
+
+        // Open preview panel
+        await page.getByRole('button', { name: 'Preview' }).click()
+
+        const currentSelection = page.locator('span.cm-sg-static-highlight-selected')
+        const nextButton = page.locator('button[aria-label="next result"]')
+        const previousButton = page.locator('button[aria-label="previous result"]')
+
+        await expect(currentSelection, 'the first match is selected by default').toHaveText('lorem')
+
+        await nextButton.click()
+        await expect(currentSelection, 'clicking next should select the next match').toHaveText('sit')
+
+        await previousButton.click()
+        await expect(currentSelection, 'clicking previous should select the previous match').toHaveText('lorem')
+
+        await previousButton.click()
+        await expect(currentSelection, 'clicking previous from the first result wraps backwards').toHaveText('sit')
+
+        await nextButton.click()
+        await expect(currentSelection, 'clicking next on the last result should wrap forwards').toHaveText('lorem')
+    })
 })

--- a/client/web-sveltekit/src/routes/search/page.spec.ts
+++ b/client/web-sveltekit/src/routes/search/page.spec.ts
@@ -113,6 +113,17 @@ test.describe('preview panel', async () => {
     test('can be opened and closed', async ({ page, sg }) => {
         const stream = sg.mockSearchStream()
         await page.goto('/search?q=test')
+        sg.mockOperations({
+            BlobPageQuery: () => ({
+                repository: {
+                    commit: {
+                        blob: {
+                            content: 'lorem\nipsum\ndolor\n',
+                        },
+                    },
+                },
+            }),
+        })
         await page.getByRole('heading', { name: 'Filter results' }).waitFor()
         await stream.publish(
             {
@@ -127,18 +138,6 @@ test.describe('preview panel', async () => {
         // 2 preview buttons: one for content match and one for path match
         const previewButtons = await page.getByRole('button', { name: 'Preview' }).all()
         expect(previewButtons).toHaveLength(2)
-
-        sg.mockOperations({
-            BlobPageQuery: () => ({
-                repository: {
-                    commit: {
-                        blob: {
-                            content: 'lorem\nipsum\ndolor\n',
-                        },
-                    },
-                },
-            }),
-        })
 
         // Open preview panel
         await previewButtons[0].click()


### PR DESCRIPTION
This implements the static highlights panel extension for Codemirror in Svelte, allowing a user to click through the matched ranges in the preview panel.

## Test plan

Added a playwright test for selection navigation buttons. 

Manual testing, short video demonstration below:


https://github.com/sourcegraph/sourcegraph/assets/12631702/2ba18811-0451-41e3-8470-2f6e7ed50f66

