### PR TITLE
Remove Emacs from Cody onboarding, and make links open in new tabs

### DIFF
--- a/client/web/src/cody/onboarding/CodyOnboarding.tsx
+++ b/client/web/src/cody/onboarding/CodyOnboarding.tsx
@@ -116,13 +116,6 @@ export const editorGroups: IEditor[][] = [
             docs: 'https://sourcegraph.com/docs/cody/clients/install-neovim',
             instructions: NeoVimInstructions,
         },
-        {
-            id: 10,
-            icon: 'Emacs',
-            name: 'Emacs',
-            publisher: 'GNU',
-            releaseStage: 'Coming Soon',
-        },
     ],
 ]
 

--- a/client/web/src/cody/onboarding/instructions/JetBrains.tsx
+++ b/client/web/src/cody/onboarding/instructions/JetBrains.tsx
@@ -34,7 +34,11 @@ export function JetBrainsInstructions({
                                 <div>
                                     <Text className="mb-1" weight="bold">
                                         Open the Plugins Page (or via the{' '}
-                                        <Link to="https://plugins.jetbrains.com/plugin/9682-sourcegraph-cody--code-search">
+                                        <Link
+                                            to="https://plugins.jetbrains.com/plugin/9682-sourcegraph-cody--code-search"
+                                            target="_blank"
+                                            rel="noopener"
+                                        >
                                             JetBrains Marketplace
                                         </Link>
                                         )
@@ -187,12 +191,16 @@ export function JetBrainsInstructions({
                                 <Link
                                     to="https://discord.gg/rDPqBejz93"
                                     className="d-flex w-100 justify-content-center "
+                                    target="_blank"
+                                    rel="noopener"
                                 >
                                     <strong>Discord chat</strong>
                                 </Link>
                                 <Link
                                     to="https://github.com/sourcegraph/cody/discussions/new?category=product-feedback"
                                     className="d-flex w-100 justify-content-center mt-4"
+                                    target="_blank"
+                                    rel="noopener"
                                 >
                                     <strong>GitHub Discussions</strong>
                                 </Link>


### PR DESCRIPTION
Got this report:

1. Emacs is still listed under "Choose your editor" -- can we remove this?
2. A number of links in the tutorial modal don't open in a new tab, so they redirect the user away from [sourcegraph.com/cody/manage](http://sourcegraph.com/cody/manage). Then when you navigate back, the tutorial modal will be closed. I would recommend changing these to open in a new tab so they don't interrupt the onboarding flow:
    - "JetBrains Marketplace" link
    - "Discord Chat" link
    - "GitHub Discussions" link

This PR removes Emacs and makes those three links open in a new tab.

## Test plan

Emacs is gone:

![CleanShot 2024-03-19 at 12 16 15@2x](https://github.com/sourcegraph/sourcegraph/assets/2552265/cfbdc32f-034c-4586-8c52-4f424857143f)

I couldn't trigger the tutorial, so didn't test the links, but it would be difficult to get wrong so I'm confident.
