### PR TITLE
ci: add cloud ephemeral runtype to Cloud Ephemeral deployments

### DIFF
--- a/dev/ci/images/images.go
+++ b/dev/ci/images/images.go
@@ -23,7 +23,7 @@ const (
 	SourcegraphPublicReleaseRegistry = "us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public"
 
 	// CloudEphemeralRegistry is the registry where images get published too which should be used for Cloud Ephemeral deployments
-	CloudEphemeralRegistry = "us.gcr.io/sourcegraph-dev/sourcegraph-ci/cloud-ephemeral"
+	CloudEphemeralRegistry = "us-central1-docker.pkg.dev/sourcegraph-ci/cloud-ephemeral"
 )
 
 // DevRegistryImage returns the name of the image for the given app and tag on the

--- a/dev/ci/images/images.go
+++ b/dev/ci/images/images.go
@@ -21,6 +21,9 @@ const (
 	SourcegraphInternalReleaseRegistry = "us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-internal"
 	// SourcegraphPublicReleaseRegistry is a currently private registry for storing public releases.
 	SourcegraphPublicReleaseRegistry = "us-central1-docker.pkg.dev/sourcegraph-ci/rfc795-public"
+
+	// CloudEphemeralRegistry is the registry where images get published too which should be used for Cloud Ephemeral deployments
+	CloudEphemeralRegistry = "us.gcr.io/sourcegraph-dev/sourcegraph-ci/cloud-ephemeral"
 )
 
 // DevRegistryImage returns the name of the image for the given app and tag on the
