### PR TITLE
Svelte: isolate hover handle

### DIFF
--- a/client/web-sveltekit/src/routes/search/SearchResults.svelte
+++ b/client/web-sveltekit/src/routes/search/SearchResults.svelte
@@ -187,6 +187,10 @@
         display: flex;
         flex: 1;
         overflow: hidden;
+        // Isolate everything in search results so they won't be displayed over
+        // the search suggestions. Previously, hovering over separator would
+        // overlap the suggestions panel.
+        isolation: isolate;
     }
 
     .results {


### PR DESCRIPTION
This adds an `isolation: isolate` to the search results block so that the nothing from that block will be displayed above the search suggestions panel. 

## Test plan

Before: 
![CleanShot 2024-03-19 at 09 44 37@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/e609e7a0-50a0-47ce-bf53-690a2fe00b45)

After:

![CleanShot 2024-03-19 at 09 43 41@2x](https://github.com/sourcegraph/sourcegraph/assets/12631702/58db01e1-c862-46b3-a951-51ca86722c98)
