### PR TITLE
Switch Triton to the HTTPS endpoint that doesn't use Cloudflare

### DIFF
--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -241,7 +241,7 @@ func (c *Config) Load() {
 
 	c.Attribution.Enabled = c.GetBool("CODY_GATEWAY_ENABLE_ATTRIBUTION_SEARCH", "false", "Whether attribution search endpoint is available.")
 
-	c.Sourcegraph.TritonURL = c.Get("CODY_GATEWAY_SOURCEGRAPH_TRITON_URL", "https://embeddings-triton.sgdev.org/v2/models/ensemble_model/infer", "URL of the Triton server.")
+	c.Sourcegraph.TritonURL = c.Get("CODY_GATEWAY_SOURCEGRAPH_TRITON_URL", "https://embeddings-triton-direct.sgdev.org/v2/models/ensemble_model/infer", "URL of the Triton server.")
 }
 
 // splitMaybe splits on commas, but only returns at least one element if the input


### PR DESCRIPTION
We now have a HTTPS endpoint for Triton that doesn't use Cloudflare (which improves latency and reduces cost) - all Cody Gateway traffic already goes through Cloudflare, so there's no point in doing that again.

## Test plan

- tested in dev by overriding manually