### PR TITLE
feat/ci: ship a static variant of sg linux/amd64 on

### DIFF
--- a/.github/workflows/sg-binary-release.yml
+++ b/.github/workflows/sg-binary-release.yml
@@ -115,12 +115,27 @@ jobs:
           GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
           GOARCH=${{ matrix.arch }} go build -o "sg-msp_$(go env GOOS)_${{ matrix.arch }}" -tags=msp -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
 
+          # On certain CI agents, the glibc might not be the right one, so we build a static variant
+          CGO_ENABLED=0 GOARCH=${{ matrix.arch }} go build -o "sg_$(go env GOOS)_${{ matrix.arch }}_static" -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+          CGO_ENABLED=0 GOARCH=${{ matrix.arch }} go build -o "sg-msp_$(go env GOOS)_${{ matrix.arch }}_static" -tags=msp -trimpath -ldflags "-s -w -X main.BuildCommit=$(git rev-list -1 HEAD .)" .
+
       - name: Upload release asset
         run: |
           cd dev/sg
           release_name="${{ needs.create_release.outputs.release_name }}"
           gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_${{ matrix.arch }}"
           gh release upload -R="${repo}" ${release_name} "sg-msp_$(go env GOOS)_${{ matrix.arch }}"
+        env:
+          repo: sourcegraph/sg
+          GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}
+
+      - name: Upload release asset (linux-amd64-static)
+        if: startswith(matrix.os, 'ubuntu-') == true
+        run: |
+          cd dev/sg
+          release_name="${{ needs.create_release.outputs.release_name }}"
+          gh release upload -R="${repo}" ${release_name} "sg_$(go env GOOS)_${{ matrix.arch }}_static"
+          gh release upload -R="${repo}" ${release_name} "sg-msp_$(go env GOOS)_${{ matrix.arch }}_static"
         env:
           repo: sourcegraph/sg
           GITHUB_TOKEN: ${{ secrets.SG_RELEASE_TOKEN }}


### PR DESCRIPTION
Because of https://github.com/sourcegraph/sourcegraph/commit/82215eb8c1da895cdf2272863785b349d1a06bd4 we build `sg` releases with CGO enabled. 

But in CI when we need `sg` for pipelines for stateless agents, the glibc ends up being the wrong one. This PR ships a statically built one for these, as we absolutely do not care about watching files in CI. 

This is not the best solution, but that'll unblock https://github.com/sourcegraph/sourcegraph/issues/61061 for now. 

## Test plan

CI + will test the newly built binary in a stateless agent
 - ✅ working as intended https://buildkite.com/sourcegraph/deploy-sourcegraph-k8s/builds/299#018e41f7-bce1-4c96-aafa-e8c88fef31c8/247-248


<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
