### PR TITLE
chg/rel: adjust version flag requirement in sg rel

### DIFF
--- a/dev/sg/internal/release/release.go
+++ b/dev/sg/internal/release/release.go
@@ -10,7 +10,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var releaseRunFlags = []cli.Flag{
+// releaseBaseFlags are the flags that are common to all subcommands of the release command.
+// In particular, the version flag is not included in that list, because while it's required
+// for create and promote-to-public, it's not for the others (to allow --config-from-commit).
+var releaseBaseFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:  "workdir",
 		Value: ".",
@@ -31,11 +34,6 @@ var releaseRunFlags = []cli.Flag{
 		Usage: "Preview all the commands that would be performed",
 	},
 	&cli.StringFlag{
-		Name:     "version",
-		Usage:    "Force version",
-		Required: true,
-	},
-	&cli.StringFlag{
 		Name:  "inputs",
 		Usage: "Set inputs to use for a given release, ex: --input=server=v5.2.404040,foobar=ffefe",
 	},
@@ -45,6 +43,24 @@ var releaseRunFlags = []cli.Flag{
 		Usage: "Infer run configuration from last commit instead of flags.",
 	},
 }
+
+// releaseRunFlags are the flags for the release run * subcommands. Version is optional here, because
+// we can also use --infer-from-commit.
+var releaseRunFlags = append(releaseBaseFlags, &cli.StringFlag{
+	Name:  "version",
+	Usage: "Force version",
+})
+
+// releaseCreatePromoteFlags are the flags for the release create and promote-to-public subcommands, Version
+// is required here, because it makes no sense to create a release without one.
+//
+// TODO https://github.com/sourcegraph/sourcegraph/issues/61077 to add the "auto" value that ask
+// the releaseregistry to provide the version number.
+var releaseCreatePromoteFlags = append(releaseBaseFlags, &cli.StringFlag{
+	Name:     "version",
+	Usage:    "Force version (required)",
+	Required: true,
+})
 
 var Command = &cli.Command{
 	Name:     "release",
@@ -123,7 +139,7 @@ var Command = &cli.Command{
 			Description: "See https://go/releases",
 			UsageText:   "sg release create --workdir [path-to-folder-with-manifest] --version vX.Y.Z",
 			Category:    category.Util,
-			Flags:       releaseRunFlags,
+			Flags:       releaseCreatePromoteFlags,
 			Action: func(cctx *cli.Context) error {
 				r, err := newReleaseRunnerFromCliContext(cctx)
 				if err != nil {
@@ -137,7 +153,7 @@ var Command = &cli.Command{
 			Usage:     "Promote an internal release to the public",
 			UsageText: "sg release promote-to-public --workdir [path-to-folder-with-manifest] --version vX.Y.Z",
 			Category:  category.Util,
-			Flags:     releaseRunFlags,
+			Flags:     releaseCreatePromoteFlags,
 			Action: func(cctx *cli.Context) error {
 				r, err := newReleaseRunnerFromCliContext(cctx)
 				if err != nil {
@@ -150,6 +166,14 @@ var Command = &cli.Command{
 }
 
 func newReleaseRunnerFromCliContext(cctx *cli.Context) (*releaseRunner, error) {
+	if cctx.Bool("config-from-commit") && cctx.String("version") != "" {
+		return nil, errors.New("You cannot use --config-from-commit and --version at the same time")
+	}
+
+	if !cctx.Bool("config-from-commit") && cctx.String("version") == "" {
+		return nil, errors.New("You must provide a version through --version or --config-from-commit")
+	}
+
 	workdir := cctx.String("workdir")
 	pretend := cctx.Bool("pretend")
 	// Normalize the version string, to prevent issues where this was given with the wrong convention

--- a/dev/sg/internal/release/release.go
+++ b/dev/sg/internal/release/release.go
@@ -171,7 +171,7 @@ func newReleaseRunnerFromCliContext(cctx *cli.Context) (*releaseRunner, error) {
 	}
 
 	if !cctx.Bool("config-from-commit") && cctx.String("version") == "" {
-		return nil, errors.New("You must provide a version through --version or --config-from-commit")
+		return nil, errors.New("You must provide a version by specifying either --version or --config-from-commit")
 	}
 
 	workdir := cctx.String("workdir")


### PR DESCRIPTION
Introduced a regression in a previous PR that made the `--version` flag required, as it breaks the `--config-from-commit` flag. 

Now, the `create` and `promote-to-public` commands expects the `--version` flag to be provided, and everything else considers it optional. 

## Test plan

skipping `--version` on `create` fails as intended: 

```
~/work/sourcegraph S jh/rel/adjust-flags $ go run ./dev/sg release create --workdir=. --pretend        
NAME:
   sg release create - Create a release for a given product

USAGE:
   sg release create --workdir [path-to-folder-with-manifest] --version vX.Y.Z

CATEGORY:
   4 - Utilities

DESCRIPTION:
   See https://go/releases

OPTIONS:
   --workdir value       Set the working directory to load release scripts from (default: ".")
   --type value          Select release type: major, minor, patch (default: "patch")
   --branch main         Branch to create release from, usually main or `5.3` if you're cutting a patch release
   --pretend             Preview all the commands that would be performed (default: false)
   --inputs value        Set inputs to use for a given release, ex: --input=server=v5.2.404040,foobar=ffefe
   --config-from-commit  Infer run configuration from last commit instead of flags. (default: false)
   --version value       Force version
   --help, -h            show help
❌ Required flag "version" not set
exit status 1
```

`--from-commmit` + `sg release run test` 

```
~/work/deploy-sourcegraph-k8s  wip_v5.3.666 $ ../sourcegraph/sgd release run test --config-from-commit --pretend
👉 [     setup] Finding release manifest in "."
   [     setup] No explicit branch name was provided, assuming current branch is the target: wip_v5.3.666
   [     setup] Found manifest for "deploy-sourcegraph-k8s" (github.com/sourcegraph/deploy-sourcegraph-k8s)
   [      meta] Owners: @sourcegraph/release
   [      meta] Repository: github.com/sourcegraph/deploy-sourcegraph-k8s
👉 [      vars] Variables
   [      vars] git.branch="wip_v5.3.666"
   [      vars] inputs.server.version="v5.3.666"
   [      vars] inputs.server.tag="5.3.666"
   [      vars] version="v5.3.666"
   [      vars] tag="5.3.666"
   [      vars] config="{\"version\":\"v5.3.666\",\"inputs\":\"server=v5.3.666\",\"type\":\"patch\"}"
👉 [      test] Running testing steps for v5.3.666
👉 [      step] Pretending to run step "placeholder"
   [placeholder] echo "-- pretending to test release ..."
   [placeholder] 
```

`--version` and `--config-from-commit` are mutually exclusive but you need one of the two. 

```
~/work/sourcegraph U jh/rel/adjust-flags $ go run ./dev/sg release run test --branch main --pretend
❌ You must provide a version through --version or --config-from-commit
exit status 1
~/work/sourcegraph U jh/rel/adjust-flags $ go run ./dev/sg release run test --branch main --pretend --version=v5.3.777 --config-from-commit
❌ You cannot use --config-from-commit and --version at the same time
exit status 1
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
