### PR TITLE
fix regression and add test

### DIFF
--- a/dev/ci/internal/ci/BUILD.bazel
+++ b/dev/ci/internal/ci/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
 go_test(
     name = "ci_test",
     srcs = [
+        "aspect_workflows_test.go",
         "bazel_operations_test.go",
         "wolfi_operations_test.go",
     ],

--- a/dev/ci/internal/ci/aspect_workflows.go
+++ b/dev/ci/internal/ci/aspect_workflows.go
@@ -1,5 +1,7 @@
 package ci
 
+import "fmt"
+
 var AspectWorkflows = struct {
 	// TestStepKey is the key of the primary test step
 	TestStepKey string
@@ -20,9 +22,10 @@ var AspectWorkflows = struct {
 	QueueSmall:             "aspect-small",
 }
 
-func aspectBazelRC() (string, string) {
-	path := "/tmp/aspect-generated.bazelrc"
-	bazelRCCmd := "rosetta bazelrc > " + path
+const AspectGeneratedBazelRCPath = "/tmp/aspect-generated.bazelrc"
 
-	return bazelRCCmd, path
+func aspectBazelRC() (string, string) {
+	bazelRCCmd := fmt.Sprintf("rosetta bazelrc > %s;", AspectGeneratedBazelRCPath)
+
+	return bazelRCCmd, AspectGeneratedBazelRCPath
 }

--- a/dev/ci/internal/ci/aspect_workflows_test.go
+++ b/dev/ci/internal/ci/aspect_workflows_test.go
@@ -1,0 +1,19 @@
+package ci
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAspectBazelRC(t *testing.T) {
+	cmd, path := aspectBazelRC()
+
+	if path != AspectGeneratedBazelRCPath {
+		t.Fatalf("expected path to be %s, got %s", AspectGeneratedBazelRCPath, path)
+	}
+
+	// cmd should end with a semicolon so that it can be executed on its own and not interfere with other commands
+	if !strings.HasSuffix(cmd, ";") {
+		t.Fatalf("expected command to end with ';', got %s", cmd)
+	}
+}


### PR DESCRIPTION
Generated command was missing a `;`
## Test plan
CI and [bazel-do invoke](https://buildkite.com/sourcegraph/sourcegraph/builds/265638#018e55e9-270a-4234-b1d9-9da8b7c40f63)
