### PR TITLE
Expose an embeddings handler that doesn't implement rate-limiting

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
+++ b/cmd/cody-gateway/internal/httpapi/embeddings/handler.go
@@ -27,6 +27,7 @@ import (
 )
 
 const usageHeaderName = "X-Token-Usage"
+const baseLoggerScope = "embeddingshandler"
 
 func NewHandler(
 	baseLogger log.Logger,
@@ -36,7 +37,7 @@ func NewHandler(
 	mf ModelFactory,
 	allowedModels []string,
 ) http.Handler {
-	baseLogger = baseLogger.Scoped("embeddingshandler")
+	baseLogger = baseLogger.Scoped(baseLoggerScope)
 
 	return featurelimiter.HandleFeature(
 		baseLogger,
@@ -44,141 +45,7 @@ func NewHandler(
 		rs,
 		rateLimitNotifier,
 		codygateway.FeatureEmbeddings,
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-			act := actor.FromContext(r.Context())
-			logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))
-			// This will never be nil as the rate limiter middleware checks this before.
-			// TODO: Should we read the rate limit from context, and store it in the rate
-			// limiter to make this less dependent on these two logics to remain the same?
-			rateLimit, ok := act.RateLimits[codygateway.FeatureEmbeddings]
-			if !ok {
-				response.JSONError(logger, w, http.StatusInternalServerError, errors.Newf("rate limit for %q not found", string(codygateway.FeatureEmbeddings)))
-				return
-			}
-
-			// Parse the request body.
-			var body codygateway.EmbeddingsRequest
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				response.JSONError(logger, w, http.StatusBadRequest, errors.Wrap(err, "failed to parse request body"))
-				return
-			}
-
-			if !isAllowedModel(intersection(allowedModels, rateLimit.AllowedModels), body.Model) {
-				response.JSONError(logger, w, http.StatusBadRequest, errors.Newf("model %q is not allowed", body.Model))
-				return
-			}
-
-			c, ok := mf.ForModel(body.Model)
-			if !ok {
-				response.JSONError(logger, w, http.StatusBadRequest, errors.Newf("model %q not known", body.Model))
-				return
-			}
-
-			// Add the client type to the logger fields.
-			logger = logger.With(log.String("client", c.ProviderName()))
-
-			var (
-				upstreamStarted    = time.Now()
-				upstreamFinished   time.Duration
-				upstreamStatusCode = -1
-				// resolvedStatusCode is the status code that we returned to the
-				// client - in most case it is the same as upstreamStatusCode,
-				// but sometimes we write something different.
-				resolvedStatusCode int = -1
-				usedTokens         int = -1
-			)
-			defer func() {
-				o := overhead.FromContext(r.Context())
-				o.Feature = codygateway.FeatureEmbeddings
-				o.UpstreamLatency = upstreamFinished
-				o.Provider = c.ProviderName()
-				o.Stream = false
-
-				if span := oteltrace.SpanFromContext(r.Context()); span.IsRecording() {
-					span.SetAttributes(
-						attribute.Int("upstreamStatusCode", upstreamStatusCode),
-						attribute.Int("resolvedStatusCode", resolvedStatusCode))
-				}
-				err := eventLogger.LogEvent(
-					r.Context(),
-					events.Event{
-						Name:       codygateway.EventNameEmbeddingsFinished,
-						Source:     act.Source.Name(),
-						Identifier: act.ID,
-						Metadata: map[string]any{
-							"model": body.Model,
-							codygateway.CompletionsEventFeatureMetadataField: codygateway.CompletionsEventFeatureEmbeddings,
-							"upstream_request_duration_ms":                   upstreamFinished.Milliseconds(),
-							"resolved_status_code":                           resolvedStatusCode,
-							codygateway.EmbeddingsTokenUsageMetadataField:    usedTokens,
-							"batch_size": len(body.Input),
-							"input_character_count": func() (characters int) {
-								for _, input := range body.Input {
-									characters += len(input)
-								}
-								return characters
-							}(),
-						},
-					},
-				)
-				if err != nil {
-					logger.Error("failed to log event", log.Error(err))
-				}
-			}()
-
-			resp, ut, err := c.GenerateEmbeddings(r.Context(), body)
-			usedTokens = ut
-			upstreamFinished = time.Since(upstreamStarted)
-			if err != nil {
-				// This is an error path, so always set a default retry-after
-				// on errors that discourages Sourcegraph clients from retrying
-				// at all - embeddings will likely be run by embeddings workers
-				// that will eventually retry on a more reasonable schedule.
-				w.Header().Set("retry-after", "60")
-
-				// If a status error is returned, pass through the code and error
-				var statusCodeErr response.HTTPStatusCodeError
-				if errors.As(err, &statusCodeErr) {
-					resolvedStatusCode = statusCodeErr.HTTPStatusCode()
-					response.JSONError(logger, w, resolvedStatusCode, statusCodeErr)
-					// Record original code if the status error is a custom one
-					if originalCode, ok := statusCodeErr.IsCustom(); ok {
-						upstreamStatusCode = originalCode
-					}
-					return
-				}
-
-				// More user-friendly message for timeouts
-				if errors.Is(err, context.DeadlineExceeded) {
-					resolvedStatusCode = http.StatusGatewayTimeout
-					response.JSONError(logger, w, resolvedStatusCode,
-						errors.Newf("request to upstream provider %s timed out", c.ProviderName()))
-					return
-				}
-
-				// Return generic error for other unexpected errors.
-				resolvedStatusCode = http.StatusInternalServerError
-				response.JSONError(logger, w, resolvedStatusCode, err)
-				return
-			}
-
-			w.Header().Add(usageHeaderName, strconv.Itoa(usedTokens))
-
-			data, err := json.Marshal(resp)
-			if err != nil {
-				resolvedStatusCode = http.StatusInternalServerError
-				response.JSONError(logger, w, resolvedStatusCode, errors.Wrap(err, "failed to marshal response"))
-				return
-			}
-
-			w.Header().Add("Content-Type", "application/json; charset=utf-8")
-			// Write implicitly returns a 200 status code if one isn't set yet
-			if resolvedStatusCode <= 0 {
-				resolvedStatusCode = 200
-			}
-			_, _ = w.Write(data)
-		}),
+		embeddingsHandler(baseLogger, eventLogger, allowedModels, mf),
 		func(responseHeaders http.Header) (int, error) {
 			uh := responseHeaders.Get(usageHeaderName)
 			if uh == "" {
@@ -190,6 +57,156 @@ func NewHandler(
 			}
 			return usage, nil
 		})
