### PR TITLE
svelte: Update global Window definition

### DIFF
--- a/client/web-sveltekit/src/global.d.ts
+++ b/client/web-sveltekit/src/global.d.ts
@@ -1,3 +1,14 @@
+// These are currently used by the web app and because the web-sveltekit app uses
+// code from the web app these need to be defined here as well.
+interface PageError {
+    statusCode: number
+    statusText: string
+    error: string
+    errorID: string
+}
+
 interface Window {
-    context: { xhrHeaders: { [key: string]: string } }
+    pageError?: PageError
+    buildInfo: BuildInfo
+    context: import('@sourcegraph/web/src/jscontext').SourcegraphContext
 }


### PR DESCRIPTION
The web app uses `window.context` and `pnpm check` (which runs `svelte-check`) currently reports errors related to accessing this property.

This PR extends this packages own declaration to match with the one in web.

Eventually we'll use `window.context` too but not yet. However it's still useful to do this now to make the output of `pnpm check` less noisy.



## Test plan

`pnpm check` doesn't report issues regarding `window.context` anymore.
