### PR TITLE
Update teams.yml for product platform teams

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -1,5 +1,27 @@
-team/source:
-  - '@ryphil'
+team/source: 
   - '@pjlast'
   - '@eseliger'
   - '@ggilmore'
+
+team/search-platform: 
+  - '@jtibshirani'
+  - '@stefanhengl'
+  - '@keegancsmith'
+
+team/graph:
+  - '@varungandhi-src'
+  - '@kritzcreek'
+  - '@keynmol'
+
+
+team/product-platform:
+  - '@mmanela'
+  - '@pjlast'
+  - '@eseliger'
+  - '@ggilmore'
+  - '@varungandhi-src'
+  - '@kritzcreek'
+  - '@keynmol'
+  - '@jtibshirani'
+  - '@stefanhengl'
+  - '@keegancsmith'


### PR DESCRIPTION
Update the teams.yml which is used the the auto-labeler to label each of the product platform teams and product platform overall.

## Test plan

 - Validate that new prs from product platform teams are labeled properly. 
 