### PR TITLE
Cleanup Cody Gateway upstreams.go

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -22,8 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const anthropicAPIURL = "https://api.anthropic.com/v1/complete"
-
 const (
 	logPromptPrefixLength = 250
 )
@@ -57,7 +55,6 @@ func NewAnthropicHandler(
 		rateLimitNotifier,
 		httpClient,
 		string(conftypes.CompletionsProviderNameAnthropic),
-		func(_ codygateway.Feature) string { return anthropicAPIURL },
 		config.AllowedModels,
 		&AnthropicHandlerMethods{config: config, anthropicTokenizer: anthropicTokenizer, promptRecorder: promptRecorder},
 
@@ -133,6 +130,10 @@ type AnthropicHandlerMethods struct {
 	anthropicTokenizer *tokenizer.Tokenizer
 	promptRecorder     PromptRecorder
 	config             config.AnthropicConfig
+}
+
+func (a *AnthropicHandlerMethods) getAPIURLByFeature(feature codygateway.Feature) string {
+	return "https://api.anthropic.com/v1/complete"
 }
 
 func (a *AnthropicHandlerMethods) validateRequest(ctx context.Context, logger log.Logger, _ codygateway.Feature, ar anthropicRequest) (int, *flaggingResult, error) {

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -23,9 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
-const fireworksAPIURL = "https://api.fireworks.ai/inference/v1/completions"
-const fireworksChatAPIURL = "https://api.fireworks.ai/inference/v1/chat/completions"
-
 func NewFireworksHandler(
 	baseLogger log.Logger,
 	eventLogger events.Logger,
@@ -42,13 +39,6 @@ func NewFireworksHandler(
 		rateLimitNotifier,
 		httpClient,
 		string(conftypes.CompletionsProviderNameFireworks),
-		func(feature codygateway.Feature) string {
-			if feature == codygateway.FeatureChatCompletions {
-				return fireworksChatAPIURL
-			} else {
-				return fireworksAPIURL
-			}
-		},
 		config.AllowedModels,
 		&FireworksHandlerMethods{
 			baseLogger:  baseLogger,
@@ -119,6 +109,14 @@ type FireworksHandlerMethods struct {
 	baseLogger  log.Logger
 	eventLogger events.Logger
 	config      config.FireworksConfig
+}
+
+func (f *FireworksHandlerMethods) getAPIURLByFeature(feature codygateway.Feature) string {
+	if feature == codygateway.FeatureChatCompletions {
+		return "https://api.fireworks.ai/inference/v1/chat/completions"
+	} else {
+		return "https://api.fireworks.ai/inference/v1/completions"
+	}
 }
 
 func (f *FireworksHandlerMethods) validateRequest(_ context.Context, _ log.Logger, _ codygateway.Feature, _ fireworksRequest) (int, *flaggingResult, error) {

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/log"
+
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/shared/config"
 	"github.com/sourcegraph/sourcegraph/internal/completions/client/openai"
 	"github.com/sourcegraph/sourcegraph/lib/errors"
@@ -20,8 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
-
-const openAIURL = "https://api.openai.com/v1/chat/completions"
 
 func NewOpenAIHandler(
 	baseLogger log.Logger,
@@ -39,7 +38,6 @@ func NewOpenAIHandler(
 		rateLimitNotifier,
 		httpClient,
 		string(conftypes.CompletionsProviderNameOpenAI),
-		func(_ codygateway.Feature) string { return openAIURL },
 		config.AllowedModels,
 		&OpenAIHandlerMethods{config: config},
 
@@ -118,7 +116,11 @@ type OpenAIHandlerMethods struct {
 	config config.OpenAIConfig
 }
 
-func (_ *OpenAIHandlerMethods) validateRequest(_ context.Context, _ log.Logger, feature codygateway.Feature, _ openaiRequest) (int, *flaggingResult, error) {
+func (*OpenAIHandlerMethods) getAPIURLByFeature(feature codygateway.Feature) string {
+	return "https://api.openai.com/v1/chat/completions"
+}
+
+func (*OpenAIHandlerMethods) validateRequest(_ context.Context, _ log.Logger, feature codygateway.Feature, _ openaiRequest) (int, *flaggingResult, error) {
 	if feature == codygateway.FeatureCodeCompletions {
 		return http.StatusNotImplemented, nil,
 			errors.Newf("feature %q is currently not supported for OpenAI",
@@ -126,7 +128,8 @@ func (_ *OpenAIHandlerMethods) validateRequest(_ context.Context, _ log.Logger, 
 	}
 	return 0, nil, nil
 }
-func (_ *OpenAIHandlerMethods) transformBody(body *openaiRequest, identifier string) {
+
+func (*OpenAIHandlerMethods) transformBody(body *openaiRequest, identifier string) {
 	// We don't want to let users generate multiple responses, as this would
 	// mess with rate limit counting.
 	if body.N > 1 {
@@ -135,7 +138,8 @@ func (_ *OpenAIHandlerMethods) transformBody(body *openaiRequest, identifier str
 	// We forward the actor ID to support tracking.
 	body.User = identifier
 }
-func (_ *OpenAIHandlerMethods) getRequestMetadata(body openaiRequest) (model string, additionalMetadata map[string]any) {
+
+func (*OpenAIHandlerMethods) getRequestMetadata(body openaiRequest) (model string, additionalMetadata map[string]any) {
 	return body.Model, map[string]any{"stream": body.Stream}
 }
 
@@ -147,7 +151,7 @@ func (o *OpenAIHandlerMethods) transformRequest(r *http.Request) {
 	}
 }
 
-func (_ *OpenAIHandlerMethods) parseResponseAndUsage(logger log.Logger, body openaiRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
+func (*OpenAIHandlerMethods) parseResponseAndUsage(logger log.Logger, body openaiRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
 	// First, extract prompt usage details from the request.
 	for _, m := range body.Messages {
 		promptUsage.characters += len(m.Content)

--- a/cmd/cody-gateway/internal/httpapi/completions/upstream.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/upstream.go
@@ -63,10 +63,12 @@ const phrasePrefixLength = 5
 //
 // Methods do not need to be concurrency-safe, as they are only called sequentially.
 type upstreamHandlerMethods[ReqT UpstreamRequest] interface {
+	// getAPIURLByFeature returns the upstream API endpoint to call for the given feature.
+	getAPIURLByFeature(codygateway.Feature) string
+
 	// validateRequest can be used to validate the HTTP request before it is sent upstream.
 	// Returning a non-nil error will stop further processing and return the given error
-	// code, or a 400.
-	// Second return value is a boolean indicating whether the request was flagged during validation.
+	// code. Defaulting to 400.
 	//
 	// The provided logger already contains actor context.
 	validateRequest(context.Context, log.Logger, codygateway.Feature, ReqT) (int, *flaggingResult, error)
@@ -100,6 +102,9 @@ type UpstreamRequest interface {
 	BuildPrompt() string
 }
 
+// makeUpstreamHandler a big deal. This method will produce an http.Handler that will handle converting
+// the Cody Gateway user's request to the backing LLM ("upstream provider"). This is how we provide a
+// consistent way for providing logging, telemetry, rate limiting, etc. across multiple upstream providers.
 func makeUpstreamHandler[ReqT UpstreamRequest](
 	baseLogger log.Logger,
 	eventLogger events.Logger,
@@ -111,7 +116,6 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 	// provider names defined clientside, i.e. "anthropic" or "openai".
 	upstreamName string,
 
-	upstreamAPIURL func(feature codygateway.Feature) string,
 	allowedModels []string,
 
 	methods upstreamHandlerMethods[ReqT],
@@ -123,9 +127,7 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 	autoFlushStreamingResponses bool,
 	patternsToDetect []string,
 ) http.Handler {
-	baseLogger = baseLogger.Scoped(upstreamName).
-		// This URL is used only for logging reason so we default to the chat endpoint
-		With(log.String("upstream.url", upstreamAPIURL(codygateway.FeatureChatCompletions)))
+	baseLogger = baseLogger.Scoped(upstreamName)
 
 	// Convert allowedModels to the Cody Gateway configuration format with the
 	// provider as a prefix. This aligns with the models returned when we query
@@ -136,220 +138,94 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 		clonedAllowedModels[i] = fmt.Sprintf("%s/%s", upstreamName, clonedAllowedModels[i])
 	}
 
-	// turn off sanitization for profanity detection
-	d := goaway.NewProfanityDetector().WithSanitizeAccents(false).WithSanitizeLeetSpeak(false).WithSanitizeSpaces(false).WithSanitizeSpecialCharacters(false)
+	// Create a single profanity detector to be used for all requests.
+	profDetector := goaway.NewProfanityDetector().
+		WithSanitizeAccents(false).
+		WithSanitizeLeetSpeak(false).
+		WithSanitizeSpaces(false).
+		WithSanitizeSpecialCharacters(false)
 
 	if len(patternsToDetect) > 0 {
 		baseLogger.Debug("initializing pattern detector", log.Strings("patterns", patternsToDetect))
 	}
 
-	return featurelimiter.Handle(
-		baseLogger,
-		eventLogger,
-		rs,
-		rateLimitNotifier,
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			act := actor.FromContext(r.Context())
+	// upstreamHandler is the actual HTTP handle that will perform "all of the things"
+	// in order to call the upstream API. e.g. calling the upstreamHandlerMethods in
+	// the correct order, enforcing rate limits and anti-abuse mechanisms, etc.
+	upstreamHandler := func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		act := actor.FromContext(ctx)
 
-			// TODO: Investigate using actor propagation handler for extracting
-			// this. We had some issues before getting that to work, so for now
-			// just stick with what we've seen working so far.
-			sgActorID := r.Header.Get("X-Sourcegraph-Actor-UID")
-			sgActorAnonymousUID := r.Header.Get("X-Sourcegraph-Actor-Anonymous-UID")
+		// TODO: Investigate using actor propagation handler for extracting
+		// this. We had some issues before getting that to work, so for now
+		// just stick with what we've seen working so far.
+		sgActorID := r.Header.Get("X-Sourcegraph-Actor-UID")
+		sgActorAnonymousUID := r.Header.Get("X-Sourcegraph-Actor-Anonymous-UID")
 
-			// Build logger for lifecycle of this request with lots of details.
-			logger := act.Logger(sgtrace.Logger(r.Context(), baseLogger)).With(
-				append(
-					requestclient.FromContext(r.Context()).LogFields(),
-					// Sourcegraph actor details
-					log.String("sg.actorID", sgActorID),
-					log.String("sg.anonymousID", sgActorAnonymousUID),
-				)...,
-			)
+		// Build logger for lifecycle of this request with lots of details.
+		logger := act.Logger(sgtrace.Logger(ctx, baseLogger)).With(
+			append(
+				requestclient.FromContext(ctx).LogFields(),
+				// Sourcegraph actor details
+				log.String("sg.actorID", sgActorID),
+				log.String("sg.anonymousID", sgActorAnonymousUID),
+			)...,
+		)
 
-			feature := featurelimiter.GetFeature(r.Context())
-			if feature == "" {
-				response.JSONError(logger, w, http.StatusBadRequest, errors.New("no feature provided"))
-				return
+		feature := featurelimiter.GetFeature(ctx)
+		if feature == "" {
+			response.JSONError(logger, w, http.StatusBadRequest, errors.New("no feature provided"))
+			return
+		}
+
+		// This will never be nil as the rate limiter middleware checks this before.
+		// TODO: Should we read the rate limit from context, and store it in the rate
+		// limiter to make this less dependent on these two logics to remain the same?
+		rateLimit, ok := act.RateLimits[feature]
+		if !ok {
+			response.JSONError(logger, w, http.StatusInternalServerError, errors.Newf("rate limit for %q not found", string(feature)))
+			return
+		}
+
+		// TEMPORARY: Add provider prefixes to AllowedModels for back-compat
+		// if it doesn't look like there is a prefix yet.
+		//
+		// This isn't very robust, but should tide us through a brief transition
+		// period until everything deploys and our caches refresh.
+		for i := range rateLimit.AllowedModels {
+			if !strings.Contains(rateLimit.AllowedModels[i], "/") {
+				rateLimit.AllowedModels[i] = fmt.Sprintf("%s/%s", upstreamName, rateLimit.AllowedModels[i])
 			}
+		}
 
-			// This will never be nil as the rate limiter middleware checks this before.
-			// TODO: Should we read the rate limit from context, and store it in the rate
-			// limiter to make this less dependent on these two logics to remain the same?
-			rateLimit, ok := act.RateLimits[feature]
-			if !ok {
-				response.JSONError(logger, w, http.StatusInternalServerError, errors.Newf("rate limit for %q not found", string(feature)))
-				return
-			}
-
-			// TEMPORARY: Add provider prefixes to AllowedModels for back-compat
-			// if it doesn't look like there is a prefix yet.
-			//
-			// This isn't very robust, but should tide us through a brief transition
-			// period until everything deploys and our caches refresh.
-			for i := range rateLimit.AllowedModels {
-				if !strings.Contains(rateLimit.AllowedModels[i], "/") {
-					rateLimit.AllowedModels[i] = fmt.Sprintf("%s/%s", upstreamName, rateLimit.AllowedModels[i])
-				}
-			}
-
-			// Parse the request body.
-			var body ReqT
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				response.JSONError(logger, w, http.StatusBadRequest, errors.Wrap(err, "failed to parse request body"))
-				return
-			}
-			status, flaggingResult, err := methods.validateRequest(r.Context(), logger, feature, body)
-			if err != nil {
-				if status == 0 {
-					response.JSONError(logger, w, http.StatusBadRequest, errors.Wrap(err, "invalid request"))
-				}
-				if flaggingResult.IsFlagged() && flaggingResult.shouldBlock {
-					requestMetadata := getFlaggingMetadata(flaggingResult, act)
-					err := eventLogger.LogEvent(
-						r.Context(),
-						events.Event{
-							Name:       codygateway.EventNameRequestBlocked,
-							Source:     act.Source.Name(),
-							Identifier: act.ID,
-							Metadata: events.MergeMaps(requestMetadata, map[string]any{
-								codygateway.CompletionsEventFeatureMetadataField: feature,
-								"model":    fmt.Sprintf("%s/%s", upstreamName, body.GetModel()),
-								"provider": upstreamName,
-
-								// Response details
-								"resolved_status_code": status,
-
-								// Request metadata
-								"prompt_token_count":   flaggingResult.promptTokenCount,
-								"max_tokens_to_sample": flaggingResult.maxTokensToSample,
-
-								// Actor details, specific to the actor Source
-								"sg_actor_id":            sgActorID,
-								"sg_actor_anonymous_uid": sgActorAnonymousUID,
-							}),
-						},
-					)
-					if err != nil {
-						logger.Error("failed to log event", log.Error(err))
-					}
-				}
-
-				response.JSONError(logger, w, status, err)
-				return
-			}
-
-			// identifier that can be provided to upstream for abuse detection
-			// has the format '$ACTOR_ID:$SG_ACTOR_ID'. The latter is anonymized
-			// (specific per-instance)
-			identifier := fmt.Sprintf("%s:%s", act.ID, sgActorID)
-			methods.transformBody(&body, identifier)
-
-			// Re-marshal the payload for upstream to unset metadata and remove any properties
-			// not known to us.
-			upstreamPayload, err := json.Marshal(body)
-			if err != nil {
-				response.JSONError(logger, w, http.StatusInternalServerError, errors.Wrap(err, "failed to marshal request body"))
-				return
-			}
-
-			// Create a new request to send upstream, making sure we retain the same context.
-			req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, upstreamAPIURL(feature), bytes.NewReader(upstreamPayload))
-			if err != nil {
-				response.JSONError(logger, w, http.StatusInternalServerError, errors.Wrap(err, "failed to create request"))
-				return
-			}
-
-			// Run the request transformer.
-			methods.transformRequest(req)
-
-			// Retrieve metadata from the initial request.
-			model, requestMetadata := methods.getRequestMetadata(body)
-
-			if feature == codygateway.FeatureChatCompletions {
-				prompt := strings.ToLower(body.BuildPrompt())
-				prof := d.ExtractProfanity(prompt)
-				if prof != "" {
-					requestMetadata["profanity"] = prof
-				}
-				for _, p := range patternsToDetect {
-					if strings.Contains(prompt, p) {
-						requestMetadata["detected_phrase"] = truncateToPrefix(p)
-						break
-					}
-				}
-			}
-
-			// Match the model against the allowlist of models, which are configured
-			// with the Cody Gateway model format "$PROVIDER/$MODEL_NAME". Models
-			// are sent as if they were against the upstream API, so they don't have
-			// the prefix yet when extracted - we need to add it back here. This
-			// full gatewayModel is also used in events tracking.
-			gatewayModel := fmt.Sprintf("%s/%s", upstreamName, model)
-			if allowed := intersection(clonedAllowedModels, rateLimit.AllowedModels); !isAllowedModel(allowed, gatewayModel) {
-				response.JSONError(logger, w, http.StatusBadRequest,
-					errors.Newf("model %q is not allowed, allowed: [%s]",
-						gatewayModel, strings.Join(allowed, ", ")))
-				return
-			}
-
-			w.Header().Add("x-cody-resolved-model", gatewayModel)
-
-			var (
-				upstreamStarted    = time.Now()
-				upstreamLatency    time.Duration
-				upstreamStatusCode int = -1
-				// resolvedStatusCode is the status code that we returned to the
-				// client - in most case it is the same as upstreamStatusCode,
-				// but sometimes we write something different.
-				resolvedStatusCode int = -1
-				// promptUsage and completionUsage are extracted from parseResponseAndUsage.
-				promptUsage, completionUsage usageStats
-			)
-			defer func() {
-				if span := oteltrace.SpanFromContext(r.Context()); span.IsRecording() {
-					span.SetAttributes(
-						attribute.Int("upstreamStatusCode", upstreamStatusCode),
-						attribute.Int("resolvedStatusCode", resolvedStatusCode))
-				}
-				if flaggingResult.IsFlagged() {
-					requestMetadata = events.MergeMaps(requestMetadata, getFlaggingMetadata(flaggingResult, act))
-				}
-				usageData := map[string]any{
-					"prompt_character_count":     promptUsage.characters,
-					"prompt_token_count":         promptUsage.tokens,
-					"completion_character_count": completionUsage.characters,
-					"completion_token_count":     completionUsage.tokens,
-				}
-				for k, v := range usageData {
-					// Drop usage fields that are invalid/unimplemented. All
-					// usageData fields are ints - we use map[string]any for
-					// convenience with mergeMaps utility.
-					if n, _ := v.(int); n < 0 {
-						delete(usageData, k)
-					}
-				}
-				o := overhead.FromContext(r.Context())
-				o.Feature = feature
-				o.UpstreamLatency = upstreamLatency
-				o.Provider = upstreamName
-				o.Stream = body.ShouldStream()
-
+		// Parse the request body.
+		var body ReqT
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			response.JSONError(logger, w, http.StatusBadRequest, errors.Wrap(err, "failed to parse request body"))
+			return
+		}
+		status, flaggingResult, err := methods.validateRequest(ctx, logger, feature, body)
+		if err != nil {
+			// Log that the request was outright blocked.
+			if flaggingResult != nil && flaggingResult.IsFlagged() && flaggingResult.shouldBlock {
+				requestMetadata := getFlaggingMetadata(flaggingResult, act)
 				err := eventLogger.LogEvent(
-					r.Context(),
+					ctx,
 					events.Event{
-						Name:       codygateway.EventNameCompletionsFinished,
+						Name:       codygateway.EventNameRequestBlocked,
 						Source:     act.Source.Name(),
 						Identifier: act.ID,
-						Metadata: events.MergeMaps(requestMetadata, usageData, map[string]any{
+						Metadata: events.MergeMaps(requestMetadata, map[string]any{
 							codygateway.CompletionsEventFeatureMetadataField: feature,
-							"model":    gatewayModel,
+							"model":    fmt.Sprintf("%s/%s", upstreamName, body.GetModel()),
 							"provider": upstreamName,
 
-							// Request details
-							"upstream_request_duration_ms": upstreamLatency.Milliseconds(),
-							"upstream_status_code":         upstreamStatusCode,
-							"resolved_status_code":         resolvedStatusCode,
+							// Response details
+							"resolved_status_code": status,
+
+							// Request metadata
+							"prompt_token_count":   flaggingResult.promptTokenCount,
+							"max_tokens_to_sample": flaggingResult.maxTokensToSample,
 
 							// Actor details, specific to the actor Source
 							"sg_actor_id":            sgActorID,
@@ -360,101 +236,241 @@ func makeUpstreamHandler[ReqT UpstreamRequest](
 				if err != nil {
 					logger.Error("failed to log event", log.Error(err))
 				}
-			}()
-			resp, err := httpClient.Do(req)
+			}
+
+			// Ensure that we return a meaningful error to the client for validation failures.
+			if status < 400 {
+				status = http.StatusBadRequest
+				err = errors.Wrap(err, "invalid request")
+			}
+			response.JSONError(logger, w, status, err)
+			return
+		}
+
+		// identifier that can be provided to upstream for abuse detection
+		// has the format '$ACTOR_ID:$SG_ACTOR_ID'. The latter is anonymized
+		// (specific per-instance)
+		identifier := fmt.Sprintf("%s:%s", act.ID, sgActorID)
+		methods.transformBody(&body, identifier)
+
+		// Re-marshal the payload for upstream to unset metadata and remove any properties
+		// not known to us.
+		upstreamPayload, err := json.Marshal(body)
+		if err != nil {
+			response.JSONError(logger, w, http.StatusInternalServerError, errors.Wrap(err, "failed to marshal request body"))
+			return
+		}
+
+		// Create a new request to send upstream, making sure we retain the same context.
+		upstreamURL := methods.getAPIURLByFeature(feature)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, bytes.NewReader(upstreamPayload))
+		if err != nil {
+			response.JSONError(logger, w, http.StatusInternalServerError, errors.Wrap(err, "failed to create request"))
+			return
+		}
+
+		// Run the request transformer.
+		methods.transformRequest(req)
+
+		// Retrieve metadata from the initial request.
+		model, requestMetadata := methods.getRequestMetadata(body)
+
+		if feature == codygateway.FeatureChatCompletions {
+			prompt := strings.ToLower(body.BuildPrompt())
+			profanity := profDetector.ExtractProfanity(prompt)
+			if profanity != "" {
+				requestMetadata["profanity"] = profanity
+			}
+			for _, p := range patternsToDetect {
+				if strings.Contains(prompt, p) {
+					requestMetadata["detected_phrase"] = truncateToPrefix(p)
+					break
+				}
+			}
+		}
+
+		// Match the model against the allowlist of models, which are configured
+		// with the Cody Gateway model format "$PROVIDER/$MODEL_NAME". Models
+		// are sent as if they were against the upstream API, so they don't have
+		// the prefix yet when extracted - we need to add it back here. This
+		// full gatewayModel is also used in events tracking.
+		gatewayModel := fmt.Sprintf("%s/%s", upstreamName, model)
+		if allowed := intersection(clonedAllowedModels, rateLimit.AllowedModels); !isAllowedModel(allowed, gatewayModel) {
+			response.JSONError(logger, w, http.StatusBadRequest,
+				errors.Newf("model %q is not allowed, allowed: [%s]",
+					gatewayModel, strings.Join(allowed, ", ")))
+			return
+		}
+
+		w.Header().Add("x-cody-resolved-model", gatewayModel)
+
+		var (
+			upstreamStarted    = time.Now()
+			upstreamLatency    time.Duration
+			upstreamStatusCode int = -1
+			// resolvedStatusCode is the status code that we returned to the
+			// client - in most case it is the same as upstreamStatusCode,
+			// but sometimes we write something different.
+			resolvedStatusCode int = -1
+			// promptUsage and completionUsage are extracted from parseResponseAndUsage.
+			promptUsage, completionUsage usageStats
+		)
+		defer func() {
+			if span := oteltrace.SpanFromContext(ctx); span.IsRecording() {
+				span.SetAttributes(
+					attribute.Int("upstreamStatusCode", upstreamStatusCode),
+					attribute.Int("resolvedStatusCode", resolvedStatusCode))
+			}
+			if flaggingResult.IsFlagged() {
+				requestMetadata = events.MergeMaps(requestMetadata, getFlaggingMetadata(flaggingResult, act))
+			}
+			usageData := map[string]any{
+				"prompt_character_count":     promptUsage.characters,
+				"prompt_token_count":         promptUsage.tokens,
+				"completion_character_count": completionUsage.characters,
+				"completion_token_count":     completionUsage.tokens,
+			}
+			for k, v := range usageData {
+				// Drop usage fields that are invalid/unimplemented. All
+				// usageData fields are ints - we use map[string]any for
+				// convenience with mergeMaps utility.
+				if n, _ := v.(int); n < 0 {
+					delete(usageData, k)
+				}
+			}
+			o := overhead.FromContext(ctx)
+			o.Feature = feature
+			o.UpstreamLatency = upstreamLatency
+			o.Provider = upstreamName
+			o.Stream = body.ShouldStream()
+
+			err := eventLogger.LogEvent(
+				ctx,
+				events.Event{
+					Name:       codygateway.EventNameCompletionsFinished,
+					Source:     act.Source.Name(),
+					Identifier: act.ID,
+					Metadata: events.MergeMaps(requestMetadata, usageData, map[string]any{
+						codygateway.CompletionsEventFeatureMetadataField: feature,
+						"model":    gatewayModel,
+						"provider": upstreamName,
+
+						// Request details
+						"upstream_request_duration_ms": upstreamLatency.Milliseconds(),
+						"upstream_status_code":         upstreamStatusCode,
+						"resolved_status_code":         resolvedStatusCode,
+
+						// Actor details, specific to the actor Source
+						"sg_actor_id":            sgActorID,
+						"sg_actor_anonymous_uid": sgActorAnonymousUID,
+					}),
+				},
+			)
 			if err != nil {
-				// Ignore reporting errors where client disconnected
-				if req.Context().Err() == context.Canceled && errors.Is(err, context.Canceled) {
-					oteltrace.SpanFromContext(req.Context()).
-						SetStatus(codes.Error, err.Error())
-					logger.Info("request canceled", log.Error(err))
-					return
-				}
-
-				// More user-friendly message for timeouts
-				if errors.Is(err, context.DeadlineExceeded) {
-					resolvedStatusCode = http.StatusGatewayTimeout
-					response.JSONError(logger, w, resolvedStatusCode,
-						errors.Newf("request to upstream provider %s timed out", upstreamName))
-					return
-				}
-
-				resolvedStatusCode = http.StatusInternalServerError
-				response.JSONError(logger, w, resolvedStatusCode,
-					errors.Wrapf(err, "failed to make request to upstream provider %s", upstreamName))
+				logger.Error("failed to log event", log.Error(err))
+			}
+		}()
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			// Ignore reporting errors where client disconnected
+			if req.Context().Err() == context.Canceled && errors.Is(err, context.Canceled) {
+				oteltrace.SpanFromContext(req.Context()).
+					SetStatus(codes.Error, err.Error())
+				logger.Info("request canceled", log.Error(err))
 				return
 			}
-			defer func() { _ = resp.Body.Close() }()
-			// Forward upstream http headers.
-			for k, vv := range resp.Header {
-				if _, ok := hopHeaders[http.CanonicalHeaderKey(k)]; ok {
-					// do not forward
-					continue
-				}
-				for _, v := range vv {
-					w.Header().Add(k, v)
-				}
+
+			// More user-friendly message for timeouts
+			if errors.Is(err, context.DeadlineExceeded) {
+				resolvedStatusCode = http.StatusGatewayTimeout
+				response.JSONError(logger, w, resolvedStatusCode,
+					errors.Newf("request to upstream provider %s timed out", upstreamName))
+				return
 			}
 
-			// Record upstream's status code and decide what we want to send to
-			// the client. By default, we just send upstream's status code.
-			upstreamStatusCode = resp.StatusCode
-			resolvedStatusCode = upstreamStatusCode
-			if upstreamStatusCode == http.StatusTooManyRequests {
-				// Rewrite 429 to 503 because we share a quota when talking to upstream,
-				// and a 429 from upstream should NOT indicate to the client that they
-				// should liberally retry until the rate limit is lifted. To ensure we are
-				// notified when this happens, log this as an error and record the headers
-				// that are provided to us.
-				var headers bytes.Buffer
-				_ = resp.Header.Write(&headers)
-				logger.Error("upstream returned 429, rewriting to 503",
-					log.Error(errors.New(resp.Status)), // real error needed for Sentry reporting
-					log.String("resp.headers", headers.String()))
-				resolvedStatusCode = http.StatusServiceUnavailable
+			resolvedStatusCode = http.StatusInternalServerError
+			response.JSONError(logger, w, resolvedStatusCode,
+				errors.Wrapf(err, "failed to make request to upstream provider %s", upstreamName))
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		// Forward upstream http headers.
+		for k, vv := range resp.Header {
+			if _, ok := hopHeaders[http.CanonicalHeaderKey(k)]; ok {
+				// do not forward
+				continue
 			}
-
-			// This handles upstream 429 responses as well, since they get
-			// resolved to http.StatusServiceUnavailable.
-			if resolvedStatusCode == http.StatusServiceUnavailable {
-				// Propagate retry-after in case it is handle-able by the client,
-				// or write our default. 503 errors can have retry-after as well.
-				if upstreamRetryAfter := resp.Header.Get("retry-after"); upstreamRetryAfter != "" {
-					w.Header().Set("retry-after", upstreamRetryAfter)
-				} else {
-					w.Header().Set("retry-after", strconv.Itoa(defaultRetryAfterSeconds))
-				}
+			for _, v := range vv {
+				w.Header().Add(k, v)
 			}
+		}
 
-			// Write the resolved status code.
-			w.WriteHeader(resolvedStatusCode)
+		// Record upstream's status code and decide what we want to send to
+		// the client. By default, we just send upstream's status code.
+		upstreamStatusCode = resp.StatusCode
+		resolvedStatusCode = upstreamStatusCode
+		if upstreamStatusCode == http.StatusTooManyRequests {
+			// Rewrite 429 to 503 because we share a quota when talking to upstream,
+			// and a 429 from upstream should NOT indicate to the client that they
+			// should liberally retry until the rate limit is lifted. To ensure we are
+			// notified when this happens, log this as an error and record the headers
+			// that are provided to us.
+			var headers bytes.Buffer
+			_ = resp.Header.Write(&headers)
+			logger.Error("upstream returned 429, rewriting to 503",
+				log.Error(errors.New(resp.Status)), // real error needed for Sentry reporting
+				log.String("resp.headers", headers.String()))
+			resolvedStatusCode = http.StatusServiceUnavailable
+		}
 
-			// Set up a buffer to capture the response as it's streamed and sent to the client.
-			var responseBuf bytes.Buffer
-			respBody := io.TeeReader(resp.Body, &responseBuf)
-			// if this is a streaming request, we want to flush ourselves instead of leaving that to the http.Server
-			// (so events are sent to the client as soon as possible)
-			var responseWriter io.Writer = w
-			if autoFlushStreamingResponses && body.ShouldStream() {
-				if fw, err := response.NewAutoFlushingWriter(w); err == nil {
-					responseWriter = fw
-				} else {
-					// We can't stream the response, but it's better to write it without streaming that fail, so we just log the error
-					logger.Error("failed to create auto-flushing writer", log.Error(err))
-				}
+		// This handles upstream 429 responses as well, since they get
+		// resolved to http.StatusServiceUnavailable.
+		if resolvedStatusCode == http.StatusServiceUnavailable {
+			// Propagate retry-after in case it is handle-able by the client,
+			// or write our default. 503 errors can have retry-after as well.
+			if upstreamRetryAfter := resp.Header.Get("retry-after"); upstreamRetryAfter != "" {
+				w.Header().Set("retry-after", upstreamRetryAfter)
+			} else {
+				w.Header().Set("retry-after", strconv.Itoa(defaultRetryAfterSeconds))
 			}
-			_, _ = io.Copy(responseWriter, respBody)
-			// record latency of upstream request after we read the whole response, but without recording the time we spend parsing it in parseResponseAndUsage()
-			upstreamLatency = time.Since(upstreamStarted)
+		}
 
-			if upstreamStatusCode >= 200 && upstreamStatusCode < 300 {
-				// Pass reader to response transformer to capture token counts.
-				promptUsage, completionUsage = methods.parseResponseAndUsage(logger, body, &responseBuf)
-			} else if upstreamStatusCode >= 500 {
-				logger.Error("error from upstream",
-					log.Int("status_code", upstreamStatusCode))
+		// Write the resolved status code.
+		w.WriteHeader(resolvedStatusCode)
+
+		// Set up a buffer to capture the response as it's streamed and sent to the client.
+		var responseBuf bytes.Buffer
+		respBody := io.TeeReader(resp.Body, &responseBuf)
+		// if this is a streaming request, we want to flush ourselves instead of leaving that to the http.Server
+		// (so events are sent to the client as soon as possible)
+		var responseWriter io.Writer = w
+		if autoFlushStreamingResponses && body.ShouldStream() {
+			if fw, err := response.NewAutoFlushingWriter(w); err == nil {
+				responseWriter = fw
+			} else {
+				// We can't stream the response, but it's better to write it without streaming that fail, so we just log the error
+				logger.Error("failed to create auto-flushing writer", log.Error(err))
 			}
-		}))
+		}
+		_, _ = io.Copy(responseWriter, respBody)
+		// record latency of upstream request after we read the whole response, but without recording the time we spend parsing it in parseResponseAndUsage()
+		upstreamLatency = time.Since(upstreamStarted)
+
+		if upstreamStatusCode >= 200 && upstreamStatusCode < 300 {
+			// Pass reader to response transformer to capture token counts.
+			promptUsage, completionUsage = methods.parseResponseAndUsage(logger, body, &responseBuf)
+		} else if upstreamStatusCode >= 500 {
+			logger.Error("error from upstream",
+				log.Int("status_code", upstreamStatusCode))
+		}
+	}
+
+	return featurelimiter.Handle(
+		baseLogger,
+		eventLogger,
+		rs,
+		rateLimitNotifier,
+		http.HandlerFunc(upstreamHandler))
 }
 
 func truncateToPrefix(p string) string {


### PR DESCRIPTION
This PR applies some general code cleanups and refactoring to `upstream.go`, which IMO is a bit too gnarly for being such a crucial part of the codebase.

Changes:

**Added a `getAPIURLByFeature(codygateway.Feature) string` function to the methods interface**

Added a new `getAPIURLByFeature` function to the `upstreamHandlerMethods[ReqT UpstreamRequest]` interface.

This removes one of the parameters to `makeUpstreamHandler`, and also makes more sense IMHO. Because the `upstreamHandlerMethods` interface is a facade in front of an LLM API, and so it seemed rather awkward to rely on a one-off function for determining the API URL to use.

As part of this, I also moved the package-level constants for the API URLs to just be constant literals in the `getAPIURLByFeature` functions. This may not be as clear-cut of an improvement, but given that the `const` value was only ever read in one place, it seems better to not "pollute" the package namespace with it. And just keep it hard-coded in that one function.

**Rename `d` to `profDetector`**

Given the vast distance between declaration and usage, renaming `d` to `profDetector` seems like a good call. 

There's a lot of great advice in finding balance between short and long identifiers in Go here:
https://dave.cheney.net/practical-go/presentations/gophercon-israel.html#_the_larger_the_identifiers_scope_the_larger_its_name
The general rule I try to remember is just:

> The greater the distance between a name’s declaration and its uses, the longer the name should be.

**Replace `r.Context()` with `ctx`**

It seems preferable to have a local variable named `ctx` than keep on calling `r.Context()`. This (IMHO) keeps things easier to read. But a more practical argument for doing so is that it doesn't lead to bugs if we need to _alias_ the context later.

e.g. a common pattern is that within an HTTP handler you'd replace `ctx` with something like `ctx = context.WithTimeout(ctx, ...)` or something. And that isn't possible if you keep calling `r.Context()`.

(But I'd be lying if I wasn't just removing this because I personally just want to avoid all the unnecessary function calls and keep the code more tidy and concise.)

There are a couple of other changes I'll explain in PR comments.

## Test plan

Relying on existing unit tests.

(I'd love to write more, but first we need to untangle all of the dependencies in `makeUpstreamHandler`, as mocking out ~~12~~ now 11 parameters is going to be a PITA.