### PR TITLE
release: dont append buildkite build number for executor AMIs during internal release

### DIFF
--- a/cmd/executor/vm-image/_ami.push.sh
+++ b/cmd/executor/vm-image/_ami.push.sh
@@ -24,7 +24,12 @@ export AWS_ACCESS_KEY_ID="${AWS_EXECUTOR_AMI_ACCESS_KEY}"
 export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
 
 # Point to GCP boot disk image/AMI built by //cmd/executor/vm-image:ami.build
-NAME="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
+if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
+  NAME="${IMAGE_FAMILY}"
+else
+  NAME="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
+fi
+
 GOOGLE_IMAGE_NAME="${NAME}"
 
 # Mark GCP boot disk as released and make it usable outside of Sourcegraph.

--- a/cmd/executor/vm-image/_ami.push.sh
+++ b/cmd/executor/vm-image/_ami.push.sh
@@ -24,10 +24,9 @@ export AWS_ACCESS_KEY_ID="${AWS_EXECUTOR_AMI_ACCESS_KEY}"
 export AWS_SECRET_ACCESS_KEY="${AWS_EXECUTOR_AMI_SECRET_KEY}"
 
 # Point to GCP boot disk image/AMI built by //cmd/executor/vm-image:ami.build
-if [ "${RELEASE_INTERNAL:-}" == "true" ]; then
-  NAME="${IMAGE_FAMILY}"
-else
-  NAME="${IMAGE_FAMILY}-${BUILDKITE_BUILD_NUMBER}"
+NAME="${IMAGE_FAMILY}"
+if [ "${RELEASE_INTERNAL:-}" != "true" ]; then
+  NAME="${NAME}-${BUILDKITE_BUILD_NUMBER}"
 fi
 
 GOOGLE_IMAGE_NAME="${NAME}"

--- a/dev/ci/internal/ci/executor_operations.go
+++ b/dev/ci/internal/ci/executor_operations.go
@@ -87,6 +87,7 @@ func bazelPublishExecutorDockerMirror(c Config) operations.Operation {
 			bk.Env("VERSION", c.Version),
 			bk.Env("IMAGE_FAMILY", imageFamily),
 			bk.Env("EXECUTOR_IS_TAGGED_RELEASE", strconv.FormatBool(c.RunType.Is(runtype.TaggedRelease, runtype.InternalRelease))),
+			bk.Env("RELEASE_INTERNAL", strconv.FormatBool(c.RunType.Is(runtype.InternalRelease))),
 			bk.Cmd(bazelStampedCmd("run //cmd/executor/docker-mirror:ami.push")),
 		}
 		pipeline.AddStep(":bazel::packer: :white_check_mark: Publish docker registry mirror image", stepOpts...)


### PR DESCRIPTION
Part 1 of #61064

## Test plan

CI passing.
