### PR TITLE
chg/bzl: shard graphqlbackend go tests

### DIFF
--- a/cmd/frontend/graphqlbackend/BUILD.bazel
+++ b/cmd/frontend/graphqlbackend/BUILD.bazel
@@ -465,6 +465,7 @@ go_test(
     # graphqlbackend_test.go opens itself during its test, so we need to make it available.
     data = ["graphqlbackend_test.go"],
     embed = [":graphqlbackend"],
+    shard_count = 2,
     tags = [
         # Test requires localhost database
         "requires-network",


### PR DESCRIPTION
`rules_go` has support for sharding tests, got me curious to see how it affects one of our slowest go test suite. Without surprise, it's better. 

I only went to two shards, given Bazel runs as many targets as it can concurrently, it's most likely going to get us diminishing returns. 

We should expect to see https://buildkite.com/organizations/sourcegraph/analytics/suites/sourcegraph-bazel/tests/0189f3a8-2a0f-7780-b50b-b61fcfc916ee?branch=main going down in the upcoming days. 

## Test plan

local: 
- before: `//cmd/frontend/graphqlbackend:graphqlbackend_test                        PASSED in 107.6s`
- after: `//cmd/frontend/graphqlbackend:graphqlbackend_test                        PASSED in 69.6s`

CI:

- before: `//cmd/frontend/graphqlbackend:graphqlbackend_test                        PASSED in 207.2s`
- after: `//cmd/frontend/graphqlbackend:graphqlbackend_test                        PASSED in 107.6s`

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
