### PR TITLE
Svelte: Add below search home notification UI

### DIFF
--- a/client/web-sveltekit/src/lib/global-notifications/GlobalNotifications.svelte
+++ b/client/web-sveltekit/src/lib/global-notifications/GlobalNotifications.svelte
@@ -44,7 +44,7 @@
     export let globalAlerts: GlobalNotifications
 
     $: settingsMotd = $settings?.motd
-    $: notices = $settings?.notices
+    $: notices = $settings?.notices?.filter(notice => notice.location === 'top')
 
     $: noLicenseWarningUserCount = globalAlerts.productSubscription.noLicenseWarningUserCount
     $: expiresAt = parseISO(globalAlerts.productSubscription.license.expiresAt)

--- a/client/web-sveltekit/src/routes/search/SearchHome.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchHome.svelte
@@ -7,6 +7,8 @@
     import type { SearchPageContext } from '$lib/search/utils'
     import { isLightTheme } from '$lib/stores'
 
+    import SearchHomeNotifications from './SearchHomeNotifications.svelte'
+
     export let queryState: QueryStateStore
 
     setContext<SearchPageContext>('search-context', {
@@ -21,6 +23,7 @@
         <img class="logo" src={$isLightTheme ? logoLight : logoDark} alt="Sourcegraph Logo" />
         <div class="search">
             <SearchInput {queryState} autoFocus />
+            <SearchHomeNotifications/>
         </div>
     </div>
 </section>
@@ -50,6 +53,9 @@
 
     .search {
         width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
     }
 
     img.logo {

--- a/client/web-sveltekit/src/routes/search/SearchHomeNotifications.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchHomeNotifications.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+    import {settings} from '$lib/stores'
+    import {Markdown} from '$lib/wildcard'
+
+    $: notices = $settings?.notices?.filter(notice => notice.location === 'home')
+</script>
+
+{#if notices}
+    <ul class="root">
+        {#each notices as notice (notice.message)}
+            <li class="item">
+                <Markdown content={notice.message}/>
+            </li>
+        {/each}
+    </ul>
+{/if}
+
+<style lang="scss">
+    .root {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        margin: 0;
+        padding: 0;
+    }
+
+    .item {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        border: 1px solid var(--border-color);
+        padding: 0.5rem;
+    }
+</style>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/60731

Prior to this PR both home and top like notification were rendered within global top-style notification UI. This PR adds new UI on the home page below the search input 

## Test plan
- Run any staging with home page notifications (like k8s) 
- Check that notification are visible to you on the home page below the search page
- Check that you can't see the same notification in the global top panel.

