### PR TITLE
feat/ci: when detecting changes affecting the generated docs, push them to docs repo as a PR

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -34,16 +34,13 @@ tasks:
       auto_deliver: true
       icon: 'ship'
       rules:
+        - deliverable: 'attr(tags, "docs-deliverable", //doc/...)'
+          condition:
+            # only_on_change: true
+            branches: ['jh/bzl/gh']
         - deliverable: 'attr(tags, "msp-deliverable", //cmd/...)'
           condition:
             branches:
               - '^main$'
   - finalization:
       queue: aspect-small
-  - delivery:
-      auto_deliver: true
-      rules:
-        - deliverable: 'attr(tags, "docs-deliverable", //doc/...)'
-          condition:
-            # only_on_change: true
-            branches: ['jh/bzl/gh']

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -40,3 +40,10 @@ tasks:
               - '^main$'
   - finalization:
       queue: aspect-small
+  - delivery:
+      auto_deliver: true
+      rules:
+        - deliverable: 'attr(tags, "docs-deliverable", //doc/...)'
+          condition:
+            # only_on_change: true
+            branches: ['jh/bzl/gh']

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -36,8 +36,9 @@ tasks:
       rules:
         - deliverable: 'attr(tags, "docs-deliverable", //doc/...)'
           condition:
-            # only_on_change: true
-            branches: ['jh/bzl/gh']
+            only_on_change: true
+            branches:
+              - '^main$'
         - deliverable: 'attr(tags, "msp-deliverable", //cmd/...)'
           condition:
             branches:

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -36,9 +36,11 @@ sh_binary(
     srcs = ["_generated.push.sh"],
     args = [
         "$(location //dev/tools:gh)",
+        "$(location //tools/md2mdx:md2mdx)",
     ],
     data = [
         "//dev/tools:gh",
+        "//tools/md2mdx",
         "//monitoring:generate_config",
         # TODO: once we've put in place the redirections, we can instead
         # use the //doc/cli/references:generate_doc target.

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -39,7 +39,10 @@ sh_binary(
     ],
     data = [
         "//dev/tools:gh",
-        "//doc/admin/observability:doc_files",
+        "//monitoring:generate_config",
+        # TODO: once we've put in place the redirections, we can instead
+        # use the //doc/cli/references:generate_doc target.
+        # https://github.com/sourcegraph/sourcegraph/issues/61230
         "//doc/cli/references:doc_files",
     ],
     tags = ["docs-deliverable"],

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -42,4 +42,5 @@ sh_binary(
         "//doc/admin/observability:doc_files",
         "//doc/cli/references:doc_files",
     ],
+    tags = ["docs-deliverable"],
 )

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -30,3 +30,16 @@ sh_binary(
         ["test.sh"],
     ),
 )
+
+sh_binary(
+    name = "generated.push",
+    srcs = ["_generated.push.sh"],
+    args = [
+        "$(location //dev/tools:gh)",
+    ],
+    data = [
+        "//dev/tools:gh",
+        "//doc/admin/observability:doc_files",
+        "//doc/cli/references:doc_files",
+    ],
+)

--- a/doc/_generated.push.sh
+++ b/doc/_generated.push.sh
@@ -73,6 +73,6 @@ unset GH_TOKEN
 export GITHUB_TOKEN="$BUILDKITE_GITHUBDOTCOM_TOKEN"
 "$_gh" pr create \
   --draft \
-  --reviewer jhchabran \
+  --reviewer MaedahBatool \
   --title "🤖 Sync generated docs from sourcegraph/sourcegraph (${_current_date})" \
   --body "This is an automated pull request, created by //doc:generated:push on sourcegraph/sourcegraph"

