### PR TITLE
guardrails: make graphqlbackend test race free

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -486,6 +486,7 @@ go_test(
         "//internal/binary",
         "//internal/codeintel",
         "//internal/conf",
+        "//internal/conf/conftypes",
         "//internal/database",
         "//internal/database/basestore",
         "//internal/database/dbmocks",

--- a/cmd/frontend/graphqlbackend/guardrails_test.go
+++ b/cmd/frontend/graphqlbackend/guardrails_test.go
@@ -1,6 +1,3 @@
-// TODO: Consider making config thread-safe.
-//go:build !race
-
 package graphqlbackend_test
 
 import (
@@ -8,10 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"sync"
+	"sync/atomic"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
 	"github.com/stretchr/testify/require"
 
@@ -20,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/guardrails"
 	"github.com/sourcegraph/sourcegraph/internal/codeintel"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbmocks"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -144,61 +141,35 @@ func TestGuardrailsFeatureCodyDisabled(t *testing.T) {
 	})
 }
 
-// syncConfMocking is a helper to allow mocking site config in a syncronous manner.
-// Specifically, observers that are watching config changes will have been updated
-// by the time `Update`	returns.
-type syncConfMocking struct {
-	// cond is used to synchronize between the watchers and the update method.
-	cond *sync.Cond
-	// watching is true iff this instance of mocking has observers notified of config changes.
-	watching bool
-	// lastConfig seen is memoized so that `Update` can ensure the value of the config
-	// reaches the parameter before it returns.
-	lastConfig schema.SiteConfiguration
+// syncConfMock is a helper to allow mocking site config in a syncronous
+// manner. Specifically, observers that are watching config changes will have
+// been updated by the time `Update` returns.
+type syncConfMock struct {
+	watcher func()
+	config  atomic.Pointer[schema.SiteConfiguration]
 }
 
-func newSyncConfMocking(t *testing.T) *syncConfMocking {
-	t.Helper()
-	m := &syncConfMocking{
-		cond: sync.NewCond(&sync.Mutex{}),
-	}
-	m.cond.L.Lock()
-	m.watching = true
-	m.cond.L.Unlock()
-	conf.Watch(m.onConfigChange)
-	t.Cleanup(m.Cleanup)
-	return m
-}
+var _ conftypes.UnifiedWatchable = &syncConfMock{}
 
-// Update the site config and await the new config to be propagated to the watchers.
-func (m *syncConfMocking) Update(c schema.SiteConfiguration) {
-	conf.MockAndNotifyWatchers(&conf.Unified{SiteConfiguration: c})
-	m.cond.L.Lock()
-	defer m.cond.L.Unlock()
-	diff := cmp.Diff(m.lastConfig, c)
-	for m.watching && diff != "" {
-		m.cond.Wait()
-		diff = cmp.Diff(m.lastConfig, c)
+func (m *syncConfMock) Update(c schema.SiteConfiguration) {
+	m.config.Store(&c)
+	if m.watcher != nil {
+		m.watcher()
 	}
 }
 
-// onConfigChange is used in `conf.Watch`, and wakes up `Update` which is waiting
-// on config change to propagate to watchers.
-func (m *syncConfMocking) onConfigChange() {
-	m.cond.L.Lock()
-	defer m.cond.L.Unlock()
-	if m.watching {
-		m.lastConfig = conf.Get().SiteConfiguration
-		m.cond.Broadcast()
+func (m *syncConfMock) Watch(cb func()) {
+	if m.watcher != nil {
+		panic("syncConfMocking only supports one watcher")
 	}
+	m.watcher = cb
+	cb() // Part of the Watch contract is calling cb before returning
 }
-
-// Cleanup invalidates the watcher.
-func (m *syncConfMocking) Cleanup() {
-	m.cond.L.Lock()
-	defer m.cond.L.Unlock()
-	m.watching = false
-	m.cond.Broadcast() // ensure to wake up every waiting goroutine
+func (m *syncConfMock) SiteConfig() schema.SiteConfiguration {
+	return *m.config.Load()
+}
+func (c *syncConfMock) ServiceConnections() conftypes.ServiceConnections {
+	panic("unimplemented")
 }
 
 // gatewayResponse that `makeGatewayEndpoint` responds with.
@@ -230,15 +201,15 @@ func TestSnippetAttributionReactsToSiteConfigChanges(t *testing.T) {
 		CodyEnabled:        pointers.Ptr(true),
 		AttributionEnabled: pointers.Ptr(true),
 	}
-	confMock := newSyncConfMocking(t)
+	confMock := &syncConfMock{}
 	confMock.Update(noAttributionConfigured)
-	t.Cleanup(func() { confMock.Update(schema.SiteConfiguration{}) })
+
 	// Initialize graphQL schema with snippetAttribution.
 	db := dbmocks.NewMockDB()
 	ctx := context.Background()
 	g := gitserver.NewClient("graphql.test")
 	var enterpriseServices enterprise.Services
-	require.NoError(t, guardrails.Init(ctx, &observation.TestContext, db, codeintel.Services{}, nil, &enterpriseServices))
+	require.NoError(t, guardrails.Init(ctx, &observation.TestContext, db, codeintel.Services{}, confMock, &enterpriseServices))
 	s, err := graphqlbackend.NewSchema(db, g, []graphqlbackend.OptionalResolver{{GuardrailsResolver: enterpriseServices.OptionalResolver.GuardrailsResolver}})
 	require.NoError(t, err)
 	// Same query runs in every test:

--- a/cmd/frontend/internal/completions/init.go
+++ b/cmd/frontend/internal/completions/init.go
@@ -22,7 +22,7 @@ func Init(
 	observationCtx *observation.Context,
 	db database.DB,
 	_ codeintel.Services,
-	_ conftypes.UnifiedWatchable,
+	conf conftypes.UnifiedWatchable,
 	enterpriseServices *enterprise.Services,
 ) error {
 	logger := log.Scoped("completions")
@@ -32,7 +32,7 @@ func Init(
 		return requireVerifiedEmailMiddleware(db, observationCtx.Logger, completionsHandler)
 	}
 	enterpriseServices.NewCodeCompletionsHandler = func() http.Handler {
-		codeCompletionsHandler := httpapi.NewCodeCompletionsHandler(logger, db, guardrails.NewAttributionTest(observationCtx))
+		codeCompletionsHandler := httpapi.NewCodeCompletionsHandler(logger, db, guardrails.NewAttributionTest(observationCtx, conf))
 		return requireVerifiedEmailMiddleware(db, observationCtx.Logger, codeCompletionsHandler)
 	}
 	enterpriseServices.CompletionsResolver = resolvers.NewCompletionsResolver(db, observationCtx.Logger)


### PR DESCRIPTION
We switch to using the passed in conftypes.UnifiedWatchable which allows us to have more gaurantees around when config is read after being watched. This allows us to simplify the implementation of syncConfMock and I believe make it correct.

Note: previously conf.Watch was run in a goroutine. However, the implementation of conf.Watch is to run your callback once synchronously, then in future call the callback async. Removing the extra goroutine was needed to make extra sure we didn't have a race in the tests.

When trying to work out why this test was failing for me in https://github.com/sourcegraph/sourcegraph/pull/61165 I noticed this simplification.

Test Plan: `go test -race -count=10 -run '(Snippet|Guardrails)'`