+}
+
+func NewUnlimitedHandler(
+	baseLogger log.Logger,
+	eventLogger events.Logger,
+	mf ModelFactory,
+	allowedModels []string,
+) http.Handler {
+
+	baseLogger = baseLogger.Scoped(baseLoggerScope)
+
+	return embeddingsHandler(baseLogger, eventLogger, allowedModels, mf)
+}
+
+func embeddingsHandler(baseLogger log.Logger, eventLogger events.Logger, allowedModels []string, mf ModelFactory) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		act := actor.FromContext(r.Context())
+		logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger))
+		// This will never be nil as the rate limiter middleware checks this before.
+		// TODO: Should we read the rate limit from context, and store it in the rate
+		// limiter to make this less dependent on these two logics to remain the same?
+		rateLimit, ok := act.RateLimits[codygateway.FeatureEmbeddings]
+		if !ok {
+			response.JSONError(logger, w, http.StatusInternalServerError, errors.Newf("rate limit for %q not found", string(codygateway.FeatureEmbeddings)))
+			return
+		}
+
+		// Parse the request body.
+		var body codygateway.EmbeddingsRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			response.JSONError(logger, w, http.StatusBadRequest, errors.Wrap(err, "failed to parse request body"))
+			return
+		}
+
+		if !isAllowedModel(intersection(allowedModels, rateLimit.AllowedModels), body.Model) {
+			response.JSONError(logger, w, http.StatusBadRequest, errors.Newf("model %q is not allowed", body.Model))
+			return
+		}
+
+		c, ok := mf.ForModel(body.Model)
+		if !ok {
+			response.JSONError(logger, w, http.StatusBadRequest, errors.Newf("model %q not known", body.Model))
+			return
+		}
+
+		// Add the client type to the logger fields.
+		logger = logger.With(log.String("client", c.ProviderName()))
+
+		var (
+			upstreamStarted    = time.Now()
+			upstreamFinished   time.Duration
+			upstreamStatusCode = -1
+			// resolvedStatusCode is the status code that we returned to the
+			// client - in most case it is the same as upstreamStatusCode,
+			// but sometimes we write something different.
+			resolvedStatusCode int = -1
+			usedTokens         int = -1
+		)
+		defer func() {
+			o := overhead.FromContext(r.Context())
+			o.Feature = codygateway.FeatureEmbeddings
+			o.UpstreamLatency = upstreamFinished
+			o.Provider = c.ProviderName()
+			o.Stream = false
+
+			if span := oteltrace.SpanFromContext(r.Context()); span.IsRecording() {
+				span.SetAttributes(
+					attribute.Int("upstreamStatusCode", upstreamStatusCode),
+					attribute.Int("resolvedStatusCode", resolvedStatusCode))
+			}
+			err := eventLogger.LogEvent(
+				r.Context(),
+				events.Event{
+					Name:       codygateway.EventNameEmbeddingsFinished,
+					Source:     act.Source.Name(),
+					Identifier: act.ID,
+					Metadata: map[string]any{
+						"model": body.Model,
+						codygateway.CompletionsEventFeatureMetadataField: codygateway.CompletionsEventFeatureEmbeddings,
+						"upstream_request_duration_ms":                   upstreamFinished.Milliseconds(),
+						"resolved_status_code":                           resolvedStatusCode,
+						codygateway.EmbeddingsTokenUsageMetadataField:    usedTokens,
+						"batch_size": len(body.Input),
+						"input_character_count": func() (characters int) {
+							for _, input := range body.Input {
+								characters += len(input)
+							}
+							return characters
+						}(),
+					},
+				},
+			)
+			if err != nil {
+				logger.Error("failed to log event", log.Error(err))
+			}
+		}()
+
+		resp, ut, err := c.GenerateEmbeddings(r.Context(), body)
+		usedTokens = ut
+		upstreamFinished = time.Since(upstreamStarted)
+		if err != nil {
+			// This is an error path, so always set a default retry-after
+			// on errors that discourages Sourcegraph clients from retrying
+			// at all - embeddings will likely be run by embeddings workers
+			// that will eventually retry on a more reasonable schedule.
+			w.Header().Set("retry-after", "60")
+
+			// If a status error is returned, pass through the code and error
+			var statusCodeErr response.HTTPStatusCodeError
+			if errors.As(err, &statusCodeErr) {
+				resolvedStatusCode = statusCodeErr.HTTPStatusCode()
+				response.JSONError(logger, w, resolvedStatusCode, statusCodeErr)
+				// Record original code if the status error is a custom one
+				if originalCode, ok := statusCodeErr.IsCustom(); ok {
+					upstreamStatusCode = originalCode
+				}
+				return
+			}
+
+			// More user-friendly message for timeouts
+			if errors.Is(err, context.DeadlineExceeded) {
+				resolvedStatusCode = http.StatusGatewayTimeout
+				response.JSONError(logger, w, resolvedStatusCode,
+					errors.Newf("request to upstream provider %s timed out", c.ProviderName()))
+				return
+			}
+
+			// Return generic error for other unexpected errors.
+			resolvedStatusCode = http.StatusInternalServerError
+			response.JSONError(logger, w, resolvedStatusCode, err)
+			return
+		}
+
+		w.Header().Add(usageHeaderName, strconv.Itoa(usedTokens))
+
+		data, err := json.Marshal(resp)
+		if err != nil {
+			resolvedStatusCode = http.StatusInternalServerError
+			response.JSONError(logger, w, resolvedStatusCode, errors.Wrap(err, "failed to marshal response"))
+			return
+		}
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		// Write implicitly returns a 200 status code if one isn't set yet
+		if resolvedStatusCode <= 0 {
+			resolvedStatusCode = 200
+		}
+		_, _ = w.Write(data)
+	}
 }
 
 func isAllowedModel(allowedModels []string, model string) bool {

--- a/cmd/cody-gateway/shared/config/config.go
+++ b/cmd/cody-gateway/shared/config/config.go
@@ -105,7 +105,8 @@ type OpenAIConfig struct {
 }
 
 type SourcegraphConfig struct {
-	TritonURL string
+	TritonURL           string
+	UnlimitedEmbeddings bool
 }
 
 func (c *Config) Load() {
@@ -242,6 +243,8 @@ func (c *Config) Load() {
 	c.Attribution.Enabled = c.GetBool("CODY_GATEWAY_ENABLE_ATTRIBUTION_SEARCH", "false", "Whether attribution search endpoint is available.")
 
 	c.Sourcegraph.TritonURL = c.Get("CODY_GATEWAY_SOURCEGRAPH_TRITON_URL", "https://embeddings-triton-direct.sgdev.org/v2/models/ensemble_model/infer", "URL of the Triton server.")
+	c.Sourcegraph.UnlimitedEmbeddings = c.GetBool("CODY_GATEWAY_SOURCEGRAPH_UNLIMITED_EMBEDDINGS", "false", "Enable unlimited embeddings.")
+
 }
 
 // splitMaybe splits on commas, but only returns at least one element if the input


### PR DESCRIPTION
Expose an additional Embeddings handler that does not implement rate-limiting (reduced overhead + we don't have token counts for our models).

This is proof-of-concept only - will be used for performance testing in staging (off by default). 
## Test plan

- tested locally
- old functionality still E2E tested