--- a/doc/_generated.push.sh
+++ b/doc/_generated.push.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu
+
+cwd="$(pwd)"
+_gh="$1"
+
+# Ensure we leave the output tree clean.
+trap "rm -Rf ${cwd}/_clone" EXIT
+
+mkdir -p _clone/
+gh repo clone sourcegraph/docs _clone/ -- --quiet
+
+cp -R doc/admin/** _clone/docs/admin/
+cp -R doc/cli/** _clone/docs/cli/
+
+find _clone/docs/admin -name "*.bazel" | xargs rm
+find _clone/docs/cli -name "*.bazel" | xargs rm
+
+pushd _clone
+_current_date="$(date "+%Y-%m-%d/%H-%M-%S")"
+_branch="sync/${_current_date}"
+git checkout -b "$_branch"
+git add .
+git commit -m "🤖 sync'ing generated docs"
+
+git push
+gh pr create \
+  --draft \
+  --reviewer jhchabran \
+  --title "🤖 Sync generated docs from sourcegraph/sourcegraph (${_current_date})" \
+  --body "This is an automated pull request, created by //doc:generated:push on sourcegraph/sourcegraph"

--- a/doc/_generated.push.sh
+++ b/doc/_generated.push.sh
@@ -11,17 +11,40 @@ trap 'rm -Rf ${cwd}/_clone' EXIT
 mkdir -p _clone/
 git clone --quiet git@github.com:sourcegraph/docs.git _clone/
 
-cp -R -L doc/admin/** _clone/docs/admin/
+# See //monitoring:generate_config
+cp -R -L monitoring/outputs/docs/* _clone/docs/admin/observability
 cp -R -L doc/cli/** _clone/docs/cli/
 
-find _clone/docs/admin -name "*.bazel" -print0 | xargs --null rm
-find _clone/docs/cli -name "*.bazel" -print0 | xargs --null rm
-
+# From now on, we're inside the cloned sourcegraph/docs repo.
 pushd _clone
+
+# Create a fresh branch from `main`
 _current_date="$(date "+%Y-%m-%d/%H-%M-%S")"
 _branch="sync/${_current_date}"
 git checkout -b "$_branch"
+
+# A bit unecessary, but better be safe than sorry
+cd docs/
+
+# Rename unstaged changes (for if the file exists in the docs)
+for f in $(git ls-files --modified | grep '.md' | grep -v '.mdx'); do
+  # Turn .md into .mdx
+  mv "$f" "${f}x"
+done
+
+# Rename untracked changes (for if the file doesn't exists yet in the docs)
+for f in $(git ls-files --others | grep '.md' | grep -v '.mdx'); do
+  # Turn .md into .mdx
+  mv "$f" "${f}x"
+done
+
+cd ..
+
+find docs/admin/observability -name "*.bazel" -print0 | xargs --null rm
+find docs/cli -name "*.bazel" -print0 | xargs --null rm
+
 git add .
+git diff
 git commit -m "🤖 sync'ing generated docs"
 
 git push origin "$_branch"

--- a/doc/_generated.push.sh
+++ b/doc/_generated.push.sh
@@ -3,19 +3,19 @@
 set -eu
 
 cwd="$(pwd)"
-_gh="$1"
+_gh="${cwd}/$1"
 
 # Ensure we leave the output tree clean.
-trap "rm -Rf ${cwd}/_clone" EXIT
+trap 'rm -Rf ${cwd}/_clone' EXIT
 
 mkdir -p _clone/
-gh repo clone sourcegraph/docs _clone/ -- --quiet
+git clone --quiet git@github.com:sourcegraph/docs.git _clone/
 
-cp -R doc/admin/** _clone/docs/admin/
-cp -R doc/cli/** _clone/docs/cli/
+cp -R -L doc/admin/** _clone/docs/admin/
+cp -R -L doc/cli/** _clone/docs/cli/
 
-find _clone/docs/admin -name "*.bazel" | xargs rm
-find _clone/docs/cli -name "*.bazel" | xargs rm
+find _clone/docs/admin -name "*.bazel" -print0 | xargs --null rm
+find _clone/docs/cli -name "*.bazel" -print0 | xargs --null rm
 
 pushd _clone
 _current_date="$(date "+%Y-%m-%d/%H-%M-%S")"
@@ -24,8 +24,12 @@ git checkout -b "$_branch"
 git add .
 git commit -m "🤖 sync'ing generated docs"
 
-git push
-gh pr create \
+git push origin "$_branch"
+
+# For some reason, the GH_TOKEN takes precedence over GITHUB_TOKEN (RIP my dear sanity)
+unset GH_TOKEN
+export GITHUB_TOKEN="$BUILDKITE_GITHUBDOTCOM_TOKEN"
+"$_gh" pr create \
   --draft \
   --reviewer jhchabran \
   --title "🤖 Sync generated docs from sourcegraph/sourcegraph (${_current_date})" \

--- a/doc/_generated.push.sh
+++ b/doc/_generated.push.sh
@@ -55,6 +55,8 @@ git commit -m "🤖 sync'ing generated docs"
 git push origin "$_branch"
 
 # For some reason, the GH_TOKEN takes precedence over GITHUB_TOKEN (RIP my dear sanity)
+# TODO(burmudar): fix this token in the agent image so that we don't have to do this.
+# https://github.com/sourcegraph/sourcegraph/issues/61315
 unset GH_TOKEN
 export GITHUB_TOKEN="$BUILDKITE_GITHUBDOTCOM_TOKEN"
 "$_gh" pr create \

--- a/doc/_generated.push.sh
+++ b/doc/_generated.push.sh
@@ -9,20 +9,6 @@ _md2mdx="${cwd}/$2"
 # Ensure we leave the output tree clean.
 trap 'rm -Rf ${cwd}/_clone' EXIT
 
-# function convert {
-#   local file
-#   file="$1"
-#   local _sed
-#   _sed="sed"
-#
-#   if command -v gsed >/dev/null 2>&1; then
-#     _sed="gsed"
-#   fi
-#
-#   "$_sed" -i -re 's|<!-- (.*) -->|{/* \1 */}|g' "$file"
-#   "$_sed" -i -re 's|(<([0-9]+))|\&lt;\2|g' "$file"
-# }
-
 mkdir -p _clone/
 git clone --quiet git@github.com:sourcegraph/docs.git _clone/
 
