### PR TITLE
revert MainDryRun non capturing group

### DIFF
--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -130,8 +130,7 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		}
 	case MainDryRun:
 		return &RunTypeMatcher{
-			Branch:       "(?:main-dry-run/)",
-			BranchRegexp: true,
+			Branch: "main-dry-run/",
 		}
 	case ManuallyTriggered:
 		return &RunTypeMatcher{


### PR DESCRIPTION
in `sg ci build main-dry-run` we use the runtype branch value as part of the branch we push to remotely aka <runtype.Branch>/<original-branch>. With the regexp value this lead to an invalid branch and this `sg ci build main-dry-run` broke.

## Test plan
Tested locally
```
go run ./dev/sg/... ci build main-dry-run
Pushing 2f760d00227390cd45a13ecf91c535c559a2a6e2 to main-dry-run/wb/sg/fix-main-dry...
 remote:
 remote: Create a pull request for 'main-dry-run/wb/sg/fix-main-dry' on GitHub by visiting:
 remote:      https://github.com/sourcegraph/sourcegraph/pull/new/main-dry-run/wb/sg/fix-main-dry
 remote:
 remote: GitHub found 80 vulnerabilities on sourcegraph/sourcegraph's default branch (8 critical, 16 high, 50 moderate, 6 low). To find out more, visit:
 remote:      https://github.com/sourcegraph/sourcegraph/security/dependabot
 remote:
 To github.com:sourcegraph/sourcegraph
  * [new branch]              2f760d00227390cd45a13ecf91c535c559a2a6e2 -> main-dry-run/wb/sg/fix-main-dry
```