### PR TITLE
remove jaeger image from deploy docker images list

### DIFF
--- a/dev/ci/images/images.go
+++ b/dev/ci/images/images.go
@@ -106,7 +106,6 @@ var DeploySourcegraphDockerImages = []string{
 	"gitserver",
 	"grafana",
 	"indexed-searcher",
-	"jaeger",
 	"jaeger-all-in-one",
 	"migrator",
 	"node-exporter",


### PR DESCRIPTION
Closes #61159

## Test plan

The image doesn't exist on dockerhub anymore so it's safe to remove.
