### PR TITLE
release: properly generate image family for executors on docker mirror

### DIFF
--- a/dev/ci/internal/ci/executor_operations.go
+++ b/dev/ci/internal/ci/executor_operations.go
@@ -123,7 +123,7 @@ func executorDockerMirrorImageFamilyForConfig(c Config) string {
 		if err != nil {
 			panic("cannot parse version")
 		}
-		imageFamily = fmt.Sprintf("sourcegraph-executors-docker-mirror-%d-%d-%d", ver.Major(), ver.Minor(), ver.Patch())
+		imageFamily = fmt.Sprintf("sourcegraph-executors-internal-docker-mirror-%d-%d-%d", ver.Major(), ver.Minor(), ver.Patch())
 	}
 	return imageFamily
 }


### PR DESCRIPTION
[Context](https://sourcegraph.slack.com/archives/C05RRHSQ3QD/p1710774833681369?thread_ts=1710770293.893109&cid=C05RRHSQ3QD)

## Test plan

This was an oversight. The `imageFamily` for internal releases should contain the word `internal`.