@@ -41,6 +44,11 @@ func InternalReleaseRegistry(app, tag string) string {
 // publish registry.
 func PublishedRegistryImage(app, tag string) string {
 	root := fmt.Sprintf("%s/%s", SourcegraphDockerPublishRegistry, app)
+	return maybeTaggedImage(root, tag)
+}
+
+func CloudEphemeralRegistryImage(app, tag string) string {
+	root := fmt.Sprintf("%s/%s", CloudEphemeralRegistry, app)
 	return maybeTaggedImage(root, tag)
 }
 

--- a/dev/ci/internal/ci/executor_operations.go
+++ b/dev/ci/internal/ci/executor_operations.go
@@ -151,11 +151,16 @@ func executorImageFamilyForConfig(c Config) string {
 }
 
 func executorsE2E(c Config) operations.Operation {
+	registry := images.SourcegraphDockerDevRegistry
+	if c.RunType.Is(runtype.CloudEphemeral) {
+		registry = images.CloudEphemeralRegistry
+	}
+
 	return func(p *bk.Pipeline) {
 		p.AddStep(":bazel::docker::packer: Executors E2E",
 			bk.DependsOn("bazel-push-images-candidate"),
 			bk.Agent("queue", AspectWorkflows.QueueDefault),
-			bk.Env("REGISTRY", images.SourcegraphDockerDevRegistry),
+			bk.Env("REGISTRY", registry),
 			bk.Env("CANDIDATE_VERSION", c.candidateImageTag()),
 			bk.Env("SOURCEGRAPH_BASE_URL", "http://127.0.0.1:7080"),
 			bk.Env("SOURCEGRAPH_SUDO_USER", "admin"),

--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -102,7 +102,7 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 	case runtype.InternalRelease:
 		prodRegistry = images.SourcegraphInternalReleaseRegistry
 	case runtype.CloudEphemeral:
-		devRegistry = images.SourcegraphCloudEphemeralRegistry
+		devRegistry = images.CloudEphemeralRegistry
 	}
 
 	_, bazelRC := aspectBazelRC()

--- a/dev/ci/internal/ci/images_operations.go
+++ b/dev/ci/internal/ci/images_operations.go
@@ -98,8 +98,11 @@ func bazelPushImagesCmd(c Config, isCandidate bool, opts ...bk.StepOpt) func(*bk
 
 	// If we're building an internal release, we push the final images to that specific registry instead.
 	// See also: release_operations.go
-	if c.RunType.Is(runtype.InternalRelease) {
+	switch c.RunType {
+	case runtype.InternalRelease:
 		prodRegistry = images.SourcegraphInternalReleaseRegistry
+	case runtype.CloudEphemeral:
+		devRegistry = images.SourcegraphCloudEphemeralRegistry
 	}
 
 	_, bazelRC := aspectBazelRC()

--- a/dev/ci/internal/ci/legacy_operations.go
+++ b/dev/ci/internal/ci/legacy_operations.go
@@ -40,7 +40,7 @@ func legacyBuildCandidateDockerImages(apps []string, version string, tag string,
 
 			// Add Sentry environment variables if we are building off main branch
 			// to enable building the webapp with source maps enabled
-			if rt.Is(runtype.MainDryRun) && app == "frontend" {
+			if rt.Is(runtype.MainDryRun, runtype.CloudEphemeral) && app == "frontend" {
 				cmds = append(cmds,
 					bk.Env("SENTRY_UPLOAD_SOURCE_MAPS", "1"),
 					bk.Env("SENTRY_ORGANIZATION", "sourcegraph"),
@@ -122,7 +122,7 @@ func legacyBuildCandidateDockerImage(app string, version string, tag string, rt 
 
 		// Add Sentry environment variables if we are building off main branch
 		// to enable building the webapp with source maps enabled
-		if rt.Is(runtype.MainDryRun) && app == "frontend" {
+		if rt.Is(runtype.MainDryRun, runtype.CloudEphemeral) && app == "frontend" {
 			cmds = append(cmds,
 				bk.Env("SENTRY_UPLOAD_SOURCE_MAPS", "1"),
 				bk.Env("SENTRY_ORGANIZATION", "sourcegraph"),

--- a/dev/ci/internal/ci/misc_operations.go
+++ b/dev/ci/internal/ci/misc_operations.go
@@ -54,7 +54,7 @@ func addSgLints(targets []string) func(*bk.Pipeline) {
 	)
 
 	formatCheck := ""
-	if runType.Is(runtype.MainBranch) || runType.Is(runtype.MainDryRun) {
+	if runType.Is(runtype.MainBranch, runtype.MainDryRun, runtype.CloudEphemeral) {
 		formatCheck = "--skip-format-check "
 	}
 

--- a/dev/ci/internal/ci/pipeline.go
+++ b/dev/ci/internal/ci/pipeline.go
@@ -270,7 +270,14 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// Slow image builds
 		imageBuildOps := operations.NewNamedSet("Image builds")
 
-		if c.RunType.Is(runtype.MainDryRun, runtype.MainBranch, runtype.ReleaseBranch, runtype.TaggedRelease, runtype.InternalRelease) {
+		if c.RunType.Is(
+			runtype.MainDryRun,
+			runtype.MainBranch,
+			runtype.ReleaseBranch,
+			runtype.TaggedRelease,
+			runtype.InternalRelease,
+			runtype.CloudEphemeral,
+		) {
 			imageBuildOps.Append(bazelBuildExecutorVM(c, alwaysRebuild))
 			if c.RunType.Is(runtype.ReleaseBranch, runtype.TaggedRelease) || c.Diff.Has(changed.ExecutorDockerRegistryMirror) {
 				imageBuildOps.Append(bazelBuildExecutorDockerMirror(c))
@@ -283,7 +290,7 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			ChromaticShouldAutoAccept: c.RunType.Is(runtype.MainBranch, runtype.ReleaseBranch, runtype.TaggedRelease, runtype.InternalRelease),
 			MinimumUpgradeableVersion: minimumUpgradeableVersion,
 			ForceReadyForReview:       c.MessageFlags.ForceReadyForReview,
-			CacheBundleSize:           c.RunType.Is(runtype.MainBranch, runtype.MainDryRun),
+			CacheBundleSize:           c.RunType.Is(runtype.MainBranch, runtype.MainDryRun, runtype.CloudEphemeral),
 			IsMainBranch:              true,
 		}))
 

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -114,6 +114,7 @@ elif [[ "$BUILDKITE_BRANCH" =~ ^main-dry-run/.*  ]]; then
   prod_tags+=("insiders")
   push_prod=false
 elif [[ "$BUILDKITE_BRANCH" =~ ^cloud-ephemeral/.* ]]; then
+  # Cloud Ephemeral images need a proper semver version
   dev_tags+=("insiders" "${PUSH_VERSION}")
   prod_tags+=("insiders")
   push_prod=false

--- a/dev/ci/push_all.sh
+++ b/dev/ci/push_all.sh
@@ -113,6 +113,11 @@ elif [[ "$BUILDKITE_BRANCH" =~ ^main-dry-run/.*  ]]; then
   dev_tags+=("insiders")
   prod_tags+=("insiders")
   push_prod=false
+elif [[ "$BUILDKITE_BRANCH" =~ ^cloud-ephemeral/.* ]]; then
+  dev_tags+=("insiders" "${PUSH_VERSION}")
+  prod_tags+=("insiders")
+  push_prod=false
+
 elif [[ "$BUILDKITE_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
   # All release branch builds must be published to prod tags to support
   # format introduced by https://github.com/sourcegraph/sourcegraph/pull/48050

--- a/dev/ci/runtype/runtype.go
+++ b/dev/ci/runtype/runtype.go
@@ -40,6 +40,7 @@ const (
 	ImagePatchNoTest    // build a patched image without testing
 	ExecutorPatchNoTest // build executor image without testing
 	CandidatesNoTest    // build one or all candidate images without testing
+	CloudEphemeral      // build all images and push to cloud ephemeral registry for use with cloud deployment
 
 	BazelDo // run a specific bazel command
 
@@ -159,6 +160,10 @@ func (t RunType) Matcher() *RunTypeMatcher {
 		return &RunTypeMatcher{
 			Branch: "bazel-do/",
 		}
+	case CloudEphemeral:
+		return &RunTypeMatcher{
+			Branch: "cloud-ephemeral/",
+		}
 
 	}
 
@@ -201,6 +206,8 @@ func (t RunType) String() string {
 		return "Internal release"
 	case PromoteRelease:
 		return "Public release"
+	case CloudEphemeral:
+		return "Cloud ephemeral"
 	}
 	return "None"
 }


### PR DESCRIPTION
Closes #61208,#61110

This adds the Cloud Ephemeral runtype which is a runtype which:
- Matches on branches which starts with `cloud-ephemeral/`
- Does everything a main-dry-run does except pushes images to the registry `sourcegraph-ci/cloud-ephemeral`

## Test plan
* CI
* [Test run](https://buildkite.com/sourcegraph/sourcegraph/builds/265572)