### PR TITLE
release: update formatting for slack automation

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -9,6 +9,12 @@ requirements:
     cmd: "curl --help"
   - name: "Buidkite access token"
     env: BUILDKITE_ACCESS_TOKEN
+
+  # #announce-engineering slack webhook url:
+  # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=dnrhbauihkhjs5ag6vszsme45a&i=pldpna5vivapxe4phewnqd42ji&h=team-sourcegraph.1password.com
+
+  # #bolaji-release-testing
+  # https://start.1password.com/open/i?a=HEDEDSLHPBFGRBTKAKJWE23XX4&v=isv4abynddpox72wwbhaamo76e&i=7zjax5rm5hlilbgrzeb257i62i&h=team-sourcegraph.1password.com
   - name: "Slack Webhook URL"
     env: SLACK_WEBHOOK_URL
 
@@ -96,7 +102,8 @@ promoteToPublic:
           tag="{{tag}}"
           changelog_version="${tag//./}"
           body=$(curl -s --fail-with-body -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d '{
-            "text": "*Sourcegraph {{tag}} has been published*\n\n* [Changelog](https://sourcegraph.com/docs/CHANGELOG#${changelog_version})\n* [GitHub release](https://github.com/sourcegraph/sourcegraph/releases/tag/{{version}})"
+            "type": "mrkdwn"
+            "text": "*Sourcegraph {{tag}} has been published*\n\n• [Changelog](https://sourcegraph.com/docs/CHANGELOG#${changelog_version})\n• [GitHub release](https://github.com/sourcegraph/sourcegraph/releases/tag/{{version}})"
           }')
           exit_code=$?
 

--- a/release.yaml
+++ b/release.yaml
@@ -103,7 +103,7 @@ promoteToPublic:
           changelog_version="${tag//./}"
           body=$(curl -s --fail-with-body -X POST "$SLACK_WEBHOOK_URL" -H "Content-Type: application/json" -d '{
             "type": "mrkdwn"
-            "text": "*Sourcegraph {{tag}} has been published*\n\n• [Changelog](https://sourcegraph.com/docs/CHANGELOG#${changelog_version})\n• [GitHub release](https://github.com/sourcegraph/sourcegraph/releases/tag/{{version}})"
+            "text": "*Sourcegraph {{tag}} has been published*\n\n• <https://sourcegraph.com/docs/CHANGELOG#${changelog_version} | Changelog>\n• <https://github.com/sourcegraph/sourcegraph/releases/tag/{{version}} | GitHub release>"
           }')
           exit_code=$?
 


### PR DESCRIPTION
I added a comment to include the link to the webhook URLs for testing and for live.
Also formatted the text a bit so it looks nicer.

## Test plan

Testing with #bolaji-release-testing channel. Will test further during the release.

![CleanShot 2024-03-19 at 11 42 16@2x](https://github.com/sourcegraph/sourcegraph/assets/25608335/5bbe09ef-3ea4-47e5-b71c-311169a7ecc3)
