### PR TITLE
msp: add support for secret volume mounts

### DIFF
--- a/dev/managedservicesplatform/managedservicesplatform.go
+++ b/dev/managedservicesplatform/managedservicesplatform.go
@@ -108,6 +108,7 @@ func (r *Renderer) RenderEnvironment(
 		Image:           svc.Build.Image,
 		Service:         svc.Service,
 		SecretEnv:       env.SecretEnv,
+		SecretVolumes:   env.SecretVolumes,
 		PreventDestroys: preventDestroys,
 
 		IsFinalStageOfRollout: rolloutPipeline != nil,

--- a/dev/managedservicesplatform/stacks/iam/BUILD.bazel
+++ b/dev/managedservicesplatform/stacks/iam/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     srcs = ["iam_test.go"],
     embed = [":iam"],
     deps = [
+        "//dev/managedservicesplatform/spec",
         "//lib/pointers",
         "@com_github_hexops_autogold_v2//:autogold",
         "@com_github_stretchr_testify//assert",


### PR DESCRIPTION
Closes https://github.com/sourcegraph/managed-services/issues/589, which blocks https://github.com/sourcegraph/managed-services/pull/655

This allows operators to specify volumes to mount from secrets. The configuration is intentionally limited for now, for example:

```yaml
secretVolumes:
  myVolumeName:
    mountPath: "foobar.pem"
    secret: "foobar"
```

It has similar capabilities as `secretEnv`, e.g. being able to source from external secrets and automatically have the appropriate access provisioned.

## Test plan

n/a - we use this already internally with Redis certs. This just exposes the same functionality to operators