### PR TITLE
ci: call Aspect Agent Health check before doing rc gen

### DIFF
--- a/dev/ci/internal/ci/aspect_workflows.go
+++ b/dev/ci/internal/ci/aspect_workflows.go
@@ -1,14 +1,35 @@
 package ci
 
+import "fmt"
+
 var AspectWorkflows = struct {
-	TestStepKey            string
+	// TestStepKey is the key of the primary test step
+	TestStepKey string
+	// IntegrationTestStepKey is the key of the secondary test step where Integration and E2E tests are done
 	IntegrationTestStepKey string
 
+	// QueueDefault is the name of the default queue and uses a "big" machine. Jobs requiring big builds or big tests should use this queue
 	QueueDefault string
-	QueueSmall   string
+	// QueueSmall is the name of the small queue and uses a "small" machine. Jobs that typically do not use bazel or use prebuilt binaries should use this queue
+	QueueSmall string
+
+	// AgentHealthCheckScript is the script that gets executed to check that the current agent is healthy
+	AgentHealthCheckScript string
 }{
 	TestStepKey:            "__main__::test",
 	IntegrationTestStepKey: "__main__::test_2",
 	QueueDefault:           "aspect-default",
 	QueueSmall:             "aspect-small",
+	AgentHealthCheckScript: "/etc/aspect/workflows/bin/agent_health_check",
+}
+
+func withAspectHealthCheck(cmd string) string {
+	return fmt.Sprintf("%s; %s", AspectWorkflows.AgentHealthCheckScript, cmd)
+}
+
+func aspectBazelRC() (string, string) {
+	path := "/tmp/aspect-generated.bazelrc"
+	bazelRCCmd := "rosetta bazelrc > " + path
+
+	return withAspectHealthCheck(bazelRCCmd), path
 }

--- a/dev/ci/internal/ci/bazel_helpers.go
+++ b/dev/ci/internal/ci/bazel_helpers.go
@@ -58,13 +58,6 @@ func bazelStampedCmd(args ...string) string {
 	return strings.Join(cmd, " ")
 }
 
-func aspectBazelRC() (string, string) {
-	path := "/tmp/aspect-generated.bazelrc"
-	cmd := fmt.Sprintf("rosetta bazelrc > %s;", path)
-
-	return cmd, path
-}
-
 // TODO(burmudar): do we remove this?
 func bazelPrechecks() func(*bk.Pipeline) {
 	cmds := []bk.StepOpt{


### PR DESCRIPTION
Sometimes commands might not start on Aspect agents since they're waiting for previous bazel comamnds to stop. This is especially happens with our own custom commands since this is mitigated by the aspect job by calling `Agent Health checks`. As per thread, we now call the same Aspect Agent health check before doing anything bazel related.

## Test plan
CI
