### PR TITLE
Generalize Cody Gateway request flagging

### DIFF
--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -169,7 +169,7 @@ func (a *AnthropicHandlerMethods) shouldFlagRequest(ctx context.Context, logger 
 		}
 		result.shouldBlock = result.shouldBlock && a.config.RequestBlockingEnabled
 	}
-	return nil, nil
+	return result, nil
 }
 
 func (a *AnthropicHandlerMethods) transformBody(body *anthropicRequest, identifier string) {

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic.go
@@ -22,10 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/errors"
 )
 
-const (
-	logPromptPrefixLength = 250
-)
-
 // PromptRecorder implementations should save select completions prompts for
 // a short amount of time for security review.
 type PromptRecorder interface {
@@ -136,27 +132,46 @@ func (a *AnthropicHandlerMethods) getAPIURLByFeature(feature codygateway.Feature
 	return "https://api.anthropic.com/v1/complete"
 }
 
-func (a *AnthropicHandlerMethods) validateRequest(ctx context.Context, logger log.Logger, _ codygateway.Feature, ar anthropicRequest) (int, *flaggingResult, error) {
+func (a *AnthropicHandlerMethods) validateRequest(ctx context.Context, logger log.Logger, _ codygateway.Feature, ar anthropicRequest) error {
 	if ar.MaxTokensToSample > int32(a.config.MaxTokensToSample) {
-		return http.StatusBadRequest, nil, errors.Errorf("max_tokens_to_sample exceeds maximum allowed value of %d: %d", a.config.MaxTokensToSample, ar.MaxTokensToSample)
+		return errors.Errorf("max_tokens_to_sample exceeds maximum allowed value of %d: %d", a.config.MaxTokensToSample, ar.MaxTokensToSample)
+	}
+	return nil
+}
+
+func (a *AnthropicHandlerMethods) shouldFlagRequest(ctx context.Context, logger log.Logger, ar anthropicRequest) (*flaggingResult, error) {
+	cfg := a.config
+	result, err := isFlaggedRequest(a.anthropicTokenizer,
+		flaggingRequest{
+			FlattenedPrompt: ar.Prompt,
+			MaxTokens:       int(ar.MaxTokensToSample),
+		},
+		flaggingConfig{
+			AllowedPromptPatterns:          cfg.AllowedPromptPatterns,
+			BlockedPromptPatterns:          cfg.BlockedPromptPatterns,
+			PromptTokenFlaggingLimit:       cfg.PromptTokenFlaggingLimit,
+			PromptTokenBlockingLimit:       cfg.PromptTokenBlockingLimit,
+			MaxTokensToSampleFlaggingLimit: cfg.MaxTokensToSampleFlaggingLimit,
+			ResponseTokenBlockingLimit:     cfg.ResponseTokenBlockingLimit,
+		},
+	)
+	if err != nil {
+		return nil, err
 	}
 
-	if result, err := isFlaggedAnthropicRequest(a.anthropicTokenizer, ar, a.config); err != nil {
-		logger.Error("error checking anthropic request - treating as non-flagged",
-			log.Error(err))
-	} else if result.IsFlagged() {
-		// Record flagged prompts in hotpath - they usually take a long time on the backend side, so this isn't going to make things meaningfully worse
-		if err := a.promptRecorder.Record(ctx, ar.Prompt); err != nil {
+	if result.IsFlagged() {
+		// Record flagged prompts. The prompt recorder's implementation has a short TTL for
+		// this data, but is made available to troubleshoot ongoing abuse waves. This does
+		// incur some additional latency, but so this isn't going to make things meaningfully worse
+		// since flagged abuse requests take longer to process on the LLM-provider side.
+		if err := a.promptRecorder.Record(ctx, ar.BuildPrompt()); err != nil {
 			logger.Warn("failed to record flagged prompt", log.Error(err))
 		}
-		if a.config.RequestBlockingEnabled && result.shouldBlock {
-			return http.StatusBadRequest, result, requestBlockedError(ctx)
-		}
-		return 0, result, nil
+		result.shouldBlock = result.shouldBlock && a.config.RequestBlockingEnabled
 	}
-
-	return 0, nil, nil
+	return nil, nil
 }
+
 func (a *AnthropicHandlerMethods) transformBody(body *anthropicRequest, identifier string) {
 	// Overwrite the metadata field, we don't want to allow users to specify it:
 	body.Metadata = &anthropicRequestMetadata{
@@ -164,12 +179,14 @@ func (a *AnthropicHandlerMethods) transformBody(body *anthropicRequest, identifi
 		UserID: identifier,
 	}
 }
+
 func (a *AnthropicHandlerMethods) getRequestMetadata(body anthropicRequest) (model string, additionalMetadata map[string]any) {
 	return body.Model, map[string]any{
 		"stream":               body.Stream,
 		"max_tokens_to_sample": body.MaxTokensToSample,
 	}
 }
+
 func (a *AnthropicHandlerMethods) transformRequest(r *http.Request) {
 	// Mimic headers set by the official Anthropic client:
 	// https://sourcegraph.com/github.com/anthropics/anthropic-sdk-typescript@493075d70f50f1568a276ed0cb177e297f5fef9f/-/blob/src/index.ts
@@ -180,6 +197,7 @@ func (a *AnthropicHandlerMethods) transformRequest(r *http.Request) {
 	r.Header.Set("X-API-Key", a.config.AccessToken)
 	r.Header.Set("anthropic-version", "2023-01-01")
 }
+
 func (a *AnthropicHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBody anthropicRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
 	var err error
 	// First, extract prompt usage details from the request.
@@ -241,27 +259,4 @@ func (a *AnthropicHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBo
 		completionUsage.tokens = len(tokens)
 	}
 	return promptUsage, completionUsage
-}
-
-func isFlaggedAnthropicRequest(tk *tokenizer.Tokenizer, ar anthropicRequest, cfg config.AnthropicConfig) (*flaggingResult, error) {
-	// Only usage of chat models us currently flagged, so if the request
-	// is using another model, we skip other checks.
-	if ar.Model != "claude-2" && ar.Model != "claude-2.0" && ar.Model != "claude-2.1" && ar.Model != "claude-v1" {
-		return nil, nil
-	}
-
-	return isFlaggedRequest(tk,
-		flaggingRequest{
-			FlattenedPrompt: ar.Prompt,
-			MaxTokens:       int(ar.MaxTokensToSample),
-		},
-		flaggingConfig{
-			AllowedPromptPatterns:          cfg.AllowedPromptPatterns,
-			BlockedPromptPatterns:          cfg.BlockedPromptPatterns,
-			PromptTokenFlaggingLimit:       cfg.PromptTokenFlaggingLimit,
-			PromptTokenBlockingLimit:       cfg.PromptTokenBlockingLimit,
-			MaxTokensToSampleFlaggingLimit: cfg.MaxTokensToSampleFlaggingLimit,
-			ResponseTokenBlockingLimit:     cfg.ResponseTokenBlockingLimit,
-		},
-	)
 }

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropic_test.go
@@ -1,6 +1,7 @@
 package completions
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -9,10 +10,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sourcegraph/log/logtest"
+
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/shared/config"
 
 	"github.com/sourcegraph/sourcegraph/cmd/cody-gateway/internal/tokenizer"
 )
+
+type mockPromptRecorder struct{}
+
+func (*mockPromptRecorder) Record(ctx context.Context, prompt string) error {
+	return nil
+}
 
 func TestIsFlaggedAnthropicRequest(t *testing.T) {
 	validPreamble := "You are cody-gateway."
@@ -22,20 +31,36 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 		PromptTokenBlockingLimit:       20000,
 		MaxTokensToSampleFlaggingLimit: 1000,
 		ResponseTokenBlockingLimit:     1000,
+		RequestBlockingEnabled:         true,
 	}
 	cfgWithPreamble := config.AnthropicConfig{
 		PromptTokenFlaggingLimit:       18000,
 		PromptTokenBlockingLimit:       20000,
 		MaxTokensToSampleFlaggingLimit: 1000,
 		ResponseTokenBlockingLimit:     1000,
+		RequestBlockingEnabled:         true,
 		AllowedPromptPatterns:          []string{strings.ToLower(validPreamble)},
 	}
 	tk, err := tokenizer.NewAnthropicClaudeTokenizer()
 	require.NoError(t, err)
 
+	// Helper function for calling the AnthropicHandlerMethod's shouldFlagRequest, using the supplied
+	// request and configuration.
+	callShouldFlagRequest := func(t *testing.T, ar anthropicRequest, cfg config.AnthropicConfig) (*flaggingResult, error) {
+		t.Helper()
+		anthropicUpstream := &AnthropicHandlerMethods{
+			anthropicTokenizer: tk,
+			promptRecorder:     &mockPromptRecorder{},
+			config:             cfg,
+		}
+		ctx := context.Background()
+		logger := logtest.NoOp(t)
+		return anthropicUpstream.shouldFlagRequest(ctx, logger, ar)
+	}
+
 	t.Run("missing known preamble", func(t *testing.T) {
 		ar := anthropicRequest{Model: "claude-2", Prompt: "some prompt without known preamble"}
-		result, err := isFlaggedAnthropicRequest(tk, ar, cfgWithPreamble)
+		result, err := callShouldFlagRequest(t, ar, cfgWithPreamble)
 		require.NoError(t, err)
 		require.True(t, result.IsFlagged())
 		require.False(t, result.shouldBlock)
@@ -44,14 +69,14 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 
 	t.Run("preamble not configured ", func(t *testing.T) {
 		ar := anthropicRequest{Model: "claude-2", Prompt: "some prompt without known preamble"}
-		result, err := isFlaggedAnthropicRequest(tk, ar, cfg)
+		result, err := callShouldFlagRequest(t, ar, cfg)
 		require.NoError(t, err)
 		require.False(t, result.IsFlagged())
 	})
 
 	t.Run("high max tokens to sample", func(t *testing.T) {
 		ar := anthropicRequest{Model: "claude-2", MaxTokensToSample: 10000, Prompt: validPreamble}
-		result, err := isFlaggedAnthropicRequest(tk, ar, cfg)
+		result, err := callShouldFlagRequest(t, ar, cfg)
 		require.NoError(t, err)
 		require.True(t, result.IsFlagged())
 		require.True(t, result.shouldBlock)
@@ -66,7 +91,7 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 		validPreambleTokens := len(tokenLengths)
 		longPrompt := strings.Repeat("word ", cfg.PromptTokenFlaggingLimit+1)
 		ar := anthropicRequest{Model: "claude-2", Prompt: validPreamble + " " + longPrompt}
-		result, err := isFlaggedAnthropicRequest(tk, ar, cfgWithPreamble)
+		result, err := callShouldFlagRequest(t, ar, cfgWithPreamble)
 		require.NoError(t, err)
 		require.True(t, result.IsFlagged())
 		require.False(t, result.shouldBlock)
@@ -75,22 +100,22 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 	})
 
 	t.Run("high prompt token count and bad phrase", func(t *testing.T) {
-		cfgWithBadPhrase := &cfgWithPreamble
+		cfgWithBadPhrase := cfgWithPreamble
 		cfgWithBadPhrase.BlockedPromptPatterns = []string{"bad phrase"}
 		longPrompt := strings.Repeat("word ", cfg.PromptTokenFlaggingLimit+1)
 		ar := anthropicRequest{Model: "claude-2", Prompt: validPreamble + " " + longPrompt + "bad phrase"}
-		result, err := isFlaggedAnthropicRequest(tk, ar, *cfgWithBadPhrase)
+		result, err := callShouldFlagRequest(t, ar, cfgWithBadPhrase)
 		require.NoError(t, err)
 		require.True(t, result.IsFlagged())
 		require.True(t, result.shouldBlock)
 	})
 
 	t.Run("low prompt token count and bad phrase", func(t *testing.T) {
-		cfgWithBadPhrase := &cfgWithPreamble
+		cfgWithBadPhrase := cfgWithPreamble
 		cfgWithBadPhrase.BlockedPromptPatterns = []string{"bad phrase"}
 		longPrompt := strings.Repeat("word ", 5)
 		ar := anthropicRequest{Model: "claude-2", Prompt: validPreamble + " " + longPrompt + "bad phrase"}
-		result, err := isFlaggedAnthropicRequest(tk, ar, *cfgWithBadPhrase)
+		result, err := callShouldFlagRequest(t, ar, cfgWithBadPhrase)
 		require.NoError(t, err)
 		// for now, we should not flag requests purely because of bad phrases
 		require.False(t, result.IsFlagged())
@@ -103,7 +128,7 @@ func TestIsFlaggedAnthropicRequest(t *testing.T) {
 		validPreambleTokens := len(tokenLengths)
 		longPrompt := strings.Repeat("word ", cfg.PromptTokenBlockingLimit+1)
 		ar := anthropicRequest{Model: "claude-2", Prompt: validPreamble + " " + longPrompt}
-		result, err := isFlaggedAnthropicRequest(tk, ar, cfgWithPreamble)
+		result, err := callShouldFlagRequest(t, ar, cfgWithPreamble)
 		require.NoError(t, err)
 		require.True(t, result.IsFlagged())
 		require.True(t, result.shouldBlock)

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
@@ -202,7 +202,7 @@ func (a *AnthropicMessagesHandlerMethods) shouldFlagRequest(ctx context.Context,
 		}
 		result.shouldBlock = result.shouldBlock && a.config.RequestBlockingEnabled
 	}
-	return nil, nil
+	return result, nil
 }
 
 func (a *AnthropicMessagesHandlerMethods) transformBody(body *anthropicMessagesRequest, identifier string) {

--- a/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/anthropicmessages.go
@@ -166,27 +166,45 @@ func (a *AnthropicMessagesHandlerMethods) getAPIURLByFeature(feature codygateway
 	return "https://api.anthropic.com/v1/messages"
 }
 
-func (a *AnthropicMessagesHandlerMethods) validateRequest(ctx context.Context, logger log.Logger, _ codygateway.Feature, ar anthropicMessagesRequest) (int, *flaggingResult, error) {
+func (a *AnthropicMessagesHandlerMethods) validateRequest(ctx context.Context, logger log.Logger, _ codygateway.Feature, ar anthropicMessagesRequest) error {
 	if ar.MaxTokens > int32(a.config.MaxTokensToSample) {
-		return http.StatusBadRequest, nil, errors.Errorf("max_tokens exceeds maximum allowed value of %d: %d", a.config.MaxTokensToSample, ar.MaxTokens)
+		return errors.Errorf("max_tokens exceeds maximum allowed value of %d: %d", a.config.MaxTokensToSample, ar.MaxTokens)
+	}
+	return nil
+}
+
+func (a *AnthropicMessagesHandlerMethods) shouldFlagRequest(ctx context.Context, logger log.Logger, ar anthropicMessagesRequest) (*flaggingResult, error) {
+	cfg := a.config
+	result, err := isFlaggedRequest(a.tokenizer,
+		flaggingRequest{
+			FlattenedPrompt: ar.BuildPrompt(),
+			MaxTokens:       int(ar.MaxTokens),
+		},
+		flaggingConfig{
+			AllowedPromptPatterns:          cfg.AllowedPromptPatterns,
+			BlockedPromptPatterns:          cfg.BlockedPromptPatterns,
+			PromptTokenFlaggingLimit:       cfg.PromptTokenFlaggingLimit,
+			PromptTokenBlockingLimit:       cfg.PromptTokenBlockingLimit,
+			MaxTokensToSampleFlaggingLimit: cfg.MaxTokensToSampleFlaggingLimit,
+			ResponseTokenBlockingLimit:     cfg.ResponseTokenBlockingLimit,
+		})
+	if err != nil {
+		return nil, err
 	}
 
-	if result, err := isFlaggedAnthropicMessagesRequest(a.tokenizer, ar, a.config); err != nil {
-		logger.Error("error checking AnthropicMessages request - treating as non-flagged",
-			log.Error(err))
-	} else if result.IsFlagged() {
-		// Record flagged prompts in hotpath - they usually take a long time on the backend side, so this isn't going to make things meaningfully worse
+	if result.IsFlagged() {
+		// Record flagged prompts. The prompt recorder's implementation has a short TTL for
+		// this data, but is made available to troubleshoot ongoing abuse waves. This does
+		// incur some additional latency, but so this isn't going to make things meaningfully worse
+		// since flagged abuse requests take longer to process on the LLM-provider side.
 		if err := a.promptRecorder.Record(ctx, ar.BuildPrompt()); err != nil {
 			logger.Warn("failed to record flagged prompt", log.Error(err))
 		}
-		if a.config.RequestBlockingEnabled && result.shouldBlock {
-			return http.StatusBadRequest, result, requestBlockedError(ctx)
-		}
-		return 0, result, nil
+		result.shouldBlock = result.shouldBlock && a.config.RequestBlockingEnabled
 	}
-
-	return 0, nil, nil
+	return nil, nil
 }
+
 func (a *AnthropicMessagesHandlerMethods) transformBody(body *anthropicMessagesRequest, identifier string) {
 	// Overwrite the metadata field, we don't want to allow users to specify it:
 	body.Metadata = &anthropicMessagesRequestMetadata{
@@ -282,21 +300,4 @@ func (a *AnthropicMessagesHandlerMethods) parseResponseAndUsage(logger log.Logge
 	}
 
 	return promptUsage, completionUsage
-}
-
-func isFlaggedAnthropicMessagesRequest(tk *tokenizer.Tokenizer, r anthropicMessagesRequest, cfg config.AnthropicConfig) (*flaggingResult, error) {
-	return isFlaggedRequest(tk,
-		flaggingRequest{
-			FlattenedPrompt: r.BuildPrompt(),
-			MaxTokens:       int(r.MaxTokens),
-		},
-		flaggingConfig{
-			AllowedPromptPatterns:          cfg.AllowedPromptPatterns,
-			BlockedPromptPatterns:          cfg.BlockedPromptPatterns,
-			PromptTokenFlaggingLimit:       cfg.PromptTokenFlaggingLimit,
-			PromptTokenBlockingLimit:       cfg.PromptTokenBlockingLimit,
-			MaxTokensToSampleFlaggingLimit: cfg.MaxTokensToSampleFlaggingLimit,
-			ResponseTokenBlockingLimit:     cfg.ResponseTokenBlockingLimit,
-		},
-	)
 }

--- a/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/fireworks.go
@@ -119,9 +119,16 @@ func (f *FireworksHandlerMethods) getAPIURLByFeature(feature codygateway.Feature
 	}
 }
 
-func (f *FireworksHandlerMethods) validateRequest(_ context.Context, _ log.Logger, _ codygateway.Feature, _ fireworksRequest) (int, *flaggingResult, error) {
-	return 0, nil, nil
+func (f *FireworksHandlerMethods) validateRequest(_ context.Context, _ log.Logger, _ codygateway.Feature, _ fireworksRequest) error {
+	// TODO[#61278]: Add missing request validation for all LLM providers in Cody Gateway.
+	return nil
 }
+
+func (f *FireworksHandlerMethods) shouldFlagRequest(_ context.Context, _ log.Logger, _ fireworksRequest) (*flaggingResult, error) {
+	// TODO[#61278]: Add missing request validation for all LLM providers in Cody Gateway.
+	return nil, nil
+}
+
 func (f *FireworksHandlerMethods) transformBody(body *fireworksRequest, _ string) {
 	// We don't want to let users generate multiple responses, as this would
 	// mess with rate limit counting.
@@ -131,13 +138,16 @@ func (f *FireworksHandlerMethods) transformBody(body *fireworksRequest, _ string
 
 	body.Model = pickStarCoderModel(body.Model, f.config)
 }
+
 func (f *FireworksHandlerMethods) getRequestMetadata(body fireworksRequest) (model string, additionalMetadata map[string]any) {
 	return body.Model, map[string]any{"stream": body.Stream}
 }
+
 func (f *FireworksHandlerMethods) transformRequest(r *http.Request) {
 	r.Header.Set("Content-Type", "application/json")
 	r.Header.Set("Authorization", "Bearer "+f.config.AccessToken)
 }
+
 func (f *FireworksHandlerMethods) parseResponseAndUsage(logger log.Logger, reqBody fireworksRequest, r io.Reader) (promptUsage, completionUsage usageStats) {
 	// First, extract prompt usage details from the request.
 	promptUsage.characters = len(reqBody.Prompt)

--- a/cmd/cody-gateway/internal/httpapi/completions/openai.go
+++ b/cmd/cody-gateway/internal/httpapi/completions/openai.go
@@ -120,13 +120,16 @@ func (*OpenAIHandlerMethods) getAPIURLByFeature(feature codygateway.Feature) str
 	return "https://api.openai.com/v1/chat/completions"
 }
 
-func (*OpenAIHandlerMethods) validateRequest(_ context.Context, _ log.Logger, feature codygateway.Feature, _ openaiRequest) (int, *flaggingResult, error) {
+func (*OpenAIHandlerMethods) validateRequest(_ context.Context, _ log.Logger, feature codygateway.Feature, _ openaiRequest) error {
 	if feature == codygateway.FeatureCodeCompletions {
-		return http.StatusNotImplemented, nil,
-			errors.Newf("feature %q is currently not supported for OpenAI",
-				feature)
+		return errors.Newf("feature %q is currently not supported for OpenAI", feature)
 	}
-	return 0, nil, nil
+	return nil
+}
+
+func (*OpenAIHandlerMethods) shouldFlagRequest(_ context.Context, _ log.Logger, _ openaiRequest) (*flaggingResult, error) {
+	// TODO[#61278]: Add missing request validation for all LLM providers in Cody Gateway.
+	return nil, nil
 }
 
 func (*OpenAIHandlerMethods) transformBody(body *openaiRequest, identifier string) {


### PR DESCRIPTION
This PR continues my crusade to tidy up the Cody Gateway upstream code and try to make our anti-abuse measures a bit more general.

The crux of this PR is the following:

```diff
-	validateRequest(context.Context, log.Logger, codygateway.Feature, ReqT) (int, *flaggingResult, error)
+	validateRequest(context.Context, log.Logger, codygateway.Feature, ReqT) error
+	shouldFlagRequest(context.Context, log.Logger, ReqT) (*flaggingResult, error)
```

Previously we were performing "abuse flagging" as part of the request `validateRequest` function. And also had an awkward function signature, where the `int` return value signified an HTTP status code (or defaulted to zero, which would then be defaulted again into `http.BadRequest`.)

So this PR changes three things:

### Simplify `validateRequest`

Now, the function just returns an error. A non-nil response will serve a `400 Bad Request`, along with the error.

:warning: This does change the behavior for our OpenAI endpoint. We were previously returning a more accurate `501 Not Implemented` if trying to use that provider for "chat". But I'd argue that serving the less accurate HTTP error response (400) is probably less important than a simpler function signature for the `upstreamHandlerMethods` interface.

And if we _really_ wanted to do that, we could check for the appropriate status code some other way. e.g. `errors.As(err, &httpStatusCodeError)

### Add new `shouldFlagRequest` function

We call `shouldFlagRequest` as part of processing an upstream request immediately after calling `validateRequest`. This provides an arguably cleaner way to isolate code for flagging LLM requests on a per-upstream provider basis. Though in practice, I expect all of our implementations here to just wrap the `isFlaggedRequest` function. (Like is the case for Anthropic now.)

⚠️ Part of my refactoring here is that I removed the LLM check that was inside of `isFlaggedAnthropicRequest`. (So with this change, we would _start_ flagging requests sent to "claude-2.0", "claude-v1", etc.)

My understanding is that this is what we want to do in general. So this is the right fix. The concern however is that it could lead to a sudden change in requests being flagged as abuse. (e.g. a spike in false-positives when using those older LLMs, etc.)

Since discussions about <REDACTED> shouldn't be made in this issue tracker, ping me on Slack. Because of the way <REDACTED> works today, I don't think this will be a problem.

### Opportunistic code cleanups

This PR also made a few refactoring for clarity and maintainability. If you feel I went too far in this regard, or would rather I tease those changes out into a separate PR let me know.

But in general I'm looking for patterns like:

```
if predicate {
    long block of code
} else {
    short block of code
}
```

And inverting the predicate so that the predicate, "short block of code", and the start of the "long block of code" can all be seen together. (Otherwise it arguably is more difficult to read the code as a human.)

Similarly, updating patterns like:

```
if predicate {
   long block of code
   return x
}
return y
```

to just be `if !predicate { return y }`. Then, the "long block of code" does not need to be indented. (e.g. having multiple return statements to avoid overall cyclomatic complexity, if I am using that term right.)

### Next Steps

Provide this PR looks good, then my next step is to follow up and fix https://github.com/sourcegraph/sourcegraph/issues/61278. That is add new configuration knobs like `fireworksconfig.RequestBlockingEnabled` and have fireworks and OpenAI requests be routed through `isFlaggedRequest`.

That shouldn't cause any disruption, and will mean we start flagging abusive requests in paths that we aren't today. But I'd need some help to understand how to roll that out in such a way we can understand if it is causing an unexpected uptick in false-positives, etc.

And, after that, my master plan is to update `isFlaggedRequest` to introduce a new type of flag: "flagged-for-moderation". These would be requests that we want to set aside for an async review (e.g. running it through a proper moderation classifier as part of <REDACTED>.)

## Test plan

Relying on current tests, and aside from trivial things there shouldn't be any functional changes here. (But when I go back to actually start flagging new types of requests, will certainly be adding the relevant tests.)