### PR TITLE
feat/bzl: add runnable `gh` target

### DIFF
--- a/dev/tool_deps.bzl
+++ b/dev/tool_deps.bzl
@@ -7,6 +7,15 @@ SRC_CLI_VERSION = "5.3.0"
 CTAGS_VERSION = "6.0.0.2783f009"
 PACKER_VERSION = "1.8.3"
 P4_FUSION_VERSION = "v1.13.2-sg.04a293a"
+GH_VERSION = "2.45.0"
+
+GH_BUILDFILE = """
+filegroup(
+    name = "gh",
+    srcs = ["bin/gh"],
+    visibility = ["//visibility:public"],
+)
+"""
 
 SRC_CLI_BUILDFILE = """
 filegroup(
@@ -174,4 +183,28 @@ def tool_deps():
         sha256 = "f97942e145902e682a5c1bc2608071a24d17bf943f35faaf18f359cbbaacddcd",
         url = "https://storage.googleapis.com/p4-fusion/aarch64-darwin/dist/p4-fusion-{0}".format(P4_FUSION_VERSION),
         executable = True,
+    )
+
+    http_archive(
+        name = "gh_darwin-arm64",
+        build_file_content = GH_BUILDFILE,
+        sha256 = "a0423acd5954932a817d531a8160b67cf0456ea6c9e68c11c054c19ea7a6714b",
+        strip_prefix = "gh_{0}_macOS_arm64".format(GH_VERSION),
+        url = "https://github.com/cli/cli/releases/download/v{0}/gh_{0}_macOS_arm64.zip".format(GH_VERSION),
+    )
+
+    http_archive(
+        name = "gh_darwin-amd64",
+        build_file_content = GH_BUILDFILE,
+        sha256 = "82bea89eea5ddfcd5f88c53857fc2220ee361e0b65629f153d10695971a44195",
+        strip_prefix = "gh_{0}_macOS_amd64".format(GH_VERSION),
+        url = "https://github.com/cli/cli/releases/download/v{0}/gh_{0}_macOS_amd64.zip".format(GH_VERSION),
+    )
+
+    http_archive(
+        name = "gh_linux-amd64",
+        build_file_content = GH_BUILDFILE,
+        sha256 = "79e89a14af6fc69163aee00e764e86d5809d0c6c77e6f229aebe7a4ed115ee67",
+        strip_prefix = "gh_{0}_linux_amd64".format(GH_VERSION),
+        url = "https://github.com/cli/cli/releases/download/v{0}/gh_{0}_linux_amd64.tar.gz".format(GH_VERSION),
     )

--- a/dev/tools/BUILD.bazel
+++ b/dev/tools/BUILD.bazel
@@ -67,3 +67,13 @@ sh_binary(
     }),
     visibility = ["//visibility:public"],
 )
+
+sh_binary(
+    name = "gh",
+    srcs = select({
+        "@bazel_tools//src/conditions:darwin_x86_64": ["@gh_darwin-amd64//:gh"],
+        "@bazel_tools//src/conditions:darwin_arm64": ["@gh_darwin-arm64//:gh"],
+        "@bazel_tools//src/conditions:linux_x86_64": ["@gh_linux-amd64//:gh"],
+    }),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
As part of https://github.com/sourcegraph/sourcegraph/issues/61229 I need to be able to use `gh` directly from Bazel. We could assume the host always has it, but it's more reliable this way. 

## Test plan

- locally tested on darwin-arm64 
- ensured that the archives structure stays the same in zip and tar.gz

```
~/work/sourcegraph U main $ bazel run //dev/tools:gh
INFO: Analyzed target //dev/tools:gh (4 packages loaded, 10 targets configured).
INFO: Found 1 target...
Target //dev/tools:gh up-to-date:
  bazel-bin/dev/tools/gh
Aspect @@rules_rust//rust/private:clippy.bzl%rust_clippy_aspect of //dev/tools:gh up-to-date (nothing to build)
INFO: Elapsed time: 0.634s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/dev/tools/gh
Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:        Authenticate gh and git with GitHub
  browse:      Open the repository in the browser
  codespace:   Connect to and manage codespaces
# ...
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