@@ -72,7 +58,6 @@ git push origin "$_branch"
 unset GH_TOKEN
 export GITHUB_TOKEN="$BUILDKITE_GITHUBDOTCOM_TOKEN"
 "$_gh" pr create \
-  --draft \
   --reviewer MaedahBatool \
   --title "🤖 Sync generated docs from sourcegraph/sourcegraph (${_current_date})" \
   --body "This is an automated pull request, created by //doc:generated:push on sourcegraph/sourcegraph"

--- a/doc/_generated.push.sh
+++ b/doc/_generated.push.sh
@@ -40,8 +40,8 @@ done
 
 cd ..
 
-find docs/admin/observability -name "*.bazel" -print0 | xargs --null rm
-find docs/cli -name "*.bazel" -print0 | xargs --null rm
+find docs/admin/observability -name "*.bazel" -print0 | xargs --null --no-run-if-empty rm
+find docs/cli -name "*.bazel" -print0 | xargs --null --no-run-if-empty rm
 
 git add .
 git diff

--- a/tools/md2mdx/BUILD.bazel
+++ b/tools/md2mdx/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//dev:go_defs.bzl", "go_test")
+
+go_library(
+    name = "md2mdx_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/sourcegraph/sourcegraph/tools/md2mdx",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "md2mdx",
+    embed = [":md2mdx_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "md2mdx_test",
+    srcs = ["main_test.go"],
+    embed = [":md2mdx_lib"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/tools/md2mdx/README.md
+++ b/tools/md2mdx/README.md
@@ -1,0 +1,33 @@
+# md2mdx
+
+> WARNING
+
+If you arrived here from a search engine, this is not a full markdown to `mdx` converter. This is merely a hack
+to turn our generated docs from the monitoring stack and `src-cli` which are outputting markdown into `mdx`.
+
+This is heavily tied to our content, and is built empirically. TL;DR Don't use this.
+
+---
+
+Right now, the docsite served at https://sourcegraph.com/docs uses a different stack than the previous docsite.
+Most notably, it uses the `mdx` format, which is full of quirks and to be frank, quite unpredictable (which is a
+big departure from the original spirit of markdown if I were to disgress).
+
+For example, there are times where you need to escape `|` like inside backticks. And `{` needs to be escaped everywhere but inside backticks.
+Luckily the triple backticks are safe.
+
+## Usage
+
+It takes the path to a `.md` file and prints the converted output on `stdout`.
+
+```
+md2mdx [docs root]/your/file/in/markdown.md
+```
+
+It's important to make sure to start from the docs root, because there's a bug with linking from an `index.md` because the new docsite
+eliminates the trailing slash for index pages, but doesn't account for that when rendering the links.
+
+## Contributing
+
+As mentioned above, it's pretty empirical. When finding some broken rendering, add a unit test in `main_test.go` and work out
+some way to get it right.

--- a/tools/md2mdx/main.go
+++ b/tools/md2mdx/main.go
@@ -75,6 +75,7 @@ func convert(r io.Reader, path string) (string, error) {
 		}
 
 		line = htmlCommentsRe.ReplaceAllString(line, `{/* $1 */}`)
+
 		line = replaceTagsOrLtGt(line)
 		line = replaceLinks(line, parentFolder, isIndex)
 		line = replaceCurlies(line)
@@ -144,8 +145,10 @@ var tagsRe = regexp.MustCompile(`<([^>]+)>`)
 
 // replaceTagsOrLtGt replaces all tags with their HTML entity equivalents, and all < with &lt; and all > with &gt;.
 // This is quite fragile, and it's surely not going to work if you mix both.
+//
+// We also have a special case for <extID> from src-cli (see tests).
 func replaceTagsOrLtGt(line string) string {
-	if !tagsRe.MatchString(line) {
+	if !tagsRe.MatchString(line) || strings.Contains(line, "<extID>") {
 		line = strings.ReplaceAll(line, "<", "&lt;")
 		line = strings.ReplaceAll(line, ">", "&gt;")
 	}

--- a/tools/md2mdx/main.go
+++ b/tools/md2mdx/main.go
@@ -28,6 +28,8 @@ func main() {
 		panic(err)
 	}
 
+	// Because of the index page issue when linking, we need the path to the file,
+	// so we can work our way to compensate the bug with the relative urls.
 	out, err := convert(f, path)
 	if err != nil {
 		panic(err)
@@ -42,13 +44,15 @@ func main() {
 	}
 }
 
+// htmlCommentsRe matches HTML comments and outputs the comments that MDX wants.
 var htmlCommentsRe = regexp.MustCompile(`<!-- (.*) -->`)
-var relativeLinksRe = regexp.MustCompile(`\[(.*)\]\((.*\.md)\)`)
 
 func convert(r io.Reader, path string) (string, error) {
 	res := []string{}
 	s := bufio.NewScanner(r)
 	_, parentFolder := filepath.Split(filepath.Dir(path))
+
+	isIndex := strings.HasSuffix(path, "index.md")
 
 	var withinTripleBackticks bool
 
@@ -72,7 +76,7 @@ func convert(r io.Reader, path string) (string, error) {
 
 		line = htmlCommentsRe.ReplaceAllString(line, `{/* $1 */}`)
 		line = replaceTagsOrLtGt(line)
-		line = replaceLinks(line, parentFolder)
+		line = replaceLinks(line, parentFolder, isIndex)
 		line = replaceCurlies(line)
 		line = replacePipes(line)
 
@@ -87,7 +91,19 @@ func convert(r io.Reader, path string) (string, error) {
 	return strings.Join(res, "\n"), nil
 }
 
-func replaceLinks(s string, parentFolder string) string {
+var relativeLinksRe = regexp.MustCompile(`\[(.*)\]\((.*\.md[#\w-_]*)\)`)
+
+// replaceLinks does some magic to handle some issues which should be fixed on
+// the new docsite. In particular, because the new docsite renders index pages by removing
+// the trailing slash, but do not take that in account when rendering the link, we have
+// to artificially fix the rendered link by prefixing the destination with the enclosing folder
+// of the index.md
+//
+// If we're not linking from an index.md, relative links work properly.
+//
+// Along the way, we have to drop the `.md` extension, and we don't inject the `.mdx` extension
+// because it's not supported by the new docsite yet.
+func replaceLinks(s string, parentFolder string, isIndex bool) string {
 	matches := relativeLinksRe.FindStringSubmatch(s)
 	if len(matches) == 0 {
 		return s
@@ -97,17 +113,37 @@ func replaceLinks(s string, parentFolder string) string {
 	text := matches[1]
 	link := matches[2]
 
-	if strings.HasSuffix(link, "/index.md") {
-		link = strings.TrimSuffix(link, "/index.md")
-	} else if strings.HasSuffix(link, ".md") {
-		link = link + "x"
+	link = strings.TrimPrefix(link, "./")
+
+	var anchor string
+	if strings.Contains(link, "#") {
+		r := regexp.MustCompile(`.*\#(.*)$`)
+		matches = r.FindStringSubmatch(link)
+		anchor = matches[1]
+		link = strings.Replace(link, "#"+anchor, "", 1)
 	}
 
-	return strings.Replace(s, content, fmt.Sprintf("[%s](%s/%s)", text, parentFolder, link), -1)
+	if strings.HasSuffix(link, "/index.md") {
+		link = strings.TrimSuffix(link, "/index.md")
+	} else {
+		link = strings.TrimSuffix(link, ".md")
+	}
+
+	if anchor != "" {
+		link = link + "#" + anchor
+	}
+
+	if isIndex {
+		return strings.Replace(s, content, fmt.Sprintf("[%s](%s/%s)", text, parentFolder, link), -1)
+	} else {
+		return strings.Replace(s, content, fmt.Sprintf("[%s](%s)", text, link), -1)
+	}
 }
 
 var tagsRe = regexp.MustCompile(`<([^>]+)>`)
 
+// replaceTagsOrLtGt replaces all tags with their HTML entity equivalents, and all < with &lt; and all > with &gt;.
+// This is quite fragile, and it's surely not going to work if you mix both.
 func replaceTagsOrLtGt(line string) string {
 	if !tagsRe.MatchString(line) {
 		line = strings.ReplaceAll(line, "<", "&lt;")
@@ -116,9 +152,12 @@ func replaceTagsOrLtGt(line string) string {
 	return line
 }
 
+// replaceCurlies replaces all curlies when they should be replaced, which follows
+// some strange rules.
 func replaceCurlies(s string) string {
 	singleQuoteRe := regexp.MustCompile(`'([^']+)'`)
 	doubleQuoteRe := regexp.MustCompile(`"([^']+)"`)
+	rawDoubleCurlies := regexp.MustCompile("[^`]{{([^{}]+)}}[^`]?")
 
 	replace := func(s string, r *regexp.Regexp) string {
 		chunks := r.FindAllString(s, -1)
@@ -136,13 +175,15 @@ func replaceCurlies(s string) string {
 		return s
 	}
 
-	for _, r := range []*regexp.Regexp{singleQuoteRe, doubleQuoteRe} {
+	for _, r := range []*regexp.Regexp{singleQuoteRe, doubleQuoteRe, rawDoubleCurlies} {
 		s = replace(s, r)
 	}
 
 	return s
 }
 
+// replacePipes replaces all pipes when they're inside backticks, because apparently,
+// they should be escaped in there.
 func replacePipes(s string) string {
 	backticksRe := regexp.MustCompile("`([^`]+)`")
 

--- a/tools/md2mdx/main.go
+++ b/tools/md2mdx/main.go
@@ -1,5 +1,9 @@
 package main
 
+// This code is a hack, it could be improved a lot, but ideally we would fix the docsite rather than
+// having to do this. For example, the docsite could simply support normal markdown along mdx, as
+// generated docs are not going to have fancy components.
+
 import (
 	"bufio"
 	"fmt"

--- a/tools/md2mdx/main.go
+++ b/tools/md2mdx/main.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		println("Usage: md2mdx <path>")
+		os.Exit(1)
+	}
+
+	path := os.Args[1]
+
+	if filepath.Ext(path) != ".md" {
+		println("Must pass a markdown file")
+		os.Exit(1)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		panic(err)
+	}
+
+	out, err := convert(f, path)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := f.Close(); err != nil {
+		panic(err)
+	}
+
+	if _, err := os.Stdout.Write([]byte(out)); err != nil {
+		panic(err)
+	}
+}
+
+var htmlCommentsRe = regexp.MustCompile(`<!-- (.*) -->`)
+var relativeLinksRe = regexp.MustCompile(`\[(.*)\]\((.*\.md)\)`)
+
+func convert(r io.Reader, path string) (string, error) {
+	res := []string{}
+	s := bufio.NewScanner(r)
+	_, parentFolder := filepath.Split(filepath.Dir(path))
+
+	var withinTripleBackticks bool
+
+	for s.Scan() {
+		line := s.Text()
+
+		if withinTripleBackticks && strings.Contains(line, "```") {
+			withinTripleBackticks = false
+			goto APPEND
+		}
+
+		if withinTripleBackticks {
+			goto APPEND
+		}
+
+		// Yes, the first part of the predicate is useless, but it's easier to read.
+		if !withinTripleBackticks && strings.Contains(line, "```") {
+			withinTripleBackticks = true
+			goto APPEND
+		}
+
+		line = htmlCommentsRe.ReplaceAllString(line, `{/* $1 */}`)
+		line = replaceTagsOrLtGt(line)
+		line = replaceLinks(line, parentFolder)
+		line = replaceCurlies(line)
+		line = replacePipes(line)
+
+	APPEND:
+		res = append(res, line)
+	}
+
+	if err := s.Err(); err != nil {
+		return "", err
+	}
+
+	return strings.Join(res, "\n"), nil
+}
+
+func replaceLinks(s string, parentFolder string) string {
+	matches := relativeLinksRe.FindStringSubmatch(s)
+	if len(matches) == 0 {
+		return s
+	}
+
+	content := matches[0]
+	text := matches[1]
+	link := matches[2]
+
+	if strings.HasSuffix(link, "/index.md") {
+		link = strings.TrimSuffix(link, "/index.md")
+	} else if strings.HasSuffix(link, ".md") {
+		link = link + "x"
+	}
+
+	return strings.Replace(s, content, fmt.Sprintf("[%s](%s/%s)", text, parentFolder, link), -1)
+}
+
+var tagsRe = regexp.MustCompile(`<([^>]+)>`)
+
+func replaceTagsOrLtGt(line string) string {
+	if !tagsRe.MatchString(line) {
+		line = strings.ReplaceAll(line, "<", "&lt;")
+		line = strings.ReplaceAll(line, ">", "&gt;")
+	}
+	return line
+}
+
+func replaceCurlies(s string) string {
+	singleQuoteRe := regexp.MustCompile(`'([^']+)'`)
+	doubleQuoteRe := regexp.MustCompile(`"([^']+)"`)
+
+	replace := func(s string, r *regexp.Regexp) string {
+		chunks := r.FindAllString(s, -1)
+		if len(chunks) == 0 {
+			return s
+		}
+		for _, content := range chunks {
+			newContent := content
+			newContent = strings.Replace(newContent, "{", "\\{", -1)
+			newContent = strings.Replace(newContent, "}", "\\}", -1)
+			newContent = strings.Replace(newContent, "|", "\\|", -1)
+
+			s = strings.ReplaceAll(s, content, newContent)
+		}
+		return s
+	}
+
+	for _, r := range []*regexp.Regexp{singleQuoteRe, doubleQuoteRe} {
+		s = replace(s, r)
+	}
+
+	return s
+}
+
+func replacePipes(s string) string {
+	backticksRe := regexp.MustCompile("`([^`]+)`")
+
+	chunks := backticksRe.FindAllString(s, -1)
+	if len(chunks) == 0 {
+		return s
+	}
+	for _, content := range chunks {
+		newContent := content
+		newContent = strings.Replace(newContent, "|", "\\|", -1)
+
+		s = strings.ReplaceAll(s, content, newContent)
+	}
+	return s
+}

--- a/tools/md2mdx/main_test.go
+++ b/tools/md2mdx/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConversion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "html comments",
+			input: "foobar\n<!-- comment -->\nbazbar",
+			want:  "foobar\n{/* comment */}\nbazbar",
+		},
+		{
+			name:  "less than",
+			input: "foobar\n<!-- comment -->\nbazbar",
+			want:  "foobar\n{/* comment */}\nbazbar",
+		},
+		{
+			name:  "curlies inside single quotes",
+			input: "foobar\n'query { foo { bar } }'\nbazbar",
+			want:  "foobar\n" + `'query \{ foo \{ bar \} \}'` + "\nbazbar",
+		},
+		{
+			name:  "curlies inside double quotes",
+			input: "foobar\n\"query { foo { bar } }\"\nbazbar",
+			want:  "foobar\n" + `"query \{ foo \{ bar \} \}"` + "\nbazbar",
+		},
+		{
+			name:  "curlies inside are fine inside backticks",
+			input: "foobar\n`query { foo { bar } }`\nbazbar",
+			want:  "foobar\n`query { foo { bar } }`\nbazbar",
+		},
+		{
+			name:  "but pipes are not (wtf) inside backticks",
+			input: "foobar\n`query {.|jsonIndent}`\nbazbar",
+			want:  "foobar\n`query {.\\|jsonIndent}`\nbazbar",
+		},
+		{
+			name:  "real curlies example",
+			input: `GraphQL query variables to include as JSON string, e.g. '{"var": "val", "var2": "val2"}' |`,
+			want:  `GraphQL query variables to include as JSON string, e.g. '\{"var": "val", "var2": "val2"\}' |`,
+		},
+		{
+			name:  "another real curlies example",
+			input: "| `-f` | Format for the output, using the syntax of Go package text/template. (e.g. \"{{.|json}}\") | `{{.|jsonIndent}}` |",
+			want:  "| `-f` | Format for the output, using the syntax of Go package text/template. (e.g. \"\\{\\{.\\|json\\}\\}\") | `{{.\\|jsonIndent}}` |",
+		},
+		{
+			name:  "ignore triple backticks",
+			input: "foobar\n```\n<!-- comment -->\n```\nbazbar",
+			want:  "foobar\n```\n<!-- comment -->\n```\nbazbar",
+		},
+		{
+			name:  "details tag",
+			input: `<p class="subtitle">Hard error search API responses every 5m</p>`,
+			want:  `<p class="subtitle">Hard error search API responses every 5m</p>`,
+		},
+		{
+			name:  "latency is >50ms",
+			input: `latency is >50ms but <50s`,
+			want:  `latency is &gt;50ms but &lt;50s`,
+		},
+		// {
+		// 	name:  "real tags example",
+		// 	input: "| `-extension-id` | The <extID> in https://sourcegraph.com/extensions/<extID> (e.g. sourcegraph/java) |  |",
+		// 	want:  "| `-extension-id` | The &lt;extID&gt; in https://sourcegraph.com/extensions/&lt;extID&gt; (e.g. sourcegraph/java) |  |",
+		// },
+		{
+			name:  "relative links to .md should point to mdx",
+			input: "* [`admin`](admin.md)\n* [`api`](api.md)\n* [`batch`](batch/index.md)",
+			want:  "* [`admin`](references/admin.mdx)\n* [`api`](references/api.mdx)\n* [`batch`](references/batch)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := strings.NewReader(tt.input)
+			out, err := convert(r, "foo/bar/references/index.md")
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}

--- a/tools/md2mdx/main_test.go
+++ b/tools/md2mdx/main_test.go
@@ -66,6 +66,11 @@ func TestConversion(t *testing.T) {
 			want:  `<p class="subtitle">Hard error search API responses every 5m</p>`,
 		},
 		{
+			name:  "extid tag from src-cli usage",
+			input: "| `-extension-id` | The <extID> in https://sourcegraph.com/extensions/<extID> (e.g. sourcegraph/java) |  |",
+			want:  "| `-extension-id` | The &lt;extID&gt; in https://sourcegraph.com/extensions/&lt;extID&gt; (e.g. sourcegraph/java) |  |",
+		},
+		{
 			name:  "latency is >50ms",
 			input: `latency is >50ms but <50s`,
 			want:  `latency is &gt;50ms but &lt;50s`,

--- a/tools/md2mdx/main_test.go
+++ b/tools/md2mdx/main_test.go
@@ -13,6 +13,7 @@ func TestConversion(t *testing.T) {
 		input   string
 		want    string
 		wantErr bool
+		path    string
 	}{
 		{
 			name:  "html comments",
@@ -69,22 +70,40 @@ func TestConversion(t *testing.T) {
 			input: `latency is >50ms but <50s`,
 			want:  `latency is &gt;50ms but &lt;50s`,
 		},
-		// {
-		// 	name:  "real tags example",
-		// 	input: "| `-extension-id` | The <extID> in https://sourcegraph.com/extensions/<extID> (e.g. sourcegraph/java) |  |",
-		// 	want:  "| `-extension-id` | The &lt;extID&gt; in https://sourcegraph.com/extensions/&lt;extID&gt; (e.g. sourcegraph/java) |  |",
-		// },
+		{
+			name:  "{{CONTAINER_NAME}}",
+			input: "foobar {{CONTAINER_NAME}} baz",
+			want:  "foobar \\{\\{CONTAINER_NAME\\}\\} baz",
+		},
+		{
+			name:  "`{{CONTAINER_NAME}}` shouldn't be escaped",
+			input: "foobar `{{CONTAINER_NAME}}` baz",
+			want:  "foobar `{{CONTAINER_NAME}}` baz",
+		},
+		{
+			name:  "alert links",
+			input: "Refer to the [alerts reference](./alerts.md#frontend-99th-percentile-search-request-duration) for 1 alert related to this panel.",
+			want:  "Refer to the [alerts reference](alerts#frontend-99th-percentile-search-request-duration) for 1 alert related to this panel.",
+			path:  "docs/admin/observability/dashboards.md",
+		},
 		{
 			name:  "relative links to .md should point to mdx",
 			input: "* [`admin`](admin.md)\n* [`api`](api.md)\n* [`batch`](batch/index.md)",
-			want:  "* [`admin`](references/admin.mdx)\n* [`api`](references/api.mdx)\n* [`batch`](references/batch)",
+			want:  "* [`admin`](references/admin)\n* [`api`](references/api)\n* [`batch`](references/batch)",
+			path:  "foo/bar/references/index.md",
+		},
+		{
+			name:  "some other links",
+			input: "* [`edit`](edit.md)\n* [`get`](get.md)\n* [`list`](list.md)",
+			want:  "* [`edit`](config/edit)\n* [`get`](config/get)\n* [`list`](config/list)",
+			path:  "cli/references/config/index.md",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := strings.NewReader(tt.input)
-			out, err := convert(r, "foo/bar/references/index.md")
+			out, err := convert(r, tt.path)
 
 			if tt.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/61229
Fixes https://github.com/sourcegraph/sourcegraph/issues/61085
Fixes https://github.com/sourcegraph/sourcegraph/issues/61228

Adds a `//doc:generated.push` target, that gets triggered by the delivery feature, configured to only run when changes are detected. Basically, it sends a PR on the new docs repo, whenever changes to the generated docs is detected. 

Wrote a `md2mdx` which is more of a pile of hacks, but will buy us time while a better approach is figured out. 

Reviewers: please review as usual for the delivery part, but the new tool that processes the docs, keep in mind it's a hack so the KPI is that it works more than it's in a good shape. There's a tons of nit comments that could be made, but it gets the job done.

## Test plan

See the final result over https://github.com/sourcegraph/docs/pull/185

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
